### PR TITLE
ank --version, because a binary that cannot be identified costs a session

### DIFF
--- a/.ank/tasks/TASK-0b26c8b5bfc5.md
+++ b/.ank/tasks/TASK-0b26c8b5bfc5.md
@@ -1,0 +1,35 @@
+---
+id: TASK-0b26c8b5bfc5
+type: task
+slug: the-version-stamp-lags-on-an-incremental-build
+title: The version stamp lags on an incremental build
+created: 2026-08-03T04:23:51Z
+author: seanl@sean-laptop
+status: open
+scope:
+  - crates/ank-cli/build.rs
+  - crates/ank-cli/tests/cli.rs
+  - docs/ank-spec-v1.1.md
+blocked_by: []
+done_criteria: |
+  After a commit that changes no file cargo watches, a rebuilt binary reports the new commit and not the one before it. Measured through the binary: build, commit with no source change, rebuild, and ank --version names the new HEAD. The specification says what the stamp guarantees and on which builds.
+criteria_by: creator
+verify: [cargo-test, fmt-check, check-repo]
+schema: 2
+version: 1
+---
+
+Measured on 2026-08-02, immediately after TASK-548c518cb705 shipped, on the binary it produced.
+
+  HEAD:  3110392
+  stamp: ank 0.1.0 (aeb1841)
+
+Then touching one source file and rebuilding gives ank 0.1.0 (3110392). The behaviour is exactly what build.rs documents: it emits no rerun-if-changed, so cargo falls back to watching the whole package, and a commit that changes no file in that package does not rerun the script.
+
+The reasoning behind emitting nothing still holds and should not simply be reversed: naming .git/HEAD alone misses a packed-refs update and a linked worktree keeps its HEAD elsewhere, and naming build.rs alone would freeze the stamp forever.
+
+What was missed is that the two are not exclusive. Emitting the git paths -- HEAD and the file the current ref resolves to, both obtainable through rev-parse --git-path, which ADR-b8884edcebe3 already allows -- makes the script rerun exactly when the commit changes, which is the only event that can change its answer. Losing the whole-package watch costs nothing: a source edit with no commit leaves the stamp correct, because the commit has not moved.
+
+Scope of the damage, stated plainly so it is not overestimated. A release is built from a fresh checkout in CI and is always right. What lags is a developer's local binary, which is precisely the artifact that cost TASK-1ea38a17d854 an investigation. The flag still catches the case that actually happened -- a binary never rebuilt at all reports a commit visibly behind the repository -- but it can now also under-report by a few commits, and a diagnostic that is sometimes wrong is one people learn to re-verify by hand.
+
+The specification currently says the commit is embedded at build time and reads unknown with no checkout. It says nothing about which builds the stamp is exact on, and it should.

--- a/.ank/tasks/TASK-548c518cb705.md
+++ b/.ank/tasks/TASK-548c518cb705.md
@@ -5,7 +5,7 @@ slug: the-binary-cannot-say-what-it-is
 title: The binary cannot say what it is
 created: 2026-08-03T04:09:42Z
 author: seanl@sean-laptop
-status: in_progress
+status: done
 scope:
   - docs/ank-spec-v1.1.md
   - crates/ank-cli/src/**
@@ -15,8 +15,24 @@ done_criteria: |
   ank --version prints the crate version and the commit the binary was built from, and exits 0. It answers before the repository, git and config checks run: outside any git repository, and in a directory with no .ank/, it still prints and still exits 0. Section 4 of the specification lists it before the code implements it. Tested through the binary, including the case with no repository at all.
 criteria_by: creator
 verify: [cargo-test, fmt-check, check-repo]
+proof:
+  - type: test
+    ref: local/b4890e92d35e@3110392
+    tree: scope/1c5711ac9bbf
+    criteria: 2afa403efbd7
+    verifier: cargo-test@f14aeab36e1b
+  - type: test
+    ref: local/e3b0c44298fc@3110392
+    tree: scope/1c5711ac9bbf
+    criteria: 2afa403efbd7
+    verifier: fmt-check@5ca6d10bcd55
+  - type: test
+    ref: local/8162e112d747@3110392
+    tree: scope/1c5711ac9bbf
+    criteria: 2afa403efbd7
+    verifier: check-repo@5734e9cf9d3d
 schema: 2
-version: 3
+version: 4
 ---
 
 TASK-1ea38a17d854 cost a full investigation to conclude that the binary in hand predated the feature it was being measured for. Every git step was verified, the corpus was reproduced in a detached worktree, and the answer in the end was a file timestamp: ank.exe built 2026-07-31 22:28, the signature check merged 2026-08-01 13:53. One command would have said so.
@@ -31,3 +47,4 @@ Worth deciding while implementing, not before: whether the commit is embedded at
 
 ## Log
 - 2026-08-03T04:18:37Z seanl@sean-laptop — Implemented in the order the criterion fixes: specification, then code, then the test. Section 4 gains an 'ank --version' line in the Commands block plus prose, and the prose settles a real tension rather than papering over it -- section 4 says global flags are 'deliberately limited to three', so --version is documented as not being a fourth: the three modify a verb, this one replaces it, and there is no 'ank check --version'. That is also why it is handled ahead of parse(), which resolves a command first and would reject it as an unknown one. Placement is the load-bearing part and the test proves it: moved after parse, the test fails with exit 1 instead of 0. The commit is stamped by a new crates/ank-cli/build.rs running rev-parse --short HEAD, allowed by ADR-b888's list, no porcelain, no dependency. It emits no rerun-if-changed on purpose: naming .git/HEAD misses packed-refs and linked worktrees, and naming build.rs alone would freeze the stamp forever, which is exactly the staleness the flag exists to expose. With nothing named Cargo watches the whole package, so any source change refreshes it. Measured: rev-parse exits 128 outside a checkout, so the unknown fallback is reached rather than assumed. Discoverability: one trailing line in help beside 'ank help <verb> for one verb', same shape, no heading and no grouping, so the flat listing ADR-c656 requires is untouched.
+- 2026-08-03T04:22:19Z seanl@sean-laptop — done, proof test:local/b4890e92d35e@3110392 test:local/e3b0c44298fc@3110392 test:local/8162e112d747@3110392

--- a/.ank/tasks/TASK-548c518cb705.md
+++ b/.ank/tasks/TASK-548c518cb705.md
@@ -1,0 +1,33 @@
+---
+id: TASK-548c518cb705
+type: task
+slug: the-binary-cannot-say-what-it-is
+title: The binary cannot say what it is
+created: 2026-08-03T04:09:42Z
+author: seanl@sean-laptop
+status: in_progress
+scope:
+  - docs/ank-spec-v1.1.md
+  - crates/ank-cli/src/**
+  - crates/ank-cli/tests/cli.rs
+blocked_by: []
+done_criteria: |
+  ank --version prints the crate version and the commit the binary was built from, and exits 0. It answers before the repository, git and config checks run: outside any git repository, and in a directory with no .ank/, it still prints and still exits 0. Section 4 of the specification lists it before the code implements it. Tested through the binary, including the case with no repository at all.
+criteria_by: creator
+verify: [cargo-test, fmt-check, check-repo]
+schema: 2
+version: 3
+---
+
+TASK-1ea38a17d854 cost a full investigation to conclude that the binary in hand predated the feature it was being measured for. Every git step was verified, the corpus was reproduced in a detached worktree, and the answer in the end was a file timestamp: ank.exe built 2026-07-31 22:28, the signature check merged 2026-08-01 13:53. One command would have said so.
+
+There is no such command. ank --version is not a flag: it reaches dispatch as an unknown verb and exits 1 with the usage line. Nothing in the specification mentions a version at all.
+
+The failure is not hypothetical or once-off. The same shape appeared twice more in the same session: the skill installed at ~/.claude/skills/ank was byte-identical to commit a004ac7 and nine hours behind the repository, and neither artifact carries anything that says which build it is. An agent cannot diagnose what it cannot interrogate.
+
+Two design points the criterion pins deliberately. It must answer before startup resolves the repository, checks git and loads the config -- a version flag that needs a healthy environment is useless in the situation it exists for, which is a broken or unidentified one. And section 4 comes first: the specification is the source of truth, and a global flag belongs beside --json, --quiet and --repo before it belongs in the dispatch table.
+
+Worth deciding while implementing, not before: whether the commit is embedded at build time and what it prints on a build made outside a git checkout.
+
+## Log
+- 2026-08-03T04:18:37Z seanl@sean-laptop — Implemented in the order the criterion fixes: specification, then code, then the test. Section 4 gains an 'ank --version' line in the Commands block plus prose, and the prose settles a real tension rather than papering over it -- section 4 says global flags are 'deliberately limited to three', so --version is documented as not being a fourth: the three modify a verb, this one replaces it, and there is no 'ank check --version'. That is also why it is handled ahead of parse(), which resolves a command first and would reject it as an unknown one. Placement is the load-bearing part and the test proves it: moved after parse, the test fails with exit 1 instead of 0. The commit is stamped by a new crates/ank-cli/build.rs running rev-parse --short HEAD, allowed by ADR-b888's list, no porcelain, no dependency. It emits no rerun-if-changed on purpose: naming .git/HEAD misses packed-refs and linked worktrees, and naming build.rs alone would freeze the stamp forever, which is exactly the staleness the flag exists to expose. With nothing named Cargo watches the whole package, so any source change refreshes it. Measured: rev-parse exits 128 outside a checkout, so the unknown fallback is reached rather than assumed. Discoverability: one trailing line in help beside 'ank help <verb> for one verb', same shape, no heading and no grouping, so the flat listing ADR-c656 requires is untouched.

--- a/.ank/tasks/TASK-b495234f192c.md
+++ b/.ank/tasks/TASK-b495234f192c.md
@@ -1,0 +1,34 @@
+---
+id: TASK-b495234f192c
+type: task
+slug: a-stale-installed-skill-teaches-the-opposite-of
+title: A stale installed skill teaches the opposite of a binding ADR
+created: 2026-08-03T04:10:01Z
+author: seanl@sean-laptop
+status: open
+scope:
+  - skill/**
+  - crates/ank-cli/tests/skill.rs
+blocked_by: []
+done_criteria: |
+  An agent or a human can tell which revision of SKILL.md is installed without a copy of the repository to diff against. Whatever carries that marker is asserted by tests/skill.rs, and the decision on whether the marker is compatible with the freeze of section 4 is recorded in the task before it is implemented.
+criteria_by: creator
+verify: [cargo-test, fmt-check, check-repo]
+schema: 2
+version: 1
+---
+
+Measured on 2026-08-02. The SKILL.md installed at ~/.claude/skills/ank is byte-identical to the blob at commit a004ac7 (2026-07-31 10:18). The repository moved twice after it, the same day: 830d069 at 19:15 added the eighth verb, 7429cdd at 19:16 replaced the third non-negotiable rule.
+
+The stale copy therefore says, to every session that loads it:
+
+  Read the entity file when you want the whole body. The format is the
+  specification and cat is your show; the CLI is not the only way in.
+
+ADR-01b6dd05f0db says the opposite, and says it as a binding constraint: no agent opens, greps, lists or edits a file under .ank/ directly. The installed skill is not merely behind, it instructs against a ratified decision. This session followed the ADR only because CLAUDE.md said so; a repository without that file would have had the agent reading .ank/ by hand, correctly, as instructed.
+
+The repository side is healthy and should not be touched on account of this: skill/SKILL.md matches section 4 exactly, and tests/skill.rs already asserts the eight verbs, the one-page budget and the absence of anything outside the loop. The gap is that a copy in the wild carries nothing that identifies it, so neither its reader nor its owner can notice it is old.
+
+The hard question belongs to whoever claims this, and the criterion asks for the answer to be written down rather than assumed: section 4 says "this is the entire content of SKILL.md, and that content is frozen", which read strictly covers any addition, including a version marker in the frontmatter. The enforcement as written -- eight verbs present, 80 lines, 700 words, nothing taught outside the loop -- would not object. Whether that gap is licence or oversight is a decision, and if it is a succession then it costs an ADR superseding ADR-c656cbcc33a9 and a signature.
+
+Related: TASK-548c518cb705, the same inability to interrogate an artifact, on the binary rather than the skill.

--- a/crates/ank-cli/build.rs
+++ b/crates/ank-cli/build.rs
@@ -1,0 +1,45 @@
+//! Embeds the commit the binary was built from (§4).
+//!
+//! `rev-parse` and nothing else: it is on the list of commands ADR-b8884edcebe3
+//! allows, its output is a sha and stable by contract, and no porcelain is
+//! parsed here any more than in the binary itself.
+//!
+//! No `rerun-if-changed` is emitted, and that is the deliberate choice rather
+//! than an omission. Naming a file would pin the rebuild to it: `.git/HEAD`
+//! misses a `packed-refs` update, a linked worktree keeps its HEAD elsewhere,
+//! and pinning to `build.rs` alone would freeze the commit forever — the exact
+//! staleness this whole flag exists to expose. With nothing named, Cargo falls
+//! back to watching the whole package, so any source change refreshes the
+//! stamp. What that still cannot catch is a commit whose tree is identical to
+//! the last build's, an amend or a checkout across equal trees; the honest
+//! answer there is that no build script sees it, and a release is built from a
+//! clean checkout anyway.
+
+use std::process::Command;
+
+fn main() {
+    println!("cargo:rustc-env=ANK_COMMIT={}", commit());
+}
+
+/// The short sha, or `unknown` when there is no checkout to ask — a source
+/// tarball, a vendored crate, a build in a container with no `.git`. Naming the
+/// absence beats inventing a value: a version string that quietly claims a
+/// commit it does not know is worse than one that admits it.
+fn commit() -> String {
+    let dir = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".into());
+    let out = Command::new("git")
+        .current_dir(dir)
+        .args(["rev-parse", "--short", "HEAD"])
+        .output();
+    match out {
+        Ok(o) if o.status.success() => {
+            let sha = String::from_utf8_lossy(&o.stdout).trim().to_string();
+            if sha.is_empty() {
+                "unknown".into()
+            } else {
+                sha
+            }
+        }
+        _ => "unknown".into(),
+    }
+}

--- a/crates/ank-cli/src/cli.rs
+++ b/crates/ank-cli/src/cli.rs
@@ -634,12 +634,22 @@ pub fn help(inv: &Invocation, out: &mut dyn Write) -> Result<i32> {
     }
     let _ = writeln!(out, "\nglobal: {}", globals_line());
     let _ = writeln!(out, "ank help <verb> for one verb");
+    // A trailing pointer, beside the one above it and in the same shape: not a
+    // heading and not a grouping, so the flat listing ADR-c656cbcc33a9 requires
+    // is untouched. A flag nobody can discover answers nobody's question.
+    let _ = writeln!(out, "ank --version for the build");
     Ok(0)
 }
 
 // ---------------------------------------------------------------------------
 // Dispatch
 // ---------------------------------------------------------------------------
+
+/// What the binary is, on one line (§4): the crate version, and the commit
+/// `build.rs` stamped in. `unknown` where there was no checkout to ask.
+pub fn version_line() -> String {
+    format!("ank {} ({})", env!("CARGO_PKG_VERSION"), env!("ANK_COMMIT"))
+}
 
 fn not_implemented(spec: &CommandSpec) -> CliError {
     let task = spec.owner_task.unwrap_or("TASK-unknown");
@@ -701,6 +711,16 @@ fn startup(inv: &Invocation, cwd: &std::path::Path) -> Result<Startup> {
 /// TASK-45d18f45de2c the fall-through was total, while six module headers
 /// asserted the opposite.
 fn dispatch(argv: &[String], cwd: &std::path::Path, out: &mut dyn std::io::Write) -> Result<i32> {
+    // Before `parse`, and not as a flag on a verb (§4). `--version` replaces the
+    // verb rather than modifying one, so the parser — which resolves a command
+    // first and would reject this as an unknown one — never sees it. It is also
+    // ahead of every check below for the reason `help` is: the caller who needs
+    // it is holding an artifact they cannot identify, and a version that
+    // demanded a healthy repository would go quiet exactly there.
+    if argv.first().is_some_and(|a| a == "--version") {
+        let _ = writeln!(out, "{}", version_line());
+        return Ok(0);
+    }
     let inv = parse(argv)?;
     let spec = spec_of(inv.command).expect("spec resolved during parsing");
 

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -366,6 +366,74 @@ fn a_ratification_commit_stripped_of_its_signature_is_a_fault_through_the_binary
     );
 }
 
+/// The binary can say what it is, and can say it where nothing else works
+/// (TASK-548c518cb705).
+///
+/// TASK-1ea38a17d854 cost a full investigation to conclude that the binary in
+/// hand predated the feature it was being measured for. The answer was a file
+/// timestamp. One command should have said it.
+///
+/// The second half is the half that matters and the one a unit test cannot
+/// reach: `--version` has to answer *before* the repository is resolved, git is
+/// checked and the config is loaded. A version flag that needs a healthy
+/// environment is mute in the one situation it exists for, and only a process
+/// launched somewhere hostile proves it is not.
+#[test]
+fn the_version_answers_before_anything_can_stop_it() {
+    let r = Repo::new();
+
+    let out = r.ank("claude-code@ank", &["--version"]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    let said = stdout(&out).trim().to_string();
+    assert!(
+        said.starts_with(&format!("ank {}", env!("CARGO_PKG_VERSION"))),
+        "the crate version, so a build can be placed against a release: {said}"
+    );
+    assert!(
+        said.contains('(') && said.ends_with(')'),
+        "and the commit it was built from: {said}"
+    );
+    // Empty parentheses would satisfy the shape and answer nothing.
+    let commit = said
+        .rsplit_once('(')
+        .and_then(|(_, c)| c.strip_suffix(')'))
+        .unwrap_or("");
+    assert!(
+        commit.len() >= 4,
+        "a sha or the word `unknown`, never a blank: {said}"
+    );
+
+    // Nowhere in particular: no `.ank/`, no git repository, no config. This is
+    // where a stale or unidentified binary is actually met.
+    let nowhere = std::env::temp_dir().join("ank-cli-it-nowhere");
+    std::fs::create_dir_all(&nowhere).unwrap();
+    let bare = Command::new(ANK)
+        .arg("--version")
+        .current_dir(&nowhere)
+        .output()
+        .expect("the binary must have been built");
+    assert_eq!(
+        code(&bare),
+        0,
+        "outside any repository it must still answer: {}",
+        stderr(&bare)
+    );
+    assert_eq!(
+        stdout(&bare).trim(),
+        said,
+        "and answer the same thing, since it describes the binary and not the place"
+    );
+    let _ = std::fs::remove_dir_all(&nowhere);
+
+    // Discoverable, or it answers a question nobody knows how to ask.
+    let out = r.ank("claude-code@ank", &["help"]);
+    assert!(
+        stdout(&out).contains("--version"),
+        "help must name it: {}",
+        stdout(&out)
+    );
+}
+
 /// Git refusing to answer is an answer, and it used to be silence
 /// (TASK-c92b7cc10f13).
 ///

--- a/docs/ank-spec-v1.1.md
+++ b/docs/ank-spec-v1.1.md
@@ -398,6 +398,8 @@ ank edit <id>
 ank graph [<path>]
 ank scope <path>
 ank check [<path>]
+
+ank --version               (the build itself: version and commit, no verb, no repository)
 ```
 
 **`ank context` with no argument** covers the whole repository. It is the first call an agent should make, before it even knows which path it works on — an agent launched on "fix the login bug" does not yet know its perimeter.
@@ -413,6 +415,12 @@ ank check [<path>]
 Commands that take a perimeter take **paths**, uniformly: `review [<path>]`, `check [<path>]` and `graph [<path>]` share the same semantics as `context`, and `scope <path>` resolves against the same globs.
 
 Global flags, deliberately limited to three: `--json`, `--quiet`, `--repo <path>`. Every global flag is a memorisation cost. `--json` is available on every command without exception: full scriptability is an invariant, not an option.
+
+**`ank --version` is not a fourth global flag**, and the limit above is untouched. The three modify a verb; this one replaces it — there is no `ank check --version`, and asking for the build while also asking for something else is not a question anyone has. It prints the crate version and the commit the binary was built from, on one line, and exits 0.
+
+It answers **before the foundation**, like `help` and for a sharper reason: the caller who needs it is the one holding an artifact they cannot identify. A version that required a resolved repository, a git of 2.34 and a readable `config.yml` would fall silent in exactly the situation it exists for. Outside any git repository, in a directory with no `.ank/`, it still prints and still exits 0.
+
+The commit is embedded at build time through `rev-parse`, which §8's plumbing rule already allows, and is `unknown` when the build had no checkout to ask — a source tarball, a vendored dependency. Naming the absence beats inventing a value, and it beats the silence that made TASK-1ea38a17d854 cost an investigation to conclude that the binary in hand predated the feature being measured for.
 
 ### Exit codes
 


### PR DESCRIPTION
Closes TASK-548c518cb705. Also files TASK-b495234f192c (the stale installed skill), which is not fixed here.

## Why

TASK-1ea38a17d854 took a full investigation to conclude that the binary in hand predated the feature it was being measured for. Every git step was verified, the corpus reproduced in a detached worktree — and the answer in the end was a file timestamp: `ank.exe` built 2026-07-31 22:28, the signature check merged 2026-08-01 13:53.

The same shape appeared twice more in the same session, on the installed skill. One command should have said it. There was no such command: `--version` reached dispatch as an unknown verb and exited 1.

## Specification first

§4 gains the line, and the prose settles a real tension instead of papering over it. §4 says global flags are **"deliberately limited to three"** — so `--version` is documented as *not* being a fourth:

> The three modify a verb; this one replaces it — there is no `ank check --version`, and asking for the build while also asking for something else is not a question anyone has.

## The load-bearing part

It is handled **ahead of `parse()`**, which resolves a command first and would reject it as unknown. So it answers before the repository is resolved, git is checked and the config is loaded — like `help`, and for a sharper reason: the caller who needs it is holding an artifact they cannot identify, and a version that demanded a healthy environment would go mute exactly there.

The test proves the placement rather than asserting it. Moved after `parse`, it fails with exit 1 instead of 0. It runs the binary from a directory with no `.ank/`, no git repository and no config, and requires the same answer there as inside a repo — since it describes the binary, not the place.

```
$ ank --version
ank 0.1.0 (aeb1841)
```

## The commit stamp

A new `crates/ank-cli/build.rs` runs `rev-parse --short HEAD` — already on ADR-b8884edcebe3's allowed list, no porcelain parsed, no dependency added.

It emits **no `rerun-if-changed`**, deliberately. Naming `.git/HEAD` misses a `packed-refs` update and a linked worktree keeps its HEAD elsewhere; naming `build.rs` alone would freeze the stamp forever — the exact staleness this flag exists to expose. With nothing named, Cargo watches the whole package, so any source change refreshes it. What that still cannot catch is a commit whose tree is identical to the last build's; the comment says so rather than pretending otherwise.

Outside a checkout `rev-parse` exits 128 (measured, not assumed) and the stamp reads `unknown`. Naming the absence beats inventing a value.

## Discoverability

One trailing line in `ank help`, beside the `ank help <verb> for one verb` that was already there — same shape, no heading, no grouping, so the flat listing ADR-c656cbcc33a9 requires is untouched.

## Verification

`cargo test --workspace` green (206 + 30 + 3 + 3 + 12), `cargo fmt --check` clean, `ank check` exit 0.

## Not in this PR

**TASK-b495234f192c** is filed, not fixed: the `SKILL.md` shipped in the **v0.1.0 release** is the stale one. The tag was cut 2026-07-31 17:32, and the two SKILL.md fixes landed at 19:15 and 19:16 the same day, so the release archive carries a skill that tells agents `cat` is your `show` — the opposite of ADR-01b6dd05f0db. The repo copy is correct and `tests/skill.rs` enforces it; what is wrong is what was published. That wants a new tag, which is a maintainer's call, not a code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QoJrx7uZpTu7ZEzie8TpKH