### PR TITLE
0.1.1, so the archive and the binary agree on what they are

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "ank-cli"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ank-core",
  "hex",
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "ank-core"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "globset",
  "hex",

--- a/crates/ank-cli/Cargo.toml
+++ b/crates/ank-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ank-cli"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 # Measured on 2026-08-01 by walking toolchains upward against this tree, which
 # is the only way this number means anything: 1.78, 1.91, 1.92, 1.93 and 1.94

--- a/crates/ank-core/Cargo.toml
+++ b/crates/ank-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ank-core"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 # Measured, not assumed: see the note in ank-cli's manifest. This crate's own
 # code needs far less, but the workspace resolves one lockfile and builds as a


### PR DESCRIPTION
Preparation for the v0.1.1 tag. No behaviour change: two crate versions and the lock.

## Why this is not a formality

`release.yml` names the archive from the **tag** (`ank-${GITHUB_REF_NAME#v}-${target}`) and, since TASK-548c518cb705, the binary names itself from the **crate version**. Tagging `v0.1.1` on `05b9a75` as it stands would have published `ank-0.1.1-x86_64-pc-windows-msvc.zip` containing a binary that answers:

```
ank 0.1.0 (05b9a75)
```

That is the identification defect the last two tasks were about, reintroduced one layer up, in the artefact people actually download.

```
$ ank --version
ank 0.1.1 (05b9a75)
```

## What the tag is for

The v0.1.0 archive ships the pre-`7429cdd` `SKILL.md` — the tag was cut 2026-07-31 17:32, and the two fixes landed at 19:15 and 19:16 the same day. Anyone installing that release gets a skill telling them `cat` is your `show`, which is the opposite of ADR-01b6dd05f0db. `release.yml` copies `skill/SKILL.md` into every archive, so a new tag is what corrects it.

TASK-b495234f192c remains open: this fixes what is published, not the inability of a copy in the wild to say which revision it is.

## Verification

`cargo test --workspace` green (206 + 31 + 3 + 3 + 12) at 0.1.1. After merge I will run the `workflow_dispatch` dry run — which builds all three targets and publishes nothing, exactly as its comment intends — before the tag goes anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QoJrx7uZpTu7ZEzie8TpKH