### PR TITLE
A directory means one thing however the path is typed

### DIFF
--- a/.ank/tasks/TASK-df4c39031583.md
+++ b/.ank/tasks/TASK-df4c39031583.md
@@ -1,0 +1,43 @@
+---
+id: TASK-df4c39031583
+type: task
+slug: one-directory-five-answers-the-path-argument-is
+title: "One directory, five answers: the path argument is never normalised"
+created: 2026-08-03T06:09:38Z
+author: seanl@sean-laptop
+status: in_progress
+scope:
+  - crates/ank-cli/**
+  - crates/ank-core/**
+  - docs/ank-spec-v1.1.md
+blocked_by: []
+done_criteria: |
+  context, review, check and scope give the same answer for one directory however the path is written: docs, docs/, docs\ , ./docs and .\docs\ all resolve identically, measured through the binary against a fixture with a known expected set. A form the tool will not resolve is refused with the command to run next, never answered with a silently partial set. Section 4 states the normalisation.
+criteria_by: creator
+verify: [cargo-test, fmt-check, check-repo]
+schema: 2
+version: 3
+---
+
+Reported from a Windows shell on 2026-08-03, on the real corpus, against docs/ -- which five ADRs bind and seven cover.
+
+  path written as   context  review  scope
+  docs              5        5       7
+  docs/             5        5       7
+  docs\             4        4       7
+  ./docs            0        0       0
+  .\docs\           0        0       0
+  docs/../docs      4        4       5
+
+The zeros are survivable because they are obvious. The four is not. It is the answer to the path form Windows tab-completion produces by default, it looks exactly like a correct answer, and it silently drops one of the five constraints that bind the perimeter. An agent reading it has no way to know a rule was withheld, and constraint injection is the one thing the tool exists to get right.
+
+The cause is that the argument is passed to glob matching verbatim. ScopeSet::overlaps_dir trims a trailing slash and nothing else, so a backslash survives into the match: globs written with ** still match it as an ordinary character, globs naming a segment do not, and the result is a partial set rather than an empty one. A leading ./ fails every glob, which is why those forms answer zero.
+
+scope has the same defect and shipped with it an hour ago (TASK-e717ee625c5c). It normalises the separator and the trailing slash and not the leading ./, which is how it reaches seven where the others reach four and still zero where they do.
+
+Two decisions belong to whoever claims this rather than to the filing. Whether .. is resolved lexically or refused: today it silently answers about a different perimeter, and either alternative beats that. And case, which should stay sensitive on purpose -- DOCS answers zero on both platforms today, and making it match on Windows alone would give the same corpus two meanings depending on where it is read, which is worse than the surprise it removes.
+
+The normalisation belongs at one choke point. context::in_perimeter is already the single matcher since TASK-e717ee625c5c, so the four verbs converge there, but the normalised form also has to reach what scope echoes back, or the verb prints a path it did not use.
+
+## Log
+- 2026-08-03T06:18:40Z seanl@sean-laptop — Fixed at one choke point. ank_core::normalize_path does the lexical work -- separators unified to /, repeated and trailing ones collapsed, . dropped, .. resolved by popping, None when the path is absolute or climbs above the root -- and context::perimeter is the single place the four path-taking verbs read their argument. Normalising inside in_perimeter would have been cheaper and wrong twice: a refusal cannot be expressed through a bool, and scope echoes the perimeter it drew, which has to be the one it used. Found while wiring it: a third private copy of the matching, inside review's live-constraint loop, which is why review and context disagreed about docs backslash in the first place. It now calls in_perimeter like the others, so there is one implementation rather than three. .. is resolved rather than refused, since docs/../docs is docs and answering about a different perimeter was the defect. Case stays sensitive: folding it on Windows alone would give one corpus two meanings depending on the machine reading it. Two mistakes in my own verification, both caught by assertions I had written rather than by reading. Measuring the fix by hand, context reported 8 for every path form and looked fixed -- it was in execution mode because I held a claim, so it was ignoring the path entirely; the fixture holds no claim, and the test comment says why. Then the fixture itself failed the discriminator twice: review lists only accepted ADRs, so a proposed one made both perimeters answer zero, and check reports corpus-wide totals, so without a finding present on one side only it answered identically for every path. Both now real: the ADR is accepted, and a second ADR carries a dead scope under docs and nowhere else. Mutation: passing the raw path through the choke point fails the test on ank context docs backslash.

--- a/.ank/tasks/TASK-df4c39031583.md
+++ b/.ank/tasks/TASK-df4c39031583.md
@@ -5,7 +5,7 @@ slug: one-directory-five-answers-the-path-argument-is
 title: "One directory, five answers: the path argument is never normalised"
 created: 2026-08-03T06:09:38Z
 author: seanl@sean-laptop
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/**
   - crates/ank-core/**
@@ -15,8 +15,24 @@ done_criteria: |
   context, review, check and scope give the same answer for one directory however the path is written: docs, docs/, docs\ , ./docs and .\docs\ all resolve identically, measured through the binary against a fixture with a known expected set. A form the tool will not resolve is refused with the command to run next, never answered with a silently partial set. Section 4 states the normalisation.
 criteria_by: creator
 verify: [cargo-test, fmt-check, check-repo]
+proof:
+  - type: test
+    ref: local/883b88172e68@cd748be
+    tree: scope/9c8c64aa69a4
+    criteria: 398986432b31
+    verifier: cargo-test@f14aeab36e1b
+  - type: test
+    ref: local/e3b0c44298fc@cd748be
+    tree: scope/9c8c64aa69a4
+    criteria: 398986432b31
+    verifier: fmt-check@5ca6d10bcd55
+  - type: test
+    ref: local/1535b6175fc5@cd748be
+    tree: scope/9c8c64aa69a4
+    criteria: 398986432b31
+    verifier: check-repo@5734e9cf9d3d
 schema: 2
-version: 3
+version: 5
 ---
 
 Reported from a Windows shell on 2026-08-03, on the real corpus, against docs/ -- which five ADRs bind and seven cover.
@@ -41,3 +57,4 @@ The normalisation belongs at one choke point. context::in_perimeter is already t
 
 ## Log
 - 2026-08-03T06:18:40Z seanl@sean-laptop — Fixed at one choke point. ank_core::normalize_path does the lexical work -- separators unified to /, repeated and trailing ones collapsed, . dropped, .. resolved by popping, None when the path is absolute or climbs above the root -- and context::perimeter is the single place the four path-taking verbs read their argument. Normalising inside in_perimeter would have been cheaper and wrong twice: a refusal cannot be expressed through a bool, and scope echoes the perimeter it drew, which has to be the one it used. Found while wiring it: a third private copy of the matching, inside review's live-constraint loop, which is why review and context disagreed about docs backslash in the first place. It now calls in_perimeter like the others, so there is one implementation rather than three. .. is resolved rather than refused, since docs/../docs is docs and answering about a different perimeter was the defect. Case stays sensitive: folding it on Windows alone would give one corpus two meanings depending on the machine reading it. Two mistakes in my own verification, both caught by assertions I had written rather than by reading. Measuring the fix by hand, context reported 8 for every path form and looked fixed -- it was in execution mode because I held a claim, so it was ignoring the path entirely; the fixture holds no claim, and the test comment says why. Then the fixture itself failed the discriminator twice: review lists only accepted ADRs, so a proposed one made both perimeters answer zero, and check reports corpus-wide totals, so without a finding present on one side only it answered identically for every path. Both now real: the ADR is accepted, and a second ADR carries a dead scope under docs and nowhere else. Mutation: passing the raw path through the choke point fails the test on ank context docs backslash.
+- 2026-08-03T06:51:48Z seanl@sean-laptop — done, proof test:local/883b88172e68@cd748be test:local/e3b0c44298fc@cd748be test:local/1535b6175fc5@cd748be

--- a/crates/ank-cli/src/commands.rs
+++ b/crates/ank-cli/src/commands.rs
@@ -448,16 +448,15 @@ pub fn find(inv: &Invocation, repo: &Repo, cfg: &Config, out: &mut dyn Write) ->
 /// rather than short, since the constraint left out is exactly the one nobody
 /// would then read.
 pub fn scope(inv: &Invocation, repo: &Repo, out: &mut dyn Write) -> Result<i32> {
-    let Some(raw) = inv.positionals.first() else {
-        return Err(CliError::new(1, "scope needs a path").with_hint("ank scope <path>"));
-    };
-    // `/`-separated, as globs are written and as git speaks on all three
-    // platforms; a trailing separator is the same directory named twice.
-    let path = raw.replace('\\', "/");
-    let path = path.trim_end_matches('/');
-    if path.is_empty() {
+    if inv.positionals.first().is_none() {
         return Err(CliError::new(1, "scope needs a path").with_hint("ank scope <path>"));
     }
+    // Normalised by the one helper every path-taking verb uses, rather than
+    // here: this verb shipped with its own half of the rule -- separator and
+    // trailing slash, not a leading `./` -- and answered differently from
+    // `context` about the same directory for it (TASK-df4c39031583).
+    let perimeter = context::perimeter(inv, repo)?;
+    let shown = perimeter.as_deref().unwrap_or(".");
 
     let index = Index::open(&repo.ank)?;
     let all = index.all()?;
@@ -469,7 +468,7 @@ pub fn scope(inv: &Invocation, repo: &Repo, out: &mut dyn Write) -> Result<i32> 
     // consulted, and a path that does not exist yet resolves like any other.
     let hits: Vec<&Row> = all
         .iter()
-        .filter(|r| context::in_perimeter(&r.scope, Some(path)))
+        .filter(|r| context::in_perimeter(&r.scope, perimeter.as_deref()))
         .collect();
     let (adrs, tasks): (Vec<&Row>, Vec<&Row>) =
         hits.iter().partition(|r| r.kind == EntityKind::Adr);
@@ -489,7 +488,7 @@ pub fn scope(inv: &Invocation, repo: &Repo, out: &mut dyn Write) -> Result<i32> 
         let _ = writeln!(
             out,
             "{{\"path\":{},\"total\":{},\"adr\":[{}],\"tasks\":[{}]}}",
-            json_string(path),
+            json_string(shown),
             hits.len(),
             adr.join(","),
             task.join(",")
@@ -503,7 +502,7 @@ pub fn scope(inv: &Invocation, repo: &Repo, out: &mut dyn Write) -> Result<i32> 
     // Names the perimeter it drew, the way §4 asks `graph` to: an answer about
     // a path the caller mistyped is indistinguishable from an empty one unless
     // the path is echoed.
-    let _ = writeln!(out, "{path}");
+    let _ = writeln!(out, "{shown}");
     if hits.is_empty() {
         // Explicit, never an empty answer. Silence here reads as "nothing
         // constrains this", which is the same sentence as "ank could not tell",

--- a/crates/ank-cli/src/context.rs
+++ b/crates/ank-cli/src/context.rs
@@ -228,6 +228,41 @@ pub fn short_ids(ids: &[EntityId]) -> HashMap<EntityId, String> {
     out
 }
 
+/// The perimeter a path-taking verb was given, normalised once (§4).
+///
+/// Every verb that takes a path goes through here — `context`, `review`,
+/// `check`, `scope` — so that a directory has one meaning rather than one per
+/// way of typing it (TASK-df4c39031583). Normalising inside [`in_perimeter`]
+/// instead would be cheaper and wrong twice over: a refusal cannot be expressed
+/// through a `bool`, and `scope` echoes the perimeter it drew, which has to be
+/// the one it actually used.
+///
+/// `None` is the whole repository: no argument at all, or `.`, which names the
+/// root and therefore everything.
+pub(crate) fn perimeter(inv: &Invocation, repo: &Repo) -> Result<Option<String>> {
+    let Some(raw) = inv.positionals.first() else {
+        return Ok(None);
+    };
+    if let Some(path) = ank_core::normalize_path(raw) {
+        return Ok((!path.is_empty()).then_some(path));
+    }
+    // Never a silent answer about an invented perimeter. The hint is the exact
+    // command when the path is simply the absolute form of one inside the
+    // repository, which is the way this is usually typed.
+    let hint = std::path::Path::new(raw)
+        .strip_prefix(&repo.root)
+        .ok()
+        .map(|rel| rel.to_string_lossy().replace('\\', "/"))
+        .filter(|rel| !rel.is_empty())
+        .map(|rel| format!("ank {} {rel}", inv.command))
+        .unwrap_or_else(|| format!("ank {} <path inside the repository>", inv.command));
+    Err(CliError::new(
+        1,
+        format!("'{raw}' does not name a path in this repository"),
+    )
+    .with_hint(hint))
+}
+
 /// Whether an entity's scope meets the requested perimeter. `None` is the whole
 /// repository, which is what `context` with no argument covers — an agent
 /// launched on "fix the login bug" does not know its perimeter yet.
@@ -922,8 +957,8 @@ pub fn run(
         })?),
         None => None,
     };
-    let path = inv.positionals.first().map(|s| s.as_str());
-    let mut view = build(repo, cfg, identity, path, limit)?;
+    let path = perimeter(inv, repo)?;
+    let mut view = build(repo, cfg, identity, path.as_deref(), limit)?;
 
     // A path argument with a claim in hand is ignored, and said so: exploring
     // another perimeter mid-task is what the one-claim-per-agent rule

--- a/crates/ank-cli/src/human.rs
+++ b/crates/ank-cli/src/human.rs
@@ -124,8 +124,8 @@ impl Report {
 // ---------------------------------------------------------------------------
 
 pub fn check(inv: &Invocation, repo: &Repo, cfg: &Config, out: &mut dyn Write) -> Result<i32> {
-    let path = inv.positionals.first().map(|s| s.as_str());
-    let report = inspect(repo, cfg, path, true)?;
+    let path = crate::context::perimeter(inv, repo)?;
+    let report = inspect(repo, cfg, path.as_deref(), true)?;
     render(&report, inv, out);
     Ok(report.exit_code())
 }
@@ -1255,8 +1255,8 @@ fn json_str(s: &str) -> String {
 /// The human read of a perimeter: what binds it, what has died, and what
 /// `check` would say — without touching the coordination plane.
 pub fn review(inv: &Invocation, repo: &Repo, cfg: &Config, out: &mut dyn Write) -> Result<i32> {
-    let path = inv.positionals.first().map(|s| s.as_str());
-    let report = inspect(repo, cfg, path, false)?;
+    let path = crate::context::perimeter(inv, repo)?;
+    let report = inspect(repo, cfg, path.as_deref(), false)?;
     let index = Index::open(&repo.ank)?;
     let files = tracked_files(&repo.root);
 
@@ -1274,13 +1274,11 @@ pub fn review(inv: &Invocation, repo: &Repo, cfg: &Config, out: &mut dyn Write) 
         if row.kind != EntityKind::Adr || row.status != "accepted" {
             continue;
         }
-        if let Some(p) = path {
-            let touches = ScopeSet::new(&row.scope)
-                .map(|s| s.overlaps_dir(p, &row.scope))
-                .unwrap_or(false);
-            if !touches {
-                continue;
-            }
+        // The third copy of this matching, now gone the way of the other two:
+        // `review` deciding for itself what a perimeter contains is how it came
+        // to disagree with `context` about `docs\` (TASK-df4c39031583).
+        if !crate::context::in_perimeter(&row.scope, path.as_deref()) {
+            continue;
         }
         if dead.contains(&row.id.to_string()) {
             continue;

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -366,6 +366,110 @@ fn a_ratification_commit_stripped_of_its_signature_is_a_fault_through_the_binary
     );
 }
 
+/// One directory, one answer, however it is typed (TASK-df4c39031583).
+///
+/// Reported from a Windows shell against the real corpus. `docs` answered five
+/// live constraints, `docs\` answered **four**, `.\docs\` answered zero. The
+/// zeros were survivable because they were obvious; the four was not. It is what
+/// tab-completion produces on Windows, it looks like a correct answer, and it
+/// silently dropped a rule that binds — because the argument reached glob
+/// matching verbatim, where a `**` glob still matched a backslash as an ordinary
+/// character and a glob naming a segment did not.
+///
+/// Through the binary and across all four path-taking verbs, because the defect
+/// was never in the matcher: it was in what each verb handed to it, and three of
+/// them had their own copy of the handing.
+///
+/// **No claim is held in this fixture, and that is load-bearing.** `context`
+/// with a claim is in execution mode and ignores the path entirely (§5), so a
+/// comparison made while holding one would pass whatever the code did. I made
+/// that exact mistake measuring the fix by hand.
+#[test]
+fn a_directory_resolves_the_same_however_the_path_is_written() {
+    const ADR: &str = "ADR-00000000dddd";
+    let r = Repo::new();
+    r.enable_signing();
+    std::fs::create_dir_all(r.0.join("docs")).unwrap();
+    std::fs::write(r.0.join("docs/guide.md"), "# guide\n").unwrap();
+    std::fs::create_dir_all(r.0.join("src")).unwrap();
+    std::fs::write(r.0.join("src/main.rs"), "fn main() {}\n").unwrap();
+    // One entity inside the perimeter, one outside: an answer that ignored the
+    // path would match both and look like success.
+    r.seed_adr(ADR, "Do not do X.", "docs/**");
+    r.seed_task(ID, Some("A verifiable criterion."));
+    // A dead scope under `docs/` and nowhere else. `check` reports corpus-wide
+    // totals whatever the perimeter, so without a finding that exists on one
+    // side and not the other it answers identically for every path — and the
+    // comparison below would be measuring nothing. The assertion caught that too.
+    r.seed_adr("ADR-00000000eeee", "Do not do Y.", "docs/missing/**");
+    r.git(&["add", "-A"]);
+    r.git(&["-c", "commit.gpgsign=false", "commit", "-qm", "seed"]);
+    // Ratified, or `review` lists no live constraint at all and the two
+    // perimeters answer identically for a reason that has nothing to do with
+    // the path. The assertion below catches exactly that, and did.
+    let out = r.ank("marie@laptop", &["accept", ADR]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+
+    let forms = [
+        "docs",
+        "docs/",
+        "docs\\",
+        "./docs",
+        ".\\docs\\",
+        "docs/../docs",
+        "docs//",
+    ];
+    for verb in ["context", "review", "check", "scope"] {
+        let base = r.ank("claude-code@ank", &[verb, "docs"]);
+        let expected = stdout(&base);
+        let expected_code = code(&base);
+        for form in forms {
+            let got = r.ank("claude-code@ank", &[verb, form]);
+            assert_eq!(
+                code(&got),
+                expected_code,
+                "`ank {verb} {form}` exits differently from `ank {verb} docs`: {}",
+                stderr(&got)
+            );
+            assert_eq!(
+                stdout(&got),
+                expected,
+                "`ank {verb} {form}` must answer as `ank {verb} docs` does"
+            );
+        }
+        // And the perimeter is real: the ADR lives under docs/, the task under
+        // src/, so the two paths must not give the same answer.
+        let elsewhere = stdout(&r.ank("claude-code@ank", &[verb, "src"]));
+        assert_ne!(
+            elsewhere, expected,
+            "`ank {verb}` gives one answer for two different perimeters, so \
+             comparing path forms proves nothing"
+        );
+    }
+
+    // `scope` echoes the perimeter it drew, and it has to echo the one it used.
+    let out = r.ank("claude-code@ank", &["scope", ".\\docs\\"]);
+    assert_eq!(
+        stdout(&out).lines().next().unwrap_or_default(),
+        "docs",
+        "the echoed path is the normalised one: {}",
+        stdout(&out)
+    );
+
+    // A path that leaves the repository has no answer, and saying nothing would
+    // be the silently-partial set all over again.
+    for outside in ["/etc/passwd", "..", "../sibling", "docs/../../elsewhere"] {
+        let out = r.ank("claude-code@ank", &["review", outside]);
+        assert_eq!(code(&out), 1, "{outside} must be refused: {}", stdout(&out));
+        let err = stderr(&out);
+        assert!(err.starts_with("error[1]:"), "{err}");
+        assert!(
+            err.contains("ank review"),
+            "a refusal always says what to run next: {err}"
+        );
+    }
+}
+
 /// `ank scope <path>` answers what covers a path (TASK-e717ee625c5c).
 ///
 /// The `check-ignore` of ank: a glob that matches nothing is otherwise only

--- a/crates/ank-core/src/lib.rs
+++ b/crates/ank-core/src/lib.rs
@@ -34,4 +34,4 @@ pub use parse::{
     has_crlf, normalise_line_endings, parse_adr, parse_entity, parse_task, serialize_adr,
     serialize_entity, serialize_task,
 };
-pub use scope::ScopeSet;
+pub use scope::{normalize_path, ScopeSet};

--- a/crates/ank-core/src/scope.rs
+++ b/crates/ank-core/src/scope.rs
@@ -1,6 +1,57 @@
 use crate::error::{Error, Result};
 use globset::{Glob, GlobSet, GlobSetBuilder};
 
+/// A perimeter path in the one form globs are written in: `/`-separated,
+/// relative to the repository root, no `.` and no `..` left in it.
+///
+/// This exists because the argument used to reach glob matching verbatim, and a
+/// directory then had as many meanings as ways of typing it (TASK-df4c39031583).
+/// Measured on the real corpus against `docs/`, which five ADRs bind: `docs` and
+/// `docs/` answered five, `docs\` answered **four**, `./docs` and `.\docs\`
+/// answered zero. The zeros are survivable because they are obvious. The four is
+/// not: it is what Windows tab-completion produces, it looks like a correct
+/// answer, and it silently drops a constraint that binds. A backslash survived
+/// into the match, where a `**` glob still matched it as an ordinary character
+/// and a glob naming a segment did not.
+///
+/// `None` means the path names nothing inside the repository — it is absolute,
+/// or it climbs above the root — and the caller refuses rather than answering
+/// about a perimeter it had to invent. An empty result is the repository root
+/// itself, which is the whole corpus and what `.` means.
+///
+/// Case is left alone, deliberately. `DOCS` matches nothing here and matches
+/// nothing on Linux; folding it on Windows would give one corpus two meanings
+/// depending on the machine reading it, which is worse than the surprise it
+/// removes.
+pub fn normalize_path(path: &str) -> Option<String> {
+    let unified = path.replace('\\', "/");
+    // An absolute path names a place on a machine, not a place in the corpus,
+    // and `C:/...` is absolute just as `/...` is.
+    let drive_letter = {
+        let b = unified.as_bytes();
+        b.len() >= 2 && b[0].is_ascii_alphabetic() && b[1] == b':'
+    };
+    if unified.starts_with('/') || drive_letter {
+        return None;
+    }
+    let mut out: Vec<&str> = Vec::new();
+    for segment in unified.split('/') {
+        match segment {
+            // A repeated or trailing separator, and `.`, name the same place.
+            "" | "." => {}
+            // Resolved lexically rather than refused: `docs/../docs` is `docs`,
+            // and answering about a different perimeter was the defect. Popping
+            // nothing means climbing out of the repository, which is the one
+            // case with no answer to give.
+            ".." => {
+                out.pop()?;
+            }
+            s => out.push(s),
+        }
+    }
+    Some(out.join("/"))
+}
+
 /// Validates a scope's globs without building a matcher.
 pub fn validate_globs(globs: &[String]) -> Result<()> {
     for g in globs {
@@ -37,5 +88,77 @@ impl ScopeSet {
     pub fn overlaps_dir(&self, dir: &str, globs: &[String]) -> bool {
         let d = dir.trim_end_matches('/');
         self.matches(d) || globs.iter().any(|g| g.starts_with(&format!("{d}/")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The forms a shell actually produces, and the one answer they all name.
+    /// `docs\` is the one that mattered: it used to survive into the match and
+    /// come back with a partial set rather than an empty one.
+    #[test]
+    fn every_way_of_writing_a_directory_normalises_to_one() {
+        for raw in [
+            "docs",
+            "docs/",
+            "docs\\",
+            "./docs",
+            ".\\docs\\",
+            "docs/../docs",
+            "docs//",
+            "./docs/./",
+        ] {
+            assert_eq!(
+                normalize_path(raw).as_deref(),
+                Some("docs"),
+                "{raw} must name the same directory as `docs`"
+            );
+        }
+    }
+
+    /// The root is the whole corpus, and `.` is how it is typed.
+    #[test]
+    fn the_repository_root_normalises_to_nothing() {
+        for raw in [".", "./", ".\\", "", "docs/.."] {
+            assert_eq!(normalize_path(raw).as_deref(), Some(""), "{raw}");
+        }
+    }
+
+    /// No answer rather than a wrong one. A path leaving the repository names a
+    /// place on a machine, and the caller refuses instead of inventing a
+    /// perimeter.
+    #[test]
+    fn a_path_outside_the_repository_has_no_normal_form() {
+        for raw in [
+            "/etc/passwd",
+            "C:/Windows",
+            "c:\\Windows",
+            "..",
+            "../sibling",
+            "docs/../../elsewhere",
+        ] {
+            assert_eq!(normalize_path(raw), None, "{raw} is not in the repository");
+        }
+    }
+
+    /// Case is left alone on purpose: folding it on Windows alone would give one
+    /// corpus two meanings depending on the machine reading it.
+    #[test]
+    fn case_is_not_folded() {
+        assert_eq!(normalize_path("DOCS").as_deref(), Some("DOCS"));
+    }
+
+    /// The normal form is what the matcher was always meant to receive.
+    #[test]
+    fn the_normal_form_is_what_the_matcher_matches() {
+        let globs = vec!["docs/**".to_string()];
+        let set = ScopeSet::new(&globs).unwrap();
+        assert!(set.overlaps_dir("docs", &globs));
+        // The raw Windows form, which is what used to reach here.
+        assert!(!set.overlaps_dir(".\\docs\\", &globs));
+        let normal = normalize_path(".\\docs\\").unwrap();
+        assert!(set.overlaps_dir(&normal, &globs));
     }
 }

--- a/docs/ank-spec-v1.1.md
+++ b/docs/ank-spec-v1.1.md
@@ -420,6 +420,10 @@ ank --version               (the build itself: version and commit, no verb, no r
 
 Commands that take a perimeter take **paths**, uniformly: `review [<path>]`, `check [<path>]` and `graph [<path>]` share the same semantics as `context`, and `scope <path>` resolves against the same globs.
 
+**A path is normalised before it is matched, and a directory has one meaning however it is typed.** Separators are unified to `/`, repeated and trailing ones collapse, `.` disappears and `..` is resolved lexically — so `docs`, `docs/`, `docs\`, `./docs`, `.\docs\` and `docs/../docs` are one perimeter. A path naming nothing inside the repository, because it is absolute or because it climbs above the root, is **refused with the command to run next**; it is never answered. Case is not folded, deliberately: `DOCS` matches nothing here and matches nothing on Linux, and folding it on Windows alone would give one corpus two meanings depending on the machine reading it.
+
+The rule is not cosmetic, and it is written down because its absence was not obvious. Measured on this repository against `docs/`, which five accepted ADRs bind: `docs` answered five, `docs\` answered **four**, `./docs` answered zero (TASK-df4c39031583). The zeros announce themselves. The four does not — it is the form Windows tab-completion produces, it looks like an answer, and it withholds a binding rule from an agent that has no way to know one is missing. A perimeter resolved two ways is a constraint set that depends on typing.
+
 Global flags, deliberately limited to three: `--json`, `--quiet`, `--repo <path>`. Every global flag is a memorisation cost. `--json` is available on every command without exception: full scriptability is an invariant, not an option.
 
 **`ank --version` is not a fourth global flag**, and the limit above is untouched. The three modify a verb; this one replaces it — there is no `ank check --version`, and asking for the build while also asking for something else is not a question anyone has. It prints the crate version and the commit the binary was built from, on one line, and exits 0.


### PR DESCRIPTION
Closes TASK-df4c39031583. Reported from a Windows shell, against the real corpus.

## The defect

`docs/` is bound by five accepted ADRs. It answered five different ways depending on how the path was typed:

| written as | `context` | `review` | `scope` |
|---|---|---|---|
| `docs` · `docs/` | 5 | 5 | 7 |
| `docs\` | **4** | **4** | 7 |
| `./docs` · `.\docs\` | **0** | **0** | **0** |
| `docs/../docs` | **4** | **4** | **5** |

The zeros are survivable because they announce themselves. **The four is not.** It is the form Windows tab-completion produces by default, it looks exactly like a correct answer, and it silently withholds one of the five rules binding the perimeter — from an agent that has no way to know one is missing.

The cause: the argument reached glob matching verbatim. A backslash survived into the match, where a `**` glob still matched it as an ordinary character and a glob naming a segment did not — so the result was a *partial* set rather than an empty one. A leading `./` failed every glob, hence the zeros.

## The fix

`ank_core::normalize_path` does the lexical work — separators unified to `/`, repeated and trailing ones collapsed, `.` dropped, `..` resolved by popping, `None` when the path is absolute or climbs above the root. `context::perimeter` is the single place all four path-taking verbs read their argument.

Normalising inside `in_perimeter` would have been cheaper and wrong twice over: a refusal cannot be expressed through a `bool`, and `scope` echoes the perimeter it drew, which has to be the one it actually used.

**Found while wiring it:** a third private copy of the matching, inside `review`'s live-constraint loop — which is exactly why `review` and `context` disagreed about `docs\`. It calls `in_perimeter` now, so there is one implementation instead of three.

Decisions, stated rather than left implicit: `..` is resolved rather than refused, since `docs/../docs` *is* `docs` and answering about a different perimeter was the defect; a path leaving the repository is refused with the command to run next; case stays sensitive, because folding it on Windows alone would give one corpus two meanings depending on the machine reading it.

## Two mistakes in my own verification

Both caught by assertions I had written, not by reading output — worth recording, since each would have produced a green test that proved nothing.

1. **Measuring by hand, `context` returned the same number for every form and looked fixed.** It was in execution mode because I held a claim, so it was ignoring the path entirely (§5). The fixture holds no claim, and the test comment says why.
2. **The fixture failed its own discriminator twice.** `review` lists only *accepted* ADRs, so a proposed one made both perimeters answer zero; and `check` reports corpus-wide totals, so without a finding present on one side only it answered identically for every path. The fixture now ratifies the ADR and carries a dead scope under `docs/` and nowhere else.

The test compares stdout **and exit code** across seven forms, for all four verbs, and asserts that two genuinely different perimeters do not answer alike — that last assertion is what caught both mistakes above.

Mutation: passing the raw path through the choke point fails it on `ank context docs\`.

## Verification

`cargo test --workspace` green (206 + 33 + 6 + 8 + 12), `cargo fmt --check` clean, `ank check` exit 0. §4 states the normalisation and why it is not cosmetic.

Your original command, now:

```
$ ank review .\docs\      # identical, byte for byte, to `ank review docs`
LIVE CONSTRAINTS (5)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QoJrx7uZpTu7ZEzie8TpKH