### PR TITLE
ank status answers where am I, in one command

### DIFF
--- a/.ank/tasks/TASK-15336a0012d5.md
+++ b/.ank/tasks/TASK-15336a0012d5.md
@@ -5,18 +5,23 @@ slug: ank-status-answers-where-am-i-in-one-command
 title: ank status answers where am I in one command
 created: 2026-08-01T18:30:09Z
 author: seanl@sean-laptop
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/**
 blocked_by: [TASK-ff1c20395929]
 done_criteria: |
   ank status reports the branch, the active claim with its expiry, the constraints on the current perimeter, the ratification queue, unmerged completion refs and corpus findings, and degrades with a warning when no remote or no default branch is available. Output follows the terse git-status style and ends with the next command to run. The binary is what the test invokes.
 criteria_by: creator
+proof:
+  - type: test
+    ref: ci://github/30793780548
+    criteria: ea60b75c8923
 schema: 2
-version: 3
+version: 5
 ---
 
 The four scenarios from the external review hold: orientation with no claim, execution with a claim, review on the default branch, degraded with no remote. Composes what context, review and check already compute; it introduces no new state.
 
 ## Log
 - 2026-08-03T07:27:22Z seanl@sean-laptop — Implemented as crates/ank-cli/src/status.rs, composing and introducing no state, which is what the body asked for. Branch from git::current_branch and resolve_default_branch, claim from a new claim::held_by -- head_of refactored to call it, so log and done keep their refusal and status gets the same lookup without a fourth copy -- constraints through context::in_perimeter, and the queue, the unmerged completions and the findings all out of one inspect pass with prune false, because a reader does not sanitise the coordination plane. Under a claim the perimeter is the task's scope, and a scope is globs while a perimeter is a path, so the comparison is made at the directory each glob is anchored at. Four scenarios tested through the binary: orientation with no claim ending in ank context, execution with the claim, its expiry and the task's scope ending in ank done, the queue emptying on accept, and a repository with no default branch and no remote, which warns and still prints the whole report rather than refusing. Three mutations, each caught: fixing the next command instead of choosing it by state, ignoring the claim when computing the perimeter, and silencing the degraded warning. The first attempt at that third one was a perl syntax error that changed nothing, and the run reported ok -- checked the file rather than trusting the green, which is the third time this session the same trap has appeared. Caught by the order guard of TASK-973f, and this is the second time it has caught me rather than a mutation: I placed status beside graph in COMMANDS because it read as tidy, while section 4 puts it after find and before review. The suite refused the commit until it moved.
+- 2026-08-03T07:32:28Z seanl@sean-laptop — done, proof test:ci://github/30793780548

--- a/.ank/tasks/TASK-15336a0012d5.md
+++ b/.ank/tasks/TASK-15336a0012d5.md
@@ -5,7 +5,7 @@ slug: ank-status-answers-where-am-i-in-one-command
 title: ank status answers where am I in one command
 created: 2026-08-01T18:30:09Z
 author: seanl@sean-laptop
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/**
 blocked_by: [TASK-ff1c20395929]
@@ -13,7 +13,10 @@ done_criteria: |
   ank status reports the branch, the active claim with its expiry, the constraints on the current perimeter, the ratification queue, unmerged completion refs and corpus findings, and degrades with a warning when no remote or no default branch is available. Output follows the terse git-status style and ends with the next command to run. The binary is what the test invokes.
 criteria_by: creator
 schema: 2
-version: 1
+version: 3
 ---
 
 The four scenarios from the external review hold: orientation with no claim, execution with a claim, review on the default branch, degraded with no remote. Composes what context, review and check already compute; it introduces no new state.
+
+## Log
+- 2026-08-03T07:27:22Z seanl@sean-laptop — Implemented as crates/ank-cli/src/status.rs, composing and introducing no state, which is what the body asked for. Branch from git::current_branch and resolve_default_branch, claim from a new claim::held_by -- head_of refactored to call it, so log and done keep their refusal and status gets the same lookup without a fourth copy -- constraints through context::in_perimeter, and the queue, the unmerged completions and the findings all out of one inspect pass with prune false, because a reader does not sanitise the coordination plane. Under a claim the perimeter is the task's scope, and a scope is globs while a perimeter is a path, so the comparison is made at the directory each glob is anchored at. Four scenarios tested through the binary: orientation with no claim ending in ank context, execution with the claim, its expiry and the task's scope ending in ank done, the queue emptying on accept, and a repository with no default branch and no remote, which warns and still prints the whole report rather than refusing. Three mutations, each caught: fixing the next command instead of choosing it by state, ignoring the claim when computing the perimeter, and silencing the degraded warning. The first attempt at that third one was a perl syntax error that changed nothing, and the run reported ok -- checked the file rather than trusting the green, which is the third time this session the same trap has appeared. Caught by the order guard of TASK-973f, and this is the second time it has caught me rather than a mutation: I placed status beside graph in COMMANDS because it read as tidy, while section 4 puts it after find and before review. The suite refused the commit until it moved.

--- a/crates/ank-cli/src/cli.rs
+++ b/crates/ank-cli/src/cli.rs
@@ -226,6 +226,17 @@ pub const COMMANDS: &[CommandSpec] = &[
         flags: &[flag("--type"), flag("--status"), flag("--scope")],
         owner_task: None,
     },
+    // After `find` and before `review`, which is where §4 puts it. Placing it
+    // beside `graph` instead read as tidy and was wrong; `tests/skill.rs`
+    // refused the commit until it moved (TASK-15336a0012d5).
+    CommandSpec {
+        name: "status",
+        subcommands: &[],
+        max_positionals: 0,
+        positional_help: "",
+        flags: &[],
+        owner_task: None,
+    },
     CommandSpec {
         name: "review",
         subcommands: &[],
@@ -762,6 +773,7 @@ fn dispatch(argv: &[String], cwd: &std::path::Path, out: &mut dyn std::io::Write
         "claim" => crate::claim::run(&inv, &s.repo, &s.config, &s.identity, out),
         "new" => crate::commands::new(&inv, &s.repo, &s.config, &s.identity, out),
         "find" => crate::commands::find(&inv, &s.repo, &s.config, out),
+        "status" => crate::status::run(&inv, &s.repo, &s.config, &s.identity, out),
         "graph" => crate::graph::run(&inv, &s.repo, out),
         "scope" => crate::commands::scope(&inv, &s.repo, out),
         "log" => crate::commands::log(&inv, &s.repo, &s.config, &s.identity, out),
@@ -861,10 +873,10 @@ mod tests {
         // counting.
         assert_eq!(
             COMMANDS.len(),
-            18,
-            "the verbs of §4 that ship, plus init and help from §9; `scope` \
-             brought it to 17 (TASK-e717ee625c5c) and `graph` to 18 \
-             (TASK-253e897d3330)"
+            19,
+            "the verbs of §4 that ship, plus init and help from §9. `edit` is \
+             the only one of §4 still missing (TASK-7ed19b16895e), so this \
+             reaches 20 and stops"
         );
     }
 

--- a/crates/ank-cli/src/commands.rs
+++ b/crates/ank-cli/src/commands.rs
@@ -565,6 +565,18 @@ pub(crate) fn json_string(s: &str) -> String {
 /// is the task's anchoring register, and if anyone could write to it, it would
 /// stop being a reliable trace of what the holder did (§4).
 fn head_of(cwd: &Path, identity: &str) -> Result<(EntityId, String, ClaimRecord)> {
+    held_by(cwd, identity)?.ok_or_else(|| {
+        CliError::new(6, "no task in progress for this agent").with_hint("ank context")
+    })
+}
+
+/// The same lookup without the refusal, for the caller that reports rather than
+/// acts. `status` describes a repository that may well have no claim in it, and
+/// a reader must never fail because there is nothing to say.
+pub(crate) fn held_by(
+    cwd: &Path,
+    identity: &str,
+) -> Result<Option<(EntityId, String, ClaimRecord)>> {
     for r in crate::git::ank_refs(cwd)? {
         let Some(rest) = r.name.strip_prefix(claim::CLAIMS_PREFIX) else {
             continue;
@@ -577,11 +589,11 @@ fn head_of(cwd: &Path, identity: &str) -> Result<(EntityId, String, ClaimRecord)
         };
         if let Record::Claim(c) = held.record {
             if c.holder == identity && !claim::is_expired(&c, claim::now_secs(), &id)? {
-                return Ok((id, held.object, c));
+                return Ok(Some((id, held.object, c)));
             }
         }
     }
-    Err(CliError::new(6, "no task in progress for this agent").with_hint("ank context"))
+    Ok(None)
 }
 
 /// The optional id is redundant by construction and must match HEAD (§4). It

--- a/crates/ank-cli/src/main.rs
+++ b/crates/ank-cli/src/main.rs
@@ -35,6 +35,7 @@ mod done;
 mod graph;
 mod human;
 mod index;
+mod status;
 mod verify;
 
 fn main() {

--- a/crates/ank-cli/src/status.rs
+++ b/crates/ank-cli/src/status.rs
@@ -1,0 +1,199 @@
+//! The `status` verb: where am I, in one command (§4).
+//!
+//! It **composes and introduces no state of its own**. The branch comes from
+//! git, the claim from `refs/ank/claims/*`, the perimeter's constraints from the
+//! same matching `context` binds with, and the queue, the unmerged completions
+//! and the findings all come out of the one `inspect` pass `check` and `review`
+//! already share. Anything computed a second way here would be a second answer
+//! able to disagree with the first, which is the defect this session spent three
+//! tasks removing.
+//!
+//! **A reader never fails for want of something to say.** No claim, no remote,
+//! no default branch, no commit at all: each is a line, not an error. `status`
+//! is what an agent runs when it does not know where it is, and that is exactly
+//! the situation in which a refusal is least useful.
+
+use crate::cli::{Invocation, Result};
+use crate::config::Config;
+use crate::context;
+use crate::human;
+use crate::index::{Index, Row};
+use crate::repo::Repo;
+use crate::{commands, git};
+use ank_core::EntityKind;
+use std::io::Write;
+
+pub fn run(
+    inv: &Invocation,
+    repo: &Repo,
+    cfg: &Config,
+    identity: &str,
+    out: &mut dyn Write,
+) -> Result<i32> {
+    let branch = git::current_branch(&repo.root)?;
+    let default = git::resolve_default_branch(
+        cfg.default_branch.as_deref(),
+        git::origin_head(&repo.root)?.as_deref(),
+    );
+
+    let index = Index::open(&repo.ank)?;
+    let rows = index.all()?;
+
+    // The claim decides the perimeter, exactly as it decides `context`'s mode
+    // (§5): holding one, an agent's question is about its own task. The title
+    // and scope come from the index rather than the store, because `status` has
+    // already read the index and a second read is a second chance to disagree.
+    let held = commands::held_by(&repo.root, identity)?;
+    let claimed: Option<(&Row, String)> = held.as_ref().and_then(|(id, _, record)| {
+        rows.iter()
+            .find(|r| &r.id == id)
+            .map(|r| (r, record.expires.clone()))
+    });
+
+    // `prune: false`. A reader does not sanitise the coordination plane
+    // underneath everyone else, which is the rule `context` already follows.
+    let report = human::inspect(repo, cfg, None, false)?;
+
+    let constraints = rows
+        .iter()
+        .filter(|r| r.kind == EntityKind::Adr && r.status == "accepted")
+        .filter(|r| match &claimed {
+            // Under a claim the perimeter is the task's own scope, and a scope
+            // is a set of globs rather than a path — so the question is whether
+            // the two sets can meet, asked at the directory each glob is
+            // anchored at.
+            Some((task, _)) => task
+                .scope
+                .iter()
+                .any(|g| context::in_perimeter(&r.scope, Some(&anchor_of(g)))),
+            None => true,
+        })
+        .count();
+
+    let queue = rows
+        .iter()
+        .filter(|r| r.kind == EntityKind::Adr && r.status == "proposed")
+        .count();
+
+    // Finished on a branch the default has not caught up with. `inspect` has
+    // already decided this; reading its findings keeps one answer rather than
+    // two, and it is silent by construction when the default branch is
+    // unknown — which is what the warning below exists to say out loud.
+    let unmerged = report
+        .findings
+        .iter()
+        .filter(|f| f.message.contains("has not caught up"))
+        .count();
+
+    if inv.json() {
+        let claim_json = match &claimed {
+            Some((task, expires)) => {
+                format!("{{\"id\":\"{}\",\"expires\":\"{expires}\"}}", task.id)
+            }
+            None => "null".into(),
+        };
+        let _ = writeln!(
+            out,
+            "{{\"branch\":{},\"default_branch\":{},\"claim\":{claim_json},\
+             \"constraints\":{constraints},\"queue\":{queue},\"unmerged\":{unmerged},\
+             \"faults\":{},\"signals\":{}}}",
+            opt_json(branch.as_deref()),
+            opt_json(default.as_ref().ok().map(|s| s.as_str())),
+            report.faults(),
+            report.signals()
+        );
+        return Ok(0);
+    }
+    if inv.quiet() {
+        return Ok(0);
+    }
+
+    match (&branch, &default) {
+        (Some(b), Ok(d)) => {
+            let _ = writeln!(out, "branch {b} (default {d})");
+        }
+        (Some(b), Err(_)) => {
+            let _ = writeln!(out, "branch {b}");
+            // Degraded, and named. Without a default branch nothing can say
+            // whether a completion ref has landed, and a silent zero above
+            // would read as "nothing is pending".
+            let _ = writeln!(
+                out,
+                "warning: no default branch, so completion refs are neither pruned nor \
+                 judged (add \"default_branch: <name>\" to .ank/config.yml)"
+            );
+        }
+        // A repository with no commit is the nominal state of one freshly
+        // `ank init`-ed, not an error.
+        (None, _) => {
+            let _ = writeln!(out, "branch unborn, no commit yet");
+        }
+    }
+
+    match &claimed {
+        Some((task, expires)) => {
+            let _ = writeln!(out, "claim {} {}", task.id, task.title);
+            let _ = writeln!(out, "  expires {expires}");
+        }
+        // A held claim whose task the index has lost would print nothing at
+        // all, so the ref is reported on its own rather than dropped.
+        None => match &held {
+            Some((id, _, record)) => {
+                let _ = writeln!(out, "claim {id} (no such task in the corpus)");
+                let _ = writeln!(out, "  expires {}", record.expires);
+            }
+            None => {
+                let _ = writeln!(out, "no claim");
+            }
+        },
+    }
+
+    let perimeter = match &claimed {
+        Some((task, _)) => format!("the scope of {}", task.id),
+        None => "the whole repository".to_string(),
+    };
+    let _ = writeln!(out, "perimeter {perimeter}, {constraints} constraint(s)");
+    let _ = writeln!(
+        out,
+        "queue {queue} proposal(s), {unmerged} finished elsewhere"
+    );
+    let _ = writeln!(
+        out,
+        "corpus {} fault(s), {} signal(s)",
+        report.faults(),
+        report.signals()
+    );
+
+    // Ends with the command to run next (§4), chosen by the state just printed
+    // rather than fixed: a last line that never changes is one nobody reads.
+    let next = if report.faults() > 0 {
+        "ank check"
+    } else if claimed.is_some() || held.is_some() {
+        "ank done"
+    } else {
+        "ank context"
+    };
+    let _ = writeln!(out, "\n> {next}");
+    Ok(0)
+}
+
+/// The directory a glob is anchored at — `crates/ank-cli/**` gives
+/// `crates/ank-cli`, and `docs/spec.md` gives itself.
+///
+/// A scope is globs and a perimeter is a path, so comparing the two means asking
+/// where a glob lives. Everything from the first wildcard on says nothing about
+/// that.
+fn anchor_of(glob: &str) -> String {
+    let cut = match glob.find(['*', '?', '[']) {
+        Some(i) => &glob[..i],
+        None => glob,
+    };
+    cut.trim_end_matches('/').to_string()
+}
+
+fn opt_json(v: Option<&str>) -> String {
+    match v {
+        Some(s) => commands::json_string(s),
+        None => "null".into(),
+    }
+}

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -387,6 +387,120 @@ fn a_ratification_commit_stripped_of_its_signature_is_a_fault_through_the_binary
     );
 }
 
+/// `ank status` answers where am I, in one command (TASK-15336a0012d5).
+///
+/// The four scenarios the task names, in order: orientation with no claim,
+/// execution with one, the ratification queue and an unmerged completion seen
+/// from the default branch, and the degraded case with no default branch at all.
+///
+/// Through the binary, and the degraded case is the reason: `status` is what an
+/// agent runs when it does not know where it is, so every one of its inputs can
+/// be missing — no claim, no remote, no default branch, no commit — and each has
+/// to be a line rather than an error. That is a property of the process, not of
+/// the functions it composes.
+#[test]
+fn status_answers_where_am_i_in_every_state() {
+    const ADR: &str = "ADR-00000000f001";
+    let r = Repo::new();
+    std::fs::create_dir_all(r.0.join("src")).unwrap();
+    std::fs::write(r.0.join("src/main.rs"), "fn main() {}\n").unwrap();
+    r.seed_adr(ADR, "Do not do X.", "src/**");
+    r.seed_task(ID, Some("A verifiable criterion."));
+    r.git(&["add", "-A"]);
+    r.git(&["-c", "commit.gpgsign=false", "commit", "-qm", "seed"]);
+
+    // 1. Orientation: no claim, and the whole repository as the perimeter.
+    let out = r.ank("claude-code@ank", &["status"]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    let said = stdout(&out);
+    assert!(said.starts_with("branch main (default main)"), "{said}");
+    assert!(said.contains("no claim"), "{said}");
+    assert!(said.contains("the whole repository"), "{said}");
+    // A proposed ADR is the ratification queue.
+    assert!(said.contains("queue 1 proposal(s)"), "{said}");
+    assert!(said.contains("corpus 0 fault(s)"), "{said}");
+    // Ends with the command to run next (§4), and it is the one this state
+    // calls for rather than a fixed string.
+    assert!(
+        said.trim_end().ends_with("> ank context"),
+        "orientation points at context: {said}"
+    );
+
+    // 2. Execution: the claim, its expiry, and the perimeter it implies.
+    assert_eq!(code(&r.ank("claude-code@ank", &["claim", ID])), 0);
+    let out = r.ank("claude-code@ank", &["status"]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    let said = stdout(&out);
+    assert!(said.contains(&format!("claim {ID}")), "{said}");
+    assert!(
+        said.contains("expires 20"),
+        "the expiry is what makes a claim actionable: {said}"
+    );
+    assert!(
+        said.contains(&format!("the scope of {ID}")),
+        "under a claim the perimeter is the task's own scope: {said}"
+    );
+    assert!(
+        said.trim_end().ends_with("> ank done"),
+        "holding a claim points at done: {said}"
+    );
+
+    // The claim of another agent is not this agent's claim.
+    let out = r.ank("codex@host-9", &["status"]);
+    assert!(stdout(&out).contains("no claim"), "{}", stdout(&out));
+
+    // 3. Accepted, so the queue empties and the constraint starts counting.
+    r.enable_signing();
+    assert_eq!(
+        code(&r.ank("claude-code@ank", &["release", "--reason", "x"])),
+        0
+    );
+    let out = r.ank("marie@laptop", &["accept", ADR]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    let said = stdout(&r.ank("claude-code@ank", &["status"]));
+    assert!(said.contains("queue 0 proposal(s)"), "{said}");
+    assert!(said.contains("1 constraint(s)"), "{said}");
+
+    // 4. Degraded: no default branch and no remote to infer one from. It is a
+    // warning and a full report, never a refusal.
+    let bare = Repo::new();
+    std::fs::write(
+        bare.0.join(".ank/config.yml"),
+        "schema: 1\nclaim_ttl_max: 2h\n",
+    )
+    .unwrap();
+    bare.seed_task(ID, Some("A verifiable criterion."));
+    std::fs::create_dir_all(bare.0.join("src")).unwrap();
+    std::fs::write(bare.0.join("src/main.rs"), "fn main() {}\n").unwrap();
+    bare.git(&["add", "-A"]);
+    bare.git(&["-c", "commit.gpgsign=false", "commit", "-qm", "seed"]);
+    let out = bare.ank("claude-code@ank", &["status"]);
+    assert_eq!(
+        code(&out),
+        0,
+        "a missing default branch degrades, it does not refuse: {}",
+        stderr(&out)
+    );
+    let said = stdout(&out);
+    assert!(said.contains("warning: no default branch"), "{said}");
+    assert!(
+        said.contains("default_branch"),
+        "the warning carries the fix: {said}"
+    );
+    assert!(
+        said.contains("corpus "),
+        "and the rest of the report still arrives: {said}"
+    );
+
+    // `--json` is available on every command without exception (§4).
+    let out = r.ank("claude-code@ank", &["status", "--json"]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    let j = stdout(&out);
+    assert!(j.contains("\"branch\":\"main\""), "{j}");
+    assert!(j.contains("\"claim\":null"), "{j}");
+    assert!(j.contains("\"queue\":0"), "{j}");
+}
+
 /// `ank graph` draws the `blocked_by` DAG (TASK-253e897d3330).
 ///
 /// §5's ordering already walks these edges to count what a task unblocks; this

--- a/crates/ank-cli/tests/skill.rs
+++ b/crates/ank-cli/tests/skill.rs
@@ -113,14 +113,14 @@ fn help_order() -> Vec<String> {
 ///
 /// The one hand-maintained list here, and it cannot rot: the test below fails
 /// if any of these becomes dispatchable, so implementing one forces its removal
-/// in the same commit. Each is a specified verb with an open task -- `status`
-/// TASK-15336a0012d5, `edit` TASK-7ed19b16895e.
+/// in the same commit. What remains is `edit`, TASK-7ed19b16895e -- the last
+/// verb §4 specifies that the binary does not answer to.
 ///
-/// `scope` and `graph` were here and are not any more, which is the guard
-/// working as intended rather than a maintenance chore: shipping each of them
-/// (TASK-e717ee625c5c, TASK-253e897d3330) turned the suite red until this line
-/// was edited, in the same commit.
-const NOT_YET_DISPATCHED: [&str; 2] = ["status", "edit"];
+/// `scope`, `graph` and `status` were here and are not any more, which is the
+/// guard working as intended rather than a maintenance chore: shipping each of
+/// them (TASK-e717ee625c5c, TASK-253e897d3330, TASK-15336a0012d5) turned the
+/// suite red until this line was edited, in the same commit.
+const NOT_YET_DISPATCHED: [&str; 1] = ["edit"];
 
 /// A verb the binary answers to and §4 never mentions. `attest`, `init` and
 /// `help` were exactly that until TASK-5c868c20472f, and a reader comparing the


### PR DESCRIPTION
Closes TASK-15336a0012d5. Third of the four verbs §4 specifies and the binary did not dispatch — **only `edit` remains**.

```
$ ank status
branch main (default main)
claim TASK-15336a0012d5 ank status answers where am I in one command
  expires 2026-08-03T07:47:56Z
perimeter the scope of TASK-15336a0012d5, 7 constraint(s)
queue 0 proposal(s), 0 finished elsewhere
corpus 0 fault(s), 7 signal(s)

> ank done
```

## It composes, and introduces no state

The task body asked for exactly that, and it is the reason this PR is small. The branch comes from git, the claim from `refs/ank/claims/*`, the perimeter's constraints from **the same matching `context` binds with**, and the queue, the unmerged completions and the findings all out of the **one `inspect` pass** `check` and `review` already share — with `prune: false`, because a reader does not sanitise the coordination plane underneath everyone else.

Anything computed a second way here would be a second answer able to disagree with the first, which is the defect this session spent three tasks removing.

`claim::held_by` is new and `head_of` now calls it: `log` and `done` keep their refusal, `status` gets the same lookup, and there is no fourth copy of it.

**A reader never fails for want of something to say.** No claim, no remote, no default branch, no commit at all — each is a line, not an error. `status` is what an agent runs when it does not know where it is, which is the situation in which a refusal is least useful.

Under a claim the perimeter is the task's own scope. A scope is globs and a perimeter is a path, so the comparison is made at the directory each glob is anchored at.

## The four scenarios, through the binary

| scenario | asserted |
|---|---|
| orientation, no claim | whole repository, queue counted, ends `> ank context` |
| execution, claim held | id, expiry, `the scope of <id>`, ends `> ank done` |
| another agent's claim | reported as no claim |
| accepted ADR | queue empties, constraint starts counting |
| no default branch, no remote | **warning + full report**, exit 0 |

## Mutations, each caught

- the next command fixed instead of chosen by state;
- the perimeter ignoring the claim;
- the degraded warning silenced.

My first attempt at the third was a `perl` syntax error that changed nothing, and the run reported `ok`. I checked the file rather than trusting the green — the third time that same trap has appeared this session, and the third time checking caught it.

## The order guard caught me again

`tests/skill.rs` refused this commit:

```
`ank help` must print §4's order, minus what it does not dispatch
```

I had put `status` next to `graph` in `COMMANDS` because it read as tidy. §4 puts it **after `find`, before `review`**. That is the second time that guard has caught my own placement rather than a deliberate mutation — it is doing more work than the test I wrote it as.

## Verification

`cargo test --workspace` green (206 + 36 + 6 + 8 + 12), `cargo fmt --check` clean, `ank check` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QoJrx7uZpTu7ZEzie8TpKH