### PR TITLE
The unsigned ratification is caught through the binary, not only under it

### DIFF
--- a/.ank/tasks/TASK-1ea38a17d854.md
+++ b/.ank/tasks/TASK-1ea38a17d854.md
@@ -5,7 +5,7 @@ slug: check-answered-0-on-a-ratification-commit-nobody
 title: check answered 0 on a ratification commit nobody signed
 created: 2026-08-01T23:42:26Z
 author: seanl@sean-laptop
-status: open
+status: done
 scope:
   - crates/ank-cli/src/human.rs
   - crates/ank-cli/tests/cli.rs
@@ -14,8 +14,24 @@ done_criteria: |
   ank check exits 8 and names the ADR when an accepted ADR carries an anchor and its ratification commit is unsigned. The case is built and run through the binary, not through signature_state alone: the unit tests covering every signature state already pass, and the binary still answered 0 on a real corpus in that exact situation. The cause is identified and stated in the log, whether it lies in reaching the commit or in judging it.
 criteria_by: creator
 verify: [cargo-test, fmt-check, check-repo]
+proof:
+  - type: test
+    ref: local/40b5b12d7e59@b728548
+    tree: scope/b3923d95b8d8
+    criteria: 67e5d10bc17b
+    verifier: cargo-test@f14aeab36e1b
+  - type: test
+    ref: local/e3b0c44298fc@b728548
+    tree: scope/b3923d95b8d8
+    criteria: 67e5d10bc17b
+    verifier: fmt-check@5ca6d10bcd55
+  - type: test
+    ref: local/598707f99836@b728548
+    tree: scope/b3923d95b8d8
+    criteria: 67e5d10bc17b
+    verifier: check-repo@5734e9cf9d3d
 schema: 2
-version: 1
+version: 8
 ---
 
 Found by an incident on 2026-08-01, not by reading. GitHub rebased the ratification commit of ADR-c656cbcc33a9 while merging a pull request, which rewrote it and stripped its signature. Measured on the resulting commit f770c98: git verify-commit exits 1 and git cat-file commit shows no gpgsig header. The signed original, 3233040, exits 0 and carries the header.
@@ -27,3 +43,8 @@ The ADR was accepted and did carry its anchor at the time -- status accepted, ra
 The commits are still in the object database as unreachable objects at filing time (f770c98, 7cde6ce) and will be collected eventually. Do not build the reproduction on them: an unsigned commit whose subject is "ratify <id>", over an accepted ADR carrying an anchor, is the case, and it costs one fixture.
 
 TASK-d31af22248d9 and TASK-e162e649298f already taught this corner once. The signature test was asserting a property of the clone rather than of the code, and CI caught it. This is the same shape one level down: the unit tests assert what signature_state answers when it is called, and nothing asserted that check calls it and acts on the answer against a real repository. A criterion about the binary is tested through the binary.
+
+## Log
+- 2026-08-02T22:21:49Z seanl@sean-laptop — Reproduced and cause found: the code was never wrong. Ran the incident state directly -- a detached worktree at 7cde6ce, whose history carries the rewritten, unsigned ratification commit f770c98 for ADR-c656cbcc33a9. The installed ank.exe (C:\Users\seanl\.local\bin, built 2026-07-31 22:28) answers 0 there. The binary freshly built from this tree answers 8 with 'ADR-c656cbcc33a9: its ratification commit is not signed: the anchor proves nothing'. The installed binary predates d93af3b (2026-08-01 13:53), the commit that added the signature check: it has no signature check to run. So the cause lies neither in reaching the commit nor in judging it -- every git step answers correctly under both (rev-list finds f770c98 on the ADR path, allowed_signers is tracked and present, rev-list --format=%G? returns N). The measurement was taken with a binary older than the feature. What is still missing, and is the real hole: nothing exercises check through the binary on this case, so nothing would have caught a stale or broken wiring either.
+- 2026-08-02T22:27:06Z seanl@sean-laptop — The test is proved non-vacuous by mutation: with the Absent arm of check_adr replaced by a no-op, a_ratification_commit_stripped_of_its_signature_is_a_fault_through_the_binary fails with 'check: ok' and exit 0 -- the incident's exact output. Restored, it passes. The fixture reproduces the rewrite faithfully: accept signs for real, check is asserted silent first, then git commit --amend --no-edit with commit.gpgsign=false keeps the tree, the message and the constraint+scope trailer and drops the signature, which is what the merge did to f770c98. It also declares the generated key in .ank/allowed_signers, without which section 8 puts the corpus in advisory mode and every verdict is None -- the silence the test exists to refuse. No production code changed: none was wrong.
+- 2026-08-02T22:30:42Z seanl@sean-laptop — done, proof test:local/40b5b12d7e59@b728548 test:local/e3b0c44298fc@b728548 test:local/598707f99836@b728548

--- a/.ank/tasks/TASK-52fbffbfdf65.md
+++ b/.ank/tasks/TASK-52fbffbfdf65.md
@@ -1,0 +1,25 @@
+---
+id: TASK-52fbffbfdf65
+type: task
+slug: check-prunes-a-live-claim-ref-when-it-runs-from
+title: check prunes a live claim ref when it runs from an older checkout
+created: 2026-08-02T22:31:35Z
+author: seanl@sean-laptop
+status: open
+scope:
+  - crates/ank-cli/src/human.rs
+blocked_by: []
+done_criteria: |
+  A claim ref held on a task that exists on the default branch survives an ank check run from a worktree checked out at a commit predating that task. Proved through the binary, with the ref read by git afterwards.
+criteria_by: creator
+schema: 2
+version: 1
+---
+
+Observed three times while reproducing TASK-1ea38a17d854, each time on a claim I was holding. A detached worktree at 7cde6ce, an older commit, then ank check in it: "pruned refs/ank/claims/TASK-1ea38a17d854", and the ref was gone from the shared ref store. The task was in_progress on main; the claim had to be retaken twice before done could run.
+
+maintain treats a ref whose id is absent from statuses as an orphan and deletes it. Its own comment says "a ref for a task that no longer exists anywhere", and that is the gap: statuses is built from the entities of the current working tree, so the code answers "does not exist here" while the comment claims "does not exist anywhere". refs/ank/ is shared across worktrees, so an old checkout deletes claims that a current one is actively holding.
+
+The settled branch below it already knows how to ask the right question: it reads the task at default_branch through git::file_at rather than from disk. The orphan branch could ask the same way before deleting, and report rather than prune when the answer is unreachable -- the reader's behaviour section 2 asks for.
+
+The blast radius is small but it is the coordination plane: a lost claim is a task two agents can hold at once.

--- a/.ank/tasks/TASK-c92b7cc10f13.md
+++ b/.ank/tasks/TASK-c92b7cc10f13.md
@@ -1,0 +1,27 @@
+---
+id: TASK-c92b7cc10f13
+type: task
+slug: a-git-failure-in-the-signature-read-degrades-to
+title: A git failure in the signature read degrades to no verdict at all
+created: 2026-08-02T22:31:49Z
+author: seanl@sean-laptop
+status: open
+scope:
+  - crates/ank-cli/src/human.rs
+blocked_by: []
+done_criteria: |
+  When the signature of a reachable ratification commit cannot be read because git fails, check says so rather than staying silent. The case is built and run through the binary.
+criteria_by: creator
+schema: 2
+version: 1
+---
+
+Found by reading while diagnosing TASK-1ea38a17d854, not by an incident.
+
+signature_state ends with git::signature_of(...).ok()?, so any error from the git invocation becomes None, and None is the one verdict check_adr says nothing about. The ADR then passes in silence with no signal, no fault and no count -- indistinguishable from a corpus with no allowlist.
+
+This is the shape ADR-6b3f and the Unchecked case both refuse elsewhere: "a verification that degrades to success is not a verification", which is exactly why Unchecked is counted rather than dropped. Here the same degradation happens one level up, on the error path instead of the status path.
+
+It is narrow: freeze_state has already reached the same commit through the same memo, so a git that answers there usually answers here. Narrow is not never -- a bad allowed_signers path, a gpg.format git refuses, an object read that fails mid-run -- and the cost of being wrong is silence on the one case the whole mechanism exists for.
+
+The fix is probably a sixth state or a second corpus counter, not a fault: a broken environment is not a forged ratification, and reporting one as the other is how a finding becomes noise. Whatever it becomes, it must not be nothing.

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -262,6 +262,102 @@ fn an_edited_constraint_is_reported_altered_and_stops_being_injected() {
     );
 }
 
+/// Declares the key `enable_signing` generated, so the signature is judged at
+/// all. Without the file there is no allowlist and §8 puts the corpus in
+/// advisory mode, where every verdict is `None` — which is the shape of silence
+/// this test exists to refuse.
+fn declare_signing_key(r: &Repo) {
+    let pub_key = std::fs::read_to_string(r.0.join("signing-key.pub")).unwrap();
+    std::fs::write(
+        r.0.join(".ank/allowed_signers"),
+        format!("test@ank.local {}", pub_key.trim()),
+    )
+    .unwrap();
+}
+
+/// The incident of TASK-1ea38a17d854, reproduced at the only altitude that
+/// would have caught it. GitHub rebased a ratification commit while merging a
+/// pull request: same tree, same message, same anchor, signature gone. Anyone
+/// who can push a branch can produce that commit, and the anchor it carries is
+/// then worth nothing.
+///
+/// Through the binary, and that is the whole point. `signature_state` already
+/// answered `Absent` in a unit test, and `check` already turned `Absent` into a
+/// fault in another — and the binary measured on the real corpus still exited
+/// 0, because the binary in hand was older than the check itself. Nothing
+/// asserted that a process invocation runs the wiring end to end, so nothing
+/// noticed that one wasn't.
+///
+/// The negative is only worth what the positive above it is worth: a real
+/// `accept` runs first and must be silent, or an exit 8 here would prove
+/// nothing but a broken fixture.
+#[test]
+fn a_ratification_commit_stripped_of_its_signature_is_a_fault_through_the_binary() {
+    const ADR: &str = "ADR-0000000000cd";
+    let r = Repo::new();
+    r.enable_signing();
+    r.seed_adr(ADR, "Do not do X.", "src/**");
+    // A scope matching nothing is a fault of its own, and it would exit 8
+    // before the signature was ever consulted.
+    std::fs::create_dir_all(r.0.join("src")).unwrap();
+    std::fs::write(r.0.join("src/main.rs"), "fn main() {}\n").unwrap();
+    declare_signing_key(&r);
+    r.git(&["add", "-A"]);
+    r.git(&["-c", "commit.gpgsign=false", "commit", "-qm", "seed"]);
+
+    let out = r.ank("marie@laptop", &["accept", ADR]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    let ratification = r.head();
+
+    let out = r.ank("claude-code@ank", &["check"]);
+    assert_eq!(
+        code(&out),
+        0,
+        "a real ratification must be silent, or the fault below proves nothing: {}{}",
+        stdout(&out),
+        stderr(&out)
+    );
+    assert!(!stdout(&out).contains("not signed"), "{}", stdout(&out));
+
+    // The rewrite. `--amend` keeps the message and the tree and drops the
+    // signature, which is exactly what the merge did to f770c98.
+    r.git(&[
+        "-c",
+        "commit.gpgsign=false",
+        "commit",
+        "--amend",
+        "--no-edit",
+        "-q",
+    ]);
+    assert_ne!(
+        r.head(),
+        ratification,
+        "the commit must have been rewritten"
+    );
+
+    let out = r.ank("claude-code@ank", &["check"]);
+    assert_eq!(
+        code(&out),
+        8,
+        "an unsigned ratification is a fault: {}{}",
+        stdout(&out),
+        stderr(&out)
+    );
+    let said = stdout(&out);
+    assert!(
+        said.contains(ADR) && said.contains("not signed"),
+        "the finding names the ADR and says what is wrong: {said}"
+    );
+
+    // And it is that finding and no other. The anchor still agrees with the
+    // file and the commit is still reachable, so a report crying divergence or
+    // unverifiability here would be describing a different repository.
+    assert!(
+        !said.contains("altered since ratification") && !said.contains("is reachable"),
+        "only the signature is gone: {said}"
+    );
+}
+
 #[test]
 fn claiming_through_the_binary_takes_the_ref_and_moves_the_task() {
     let r = Repo::new();


### PR DESCRIPTION
Closes TASK-1ea38a17d854.

## The cause was not in the code

The task was filed on a real incident: GitHub rebased the ratification commit of ADR-c656cbcc33a9 while merging #4, which rewrote it and stripped its signature, and `ank check` against that state exited 0 without a word about the ADR.

`check` was never broken. The `ank` binary in hand was built 2026-07-31 22:28; `d93af3b`, the commit that added the signature check, landed 2026-08-01 13:53. It had no signature check to run.

Reproduced on the incident state itself — `f770c98` and `7cde6ce` are still in the object database, so a detached worktree at the merged commit gives the measurement directly:

| binary | result |
|---|---|
| the installed one (2026-07-31) | exit 0, no finding for the ADR |
| built from this tree | **exit 8** — `ADR-c656cbcc33a9: its ratification commit is not signed: the anchor proves nothing (§8)` |

Every git step answers correctly under both: `rev-list --full-history` reaches `f770c98` on the ADR path, `.ank/allowed_signers` is tracked and present, `rev-list --format=%G?` returns `N`. Neither reaching the commit nor judging it. The measurement predated the feature.

## What was actually missing

`signature_state` answering `Absent` was tested. `check_adr` turning `Absent` into a fault was tested. Nothing ever ran a process end to end — so a binary with the entire check absent was indistinguishable from a passing one.

`a_ratification_commit_stripped_of_its_signature_is_a_fault_through_the_binary` builds the case and runs the binary:

- a real signed `accept`, then `check` asserted silent — the negative is worth nothing without the positive above it;
- `git commit --amend` with signing off: same tree, same message, same `constraint+scope` trailer, signature gone, which is what the merge did to `f770c98`;
- exit 8, the ADR named, and *that* finding and no other — not "altered", not "unreachable", since the anchor still agrees and the commit is still there;
- `.ank/allowed_signers` declared, without which §8 puts the corpus in advisory mode and every verdict is `None` — the silence the test exists to refuse.

Proved non-vacuous by mutation: with the `Absent` arm of `check_adr` replaced by a no-op, it fails with `check: ok` and exit 0 — the incident's exact output.

**No production code changed. None was wrong.**

## Filed, not fixed here

- **TASK-52fbffbfdf65** — `check` pruned a live claim ref three times during this work. `maintain` calls a ref an orphan when the task is absent from the *current working tree*, while its own comment says "no longer exists anywhere", and `refs/ank/` is shared across worktrees. A lost claim is a task two agents can hold at once.
- **TASK-c92b7cc10f13** — `signature_state` ends in `.ok()?`, so a git failure becomes `None`, the one verdict `check_adr` says nothing about. The same degradation-to-silence the `Unchecked` counter exists to refuse, one level up on the error path.

## Verification

`ank done` ran the three declared verifiers and recorded the proof: `cargo-test`, `fmt-check`, `check-repo`, all green at `b728548`. `ank check` is green on the corpus.

> A note on merging this one: rebase-merge is what stripped the signature in #4. This branch carries no ratification commit, so it is harmless here — but a branch produced by `ank accept` must not be merged that way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QoJrx7uZpTu7ZEzie8TpKH