### PR TITLE
ank scope says what covers a path

### DIFF
--- a/.ank/tasks/TASK-e717ee625c5c.md
+++ b/.ank/tasks/TASK-e717ee625c5c.md
@@ -5,7 +5,7 @@ slug: ank-scope-says-what-covers-a-path
 title: ank scope says what covers a path
 created: 2026-08-01T18:30:10Z
 author: seanl@sean-laptop
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/**
   - crates/ank-core/**
@@ -13,11 +13,16 @@ blocked_by: [TASK-ff1c20395929]
 done_criteria: |
   ank scope <path> lists every entity whose scope matches the path, grouped by type, one line each with status, and says so explicitly when nothing matches. The resolution is the same glob matching context uses, deterministic against the filesystem. The binary is what the test invokes.
 criteria_by: creator
+proof:
+  - type: test
+    ref: ci://github/30788777196
+    criteria: cf7495991d64
 schema: 2
-version: 3
+version: 4
 ---
 
 The check-ignore of ank: a dead scope is today only visible after the fact, through check. This makes glob resolution observable before an entity is written wrong.
 
 ## Log
 - 2026-08-03T05:59:35Z seanl@sean-laptop — Implemented in commands.rs beside find, which it resembles. The matching is not a copy: context::in_perimeter became pub(crate) and is now the single implementation, with commands::scope_touches -- what find --scope already used -- reduced to a call into it. There were two identical four-line wrappers over ScopeSet before, so the criterion's 'the same glob matching context uses' was true by coincidence and is now true by construction. No budget cap, unlike find, and that is a decision rather than an omission: find is an open query over the corpus and must cap, while scope is asked about one path and its answer is bounded by what the caller already named. Capping would also make the verb lie, since the constraint left out of a partial answer is exactly the one nobody would then read. The criterion says every entity, and it gets every entity. Placement: the spec entry sits between attest and check, which is where section 4 puts scope once edit and graph are skipped for not existing, and tests/skill.rs is what holds that rather than my memory. The guard filed an hour ago earned itself immediately -- shipping the verb turned the suite red with 'ank scope ships and is still declared unimplemented: remove it from NOT_YET_DISPATCHED, in the commit that implemented it', which is the anti-rot assertion firing on real work instead of on a mutation. A second existing guard also fired: a unit test asserting COMMANDS.len() == 16, now 17. Three mutations, each caught: removing the dispatch arm while keeping the spec entry reproduces the TASK-45d1 failure mode and the test reports 'scope is not implemented yet'; removing the group headers fails it; leaving the empty answer silent fails it. The first attempt at the grouping mutation reported a pass because the sed had not matched -- checked the file rather than trusting the green, the same way as on TASK-973f.
+- 2026-08-03T06:03:39Z seanl@sean-laptop — done, proof test:ci://github/30788777196

--- a/.ank/tasks/TASK-e717ee625c5c.md
+++ b/.ank/tasks/TASK-e717ee625c5c.md
@@ -5,7 +5,7 @@ slug: ank-scope-says-what-covers-a-path
 title: ank scope says what covers a path
 created: 2026-08-01T18:30:10Z
 author: seanl@sean-laptop
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/**
   - crates/ank-core/**
@@ -14,7 +14,10 @@ done_criteria: |
   ank scope <path> lists every entity whose scope matches the path, grouped by type, one line each with status, and says so explicitly when nothing matches. The resolution is the same glob matching context uses, deterministic against the filesystem. The binary is what the test invokes.
 criteria_by: creator
 schema: 2
-version: 1
+version: 3
 ---
 
 The check-ignore of ank: a dead scope is today only visible after the fact, through check. This makes glob resolution observable before an entity is written wrong.
+
+## Log
+- 2026-08-03T05:59:35Z seanl@sean-laptop — Implemented in commands.rs beside find, which it resembles. The matching is not a copy: context::in_perimeter became pub(crate) and is now the single implementation, with commands::scope_touches -- what find --scope already used -- reduced to a call into it. There were two identical four-line wrappers over ScopeSet before, so the criterion's 'the same glob matching context uses' was true by coincidence and is now true by construction. No budget cap, unlike find, and that is a decision rather than an omission: find is an open query over the corpus and must cap, while scope is asked about one path and its answer is bounded by what the caller already named. Capping would also make the verb lie, since the constraint left out of a partial answer is exactly the one nobody would then read. The criterion says every entity, and it gets every entity. Placement: the spec entry sits between attest and check, which is where section 4 puts scope once edit and graph are skipped for not existing, and tests/skill.rs is what holds that rather than my memory. The guard filed an hour ago earned itself immediately -- shipping the verb turned the suite red with 'ank scope ships and is still declared unimplemented: remove it from NOT_YET_DISPATCHED, in the commit that implemented it', which is the anti-rot assertion firing on real work instead of on a mutation. A second existing guard also fired: a unit test asserting COMMANDS.len() == 16, now 17. Three mutations, each caught: removing the dispatch arm while keeping the spec entry reproduces the TASK-45d1 failure mode and the test reports 'scope is not implemented yet'; removing the group headers fails it; leaving the empty answer silent fails it. The first attempt at the grouping mutation reported a pass because the sed had not matched -- checked the file rather than trusting the green, the same way as on TASK-973f.

--- a/crates/ank-cli/src/cli.rs
+++ b/crates/ank-cli/src/cli.rs
@@ -276,6 +276,17 @@ pub const COMMANDS: &[CommandSpec] = &[
         flags: &[flag("--proof")],
         owner_task: None,
     },
+    // Between `attest` and `check`, which is where §4 puts it once the verbs it
+    // sits behind there — `edit` and `graph` — are skipped for not existing yet.
+    // `tests/skill.rs` is what holds this to §4's order rather than to memory.
+    CommandSpec {
+        name: "scope",
+        subcommands: &[],
+        max_positionals: 1,
+        positional_help: "<path>",
+        flags: &[],
+        owner_task: None,
+    },
     CommandSpec {
         name: "check",
         subcommands: &[],
@@ -743,6 +754,7 @@ fn dispatch(argv: &[String], cwd: &std::path::Path, out: &mut dyn std::io::Write
         "claim" => crate::claim::run(&inv, &s.repo, &s.config, &s.identity, out),
         "new" => crate::commands::new(&inv, &s.repo, &s.config, &s.identity, out),
         "find" => crate::commands::find(&inv, &s.repo, &s.config, out),
+        "scope" => crate::commands::scope(&inv, &s.repo, out),
         "log" => crate::commands::log(&inv, &s.repo, &s.config, &s.identity, out),
         "release" => crate::commands::release(&inv, &s.repo, &s.identity, out),
         "check" => crate::human::check(&inv, &s.repo, &s.config, out),
@@ -834,11 +846,15 @@ mod tests {
                 .unwrap_or_else(|e| panic!("--json refused on {}: {}", spec.name, e.render()));
             assert!(inv.json(), "--json not retained on {}", spec.name);
         }
+        // A count, so that a verb added without a thought about `--json` fails
+        // here. What §4 lists and what this table holds is a stronger question
+        // and has its own test, in `tests/skill.rs`, which reads §4 rather than
+        // counting.
         assert_eq!(
             COMMANDS.len(),
-            16,
-            "twelve verbs from §4, plus attest and amend, plus init and help \
-             from §9"
+            17,
+            "the verbs of §4 that ship, plus init and help from §9; `scope` \
+             brought it to 17 (TASK-e717ee625c5c)"
         );
     }
 

--- a/crates/ank-cli/src/commands.rs
+++ b/crates/ank-cli/src/commands.rs
@@ -1,9 +1,9 @@
-//! The new, find, log and release verbs.
+//! The new, find, log, release and scope verbs.
 //!
-//! Four verbs that share almost nothing except being the part of the loop that
-//! is not the loop's spine — SKILL.md teaches them off-loop (§4). What they do
-//! have in common is the discipline of §4: each refuses precisely, names the
-//! command to run next, and writes as little as the transition needs.
+//! Verbs that share almost nothing except being off the loop's spine — SKILL.md
+//! teaches the first four off-loop and does not teach `scope` at all (§4). What
+//! they do have in common is the discipline of §4: each refuses precisely, names
+//! the command to run next, and writes as little as the transition needs.
 //!
 //! - **`new`** requires a scope. A glob is the only mechanism attaching an
 //!   entity to code, and an entity attached to nothing is invisible to
@@ -16,6 +16,9 @@
 //!   Working is what keeps the lock; there is no heartbeat verb to memorise.
 //! - **`release`** requires a reason, because it is the delegation mechanism
 //!   between agents: the reason reaches the next holder through the log.
+//! - **`scope`** makes glob resolution observable before an entity is written
+//!   wrong, and answers with the matching `context` binds with rather than one
+//!   of its own.
 
 use crate::claim::{self, ClaimRecord, Record};
 use crate::cli::{CliError, Invocation, Result};
@@ -26,7 +29,7 @@ use crate::repo::Repo;
 use crate::store::{version_of, Store};
 use ank_core::{
     append_log, serialize_entity, Adr, AdrStatus, CriteriaBy, Entity, EntityId, EntityKind,
-    LogEntry, ScopeSet, Task, TaskStatus, SCHEMA_VERSION,
+    LogEntry, Task, TaskStatus, SCHEMA_VERSION,
 };
 use std::io::Write;
 use std::path::Path;
@@ -425,6 +428,105 @@ pub fn find(inv: &Invocation, repo: &Repo, cfg: &Config, out: &mut dyn Write) ->
     Ok(0)
 }
 
+// ---------------------------------------------------------------------------
+// scope
+// ---------------------------------------------------------------------------
+
+/// `ank scope <path>`: what covers a path (§4).
+///
+/// The `check-ignore` of ank. A dead scope is otherwise only visible after the
+/// fact, through `check`, and a glob that matches nothing is discovered once the
+/// entity is already written and already invisible. This makes the resolution
+/// observable before that, and it answers with [`context::in_perimeter`] — the
+/// same matching `context` binds with, not a second implementation that agrees
+/// today (TASK-e717ee625c5c).
+///
+/// **No budget cap, unlike `find`.** `find` is an open query over the corpus and
+/// caps because it must; `scope` is asked about one path, so its answer is
+/// bounded by what the caller already named. Capping would also make the verb
+/// lie: "what covers this path" is a question whose partial answer is wrong
+/// rather than short, since the constraint left out is exactly the one nobody
+/// would then read.
+pub fn scope(inv: &Invocation, repo: &Repo, out: &mut dyn Write) -> Result<i32> {
+    let Some(raw) = inv.positionals.first() else {
+        return Err(CliError::new(1, "scope needs a path").with_hint("ank scope <path>"));
+    };
+    // `/`-separated, as globs are written and as git speaks on all three
+    // platforms; a trailing separator is the same directory named twice.
+    let path = raw.replace('\\', "/");
+    let path = path.trim_end_matches('/');
+    if path.is_empty() {
+        return Err(CliError::new(1, "scope needs a path").with_hint("ank scope <path>"));
+    }
+
+    let index = Index::open(&repo.ank)?;
+    let all = index.all()?;
+    let ids: Vec<EntityId> = all.iter().map(|r| r.id.clone()).collect();
+    let shorts = context::short_ids(&ids);
+
+    // `all()` arrives in identifier order, so the answer is a function of the
+    // corpus and the path and of nothing else — the filesystem is never
+    // consulted, and a path that does not exist yet resolves like any other.
+    let hits: Vec<&Row> = all
+        .iter()
+        .filter(|r| context::in_perimeter(&r.scope, Some(path)))
+        .collect();
+    let (adrs, tasks): (Vec<&Row>, Vec<&Row>) =
+        hits.iter().partition(|r| r.kind == EntityKind::Adr);
+
+    if inv.json() {
+        let item = |r: &&Row| {
+            format!(
+                "{{\"id\":\"{}\",\"kind\":\"{}\",\"status\":\"{}\",\"title\":{}}}",
+                r.id,
+                r.kind.as_str(),
+                r.status,
+                json_string(&r.title)
+            )
+        };
+        let adr: Vec<String> = adrs.iter().map(item).collect();
+        let task: Vec<String> = tasks.iter().map(item).collect();
+        let _ = writeln!(
+            out,
+            "{{\"path\":{},\"total\":{},\"adr\":[{}],\"tasks\":[{}]}}",
+            json_string(path),
+            hits.len(),
+            adr.join(","),
+            task.join(",")
+        );
+        return Ok(0);
+    }
+    if inv.quiet() {
+        return Ok(0);
+    }
+
+    // Names the perimeter it drew, the way §4 asks `graph` to: an answer about
+    // a path the caller mistyped is indistinguishable from an empty one unless
+    // the path is echoed.
+    let _ = writeln!(out, "{path}");
+    if hits.is_empty() {
+        // Explicit, never an empty answer. Silence here reads as "nothing
+        // constrains this", which is the same sentence as "ank could not tell",
+        // and only one of the two is safe to act on.
+        let _ = writeln!(out, "nothing covers this path");
+        return Ok(0);
+    }
+    for (label, group) in [("ADR", &adrs), ("TASKS", &tasks)] {
+        if group.is_empty() {
+            continue;
+        }
+        let _ = writeln!(out, "\n{label} ({})", group.len());
+        for r in group.iter() {
+            let short = shorts
+                .get(&r.id)
+                .cloned()
+                .unwrap_or_else(|| r.id.to_string());
+            let _ = writeln!(out, "  {short}  [{}] {}", r.status, r.title);
+        }
+    }
+    Ok(0)
+}
+
 /// The same budget `context` answers under (§4, §5), converted to a number of
 /// one-line results. A cap in characters and a cap in lines are the same rule
 /// seen from two sides; expressing it in lines here keeps the output stable
@@ -434,10 +536,7 @@ fn cap_from(cfg: &Config) -> usize {
 }
 
 fn scope_touches(scope: &[String], path: &str) -> bool {
-    match ScopeSet::new(scope) {
-        Ok(set) => set.overlaps_dir(path, scope),
-        Err(_) => false,
-    }
+    context::in_perimeter(scope, Some(path))
 }
 
 /// Title, identifier and slug first, then the text that carries the meaning: a

--- a/crates/ank-cli/src/context.rs
+++ b/crates/ank-cli/src/context.rs
@@ -231,7 +231,12 @@ pub fn short_ids(ids: &[EntityId]) -> HashMap<EntityId, String> {
 /// Whether an entity's scope meets the requested perimeter. `None` is the whole
 /// repository, which is what `context` with no argument covers — an agent
 /// launched on "fix the login bug" does not know its perimeter yet.
-fn in_perimeter(scope: &[String], path: Option<&str>) -> bool {
+///
+/// Shared rather than reimplemented: `find --scope` and `scope` answer the same
+/// question and must answer it identically, or the perimeter an agent explores
+/// stops being the perimeter that binds it. `scope` in particular exists to make
+/// this resolution observable, which is worth nothing if it is a second copy.
+pub(crate) fn in_perimeter(scope: &[String], path: Option<&str>) -> bool {
     let Some(path) = path else {
         return true;
     };

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -366,6 +366,84 @@ fn a_ratification_commit_stripped_of_its_signature_is_a_fault_through_the_binary
     );
 }
 
+/// `ank scope <path>` answers what covers a path (TASK-e717ee625c5c).
+///
+/// The `check-ignore` of ank: a glob that matches nothing is otherwise only
+/// discovered through `check`, after the entity is written and already
+/// invisible. Through the binary, because the criterion is about what the
+/// process prints and because dispatch reaching a new verb is the thing that
+/// has silently failed here before (TASK-45d18f45de2c).
+#[test]
+fn scope_says_what_covers_a_path_and_says_when_nothing_does() {
+    const ADR: &str = "ADR-00000000c0de";
+    let r = Repo::new();
+    std::fs::create_dir_all(r.0.join("src")).unwrap();
+    std::fs::write(r.0.join("src/main.rs"), "fn main() {}\n").unwrap();
+    r.seed_adr(ADR, "Do not do X.", "src/**");
+    r.seed_task(ID, Some("A verifiable criterion."));
+
+    let out = r.ank("claude-code@ank", &["scope", "src/main.rs"]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    let said = stdout(&out);
+
+    // Grouped by type, one line each, carrying the status.
+    assert!(said.contains("ADR (1)"), "{said}");
+    assert!(said.contains("TASKS (1)"), "{said}");
+    assert!(said.contains("[proposed] A decision"), "{said}");
+    assert!(said.contains("[open] Example task"), "{said}");
+    assert!(
+        said.lines()
+            .next()
+            .unwrap_or_default()
+            .contains("src/main.rs"),
+        "it names the perimeter it drew: {said}"
+    );
+
+    // The same resolution `context` binds with. A directory the globs reach
+    // under is covered, which is what `overlaps_dir` means and what an agent
+    // asking about a package rather than a file needs.
+    let out = r.ank("claude-code@ank", &["scope", "src"]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    assert!(stdout(&out).contains("ADR (1)"), "{}", stdout(&out));
+
+    // Nothing matching is said, never left to an empty answer: silence reads as
+    // "nothing constrains this", which is the same sentence as "ank could not
+    // tell", and only one of the two is safe to act on.
+    let out = r.ank("claude-code@ank", &["scope", "docs/whitepaper.md"]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    assert!(
+        stdout(&out).contains("nothing covers this path"),
+        "{}",
+        stdout(&out)
+    );
+
+    // It answers about a path, not about the filesystem: a file that does not
+    // exist yet resolves like any other, which is the point of asking before
+    // writing the entity.
+    let out = r.ank("claude-code@ank", &["scope", "src/not_written_yet.rs"]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    assert!(stdout(&out).contains("ADR (1)"), "{}", stdout(&out));
+
+    // `--json` is available on every command without exception (§4).
+    let out = r.ank("claude-code@ank", &["scope", "src/main.rs", "--json"]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    let j = stdout(&out);
+    assert!(j.contains("\"path\":\"src/main.rs\""), "{j}");
+    assert!(j.contains("\"total\":2"), "{j}");
+    assert!(j.contains("\"adr\":[{"), "{j}");
+    assert!(j.contains("\"tasks\":[{"), "{j}");
+
+    // A missing path is a refusal carrying the command to run next, not a
+    // silent listing of the whole corpus.
+    let out = r.ank("claude-code@ank", &["scope"]);
+    assert_eq!(code(&out), 1, "{}", stderr(&out));
+    assert!(
+        stderr(&out).contains("ank scope <path>"),
+        "{}",
+        stderr(&out)
+    );
+}
+
 /// The stamp follows the commit, including a commit that changes no file
 /// (TASK-0b26c8b5bfc5).
 ///

--- a/crates/ank-cli/tests/skill.rs
+++ b/crates/ank-cli/tests/skill.rs
@@ -114,9 +114,12 @@ fn help_order() -> Vec<String> {
 /// The one hand-maintained list here, and it cannot rot: the test below fails
 /// if any of these becomes dispatchable, so implementing one forces its removal
 /// in the same commit. Each is a specified verb with an open task -- `status`
-/// TASK-15336a0012d5, `edit` TASK-7ed19b16895e, `graph` TASK-253e897d3330,
-/// `scope` TASK-e717ee625c5c.
-const NOT_YET_DISPATCHED: [&str; 4] = ["status", "edit", "graph", "scope"];
+/// TASK-15336a0012d5, `edit` TASK-7ed19b16895e, `graph` TASK-253e897d3330.
+///
+/// `scope` was here and is not any more, which is the guard working as intended
+/// rather than a maintenance chore: shipping it (TASK-e717ee625c5c) turned the
+/// suite red until this line was edited, in the same commit.
+const NOT_YET_DISPATCHED: [&str; 3] = ["status", "edit", "graph"];
 
 /// A verb the binary answers to and §4 never mentions. `attest`, `init` and
 /// `help` were exactly that until TASK-5c868c20472f, and a reader comparing the


### PR DESCRIPTION
Closes TASK-e717ee625c5c. The first of the four verbs §4 specifies and the binary did not dispatch.

## What it does

```
$ ank scope crates/ank-cli/src/human.rs
crates/ank-cli/src/human.rs

ADR (11)
  ADR-4e7c  [accepted] Claims live in git refs, never in the files
  ADR-6b3f  [accepted] Immutability is verifiable by hash, never defended by the CLI
  ...

TASKS (33)
  TASK-039e  [open] new without its flags opens a template in the editor
  ...
```

The `check-ignore` of ank. A glob that matches nothing was visible only after the fact, through `check` — once the entity was already written and already invisible to `context`.

## The matching is not a copy

`context::in_perimeter` became `pub(crate)` and is now the single implementation; `commands::scope_touches`, which `find --scope` already used, reduces to a call into it.

There were **two identical four-line wrappers** over `ScopeSet` before this. So the criterion's *"the same glob matching `context` uses"* was true by coincidence, and is now true by construction — which matters for a verb whose entire purpose is to show an agent the perimeter that will bind it.

## No budget cap, unlike `find`

A decision, not an omission. `find` is an open query over the corpus and must cap; `scope` is asked about one path, so its answer is bounded by what the caller already named. Capping would also make the verb lie: the constraint left out of a partial answer is exactly the one nobody would then read. The criterion says *every* entity, and it gets every entity.

## The guard from an hour ago earned itself

Placement between `attest` and `check` is where §4 puts `scope` once `edit` and `graph` are skipped for not existing yet. `tests/skill.rs` is what holds it there rather than memory — and shipping this verb turned the suite red immediately:

```
`ank scope` ships and is still declared unimplemented: remove it from
NOT_YET_DISPATCHED, in the commit that implemented it
```

That is TASK-973fc0173b98's anti-rot assertion firing on real work rather than on a mutation, one PR after it was written. A second existing guard fired too — the unit test counting `COMMANDS`.

## Proved by mutation

| mutation | result |
|---|---|
| dispatch arm removed, spec entry kept | caught — `'scope' is not implemented yet`, the TASK-45d18f45de2c failure mode exactly |
| group headers removed | caught |
| the empty answer left silent | caught |

The test also covers a directory rather than a file (`overlaps_dir`, what an agent asking about a package needs), a path that does not exist yet — the point of asking *before* writing the entity — `--json`, and the refusal when no path is given.

One note on method: my first attempt at the grouping mutation reported a pass, because the `sed` had not matched. I checked the file rather than trusting the green, same as on TASK-973fc0173b98.

## Verification

`cargo test --workspace` green (206 + 32 + 6 + 3 + 12), `cargo fmt --check` clean, `ank check` exit 0. Task declares no `verify:` list, so this PR's CI run is the proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QoJrx7uZpTu7ZEzie8TpKH