### PR TITLE
An orphan ref is one no branch claims, not one this checkout cannot see

### DIFF
--- a/.ank/tasks/TASK-52fbffbfdf65.md
+++ b/.ank/tasks/TASK-52fbffbfdf65.md
@@ -5,15 +5,19 @@ slug: check-prunes-a-live-claim-ref-when-it-runs-from
 title: check prunes a live claim ref when it runs from an older checkout
 created: 2026-08-02T22:31:35Z
 author: seanl@sean-laptop
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/src/human.rs
 blocked_by: []
 done_criteria: |
   A claim ref held on a task that exists on the default branch survives an ank check run from a worktree checked out at a commit predating that task. Proved through the binary, with the ref read by git afterwards.
 criteria_by: creator
+proof:
+  - type: test
+    ref: ci://github/30771346358
+    criteria: ce710f86f3e8
 schema: 2
-version: 3
+version: 4
 ---
 
 Observed three times while reproducing TASK-1ea38a17d854, each time on a claim I was holding. A detached worktree at 7cde6ce, an older commit, then ank check in it: "pruned refs/ank/claims/TASK-1ea38a17d854", and the ref was gone from the shared ref store. The task was in_progress on main; the claim had to be retaken twice before done could run.
@@ -26,3 +30,4 @@ The blast radius is small but it is the coordination plane: a lost claim is a ta
 
 ## Log
 - 2026-08-02T22:58:12Z seanl@sean-laptop — Fixed in maintain: the orphan test now asks the default branch through git::file_at before deleting, the same source and the same call the settled test below it already uses. Ok(Some) means the task exists on the default branch and this checkout is merely older than it -- not an orphan, and silent, because a signal there would fire on every check run from every branch predating the task. Ok(None) prunes as before. Err keeps the ref and reports once through unreachable_branch: unable to ask is not permission to delete. Proved by reverting only human.rs with the test in place: it fails with 'pruned refs/ank/claims/TASK-000000000001', the incident's exact line. The test also carries the other half, or the fix could have been 'never prune': a task whose file is deleted and the deletion committed to the default branch is still collected in the same pass that leaves the live claim alone.
+- 2026-08-02T23:03:35Z seanl@sean-laptop — done, proof test:ci://github/30771346358

--- a/.ank/tasks/TASK-52fbffbfdf65.md
+++ b/.ank/tasks/TASK-52fbffbfdf65.md
@@ -5,7 +5,7 @@ slug: check-prunes-a-live-claim-ref-when-it-runs-from
 title: check prunes a live claim ref when it runs from an older checkout
 created: 2026-08-02T22:31:35Z
 author: seanl@sean-laptop
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/src/human.rs
 blocked_by: []
@@ -13,7 +13,7 @@ done_criteria: |
   A claim ref held on a task that exists on the default branch survives an ank check run from a worktree checked out at a commit predating that task. Proved through the binary, with the ref read by git afterwards.
 criteria_by: creator
 schema: 2
-version: 1
+version: 3
 ---
 
 Observed three times while reproducing TASK-1ea38a17d854, each time on a claim I was holding. A detached worktree at 7cde6ce, an older commit, then ank check in it: "pruned refs/ank/claims/TASK-1ea38a17d854", and the ref was gone from the shared ref store. The task was in_progress on main; the claim had to be retaken twice before done could run.
@@ -23,3 +23,6 @@ maintain treats a ref whose id is absent from statuses as an orphan and deletes 
 The settled branch below it already knows how to ask the right question: it reads the task at default_branch through git::file_at rather than from disk. The orphan branch could ask the same way before deleting, and report rather than prune when the answer is unreachable -- the reader's behaviour section 2 asks for.
 
 The blast radius is small but it is the coordination plane: a lost claim is a task two agents can hold at once.
+
+## Log
+- 2026-08-02T22:58:12Z seanl@sean-laptop — Fixed in maintain: the orphan test now asks the default branch through git::file_at before deleting, the same source and the same call the settled test below it already uses. Ok(Some) means the task exists on the default branch and this checkout is merely older than it -- not an orphan, and silent, because a signal there would fire on every check run from every branch predating the task. Ok(None) prunes as before. Err keeps the ref and reports once through unreachable_branch: unable to ask is not permission to delete. Proved by reverting only human.rs with the test in place: it fails with 'pruned refs/ank/claims/TASK-000000000001', the incident's exact line. The test also carries the other half, or the fix could have been 'never prune': a task whose file is deleted and the deletion committed to the default branch is still collected in the same pass that leaves the live claim alone.

--- a/crates/ank-cli/src/human.rs
+++ b/crates/ank-cli/src/human.rs
@@ -1048,19 +1048,43 @@ fn maintain(
     ids.sort_by_key(|i| i.to_string());
     for id in ids {
         let record = &coord[id];
+        let path = format!("{rel}/tasks/{id}.md");
         // An orphan: a ref for a task that no longer exists anywhere.
+        //
+        // "Anywhere" is the load-bearing word, and asking the working tree
+        // cannot answer it. `refs/ank/` is shared by every worktree of a
+        // repository, so a checkout older than a task sees no such task and
+        // used to delete a claim another worktree was holding at that moment
+        // (TASK-52fbffbfdf65). The default branch is the one copy every
+        // checkout agrees on, and the `settled` test below already reads it —
+        // this asks the same question of the same source, one step earlier.
         if !statuses.contains_key(id) {
-            if prune {
-                claim::delete(&repo.root, id)?;
-                report.pruned.push(claim::ref_name(id));
-            } else {
-                report
-                    .findings
-                    .push(Finding::signal(id, "orphan ref: no such task"));
+            match git::file_at(&repo.root, default_branch, &path) {
+                // Not an orphan: this checkout is simply older than the task,
+                // or on a branch that never carried it. Silent on purpose. The
+                // ref belongs to whoever holds it now, and a signal here would
+                // fire on every check run from every branch predating the task.
+                Ok(Some(_)) => {}
+                Ok(None) => {
+                    if prune {
+                        claim::delete(&repo.root, id)?;
+                        report.pruned.push(claim::ref_name(id));
+                    } else {
+                        report
+                            .findings
+                            .push(Finding::signal(id, "orphan ref: no such task"));
+                    }
+                }
+                // Unable to ask is not permission to delete: report once and
+                // keep the ref, which is the reader's behaviour §2 asks for.
+                Err(_) => {
+                    if unreachable_branch.is_none() {
+                        unreachable_branch = Some(default_branch.to_string());
+                    }
+                }
             }
             continue;
         }
-        let path = format!("{rel}/tasks/{id}.md");
         // A branch that names nothing yet is the nominal state of a repository
         // freshly `ank init`-ed: it has a default branch and no commit on it.
         // Reporting once and pruning nothing is the reader's behaviour (§2);

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -168,10 +168,18 @@ impl Repo {
     /// `--repo` rather than a working directory, so that the flag stays on a
     /// path a real invocation takes.
     fn ank(&self, agent: &str, args: &[&str]) -> Output {
+        self.ank_at(agent, args, &self.0)
+    }
+
+    /// The same invocation, pointed at another checkout of the same
+    /// repository. A worktree shares `refs/ank/` with the checkout that made
+    /// it, which is why a question about a ref can never be answered from a
+    /// working tree.
+    fn ank_at(&self, agent: &str, args: &[&str], repo: &Path) -> Output {
         Command::new(ANK)
             .args(args)
             .arg("--repo")
-            .arg(&self.0)
+            .arg(repo)
             .env("ANK_AGENT", agent)
             .current_dir(std::env::temp_dir())
             .output()
@@ -356,6 +364,91 @@ fn a_ratification_commit_stripped_of_its_signature_is_a_fault_through_the_binary
         !said.contains("altered since ratification") && !said.contains("is reachable"),
         "only the signature is gone: {said}"
     );
+}
+
+/// A claim is not an orphan just because this checkout is too old to have
+/// heard of the task (TASK-52fbffbfdf65).
+///
+/// Observed three times while diagnosing TASK-1ea38a17d854, each time on a
+/// claim being held: a `check` run from a detached worktree at an earlier
+/// commit printed `pruned refs/ank/claims/<id>` and deleted it. `refs/ank/` is
+/// shared by every worktree, so the older checkout reached into the coordination
+/// plane of the current one. A lost claim is a task two agents can hold at once.
+///
+/// Through the binary, and with the ref read by git afterwards rather than
+/// through `claim::read`: what has to be true is the state of the repository,
+/// not the module's agreement with itself.
+#[test]
+fn a_check_from_an_older_checkout_leaves_a_live_claim_alone() {
+    let r = Repo::new();
+    // An ADR-less corpus still needs its scope to exist, or `check` exits 8 on
+    // a dead scope before any of this is reached.
+    std::fs::create_dir_all(r.0.join("src")).unwrap();
+    std::fs::write(r.0.join("src/main.rs"), "fn main() {}\n").unwrap();
+    r.git(&["add", "-A"]);
+    r.git(&["-c", "commit.gpgsign=false", "commit", "-qm", "seed"]);
+    let before_the_task = r.head();
+
+    // The task arrives after that commit, which is the whole point: the older
+    // checkout below cannot see it.
+    r.seed_task(ID, Some("A verifiable criterion."));
+    r.git(&["add", "-A"]);
+    r.git(&[
+        "-c",
+        "commit.gpgsign=false",
+        "commit",
+        "-qm",
+        "add the task",
+    ]);
+
+    let out = r.ank("claude-code@ank", &["claim", ID]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    assert!(r.claim_ref(ID).is_some(), "the claim must exist to be lost");
+
+    let older = r.0.with_extension("older-checkout");
+    r.git(&[
+        "worktree",
+        "add",
+        "--detach",
+        older.to_str().unwrap(),
+        &before_the_task,
+    ]);
+
+    // Another agent, running `check` from that checkout. It sees no tasks at
+    // all, and must still not touch a ref it cannot judge.
+    let out = r.ank_at("codex@host-9", &["check"], &older);
+    assert_eq!(code(&out), 0, "{}{}", stdout(&out), stderr(&out));
+    assert!(
+        !stdout(&out).contains("pruned"),
+        "nothing to prune from a checkout that cannot see the corpus: {}",
+        stdout(&out)
+    );
+    assert!(
+        r.claim_ref(ID).is_some(),
+        "the claim survives a check run from a checkout older than the task"
+    );
+
+    r.git(&["worktree", "remove", "--force", older.to_str().unwrap()]);
+
+    // The other half, or the fix would be "never prune". A ref whose task the
+    // default branch really has lost is still collected, and the live one is
+    // still left alone in the same pass.
+    let gone = "TASK-00000000dead";
+    r.seed_task(gone, Some("A verifiable criterion."));
+    let out = r.ank("codex@host-9", &["claim", gone]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    std::fs::remove_file(r.0.join(".ank/tasks").join(format!("{gone}.md"))).unwrap();
+    r.git(&["add", "-A"]);
+    r.git(&["-c", "commit.gpgsign=false", "commit", "-qm", "drop it"]);
+
+    let out = r.ank("claude-code@ank", &["check"]);
+    assert_eq!(code(&out), 0, "{}{}", stdout(&out), stderr(&out));
+    assert!(
+        r.claim_ref(gone).is_none(),
+        "a real orphan is still collected: {}",
+        stdout(&out)
+    );
+    assert!(r.claim_ref(ID).is_some(), "and the live claim still is not");
 }
 
 #[test]


### PR DESCRIPTION
Closes TASK-52fbffbfdf65.

## The defect

`maintain` deleted a claim ref whenever its task was absent from the working tree:

```rust
// An orphan: a ref for a task that no longer exists anywhere.
if !statuses.contains_key(id) { ... prune ... }
```

`statuses` is built from the entities on disk in the current checkout, so the code answered *"does not exist here"* while the comment claimed *"does not exist anywhere"*. `refs/ank/` is shared by every worktree of a repository, so a checkout older than a task reached into the coordination plane of the current one and collected a claim someone was actively holding.

Not hypothetical: it happened three times while diagnosing TASK-1ea38a17d854, each time on a live claim, twice forcing a retake before `done` could run. A lost claim is a task two agents can hold at once.

## The fix

The orphan test now asks the default branch through `git::file_at` — the same source and the same call the `settled` test immediately below it already makes, one step earlier.

| answer | meaning | action |
|---|---|---|
| `Ok(Some(_))` | the default branch carries the task; this checkout is merely older than it | keep, silently |
| `Ok(None)` | no branch carries it | prune, as before |
| `Err(_)` | the branch cannot be read | keep, and report once |

Silence on the first row is deliberate: a signal there would fire on every `check` run from every branch created before the task. Keeping the ref on the third is the reader's behaviour §2 asks for — unable to ask is not permission to delete.

## The test

`a_check_from_an_older_checkout_leaves_a_live_claim_alone`, through the binary, from a real detached worktree at a commit predating the task, with the ref read back by git rather than through `claim::read`.

Reverting `human.rs` alone with the test in place turns it red with `pruned refs/ank/claims/TASK-000000000001` — the incident's exact line.

It carries the other half too, or the fix could have been "never prune": a task whose file is deleted and whose deletion is committed to the default branch is still collected, in the same pass that leaves the live claim alone.

## Verification

`cargo test --workspace` green (206 + 28 + 3 + 3 + 12), `cargo fmt --check` clean, `ank check` exit 0.

This task declares no `verify:` list, so `ank done` refused to grade itself (`error[5]: proof required`). The proof will be this PR's CI run, attached before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QoJrx7uZpTu7ZEzie8TpKH