### PR TITLE
The order of section 4 stops being a description and becomes a check

### DIFF
--- a/.ank/tasks/TASK-973fc0173b98.md
+++ b/.ank/tasks/TASK-973fc0173b98.md
@@ -5,7 +5,7 @@ slug: nothing-checks-that-ank-help-prints-section-4-s
 title: Nothing checks that ank help prints section 4's order
 created: 2026-08-03T05:28:30Z
 author: seanl@sean-laptop
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/tests/skill.rs
   - crates/ank-cli/src/cli.rs
@@ -14,8 +14,24 @@ done_criteria: |
   A test fails when the Commands block of section 4 and the order ank help prints disagree, in either direction: a verb the binary dispatches and section 4 omits, a verb section 4 lists as implemented and the binary does not dispatch, or the same verbs in a different relative order. The test reads section 4 rather than a second hand-maintained list.
 criteria_by: creator
 verify: [cargo-test, fmt-check, check-repo]
+proof:
+  - type: test
+    ref: local/76ae75735168@e2b3d30
+    tree: scope/b45fa0da0985
+    criteria: b63748de1d01
+    verifier: cargo-test@f14aeab36e1b
+  - type: test
+    ref: local/e3b0c44298fc@e2b3d30
+    tree: scope/b45fa0da0985
+    criteria: b63748de1d01
+    verifier: fmt-check@5ca6d10bcd55
+  - type: test
+    ref: local/2aaef6a57c6a@e2b3d30
+    tree: scope/b45fa0da0985
+    criteria: b63748de1d01
+    verifier: check-repo@5734e9cf9d3d
 schema: 2
-version: 3
+version: 4
 ---
 
 TASK-5c868c20472f found by reading that section 4 listed neither attest nor init nor help while the binary dispatched all three, and that section 10 called attest deferred while it shipped. It was fixed by hand. Nothing would catch it coming back.
@@ -30,3 +46,4 @@ Evidence it is not hypothetical: while fixing that very task, attest was first p
 
 ## Log
 - 2026-08-03T05:43:06Z seanl@sean-laptop — Three tests in tests/skill.rs, beside the ones already guarding SKILL.md under the same ADR. Section 4's Commands block is parsed from the specification, never restated: a second hand-maintained copy of the order is the drift being checked for. The order the binary prints comes from spawning ank help, because ADR-c656 is a statement about what the process prints, not about the table it derives from. NOT_YET_DISPATCHED is the one hand-maintained list -- status, edit, graph, scope, each named with its task -- and it cannot rot: a verb that both ships and is still declared unimplemented fails, so implementing one forces its removal in the same commit. Every clause of the criterion was proved by mutation rather than asserted. Dropping attest from the block: two tests fail, the missing-verb one and the order one. Moving attest after check: the order test fails. Adding a fictional ank teleport: the ships-or-declared test fails and names it. Adding check to NOT_YET_DISPATCHED: the anti-rot assertion fires. Worth recording because it nearly went the other way: the first mutation run reported six passes and I took it as a green result for two mutations before checking the file. The specification is CRLF in the working tree, so the perl substitution anchored on backslash-n had matched nothing and the file was never modified. The test was never challenged; it only looked as if it had been. Redone with sed, which matches regardless. Rust's str::lines strips the carriage return, so the parser itself was never affected.
+- 2026-08-03T05:46:54Z seanl@sean-laptop — done, proof test:local/76ae75735168@e2b3d30 test:local/e3b0c44298fc@e2b3d30 test:local/2aaef6a57c6a@e2b3d30

--- a/.ank/tasks/TASK-973fc0173b98.md
+++ b/.ank/tasks/TASK-973fc0173b98.md
@@ -5,7 +5,7 @@ slug: nothing-checks-that-ank-help-prints-section-4-s
 title: Nothing checks that ank help prints section 4's order
 created: 2026-08-03T05:28:30Z
 author: seanl@sean-laptop
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/tests/skill.rs
   - crates/ank-cli/src/cli.rs
@@ -15,7 +15,7 @@ done_criteria: |
 criteria_by: creator
 verify: [cargo-test, fmt-check, check-repo]
 schema: 2
-version: 1
+version: 3
 ---
 
 TASK-5c868c20472f found by reading that section 4 listed neither attest nor init nor help while the binary dispatched all three, and that section 10 called attest deferred while it shipped. It was fixed by hand. Nothing would catch it coming back.
@@ -27,3 +27,6 @@ The precedent is in the repository already. tests/skill.rs asserts the eight ver
 Measured while fixing the drift by hand: extracting both orders and diffing them takes four lines of shell. Section 4 minus the four verbs not yet implemented -- status, edit, graph, scope -- must equal what ank help prints, and nothing the binary dispatches may be absent from section 4. The awkward part is the four unimplemented verbs, which legitimately appear in the specification and not in the binary, so the assertion is a subsequence rather than an equality and the test has to say which verbs are exempt and why.
 
 Evidence it is not hypothetical: while fixing that very task, attest was first placed after check in the block, which would have introduced a fresh divergence in the commit repairing one. It was caught by the diff, not by review.
+
+## Log
+- 2026-08-03T05:43:06Z seanl@sean-laptop — Three tests in tests/skill.rs, beside the ones already guarding SKILL.md under the same ADR. Section 4's Commands block is parsed from the specification, never restated: a second hand-maintained copy of the order is the drift being checked for. The order the binary prints comes from spawning ank help, because ADR-c656 is a statement about what the process prints, not about the table it derives from. NOT_YET_DISPATCHED is the one hand-maintained list -- status, edit, graph, scope, each named with its task -- and it cannot rot: a verb that both ships and is still declared unimplemented fails, so implementing one forces its removal in the same commit. Every clause of the criterion was proved by mutation rather than asserted. Dropping attest from the block: two tests fail, the missing-verb one and the order one. Moving attest after check: the order test fails. Adding a fictional ank teleport: the ships-or-declared test fails and names it. Adding check to NOT_YET_DISPATCHED: the anti-rot assertion fires. Worth recording because it nearly went the other way: the first mutation run reported six passes and I took it as a green result for two mutations before checking the file. The specification is CRLF in the working tree, so the perl substitution anchored on backslash-n had matched nothing and the file was never modified. The test was never challenged; it only looked as if it had been. Redone with sed, which matches regardless. Rust's str::lines strips the carriage return, so the parser itself was never affected.

--- a/crates/ank-cli/tests/skill.rs
+++ b/crates/ank-cli/tests/skill.rs
@@ -14,12 +14,165 @@
 
 use std::fs;
 use std::path::PathBuf;
+use std::process::Command;
 
-fn skill() -> String {
+fn repo_file(rel: &str) -> String {
     let p = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("../..")
-        .join("skill/SKILL.md");
+        .join(rel);
     fs::read_to_string(&p).unwrap_or_else(|e| panic!("{}: {e}", p.display()))
+}
+
+fn skill() -> String {
+    repo_file("skill/SKILL.md")
+}
+
+// ---------------------------------------------------------------------------
+// §4's order, and the listing that has to match it (TASK-973fc0173b98)
+// ---------------------------------------------------------------------------
+
+/// The leading verb of a usage line, `ank <verb> ...`.
+///
+/// `ank --version` yields nothing and is meant to: it is not a verb, and §4
+/// says so in as many words.
+fn leading_verb(line: &str) -> Option<String> {
+    let rest = line.strip_prefix("ank ")?;
+    let verb: String = rest.chars().take_while(char::is_ascii_lowercase).collect();
+    (!verb.is_empty()).then_some(verb)
+}
+
+fn push_once(verbs: &mut Vec<String>, verb: String) {
+    if !verbs.contains(&verb) {
+        verbs.push(verb);
+    }
+}
+
+/// The verbs of §4's `Commands` block, in the order the block lists them.
+///
+/// Read from the specification rather than restated here: a second
+/// hand-maintained copy of the order is the very drift this is checking for.
+fn section_4_order() -> Vec<String> {
+    let spec = repo_file("docs/ank-spec-v1.1.md");
+    let mut verbs = Vec::new();
+    let mut seen_heading = false;
+    let mut inside = false;
+    for line in spec.lines() {
+        if line.trim() == "### Commands" {
+            seen_heading = true;
+            continue;
+        }
+        if !seen_heading {
+            continue;
+        }
+        if line.trim_start().starts_with("```") {
+            // The opening fence, then the closing one: the block is over.
+            if inside {
+                break;
+            }
+            inside = true;
+            continue;
+        }
+        if inside {
+            if let Some(v) = leading_verb(line) {
+                push_once(&mut verbs, v);
+            }
+        }
+    }
+    assert!(
+        !verbs.is_empty(),
+        "the Commands block of §4 was not found: this test reads the \
+         specification, so a renamed heading must fail loudly rather than pass \
+         on an empty list"
+    );
+    verbs
+}
+
+/// The verbs `ank help` prints, in the order it prints them.
+///
+/// Through the binary, because ADR-c656cbcc33a9 is a statement about what the
+/// process prints, not about the table it is derived from. The listing ends at
+/// the blank line before `global:`.
+fn help_order() -> Vec<String> {
+    let out = Command::new(env!("CARGO_BIN_EXE_ank"))
+        .arg("help")
+        .output()
+        .expect("the binary must have been built");
+    assert!(out.status.success(), "ank help must succeed");
+    let text = String::from_utf8_lossy(&out.stdout).to_string();
+    let mut verbs = Vec::new();
+    for line in text.lines().take_while(|l| !l.trim().is_empty()) {
+        if let Some(v) = leading_verb(line) {
+            push_once(&mut verbs, v);
+        }
+    }
+    assert!(!verbs.is_empty(), "ank help printed no verb");
+    verbs
+}
+
+/// Verbs §4 specifies and the binary does not dispatch yet.
+///
+/// The one hand-maintained list here, and it cannot rot: the test below fails
+/// if any of these becomes dispatchable, so implementing one forces its removal
+/// in the same commit. Each is a specified verb with an open task -- `status`
+/// TASK-15336a0012d5, `edit` TASK-7ed19b16895e, `graph` TASK-253e897d3330,
+/// `scope` TASK-e717ee625c5c.
+const NOT_YET_DISPATCHED: [&str; 4] = ["status", "edit", "graph", "scope"];
+
+/// A verb the binary answers to and §4 never mentions. `attest`, `init` and
+/// `help` were exactly that until TASK-5c868c20472f, and a reader comparing the
+/// two documents could not tell which one was wrong.
+#[test]
+fn every_dispatched_verb_is_listed_in_section_4() {
+    let spec = section_4_order();
+    for verb in help_order() {
+        assert!(
+            spec.contains(&verb),
+            "`ank {verb}` is dispatched and §4's Commands block does not list \
+             it: the specification is the source of truth (ADR-63b59c5c26f7), \
+             so the block is what has to change"
+        );
+    }
+}
+
+/// The other direction, and the reason the exemption list stays honest. Every
+/// verb §4 lists either ships or is declared unimplemented -- and a declared
+/// one that has started shipping fails here until the declaration is removed.
+#[test]
+fn every_verb_section_4_lists_ships_or_is_declared_unimplemented() {
+    let dispatched = help_order();
+    for verb in section_4_order() {
+        let exempt = NOT_YET_DISPATCHED.contains(&verb.as_str());
+        let ships = dispatched.contains(&verb);
+        assert!(
+            ships || exempt,
+            "§4 lists `ank {verb}`, the binary does not dispatch it, and it is \
+             not in NOT_YET_DISPATCHED: either implement it or declare it there \
+             with its task"
+        );
+        assert!(
+            !(ships && exempt),
+            "`ank {verb}` ships and is still declared unimplemented: remove it \
+             from NOT_YET_DISPATCHED, in the commit that implemented it"
+        );
+    }
+}
+
+/// **One flat listing, in the order of §4** (ADR-c656cbcc33a9). Until this
+/// test the ADR described the output rather than constraining it, and the two
+/// orders agreed only while somebody remembered. Fixing the drift of
+/// TASK-5c868c20472f introduced a fresh one in the same edit -- `attest` placed
+/// after `check` where the binary prints it before -- and only a diff caught it.
+#[test]
+fn help_prints_section_4s_order() {
+    let dispatched = help_order();
+    let expected: Vec<String> = section_4_order()
+        .into_iter()
+        .filter(|v| dispatched.contains(v))
+        .collect();
+    assert_eq!(
+        expected, dispatched,
+        "`ank help` must print §4's order, minus what it does not dispatch"
+    );
 }
 
 /// The loop, and the content of SKILL.md is frozen at exactly these


### PR DESCRIPTION
Closes TASK-973fc0173b98.

## Why

ADR-c656cbcc33a9 says `ank help` is one flat listing of every verb **in the order of §4**. That was a description, not a constraint: the order lived in the `COMMANDS` table *and* in the specification, and the two agreed only while somebody remembered.

They stopped agreeing. TASK-5c868c20472f found `attest`, `init` and `help` dispatched by the binary and listed nowhere in §4 — and the commit repairing that drift introduced a fresh one in the same edit, `attest` placed after `check` where the binary prints it before. A diff caught it, not review.

## What this adds

Three tests, in the file that already guards `SKILL.md` under the same ADR:

| test | catches |
|---|---|
| `every_dispatched_verb_is_listed_in_section_4` | a verb the binary answers to and §4 never mentions |
| `every_verb_section_4_lists_ships_or_is_declared_unimplemented` | a verb §4 specifies that neither ships nor is declared |
| `help_prints_section_4s_order` | the same verbs in a different relative order |

§4's Commands block is **parsed from the specification** and never restated — a second hand-maintained copy of the order is precisely the drift being checked for. The printed order comes from **spawning the binary**, because the ADR constrains what the process prints, not the table it derives from.

`NOT_YET_DISPATCHED` (`status`, `edit`, `graph`, `scope`, each named with its task) is the one list kept by hand, and it cannot rot: a verb that both ships *and* is still declared unimplemented fails the suite, so implementing one forces its removal in the same commit.

## Proved by mutation, not asserted

| mutation | result |
|---|---|
| drop `attest` from the block | 2 tests fail (missing verb, and order) |
| move `attest` after `check` | order test fails |
| add a fictional `ank teleport` | ships-or-declared fails, naming it |
| add `check` to `NOT_YET_DISPATCHED` | anti-rot assertion fires |

## One near miss worth recording

The first mutation run reported **6 passed**, and I read that as two mutations surviving — a green result — before checking the file. The specification is CRLF in the working tree, so a `perl` substitution anchored on `\n` had matched nothing and the file was never modified. The test had not survived a mutation; it had never been challenged.

Redone with `sed`, which matches regardless of line ending, and every result above is from that run. Rust's `str::lines()` strips the carriage return, so the parser itself was never affected — only my check of it was.

## Verification

`cargo test --workspace` green (206 + 31 + 6 + 3 + 12), `cargo fmt --check` clean, `ank check` exit 0. The specification is byte-identical to `main` after the mutation runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QoJrx7uZpTu7ZEzie8TpKH