### PR TITLE
The version stamp follows the commit, not the source tree

### DIFF
--- a/.ank/tasks/TASK-0b26c8b5bfc5.md
+++ b/.ank/tasks/TASK-0b26c8b5bfc5.md
@@ -5,7 +5,7 @@ slug: the-version-stamp-lags-on-an-incremental-build
 title: The version stamp lags on an incremental build
 created: 2026-08-03T04:23:51Z
 author: seanl@sean-laptop
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/build.rs
   - crates/ank-cli/tests/cli.rs
@@ -16,7 +16,7 @@ done_criteria: |
 criteria_by: creator
 verify: [cargo-test, fmt-check, check-repo]
 schema: 2
-version: 1
+version: 3
 ---
 
 Measured on 2026-08-02, immediately after TASK-548c518cb705 shipped, on the binary it produced.
@@ -33,3 +33,6 @@ What was missed is that the two are not exclusive. Emitting the git paths -- HEA
 Scope of the damage, stated plainly so it is not overestimated. A release is built from a fresh checkout in CI and is always right. What lags is a developer's local binary, which is precisely the artifact that cost TASK-1ea38a17d854 an investigation. The flag still catches the case that actually happened -- a binary never rebuilt at all reports a commit visibly behind the repository -- but it can now also under-report by a few commits, and a diagnostic that is sometimes wrong is one people learn to re-verify by hand.
 
 The specification currently says the commit is embedded at build time and reads unknown with no checkout. It says nothing about which builds the stamp is exact on, and it should.
+
+## Log
+- 2026-08-03T04:35:19Z seanl@sean-laptop — Fixed by asking git for the paths instead of guessing them. build.rs now emits rerun-if-changed for HEAD, packed-refs and the branch symbolic-ref names, each located through rev-parse --git-path, and only when the file exists -- a rerun-if-changed on a missing path reruns the script every build and would recompile the crate for nothing. Both original objections are answered rather than reversed: measured, --git-path from a linked worktree returns .git/worktrees/<name>/HEAD, which naming .git/HEAD blindly would have missed, and packed-refs is located wherever it lives. On a detached HEAD symbolic-ref exits 1 and there is nothing to add, since the sha is in HEAD, already watched. Losing the package-wide watch costs nothing: a source edit with no commit leaves the stamp correct because the commit has not moved. With no git nothing is emitted and cargo falls back to watching the package, which is right for a tarball where the answer is unknown however often it is recomputed. Measured by hand on the real binary, which is the literal wording of the criterion: HEAD 655ae74 stamp 655ae74, then git commit --allow-empty to f9f64ae, cargo build, stamp f9f64ae. The probe commit was dropped with reset --soft, and the working tree was checked afterwards. The automated regression uses a fixture crate driving the real build.rs file rather than rebuilding ank: rebuilding ank inside its own suite relinks target/debug/ank.exe while other tests execute it, the Windows trap CLAUDE.md documents, and a fresh target dir would rebuild libsqlite3-sys on every CI job of all three platforms. Proved non-vacuous by restoring the shipped build.rs with the test in place: it fails with left 81a6521, right 8d8a77f -- the lag, reproduced.

--- a/.ank/tasks/TASK-0b26c8b5bfc5.md
+++ b/.ank/tasks/TASK-0b26c8b5bfc5.md
@@ -5,7 +5,7 @@ slug: the-version-stamp-lags-on-an-incremental-build
 title: The version stamp lags on an incremental build
 created: 2026-08-03T04:23:51Z
 author: seanl@sean-laptop
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/build.rs
   - crates/ank-cli/tests/cli.rs
@@ -15,8 +15,24 @@ done_criteria: |
   After a commit that changes no file cargo watches, a rebuilt binary reports the new commit and not the one before it. Measured through the binary: build, commit with no source change, rebuild, and ank --version names the new HEAD. The specification says what the stamp guarantees and on which builds.
 criteria_by: creator
 verify: [cargo-test, fmt-check, check-repo]
+proof:
+  - type: test
+    ref: local/32065c4c9a7a@d63fe37
+    tree: scope/c9af8d24c522
+    criteria: 5e07c3a10892
+    verifier: cargo-test@f14aeab36e1b
+  - type: test
+    ref: local/e3b0c44298fc@d63fe37
+    tree: scope/c9af8d24c522
+    criteria: 5e07c3a10892
+    verifier: fmt-check@5ca6d10bcd55
+  - type: test
+    ref: local/23b843f2a59d@d63fe37
+    tree: scope/c9af8d24c522
+    criteria: 5e07c3a10892
+    verifier: check-repo@5734e9cf9d3d
 schema: 2
-version: 3
+version: 4
 ---
 
 Measured on 2026-08-02, immediately after TASK-548c518cb705 shipped, on the binary it produced.
@@ -36,3 +52,4 @@ The specification currently says the commit is embedded at build time and reads 
 
 ## Log
 - 2026-08-03T04:35:19Z seanl@sean-laptop — Fixed by asking git for the paths instead of guessing them. build.rs now emits rerun-if-changed for HEAD, packed-refs and the branch symbolic-ref names, each located through rev-parse --git-path, and only when the file exists -- a rerun-if-changed on a missing path reruns the script every build and would recompile the crate for nothing. Both original objections are answered rather than reversed: measured, --git-path from a linked worktree returns .git/worktrees/<name>/HEAD, which naming .git/HEAD blindly would have missed, and packed-refs is located wherever it lives. On a detached HEAD symbolic-ref exits 1 and there is nothing to add, since the sha is in HEAD, already watched. Losing the package-wide watch costs nothing: a source edit with no commit leaves the stamp correct because the commit has not moved. With no git nothing is emitted and cargo falls back to watching the package, which is right for a tarball where the answer is unknown however often it is recomputed. Measured by hand on the real binary, which is the literal wording of the criterion: HEAD 655ae74 stamp 655ae74, then git commit --allow-empty to f9f64ae, cargo build, stamp f9f64ae. The probe commit was dropped with reset --soft, and the working tree was checked afterwards. The automated regression uses a fixture crate driving the real build.rs file rather than rebuilding ank: rebuilding ank inside its own suite relinks target/debug/ank.exe while other tests execute it, the Windows trap CLAUDE.md documents, and a fresh target dir would rebuild libsqlite3-sys on every CI job of all three platforms. Proved non-vacuous by restoring the shipped build.rs with the test in place: it fails with left 81a6521, right 8d8a77f -- the lag, reproduced.
+- 2026-08-03T04:39:19Z seanl@sean-laptop — done, proof test:local/32065c4c9a7a@d63fe37 test:local/e3b0c44298fc@d63fe37 test:local/23b843f2a59d@d63fe37

--- a/crates/ank-cli/build.rs
+++ b/crates/ank-cli/build.rs
@@ -1,45 +1,81 @@
 //! Embeds the commit the binary was built from (§4).
 //!
-//! `rev-parse` and nothing else: it is on the list of commands ADR-b8884edcebe3
-//! allows, its output is a sha and stable by contract, and no porcelain is
-//! parsed here any more than in the binary itself.
+//! `rev-parse` and `symbolic-ref`, and nothing else: both are on the list of
+//! commands ADR-b8884edcebe3 allows, their output is a sha or a path and stable
+//! by contract, and no porcelain is parsed here any more than in the binary
+//! itself.
 //!
-//! No `rerun-if-changed` is emitted, and that is the deliberate choice rather
-//! than an omission. Naming a file would pin the rebuild to it: `.git/HEAD`
-//! misses a `packed-refs` update, a linked worktree keeps its HEAD elsewhere,
-//! and pinning to `build.rs` alone would freeze the commit forever — the exact
-//! staleness this whole flag exists to expose. With nothing named, Cargo falls
-//! back to watching the whole package, so any source change refreshes the
-//! stamp. What that still cannot catch is a commit whose tree is identical to
-//! the last build's, an amend or a checkout across equal trees; the honest
-//! answer there is that no build script sees it, and a release is built from a
-//! clean checkout anyway.
+//! **What the script watches is the point** (TASK-0b26c8b5bfc5). It first
+//! emitted no `rerun-if-changed` at all, on the argument that naming
+//! `.git/HEAD` misses a `packed-refs` update and that a linked worktree keeps
+//! its HEAD elsewhere. Both objections were true and the conclusion did not
+//! follow: with nothing named, Cargo watches the package instead, and a commit
+//! that changes no file in it never reruns the script — so the stamp lagged,
+//! which is the exact staleness this flag exists to expose. Measured on the
+//! build that shipped it: `HEAD 3110392`, stamp `aeb1841`.
+//!
+//! Asking git for the paths answers both objections at once. `rev-parse
+//! --git-path` resolves `HEAD` to the *current* worktree's HEAD, linked or not,
+//! and names `packed-refs` wherever it lives; `symbolic-ref` gives the branch
+//! file to watch alongside it, and fails on a detached HEAD, where the HEAD file
+//! carries the sha itself and is already watched. Losing the package-wide watch
+//! costs nothing: a source edit with no commit leaves the stamp correct, because
+//! the commit has not moved.
+//!
+//! With no git and no checkout, nothing is emitted and Cargo falls back to
+//! watching the package — the right behaviour for a tarball, where the answer is
+//! `unknown` however often it is recomputed.
 
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 fn main() {
-    println!("cargo:rustc-env=ANK_COMMIT={}", commit());
+    let dir = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".into());
+    println!("cargo:rustc-env=ANK_COMMIT={}", commit(&dir));
+    for path in watched(&dir) {
+        println!("cargo:rerun-if-changed={path}");
+    }
+}
+
+fn git(dir: &str, args: &[&str]) -> Option<String> {
+    let out = Command::new("git")
+        .current_dir(dir)
+        .args(args)
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    (!text.is_empty()).then_some(text)
 }
 
 /// The short sha, or `unknown` when there is no checkout to ask — a source
 /// tarball, a vendored crate, a build in a container with no `.git`. Naming the
 /// absence beats inventing a value: a version string that quietly claims a
 /// commit it does not know is worse than one that admits it.
-fn commit() -> String {
-    let dir = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".into());
-    let out = Command::new("git")
-        .current_dir(dir)
-        .args(["rev-parse", "--short", "HEAD"])
-        .output();
-    match out {
-        Ok(o) if o.status.success() => {
-            let sha = String::from_utf8_lossy(&o.stdout).trim().to_string();
-            if sha.is_empty() {
-                "unknown".into()
-            } else {
-                sha
-            }
-        }
-        _ => "unknown".into(),
+fn commit(dir: &str) -> String {
+    git(dir, &["rev-parse", "--short", "HEAD"]).unwrap_or_else(|| "unknown".into())
+}
+
+/// The files whose change can change the answer, and no others.
+///
+/// Only paths that exist are emitted. A `rerun-if-changed` on a missing file
+/// reruns the script on every build, which would recompile the crate every time
+/// for nothing; and emitting none at all is the deliberate fallback for a tree
+/// with no git.
+fn watched(dir: &str) -> Vec<String> {
+    let mut refs = vec!["HEAD".to_string(), "packed-refs".to_string()];
+    // The branch file, when there is a branch. On a detached HEAD this fails and
+    // there is nothing to add: the sha lives in HEAD, already listed above.
+    if let Some(head_ref) = git(dir, &["symbolic-ref", "-q", "HEAD"]) {
+        refs.push(head_ref);
     }
+    refs.iter()
+        .filter_map(|r| git(dir, &["rev-parse", "--git-path", r]))
+        // `--git-path` answers relative to the working directory, which is the
+        // package root here, and Cargo reads a relative `rerun-if-changed` the
+        // same way. A linked worktree answers absolute, which both accept.
+        .filter(|p| PathBuf::from(dir).join(Path::new(p)).is_file())
+        .collect()
 }

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -366,6 +366,112 @@ fn a_ratification_commit_stripped_of_its_signature_is_a_fault_through_the_binary
     );
 }
 
+/// The stamp follows the commit, including a commit that changes no file
+/// (TASK-0b26c8b5bfc5).
+///
+/// The first `build.rs` emitted no `rerun-if-changed`, so Cargo watched the
+/// package instead and a commit touching no file in it never reran the script.
+/// Measured on the build that shipped `--version`: `HEAD 3110392`, stamp
+/// `aeb1841`. A diagnostic that is sometimes wrong is one people learn to
+/// re-verify by hand.
+///
+/// **Why a fixture crate and not `ank` itself.** The claim is about when Cargo
+/// reruns the build script, and that needs a real `cargo build` around a real
+/// commit — but rebuilding `ank` from inside its own test suite relinks
+/// `target/debug/ank.exe` while other tests are executing it, which is the
+/// Windows relink trap the development guide documents, and a fresh target
+/// directory would rebuild `libsqlite3-sys` on every CI job of all three
+/// platforms. So the fixture is a trivial crate driving **the real
+/// `build.rs`** — the file under test, not a copy of its logic — through a real
+/// cargo build and a real git commit. What that leaves unexercised is ank's own
+/// linking, which the claim does not depend on. The literal measurement on
+/// `ank --version` was taken by hand and recorded in the task log.
+#[test]
+fn the_stamp_follows_a_commit_that_changes_no_file() {
+    let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".into());
+    let script = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("build.rs");
+
+    let dir = std::env::temp_dir().join(format!("ank-stamp-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(dir.join("src")).unwrap();
+    std::fs::copy(&script, dir.join("build.rs")).unwrap();
+    // An empty `[workspace]` so the fixture is not adopted by any workspace it
+    // happens to sit under, and no dependencies so the build needs no registry.
+    std::fs::write(
+        dir.join("Cargo.toml"),
+        "[workspace]\n\n[package]\nname = \"stamp\"\nversion = \"0.0.0\"\nedition = \"2021\"\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("src/main.rs"),
+        "fn main() { println!(\"{}\", env!(\"ANK_COMMIT\")); }\n",
+    )
+    .unwrap();
+
+    let git = |args: &[&str]| {
+        let out = Command::new("git")
+            .current_dir(&dir)
+            .args(args)
+            .output()
+            .expect("git must be installed");
+        assert!(
+            out.status.success(),
+            "git {args:?}: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        String::from_utf8_lossy(&out.stdout).trim().to_string()
+    };
+    git(&["init", "-q", "-b", "main"]);
+    git(&["config", "user.email", "test@ank.local"]);
+    git(&["config", "user.name", "Test"]);
+    git(&["add", "-A"]);
+    git(&["-c", "commit.gpgsign=false", "commit", "-qm", "seed"]);
+
+    let build_and_read = || {
+        let out = Command::new(&cargo)
+            .current_dir(&dir)
+            .args(["run", "-q"])
+            .env("CARGO_TARGET_DIR", dir.join("target"))
+            .output()
+            .expect("cargo must be on PATH");
+        assert!(
+            out.status.success(),
+            "cargo run: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        String::from_utf8_lossy(&out.stdout).trim().to_string()
+    };
+
+    let first = build_and_read();
+    assert_eq!(
+        first,
+        git(&["rev-parse", "--short", "HEAD"]),
+        "the stamp must name the commit it was built at"
+    );
+
+    // The case the old script missed: the commit moves, no file does.
+    git(&[
+        "-c",
+        "commit.gpgsign=false",
+        "commit",
+        "-q",
+        "--allow-empty",
+        "-m",
+        "nothing changes but the commit",
+    ]);
+    let moved = git(&["rev-parse", "--short", "HEAD"]);
+    assert_ne!(moved, first, "the fixture must actually have moved");
+
+    let second = build_and_read();
+    assert_eq!(
+        second, moved,
+        "a rebuild after a commit that touches no file must name the new HEAD, \
+         not the one before it"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
 /// The binary can say what it is, and can say it where nothing else works
 /// (TASK-548c518cb705).
 ///

--- a/docs/ank-spec-v1.1.md
+++ b/docs/ank-spec-v1.1.md
@@ -422,6 +422,8 @@ It answers **before the foundation**, like `help` and for a sharper reason: the 
 
 The commit is embedded at build time through `rev-parse`, which §8's plumbing rule already allows, and is `unknown` when the build had no checkout to ask — a source tarball, a vendored dependency. Naming the absence beats inventing a value, and it beats the silence that made TASK-1ea38a17d854 cost an investigation to conclude that the binary in hand predated the feature being measured for.
 
+**What the stamp guarantees, and on which builds.** It names the commit the build script last ran at, and the script reruns whenever the commit moves — including a commit that changes no source file, which is the case that catches a binary quietly left behind. It does not depend on the source having changed. The files a commit moves are located through `rev-parse --git-path` rather than assumed at `.git/`, so a linked worktree and a packed ref are covered rather than hoped for; on a detached HEAD the sha lives in the HEAD file, which is watched on its own account. A release, built from a fresh checkout, is exact by construction. The stamp is not a claim about the working tree: uncommitted edits are invisible to it, and a binary built from a dirty tree names the commit it was based on, not the code it contains (TASK-0b26c8b5bfc5).
+
 ### Exit codes
 
 The semantics are carried by the code so that the shell can route without parsing output.


### PR DESCRIPTION
Closes TASK-0b26c8b5bfc5.

## The lag

The first `build.rs` emitted no `rerun-if-changed`, so Cargo watched the package instead — and a commit that touches no file in it never reran the script. Measured on the build that shipped `--version`, one command after `ank done`:

```
HEAD:  3110392
stamp: ank 0.1.0 (aeb1841)
```

A diagnostic that is sometimes wrong is one people learn to re-verify by hand, which is exactly the habit the flag existed to remove.

## Why the original reasoning was incomplete

Both objections behind "emit nothing" were true, and the conclusion still did not follow:

- naming `.git/HEAD` misses a `packed-refs` update;
- a linked worktree keeps its HEAD elsewhere.

The answer is to **ask git for the paths rather than guess them**. Measured, not assumed:

| from | `rev-parse --git-path HEAD` |
|---|---|
| the main checkout, in `crates/ank-cli` | `../../.git/HEAD` |
| a linked worktree | `C:/…/.git/worktrees/wt2/HEAD` |

So the script watches `HEAD`, `packed-refs`, and the branch file `symbolic-ref` names — each located through `--git-path`, both commands already on ADR-b8884edcebe3's list. On a detached HEAD `symbolic-ref` exits 1 and there is nothing to add: the sha lives in `HEAD`, already watched.

Only paths that **exist** are emitted — a `rerun-if-changed` on a missing file reruns the script on every build and would recompile the crate for nothing. With no git, nothing is emitted and Cargo falls back to watching the package: right for a tarball, where the answer is `unknown` however often it is recomputed.

Losing the package-wide watch costs nothing. A source edit with no commit leaves the stamp correct, because the commit has not moved.

## Specification

§4 now says what the stamp guarantees and on which builds — and what it is not:

> The stamp is not a claim about the working tree: uncommitted edits are invisible to it, and a binary built from a dirty tree names the commit it was based on, not the code it contains.

## The test, and one honest substitution

The criterion says *"build, commit with no source change, rebuild, and `ank --version` names the new HEAD"*. I took that measurement by hand on the real binary and recorded it in the task log: `655ae74` → `git commit --allow-empty` → `f9f64ae` → rebuild → stamp `f9f64ae`. (The probe commit was dropped with `reset --soft`, working tree verified after.)

The **automated** regression drives the real `build.rs` — the file under test, not a copy of its logic — through a real `cargo build` and a real empty commit, in a trivial fixture crate rather than by rebuilding `ank`. Rebuilding `ank` inside its own suite relinks `target/debug/ank.exe` while other tests are executing it, which is the Windows relink trap `CLAUDE.md` documents, and a fresh target directory would rebuild `libsqlite3-sys` on every CI job of all three platforms. What that leaves unexercised is ank's own linking, which the claim does not depend on.

Restoring the shipped `build.rs` with the test in place turns it red with the lag itself:

```
assertion `left == right` failed: a rebuild after a commit that touches no file
must name the new HEAD, not the one before it
  left: "81a6521"   right: "8d8a77f"
```

## Verification

`cargo test --workspace` green (206 + 31 + 3 + 3 + 12), `cargo fmt --check` clean, `ank check` exit 0. The new test costs ~2s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QoJrx7uZpTu7ZEzie8TpKH