### PR TITLE
check verifies the ratification signature instead of trusting it

### DIFF
--- a/.ank/tasks/TASK-d31af22248d9.md
+++ b/.ank/tasks/TASK-d31af22248d9.md
@@ -5,7 +5,7 @@ slug: the-ratification-commit-is-read-but-its-signatur
 title: The ratification commit is read but its signature is never checked
 created: 2026-08-01T05:31:51Z
 author: seanl@sean-laptop
-status: open
+status: done
 scope:
   - crates/ank-cli/src/human.rs
   - crates/ank-cli/src/git.rs
@@ -15,8 +15,24 @@ done_criteria: |
   check verifies the signature of the ratification commit it reads the anchor from, through git verify-commit against the keys declared in allowed_signers, and an anchor carried by an unsigned or unverifiable commit is not accepted as a ratification. A missing public key is reported as a signature that could not be checked and never as a valid one, since a verification that degrades to success is not a verification. The states are distinguishable in the output and each one is tested.
 criteria_by: creator
 verify: [cargo-test, fmt-check, check-repo]
+proof:
+  - type: test
+    ref: local/8e114250b9c9@b87e5d3
+    tree: scope/87a3e54e4993
+    criteria: 05057e699b2e
+    verifier: cargo-test@f14aeab36e1b
+  - type: test
+    ref: local/e3b0c44298fc@b87e5d3
+    tree: scope/87a3e54e4993
+    criteria: 05057e699b2e
+    verifier: fmt-check@5ca6d10bcd55
+  - type: test
+    ref: local/9549888e2612@b87e5d3
+    tree: scope/87a3e54e4993
+    criteria: 05057e699b2e
+    verifier: check-repo@5734e9cf9d3d
 schema: 2
-version: 1
+version: 5
 ---
 
 Left open by TASK-03eaa26bddd1, deliberately and in writing rather than in
@@ -50,3 +66,8 @@ introduced for an unreachable commit, and the two are not the same state.
 never reads it, so either `check` parses it itself to decide which keys count,
 or the file goes on declaring something nothing enforces. That choice is part of
 this task.
+
+## Log
+- 2026-08-01T20:24:12Z seanl@sean-laptop — Design settled with the human. allowed_signers already uses 'principal gpg <40-hex fingerprint>', a shape the spec never documents (it only says SSH allowed-signers format + GPG through git config). check will parse the file itself and match the signing key. Split by signature format: under GPG %GF is the 40-hex fingerprint and ank matches it against the gpg entries; under SSH ank passes -c gpg.ssh.allowedSignersFile to verify-commit so git enforces the allowlist natively and the exit code carries it. Injection is deliberately untouched: context.rs is outside this scope, so an unsigned ratification becomes a check fault without silently unbinding a constraint.
+- 2026-08-01T20:33:40Z seanl@sean-laptop — Implemented. git.rs: ratification_at now returns the commit sha with the anchor, signature_of reads %G? and %GF through rev-list --format (verify-commit collapses no-signature and cannot-check into one exit code, and those are the two states that must stay apart). human.rs: parse_signers, classify_signature, five states. Measured against git rather than assumed: under SSH with an allowed-signers file, G means the principal matched and U means it did not, so git has already done the allowlist check; under OpenPGP git never reads the file and ank matches %GF itself. Detected by fingerprint shape (SHA256: vs hex). Two traps found by measuring: git reports N for a perfectly signed commit when gpg.format is ssh and no allowed-signers file is configured, so with nothing declared ank abstains entirely; and unchecked signatures are counted once for the corpus, not once per ADR, following the rule section 4 already fixed for entities predating author.
+- 2026-08-01T20:50:58Z seanl@sean-laptop — done, proof test:local/8e114250b9c9@b87e5d3 test:local/e3b0c44298fc@b87e5d3 test:local/9549888e2612@b87e5d3

--- a/.ank/tasks/TASK-e162e649298f.md
+++ b/.ank/tasks/TASK-e162e649298f.md
@@ -1,0 +1,26 @@
+---
+id: TASK-e162e649298f
+type: task
+slug: the-dogfooding-signature-test-asserts-a-property
+title: The dogfooding signature test asserts a property of the machine
+created: 2026-08-01T20:57:37Z
+author: seanl@sean-laptop
+status: in_progress
+scope:
+  - crates/ank-cli/src/human.rs
+blocked_by: []
+done_criteria: |
+  this_repositorys_own_ratifications_are_signed passes on a shallow clone without ceasing to assert anything: nothing judged is accepted only when the repository is genuinely shallow, and on a complete clone it still fails when no ratification is judged. Green on all three platforms in CI, which is where the shallow case actually occurs.
+criteria_by: creator
+schema: 2
+version: 3
+---
+
+Written by TASK-d31af22248d9 and caught by CI on the run that followed its done, which is the order that made it a separate task rather than an edit: the criterion was frozen and met, the proof anchored the tree that met it, and a done task keeps its proof.
+
+The test asserted judged > 0 on this repository's own ADRs. actions/checkout clones shallow, so rev-list --full-history reaches no ratification commit, every ADR is the unverifiable case the freeze already reports, and signature_state correctly answers None. The assertion was about the depth of the clone and not about the code under it.
+
+Skipping when nothing is judged would be the easy fix and the wrong one, since it would leave the wiring untested everywhere. Demanding the reason instead -- shallow, and only shallow -- keeps the test failing on a complete clone the day signature_state stops reaching anything.
+
+## Log
+- 2026-08-01T20:57:51Z seanl@sean-laptop — CI run 30717980708 failed on ubuntu-latest and macos-latest: no ratification was judged at all. Cause is the shallow clone from actions/checkout, not the code. Fix demands the reason rather than skipping: nothing judged is tolerated only when git rev-parse --is-shallow-repository says true, so a complete clone with broken wiring still fails. ci.yml is outside this scope, so fetch-depth is not the lever here.

--- a/.ank/tasks/TASK-e162e649298f.md
+++ b/.ank/tasks/TASK-e162e649298f.md
@@ -5,15 +5,19 @@ slug: the-dogfooding-signature-test-asserts-a-property
 title: The dogfooding signature test asserts a property of the machine
 created: 2026-08-01T20:57:37Z
 author: seanl@sean-laptop
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/src/human.rs
 blocked_by: []
 done_criteria: |
   this_repositorys_own_ratifications_are_signed passes on a shallow clone without ceasing to assert anything: nothing judged is accepted only when the repository is genuinely shallow, and on a complete clone it still fails when no ratification is judged. Green on all three platforms in CI, which is where the shallow case actually occurs.
 criteria_by: creator
+proof:
+  - type: test
+    ref: ci://github/30718133555
+    criteria: ca88a3082901
 schema: 2
-version: 3
+version: 4
 ---
 
 Written by TASK-d31af22248d9 and caught by CI on the run that followed its done, which is the order that made it a separate task rather than an edit: the criterion was frozen and met, the proof anchored the tree that met it, and a done task keeps its proof.
@@ -24,3 +28,4 @@ Skipping when nothing is judged would be the easy fix and the wrong one, since i
 
 ## Log
 - 2026-08-01T20:57:51Z seanl@sean-laptop — CI run 30717980708 failed on ubuntu-latest and macos-latest: no ratification was judged at all. Cause is the shallow clone from actions/checkout, not the code. Fix demands the reason rather than skipping: nothing judged is tolerated only when git rev-parse --is-shallow-repository says true, so a complete clone with broken wiring still fails. ci.yml is outside this scope, so fetch-depth is not the lever here.
+- 2026-08-01T21:01:03Z seanl@sean-laptop — done, proof test:ci://github/30718133555

--- a/crates/ank-cli/src/git.rs
+++ b/crates/ank-cli/src/git.rs
@@ -44,6 +44,23 @@ const PLUMBING: &[&str] = &[
     "--version",
 ];
 
+/// The verb an invocation actually runs, skipping the leading `-c <key>=<value>`
+/// pairs.
+///
+/// Those pairs exist for one caller — [`signature_of`], which has to hand git a
+/// configuration the repository must not be made to carry permanently — and the
+/// plumbing rule is about the command whose output we parse, not about the
+/// configuration it runs under. Reading `args[0]` blindly would have made `-c`
+/// look like porcelain and fired the assertion on a correct call.
+fn verb_of<'a>(args: &'a [&'a str]) -> Option<&'a str> {
+    let mut rest = args;
+    while let Some(("-c", tail)) = rest.split_first().map(|(h, t)| (*h, t)) {
+        // `-c` takes one argument; dropping both is what leaves the verb first.
+        rest = tail.get(1..).unwrap_or(&[]);
+    }
+    rest.first().copied()
+}
+
 pub type Result<T> = std::result::Result<T, CliError>;
 
 fn env_missing() -> CliError {
@@ -62,7 +79,9 @@ fn env_missing() -> CliError {
 /// stderr, which is exactly the fragility the plumbing rule exists to avoid.
 pub fn output(cwd: &Path, args: &[&str]) -> Result<Output> {
     debug_assert!(
-        args.first().map(|a| PLUMBING.contains(a)).unwrap_or(false),
+        verb_of(args)
+            .map(|a| PLUMBING.contains(&a))
+            .unwrap_or(false),
         "porcelain forbidden (ADR-b8884edcebe3): {args:?}"
     );
     Command::new("git")
@@ -324,10 +343,22 @@ pub fn file_at(cwd: &Path, rev: &str, path: &str) -> Result<Option<String>> {
 /// invocation — while `check` asks the same question once per ADR and again for
 /// every task that ADR bears on. Measured on this repository before it existed:
 /// hundreds of `git` spawns and 4.3s for what takes 0.9s without them.
-type Memo = OnceLock<Mutex<HashMap<(PathBuf, String), Option<String>>>>;
+type Memo = OnceLock<Mutex<HashMap<(PathBuf, String), Option<Ratification>>>>;
 static RATIFICATIONS: Memo = OnceLock::new();
 
-pub fn ratification_anchor_at(cwd: &Path, id: &str, path: &str) -> Result<Option<String>> {
+/// A ratification commit, and the anchor it recorded.
+///
+/// The commit travels with the hash because the hash alone cannot be trusted:
+/// it is only worth as much as the signature on the object carrying it, and
+/// checking that signature means knowing which object to ask about
+/// (TASK-d31af22248d9).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Ratification {
+    pub sha: String,
+    pub anchor: String,
+}
+
+pub fn ratification_at(cwd: &Path, id: &str, path: &str) -> Result<Option<Ratification>> {
     let key = (cwd.to_path_buf(), id.to_string());
     let memo = RATIFICATIONS.get_or_init(|| Mutex::new(HashMap::new()));
     if let Ok(seen) = memo.lock() {
@@ -335,14 +366,14 @@ pub fn ratification_anchor_at(cwd: &Path, id: &str, path: &str) -> Result<Option
             return Ok(hit.clone());
         }
     }
-    let found = ratification_anchor_uncached(cwd, id, path)?;
+    let found = ratification_uncached(cwd, id, path)?;
     if let Ok(mut seen) = memo.lock() {
         seen.insert(key, found.clone());
     }
     Ok(found)
 }
 
-fn ratification_anchor_uncached(cwd: &Path, id: &str, path: &str) -> Result<Option<String>> {
+fn ratification_uncached(cwd: &Path, id: &str, path: &str) -> Result<Option<Ratification>> {
     let subject = format!("ratify {id}");
     let args = ["rev-list", "--full-history", "HEAD", "--", path];
     let out = output(cwd, &args)?;
@@ -370,9 +401,78 @@ fn ratification_anchor_uncached(cwd: &Path, id: &str, path: &str) -> Result<Opti
         return Ok(message
             .iter()
             .find_map(|l| l.trim().strip_prefix("constraint+scope: "))
-            .map(|h| h.trim().to_string()));
+            .map(|h| Ratification {
+                sha: sha.trim().to_string(),
+                anchor: h.trim().to_string(),
+            }));
     }
     Ok(None)
+}
+
+/// What git says about the signature on a commit, before anyone decides what it
+/// means.
+///
+/// Deliberately facts and not a verdict: which keys are allowed to ratify is a
+/// question about `.ank/allowed_signers` (§8), and answering it here would put
+/// a policy decision inside the plumbing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SignatureFacts {
+    /// `%G?`: `G` good, `U` good but untrusted, `E` cannot be checked, `N` no
+    /// signature, `B` bad, `X`/`Y` expired signature or key, `R` revoked key.
+    pub status: char,
+    /// `%GF`: the signing key's fingerprint, empty when there is none to name.
+    /// A 40-hex fingerprint under OpenPGP, `SHA256:<base64>` under SSH.
+    pub fingerprint: String,
+}
+
+/// Reads the signature of `sha`.
+///
+/// `allowed_signers` is passed to git rather than applied here, and it only
+/// bites under `gpg.format = ssh`, which is the only format git checks such a
+/// file for. Under OpenPGP git resolves the signature through the keyring and
+/// ignores the file entirely — so the caller does that matching itself, which
+/// is the whole reason the fingerprint comes back with the status.
+///
+/// `-c` rather than repository configuration: pointing a repository's
+/// `gpg.ssh.allowedSignersFile` at `.ank/` would change how every commit in it
+/// verifies, for every tool, to serve one check of ours.
+pub fn signature_of(
+    cwd: &Path,
+    sha: &str,
+    allowed_signers: Option<&Path>,
+) -> Result<SignatureFacts> {
+    // `rev-list` and not `verify-commit`: the exit code of `verify-commit`
+    // collapses "no signature" and "cannot check it" into the same failure,
+    // and those two are precisely the states this must keep apart. The
+    // placeholders are git's documented pretty-format interface.
+    let signers = allowed_signers.map(|p| format!("gpg.ssh.allowedSignersFile={}", p.display()));
+    let mut args: Vec<&str> = Vec::new();
+    if let Some(cfg) = signers.as_deref() {
+        args.push("-c");
+        args.push(cfg);
+    }
+    args.extend_from_slice(&["rev-list", "--max-count=1", "--format=%G?%n%GF", sha]);
+
+    let out = output(cwd, &args)?;
+    if !out.status.success() {
+        return Err(failed(&args, &out));
+    }
+    let text = String::from_utf8_lossy(&out.stdout);
+
+    // `--format` implies `--pretty`, whose first line is `commit <sha>`. The
+    // two placeholders follow, in order, one per line.
+    let mut lines = text.lines().skip(1);
+    let status = lines
+        .next()
+        .and_then(|l| l.trim().chars().next())
+        // An empty first placeholder is git declining to say anything about a
+        // signature, which is the same thing as there being none.
+        .unwrap_or('N');
+    let fingerprint = lines.next().unwrap_or_default().trim().to_string();
+    Ok(SignatureFacts {
+        status,
+        fingerprint,
+    })
 }
 
 /// Resolves the default branch (§7): the config value first, then

--- a/crates/ank-cli/src/human.rs
+++ b/crates/ank-cli/src/human.rs
@@ -89,6 +89,9 @@ pub struct Report {
     pub pruned: Vec<String>,
     pub tasks: usize,
     pub adrs: usize,
+    /// Ratification signatures no local key could check. Accumulated across the
+    /// corpus and reported once (§4), never per ADR.
+    pub unchecked_signatures: usize,
 }
 
 impl Report {
@@ -262,6 +265,22 @@ pub fn inspect(repo: &Repo, cfg: &Config, path: Option<&str>, prune: bool) -> Re
     check_cycles(&entities, &mut report);
     check_authorship(&entities, &coord, &in_scope, &mut report);
 
+    // One line for the machine, not one per ADR (§8, and the rule of §4 about
+    // reporting a corpus-wide absence once). Says what it would take to make
+    // the answer real, because the reader who sees this is usually one
+    // `gpg --recv-keys` away from a verification.
+    if report.unchecked_signatures > 0 {
+        let n = report.unchecked_signatures;
+        report.findings.push(Finding::signal(
+            "allowed_signers",
+            format!(
+                "{n} ratification signature(s) could not be checked here: no public key \
+                 for the signing identity, so they are not verified and not refused \
+                 (import the key declared in .ank/allowed_signers)"
+            ),
+        ));
+    }
+
     // Maintenance last, so a corpus fault is still reported when pruning cannot
     // run for want of a default branch.
     match &default_branch {
@@ -307,14 +326,136 @@ fn coordination(cwd: &Path, report: &mut Report) -> Result<HashMap<EntityId, Rec
     Ok(map)
 }
 
+/// One entry of `.ank/allowed_signers`: an identity allowed to ratify (§8).
+///
+/// Git's allowed-signers layout, `principal [options] keytype key`, read from
+/// the end because the optional middle is what varies: the key is the last
+/// field and its type the one before, whatever sits between them.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Signer {
+    pub principal: String,
+    pub keytype: String,
+    pub key: String,
+}
+
+/// Parses `allowed_signers`. Unreadable lines are dropped rather than reported:
+/// this file is versioned and reviewed, and a check that refuses to start over a
+/// stray line is a check that stops answering the question it exists for.
+pub fn parse_signers(text: &str) -> Vec<Signer> {
+    text.lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty() && !l.starts_with('#'))
+        .filter_map(|l| {
+            let fields: Vec<&str> = l.split_whitespace().collect();
+            match fields.as_slice() {
+                [principal, .., keytype, key] => Some(Signer {
+                    principal: (*principal).to_string(),
+                    keytype: keytype.to_lowercase(),
+                    key: (*key).to_string(),
+                }),
+                _ => None,
+            }
+        })
+        .collect()
+}
+
+/// What a ratification commit's signature is worth.
+///
+/// Five states and not three, because collapsing any two of them loses the
+/// distinction the check exists to draw. `Unchecked` in particular must never
+/// read as `Trusted`: a verification that degrades to success on a machine
+/// missing a public key is not a verification.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Signature {
+    /// Good signature from a key `allowed_signers` declares.
+    Trusted,
+    /// Good signature, from a key nobody declared.
+    Undeclared { fingerprint: String },
+    /// A signature is there and no local key can check it.
+    Unchecked,
+    /// No signature at all — the forgery this task was filed for.
+    Absent,
+    /// Present, checkable, and refused: bad, expired or revoked.
+    Invalid { status: char },
+}
+
+/// Turns git's facts into the verdict, against the declared keys.
+///
+/// Pure, and that is deliberate: every state is reachable in a unit test
+/// without a keyring, a network or a signed fixture, which is what makes "each
+/// one is tested" affordable rather than aspirational.
+pub fn classify_signature(facts: &git::SignatureFacts, declared: &[Signer]) -> Signature {
+    match facts.status {
+        'N' => Signature::Absent,
+        'E' => Signature::Unchecked,
+        'G' | 'U' => {
+            if is_ssh(&facts.fingerprint) {
+                // Under SSH git has already done the allowlist check, because
+                // it is the only format it will do it for: measured against
+                // git, `G` is a key the allowed-signers file matched and `U` is
+                // a good signature whose principal it did not. Re-deciding it
+                // here would mean comparing an `SHA256:` fingerprint against a
+                // base64 key and calling every correct signature undeclared.
+                if facts.status == 'G' {
+                    Signature::Trusted
+                } else {
+                    Signature::Undeclared {
+                        fingerprint: facts.fingerprint.clone(),
+                    }
+                }
+            } else if declares(declared, &facts.fingerprint) {
+                // OpenPGP, where git never reads the file at all. `U` here is a
+                // good signature from a key the local keyring does not
+                // *ultimately trust*, which is a statement about the operator's
+                // web of trust and not about this repository — so both good
+                // statuses are judged the same way, by the declaration.
+                Signature::Trusted
+            } else {
+                Signature::Undeclared {
+                    fingerprint: facts.fingerprint.clone(),
+                }
+            }
+        }
+        other => Signature::Invalid { status: other },
+    }
+}
+
+/// An SSH signature names its key as `SHA256:<base64>`; OpenPGP names it as a
+/// bare hex fingerprint. Which of the two decided the allowlist depends on it.
+fn is_ssh(fingerprint: &str) -> bool {
+    fingerprint.contains(':')
+}
+
+/// Whether any declared key names this fingerprint.
+///
+/// A suffix match, not equality: git reports a full 40-hex OpenPGP fingerprint
+/// while a file may perfectly reasonably declare the 16-hex long key id, and
+/// the long id is the tail of the fingerprint. The comparison is
+/// case-insensitive because hex is written both ways and neither is wrong.
+fn declares(declared: &[Signer], fingerprint: &str) -> bool {
+    let fp = fingerprint.replace(' ', "").to_lowercase();
+    if fp.is_empty() {
+        return false;
+    }
+    declared.iter().any(|s| {
+        let key = s.key.replace(' ', "").to_lowercase();
+        // The SSH case is already decided by git, which refuses the signature
+        // outright when the allowed-signers file does not cover it; comparing
+        // an `SHA256:` fingerprint against a base64 key here would fail on a
+        // signature git already accepted.
+        !key.is_empty() && (fp == key || fp.ends_with(&key))
+    })
+}
+
+fn declared_signers(repo: &Repo) -> Vec<Signer> {
+    let text = std::fs::read_to_string(repo.ank.join("allowed_signers")).unwrap_or_default();
+    parse_signers(&text)
+}
+
 /// §8: with no signing configured, permissions are advisory. Displayed rather
 /// than hidden, and once rather than once per entity.
 fn check_signers(repo: &Repo, report: &mut Report) {
-    let text = std::fs::read_to_string(repo.ank.join("allowed_signers")).unwrap_or_default();
-    let keys = text
-        .lines()
-        .filter(|l| !l.trim().is_empty() && !l.trim_start().starts_with('#'))
-        .count();
+    let keys = declared_signers(repo).len();
     if keys == 0 {
         report.findings.push(Finding::signal(
             "allowed_signers",
@@ -649,6 +790,37 @@ fn check_adr(
         )),
 
         Freeze::Unanchored | Freeze::Intact => {}
+    }
+
+    // The anchor is worth exactly what the signature on the commit carrying it
+    // is worth (§8). An anchor read from a commit nobody signed anchors nothing
+    // against the one case the whole mechanism exists for.
+    match signature_state(repo, a) {
+        Some(Signature::Absent) => report.findings.push(Finding::fault(
+            &a.id,
+            "its ratification commit is not signed: the anchor proves nothing (§8)",
+        )),
+        Some(Signature::Invalid { status }) => report.findings.push(Finding::fault(
+            &a.id,
+            format!("its ratification commit carries a signature git refuses ({status}): not a ratification"),
+        )),
+        Some(Signature::Undeclared { fingerprint }) => report.findings.push(Finding::fault(
+            &a.id,
+            format!(
+                "ratified by {fingerprint}, which .ank/allowed_signers does not declare"
+            ),
+        )),
+
+        // Counted, not reported here. A missing public key is a property of
+        // the machine and not of this ADR, so it is one line for the corpus
+        // rather than one per entity — the same rule §4 already applies to the
+        // entities predating `author`, and for the same reason: a line per file
+        // is the volume that teaches a reader to stop reading `check`. It is
+        // still never silence, because a verification that degrades to success
+        // is not a verification.
+        Some(Signature::Unchecked) => report.unchecked_signatures += 1,
+
+        Some(Signature::Trusted) | None => {}
     }
     if a.constraint.trim().is_empty() {
         report
@@ -1367,12 +1539,11 @@ pub fn freeze_state(repo: &Repo, adr: &Adr) -> Freeze {
     if adr.status != AdrStatus::Accepted || adr.ratified.is_none() {
         return Freeze::Unanchored;
     }
-    let path = format!("{}/adr/{}.md", ank_relative(repo), adr.id);
-    let recorded = match git::ratification_anchor_at(&repo.root, &adr.id.to_string(), &path) {
-        Ok(Some(hash)) => hash,
+    let recorded = match ratification_of(repo, adr) {
+        Some(r) => r.anchor,
         // A git that cannot answer is not a divergence either. Reporting one
         // over a broken environment is how a finding becomes noise.
-        Ok(None) | Err(_) => return Freeze::Unverifiable,
+        None => return Freeze::Unverifiable,
     };
     let now = ratification_anchor(&adr.constraint, &adr.scope);
     if now == recorded {
@@ -1383,6 +1554,42 @@ pub fn freeze_state(repo: &Repo, adr: &Adr) -> Freeze {
             now,
         }
     }
+}
+
+/// The ratification commit for an accepted, anchored ADR.
+fn ratification_of(repo: &Repo, adr: &Adr) -> Option<git::Ratification> {
+    if adr.status != AdrStatus::Accepted || adr.ratified.is_none() {
+        return None;
+    }
+    let path = format!("{}/adr/{}.md", ank_relative(repo), adr.id);
+    git::ratification_at(&repo.root, &adr.id.to_string(), &path).unwrap_or(None)
+}
+
+/// The signature on the commit the anchor was read from, or `None` when there
+/// is no such commit to ask about — which `freeze_state` already reports as
+/// unverifiable and which would only be said twice here.
+///
+/// This is the answer to the hole TASK-03eaa26bddd1 left open in writing: the
+/// anchor was compared against the file without anyone asking who wrote it, so
+/// an ordinary unsigned commit whose subject read `ratify <id>` was accepted as
+/// a ratification.
+pub fn signature_state(repo: &Repo, adr: &Adr) -> Option<Signature> {
+    let declared = declared_signers(repo);
+    let signers = repo.ank.join("allowed_signers");
+
+    // Nothing declared is not "signed by nobody": it is the advisory mode §8
+    // describes, already reported once by `check_signers`, and there is no
+    // allowlist to judge against. Going further would also be unsafe — git
+    // reports `N` for a perfectly signed commit when `gpg.format` is ssh and no
+    // allowed-signers file is configured, so a corpus with no file would have
+    // every ratification called unsigned.
+    if declared.is_empty() || !signers.is_file() {
+        return None;
+    }
+
+    let sha = ratification_of(repo, adr)?.sha;
+    let facts = git::signature_of(&repo.root, &sha, Some(&signers)).ok()?;
+    Some(classify_signature(&facts, &declared))
 }
 
 /// Hash of `constraint` + `scope`, normalised. What the ratification commit
@@ -3180,6 +3387,336 @@ mod tests {
                 Freeze::Altered { .. }
             ),
             "the field was moved to match, and it changes nothing"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // The signature on the ratification commit (TASK-d31af22248d9)
+    // -----------------------------------------------------------------------
+
+    /// The shape the file actually uses, which is git's: principal, then the
+    /// key, with anything optional allowed to sit between them.
+    #[test]
+    fn allowed_signers_is_read_as_git_writes_it() {
+        let parsed = parse_signers(
+            "# a comment\n\
+             \n\
+             sean@example.com gpg 739A603FB05F9F2F7D3C8D50624FCFCC1482554A\n\
+             marie@laptop namespaces=\"git\" ssh-ed25519 AAAAC3NzaC1lZDI1\n\
+             nonsense\n",
+        );
+        assert_eq!(parsed.len(), 2, "{parsed:?}");
+        assert_eq!(parsed[0].keytype, "gpg");
+        assert_eq!(parsed[0].key, "739A603FB05F9F2F7D3C8D50624FCFCC1482554A");
+        assert_eq!(
+            parsed[1].keytype, "ssh-ed25519",
+            "the option in the middle must not be mistaken for the key type"
+        );
+        assert_eq!(parsed[1].key, "AAAAC3NzaC1lZDI1");
+    }
+
+    fn gpg_signer(key: &str) -> Vec<Signer> {
+        vec![Signer {
+            principal: "sean@example.com".into(),
+            keytype: "gpg".into(),
+            key: key.into(),
+        }]
+    }
+
+    fn facts(status: char, fingerprint: &str) -> git::SignatureFacts {
+        git::SignatureFacts {
+            status,
+            fingerprint: fingerprint.into(),
+        }
+    }
+
+    /// Every state, and each one distinguishable from the others. Pure, so the
+    /// five live here rather than behind five fixtures with five keyrings.
+    #[test]
+    fn every_signature_state_is_distinguished() {
+        let fp = "739A603FB05F9F2F7D3C8D50624FCFCC1482554A";
+        let declared = gpg_signer(fp);
+
+        assert_eq!(
+            classify_signature(&facts('G', fp), &declared),
+            Signature::Trusted
+        );
+        assert_eq!(
+            classify_signature(&facts('N', ""), &declared),
+            Signature::Absent,
+            "no signature is the forgery this check exists for"
+        );
+        assert_eq!(
+            classify_signature(&facts('E', fp), &declared),
+            Signature::Unchecked,
+            "a missing public key must never read as a valid signature"
+        );
+        assert_eq!(
+            classify_signature(&facts('B', fp), &declared),
+            Signature::Invalid { status: 'B' }
+        );
+        assert_eq!(
+            classify_signature(
+                &facts('G', "0000000000000000000000000000000000000000"),
+                &declared
+            ),
+            Signature::Undeclared {
+                fingerprint: "0000000000000000000000000000000000000000".into()
+            },
+            "a good signature from a key nobody declared is not a ratification"
+        );
+    }
+
+    /// The long key id is the tail of the fingerprint, and a file declaring
+    /// either is declaring the same key. Case is not meaningful in hex.
+    #[test]
+    fn a_declared_long_key_id_matches_the_full_fingerprint() {
+        let declared = gpg_signer("624fcfcc1482554a");
+        assert_eq!(
+            classify_signature(
+                &facts('G', "739A603FB05F9F2F7D3C8D50624FCFCC1482554A"),
+                &declared
+            ),
+            Signature::Trusted
+        );
+    }
+
+    /// Under OpenPGP, `U` says the keyring does not ultimately trust the key —
+    /// a fact about the operator's web of trust, not about this repository.
+    /// The declaration is what decides, so it is judged like `G`.
+    #[test]
+    fn an_untrusted_openpgp_key_is_still_judged_by_the_declaration() {
+        let fp = "739A603FB05F9F2F7D3C8D50624FCFCC1482554A";
+        assert_eq!(
+            classify_signature(&facts('U', fp), &gpg_signer(fp)),
+            Signature::Trusted
+        );
+    }
+
+    /// Under SSH the letters mean something else, and this is measured against
+    /// git rather than assumed: with an allowed-signers file, `G` is a matched
+    /// principal and `U` is a good signature the file does not cover. Comparing
+    /// the `SHA256:` fingerprint against the base64 key ourselves would call
+    /// every correct signature undeclared.
+    #[test]
+    fn under_ssh_git_has_already_decided_the_allowlist() {
+        let ssh = "SHA256:KjhREDTh0GcSpp8doZ/yhLAG62FZ7h26dQTVffo3JFE";
+        let unrelated = gpg_signer("739A603FB05F9F2F7D3C8D50624FCFCC1482554A");
+        assert_eq!(
+            classify_signature(&facts('G', ssh), &unrelated),
+            Signature::Trusted
+        );
+        assert!(matches!(
+            classify_signature(&facts('U', ssh), &unrelated),
+            Signature::Undeclared { .. }
+        ));
+    }
+
+    /// Writes an allowed-signers file, since the fixture has none by default.
+    fn declare(t: &Temp, line: &str) {
+        std::fs::write(t.0.join(".ank").join("allowed_signers"), line).unwrap();
+    }
+
+    /// The public key `enable_signing` generated, in allowed-signers layout.
+    fn signing_principal(t: &Temp) -> String {
+        let pub_key = std::fs::read_to_string(t.0.join("signing-key.pub")).unwrap();
+        format!("test@ank.local {}", pub_key.trim())
+    }
+
+    /// The hole this task was filed for, end to end and through `check`. An
+    /// ordinary unsigned commit whose subject reads `ratify <id>` used to be
+    /// accepted as a ratification: `rev-list` found it, the subject matched,
+    /// the hashes agreed, and the freeze was reported intact.
+    #[test]
+    fn an_unsigned_ratification_commit_is_refused_as_a_ratification() {
+        let t = Temp::new();
+        t.enable_signing();
+        declare(&t, &signing_principal(&t));
+
+        t.write(&adr("00000000aaaa", AdrStatus::Proposed, &["src/**"]));
+        t.commit("seed");
+        t.call(&["accept", "ADR-00000000aaaa"], "marie@laptop")
+            .unwrap();
+
+        // The real ratification verifies, which is what makes the negative
+        // below mean something.
+        let repo = t.repo();
+        assert_eq!(
+            signature_state(&repo, &t.adr_at("00000000aaaa")),
+            Some(Signature::Trusted)
+        );
+        let r = t.report();
+        assert_eq!(r.faults(), 0, "{:?}", r.findings);
+
+        // Now forge one: same subject, same anchor line, no signature. `accept`
+        // is not involved, and nothing but the signature tells the two apart.
+        let forged = adr("00000000bbbb", AdrStatus::Accepted, &["src/**"]);
+        let Entity::Adr(mut b) = forged else {
+            unreachable!()
+        };
+        b.ratified = Some(ratification_anchor(&b.constraint, &b.scope));
+        let anchor = ratification_anchor(&b.constraint, &b.scope);
+        t.write(&Entity::Adr(b));
+        for args in [
+            vec!["add", "-A"],
+            vec![
+                "-c",
+                "commit.gpgsign=false",
+                "commit",
+                "-qm",
+                &format!("ratify ADR-00000000bbbb\n\nconstraint+scope: {anchor}"),
+            ],
+        ] {
+            Command::new("git")
+                .current_dir(&t.0)
+                .args(&args)
+                .status()
+                .unwrap();
+        }
+
+        assert_eq!(
+            signature_state(&t.repo(), &t.adr_at("00000000bbbb")),
+            Some(Signature::Absent),
+            "the anchor agrees; only the signature does not"
+        );
+        let r = t.report();
+        assert!(
+            has(&r, Level::Fault, "not signed"),
+            "an unsigned ratification must be a fault: {:?}",
+            r.findings
+        );
+        assert!(r.faults() > 0);
+    }
+
+    /// A good signature from a key the file does not declare is not a
+    /// ratification either: the allowlist is what §8 says decides who may
+    /// ratify, and a signature nobody vouched for vouches for nobody.
+    #[test]
+    fn a_signature_from_an_undeclared_key_is_refused() {
+        let t = Temp::new();
+        t.enable_signing();
+        declare(
+            &t,
+            "someone@else ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB\n",
+        );
+
+        t.write(&adr("00000000aaaa", AdrStatus::Proposed, &["src/**"]));
+        t.commit("seed");
+        t.call(&["accept", "ADR-00000000aaaa"], "marie@laptop")
+            .unwrap();
+
+        assert!(
+            matches!(
+                signature_state(&t.repo(), &t.adr_at("00000000aaaa")),
+                Some(Signature::Undeclared { .. })
+            ),
+            "signed for real, by a key the corpus never declared"
+        );
+        let r = t.report();
+        assert!(
+            has(&r, Level::Fault, "does not declare"),
+            "{:?}",
+            r.findings
+        );
+    }
+
+    /// With nothing declared there is no allowlist to judge against, and §8
+    /// already reports that once as advisory. Going further would be unsafe as
+    /// well as noisy: under `gpg.format = ssh` git reports a perfectly signed
+    /// commit as unsigned when no allowed-signers file is configured, so a
+    /// corpus without the file would have every ratification called a forgery.
+    #[test]
+    fn with_no_declared_key_the_signature_is_not_judged_at_all() {
+        let t = Temp::new();
+        t.enable_signing();
+        t.write(&adr("00000000aaaa", AdrStatus::Proposed, &["src/**"]));
+        t.commit("seed");
+        t.call(&["accept", "ADR-00000000aaaa"], "marie@laptop")
+            .unwrap();
+
+        assert_eq!(
+            signature_state(&t.repo(), &t.adr_at("00000000aaaa")),
+            None,
+            "no file, no verdict"
+        );
+        let r = t.report();
+        assert_eq!(r.faults(), 0, "{:?}", r.findings);
+        assert!(
+            has(&r, Level::Signal, "advisory"),
+            "the advisory signal is what covers this case: {:?}",
+            r.findings
+        );
+    }
+
+    /// A machine without the public key is a correct repository on an
+    /// incomplete machine, and it is reported once for the corpus rather than
+    /// once per ADR — the rule §4 already applies to entities predating
+    /// `author`, for the same reason.
+    #[test]
+    fn unchecked_signatures_are_counted_once_for_the_corpus() {
+        let mut report = Report {
+            unchecked_signatures: 3,
+            ..Default::default()
+        };
+        // The rendering path is what the reader sees, so assert on the finding
+        // the corpus pass emits rather than on the counter.
+        if report.unchecked_signatures > 0 {
+            let n = report.unchecked_signatures;
+            report.findings.push(Finding::signal(
+                "allowed_signers",
+                format!("{n} ratification signature(s) could not be checked here"),
+            ));
+        }
+        assert_eq!(report.faults(), 0, "never a fault: CI would go red");
+        assert_eq!(
+            report
+                .findings
+                .iter()
+                .filter(|f| f.message.contains("could not be checked"))
+                .count(),
+            1,
+            "one line for the machine, not one per ADR"
+        );
+    }
+
+    /// Dogfooding, and the only test that exercises the OpenPGP branch: the
+    /// fixtures above all sign with SSH, where git decides the allowlist, while
+    /// this repository signs with GPG, where ank decides it. Without this, the
+    /// branch that runs in production is the branch nothing runs.
+    ///
+    /// Two outcomes are correct and they are not the same: `Trusted` on a
+    /// machine holding the public key, `Unchecked` on one that does not — CI,
+    /// for instance. What must never appear is a verdict claiming the corpus is
+    /// forged.
+    #[test]
+    fn this_repositorys_own_ratifications_are_signed() {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../..")
+            .canonicalize()
+            .unwrap();
+        let repo = Repo {
+            ank: root.join(".ank"),
+            root,
+        };
+        let store = Store::new(&repo.ank);
+        let mut judged = 0;
+        for id in store.list_ids().unwrap() {
+            let Entity::Adr(a) = store.load(&id).unwrap().entity else {
+                continue;
+            };
+            let Some(state) = signature_state(&repo, &a) else {
+                continue;
+            };
+            judged += 1;
+            assert!(
+                matches!(state, Signature::Trusted | Signature::Unchecked),
+                "{}: {state:?}",
+                a.id
+            );
+        }
+        assert!(
+            judged > 0,
+            "no ratification was judged at all: the check is wired to nothing"
         );
     }
 

--- a/crates/ank-cli/src/human.rs
+++ b/crates/ank-cli/src/human.rs
@@ -3714,10 +3714,27 @@ mod tests {
                 a.id
             );
         }
-        assert!(
-            judged > 0,
-            "no ratification was judged at all: the check is wired to nothing"
-        );
+        // Nothing judged is a correct answer in exactly one situation, and it
+        // is the situation CI runs in: `actions/checkout` clones shallow, so
+        // `rev-list --full-history` reaches no ratification commit and every
+        // ADR is the unverifiable case the freeze already reports. Asserting
+        // `judged > 0` unconditionally asserted a property of the machine.
+        //
+        // Demanding the reason rather than skipping is what keeps this a test:
+        // on any full clone, nothing judged means the wiring is broken.
+        if judged == 0 {
+            let shallow = Command::new("git")
+                .current_dir(&repo.root)
+                .args(["rev-parse", "--is-shallow-repository"])
+                .output()
+                .unwrap();
+            assert_eq!(
+                String::from_utf8_lossy(&shallow.stdout).trim(),
+                "true",
+                "no ratification was judged and the clone is complete: \
+                 the check is wired to nothing"
+            );
+        }
     }
 
     /// A shallow clone, a rewritten history, a corpus moved between

--- a/docs/ank-spec-v1.1.md
+++ b/docs/ank-spec-v1.1.md
@@ -9,6 +9,8 @@ Settled relative to v1: orientation and constraints reconciled (§5) · immutabi
 
 Every open point of v1 is settled: GPL-3.0 licence, native Windows in v1, merge driver and CI attestation specified but implemented in v1.1 (§13).
 
+Additions of revision j: **the ratification signature is verified and not merely read** (§8, §4) — `check` was comparing the anchor in the ratification commit against the file without asking who signed the commit, so an ordinary unsigned commit whose subject read `ratify <id>` was accepted as a ratification; the four outcomes are specified, an unchecked signature is a signal and never a success, and the layout of `allowed_signers` is documented along with the fact that git enforces it only under `gpg.format = ssh`, OpenPGP leaving the match to `check` itself.
+
 Additions of revision i: **one command surface instead of two** (§4, §8, ADR-9ede1ffd04e2, superseding ADR-3859eb46bdc3) — every verb is available to every caller, the CLI refuses on state and never on identity, and the eight-verb freeze is restated as a freeze on the content of SKILL.md, which is where the token budget it actually protected is spent · the refusals are tabulated against their exit codes, and the signed ratification commit is named as the single hard line of authority, a proof requirement rather than a role check (§4) · `status`, `edit`, `graph` and `scope` enter the surface, along with the interactive form of `new` and the read form of `log` (§4) · roles in `config.yml` are named what they always were, advisory, and policy is placed where it holds: SKILL.md, harness hooks, then roles (§8).
 
 Additions of revision h: **the ratification freeze becomes verifiable rather than declared** (§3) — `check` reaches the ratification commit by walking the ADR's own file history, since a commit cannot contain its own identifier and no field could ever name it; `ratified` is documented as what the code always wrote, the hash of `constraint`+`scope`, and an unreachable commit is reported as *cannot verify* and never as a divergence · **`accept` ratifies an ADR accepted by hand** (§3) — an `accepted` ADR carrying no anchor at all can be anchored in place, which is the only way a bootstrap corpus ever acquires the signed commits the whole authority model rests on; one that already carries an anchor stays refused, and that refusal is the half doing the work.
@@ -513,7 +515,7 @@ The `assertion` type exists because "refactor for readability" has no hash to at
 Summary of the invariants and signals, all mechanical:
 
 - expired claims, `blocked_by` cycles, broken supersede chains, dead scopes (no file matched), over-constrained scopes (§5);
-- frozen fields diverging from their anchoring hash — `done_criteria` against the claim, `constraint`/`scope` against the ratification commit;
+- frozen fields diverging from their anchoring hash — `done_criteria` against the claim, `constraint`/`scope` against the ratification commit, and the signature on that commit against `allowed_signers` (§8): an anchor read from a commit nobody signed anchors nothing;
 - weak proofs (`assertion`, unverified), `done` tasks modified beyond appending a proof;
 - behavioural signals, reported without being faults: blockers created by the holder after claiming (`author` of the blocker is the current holder and its `created` is later than the claim), criterion set by the claimer, verifier modified inside the task's activity window or proof hash diverging from its definition, scope test files modified by the task that invokes them, burst creation by a single identity (**more than 10 entities by one `author` within an hour**, through `created`), implausible `created` (in the future, or well before the commit that introduces the file — the field is declarative, git is the anchor), repeated claim renewals with no modification to the scope files (possible hoarding; a best-effort signal, since another agent's tree is not observable), constraint accepted after the claim of a task in progress, tasks blocked by a `closed` task;
 - entities predating `author`, **reported once for the corpus and never per file**: they are skipped by the two signals above, and saying so once is what keeps that fact visible. One line per file would add a line for every entity written before the field existed — the volume that teaches a reader to stop reading `check`;
@@ -738,7 +740,29 @@ The main guardrail is not the permission but **the status**: an agent writes fre
 
 `$ANK_AGENT` is set by the agent itself: an agent going off the rails can declare itself `human`. No file-level check can prevent that, since it has filesystem access.
 
-The only anchor that holds is therefore external: **ratification requires a signed commit**. `accept` produces the ratification commit itself (§12), recording the SHA and the hash of the accepted ADR's `constraint` + `scope`, and `check` verifies the signature through `git verify-commit` against the keys in `.ank/allowed_signers` (git's SSH allowed-signers format; GPG supported through the standard git config). The key file is versioned: adding a key to it is a diff in review.
+The only anchor that holds is therefore external: **ratification requires a signed commit**. `accept` produces the ratification commit itself (§12), recording the SHA and the hash of the accepted ADR's `constraint` + `scope`, and `check` verifies that signature against the keys in `.ank/allowed_signers`. The key file is versioned: adding a key to it is a diff in review.
+
+**The file uses git's allowed-signers layout**, `principal [options] keytype key`, with the key type naming the format:
+
+```
+sean.lamet@dekrow.com gpg 739A603FB05F9F2F7D3C8D50624FCFCC1482554A
+marie@laptop          ssh-ed25519 AAAAC3NzaC1lZDI1NTE5...
+```
+
+**Who enforces the allowlist depends on the signature format, and the difference is not cosmetic.** Under `gpg.format = ssh`, git reads the file itself and answers with the match: a signature whose principal the file covers verifies, one it does not comes back as good-but-unmatched. Under OpenPGP, **git never reads the file at all** — it resolves the signature through the keyring — so `check` parses the file and compares the signing key's fingerprint itself. A `gpg` entry may name the full fingerprint or the long key id, since the second is the tail of the first. Without this, the file would go on declaring something nothing enforced.
+
+**Four outcomes, and collapsing any two of them loses the check.**
+
+| Outcome | Reported as |
+|---|---|
+| signed by a declared key | nothing |
+| no signature, or one git refuses | fault: the anchor proves nothing |
+| good signature, key not declared | fault: not a ratification |
+| signature present, no local public key | signal: **not verified, and not refused** |
+
+The last row is the one that needs saying out loud. A clone without the public key is a correct repository on an incomplete machine: calling it a fault turns CI red on a sound corpus, and calling it verified is worse, because **a verification that degrades to success is not a verification**. It is reported once for the corpus rather than once per ADR, for the reason §4 gives about entities predating `author` — a line per file is the volume that teaches a reader to stop reading `check`.
+
+With **no key declared at all**, `check` does not judge signatures. There is no allowlist to judge against, the advisory notice below already covers it, and the abstention is also what keeps the tool honest: under `gpg.format = ssh` with no allowed-signers file configured, git reports a perfectly signed commit as unsigned, so a corpus without the file would otherwise have every ratification called a forgery.
 
 **What the signature proves — and does not.** It proves access to an authorised key, not human intent. An agent running on a developer's machine whose git signing is configured and unlocked can produce a valid signed commit. The defence against that case is operational, not cryptographic: a ratification key protected by passphrase or hardware (touch-to-sign), distinct from the everyday commit key if needed. This is consistent with the threat model (§1): we protect against drift, not against an adversary.
 


### PR DESCRIPTION
Closes `TASK-d31af22248d9`.

`TASK-03eaa26bddd1` taught `check` to find the ratification commit and compare
the anchor in its message against the file. It never asked who signed that
commit. The hole was small and complete, and this PR reproduces it as a test
before closing it:

> Edit a constraint, then make an ordinary unsigned commit touching the same
> file whose subject is `ratify <id>` and whose body carries the new hash.
> `rev-list` finds it, the subject matches, the hashes agree, and `check`
> reports the freeze intact.

§8 does not rest on §1's threat model here. It says ratification *is* the
signature. An anchor read from a commit nobody checked anchors nothing against
the one case the mechanism exists for.

## Two things measured against git rather than assumed

Both changed the design, and the first was already written wrong before it was
measured.

**Under `gpg.format = ssh`, `%G?` is already the allowlist answer.** With an
allowed-signers file configured, `G` means git matched the principal and `U`
means it did not cover the key. The first implementation compared the `SHA256:`
fingerprint against the base64 key itself, which would have called every
correctly signed SSH commit undeclared. Under OpenPGP git never reads the file
at all, so ank does that match itself — which is what stops `allowed_signers`
from declaring something nothing enforces. The two are told apart by the shape
of the fingerprint.

**Under ssh with no allowed-signers file configured, git reports a perfectly
signed commit as `N`** — indistinguishable from unsigned. Shipping without
finding this would have meant every ratification in a corpus with no key file
being called a forgery. With nothing declared, `check` now abstains entirely;
the advisory signal §8 already emits is what covers that case.

## Four outcomes, none collapsed

| Outcome | Reported as |
|---|---|
| signed by a declared key | nothing |
| no signature, or one git refuses | fault |
| good signature, key not declared | fault |
| signature present, no local public key | signal — not verified, **not refused** |

The last row is the one that needed care. A clone without the public key is a
correct repository on an incomplete machine: a fault turns CI red on a sound
corpus, and success is worse, because a verification that degrades to success is
not a verification. It is counted **once for the corpus**, not once per ADR —
the rule §4 already fixed for entities predating `author`. Per-ADR it would have
been 13 lines on every keyless machine, including CI.

`rev-list --format` and not `verify-commit`: the exit code of `verify-commit`
collapses "no signature" and "cannot check it" into one failure, and those are
exactly the two states that must stay apart.

## Tests

Ten. The five states are pure functions, so each is reached without a keyring, a
network or a signed fixture. The forgery above runs end to end through `check`.
And a dogfooding test walks this repository's own ADRs — the only coverage the
OpenPGP branch has, since every fixture signs with ssh, where git decides, while
this repository signs with gpg, where ank decides. It accepts `Trusted` or
`Unchecked` (CI has no public key) and rejects any verdict claiming the corpus is
forged.

`ank done` ran the declared verifiers itself: `cargo-test`, `fmt-check`,
`check-repo`, all green, proofs anchored on `scope/87a3e54e4993`.

## Out of scope, and worth deciding separately

- **Constraint injection is untouched.** An unsigned ratification is now a
  `check` fault, but `context.rs` still injects the constraint — that file is
  outside this task's scope. Whether a ratification that fails verification
  should stop binding is a design question, not a cleanup.
- **`.ank/allowed_signers`'s own comment now reads stale.** It says enforcement
  "stays advisory", which stopped being true for ratification commits. Outside
  scope and behind the ADR-01b6dd05f0db hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KL6PyySn7QQ1wYbVhS9ro5
