### PR TITLE
ank graph draws the blocked_by DAG

### DIFF
--- a/.ank/tasks/TASK-253e897d3330.md
+++ b/.ank/tasks/TASK-253e897d3330.md
@@ -5,7 +5,7 @@ slug: ank-graph-makes-the-blocked-by-dag-visible
 title: ank graph makes the blocked_by DAG visible
 created: 2026-08-01T18:30:10Z
 author: seanl@sean-laptop
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/**
   - crates/ank-core/**
@@ -14,5 +14,7 @@ done_criteria: |
   ank graph prints the task DAG in readable text, restricted by an optional path the way context is, with --json for the raw edges. The output names the perimeter it drew and says so when the perimeter holds no task. The binary is what the test invokes.
 criteria_by: creator
 schema: 2
-version: 1
+version: 3
 ---
+## Log
+- 2026-08-03T07:07:35Z seanl@sean-laptop — Implemented as its own module, crates/ank-cli/src/graph.rs, rather than growing human.rs further. It reads the perimeter through context::perimeter and filters with in_perimeter, so it inherits the normalisation of TASK-df4c39031583 rather than repeating it -- a fourth private copy of that matching was exactly what this session spent a task removing. Reverses blocked_by once into a blocks map, roots are the tasks with no blocker inside the perimeter, and the forest is drawn depth first. Two decisions worth stating. The forest holds only in-perimeter tasks, so a task whose blocker sits outside would otherwise draw flush left and say nothing is stopping it; those carry a (+n blocker(s) outside) marker instead. And no budget cap, for the reason scope has none: the caller named the perimeter, and a partial DAG is misleading rather than short. --json emits the raw edges, including the ones leaving the perimeter, since the drawing is a reading of the graph and the json is the graph. Cycles: check reports them as a fault, graph still has to draw a corpus that has one. Three mutations run. Flattening the indentation fails the depth assertions; removing the outside marker fails; removing the visited-path guard passed, and that was my test being weak rather than the guard being useless. A two-node cycle has no root, so nothing recurses into it and it is collected by the stranded branch -- the guard is never reached. The fixture now carries both shapes, a closed cycle with no way in and a cycle reachable from a root, and removing the guard fails the test. Found by the mutation run, not by reading the test.

--- a/.ank/tasks/TASK-253e897d3330.md
+++ b/.ank/tasks/TASK-253e897d3330.md
@@ -5,7 +5,7 @@ slug: ank-graph-makes-the-blocked-by-dag-visible
 title: ank graph makes the blocked_by DAG visible
 created: 2026-08-01T18:30:10Z
 author: seanl@sean-laptop
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/**
   - crates/ank-core/**
@@ -13,8 +13,13 @@ blocked_by: [TASK-ff1c20395929]
 done_criteria: |
   ank graph prints the task DAG in readable text, restricted by an optional path the way context is, with --json for the raw edges. The output names the perimeter it drew and says so when the perimeter holds no task. The binary is what the test invokes.
 criteria_by: creator
+proof:
+  - type: test
+    ref: ci://github/30792574980
+    criteria: 209eda29e32a
 schema: 2
-version: 3
+version: 5
 ---
 ## Log
 - 2026-08-03T07:07:35Z seanl@sean-laptop — Implemented as its own module, crates/ank-cli/src/graph.rs, rather than growing human.rs further. It reads the perimeter through context::perimeter and filters with in_perimeter, so it inherits the normalisation of TASK-df4c39031583 rather than repeating it -- a fourth private copy of that matching was exactly what this session spent a task removing. Reverses blocked_by once into a blocks map, roots are the tasks with no blocker inside the perimeter, and the forest is drawn depth first. Two decisions worth stating. The forest holds only in-perimeter tasks, so a task whose blocker sits outside would otherwise draw flush left and say nothing is stopping it; those carry a (+n blocker(s) outside) marker instead. And no budget cap, for the reason scope has none: the caller named the perimeter, and a partial DAG is misleading rather than short. --json emits the raw edges, including the ones leaving the perimeter, since the drawing is a reading of the graph and the json is the graph. Cycles: check reports them as a fault, graph still has to draw a corpus that has one. Three mutations run. Flattening the indentation fails the depth assertions; removing the outside marker fails; removing the visited-path guard passed, and that was my test being weak rather than the guard being useless. A two-node cycle has no root, so nothing recurses into it and it is collected by the stranded branch -- the guard is never reached. The fixture now carries both shapes, a closed cycle with no way in and a cycle reachable from a root, and removing the guard fails the test. Found by the mutation run, not by reading the test.
+- 2026-08-03T07:13:12Z seanl@sean-laptop — done, proof test:ci://github/30792574980

--- a/crates/ank-cli/src/cli.rs
+++ b/crates/ank-cli/src/cli.rs
@@ -276,8 +276,16 @@ pub const COMMANDS: &[CommandSpec] = &[
         flags: &[flag("--proof")],
         owner_task: None,
     },
-    // Between `attest` and `check`, which is where §4 puts it once the verbs it
-    // sits behind there — `edit` and `graph` — are skipped for not existing yet.
+    CommandSpec {
+        name: "graph",
+        subcommands: &[],
+        max_positionals: 1,
+        positional_help: "[<path>]",
+        flags: &[],
+        owner_task: None,
+    },
+    // Between `graph` and `check`, which is where §4 puts it once `edit` — the
+    // one verb still missing from that stretch — is skipped.
     // `tests/skill.rs` is what holds this to §4's order rather than to memory.
     CommandSpec {
         name: "scope",
@@ -754,6 +762,7 @@ fn dispatch(argv: &[String], cwd: &std::path::Path, out: &mut dyn std::io::Write
         "claim" => crate::claim::run(&inv, &s.repo, &s.config, &s.identity, out),
         "new" => crate::commands::new(&inv, &s.repo, &s.config, &s.identity, out),
         "find" => crate::commands::find(&inv, &s.repo, &s.config, out),
+        "graph" => crate::graph::run(&inv, &s.repo, out),
         "scope" => crate::commands::scope(&inv, &s.repo, out),
         "log" => crate::commands::log(&inv, &s.repo, &s.config, &s.identity, out),
         "release" => crate::commands::release(&inv, &s.repo, &s.identity, out),
@@ -852,9 +861,10 @@ mod tests {
         // counting.
         assert_eq!(
             COMMANDS.len(),
-            17,
+            18,
             "the verbs of §4 that ship, plus init and help from §9; `scope` \
-             brought it to 17 (TASK-e717ee625c5c)"
+             brought it to 17 (TASK-e717ee625c5c) and `graph` to 18 \
+             (TASK-253e897d3330)"
         );
     }
 

--- a/crates/ank-cli/src/commands.rs
+++ b/crates/ank-cli/src/commands.rs
@@ -541,7 +541,7 @@ fn scope_touches(scope: &[String], path: &str) -> bool {
 /// Title, identifier and slug first, then the text that carries the meaning: a
 /// task's criterion, an ADR's constraint. Not the whole body — a query matching
 /// a paragraph of reasoning is a match an agent cannot act on.
-fn json_string(s: &str) -> String {
+pub(crate) fn json_string(s: &str) -> String {
     let mut out = String::from("\"");
     for c in s.chars() {
         match c {

--- a/crates/ank-cli/src/graph.rs
+++ b/crates/ank-cli/src/graph.rs
@@ -1,0 +1,226 @@
+//! The `graph` verb: the `blocked_by` DAG, in readable text (§4).
+//!
+//! The ordering of §5 already walks these edges to count what a task unblocks;
+//! this makes the same structure visible to a reader instead of only to the
+//! sort. Everything here is computed from the corpus at read time and stored
+//! nowhere — a stored reverse edge is a second copy of `blocked_by` that can
+//! disagree with the first.
+//!
+//! **The forest is a view, and it says so.** Only tasks inside the perimeter are
+//! drawn, so a task whose blocker sits outside it would otherwise appear to be a
+//! root, and "nothing is stopping this" is the one wrong answer a reader would
+//! act on immediately. Those nodes carry the count of what was left out.
+
+use crate::cli::{Invocation, Result};
+use crate::context;
+use crate::index::{Index, Row};
+use crate::repo::Repo;
+use ank_core::{EntityId, EntityKind};
+use std::collections::{HashMap, HashSet};
+use std::io::Write;
+
+pub fn run(inv: &Invocation, repo: &Repo, out: &mut dyn Write) -> Result<i32> {
+    let perimeter = context::perimeter(inv, repo)?;
+    let shown = perimeter.as_deref().unwrap_or(".");
+
+    let index = Index::open(&repo.ank)?;
+    let all = index.all()?;
+    let ids: Vec<EntityId> = all.iter().map(|r| r.id.clone()).collect();
+    let shorts = context::short_ids(&ids);
+
+    // Sorted by identifier, like every other listing: a graph whose rows shuffle
+    // between two runs is one nobody diffs.
+    let mut nodes: Vec<&Row> = all
+        .iter()
+        .filter(|r| r.kind == EntityKind::Task)
+        .filter(|r| context::in_perimeter(&r.scope, perimeter.as_deref()))
+        .collect();
+    nodes.sort_by_key(|r| r.id.to_string());
+
+    let inside: HashSet<&EntityId> = nodes.iter().map(|r| &r.id).collect();
+    let row_of: HashMap<&EntityId, &Row> = nodes.iter().map(|r| (&r.id, *r)).collect();
+
+    // Reversed once: `blocked_by` points at what must finish first, and a reader
+    // follows the other way round.
+    let mut blocks: HashMap<&EntityId, Vec<&EntityId>> = HashMap::new();
+    let mut roots: Vec<&EntityId> = Vec::new();
+    let mut outside_count: HashMap<&EntityId, usize> = HashMap::new();
+    for row in &nodes {
+        let mut held_inside = 0usize;
+        for blocker in &row.blocked_by {
+            if let Some(b) = inside.get(blocker) {
+                blocks.entry(*b).or_default().push(&row.id);
+                held_inside += 1;
+            }
+        }
+        let outside = row.blocked_by.len() - held_inside;
+        if outside > 0 {
+            outside_count.insert(&row.id, outside);
+        }
+        if held_inside == 0 {
+            roots.push(&row.id);
+        }
+    }
+    for children in blocks.values_mut() {
+        children.sort_by_key(|i| i.to_string());
+    }
+
+    if inv.json() {
+        return json(out, shown, &nodes, &shorts);
+    }
+    if inv.quiet() {
+        return Ok(0);
+    }
+
+    // Names the perimeter it drew (§4). Without it an empty answer and an answer
+    // about the wrong directory look the same.
+    let _ = writeln!(out, "{shown}");
+    if nodes.is_empty() {
+        let _ = writeln!(out, "\nno task in this perimeter");
+        return Ok(0);
+    }
+    let _ = writeln!(out);
+
+    // Every node is cycle-safe: `check` reports a cycle as a fault, and `graph`
+    // still has to draw the corpus that has one rather than hang on it. A cycle
+    // also means no root, which would otherwise print a header and nothing
+    // under it — so what has not been drawn is drawn flat at the end.
+    let mut drawn: HashSet<&EntityId> = HashSet::new();
+    for root in &roots {
+        draw(
+            root,
+            &blocks,
+            &row_of,
+            &shorts,
+            &outside_count,
+            0,
+            &mut drawn,
+            &mut Vec::new(),
+            out,
+        );
+    }
+    let stranded: Vec<&&Row> = nodes.iter().filter(|r| !drawn.contains(&r.id)).collect();
+    if !stranded.is_empty() {
+        let _ = writeln!(out, "\nin a cycle, so under no root:");
+        for row in stranded {
+            let _ = writeln!(out, "  {}", line(&row.id, &row_of, &shorts, &outside_count));
+        }
+    }
+
+    let _ = writeln!(
+        out,
+        "\n{} task(s), {} root(s) — indented under what blocks them",
+        nodes.len(),
+        roots.len()
+    );
+    Ok(0)
+}
+
+/// One node and everything it unblocks, depth first.
+///
+/// `path` is the chain currently being drawn, and it is what makes a cycle
+/// terminate rather than recurse. `drawn` is every node already expanded
+/// somewhere: a diamond is real in a DAG, so the node appears again where it
+/// belongs, marked, and is not expanded twice.
+#[allow(clippy::too_many_arguments)]
+fn draw<'a>(
+    id: &'a EntityId,
+    blocks: &HashMap<&'a EntityId, Vec<&'a EntityId>>,
+    row_of: &HashMap<&'a EntityId, &'a Row>,
+    shorts: &HashMap<EntityId, String>,
+    outside: &HashMap<&'a EntityId, usize>,
+    depth: usize,
+    drawn: &mut HashSet<&'a EntityId>,
+    path: &mut Vec<&'a EntityId>,
+    out: &mut dyn Write,
+) {
+    let indent = "  ".repeat(depth);
+    if path.contains(&id) {
+        let _ = writeln!(out, "{indent}{} (cycle)", line(id, row_of, shorts, outside));
+        return;
+    }
+    let repeat = drawn.contains(&id);
+    let mark = if repeat { " (above)" } else { "" };
+    let _ = writeln!(out, "{indent}{}{mark}", line(id, row_of, shorts, outside));
+    if repeat {
+        return;
+    }
+    drawn.insert(id);
+    path.push(id);
+    for child in blocks.get(id).into_iter().flatten() {
+        draw(
+            child,
+            blocks,
+            row_of,
+            shorts,
+            outside,
+            depth + 1,
+            drawn,
+            path,
+            out,
+        );
+    }
+    path.pop();
+}
+
+fn line<'a>(
+    id: &'a EntityId,
+    row_of: &HashMap<&'a EntityId, &'a Row>,
+    shorts: &HashMap<EntityId, String>,
+    outside: &HashMap<&'a EntityId, usize>,
+) -> String {
+    let short = shorts.get(id).cloned().unwrap_or_else(|| id.to_string());
+    let Some(row) = row_of.get(id) else {
+        return short;
+    };
+    let mut s = format!("{short}  [{}] {}", row.status, row.title);
+    // Never silently a root. A task held up by something the perimeter excludes
+    // is not free to start, and drawing it flush left would say it is.
+    if let Some(n) = outside.get(id) {
+        s.push_str(&format!("  (+{n} blocker(s) outside)"));
+    }
+    s
+}
+
+/// The raw edges (§4): every `blocked_by` relation of an in-perimeter task,
+/// including the ones pointing outside it. The text draws a forest, which is a
+/// reading of the graph; this is the graph.
+fn json(
+    out: &mut dyn Write,
+    path: &str,
+    nodes: &[&Row],
+    shorts: &HashMap<EntityId, String>,
+) -> Result<i32> {
+    let tasks: Vec<String> = nodes
+        .iter()
+        .map(|r| {
+            format!(
+                "{{\"id\":\"{}\",\"short\":\"{}\",\"status\":\"{}\",\"title\":{}}}",
+                r.id,
+                shorts
+                    .get(&r.id)
+                    .cloned()
+                    .unwrap_or_else(|| r.id.to_string()),
+                r.status,
+                crate::commands::json_string(&r.title)
+            )
+        })
+        .collect();
+    let mut edges: Vec<String> = Vec::new();
+    for row in nodes {
+        for blocker in &row.blocked_by {
+            edges.push(format!(
+                "{{\"task\":\"{}\",\"blocked_by\":\"{blocker}\"}}",
+                row.id
+            ));
+        }
+    }
+    let _ = writeln!(
+        out,
+        "{{\"path\":{},\"tasks\":[{}],\"edges\":[{}]}}",
+        crate::commands::json_string(path),
+        tasks.join(","),
+        edges.join(",")
+    );
+    Ok(0)
+}

--- a/crates/ank-cli/src/main.rs
+++ b/crates/ank-cli/src/main.rs
@@ -32,6 +32,7 @@ mod claim;
 mod commands;
 mod context;
 mod done;
+mod graph;
 mod human;
 mod index;
 mod verify;

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -121,6 +121,27 @@ impl Repo {
         .unwrap();
     }
 
+    /// The same seed with a scope of its own, for a fixture that needs an
+    /// entity outside the perimeter under test.
+    fn seed_task_scoped(&self, id: &str, scope: &str) {
+        self.seed_task(id, Some("A verifiable criterion."));
+        let text = self
+            .task_text(id)
+            .replace("  - src/**", &format!("  - {scope}"));
+        std::fs::write(self.0.join(".ank/tasks").join(format!("{id}.md")), text).unwrap();
+    }
+
+    /// Adds blockers to a seeded task. Written into the file rather than through
+    /// `amend`, so that a graph fixture does not depend on the verb that edits
+    /// the field it is drawing.
+    fn blocked(&self, id: &str, blockers: &[&str]) {
+        let list = blockers.join(", ");
+        let text = self
+            .task_text(id)
+            .replace("blocked_by: []", &format!("blocked_by: [{list}]"));
+        std::fs::write(self.0.join(".ank/tasks").join(format!("{id}.md")), text).unwrap();
+    }
+
     fn task_text(&self, id: &str) -> String {
         std::fs::read_to_string(self.0.join(".ank/tasks").join(format!("{id}.md"))).unwrap()
     }
@@ -363,6 +384,165 @@ fn a_ratification_commit_stripped_of_its_signature_is_a_fault_through_the_binary
     assert!(
         !said.contains("altered since ratification") && !said.contains("is reachable"),
         "only the signature is gone: {said}"
+    );
+}
+
+/// `ank graph` draws the `blocked_by` DAG (TASK-253e897d3330).
+///
+/// §5's ordering already walks these edges to count what a task unblocks; this
+/// makes the same structure visible to a reader. Through the binary, because the
+/// criterion is about what the process prints.
+///
+/// The chain is built so that every clause has something to be wrong about: a
+/// root, two levels under it, a diamond, and a task whose only blocker sits
+/// outside the perimeter.
+#[test]
+fn graph_draws_the_dag_and_names_the_perimeter() {
+    let r = Repo::new();
+    std::fs::create_dir_all(r.0.join("src")).unwrap();
+    std::fs::write(r.0.join("src/main.rs"), "fn main() {}\n").unwrap();
+    std::fs::create_dir_all(r.0.join("docs")).unwrap();
+    std::fs::write(r.0.join("docs/guide.md"), "# guide\n").unwrap();
+
+    // root <- mid <- leaf, and `side` also blocked by root: a diamond only in
+    // the sense that `leaf` is reachable twice once `side` blocks it too.
+    let root = "TASK-000000000a01";
+    let mid = "TASK-000000000a02";
+    let leaf = "TASK-000000000a03";
+    let outer = "TASK-000000000a04";
+    let held = "TASK-000000000a05";
+    for id in [root, mid, leaf, held] {
+        r.seed_task(id, Some("A verifiable criterion."));
+    }
+    r.blocked(mid, &[root]);
+    r.blocked(leaf, &[mid]);
+    // Scoped to docs/, so it is outside the src/ perimeter below.
+    r.seed_task_scoped(outer, "docs/**");
+    r.blocked(held, &[outer]);
+
+    let out = r.ank("claude-code@ank", &["graph", "src"]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    let said = stdout(&out);
+
+    // Names the perimeter it drew (§4).
+    assert_eq!(
+        said.lines().next().unwrap_or_default(),
+        "src",
+        "the perimeter is named: {said}"
+    );
+
+    // The shape: each level one indent deeper than what blocks it.
+    let depth = |needle: &str| -> usize {
+        let line = said
+            .lines()
+            .find(|l| l.contains(needle))
+            .unwrap_or_else(|| panic!("{needle} missing from:\n{said}"));
+        line.len() - line.trim_start().len()
+    };
+    assert_eq!(depth("000000000a01"), 0, "the root is flush left: {said}");
+    assert_eq!(depth("000000000a02"), 2, "{said}");
+    assert_eq!(depth("000000000a03"), 4, "{said}");
+
+    // A blocker outside the perimeter is never silently dropped: drawing this
+    // one flush left with no mark would say nothing is stopping it.
+    let held_line = said
+        .lines()
+        .find(|l| l.contains("000000000a05"))
+        .unwrap_or_default();
+    assert!(
+        held_line.contains("outside"),
+        "a task held by something outside the perimeter says so: {said}"
+    );
+    assert!(
+        !said.contains("000000000a04"),
+        "and the outside task itself is not drawn: {said}"
+    );
+
+    // Says so explicitly when the perimeter holds no task (§4). `LICENSE` and
+    // not `docs/nowhere`: the latter is *inside* `docs/**`, which is the whole
+    // point of `overlaps_dir`, and the fixture would have been testing nothing.
+    let out = r.ank("claude-code@ank", &["graph", "LICENSE"]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    assert!(
+        stdout(&out).contains("no task in this perimeter"),
+        "{}",
+        stdout(&out)
+    );
+
+    // `--json` for the raw edges (§4) — including the edge leaving the
+    // perimeter, which the drawing can only mark and not show.
+    let out = r.ank("claude-code@ank", &["graph", "src", "--json"]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    let j = stdout(&out);
+    assert!(j.contains("\"path\":\"src\""), "{j}");
+    assert!(
+        j.contains(&format!("{{\"task\":\"{mid}\",\"blocked_by\":\"{root}\"}}")),
+        "{j}"
+    );
+    assert!(
+        j.contains(&format!(
+            "{{\"task\":\"{held}\",\"blocked_by\":\"{outer}\"}}"
+        )),
+        "the raw edges include the one leaving the perimeter: {j}"
+    );
+}
+
+/// A cycle is a corpus fault `check` reports, and `graph` still has to draw the
+/// repository that has one rather than hang on it.
+///
+/// **Two cycles, because they take different paths through the code and only
+/// one exercises the guard.** A cycle with no way in has no root, so nothing
+/// recurses into it and it is collected flat at the end. A cycle reachable from
+/// a root is walked, and only there does the visited-path check stand between
+/// the drawing and a stack overflow. Removing that check left the first case
+/// passing, which is how this test was found to be weaker than it looked — by a
+/// mutation run, not by reading it.
+#[test]
+fn graph_terminates_on_a_cycle_and_says_where_it_is() {
+    let r = Repo::new();
+    std::fs::create_dir_all(r.0.join("src")).unwrap();
+    std::fs::write(r.0.join("src/main.rs"), "fn main() {}\n").unwrap();
+    // Closed on itself and unreachable: no root, so nothing recurses into it.
+    let a = "TASK-000000000b01";
+    let b = "TASK-000000000b02";
+    // A root leading into a cycle: this is the one that recurses, and the only
+    // one the visited-path guard stands in front of.
+    let root = "TASK-000000000b03";
+    let mid = "TASK-000000000b04";
+    let back = "TASK-000000000b05";
+    for id in [a, b, root, mid, back] {
+        r.seed_task(id, Some("A verifiable criterion."));
+    }
+    r.blocked(a, &[b]);
+    r.blocked(b, &[a]);
+    r.blocked(mid, &[root, back]);
+    r.blocked(back, &[mid]);
+
+    let out = r.ank("claude-code@ank", &["graph", "src"]);
+    assert_eq!(
+        code(&out),
+        0,
+        "a cycle is check's fault to report, not graph's: {}",
+        stderr(&out)
+    );
+    let said = stdout(&out);
+
+    // Reachable: walked, and stopped at the repetition rather than at the stack.
+    assert!(
+        said.contains("(cycle)"),
+        "the walk names where it turned back: {said}"
+    );
+    assert!(
+        said.contains("000000000b04") && said.contains("000000000b05"),
+        "{said}"
+    );
+
+    // Unreachable: under no root, so it would vanish under a header with
+    // nothing beneath it. Drawn, and named as the reason.
+    assert!(said.contains("under no root"), "{said}");
+    assert!(
+        said.contains("000000000b01") && said.contains("000000000b02"),
+        "{said}"
     );
 }
 

--- a/crates/ank-cli/tests/skill.rs
+++ b/crates/ank-cli/tests/skill.rs
@@ -114,12 +114,13 @@ fn help_order() -> Vec<String> {
 /// The one hand-maintained list here, and it cannot rot: the test below fails
 /// if any of these becomes dispatchable, so implementing one forces its removal
 /// in the same commit. Each is a specified verb with an open task -- `status`
-/// TASK-15336a0012d5, `edit` TASK-7ed19b16895e, `graph` TASK-253e897d3330.
+/// TASK-15336a0012d5, `edit` TASK-7ed19b16895e.
 ///
-/// `scope` was here and is not any more, which is the guard working as intended
-/// rather than a maintenance chore: shipping it (TASK-e717ee625c5c) turned the
-/// suite red until this line was edited, in the same commit.
-const NOT_YET_DISPATCHED: [&str; 3] = ["status", "edit", "graph"];
+/// `scope` and `graph` were here and are not any more, which is the guard
+/// working as intended rather than a maintenance chore: shipping each of them
+/// (TASK-e717ee625c5c, TASK-253e897d3330) turned the suite red until this line
+/// was edited, in the same commit.
+const NOT_YET_DISPATCHED: [&str; 2] = ["status", "edit"];
 
 /// A verb the binary answers to and §4 never mentions. `attest`, `init` and
 /// `help` were exactly that until TASK-5c868c20472f, and a reader comparing the


### PR DESCRIPTION
Closes TASK-253e897d3330. The second of the four verbs §4 specifies and the binary did not dispatch; `status` and `edit` remain.

## What it draws

```
$ ank graph src
src

TASK-000000000a01  [open] Root task
  TASK-000000000a02  [open] Middle
    TASK-000000000a03  [open] Leaf
TASK-000000000a05  [open] Held  (+1 blocker(s) outside)

4 task(s), 2 root(s) — indented under what blocks them
```

§5's ordering already walks these edges to count what a task unblocks; this makes the same structure visible to a reader instead of only to the sort. Computed at read time and stored nowhere — a stored reverse edge is a second copy of `blocked_by` that can disagree with the first.

Its own module rather than more of `human.rs`. It reads the perimeter through `context::perimeter` and filters with `in_perimeter`, so it **inherits** the normalisation from TASK-df4c39031583 rather than repeating it — a fourth private copy of that matching is exactly what the previous task spent its time removing.

## Two decisions worth stating

**The forest holds only in-perimeter tasks, and says when that hides something.** A task whose blocker sits outside the perimeter would otherwise draw flush left, and *"nothing is stopping this"* is the one wrong answer a reader acts on immediately. Those nodes carry `(+n blocker(s) outside)`.

**No budget cap**, for the same reason `scope` has none: the caller named the perimeter, and a partial DAG misleads rather than shortens. `--json` emits the **raw** edges including the ones leaving the perimeter — the drawing is a reading of the graph, the JSON is the graph.

## The mutation that mattered

| mutation | result |
|---|---|
| indentation flattened | caught by the depth assertions |
| outside-blocker marker removed | caught |
| visited-path cycle guard removed | **passed** |

That third one was my test being weak, not the guard being useless. A two-node cycle `a ↔ b` has **no root**, so nothing ever recurses into it — it falls straight to the stranded branch and the guard is never reached. The fixture now carries both shapes: a closed cycle with no way in, and a cycle reachable from a root. With the guard removed the second one recurses, and the test fails.

I would not have found that by reading the test. The mutation run did.

## Also

The anti-rot guard from TASK-973fc0173b98 fired again the moment this shipped (`ank graph ships and is still declared unimplemented`), and the `COMMANDS` count with it. Both told me exactly what to edit — that is now three tasks in a row where those two guards did the bookkeeping.

## Verification

`cargo test --workspace` green (206 + 35 + 6 + 8 + 12), `cargo fmt --check` clean, `ank check` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QoJrx7uZpTu7ZEzie8TpKH