### PR TITLE
Section 4 lists what the binary dispatches, and attest is in v1

### DIFF
--- a/.ank/tasks/TASK-5c868c20472f.md
+++ b/.ank/tasks/TASK-5c868c20472f.md
@@ -5,15 +5,19 @@ slug: attest-and-init-are-in-the-binary-and-not-in-the
 title: attest and init are in the binary and not in the specification
 created: 2026-08-01T19:16:09Z
 author: seanl@sean-laptop
-status: in_progress
+status: done
 scope:
   - docs/ank-spec-v1.1.md
 blocked_by: []
 done_criteria: |
   Section 4 lists every verb the binary dispatches, attest and init included, and section 10 no longer describes as deferred a command that ships. Whether attest is in v1 or the field shape alone is in v1 is decided in writing rather than left to the difference between two sections.
 criteria_by: creator
+proof:
+  - type: test
+    ref: ci://github/30787252463
+    criteria: 62fae9e5e38d
 schema: 2
-version: 3
+version: 4
 ---
 
 Found while revising section 4 for TASK-ff1c20395929 and deliberately left out: the criterion of that task named the surface split and the new verbs, and widening it to cover a divergence discovered mid-flight is the move the format exists to prevent.
@@ -22,3 +26,4 @@ The divergence is old and is not a surface question. ank help lists attest and i
 
 ## Log
 - 2026-08-03T05:27:06Z seanl@sean-laptop — Reconciled in the spec only, which is the whole scope. Section 4's Commands block now carries attest, init and help, so it is the complete dispatch table; init and help keep their description in section 9 and are listed only for completeness. The decision the criterion asked for in writing is recorded in section 10: attest is in v1. The deferral was conditional -- 'the command will come when a CI calls it' -- and the command was written before that happened and has been used, this corpus carrying attested CI references. What stays deferred is not a verb but an integration: nothing calls attest automatically, and a pipeline appending its own run reference is a per-provider integration. The out-of-v1 table row was rewritten to say that instead of naming the command, and section 13 and both summary lines at the top now agree. Caught while editing: I first placed attest after check in the block, which would have created a fresh drift, since ADR-c656 makes ank help print section 4's order and the binary prints attest before check. Verified mechanically rather than by eye, by extracting both orders and diffing: section 4 minus the four verbs not yet implemented (status, edit, graph, scope) is identical to what ank help prints, and nothing the binary dispatches is absent from section 4.
+- 2026-08-03T05:30:59Z seanl@sean-laptop — done, proof test:ci://github/30787252463

--- a/.ank/tasks/TASK-5c868c20472f.md
+++ b/.ank/tasks/TASK-5c868c20472f.md
@@ -5,7 +5,7 @@ slug: attest-and-init-are-in-the-binary-and-not-in-the
 title: attest and init are in the binary and not in the specification
 created: 2026-08-01T19:16:09Z
 author: seanl@sean-laptop
-status: open
+status: in_progress
 scope:
   - docs/ank-spec-v1.1.md
 blocked_by: []
@@ -13,9 +13,12 @@ done_criteria: |
   Section 4 lists every verb the binary dispatches, attest and init included, and section 10 no longer describes as deferred a command that ships. Whether attest is in v1 or the field shape alone is in v1 is decided in writing rather than left to the difference between two sections.
 criteria_by: creator
 schema: 2
-version: 1
+version: 3
 ---
 
 Found while revising section 4 for TASK-ff1c20395929 and deliberately left out: the criterion of that task named the surface split and the new verbs, and widening it to cover a divergence discovered mid-flight is the move the format exists to prevent.
 
 The divergence is old and is not a surface question. ank help lists attest and init; the Commands block of section 4 lists neither. Section 10 defers ank attest to v1.1 with its shape frozen, and section 13 repeats it, while the verb is implemented and reachable. One of the two is wrong and a reader cannot tell which from the documents alone, which is exactly what ADR-63b59c5c26f7 orders the work to prevent.
+
+## Log
+- 2026-08-03T05:27:06Z seanl@sean-laptop — Reconciled in the spec only, which is the whole scope. Section 4's Commands block now carries attest, init and help, so it is the complete dispatch table; init and help keep their description in section 9 and are listed only for completeness. The decision the criterion asked for in writing is recorded in section 10: attest is in v1. The deferral was conditional -- 'the command will come when a CI calls it' -- and the command was written before that happened and has been used, this corpus carrying attested CI references. What stays deferred is not a verb but an integration: nothing calls attest automatically, and a pipeline appending its own run reference is a per-provider integration. The out-of-v1 table row was rewritten to say that instead of naming the command, and section 13 and both summary lines at the top now agree. Caught while editing: I first placed attest after check in the block, which would have created a fresh drift, since ADR-c656 makes ank help print section 4's order and the binary prints attest before check. Verified mechanically rather than by eye, by extracting both orders and diffing: section 4 minus the four verbs not yet implemented (status, edit, graph, scope) is identical to what ank help prints, and nothing the binary dispatches is absent from section 4.

--- a/.ank/tasks/TASK-973fc0173b98.md
+++ b/.ank/tasks/TASK-973fc0173b98.md
@@ -1,0 +1,29 @@
+---
+id: TASK-973fc0173b98
+type: task
+slug: nothing-checks-that-ank-help-prints-section-4-s
+title: Nothing checks that ank help prints section 4's order
+created: 2026-08-03T05:28:30Z
+author: seanl@sean-laptop
+status: open
+scope:
+  - crates/ank-cli/tests/skill.rs
+  - crates/ank-cli/src/cli.rs
+blocked_by: []
+done_criteria: |
+  A test fails when the Commands block of section 4 and the order ank help prints disagree, in either direction: a verb the binary dispatches and section 4 omits, a verb section 4 lists as implemented and the binary does not dispatch, or the same verbs in a different relative order. The test reads section 4 rather than a second hand-maintained list.
+criteria_by: creator
+verify: [cargo-test, fmt-check, check-repo]
+schema: 2
+version: 1
+---
+
+TASK-5c868c20472f found by reading that section 4 listed neither attest nor init nor help while the binary dispatched all three, and that section 10 called attest deferred while it shipped. It was fixed by hand. Nothing would catch it coming back.
+
+ADR-c656cbcc33a9 says ank help is one flat listing of every verb in the order of section 4. That is currently a description, not a check: the order lives in the COMMANDS table in cli.rs and in the Commands block of the specification, and the two agree only as long as someone remembers.
+
+The precedent is in the repository already. tests/skill.rs asserts the eight verbs of the loop, the one-page budget and the absence of anything outside the loop, and its header says why: SKILL.md is not documentation, its content is the thing actually frozen. The order of section 4 has the same standing under the same ADR and no equivalent test.
+
+Measured while fixing the drift by hand: extracting both orders and diffing them takes four lines of shell. Section 4 minus the four verbs not yet implemented -- status, edit, graph, scope -- must equal what ank help prints, and nothing the binary dispatches may be absent from section 4. The awkward part is the four unimplemented verbs, which legitimately appear in the specification and not in the binary, so the assertion is a subsequence rather than an equality and the test has to say which verbs are exempt and why.
+
+Evidence it is not hypothetical: while fixing that very task, attest was first placed after check in the block, which would have introduced a fresh divergence in the commit repairing one. It was caught by the diff, not by review.

--- a/docs/ank-spec-v1.1.md
+++ b/docs/ank-spec-v1.1.md
@@ -5,9 +5,9 @@ Last revised: 1 August 2026
 
 ## Decisions settled in this revision
 
-Settled relative to v1: orientation and constraints reconciled (§5) · immutability anchored by hash, verifiable without making the CLI a gatekeeper (§3, §8) · nominal execution model, one worktree per agent (§7) · claims on git refs from level 0 onward, one ref per task (§7) · Ank never commits, except `accept` (§12) · return after TTL expiry, and a TTL ceiling (§3) · `verify` becomes a list (§3) · `proof` becomes an append-only list, CI attestation deferred to v1.1 (§3, §10) · log format fixed as an append-only section of the task file (§3) · index lifecycle fixed (§6) · verifier timeout fixed (§4) · `--reason` mandatory on `release` (§4) · `check` signals extended (§4) · identity, default roles and signature verification specified (§8).
+Settled relative to v1: orientation and constraints reconciled (§5) · immutability anchored by hash, verifiable without making the CLI a gatekeeper (§3, §8) · nominal execution model, one worktree per agent (§7) · claims on git refs from level 0 onward, one ref per task (§7) · Ank never commits, except `accept` (§12) · return after TTL expiry, and a TTL ceiling (§3) · `verify` becomes a list (§3) · `proof` becomes an append-only list, with `attest` as the one write allowed after `done` (§3, §10) · log format fixed as an append-only section of the task file (§3) · index lifecycle fixed (§6) · verifier timeout fixed (§4) · `--reason` mandatory on `release` (§4) · `check` signals extended (§4) · identity, default roles and signature verification specified (§8).
 
-Every open point of v1 is settled: GPL-3.0 licence, native Windows in v1, merge driver and CI attestation specified but implemented in v1.1 (§13).
+Every open point of v1 is settled: GPL-3.0 licence, native Windows in v1, merge driver specified but implemented in v1.1 (§13). `attest` was deferred alongside it and ships in v1: the command was written before a CI ever called it, so what remains deferred is the integration and not the verb (§10).
 
 Additions of revision k: **`ank help` is one flat listing** (§4, §9, ADR-c656cbcc33a9, superseding ADR-9ede1ffd04e2) — revision i dissolved the split between an agent surface and a human one and left a layered `help` behind it, whose headings were still named after callers; layering is grouping, and a grouping printed by the binary is a claim about who a verb is for. The order of §4 carries the same information without asserting a category, and the loop stays where it is enforced, in the frozen content of SKILL.md.
 
@@ -285,6 +285,7 @@ accept    promotes a proposed ADR to accepted (produces the signed commit, §8, 
 check     mechanical invariants, exit code usable in CI
 close     closes a task that will never be done (--reason mandatory)
 amend     changes `blocked_by` and `scope` on an entity that already exists
+attest    appends a proof to a finished task: the one write §3 allows after `done`
 status    where am I: branch, claim, perimeter, queue, findings
 edit      opens an entity in the editor and validates what comes back
 graph     the `blocked_by` DAG in readable text
@@ -394,13 +395,18 @@ ank accept <id>
 ank close <id> --reason <r>
 ank amend <id>              [--blocked-by <id>...] [--drop-blocked-by <id>...]
                             [--scope <glob>...] [--drop-scope <glob>...]
+ank attest <id> --proof <type>:<ref>
 ank edit <id>
 ank graph [<path>]
 ank scope <path>
 ank check [<path>]
+ank init [<path>]           (§9)
+ank help [<verb>]           (§9)
 
 ank --version               (the build itself: version and commit, no verb, no repository)
 ```
+
+**This block is the whole dispatch table**, and that is a property worth stating rather than assuming: `attest`, `init` and `help` were reachable in the binary while appearing nowhere here, so a reader comparing the two documents could not tell which one was wrong (TASK-5c868c20472f). `init` and `help` are specified in §9 and listed here only so the list is complete; `ank help` prints this order, minus whatever is not yet implemented, which is what ADR-c656cbcc33a9 requires of it.
 
 **`ank context` with no argument** covers the whole repository. It is the first call an agent should make, before it even knows which path it works on — an agent launched on "fix the login bug" does not yet know its perimeter.
 
@@ -518,7 +524,11 @@ The dividing line is not local versus hosted, it is **who controls the environme
 
 **What local proof anchors.** An agent's nominal case is an uncommitted working tree: anchoring proof on the HEAD SHA alone would almost always point at a stale state. The proof therefore records three things: the HEAD SHA, a dirty-tree indicator, and **a hash of the scope files' content at execution time** (`tree:scope/<hash>`, git hash-object style). That last one is what actually captures what was tested. `check` additionally reports the case where the task itself modified the test files it invokes.
 
-The levels stack: local proof at `done` time, a CI reference **appended** later to the `proof` list — appending proof is the only legal post-`done` write (§3). The CI attestation mechanism itself (`ank attest`) is deferred to v1.1 (§10): the data structure allows it already, the command will come when a CI calls it.
+The levels stack: local proof at `done` time, a CI reference **appended** later to the `proof` list — appending proof is the only legal post-`done` write (§3).
+
+**`ank attest` is in v1, and this settles it.** Earlier revisions deferred it with its shape frozen, on the reasoning that the data structure was ready and the command would come *when a CI called it*. The command was implemented before that happened, and has been used: this repository's own corpus carries `attest`ed CI references. A deferral whose condition has been overtaken is not a plan, it is a document disagreeing with its binary — the state ADR-63b59c5c26f7 orders the work to prevent, and the one a reader could not resolve from §4 and §10 alone (TASK-5c868c20472f).
+
+What that deferral was actually protecting is worth keeping, because it is still deferred and it is not a command: **nothing calls `attest` automatically**. A CI provider appending its own run reference at the end of a pipeline is an integration, not a verb, and it is listed below as such. The verb exists and anyone — an agent, a human, a CI script — can call it today.
 
 The `assertion` type exists because "refactor for readability" has no hash to attach. It is allowed but visible as weak, which avoids a `--force` becoming the default path within two weeks.
 
@@ -808,14 +818,14 @@ The `skills` CLI handles multi-agent detection (Claude Code, Codex, Cursor, Open
 
 ### In
 
-File format · one command surface, refusing on state and never on identity, with the loop SKILL.md teaches frozen at eight verbs (`show` included) · HEAD · `release` (reason mandatory) · IDs and prefix resolution · mandatory declared scope · `blocked_by` and derived blocking · named verifiers as a list, timeout, local execution of proofs · freeze by hash (`done_criteria` at claim, `constraint`/`scope` at ratification) · exit codes · two-phase `context` · sync levels 0 and 1, claims on per-task refs, completion refs and their pruning by `check` · `default_branch` and `accept`'s branch precondition · advisory roles, authority anchored on a signed commit, versioned `allowed_signers` · `status`, `edit`, `graph`, `scope`, the interactive form of `new` and the read form of `log` · bootstrap skill · `check` (full scope in §4).
+File format · one command surface, refusing on state and never on identity, with the loop SKILL.md teaches frozen at eight verbs (`show` included) · HEAD · `release` (reason mandatory) · IDs and prefix resolution · mandatory declared scope · `blocked_by` and derived blocking · named verifiers as a list, timeout, local execution of proofs · freeze by hash (`done_criteria` at claim, `constraint`/`scope` at ratification) · exit codes · two-phase `context` · sync levels 0 and 1, claims on per-task refs, completion refs and their pruning by `check` · `default_branch` and `accept`'s branch precondition · advisory roles, authority anchored on a signed commit, versioned `allowed_signers` · `status`, `edit`, `graph`, `scope`, the interactive form of `new` and the read form of `log` · `attest`, the one write allowed after `done` · bootstrap skill · `check` (full scope in §4).
 
 ### Out of v1, in order of expected value
 
 | Deferred | Reason |
 |---|---|
 | `--since` (differential context) | Large token saving on long loops, but requires per-agent "seen" state. First candidate for v1.1. |
-| `ank attest <id> --proof ci://<provider>/<run-id>` | Shape frozen now; the append-only `proof` list is ready, the command will come when a CI calls it. |
+| A CI calling `attest` on its own | The verb itself is in v1 (above). What is deferred is a pipeline appending its run reference without being asked — an integration per provider, not a command. |
 | `.ank/` merge driver | The resolution rules are fixed (§7); automating them can wait for the first real conflicts. |
 | `touched` inferred from commits | Scope-drift detection. A git dependency, not blocking to get started. |
 | `enforced_by` (mechanisation) | The underlying mechanism against context inflation (see §11). Useless while the ADR corpus is small. |
@@ -891,6 +901,6 @@ The consequence to respect in the implementation: every operation must produce a
 
 **Platforms: Linux, macOS, Windows, native in v1.** Rust cross-compiles all three without friction, and the portability of the plumbing comes not from a library but from git itself, identical on all three operating systems — git is also what provides the verifiers' `sh` on Windows (§4). One external dependency, present everywhere, rather than a per-platform reimplementation. Distribution: `curl | sh`, Homebrew, Scoop/winget, npm.
 
-**Deferred to v1.1, shape frozen now**: the `.ank/` merge driver (rules fixed in §7 — `version` = max + 1, log = timestamped union — automated at the first real conflicts) and `ank attest` (command shape frozen in §10, implemented when a CI calls it).
+**Deferred to v1.1, shape frozen now**: the `.ank/` merge driver (rules fixed in §7 — `version` = max + 1, log = timestamped union — automated at the first real conflicts). `ank attest` was on this list and is not any more: it ships in v1 (§10), and what remains deferred is a CI calling it unprompted, which is an integration and not a verb.
 
 No open points remain: the format, the agent loop, the three platforms and levels 0 and 1 are fully specified.


### PR DESCRIPTION
Closes TASK-5c868c20472f. Specification only — no code changes.

## The divergence

`ank help` listed `attest`, `init` and `help`. The Commands block of §4 listed none of them. Meanwhile §10 deferred `ank attest` to v1.1 *with its shape frozen*, §13 repeated it, and the verb was implemented and reachable the whole time.

One of the two documents was wrong and a reader could not tell which from the documents alone — the state ADR-63b59c5c26f7 exists to prevent.

## The decision, in writing

The criterion asked for this to be settled rather than left to the difference between two sections. **`attest` is in v1.**

The deferral was conditional: *"the command will come when a CI calls it."* The command was written before that happened, and has since been used — this repository's own corpus carries `attest`ed CI references (TASK-daf25ab8a9b7 among them). A deferral whose condition has been overtaken is not a plan, it is a document disagreeing with its binary.

What the deferral was actually protecting is kept, because it is still true and it is **not a command**: nothing calls `attest` automatically. A pipeline appending its own run reference is an integration, per provider. The out-of-v1 table now says that instead of naming the verb:

| Deferred | Reason |
|---|---|
| A CI calling `attest` on its own | The verb itself is in v1 (above). What is deferred is a pipeline appending its run reference without being asked — an integration per provider, not a command. |

Updated in step: §4 (both the descriptive block and the Commands block), §10, §13, and the two summary lines at the top that still said "CI attestation deferred to v1.1".

## One mistake worth recording

`attest` first went into the Commands block *after* `check` — which would have created a fresh drift, since ADR-c656cbcc33a9 makes `ank help` print §4's order and the binary prints `attest` before `check`. Fixing a documentation divergence by introducing a documentation divergence.

So the orders were extracted from both sources and diffed rather than compared by eye:

```
spec: context claim show log done release new find status review accept close
      amend attest edit graph scope check init help
help: context claim show log done release new find review accept close amend
      attest check init help

spec minus unimplemented: context claim show log done release new find review
      accept close amend attest check init help
MATCH: help prints section 4 order
in help but missing from section 4: (none)
```

§4 minus the four verbs not yet implemented — `status`, `edit`, `graph`, `scope` — is identical to what `ank help` prints. ADR-c656cbcc33a9's "one flat listing, in the order of §4" now actually holds, where before it could not have.

## Verification

`ank check` exit 0. No code touched, so the suite is unaffected; CI on this PR is the proof, since the task declares no `verify:` list.

## Follow-up, not in this PR

This drift was found by reading and fixed by hand, and nothing would catch it coming back. `tests/skill.rs` already does exactly this job for `SKILL.md` — asserting the eight verbs and the page budget. The same shape applies here: a test asserting that `ank help`'s order matches §4's Commands block would make ADR-c656cbcc33a9 enforced rather than described. Out of scope here (this task is scoped to `docs/`), filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QoJrx7uZpTu7ZEzie8TpKH