### PR TITLE
The MSRV stops being asserted and becomes measured

### DIFF
--- a/.ank/tasks/TASK-973e9dc3f9ce.md
+++ b/.ank/tasks/TASK-973e9dc3f9ce.md
@@ -1,0 +1,26 @@
+---
+id: TASK-973e9dc3f9ce
+type: task
+slug: the-msrv-is-the-current-stable-and-one-dependenc
+title: The MSRV is the current stable, and one dependency decides it
+created: 2026-08-01T19:38:31Z
+author: seanl@sean-laptop
+status: open
+scope:
+  - crates/ank-cli/Cargo.toml
+  - Cargo.lock
+blocked_by: []
+done_criteria: |
+  The choice between keeping libsqlite3-sys at a version that requires the current stable and pinning back to one that does not is made in writing, measured the same way the floor was: a toolchain run against the tree, not an assumption about what a version needs. Whichever way it goes, the manifests, CLAUDE.md and ci.yml agree with the measurement afterwards.
+criteria_by: creator
+schema: 2
+version: 1
+---
+
+Found by TASK-daf25ab8a9b7, which established the floor and stopped there because its criterion was to measure and record, not to move it.
+
+The measurement: 1.78, 1.91, 1.92, 1.93 and 1.94 all fail; 1.95 is the first toolchain that compiles the workspace. The sole cause is the build script of libsqlite3-sys 0.38.1, which calls cfg_select!, stabilised in 1.95. Lockfile v4's own floor of 1.78 is real and is not the binding one.
+
+So ank currently requires the newest stable Rust, with zero headroom, and the floor will move again whenever this dependency does. For a tool distributed as a static binary on three platforms, that is an adoption cost paid for one crate.
+
+The other side of the trade is in the manifest already: bundled is what keeps the binary static, and Windows ships no libsqlite3 to link against. An older rusqlite may cost features find depends on, or nothing at all. Nobody has run it, which is the same defect this task's parent existed to correct - so the answer comes from a toolchain run, not from a changelog.

--- a/.ank/tasks/TASK-daf25ab8a9b7.md
+++ b/.ank/tasks/TASK-daf25ab8a9b7.md
@@ -15,7 +15,7 @@ done_criteria: |
   The minimum supported Rust version is established by running that toolchain against the tree, not by assertion. rust-version is declared in the manifests, CLAUDE.md states the same number, and CI builds on that exact toolchain so the claim cannot rot again without turning something red.
 criteria_by: creator
 schema: 1
-version: 3
+version: 5
 ---
 
 CLAUDE.md says "the MSRV is loose but Cargo.lock pins for rustc 1.75 (liftable
@@ -40,3 +40,6 @@ number at all — it reads as verified.
 
 The last clause of the criterion is the point. An MSRV asserted in a comment
 rots silently; an MSRV that CI builds on turns red the day it stops being true.
+
+## Log
+- 2026-08-01T19:37:10Z seanl@sean-laptop — Toolchain walk complete. Measured, not asserted: 1.78 fails (libsqlite3-sys 0.38.1 build.rs uses cfg_select!, macro not found), 1.91/1.92/1.93/1.94 all fail the same call as E0658 use of unstable library feature cfg_select. 1.95 is the first toolchain that compiles: cargo +1.95 test --workspace --locked green, 239 tests. MSRV is 1.95, the current stable, and the sole cause is one build script in libsqlite3-sys 0.38.1. The lockfile v4 floor of 1.78 is real but not binding: the dependency floor is 17 minor versions above it.

--- a/.ank/tasks/TASK-daf25ab8a9b7.md
+++ b/.ank/tasks/TASK-daf25ab8a9b7.md
@@ -4,7 +4,7 @@ type: task
 slug: the-msrv-claim-is-false-cargo-lock-v4-cannot-be
 title: "The MSRV claim is false: Cargo.lock v4 cannot be read by the toolchain CLAUDE.md names"
 created: 2026-07-31T17:33:47Z
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/Cargo.toml
   - crates/ank-core/Cargo.toml
@@ -14,8 +14,15 @@ blocked_by: []
 done_criteria: |
   The minimum supported Rust version is established by running that toolchain against the tree, not by assertion. rust-version is declared in the manifests, CLAUDE.md states the same number, and CI builds on that exact toolchain so the claim cannot rot again without turning something red.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 9b35894
+    criteria: 442b01fb69b2
+  - type: test
+    ref: ci://github/30716366063
+    criteria: 442b01fb69b2
 schema: 1
-version: 5
+version: 9
 ---
 
 CLAUDE.md says "the MSRV is loose but Cargo.lock pins for rustc 1.75 (liftable
@@ -43,3 +50,6 @@ rots silently; an MSRV that CI builds on turns red the day it stops being true.
 
 ## Log
 - 2026-08-01T19:37:10Z seanl@sean-laptop — Toolchain walk complete. Measured, not asserted: 1.78 fails (libsqlite3-sys 0.38.1 build.rs uses cfg_select!, macro not found), 1.91/1.92/1.93/1.94 all fail the same call as E0658 use of unstable library feature cfg_select. 1.95 is the first toolchain that compiles: cargo +1.95 test --workspace --locked green, 239 tests. MSRV is 1.95, the current stable, and the sole cause is one build script in libsqlite3-sys 0.38.1. The lockfile v4 floor of 1.78 is real but not binding: the dependency floor is 17 minor versions above it.
+- 2026-08-01T20:12:41Z seanl@sean-laptop — CI evidence for the last clause of the criterion: run 30716366063 on msrv/measured-not-asserted, conclusion success. All three msrv jobs green, and the ubuntu log confirms it is not a vacuous pass: rustup installed 1.95.0 (59807616e), cargo +1.95 --version reports 1.95.0, and cargo +1.95 build --workspace --locked compiled ank-core. Note for whoever meets this next: the claim TTL lapsed while waiting on CI and ank log refused with code 6. Working is what renews the lock, and waiting is not working.
+- 2026-08-01T20:13:00Z seanl@sean-laptop — done, proof commit:9b35894
+- 2026-08-01T20:13:11Z seanl@sean-laptop — attested test:ci://github/30716366063

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,3 +69,36 @@ jobs:
       #
       # Exit 8 means findings, and that is a failure here. Signals exit 0.
       - run: cargo run -q --bin ank -- check
+
+  # The MSRV declared in the manifests, built on the toolchain it names. The
+  # job above runs on whatever the runner image ships, which is what lets an
+  # MSRV claim rot in silence: it was wrong by seventeen minor versions before
+  # anyone ran the number (TASK-daf25ab8a9b7).
+  #
+  # All three platforms, because the crate that sets the floor sets it from a
+  # build script, and a build script is the one place where the floor can
+  # legitimately differ per target.
+  msrv:
+    name: msrv 1.95 / ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v5
+
+      # rustup is preinstalled on the runners, so pinning costs no new action
+      # and no new supply-chain surface — the same argument the job above makes
+      # for using the image's toolchain.
+      - name: install the declared MSRV
+        run: rustup toolchain install 1.95 --profile minimal
+
+      - name: versions
+        run: cargo +1.95 --version
+
+      # --locked because the lockfile is half the claim: lockfile v4 needs 1.78
+      # on its own, and a resolution performed here would measure a different
+      # tree from the one that ships.
+      - run: cargo +1.95 build --workspace --locked

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,8 +73,12 @@ run on all three.
 - `accept` only runs on the default branch (`default_branch` in `config.yml`,
   falling back to `refs/remotes/origin/HEAD`), with no way around it.
 - Ank never commits, except `accept`.
-- No new dependency without necessity; a static binary is the goal; the MSRV is
-  loose but Cargo.lock pins for rustc 1.75 (liftable if needed — note it).
+- No new dependency without necessity; a static binary is the goal; **the MSRV
+  is 1.95**, declared in both manifests and pinned in `ci.yml`. It was measured
+  by walking toolchains against the tree — 1.78 through 1.94 all fail — and it
+  is the current stable, so there is no headroom: `libsqlite3-sys` alone sets
+  it (TASK-973e9dc3f9ce). Raising it means re-running the walk, never editing
+  the number.
 
 ## Style
 

--- a/crates/ank-cli/Cargo.toml
+++ b/crates/ank-cli/Cargo.toml
@@ -2,6 +2,13 @@
 name = "ank-cli"
 version = "0.1.0"
 edition = "2021"
+# Measured on 2026-08-01 by walking toolchains upward against this tree, which
+# is the only way this number means anything: 1.78, 1.91, 1.92, 1.93 and 1.94
+# all fail, 1.95 is the first that compiles and passes the suite. The cause is
+# a single dependency and it is named below. Declared here so cargo refuses an
+# older toolchain by name instead of failing inside a build script, and pinned
+# in ci.yml so the claim turns something red the day it stops being true.
+rust-version = "1.95"
 license = "GPL-3.0-only"
 description = "The Ank CLI: agent surface (7 verbs) and human surface."
 
@@ -26,11 +33,18 @@ hex = "0.4"
 # against. The price is a C compiler at build time on the three platforms.
 #
 # On the MSRV: neither rusqlite 0.40 nor libsqlite3-sys 0.38 declares a
-# rust-version, and this lockfile was resolved by a 1.95 toolchain, so whether
-# it still builds under the 1.75 the pin used to assume is unknown rather than
-# known-broken — no 1.75 toolchain has been run against it. Stated as unknown
-# on purpose: a comment claiming otherwise would be a guess, and CI pins
-# nothing below stable today.
+# rust-version, and this pair is what sets the workspace floor at 1.95. The
+# build script of libsqlite3-sys 0.38.1 calls `cfg_select!`, which is unknown
+# to 1.78 and still unstable through 1.94 (E0658); 1.95 is the first stable
+# release that accepts it. Lockfile v4 puts a floor at 1.78 on its own, but
+# that floor is not the binding one and never was — the dependency is
+# seventeen minor versions above it.
+#
+# The consequence is worth stating plainly rather than discovering later: this
+# workspace requires the current stable, so it has no MSRV headroom at all, and
+# the floor moves whenever this dependency does. Whether that price is worth
+# paying for `bundled` SQLite is a dependency question, not an MSRV question,
+# and it is TASK-973e9dc3f9ce's to answer.
 #
 # `default-features = false` is not tidiness: the default set includes
 # `ffi-sqlite-wasm-rs`, which drags wasm-bindgen, js-sys and a wasm VFS into the

--- a/crates/ank-core/Cargo.toml
+++ b/crates/ank-core/Cargo.toml
@@ -2,6 +2,10 @@
 name = "ank-core"
 version = "0.1.0"
 edition = "2021"
+# Measured, not assumed: see the note in ank-cli's manifest. This crate's own
+# code needs far less, but the workspace resolves one lockfile and builds as a
+# unit, so a floor that holds only here would not be a floor.
+rust-version = "1.95"
 license = "GPL-3.0-only"
 description = "Parser and data model for the Ank format. The format is the specification; this crate is its reference implementation."
 


### PR DESCRIPTION
Closes `TASK-daf25ab8a9b7`.

CLAUDE.md claimed "the MSRV is loose but Cargo.lock pins for rustc 1.75". That
was false by seventeen minor versions, and false in the way that matters: no
toolchain had ever been run against the tree, so the number read as verified
while being a guess.

## The walk

| Toolchain | Result |
|---|---|
| 1.78 | `cannot find macro cfg_select in this scope` |
| 1.91 | `E0658: use of unstable library feature cfg_select` |
| 1.92 | `E0658` |
| 1.93 | `E0658` |
| 1.94 | `E0658` |
| **1.95** | **builds; `cargo test --workspace --locked` green, 239 tests** |

One dependency sets the floor: the build script of `libsqlite3-sys 0.38.1`
calls `cfg_select!`, stabilised in 1.95. Lockfile v4's own floor of 1.78 is
real and is **not** the binding one, so the note it justified was wrong twice
over.

## What changed

`rust-version = "1.95"` in both manifests, which turns a cryptic build-script
failure into a refusal that names itself:

```
error: rustc 1.94.1 is not supported by the following packages:
  ank-cli@0.1.0 requires rustc 1.95
  ank-core@0.1.0 requires rustc 1.95
```

A pinned `msrv` job in `ci.yml`, on all three platforms. The existing job builds
on whatever the runner image ships, which is exactly what let the old claim rot
in silence. Three platforms because the crate that sets the floor sets it from a
build script, and a build script is the one place a floor can legitimately
differ per target.

CLAUDE.md now states the measured number and says raising it means re-running
the walk, never editing the number.

## What this deliberately does not do

It does not move the floor. Requiring the current stable, with zero headroom, is
a real adoption cost for a tool that ships static binaries on three platforms,
and the trade against `bundled` SQLite is a dependency question rather than an
MSRV one. Filed as `TASK-973e9dc3f9ce`, with a criterion that it be answered by
a toolchain run rather than by reading a changelog — which is the same failure
mode this task existed to correct.

## Verification

- The walk above, each toolchain run against this tree
- `cargo test --workspace` green on stable; `cargo +1.95 test --workspace --locked` green
- `cargo fmt --check` clean, `ank check` exit 0
- The `msrv` job in this PR is the evidence for the last clause of the criterion

## Noted, not touched

`crates/ank-cli/Cargo.toml`'s `description` still reads "agent surface (7 verbs)
and human surface" — two-surface language and a wrong count. In this task's
scope but unrelated to the MSRV, and it slips through `TASK-8c376169fb6c`'s
criterion, which only catches comments citing ADR-3859eb46bdc3 by name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KL6PyySn7QQ1wYbVhS9ro5
