### PR TITLE
Failing to ask about a signature is now an answer, not silence

### DIFF
--- a/.ank/tasks/TASK-c92b7cc10f13.md
+++ b/.ank/tasks/TASK-c92b7cc10f13.md
@@ -5,15 +5,19 @@ slug: a-git-failure-in-the-signature-read-degrades-to
 title: A git failure in the signature read degrades to no verdict at all
 created: 2026-08-02T22:31:49Z
 author: seanl@sean-laptop
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/src/human.rs
 blocked_by: []
 done_criteria: |
   When the signature of a reachable ratification commit cannot be read because git fails, check says so rather than staying silent. The case is built and run through the binary.
 criteria_by: creator
+proof:
+  - type: test
+    ref: ci://github/30771892857
+    criteria: 2a27f2aeed48
 schema: 2
-version: 3
+version: 4
 ---
 
 Found by reading while diagnosing TASK-1ea38a17d854, not by an incident.
@@ -28,3 +32,4 @@ The fix is probably a sixth state or a second corpus counter, not a fault: a bro
 
 ## Log
 - 2026-08-02T23:14:41Z seanl@sean-laptop — Fixed: signature_state no longer ends in .ok()? -- a git failure becomes Signature::Unreadable { reason }, a sixth state, and check_adr counts it into report.unreadable_signatures with the first reason kept. One corpus line, like unchecked_signatures and for the same reason: 'N ratification signature(s) could not be read, so they are neither verified nor refused: <git's own message>'. A signal, not a fault -- a broken environment is not a forged ratification, and exiting 8 would fail the check-repo verifier of every task on a machine whose only defect is its gpg config. Kept apart from Unchecked on purpose: no key for an answer is not the same as no answer. The test lever is a gpg.format git rejects, one of the causes named when the task was filed. Measured before using it: with gpg.format=bogus in the repo config, rev-list --full-history, cat-file, rev-parse, for-each-ref and symbolic-ref all still exit 0, and only the signature read exits 128 -- so the corpus is still read and the ratification commit still reached, and nothing but the signature path is under test. Proved by reverting human.rs alone: the test fails with 'check: ok' and no mention of the ADR, the silence the task was filed for. Note for later: the status check in git::signature_of is load-bearing beyond this. With gpg.format=bogus git prints 'commit <sha>' and no placeholder lines, so a parser trusting the output would read the missing %G? as N and accuse a perfectly signed ratification of being unsigned.
+- 2026-08-02T23:18:52Z seanl@sean-laptop — done, proof test:ci://github/30771892857

--- a/.ank/tasks/TASK-c92b7cc10f13.md
+++ b/.ank/tasks/TASK-c92b7cc10f13.md
@@ -5,7 +5,7 @@ slug: a-git-failure-in-the-signature-read-degrades-to
 title: A git failure in the signature read degrades to no verdict at all
 created: 2026-08-02T22:31:49Z
 author: seanl@sean-laptop
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/src/human.rs
 blocked_by: []
@@ -13,7 +13,7 @@ done_criteria: |
   When the signature of a reachable ratification commit cannot be read because git fails, check says so rather than staying silent. The case is built and run through the binary.
 criteria_by: creator
 schema: 2
-version: 1
+version: 3
 ---
 
 Found by reading while diagnosing TASK-1ea38a17d854, not by an incident.
@@ -25,3 +25,6 @@ This is the shape ADR-6b3f and the Unchecked case both refuse elsewhere: "a veri
 It is narrow: freeze_state has already reached the same commit through the same memo, so a git that answers there usually answers here. Narrow is not never -- a bad allowed_signers path, a gpg.format git refuses, an object read that fails mid-run -- and the cost of being wrong is silence on the one case the whole mechanism exists for.
 
 The fix is probably a sixth state or a second corpus counter, not a fault: a broken environment is not a forged ratification, and reporting one as the other is how a finding becomes noise. Whatever it becomes, it must not be nothing.
+
+## Log
+- 2026-08-02T23:14:41Z seanl@sean-laptop — Fixed: signature_state no longer ends in .ok()? -- a git failure becomes Signature::Unreadable { reason }, a sixth state, and check_adr counts it into report.unreadable_signatures with the first reason kept. One corpus line, like unchecked_signatures and for the same reason: 'N ratification signature(s) could not be read, so they are neither verified nor refused: <git's own message>'. A signal, not a fault -- a broken environment is not a forged ratification, and exiting 8 would fail the check-repo verifier of every task on a machine whose only defect is its gpg config. Kept apart from Unchecked on purpose: no key for an answer is not the same as no answer. The test lever is a gpg.format git rejects, one of the causes named when the task was filed. Measured before using it: with gpg.format=bogus in the repo config, rev-list --full-history, cat-file, rev-parse, for-each-ref and symbolic-ref all still exit 0, and only the signature read exits 128 -- so the corpus is still read and the ratification commit still reached, and nothing but the signature path is under test. Proved by reverting human.rs alone: the test fails with 'check: ok' and no mention of the ADR, the silence the task was filed for. Note for later: the status check in git::signature_of is load-bearing beyond this. With gpg.format=bogus git prints 'commit <sha>' and no placeholder lines, so a parser trusting the output would read the missing %G? as N and accuse a perfectly signed ratification of being unsigned.

--- a/crates/ank-cli/src/human.rs
+++ b/crates/ank-cli/src/human.rs
@@ -89,6 +89,13 @@ pub struct Report {
     /// Ratification signatures no local key could check. Accumulated across the
     /// corpus and reported once (§4), never per ADR.
     pub unchecked_signatures: usize,
+    /// Ratification signatures git refused to answer about at all. Counted
+    /// apart from `unchecked_signatures` because the two are different
+    /// failures: no key for the answer, versus no answer.
+    pub unreadable_signatures: usize,
+    /// What git said the first time it refused, so the one corpus line can name
+    /// the cause instead of only reporting that there was one.
+    pub signature_failure: Option<String>,
 }
 
 impl Report {
@@ -278,6 +285,21 @@ pub fn inspect(repo: &Repo, cfg: &Config, path: Option<&str>, prune: bool) -> Re
         ));
     }
 
+    // Same rule, other cause: git was asked and did not answer. Silence here
+    // was the defect — an ADR whose signature could not be read used to look
+    // exactly like one in a corpus that declares no key at all.
+    if report.unreadable_signatures > 0 {
+        let n = report.unreadable_signatures;
+        let why = report.signature_failure.as_deref().unwrap_or("git failed");
+        report.findings.push(Finding::signal(
+            "allowed_signers",
+            format!(
+                "{n} ratification signature(s) could not be read, so they are \
+                 neither verified nor refused: {why}"
+            ),
+        ));
+    }
+
     // Maintenance last, so a corpus fault is still reported when pruning cannot
     // run for want of a default branch.
     match &default_branch {
@@ -358,10 +380,11 @@ pub fn parse_signers(text: &str) -> Vec<Signer> {
 
 /// What a ratification commit's signature is worth.
 ///
-/// Five states and not three, because collapsing any two of them loses the
+/// Six states and not three, because collapsing any two of them loses the
 /// distinction the check exists to draw. `Unchecked` in particular must never
 /// read as `Trusted`: a verification that degrades to success on a machine
-/// missing a public key is not a verification.
+/// missing a public key is not a verification. `Unreadable` is the same rule
+/// applied to the error path, where the degradation was to silence.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Signature {
     /// Good signature from a key `allowed_signers` declares.
@@ -374,6 +397,13 @@ pub enum Signature {
     Absent,
     /// Present, checkable, and refused: bad, expired or revoked.
     Invalid { status: char },
+    /// Git could not be asked at all: it exited non-zero instead of answering.
+    /// Not a verdict about the commit — a verdict about this machine.
+    ///
+    /// The one state `classify_signature` never produces, because it is the
+    /// absence of the facts that function classifies. It exists so that a
+    /// failure to ask is something rather than nothing (TASK-c92b7cc10f13).
+    Unreadable { reason: String },
 }
 
 /// Turns git's facts into the verdict, against the declared keys.
@@ -816,6 +846,16 @@ fn check_adr(
         // still never silence, because a verification that degrades to success
         // is not a verification.
         Some(Signature::Unchecked) => report.unchecked_signatures += 1,
+
+        // Counted for the same reason, and kept apart from `Unchecked` because
+        // they say different things: one machine holds no key for a signature
+        // that is there, the other could not look. Neither is a fault — a
+        // broken environment is not a forged ratification, and reporting one as
+        // the other is how a finding becomes noise. But it is never nothing.
+        Some(Signature::Unreadable { reason }) => {
+            report.unreadable_signatures += 1;
+            report.signature_failure.get_or_insert(reason);
+        }
 
         Some(Signature::Trusted) | None => {}
     }
@@ -1609,8 +1649,16 @@ pub fn signature_state(repo: &Repo, adr: &Adr) -> Option<Signature> {
     }
 
     let sha = ratification_of(repo, adr)?.sha;
-    let facts = git::signature_of(&repo.root, &sha, Some(&signers)).ok()?;
-    Some(classify_signature(&facts, &declared))
+    // `.ok()?` here used to fold every git failure into `None`, the one verdict
+    // `check_adr` says nothing about — so a machine where the signature could
+    // not be read looked exactly like a corpus that declared no key at all
+    // (TASK-c92b7cc10f13). Failing to ask has to survive as an answer.
+    match git::signature_of(&repo.root, &sha, Some(&signers)) {
+        Ok(facts) => Some(classify_signature(&facts, &declared)),
+        Err(e) => Some(Signature::Unreadable {
+            reason: e.to_string(),
+        }),
+    }
 }
 
 /// Hash of `constraint` + `scope`, normalised. What the ratification commit
@@ -3452,8 +3500,11 @@ mod tests {
         }
     }
 
-    /// Every state, and each one distinguishable from the others. Pure, so the
-    /// five live here rather than behind five fixtures with five keyrings.
+    /// Every state git's facts can produce, and each one distinguishable from
+    /// the others. Pure, so the five live here rather than behind five fixtures
+    /// with five keyrings. The sixth, `Unreadable`, is the absence of those
+    /// facts and so cannot appear here: it is covered through the binary, where
+    /// a git that refuses to answer is something one can actually arrange.
     #[test]
     fn every_signature_state_is_distinguished() {
         let fp = "739A603FB05F9F2F7D3C8D50624FCFCC1482554A";

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -366,6 +366,78 @@ fn a_ratification_commit_stripped_of_its_signature_is_a_fault_through_the_binary
     );
 }
 
+/// Git refusing to answer is an answer, and it used to be silence
+/// (TASK-c92b7cc10f13).
+///
+/// `signature_state` ended in `.ok()?`, so any failure of the git invocation
+/// became `None` — the one verdict `check_adr` says nothing about. An ADR whose
+/// signature could not be read was indistinguishable from one in a corpus that
+/// declares no key at all, which is the degradation to success ADR-6b3f refuses
+/// and the `Unchecked` counter already exists to prevent one level down.
+///
+/// The lever is a `gpg.format` git rejects, one of the causes the task named.
+/// It is surgical: `rev-list --full-history`, `cat-file`, `rev-parse` and
+/// `for-each-ref` all still answer, so the corpus is read normally and the
+/// ratification commit is still reached — only the signature read exits
+/// non-zero. That is exactly the state under test, and no other.
+///
+/// A signal and not a fault, deliberately: a broken environment is not a forged
+/// ratification, and exiting 8 over one would fail the `check-repo` verifier of
+/// every task on a machine missing nothing but a working gpg config.
+#[test]
+fn a_signature_git_cannot_read_is_reported_rather_than_passed_over() {
+    const ADR: &str = "ADR-0000000000ef";
+    let r = Repo::new();
+    r.enable_signing();
+    r.seed_adr(ADR, "Do not do X.", "src/**");
+    std::fs::create_dir_all(r.0.join("src")).unwrap();
+    std::fs::write(r.0.join("src/main.rs"), "fn main() {}\n").unwrap();
+    declare_signing_key(&r);
+    r.git(&["add", "-A"]);
+    r.git(&["-c", "commit.gpgsign=false", "commit", "-qm", "seed"]);
+
+    let out = r.ank("marie@laptop", &["accept", ADR]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+
+    // Readable and trusted: the silence below has to be broken by the config
+    // change and by nothing else.
+    let out = r.ank("claude-code@ank", &["check"]);
+    assert_eq!(code(&out), 0, "{}{}", stdout(&out), stderr(&out));
+    assert!(
+        !stdout(&out).contains("could not be read"),
+        "{}",
+        stdout(&out)
+    );
+
+    r.git(&["config", "gpg.format", "bogus"]);
+
+    let out = r.ank("claude-code@ank", &["check"]);
+    let said = stdout(&out);
+    assert!(
+        said.contains("could not be read"),
+        "a signature git refuses to answer about must be reported: {said}"
+    );
+    assert!(
+        said.contains("neither verified nor refused"),
+        "and it must say what that leaves undecided: {said}"
+    );
+    assert!(
+        said.contains("gpg.format"),
+        "carrying git's own reason, or the reader cannot act on it: {said}"
+    );
+
+    // Not a fault, and not confused with the missing-key case either.
+    assert_eq!(
+        code(&out),
+        0,
+        "a broken environment is not a forgery: {said}"
+    );
+    assert!(
+        !said.contains("not signed") && !said.contains("no public key"),
+        "an unread signature is not an absent one: {said}"
+    );
+}
+
 /// A claim is not an orphan just because this checkout is too old to have
 /// heard of the task (TASK-52fbffbfdf65).
 ///


### PR DESCRIPTION
Closes TASK-c92b7cc10f13.

## The defect

```rust
let facts = git::signature_of(&repo.root, &sha, Some(&signers)).ok()?;
```

Any failure of that git invocation became `None` — and `None` is the one verdict `check_adr` says nothing about. An ADR whose signature could not be read was indistinguishable from one in a corpus that declares no key at all: no fault, no signal, no count.

That is the degradation ADR-6b3f refuses, and precisely the one the `Unchecked` counter already exists to prevent one level down. *"A verification that degrades to success is not a verification"* — here it degraded on the error path instead of the status path, so nobody had noticed.

Found by reading while diagnosing TASK-1ea38a17d854, not by an incident.

## The fix

A sixth state, `Signature::Unreadable { reason }`, and a second corpus counter beside `unchecked_signatures`. The two are kept apart because they say different things: **no key for an answer** is not **no answer**.

```
signal: allowed_signers: 1 ratification signature(s) could not be read, so they are
        neither verified nor refused: git ... failed: error: invalid value for 'gpg.format'
```

One line for the corpus rather than one per ADR (§4), carrying git's own message so the reader can act on it. A **signal, not a fault**: a broken environment is not a forged ratification, and exiting 8 over one would fail the `check-repo` verifier of every task in the repository on a machine whose only defect is its gpg config.

## The test

Through the binary, with a `gpg.format` git rejects — one of the causes named when the task was filed.

The lever was measured before being relied on. With that config in place:

| command | exit |
|---|---|
| `rev-list --full-history` | 0 |
| `cat-file commit` | 0 |
| `rev-parse` | 0 |
| `for-each-ref` | 0 |
| `symbolic-ref` | 0 |
| the signature read | **128** |

So the corpus is still read normally and the ratification commit is still reached; nothing but the signature path is under test. The test also holds the negative: exit stays 0, and the message is neither `not signed` nor the missing-key line.

Reverting `human.rs` alone with the test in place turns it red with `check: ok` and no mention of the ADR — the exact silence the task was filed for.

## Worth knowing

The `!out.status.success()` guard in `git::signature_of` is load-bearing beyond this fix. With `gpg.format=bogus`, git prints `commit <sha>` and then no placeholder lines at all — so a parser that trusted the output would read the missing `%G?` as `N` and accuse a perfectly signed ratification of being unsigned.

## Verification

`cargo test --workspace` green (206 + 29 + 3 + 3 + 12), `cargo fmt --check` clean, `ank check` exit 0.

No `verify:` list on this task either, so the proof will be this PR's CI run, attached before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QoJrx7uZpTu7ZEzie8TpKH