### PR TITLE
ank help becomes one flat listing, and the two surfaces stop speaking

### DIFF
--- a/.ank/adr/ADR-9ede1ffd04e2.md
+++ b/.ank/adr/ADR-9ede1ffd04e2.md
@@ -5,7 +5,7 @@ slug: one-surface-and-policy-lives-above-the-tool
 title: One surface, and policy lives above the tool
 created: 2026-08-01T18:29:38Z
 author: seanl@sean-laptop
-status: accepted
+status: superseded
 scope:
   - crates/ank-cli/**
   - skill/**
@@ -15,7 +15,7 @@ constraint: |
 supersedes: ADR-3859eb46bdc3
 ratified: 5355952b8cd1
 schema: 2
-version: 2
+version: 3
 ---
 
 ADR-3859eb46bdc3 froze the agent surface at eight verbs and sent everything else to the human side. This supersedes it because the split it protected was never a boundary: the CLI told callers apart by ANK_AGENT, a variable the caller sets itself, and section 8 of the specification already names the consequence, permissions are advisory. A wall whose bricks are self-declared identity is a sign, not a wall.

--- a/.ank/adr/ADR-c656cbcc33a9.md
+++ b/.ank/adr/ADR-c656cbcc33a9.md
@@ -1,0 +1,31 @@
+---
+id: ADR-c656cbcc33a9
+type: adr
+slug: the-help-is-a-flat-listing-and-the-loop-is-taugh
+title: The help is a flat listing, and the loop is taught rather than printed
+created: 2026-08-01T23:07:04Z
+author: seanl@sean-laptop
+status: accepted
+scope:
+  - crates/ank-cli/**
+  - skill/**
+  - docs/ank-spec-v1.1.md
+constraint: |
+  The CLI exposes one surface: every verb is available to every caller, and the CLI refuses on state, never on identity. The only hard authority line is the signed ratification commit produced by accept. Who uses which verb is policy, and policy lives above the binary: SKILL.md documents the loop for agents and its content is frozen, harness hooks enforce where enforcement is real, roles in config.yml remain advisory. ank help is one flat listing of every verb, in the order of section 4, with no headings and no grouping: the loop is what SKILL.md teaches, not what help prints.
+supersedes: ADR-9ede1ffd04e2
+ratified: 7fd54c01c3e0
+schema: 2
+version: 2
+---
+
+ADR-9ede1ffd04e2 dissolved the split between an agent surface and a human one, and kept one residue of it: a help that presents the loop first and the rest layered. This supersedes it to remove that residue, and changes nothing else.
+
+Layering is grouping, and a grouping printed by the binary is a claim the binary makes about who a verb is for. That is exactly the claim ADR-9ede1ffd04e2 withdrew. The headings it left standing were named after callers -- agent loop, agent off-loop, human -- so an agent reading help still learns a boundary the dispatch table does not have.
+
+The token budget the layering appeared to protect is already protected where it operates. SKILL.md is loaded permanently and its content is frozen at the loop; help is loaded on demand, read once, and pays for itself in a single round trip. A flat listing costs no session anything.
+
+The loop survives in the one place it was ever enforced. SKILL.md teaches context, claim, show, log, done, new, find and release, and growing that content still costs a succession of this ADR. What changes is only that the binary stops repeating what the documentation already teaches.
+
+Rejected: grouping by activity, the way git help does. It is defensible for git, whose hundred commands are unreadable in one list. Ank has sixteen, section 4 already orders them with the loop first, and an ordering carries the same information as a heading without asserting a category.
+
+Consequence: ank help prints one listing, ank help <verb> prints usage, flags and globals with no audience line, and --json carries no audience key. The order of section 4 becomes the presentation order, and it is the only structure the output has.

--- a/.ank/tasks/TASK-147aca91604f.md
+++ b/.ank/tasks/TASK-147aca91604f.md
@@ -1,0 +1,49 @@
+---
+id: TASK-147aca91604f
+type: task
+slug: the-cli-still-presents-two-surfaces-to-the-reade
+title: The CLI still presents two surfaces to the reader
+created: 2026-08-01T23:21:33Z
+author: seanl@sean-laptop
+status: done
+scope:
+  - crates/ank-cli/**
+  - docs/ank-spec-v1.1.md
+  - CLAUDE.md
+blocked_by: []
+done_criteria: |
+  ank help prints one flat listing of every verb, in the order of section 4, with no headings and no grouping, and ank help <verb> prints no audience line. No comment or message in crates/ank-cli cites ADR-3859eb46bdc3 or ADR-2f8a61c04b7d as live authority. The binary is what the test invokes.
+criteria_by: creator
+verify: [cargo-test, fmt-check, check-repo]
+proof:
+  - type: test
+    ref: local/82fb1101c729@3233040
+    tree: scope/bd17faf78ba1
+    criteria: 557a118fe75f
+    verifier: cargo-test@f14aeab36e1b
+  - type: test
+    ref: local/e3b0c44298fc@3233040
+    tree: scope/bd17faf78ba1
+    criteria: 557a118fe75f
+    verifier: fmt-check@5ca6d10bcd55
+  - type: test
+    ref: local/dfa15112bfe1@3233040
+    tree: scope/bd17faf78ba1
+    criteria: 557a118fe75f
+    verifier: check-repo@5734e9cf9d3d
+schema: 2
+version: 3
+---
+
+Third filing of one piece of work, and the first two are worth recording because each was closed for a different reason.
+
+TASK-8c376169fb6c was closed because its criterion opened with "ank help presents the loop first and the rest layered" -- the sentence ADR-c656cbcc33a9 removes. Frozen at claim, so it was closed rather than weakened.
+
+TASK-671dac854896 was closed because it was created without --verify. A task that declares no verifier cannot have done run anything, and the only way through is a --proof the agent submits about its own work. amend covers blocked_by and scope and nothing else, by design, so the field cannot be added after the fact. Closing and refiling is the cheap, honest move; the alternative was an assertion proof, which is the agent grading itself.
+
+The work itself is done and its history is in TASK-671dac854896's log: the enum Audience, its four variants, heading(), as_str(), agent_surface(), the field on all sixteen command specs and the "audience" key of --json are gone, help makes one pass over COMMANDS, and the order of section 4 is the only structure the listing has. The specification landed first, revision k.
+
+The dead-ADR clause needed a walk, not a grep. Searching for the prose around the citations found six; a test walking every .rs file in the crate found two more that the prose never named -- claim.rs in a list of anchoring ADRs, commands.rs in a module header -- both asserting seven frozen verbs. The needles are assembled with concat! so the test file does not defeat its own assertion.
+
+## Log
+- 2026-08-01T23:22:08Z seanl@sean-laptop — done, proof test:local/82fb1101c729@3233040 test:local/e3b0c44298fc@3233040 test:local/dfa15112bfe1@3233040

--- a/.ank/tasks/TASK-671dac854896.md
+++ b/.ank/tasks/TASK-671dac854896.md
@@ -1,0 +1,32 @@
+---
+id: TASK-671dac854896
+type: task
+slug: the-cli-still-presents-two-surfaces-to-the-reade
+title: The CLI still presents two surfaces to the reader
+created: 2026-08-01T23:07:50Z
+author: seanl@sean-laptop
+status: closed
+scope:
+  - crates/ank-cli/**
+  - docs/ank-spec-v1.1.md
+  - CLAUDE.md
+blocked_by: []
+done_criteria: |
+  ank help prints one flat listing of every verb, in the order of section 4, with no headings and no grouping, and ank help <verb> prints no audience line. No comment or message in crates/ank-cli cites ADR-3859eb46bdc3 or ADR-2f8a61c04b7d as live authority. The binary is what the test invokes.
+criteria_by: creator
+schema: 2
+version: 5
+---
+
+Refiled from TASK-8c376169fb6c, whose criterion opened with "ank help presents the loop first and the rest layered" -- the sentence ADR-c656cbcc33a9 removes. That criterion was frozen at claim and could not be edited to fit the new direction, so it was released and closed rather than weakened.
+
+This task must not land on the default branch before ADR-c656cbcc33a9 is accepted: the specification must not describe a help the corpus has not ratified, and until the signed ratification commit exists, ADR-9ede1ffd04e2 is still what binds and it requires the layering. Same discipline as TASK-ff1c20395929.
+
+The two surfaces are not only in the output. The enum Audience carries them in the data, agent_surface() carries them in a method name, the --json help carries them in a key, and eight comments across cli.rs, human.rs, index.rs and tests/skill.rs carry them in prose citing ADRs that are dead. ADR-2f8a61c04b7d is dead twice over and still asserts seven verbs in index.rs.
+
+COMMANDS is already in the order of section 4, loop first. The flat listing needs no reordering; only the headings and the grouping pass go.
+
+## Log
+- 2026-08-01T23:08:24Z seanl@sean-laptop — amended: +scope docs/ank-spec-v1.1.md, +scope CLAUDE.md
+- 2026-08-01T23:16:48Z seanl@sean-laptop — The dead-ADR clause needed a test to be true, not a grep. My own search found six citations by looking for the prose around them (agent surface, human side); the test that walks every .rs file in the crate found two more the prose never named -- claim.rs:922 in a list of anchoring ADRs, commands.rs:4 in a module header. Both asserted seven frozen verbs. A criterion phrased as 'no comment cites X' is only worth the walk that checks it. The needles are built with concat! so the test file does not defeat its own assertion.
+- 2026-08-01T23:21:38Z seanl@sean-laptop — closed: created without --verify, so done cannot run anything and the only way through would be a proof the agent submits about its own work. verify is not amendable. Refiled as TASK-147aca91604f with cargo-test, fmt-check and check-repo declared.

--- a/.ank/tasks/TASK-8c376169fb6c.md
+++ b/.ank/tasks/TASK-8c376169fb6c.md
@@ -5,7 +5,7 @@ slug: the-cli-still-presents-two-surfaces-to-the-reade
 title: The CLI still presents two surfaces to the reader
 created: 2026-08-01T19:15:53Z
 author: seanl@sean-laptop
-status: open
+status: closed
 scope:
   - crates/ank-cli/**
 blocked_by: []
@@ -13,9 +13,13 @@ done_criteria: |
   ank help presents the loop first and the rest layered, without grouping verbs by audience: the agent loop, agent off-loop and human headings are gone, and ank help <verb> no longer prints an audience line. No comment or message in crates/ank-cli cites ADR-3859eb46bdc3 as live authority. The binary is what the test invokes.
 criteria_by: creator
 schema: 2
-version: 1
+version: 4
 ---
 
 Left by TASK-ff1c20395929, which revised the specification only. ADR-9ede1ffd04e2 requires help to present the loop first and the rest layered; today it prints three headings named for the audiences the ADR dissolved, and ank help <verb> answers with an audience: line, which is the two-surface model still speaking through the output an agent reads.
 
 The doc comment on amend (crates/ank-cli/src/human.rs) makes the same claim in prose: ADR-3859eb46bdc3 freezes that surface at eight and sends new functionality here. That ADR is superseded, and a comment that cites a dead constraint as the reason for a design is worse than no comment.
+
+## Log
+- 2026-08-01T23:07:35Z seanl@sean-laptop — released: the frozen criterion requires the layering ADR-c656cbcc33a9 removes: it opens with 'ank help presents the loop first and the rest layered', and the decision taken this session is a flat listing with no grouping at all. The criterion is not weakened, it is superseded along with the ADR it was written under. Refiled below.
+- 2026-08-01T23:07:55Z seanl@sean-laptop — closed: superseded by TASK-671dac854896, under ADR-c656cbcc33a9. The criterion required a layered help; the decision is a flat one. A frozen criterion is not edited to fit a new direction, it is closed with the reason recorded.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,9 +59,12 @@ run on all three.
 - The format is the specification: `ank-core` is the reference implementation,
   and the round-trip stays byte-identical on canonical form. Any format change
   goes through the specification first, then the goldens, then the code.
-- The agent surface is frozen at 8 verbs (`context claim show log done new find
-  release`, ADR-3859eb46bdc3). A ninth costs a superseding ADR and a human
-  signature; anything short of that goes to the human side or into the format.
+- The CLI exposes one surface (ADR-c656cbcc33a9): every verb is available to
+  every caller, and it refuses on state, never on identity. What is frozen at 8
+  verbs is not the dispatch table but the content of `skill/SKILL.md` (`context
+  claim show log done new find release`) — it is loaded permanently, so growing
+  what it teaches costs a superseding ADR and a human signature. `ank help` is
+  one flat listing, in the order of §4, with no headings and no grouping.
 - `.ank/` is reached only through the CLI, never by opening the files
   (ADR-01b6dd05f0db). A `PreToolUse` hook in `.claude/` refuses it.
 - Immutability is verifiable, not defended: freezes are anchored by hash, and

--- a/crates/ank-cli/Cargo.toml
+++ b/crates/ank-cli/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 # in ci.yml so the claim turns something red the day it stops being true.
 rust-version = "1.95"
 license = "GPL-3.0-only"
-description = "The Ank CLI: agent surface (7 verbs) and human surface."
+description = "The Ank CLI: one surface, refusing on state and never on identity."
 
 [[bin]]
 name = "ank"

--- a/crates/ank-cli/src/claim.rs
+++ b/crates/ank-cli/src/claim.rs
@@ -919,7 +919,7 @@ fn other_ready_task(store: &Store, task: &Task) -> Option<EntityId> {
 /// Anchors the ADRs whose constraint applies here, so that a reader of this
 /// module lands on them: claims in refs (ADR-4e7c25b1f639), the ref's second
 /// state (ADR-bcf222a31525), plumbing by criterion (ADR-b8884edcebe3), freeze
-/// by hash (ADR-6b3f19e08a24), seven frozen verbs (ADR-2f8a61c04b7d).
+/// by hash (ADR-6b3f19e08a24), one surface (ADR-c656cbcc33a9).
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/ank-cli/src/cli.rs
+++ b/crates/ank-cli/src/cli.rs
@@ -4,22 +4,25 @@
 //! dependency but character-level control over two surfaces read by agents:
 //! the self-correcting errors, which a generic parser would replace with its
 //! own messages, and the help, whose cost is paid on every call that triggers
-//! it. With the surface frozen at twelve verbs (ADR-3859eb46bdc3), that cost
-//! does not grow.
+//! it (§12). Neither argument depends on the verb list being frozen, which it
+//! is not: hand-written parsing costs once per verb, the verbs share one
+//! parser, and what grows is linear and small against a `help` and an error
+//! surface that stay exactly as written.
 //!
 //! `help` lives here rather than in a verb module because it has no data of
 //! its own: it is a rendering of [`COMMANDS`], [`GLOBAL_FLAGS`] and [`usage`],
 //! which are all in this file. A second, hand-maintained list of the verbs is
 //! exactly the drift the `owner_task` field was added to prevent.
 //!
-//! **`help` is not a ninth thing an agent does.** ADR-3859eb46bdc3 freezes the
-//! agent surface at eight verbs and adds none without superseding itself in
-//! turn. `help` carries no work and changes no state; it is the mechanism that
-//! *keeps* the surface at eight, because §9 buys its token economy by moving
-//! flag detail out of SKILL.md and into a command loaded on demand. It is
-//! grouped with `init` under [`Audience::Setup`] for that reason, and
-//! [`Audience::agent_surface`] asserts the eight by name so the reading cannot
-//! quietly rot into a growth.
+//! **The listing is flat, and the order of [`COMMANDS`] is the whole of its
+//! structure** (ADR-c656cbcc33a9). It used to group verbs under headings named
+//! after callers, which was the two-surface model still speaking through the
+//! output an agent reads; a heading printed by the binary is a claim about who
+//! a verb is for, and there is no such claim left to make. §4 already orders
+//! the table with the loop first, so the order says what the headings said,
+//! without asserting a category. What the loop *is* stays in SKILL.md, whose
+//! content is frozen and loaded permanently — that is where the token budget
+//! is spent, and `help` is loaded on demand precisely so it does not compete.
 //!
 //! The edge cases of parsing are where hand-written code goes wrong, and they
 //! look like business bugs once in production: every one of them is therefore
@@ -127,60 +130,6 @@ const fn multi(name: &'static str) -> FlagSpec {
 /// than declaring them per command, which would leave room to forget one.
 pub const GLOBAL_FLAGS: &[FlagSpec] = &[switch("--json"), switch("--quiet"), flag("--repo")];
 
-/// Who a verb is for. The grouping was prose in a comment until `help` needed
-/// to print it; a reader that has to be told the audience out of band is a
-/// reader that will get it wrong.
-///
-/// The split is the specification's own and not a presentation choice:
-/// `Loop` and `OffLoop` together are the eight verbs ADR-3859eb46bdc3 freezes,
-/// `Human` is what §4 puts on the other side, and `Setup` holds the two that
-/// belong to neither — `init`, which precedes the repository, and `help`, which
-/// describes the surface instead of acting on it.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Audience {
-    Loop,
-    OffLoop,
-    Human,
-    Setup,
-}
-
-impl Audience {
-    /// Printed as a heading by `help`, in this order.
-    pub const ALL: &'static [Audience] = &[
-        Audience::Loop,
-        Audience::OffLoop,
-        Audience::Human,
-        Audience::Setup,
-    ];
-
-    pub fn heading(self) -> &'static str {
-        match self {
-            Audience::Loop => "agent loop",
-            Audience::OffLoop => "agent off-loop",
-            Audience::Human => "human",
-            Audience::Setup => "setup",
-        }
-    }
-
-    /// The identifier used by `--json`, where a heading with a space in it
-    /// would be a poor key.
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Audience::Loop => "loop",
-            Audience::OffLoop => "off-loop",
-            Audience::Human => "human",
-            Audience::Setup => "setup",
-        }
-    }
-
-    /// The surface an agent works with, which ADR-3859eb46bdc3 freezes at
-    /// eight. Anything outside these two audiences is not part of it, whoever
-    /// happens to type it.
-    pub fn agent_surface(self) -> bool {
-        matches!(self, Audience::Loop | Audience::OffLoop)
-    }
-}
-
 #[derive(Debug, Clone, Copy)]
 pub struct CommandSpec {
     pub name: &'static str,
@@ -189,7 +138,6 @@ pub struct CommandSpec {
     pub max_positionals: usize,
     pub positional_help: &'static str,
     pub flags: &'static [FlagSpec],
-    pub audience: Audience,
     /// The task that carries the implementation, **while it does not exist**.
     /// It is therefore also the marker of an unrouted verb: a command that
     /// [`dispatch`] reaches clears the field, so the two never drift apart the
@@ -197,9 +145,13 @@ pub struct CommandSpec {
     pub owner_task: Option<&'static str>,
 }
 
-/// The twelve verbs of §4, plus `init` and `help` (§9). The order is the
-/// specification's, and `audience` now carries it in the data rather than in
-/// this sentence: agent loop, agent off-loop, human surface, setup.
+/// The twelve verbs of §4, plus `init` and `help` (§9).
+///
+/// **The order is the specification's, and it is load-bearing**: `help` prints
+/// this table in this order and adds nothing to it (ADR-c656cbcc33a9). §4 puts
+/// the loop first — `context claim show log done`, then `release new find` —
+/// and the rest after it, so sorting this list would erase the only structure
+/// the listing has.
 pub const COMMANDS: &[CommandSpec] = &[
     CommandSpec {
         name: "context",
@@ -207,7 +159,6 @@ pub const COMMANDS: &[CommandSpec] = &[
         max_positionals: 1,
         positional_help: "[<path>]",
         flags: &[flag("--limit")],
-        audience: Audience::Loop,
         owner_task: None,
     },
     CommandSpec {
@@ -216,7 +167,6 @@ pub const COMMANDS: &[CommandSpec] = &[
         max_positionals: 1,
         positional_help: "<id>",
         flags: &[flag("--criteria"), flag("--ttl")],
-        audience: Audience::Loop,
         owner_task: None,
     },
     CommandSpec {
@@ -225,7 +175,6 @@ pub const COMMANDS: &[CommandSpec] = &[
         max_positionals: 1,
         positional_help: "<id>",
         flags: &[],
-        audience: Audience::Loop,
         owner_task: None,
     },
     CommandSpec {
@@ -234,7 +183,6 @@ pub const COMMANDS: &[CommandSpec] = &[
         max_positionals: 2,
         positional_help: "[<id>] <message>",
         flags: &[],
-        audience: Audience::Loop,
         owner_task: None,
     },
     CommandSpec {
@@ -243,7 +191,6 @@ pub const COMMANDS: &[CommandSpec] = &[
         max_positionals: 1,
         positional_help: "[<id>]",
         flags: &[flag("--proof")],
-        audience: Audience::Loop,
         owner_task: None,
     },
     CommandSpec {
@@ -252,7 +199,6 @@ pub const COMMANDS: &[CommandSpec] = &[
         max_positionals: 1,
         positional_help: "[<id>]",
         flags: &[flag("--reason")],
-        audience: Audience::OffLoop,
         owner_task: None,
     },
     CommandSpec {
@@ -270,7 +216,6 @@ pub const COMMANDS: &[CommandSpec] = &[
             multi("--verify"),
             flag("--body"),
         ],
-        audience: Audience::OffLoop,
         owner_task: None,
     },
     CommandSpec {
@@ -279,7 +224,6 @@ pub const COMMANDS: &[CommandSpec] = &[
         max_positionals: 1,
         positional_help: "<query>",
         flags: &[flag("--type"), flag("--status"), flag("--scope")],
-        audience: Audience::OffLoop,
         owner_task: None,
     },
     CommandSpec {
@@ -288,7 +232,6 @@ pub const COMMANDS: &[CommandSpec] = &[
         max_positionals: 1,
         positional_help: "[<path>]",
         flags: &[],
-        audience: Audience::Human,
         owner_task: None,
     },
     CommandSpec {
@@ -297,7 +240,6 @@ pub const COMMANDS: &[CommandSpec] = &[
         max_positionals: 1,
         positional_help: "<id>",
         flags: &[],
-        audience: Audience::Human,
         owner_task: None,
     },
     CommandSpec {
@@ -306,7 +248,6 @@ pub const COMMANDS: &[CommandSpec] = &[
         max_positionals: 1,
         positional_help: "<id>",
         flags: &[flag("--reason")],
-        audience: Audience::Human,
         owner_task: None,
     },
     CommandSpec {
@@ -325,7 +266,6 @@ pub const COMMANDS: &[CommandSpec] = &[
             // next, and for a frozen criterion that command is `ank release`.
             flag("--criteria"),
         ],
-        audience: Audience::Human,
         owner_task: None,
     },
     CommandSpec {
@@ -334,7 +274,6 @@ pub const COMMANDS: &[CommandSpec] = &[
         max_positionals: 1,
         positional_help: "<id>",
         flags: &[flag("--proof")],
-        audience: Audience::Human,
         owner_task: None,
     },
     CommandSpec {
@@ -343,7 +282,6 @@ pub const COMMANDS: &[CommandSpec] = &[
         max_positionals: 1,
         positional_help: "[<path>]",
         flags: &[],
-        audience: Audience::Human,
         owner_task: None,
     },
     CommandSpec {
@@ -352,7 +290,6 @@ pub const COMMANDS: &[CommandSpec] = &[
         max_positionals: 1,
         positional_help: "[<path>]",
         flags: &[],
-        audience: Audience::Setup,
         owner_task: None,
     },
     CommandSpec {
@@ -361,7 +298,6 @@ pub const COMMANDS: &[CommandSpec] = &[
         max_positionals: 1,
         positional_help: "[<verb>]",
         flags: &[],
-        audience: Audience::Setup,
         owner_task: None,
     },
 ];
@@ -631,9 +567,8 @@ fn json_of(specs: &[&CommandSpec]) -> String {
                 })
                 .collect();
             format!(
-                "{{\"name\":{},\"audience\":{},\"usage\":{},\"flags\":[{}]}}",
+                "{{\"name\":{},\"usage\":{},\"flags\":[{}]}}",
                 json_str(spec.name),
-                json_str(spec.audience.as_str()),
                 json_str(&usage(spec)),
                 flags.join(",")
             )
@@ -648,9 +583,12 @@ fn json_of(specs: &[&CommandSpec]) -> String {
 /// added without appearing here. An unknown verb is a **code 2** — "entity not
 /// found" in the table of §4, the same code a missing task gets, because the
 /// thing being looked up did not exist. It is never a fallback to the general
-/// listing: an agent that asked about one verb and received all fourteen has to
+/// listing: an agent that asked about one verb and received all sixteen has to
 /// work out that its question went unanswered, and answering the wrong question
 /// silently is worse than refusing the wrong one loudly.
+///
+/// One pass, no grouping, no heading (ADR-c656cbcc33a9). The order is
+/// [`COMMANDS`]', which is §4's, and it is the only structure the output has.
 pub fn help(inv: &Invocation, out: &mut dyn Write) -> Result<i32> {
     let asked = inv.positionals.first();
 
@@ -666,7 +604,6 @@ pub fn help(inv: &Invocation, out: &mut dyn Write) -> Result<i32> {
             return Ok(0);
         }
         let _ = writeln!(out, "{}", usage(spec));
-        let _ = writeln!(out, "  audience: {}", spec.audience.heading());
         if !spec.flags.is_empty() {
             let flags: Vec<String> = spec.flags.iter().map(flag_display).collect();
             let _ = writeln!(out, "  flags:    {}", flags.join(" "));
@@ -687,22 +624,12 @@ pub fn help(inv: &Invocation, out: &mut dyn Write) -> Result<i32> {
     // One column for the usage, so the flags line up and the shape of the
     // surface is readable at a glance rather than one verb at a time.
     let width = COMMANDS.iter().map(|c| usage(c).len()).max().unwrap_or(0);
-    for audience in Audience::ALL {
-        let group: Vec<&CommandSpec> = COMMANDS
-            .iter()
-            .filter(|c| c.audience == *audience)
-            .collect();
-        if group.is_empty() {
-            continue;
-        }
-        let _ = writeln!(out, "{}", audience.heading());
-        for spec in group {
-            let names = flag_names(spec);
-            if names.is_empty() {
-                let _ = writeln!(out, "  {}", usage(spec));
-            } else {
-                let _ = writeln!(out, "  {:width$}  {names}", usage(spec));
-            }
+    for spec in COMMANDS {
+        let names = flag_names(spec);
+        if names.is_empty() {
+            let _ = writeln!(out, "{}", usage(spec));
+        } else {
+            let _ = writeln!(out, "{:width$}  {names}", usage(spec));
         }
     }
     let _ = writeln!(out, "\nglobal: {}", globals_line());
@@ -890,8 +817,8 @@ mod tests {
         assert_eq!(
             COMMANDS.len(),
             16,
-            "twelve verbs from §4, init and help from §9, and attest and amend \
-             on the human side"
+            "twelve verbs from §4, plus attest and amend, plus init and help \
+             from §9"
         );
     }
 
@@ -1028,7 +955,7 @@ mod tests {
     }
 
     #[test]
-    fn help_lists_every_verb_of_the_table_under_its_audience() {
+    fn help_lists_every_verb_of_the_table() {
         // Walks COMMANDS rather than a written-out list: a verb added later
         // that the renderer forgets fails here, which is the whole reason the
         // listing is derived from the table instead of maintained beside it.
@@ -1048,42 +975,28 @@ mod tests {
                 );
             }
         }
-        for audience in Audience::ALL {
-            assert!(
-                text.contains(audience.heading()),
-                "audience '{}' has no heading:\n{text}",
-                audience.heading()
-            );
-        }
     }
 
     #[test]
-    fn every_audience_is_populated_and_the_agent_surface_is_the_eight() {
-        // ADR-3859eb46bdc3 freezes the agent surface at eight verbs, and
-        // requires a succession for any ninth. `help` is grouped with `init`
-        // under Setup on the argument that it carries no work; that argument is
-        // only worth as much as this assertion, which fails the day someone
-        // moves it into an agent group.
-        let mut agent: Vec<&str> = COMMANDS
-            .iter()
-            .filter(|c| c.audience.agent_surface())
-            .map(|c| c.name)
-            .collect();
-        agent.sort_unstable();
-        assert_eq!(
-            agent,
-            ["claim", "context", "done", "find", "log", "new", "release", "show"],
-            "the agent surface is exactly the eight of ADR-3859eb46bdc3, and a \
-             ninth costs a superseding ADR and a human signature"
-        );
-
-        for audience in Audience::ALL {
-            assert!(
-                COMMANDS.iter().any(|c| c.audience == *audience),
-                "audience '{}' has no verb: help would print an empty heading",
-                audience.heading()
-            );
+    fn the_listing_follows_the_table_and_puts_nothing_above_it() {
+        // With the headings gone, the order of COMMANDS is the only structure
+        // the listing has (ADR-c656cbcc33a9) -- so it is asserted rather than
+        // assumed. The test above passes just as well on a renderer that sorts
+        // alphabetically, which would bury the loop in the middle.
+        let text = help_out(&["help"]);
+        let mut at = 0usize;
+        for spec in COMMANDS {
+            let u = usage(spec);
+            let found = text[at..]
+                .find(&u)
+                .unwrap_or_else(|| panic!("{} out of order or missing:\n{text}", spec.name));
+            at += found + u.len();
         }
+        assert!(
+            text.starts_with(&usage(&COMMANDS[0])),
+            "the first line is not the first verb, so something groups or \
+             titles the listing:\n{text}"
+        );
     }
 
     #[test]
@@ -1094,7 +1007,10 @@ mod tests {
         // moves out of SKILL.md and into this command.
         assert!(text.contains("--ttl <v>"), "{text}");
         assert!(text.contains("--criteria <v>"), "{text}");
-        assert!(text.contains("agent loop"), "{text}");
+        assert!(
+            !text.contains("audience"),
+            "the audience line is what ADR-c656cbcc33a9 removes:\n{text}"
+        );
         // One verb means one verb: no other usage line rides along.
         assert!(!text.contains("ank accept"), "{text}");
 
@@ -1128,7 +1044,11 @@ mod tests {
                 "{all}"
             );
         }
-        assert!(all.contains("\"audience\":\"loop\""), "{all}");
+        assert!(
+            !all.contains("audience"),
+            "the audience key carried the grouping into the scripted \
+             output:\n{all}"
+        );
         assert!(all.contains("\"takes_value\":false"), "{all}");
 
         let one = help_out(&["help", "claim", "--json"]);

--- a/crates/ank-cli/src/commands.rs
+++ b/crates/ank-cli/src/commands.rs
@@ -1,9 +1,9 @@
 //! The new, find, log and release verbs.
 //!
-//! Four verbs that share almost nothing except being the rest of the agent
-//! surface (ADR-2f8a61c04b7d). What they do have in common is the discipline of
-//! §4: each refuses precisely, names the command to run next, and writes as
-//! little as the transition needs.
+//! Four verbs that share almost nothing except being the part of the loop that
+//! is not the loop's spine — SKILL.md teaches them off-loop (§4). What they do
+//! have in common is the discipline of §4: each refuses precisely, names the
+//! command to run next, and writes as little as the transition needs.
 //!
 //! - **`new`** requires a scope. A glob is the only mechanism attaching an
 //!   entity to code, and an entity attached to nothing is invisible to

--- a/crates/ank-cli/src/human.rs
+++ b/crates/ank-cli/src/human.rs
@@ -1,16 +1,13 @@
-//! Human surface: check, review, accept, close and attest (§4, §8, §11).
+//! check, review, accept, close, attest, amend and show (§4, §8, §11).
 //!
-//! The side of the CLI that can grow freely — that is what makes the eight-verb
-//! freeze sustainable (ADR-3859eb46bdc3) — and it carries the two acts an agent
-//! must never perform alone: ratifying a constraint, and closing a task nobody
-//! finished.
-//!
-//! **`show` lives here and is not one of them.** ADR-3859eb46bdc3 moved it onto
-//! the agent surface; the ADR governs who may call a verb, not which file holds
-//! it, and moving the function would buy nothing but a diff. So this module is
-//! no longer "the half that does not run in the agent loop", and that sentence
-//! is gone rather than quietly kept: a header describing an audience is exactly
-//! the kind of prose that rots into a lie one decision at a time.
+//! **This is a file, not a side.** The CLI exposes one surface
+//! (ADR-c656cbcc33a9): every verb here is available to every caller, and what
+//! the module holds is what grew together rather than what a class of caller
+//! was allowed to run. Successive headers described this as the human half, the
+//! side that may grow freely, the half outside the loop — each true when
+//! written and each false a decision later. A header describing an audience is
+//! exactly the prose that rots into a lie one decision at a time, so there is
+//! none.
 //!
 //! **`check` is the only command that prunes.** `claim` and `context` are
 //! readers, and a reader does not sanitise the coordination plane underneath
@@ -1725,10 +1722,11 @@ pub fn close(inv: &Invocation, repo: &Repo, identity: &str, out: &mut dyn Write)
 /// observe it. Here the entries already present are carried over untouched by
 /// construction, and the version bump goes through the store's compare-and-swap.
 ///
-/// **Human side, and not as a consolation.** ADR-2f8a61c04b7d freezes the agent
-/// surface at seven verbs and sends new functionality here. Attesting to a task
-/// somebody else finished is not loop work, and an agent able to reopen its own
-/// completed tasks is an agent that can grade itself twice.
+/// **Outside the loop, and not as a consolation.** Attesting to a task somebody
+/// else finished is not loop work, and SKILL.md does not teach it. That is a
+/// fact about what an agent is taught, never a refusal: `attest` runs for
+/// whoever types it, and what stops an agent grading itself twice is the state
+/// the verb refuses on, not the identity of the caller.
 ///
 /// `tree` and `verifier` stay empty: this records an attestation made
 /// elsewhere, not a run Ank performed. Claiming either would be the overstated
@@ -1817,10 +1815,10 @@ pub fn attest(inv: &Invocation, repo: &Repo, identity: &str, out: &mut dyn Write
 /// in the resulting file, from any other edit performed by hand. A verb can
 /// guarantee that the fields it did not name come back byte-identical.
 ///
-/// **Human side.** Adding a blocker to a task that already exists is a change
-/// to a plan that is not yours, which is TASK-bc214fd815b2's reasoning for
-/// leaving it off the agent surface in the first place. ADR-3859eb46bdc3
-/// freezes that surface at eight and sends new functionality here.
+/// **Outside the loop.** Adding a blocker to a task that already exists is a
+/// change to a plan that is not yours, which is TASK-bc214fd815b2's reasoning
+/// for keeping it out of what SKILL.md teaches. Keeping it out of the teaching
+/// is the whole of it: the verb itself refuses nobody on identity.
 ///
 /// **Add and remove, never replace.** A verb taking the whole list silently
 /// drops whatever the caller forgot to repeat, and the round-trip guarantees

--- a/crates/ank-cli/src/index.rs
+++ b/crates/ank-cli/src/index.rs
@@ -10,7 +10,7 @@
 //! against those hashes and reindexes what diverged. That is why an entity
 //! edited by hand, by another tool, or by a `git checkout` is reflected on the
 //! next read with no explicit command — there is no reindex verb to forget,
-//! and the agent surface stays at seven verbs (ADR-2f8a61c04b7d).
+//! and none to teach.
 //!
 //! An index that is absent, of an unknown schema, or not a database at all is
 //! rebuilt silently rather than reported: a cache that can refuse to work is a

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -1118,9 +1118,9 @@ fn help_answers_outside_a_repository_and_lists_every_verb() {
         stderr(&out)
     );
 
-    // The verbs, by audience. Listed by hand here on purpose: cli.rs walks its
-    // own table, which would agree with itself even if the table were wrong,
-    // and the criterion is about what an agent reads.
+    // Listed by hand here on purpose: cli.rs walks its own table, which would
+    // agree with itself even if the table were wrong, and the criterion is
+    // about what an agent reads.
     for verb in [
         "context", "claim", "log", "done", "release", "new", "find", "review", "accept", "close",
         "check", "show", "init", "help", "attest",
@@ -1130,9 +1130,33 @@ fn help_answers_outside_a_repository_and_lists_every_verb() {
             "{verb} missing:\n{text}"
         );
     }
-    for heading in ["agent loop", "agent off-loop", "human", "setup"] {
-        assert!(text.contains(heading), "no '{heading}' heading:\n{text}");
+
+    // One flat listing (ADR-c656cbcc33a9). The headings were named after
+    // callers -- agent loop, agent off-loop, human -- which is the two-surface
+    // model speaking through the output an agent reads, and a CLI that refuses
+    // on state and never on identity has no such grouping to print.
+    for heading in ["agent loop", "off-loop", "human", "setup"] {
+        assert!(
+            !text.contains(heading),
+            "'{heading}' still groups the listing:\n{text}"
+        );
     }
+
+    // Flat is not sorted: §4 puts the loop first, and that order is the only
+    // structure left. Alphabetical would bury `context` between `close` and
+    // `done`, so the order is asserted through the binary rather than trusted.
+    let at = |needle: &str| {
+        text.find(needle)
+            .unwrap_or_else(|| panic!("{needle} missing:\n{text}"))
+    };
+    assert!(at("ank context") < at("ank done"), "{text}");
+    assert!(at("ank done") < at("ank release"), "{text}");
+    assert!(at("ank release") < at("ank review"), "{text}");
+    assert!(at("ank review") < at("ank check"), "{text}");
+    assert!(
+        text.starts_with("ank context"),
+        "a title or a heading precedes the first verb:\n{text}"
+    );
     // And the flags each verb takes, which is the part §9 keeps out of
     // SKILL.md.
     for flag in [
@@ -1156,6 +1180,11 @@ fn help_for_one_verb_answers_and_an_unknown_one_is_a_two() {
     assert!(text.contains("ank claim <id>"), "{text}");
     assert!(text.contains("--ttl"), "{text}");
     assert!(text.contains("--criteria"), "{text}");
+    assert!(
+        !text.contains("audience"),
+        "the audience line is what ADR-c656cbcc33a9 removes, and it is the \
+         line an agent reads about itself:\n{text}"
+    );
     assert!(
         !text.contains("ank accept"),
         "one verb means one verb:\n{text}"
@@ -1191,5 +1220,63 @@ fn help_json_reaches_the_process_intact() {
     assert!(text.starts_with("{\"verbs\":["), "{text}");
     assert!(text.trim_end().ends_with("]}"), "{text}");
     assert!(text.contains("\"name\":\"claim\""), "{text}");
-    assert!(text.contains("\"audience\":\"setup\""), "{text}");
+    assert!(
+        !text.contains("audience"),
+        "the grouping survived into the scripted output:\n{text}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Dead constraints in the prose (ADR-c656cbcc33a9)
+// ---------------------------------------------------------------------------
+
+/// A comment citing a superseded ADR as the reason for a design is worse than
+/// no comment: it hands the next reader a constraint that binds nobody, with
+/// the authority of a decision record. Two of them went on asserting a frozen
+/// agent surface -- at seven verbs in one, at eight in the other -- in module
+/// headers and doc comments, long after the split they protected had been
+/// dissolved and while the file around them had already stopped obeying it.
+///
+/// The needles are assembled from fragments so this file does not defeat its
+/// own assertion by containing what it forbids. It reads as an affectation
+/// until you picture the test failing on itself.
+///
+/// This is not a general ban on naming a superseded ADR: history is worth
+/// writing down, and `.ank/` is where it is written. It is a ban on these two,
+/// which have no live claim left to make anywhere in this crate.
+#[test]
+fn no_superseded_adr_is_cited_in_the_crate() {
+    const DEAD: [&str; 2] = [
+        concat!("ADR-", "2f8a61c04b7d"),
+        concat!("ADR-", "3859eb46bdc3"),
+    ];
+
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut walked = 0usize;
+    for dir in ["src", "tests"] {
+        for entry in std::fs::read_dir(root.join(dir)).expect("the crate has this directory") {
+            let path = entry.expect("a readable entry").path();
+            if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+                continue;
+            }
+            let text = std::fs::read_to_string(&path).expect("a readable source file");
+            for dead in DEAD {
+                assert!(
+                    !text.contains(dead),
+                    "{} cites {dead}, which is superseded: name the ADR that \
+                     binds today, or drop the citation",
+                    path.display()
+                );
+            }
+            walked += 1;
+        }
+    }
+    // A walk that quietly found nothing would pass forever, which is the one
+    // way a test like this fails at being a test.
+    assert!(walked >= 8, "only {walked} source files walked");
+
+    let manifest = std::fs::read_to_string(root.join("Cargo.toml")).expect("a readable manifest");
+    for dead in DEAD {
+        assert!(!manifest.contains(dead), "Cargo.toml cites {dead}");
+    }
 }

--- a/crates/ank-cli/tests/skill.rs
+++ b/crates/ank-cli/tests/skill.rs
@@ -1,9 +1,12 @@
 //! Conformance of the bootstrap skill.
 //!
 //! `skill/SKILL.md` is not documentation: it is loaded into an agent's context
-//! permanently, on every session, in every repository that installs it. Two
-//! properties are therefore worth a test rather than a habit -- that it carries
-//! the whole agent surface, and that it stays small enough to be worth loading.
+//! permanently, on every session, in every repository that installs it. That is
+//! what makes its content the thing actually frozen (ADR-c656cbcc33a9) -- the
+//! dispatch table refuses nobody, and the loop exists because this file teaches
+//! it and teaches nothing else. Two properties are therefore worth a test
+//! rather than a habit: that it carries the whole loop, and that it stays small
+//! enough to be worth loading.
 //!
 //! This file exists because the task's declared verifier is `cargo-test`. A
 //! criterion nothing executes is a criterion nobody checked, and a proof that
@@ -19,15 +22,16 @@ fn skill() -> String {
     fs::read_to_string(&p).unwrap_or_else(|e| panic!("{}: {e}", p.display()))
 }
 
-/// The eight of ADR-3859eb46bdc3, and the surface is frozen at exactly these.
-const AGENT_VERBS: [&str; 8] = [
+/// The loop, and the content of SKILL.md is frozen at exactly these
+/// (ADR-c656cbcc33a9).
+const LOOP_VERBS: [&str; 8] = [
     "context", "claim", "show", "log", "done", "new", "find", "release",
 ];
 
 #[test]
-fn the_skill_carries_the_whole_agent_surface() {
+fn the_skill_carries_the_whole_loop() {
     let text = skill();
-    for verb in AGENT_VERBS {
+    for verb in LOOP_VERBS {
         assert!(
             text.contains(&format!("ank {verb}")),
             "SKILL.md never shows `ank {verb}`, and an agent only knows the \
@@ -36,8 +40,8 @@ fn the_skill_carries_the_whole_agent_surface() {
     }
 }
 
-/// One page, and the budget is the reason: §9 puts the seven commands and the
-/// mental model here, and sends flag detail to `ank help`, loaded on demand.
+/// One page, and the budget is the reason: §9 puts the loop and the mental
+/// model here, and sends flag detail to `ank help`, loaded on demand.
 /// The number is a ceiling to notice drift, not a target to fill.
 #[test]
 fn the_skill_stays_within_one_page() {
@@ -52,21 +56,24 @@ fn the_skill_stays_within_one_page() {
     assert!(words <= 700, "SKILL.md is {words} words, over one page");
 }
 
-/// The human verbs are not the agent's, and this file is the agent's. Naming
-/// them as things to run would grow the surface ADR-3859eb46bdc3 freezes -- by
-/// habit rather than by decision, which is how surfaces actually grow.
+/// These verbs run for whoever types them -- nothing here is refused to an
+/// agent (ADR-c656cbcc33a9). What this asserts is narrower and is the whole of
+/// the freeze: SKILL.md does not *teach* them. Naming one as a thing to run
+/// would grow what every session pays for, by habit rather than by decision,
+/// which is how a permanently loaded file actually grows.
 ///
-/// `show` is absent from this list because it is no longer on that side:
-/// ADR-3859eb46bdc3 supersedes ADR-2f8a61c04b7d and moves it, by decision and
-/// with the reason recorded. That is what the list is for -- everything else
-/// still costs a succession.
+/// `show` is absent from this list because it was moved into the loop by
+/// decision and with the reason recorded, back when the loop was still called a
+/// surface. That is what the list is for -- everything else still costs a
+/// succession.
 #[test]
-fn the_skill_does_not_hand_the_agent_a_human_verb() {
+fn the_skill_teaches_nothing_beyond_the_loop() {
     let text = skill();
     for verb in ["accept", "review", "close", "attest", "check"] {
         assert!(
             !text.contains(&format!("ank {verb}")),
-            "SKILL.md shows `ank {verb}`, which is on the human surface"
+            "SKILL.md shows `ank {verb}`, which is outside the loop it is \
+             frozen at"
         );
     }
 }

--- a/docs/ank-spec-v1.1.md
+++ b/docs/ank-spec-v1.1.md
@@ -9,6 +9,8 @@ Settled relative to v1: orientation and constraints reconciled (§5) · immutabi
 
 Every open point of v1 is settled: GPL-3.0 licence, native Windows in v1, merge driver and CI attestation specified but implemented in v1.1 (§13).
 
+Additions of revision k: **`ank help` is one flat listing** (§4, §9, ADR-c656cbcc33a9, superseding ADR-9ede1ffd04e2) — revision i dissolved the split between an agent surface and a human one and left a layered `help` behind it, whose headings were still named after callers; layering is grouping, and a grouping printed by the binary is a claim about who a verb is for. The order of §4 carries the same information without asserting a category, and the loop stays where it is enforced, in the frozen content of SKILL.md.
+
 Additions of revision j: **the ratification signature is verified and not merely read** (§8, §4) — `check` was comparing the anchor in the ratification commit against the file without asking who signed the commit, so an ordinary unsigned commit whose subject read `ratify <id>` was accepted as a ratification; the four outcomes are specified, an unchecked signature is a signal and never a success, and the layout of `allowed_signers` is documented along with the fact that git enforces it only under `gpg.format = ssh`, OpenPGP leaving the match to `check` itself.
 
 Additions of revision i: **one command surface instead of two** (§4, §8, ADR-9ede1ffd04e2, superseding ADR-3859eb46bdc3) — every verb is available to every caller, the CLI refuses on state and never on identity, and the eight-verb freeze is restated as a freeze on the content of SKILL.md, which is where the token budget it actually protected is spent · the refusals are tabulated against their exit codes, and the signed ratification commit is named as the single hard line of authority, a proof requirement rather than a role check (§4) · `status`, `edit`, `graph` and `scope` enter the surface, along with the interactive form of `new` and the read form of `log` (§4) · roles in `config.yml` are named what they always were, advisory, and policy is placed where it holds: SKILL.md, harness hooks, then roles (§8).
@@ -255,7 +257,7 @@ The symmetric risk — an agent going off the rails and flooding the repository 
 
 ## 4. CLI surface
 
-**Ank exposes one surface** (ADR-9ede1ffd04e2). Every verb is available to every caller, and the CLI refuses on state, never on identity. Git has more than a hundred commands, every one of them reachable by anybody who types it, and stays learnable because of what a newcomer is taught first — not because the porcelain sorts callers into classes. Ank borrows that shape.
+**Ank exposes one surface** (ADR-c656cbcc33a9). Every verb is available to every caller, and the CLI refuses on state, never on identity. Git has more than a hundred commands, every one of them reachable by anybody who types it, and stays learnable because of what a newcomer is taught first — not because the porcelain sorts callers into classes. Ank borrows that shape.
 
 The memorisation budget is real; it is simply not the binary's job. It is spent on documentation, and it is enforced where it operates: what an agent is taught is the loop, and the content of what teaches it is frozen. What a human may type is everything.
 
@@ -266,7 +268,7 @@ Loop:        context → claim → show → log → done
 Off-loop:    new, find, release
 ```
 
-**This is the entire content of SKILL.md, and that content is frozen.** SKILL.md is loaded permanently (§9), so the surface an agent reads about is the one that costs tokens on every call; growing what it teaches costs an ADR superseding ADR-9ede1ffd04e2, exactly as growing a verb list once did. The freeze constrains the documentation, not the dispatch table: an agent that runs `ank graph` gets the graph; it was simply never told the verb existed, and being untold is not being refused.
+**This is the entire content of SKILL.md, and that content is frozen.** SKILL.md is loaded permanently (§9), so the surface an agent reads about is the one that costs tokens on every call; growing what it teaches costs an ADR superseding ADR-c656cbcc33a9, exactly as growing a verb list once did. The freeze constrains the documentation, not the dispatch table: an agent that runs `ank graph` gets the graph; it was simply never told the verb existed, and being untold is not being refused.
 
 That distinction is the whole revision. ADR-3859eb46bdc3 froze an *agent surface* at these same eight verbs and sent everything else to a human side, but the split it protected was never a boundary — the CLI told callers apart by `$ANK_AGENT`, a variable the caller sets itself (§8). A wall whose bricks are self-declared identity is a sign, not a wall. What the freeze actually protected was the token budget, and that protection moves here, where it holds without pretending to be a check.
 
@@ -783,6 +785,8 @@ Skills install from repositories rather than npm packages: the identifier is `ow
 The `skills` CLI handles multi-agent detection (Claude Code, Codex, Cursor, OpenCode, and many others) and creates links from each agent to a canonical copy — exactly the desired design, already maintained by a third party.
 
 **Token economy.** These files are loaded permanently, which is why the content of SKILL.md is frozen (§4): it carries the loop and the mental model, nothing else, and growing that costs a superseding ADR. Flag details and the rest of the surface stay in `ank help`, loaded on demand.
+
+**`ank help` is one flat listing** (ADR-c656cbcc33a9): every verb, in the order of §4, with no headings and no grouping. The loop is what SKILL.md teaches, not what the binary prints — a heading printed by the CLI is a claim about who a verb is for, and that is the claim §4 withdraws. The order carries what a heading would have said, since §4 puts the loop first, and it carries it without asserting a category. `ank help <verb>` answers about that verb alone: its usage, its flags with their value placeholders, and the globals. An unknown verb is a **code 2** and never a fallback to the general listing — an agent that asked about one verb and received all sixteen has to work out that its question went unanswered.
 
 `ank init` keeps a narrow perimeter: create `.ank/`, write `config.yml`, add the `refs/ank/*` refspec (§7), place a pointer in `AGENTS.md`.
 


### PR DESCRIPTION
Implements ADR-c656cbcc33a9, ratified on `main` in 3233040.

## Why

ADR-9ede1ffd04e2 dissolved the split between an agent surface and a human one and left a layered `help` behind it, whose headings were still named after callers: `agent loop`, `agent off-loop`, `human`. A heading printed by the binary is a claim about who a verb is for, and a CLI that refuses on state and never on identity has no such claim to make. `ank help <verb>` answered with an `audience:` line, which is that same model speaking through the output an agent reads.

## What changed

The specification landed first, revision k -- §4 cites the new ADR, §9 describes the flat listing.

Then the code. The enum `Audience`, its four variants, `heading()`, `as_str()`, `agent_surface()`, the field on all sixteen command specs and the `"audience"` key of `--json` are gone. `help` makes one pass over `COMMANDS`, and the order of §4 -- the loop first -- is the only structure the listing has.

```
ank context [<path>]      --limit
ank claim <id>            --criteria --ttl
ank show <id>
ank log [<id>] <message>
ank done [<id>]           --proof
ank release [<id>]        --reason
ank new <task|adr>        --title --scope --criteria ...
ank find <query>          --type --status --scope
ank review [<path>]
...
```

## Tests

Two assertions go through the binary, per the criterion: one on the absence of the headings, one on the order. Flat becomes alphabetical without anything turning red, which would bury the loop between `close` and `find`.

A third test walks every source file in the crate for citations of superseded ADRs. Searching for the prose around them found six; the walk found two more that the prose never named -- a list of anchoring ADRs in `claim.rs`, a module header in `commands.rs` -- both still asserting seven frozen verbs. Its needles are assembled with `concat!` so it cannot pass by containing what it forbids.

## Provenance

TASK-147aca91604f, proved by `cargo-test`, `fmt-check` and `check-repo`. It carries the work of two closed tasks: TASK-8c376169fb6c, whose frozen criterion required the layering this removes, and TASK-671dac854896, filed without `--verify` and therefore unable to be proved by anything but its own author.

CI is where this is actually verified on all three platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRT9v3QN6bRYV585LXHYis