### PR TITLE
new without its flags opens a template in the editor

### DIFF
--- a/.ank/tasks/TASK-039e56b2814d.md
+++ b/.ank/tasks/TASK-039e56b2814d.md
@@ -5,7 +5,7 @@ slug: new-without-its-flags-opens-a-template-in-the-ed
 title: new without its flags opens a template in the editor
 created: 2026-08-01T18:30:09Z
 author: seanl@sean-laptop
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/**
 blocked_by: [TASK-ff1c20395929]
@@ -13,7 +13,11 @@ done_criteria: |
   ank new task and ank new adr invoked without their mandatory flags open a pre-filled template in the editor named by EDITOR instead of failing, validate the result, and refuse to write an entity that would fail validation. The flag form keeps working unchanged and remains the scripted path. The binary is what the test invokes.
 criteria_by: creator
 schema: 2
-version: 1
+version: 4
 ---
 
 The git commit pattern: no -m opens the editor. Flags stay the path for agents and scripts.
+
+## Log
+- 2026-08-03T18:21:10Z seanl@sean-laptop — TASK-039e design. The interactive form triggers when none of the kind's mandatory flags is present -- title and scope for a task, title, scope and constraint for an ADR. That is the intersection of the two readings section 4 offers: the prose says 'without its mandatory flags' and the commands block says 'no flags', and keying on all-mandatory-absent satisfies both while leaving every partial invocation failing fast exactly as today. 'ank new task --title X' still exits 7 on the missing scope rather than opening an editor under a script, which is what 'the flag form keeps working unchanged' has to mean. The template is a full entity file in canonical form, not an editable subset: a second surface for the same data is the drift ADR-63b5 exists to prevent. Guidance rides in YAML comments inside the frontmatter, where the parser strips it for free -- the body stays markdown and nothing is stripped from it, because '#' there is a heading. The id and created are minted at the invocation and refused if edited: the act of creation is when new was run. Editor plumbing moves from edit.rs into a shared editor.rs rather than being duplicated.
+- 2026-08-03T18:46:45Z seanl@sean-laptop — Implemented and verified. Four mutations, four caught: the trigger rule (all-mandatory-absent to any-absent, which broke the flag-form test AND the existing whole-agent-loop test -- the scripted-path regression the rule was chosen to avoid, caught by a test written three tasks ago), the id refusal, the guidance placement below the fence, and the blocker resolution. The perl trap appeared a fourth time and in a new shape: two string replacements silently no-opped because cargo fmt had already reformatted the blocks I was matching, and the suite went green on unchanged code. Grepping the file rather than trusting green is what caught it -- and this variant is worse than a syntax error, because the script reported success. Also found sed -i is not portable: BSD sed on macOS takes a mandatory backup suffix, so 'sed -i -e' consumes -e as the suffix and the suite would have passed on two runners and failed on the third. The test editor is a POSIX shell function redirecting into a second file instead.

--- a/.ank/tasks/TASK-039e56b2814d.md
+++ b/.ank/tasks/TASK-039e56b2814d.md
@@ -5,15 +5,19 @@ slug: new-without-its-flags-opens-a-template-in-the-ed
 title: new without its flags opens a template in the editor
 created: 2026-08-01T18:30:09Z
 author: seanl@sean-laptop
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/**
 blocked_by: [TASK-ff1c20395929]
 done_criteria: |
   ank new task and ank new adr invoked without their mandatory flags open a pre-filled template in the editor named by EDITOR instead of failing, validate the result, and refuse to write an entity that would fail validation. The flag form keeps working unchanged and remains the scripted path. The binary is what the test invokes.
 criteria_by: creator
+proof:
+  - type: test
+    ref: "30842884500"
+    criteria: 3e1e76c24968
 schema: 2
-version: 4
+version: 5
 ---
 
 The git commit pattern: no -m opens the editor. Flags stay the path for agents and scripts.
@@ -21,3 +25,4 @@ The git commit pattern: no -m opens the editor. Flags stay the path for agents a
 ## Log
 - 2026-08-03T18:21:10Z seanl@sean-laptop — TASK-039e design. The interactive form triggers when none of the kind's mandatory flags is present -- title and scope for a task, title, scope and constraint for an ADR. That is the intersection of the two readings section 4 offers: the prose says 'without its mandatory flags' and the commands block says 'no flags', and keying on all-mandatory-absent satisfies both while leaving every partial invocation failing fast exactly as today. 'ank new task --title X' still exits 7 on the missing scope rather than opening an editor under a script, which is what 'the flag form keeps working unchanged' has to mean. The template is a full entity file in canonical form, not an editable subset: a second surface for the same data is the drift ADR-63b5 exists to prevent. Guidance rides in YAML comments inside the frontmatter, where the parser strips it for free -- the body stays markdown and nothing is stripped from it, because '#' there is a heading. The id and created are minted at the invocation and refused if edited: the act of creation is when new was run. Editor plumbing moves from edit.rs into a shared editor.rs rather than being duplicated.
 - 2026-08-03T18:46:45Z seanl@sean-laptop — Implemented and verified. Four mutations, four caught: the trigger rule (all-mandatory-absent to any-absent, which broke the flag-form test AND the existing whole-agent-loop test -- the scripted-path regression the rule was chosen to avoid, caught by a test written three tasks ago), the id refusal, the guidance placement below the fence, and the blocker resolution. The perl trap appeared a fourth time and in a new shape: two string replacements silently no-opped because cargo fmt had already reformatted the blocks I was matching, and the suite went green on unchanged code. Grepping the file rather than trusting green is what caught it -- and this variant is worse than a syntax error, because the script reported success. Also found sed -i is not portable: BSD sed on macOS takes a mandatory backup suffix, so 'sed -i -e' consumes -e as the suffix and the suite would have passed on two runners and failed on the third. The test editor is a POSIX shell function redirecting into a second file instead.
+- 2026-08-03T18:51:02Z seanl@sean-laptop — done, proof test:30842884500

--- a/crates/ank-cli/src/commands.rs
+++ b/crates/ank-cli/src/commands.rs
@@ -24,12 +24,13 @@ use crate::claim::{self, ClaimRecord, Record};
 use crate::cli::{CliError, Invocation, Result};
 use crate::config::Config;
 use crate::context;
+use crate::editor;
 use crate::index::{Index, Row};
 use crate::repo::Repo;
 use crate::store::{version_of, Store};
 use ank_core::{
-    append_log, serialize_entity, Adr, AdrStatus, CriteriaBy, Entity, EntityId, EntityKind,
-    LogEntry, Task, TaskStatus, SCHEMA_VERSION,
+    append_log, parse_entity, serialize_entity, Adr, AdrStatus, CriteriaBy, Entity, EntityId,
+    EntityKind, LogEntry, Task, TaskStatus, SCHEMA_VERSION,
 };
 use std::io::Write;
 use std::path::Path;
@@ -76,6 +77,13 @@ pub fn new(
             )
         }
     };
+
+    // The `git commit` pattern: no flags, an editor (§4). Checked before the
+    // first `required`, because reaching one of those is the failure the
+    // interactive form exists to replace.
+    if is_interactive(inv, kind) {
+        return new_interactive(inv, repo, cfg, identity, kind, out);
+    }
 
     let title = required(inv, "--title", "a one-line title")?;
     let scope = scope_of(inv, kind)?;
@@ -173,6 +181,422 @@ pub fn new(
         let _ = writeln!(out, "created {id} {title}");
     }
     Ok(0)
+}
+
+// ---------------------------------------------------------------------------
+// new, interactive
+// ---------------------------------------------------------------------------
+
+/// The mandatory flags of each kind, and the whole of what decides the form.
+///
+/// **All of them absent, not some.** §4 says it two ways — the prose has "`new`
+/// without its mandatory flags" and the commands block has "no flags" — and
+/// this is the reading that satisfies both: `ank new task` opens an editor,
+/// `ank new task --title "x"` still exits 7 on the missing scope. The
+/// difference matters because the flag form is the scripted path and must keep
+/// failing the way a script can act on. A build that forgot `--scope` has to
+/// stop, not sit in `vi` waiting for somebody who is not there.
+fn mandatory_flags(kind: EntityKind) -> &'static [&'static str] {
+    match kind {
+        EntityKind::Task => &["--title", "--scope"],
+        EntityKind::Adr => &["--title", "--scope", "--constraint"],
+    }
+}
+
+fn is_interactive(inv: &Invocation, kind: EntityKind) -> bool {
+    mandatory_flags(kind)
+        .iter()
+        .all(|f| inv.value(f).is_none_or(|v| v.trim().is_empty()))
+}
+
+/// The flag form of the kind, which is what every refusal on this path names.
+/// §4 requires it by name for the missing `$EDITOR`, and it is the right answer
+/// for the rest too: whoever hit this wanted an entity, and that is the other
+/// way to get one.
+fn flag_form(kind: EntityKind) -> String {
+    match kind {
+        EntityKind::Task => "ank new task --title \"<t>\" --scope \"<glob>\"".to_string(),
+        EntityKind::Adr => {
+            "ank new adr --title \"<t>\" --scope \"<glob>\" --constraint \"<rule>\"".to_string()
+        }
+    }
+}
+
+fn new_interactive(
+    inv: &Invocation,
+    repo: &Repo,
+    cfg: &Config,
+    identity: &str,
+    kind: EntityKind,
+    out: &mut dyn Write,
+) -> Result<i32> {
+    // Stamped once, here, and kept: the act of creation is the invocation of
+    // `new`, not the moment the editor happened to be closed. The id hashes it
+    // (§3) and is refused below if the file comes back carrying another.
+    let created = claim::now_utc();
+    let title = inv.value("--title").unwrap_or("").trim().to_string();
+    let id = EntityId::generate(kind, &created, identity, &title, &entropy());
+
+    let skeleton = skeleton(inv, cfg, kind, &id, &created, identity)?;
+    let hint = flag_form(kind);
+    let editor = editor::command(&hint)?;
+    let scratch = editor::scratch_path(&id.to_string());
+    std::fs::write(&scratch, template(&skeleton))
+        .map_err(|e| CliError::new(9, format!("cannot write {}: {e}", scratch.display())))?;
+
+    let store = Store::new(&repo.ank);
+    let outcome = (|| -> Result<i32> {
+        editor::open(&editor, &repo.root, &scratch, &hint)?;
+        let filled = std::fs::read_to_string(&scratch).map_err(|e| {
+            CliError::new(9, format!("cannot read back {}: {e}", scratch.display()))
+        })?;
+        create_filled(inv, &store, cfg, &skeleton, &filled, out)
+    })();
+
+    match outcome {
+        Ok(code) => {
+            let _ = std::fs::remove_file(&scratch);
+            Ok(code)
+        }
+        Err(e) => Err(editor::kept(e, &scratch)),
+    }
+}
+
+/// The entity the template renders: everything ank knows already, and empty
+/// where the caller has to speak.
+///
+/// Flags that were supplied are honoured rather than ignored. Reaching the
+/// editor does not mean nothing was said — `ank new task --criteria "..."`
+/// carries none of the mandatory flags and every word of it is still meant.
+fn skeleton(
+    inv: &Invocation,
+    cfg: &Config,
+    kind: EntityKind,
+    id: &EntityId,
+    created: &str,
+    identity: &str,
+) -> Result<Entity> {
+    let title = inv.value("--title").unwrap_or("").trim().to_string();
+    let scope: Vec<String> = inv
+        .values("--scope")
+        .iter()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
+    let slug = (!title.is_empty()).then(|| slugify(&title));
+    Ok(match kind {
+        EntityKind::Task => Entity::Task(Task {
+            id: id.clone(),
+            slug,
+            title,
+            created: created.to_string(),
+            author: Some(identity.to_string()),
+            status: TaskStatus::Open,
+            scope,
+            blocked_by: Vec::new(),
+            done_criteria: inv.value("--criteria").map(ensure_newline),
+            criteria_by: inv.value("--criteria").map(|_| CriteriaBy::Creator),
+            verify: verifiers_of(inv, cfg)?,
+            proof: Vec::new(),
+            schema: SCHEMA_VERSION,
+            version: 1,
+            body: body_of(inv),
+        }),
+        EntityKind::Adr => Entity::Adr(Adr {
+            id: id.clone(),
+            slug,
+            title,
+            created: created.to_string(),
+            author: Some(identity.to_string()),
+            status: AdrStatus::Proposed,
+            scope,
+            constraint: inv
+                .value("--constraint")
+                .map(ensure_newline)
+                .unwrap_or_default(),
+            see: None,
+            supersedes: None,
+            ratified: None,
+            schema: SCHEMA_VERSION,
+            version: 1,
+            body: body_of(inv),
+        }),
+    })
+}
+
+/// The skeleton in canonical form, with the guidance a reader needs to fill it.
+///
+/// **Canonical form and not a second rendering.** The template is a real entity
+/// file, so what the caller edits is the format itself and there is no shape
+/// here that `parse` does not already read — a template with a surface of its
+/// own would be exactly the drift ADR-63b59c5c26f7 forbids.
+///
+/// The guidance rides in YAML comments inside the frontmatter, where the parser
+/// strips it and nobody has to remember to. It never goes below the second
+/// `---`: the body is markdown, `#` there is a heading, and a tool that deleted
+/// those lines would eat the reasoning it asked for.
+fn template(skeleton: &Entity) -> String {
+    let canonical = serialize_entity(skeleton);
+    let rest = canonical
+        .strip_prefix("---\n")
+        .expect("canonical form opens with a frontmatter fence");
+    // `scope:` with nothing under it reads back as null, and serde reports it as
+    // a type error about a sequence — true, and useless. `[]` reads back as the
+    // empty scope it is, which `parse` already refuses in the words that say
+    // why. Only when empty: a scope with globs is emitted as a block list and
+    // this would corrupt it.
+    let rest = if skeleton.scope().is_empty() {
+        rest.replacen("scope:\n", "scope: []\n", 1)
+    } else {
+        rest.to_string()
+    };
+    let guidance = match skeleton {
+        Entity::Task(_) => TASK_GUIDANCE,
+        Entity::Adr(_) => ADR_GUIDANCE,
+    };
+    format!("---\n{guidance}{rest}")
+}
+
+const TASK_GUIDANCE: &str = "\
+# Fill this in and save. A # to the end of the line is a comment and is
+# dropped. Below the second --- is the body, in prose, and nothing there is
+# dropped: that is where the reasoning goes.
+# id, created and author are ank's, and are refused if they come back changed.
+# title          required, one line.
+# scope          required. The globs this attaches to, '  - <glob>' per line.
+#                Attachment happens through scope and nothing else, so an
+#                entity without one is invisible to every context, forever.
+# done_criteria  what makes this verifiably done, in one testable sentence.
+#                Leave it out and whoever claims the task sets it instead.
+# blocked_by     ids that must be done first, as [ID, ID].
+# verify         verifiers declared in .ank/config.yml, as [name, name].
+";
+
+const ADR_GUIDANCE: &str = "\
+# Fill this in and save. A # to the end of the line is a comment and is
+# dropped. Below the second --- is the body, in prose, and nothing there is
+# dropped: that is where the reasoning goes.
+# id, created and author are ank's, and are refused if they come back changed.
+# title       required, one line.
+# scope       required. The globs this binds, '  - <glob>' per line.
+#             Attachment happens through scope and nothing else, so an entity
+#             without one is invisible to every context, forever.
+# constraint  required. The binding rule, in one sentence. It is what gets
+#             injected into every context this scope covers, so write it to be
+#             obeyed rather than admired.
+# supersedes  the id of the ADR this replaces, if it replaces one.
+# status stays proposed: ratification is a signed commit, produced by accept.
+";
+
+/// Parses what came back, refuses what the flag form would have refused, and
+/// creates the entity.
+///
+/// Every check here has a counterpart on the flag path. That is the point: an
+/// interactive form that validated less would not be a convenience, it would be
+/// the hole in the wall — the way to write the entity `new` refuses.
+fn create_filled(
+    inv: &Invocation,
+    store: &Store,
+    cfg: &Config,
+    skeleton: &Entity,
+    filled: &str,
+    out: &mut dyn Write,
+) -> Result<i32> {
+    let kind = skeleton.id().kind();
+    let hint = flag_form(kind);
+    let parsed =
+        parse_entity(filled).map_err(|e| editor::invalid_entity(e, "nothing created", &hint))?;
+
+    // The id hashes the act of creation and the file name carries it. A caller
+    // who wants a different one runs `new` again; there is no command that mints
+    // one to order, so this refusal names none.
+    if parsed.id() != skeleton.id() {
+        return Err(CliError::new(
+            6,
+            format!(
+                "the id is ank's and cannot be chosen: {} came back as {}",
+                skeleton.id(),
+                parsed.id()
+            ),
+        )
+        .with_hint(hint));
+    }
+
+    let entity = match (skeleton, parsed) {
+        (Entity::Task(s), Entity::Task(mut t)) => {
+            require_title(&t.title, &hint)?;
+            // Born `open`, like the flag form writes it. A task that arrived
+            // `done` would carry a proof of nothing, and `check` reports the
+            // shape rather than the moment it was introduced.
+            if t.status != TaskStatus::Open {
+                return Err(CliError::new(
+                    7,
+                    format!("a new task is born open, not {}", t.status.as_str()),
+                )
+                .with_hint(hint));
+            }
+            if !t.proof.is_empty() {
+                return Err(CliError::new(
+                    7,
+                    "a proof is what `done` writes, and there is nothing yet to prove",
+                )
+                .with_hint(hint));
+            }
+            resolve_blockers(store, &t.blocked_by, &hint)?;
+            check_verifiers(&t.verify, cfg)?;
+            // An empty block scalar is the template's own placeholder coming
+            // back untouched, which means no criterion rather than a criterion
+            // that is blank — and `criteria_by` follows it, or `parse` refuses
+            // the pair on the next read.
+            t.done_criteria = t.done_criteria.filter(|c| !c.trim().is_empty());
+            t.criteria_by = t.done_criteria.as_ref().map(|_| CriteriaBy::Creator);
+            adopt(
+                &mut t.slug,
+                &t.title,
+                &mut t.created,
+                &s.created,
+                &mut t.author,
+                &s.author,
+            );
+            t.schema = SCHEMA_VERSION;
+            t.version = 1;
+            Entity::Task(t)
+        }
+        (Entity::Adr(s), Entity::Adr(mut a)) => {
+            require_title(&a.title, &hint)?;
+            if a.constraint.trim().is_empty() {
+                return Err(CliError::new(
+                    7,
+                    "a constraint is required: an ADR with nothing to enforce binds nobody",
+                )
+                .with_hint(hint));
+            }
+            // Never born `accepted`, and never born anchored: ratification is a
+            // signed commit produced by `accept`, on the default branch, and an
+            // ADR that arrived ratified would bind before anyone agreed to it.
+            if a.status != AdrStatus::Proposed {
+                return Err(CliError::new(
+                    7,
+                    format!("a new adr is born proposed, not {}", a.status.as_str()),
+                )
+                .with_hint("ank accept <id>"));
+            }
+            if a.ratified.is_some() {
+                return Err(CliError::new(
+                    7,
+                    "ratified names a signed commit, and only `accept` writes it",
+                )
+                .with_hint("ank accept <id>"));
+            }
+            if let Some(sup) = &a.supersedes {
+                resolve_blockers(store, std::slice::from_ref(sup), &hint)?;
+            }
+            a.constraint = ensure_newline(&a.constraint);
+            adopt(
+                &mut a.slug,
+                &a.title,
+                &mut a.created,
+                &s.created,
+                &mut a.author,
+                &s.author,
+            );
+            a.schema = SCHEMA_VERSION;
+            a.version = 1;
+            Entity::Adr(a)
+        }
+        // Unreachable: `parse` resolves the variant from `type:` and refuses a
+        // `type` the id does not carry, and the id was compared above.
+        _ => return Err(CliError::new(1, "the template came back as another kind").with_hint(hint)),
+    };
+
+    let id = entity.id().clone();
+    let title = match &entity {
+        Entity::Task(t) => t.title.clone(),
+        Entity::Adr(a) => a.title.clone(),
+    };
+    store.create(&entity)?;
+    if inv.json() {
+        let _ = writeln!(
+            out,
+            "{{\"id\":\"{id}\",\"kind\":\"{}\",\"created\":\"{}\"}}",
+            kind.as_str(),
+            match &entity {
+                Entity::Task(t) => &t.created,
+                Entity::Adr(a) => &a.created,
+            }
+        );
+    } else if !inv.quiet() {
+        let _ = writeln!(out, "created {id} {title}");
+    }
+    Ok(0)
+}
+
+fn require_title(title: &str, hint: &str) -> Result<()> {
+    if title.trim().is_empty() {
+        return Err(CliError::new(
+            7,
+            "a title is required: it is what a listing shows and what the id hashes",
+        )
+        .with_hint(hint.to_string()));
+    }
+    Ok(())
+}
+
+/// The three fields ank owns, put back where the caller moved them, and the slug
+/// derived when it was left alone.
+///
+/// `created` and `author` are the act of creation, already stamped; the template
+/// shows them so that what the caller edits is a whole entity, not so that they
+/// become an input. The slug is a handle rather than an identifier, so a caller
+/// who wrote one keeps it.
+fn adopt(
+    slug: &mut Option<String>,
+    title: &str,
+    created: &mut String,
+    born: &str,
+    author: &mut Option<String>,
+    by: &Option<String>,
+) {
+    if slug.as_deref().unwrap_or("").trim().is_empty() {
+        *slug = Some(slugify(title));
+    }
+    *created = born.to_string();
+    *author = by.clone();
+}
+
+/// Every reference resolved at the point of creation, exactly as the flag form
+/// resolves `--blocked-by`: an unknown one would otherwise surface in `check`,
+/// long afterwards, as a corpus error nobody can attribute to the act.
+fn resolve_blockers(store: &Store, ids: &[EntityId], hint: &str) -> Result<()> {
+    for id in ids {
+        if store.load(id).is_err() {
+            let _ = hint;
+            return Err(CliError::new(7, format!("no entity {id} in this corpus"))
+                .with_hint(format!("ank find {id}")));
+        }
+    }
+    Ok(())
+}
+
+/// The `verify` names, checked against `config.yml` the way `verifiers_of`
+/// checks the flag.
+fn check_verifiers(names: &[String], cfg: &Config) -> Result<()> {
+    for name in names {
+        if cfg.verifier(name.trim()).is_none() {
+            let mut known: Vec<&str> = cfg.verifiers.keys().map(|s| s.as_str()).collect();
+            known.sort_unstable();
+            let hint = if known.is_empty() {
+                "declare it under verifiers: in .ank/config.yml".to_string()
+            } else {
+                format!("declared in .ank/config.yml: {}", known.join(" "))
+            };
+            return Err(
+                CliError::new(7, format!("no verifier '{name}' in .ank/config.yml"))
+                    .with_hint(hint),
+            );
+        }
+    }
+    Ok(())
 }
 
 /// A scope is mandatory and must be made of valid globs.

--- a/crates/ank-cli/src/edit.rs
+++ b/crates/ank-cli/src/edit.rs
@@ -25,13 +25,13 @@
 use crate::claim::{self, Record};
 use crate::cli::{CliError, Invocation, Result};
 use crate::commands::json_string;
+use crate::editor;
 use crate::human::{self, Freeze};
 use crate::repo::Repo;
 use crate::store::{version_of, Store};
-use crate::verify;
 use ank_core::{freeze, parse_entity, Entity, EntityId};
 use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 pub fn run(inv: &Invocation, repo: &Repo, out: &mut dyn Write) -> Result<i32> {
     let prefix = inv
@@ -54,9 +54,10 @@ pub fn run(inv: &Invocation, repo: &Repo, out: &mut dyn Write) -> Result<i32> {
     // Before anything is written anywhere: an unset `$EDITOR` is an environment
     // failure, not a task failure (§4), and the id is already resolved so the
     // hint can name the exact invocation to retry.
-    let editor = editor_command(&id)?;
+    let hint = format!("EDITOR=vi ank edit {id}");
+    let editor = editor::command(&hint)?;
 
-    let scratch = scratch_path(&id);
+    let scratch = editor::scratch_path(&id.to_string());
     std::fs::write(&scratch, &original).map_err(|e| {
         CliError::new(9, format!("cannot write {}: {e}", scratch.display())).with_hint(format!(
             "ls -ld {}",
@@ -65,7 +66,7 @@ pub fn run(inv: &Invocation, repo: &Repo, out: &mut dyn Write) -> Result<i32> {
     })?;
 
     let outcome = (|| -> Result<i32> {
-        open_in_editor(&editor, &repo.root, &scratch, &id)?;
+        editor::open(&editor, &repo.root, &scratch, &hint)?;
         let edited = std::fs::read_to_string(&scratch).map_err(|e| {
             CliError::new(9, format!("cannot read back {}: {e}", scratch.display()))
         })?;
@@ -89,7 +90,7 @@ pub fn run(inv: &Invocation, repo: &Repo, out: &mut dyn Write) -> Result<i32> {
             let _ = std::fs::remove_file(&scratch);
             Ok(code)
         }
-        Err(e) => Err(kept(e, &scratch)),
+        Err(e) => Err(editor::kept(e, &scratch)),
     }
 }
 
@@ -108,11 +109,11 @@ fn write_back(
 ) -> Result<i32> {
     let id = before.id();
     let after = parse_entity(edited).map_err(|e| {
-        CliError::new(
-            1,
-            format!("{id} left untouched, the result does not parse: {e}"),
+        editor::invalid_entity(
+            e,
+            &format!("{id} left untouched, the result does not parse"),
+            &format!("ank edit {id}"),
         )
-        .with_hint(format!("ank edit {id}"))
     })?;
 
     check_id(id, after.id())?;
@@ -269,112 +270,6 @@ fn live_claim_anchor(cwd: &Path, id: &EntityId) -> Result<Option<String>> {
 }
 
 // ---------------------------------------------------------------------------
-// The editor
-// ---------------------------------------------------------------------------
-
-/// `$EDITOR`, or the environment failure §4 specifies for its absence.
-///
-/// Code 9 and nothing guessed: an editor picked for the caller would open
-/// something they did not ask for, on a file they are about to commit. `new`
-/// answers the same absence by naming its flag form; `edit` has no flag form,
-/// so the way through is the variable itself and the hint sets it.
-fn editor_command(id: &EntityId) -> Result<String> {
-    editor_from(std::env::var("EDITOR").ok().as_deref(), id)
-}
-
-/// The decision, separated from the reading.
-///
-/// Not a flourish: `std::env::set_var` is unsound while another thread reads
-/// the environment, and the test harness is threaded — `std::env::temp_dir`
-/// alone reads `TMPDIR`, and a neighbouring test calls it. Passing the value in
-/// is what lets the empty and untrimmed cases be tested at all without a test
-/// that is racy by construction. The absence itself is tested in
-/// `tests/cli.rs`, in a process of its own, which is where it belongs anyway.
-fn editor_from(value: Option<&str>, id: &EntityId) -> Result<String> {
-    match value {
-        // Set but empty is unset: a caller who exported it to nothing gets the
-        // same answer as one who never exported it, rather than `sh` being
-        // handed a bare file name to execute.
-        Some(v) if !v.trim().is_empty() => Ok(v.trim().to_string()),
-        _ => Err(
-            CliError::new(9, format!("EDITOR is not set, and edit opens {id} in it"))
-                .with_hint(format!("EDITOR=vi ank edit {id}")),
-        ),
-    }
-}
-
-/// Runs the editor on `file` and waits for it.
-///
-/// Through `sh -c`, like the verifiers, and for the same reason: `$EDITOR` is a
-/// command line and not a program name — `code -w`, `emacsclient -nw` and
-/// `vim -f` are all ordinary values of it — so splitting it here would mean
-/// reimplementing word splitting and quoting badly. `sh` is already a hard
-/// dependency of `done`, and `verify::find_sh` already knows where to find one
-/// on Windows.
-fn open_in_editor(editor: &str, cwd: &Path, file: &Path, id: &EntityId) -> Result<()> {
-    let sh = verify::find_sh()?;
-    let command = format!("{editor} {}", sh_quote(&file.to_string_lossy()));
-    // stdio is inherited: the editor is the foreground process for as long as it
-    // runs, and capturing any of the three would leave a full-screen editor
-    // drawing into a pipe.
-    let status = std::process::Command::new(&sh)
-        .current_dir(cwd)
-        .arg("-c")
-        .arg(&command)
-        .status()
-        .map_err(|e| {
-            CliError::new(9, format!("cannot run the editor: {e}"))
-                .with_hint(format!("EDITOR=vi ank edit {id}"))
-        })?;
-    if status.success() {
-        return Ok(());
-    }
-    // An editor that exits non-zero has not delivered a result, which is the
-    // environment failing rather than the corpus refusing — the same reading
-    // `verify` applies to a shell that cannot run what it was given.
-    let code = match status.code() {
-        Some(c) => c.to_string(),
-        None => "a signal".to_string(),
-    };
-    Err(
-        CliError::new(9, format!("the editor exited {code}, so {id} is untouched"))
-            .with_hint(format!("EDITOR=vi ank edit {id}")),
-    )
-}
-
-/// Single quotes, with the one character they cannot hold spliced out. The path
-/// is ours, but it sits under a temporary directory the environment chooses.
-fn sh_quote(s: &str) -> String {
-    format!("'{}'", s.replace('\'', r"'\''"))
-}
-
-/// A scratch file outside `.ank/`, carrying the id and the `.md` extension so
-/// that an editor opens it with the right mode and the caller recognises it in
-/// a message. Never inside `.ank/`: a stray `.md` there is a corpus fault, and
-/// a crash mid-edit would leave one.
-fn scratch_path(id: &EntityId) -> PathBuf {
-    use std::sync::atomic::{AtomicU64, Ordering};
-    static SEQ: AtomicU64 = AtomicU64::new(0);
-    std::env::temp_dir().join(format!(
-        "ank-edit-{}-{}-{id}.md",
-        std::process::id(),
-        SEQ.fetch_add(1, Ordering::Relaxed)
-    ))
-}
-
-/// Names the scratch file in a refusal, so that the text survives the message.
-fn kept(e: CliError, scratch: &Path) -> CliError {
-    CliError {
-        message: format!(
-            "{} (the edited text is kept at {})",
-            e.message,
-            scratch.display()
-        ),
-        ..e
-    }
-}
-
-// ---------------------------------------------------------------------------
 // What changed
 // ---------------------------------------------------------------------------
 
@@ -479,31 +374,6 @@ mod tests {
     }
 
     #[test]
-    fn a_quoted_path_survives_the_shell() {
-        assert_eq!(sh_quote("/tmp/a b.md"), "'/tmp/a b.md'");
-        // The one character single quotes cannot hold. Left unhandled, a
-        // temporary directory with an apostrophe in it would end the quoting
-        // and hand the rest of the path to the shell as words.
-        assert_eq!(sh_quote("/tmp/o'brien.md"), r"'/tmp/o'\''brien.md'");
-        // Backslashes are literal inside single quotes, which is what makes a
-        // Windows path survive `sh -c` unchanged.
-        assert_eq!(sh_quote(r"C:\Users\a\x.md"), r"'C:\Users\a\x.md'");
-    }
-
-    #[test]
-    fn the_scratch_file_is_outside_the_corpus_and_names_the_entity() {
-        let id = EntityId::parse("TASK-000000000001").unwrap();
-        let p = scratch_path(&id);
-        let text = p.display().to_string();
-        assert!(text.contains("TASK-000000000001"), "{text}");
-        assert!(text.ends_with(".md"), "{text}");
-        assert!(!text.contains(".ank"), "never inside the corpus: {text}");
-        // Two calls in one process must not collide: an editor left open on the
-        // first would otherwise be writing into the second's file.
-        assert_ne!(p, scratch_path(&id));
-    }
-
-    #[test]
     fn a_changed_id_is_refused_and_names_no_command() {
         let a = EntityId::parse("TASK-000000000001").unwrap();
         let b = EntityId::parse("TASK-000000000002").unwrap();
@@ -536,26 +406,5 @@ mod tests {
             changed_fields(&before, &Entity::Adr(a)),
             ["scope", "constraint"]
         );
-    }
-
-    #[test]
-    fn an_unset_editor_is_an_environment_failure_that_names_the_retry() {
-        let id = EntityId::parse("TASK-000000000001").unwrap();
-
-        let err = editor_from(None, &id).unwrap_err();
-        assert_eq!(err.code, 9);
-        assert_eq!(
-            err.hint.as_deref(),
-            Some("EDITOR=vi ank edit TASK-000000000001")
-        );
-
-        // Exported to nothing is the same answer as never exported, rather than
-        // `sh` being handed a bare file name to execute.
-        assert_eq!(editor_from(Some(""), &id).unwrap_err().code, 9);
-        assert_eq!(editor_from(Some("   "), &id).unwrap_err().code, 9);
-
-        // A command line, not a program name, and the surrounding blanks a
-        // shell profile leaves behind are not part of it.
-        assert_eq!(editor_from(Some(" vim -f "), &id).unwrap(), "vim -f");
     }
 }

--- a/crates/ank-cli/src/editor.rs
+++ b/crates/ank-cli/src/editor.rs
@@ -1,0 +1,201 @@
+//! `$EDITOR`: locating it, running it, and keeping what it wrote (§4).
+//!
+//! Not a verb — nothing dispatches here. Two callers need the same four things
+//! and need them to behave identically: `edit`, which opens an entity that
+//! exists, and the interactive form of `new`, which opens a template for one
+//! that does not. A second copy of this would be a second set of answers about
+//! quoting, exit codes and where the text went when something failed, and the
+//! two would drift the first time only one of them was fixed.
+//!
+//! **The refusals are code 9 throughout.** An editor that is not named, cannot
+//! be run, or exits non-zero has not delivered a result: that is an environment
+//! to repair, not a corpus refusing and not work that failed. It is the reading
+//! `verify` already applies to a shell it cannot run, and confusing the two
+//! sends a caller to fix something that was never wrong.
+
+use crate::cli::{CliError, Result};
+use crate::verify;
+use std::path::{Path, PathBuf};
+
+/// `$EDITOR`, or the environment failure §4 specifies for its absence.
+///
+/// `hint` is the whole of the next command, supplied by the caller because only
+/// it knows what the way through is: for `edit` that is setting the variable and
+/// running the same thing again, and for the interactive form of `new` it is the
+/// flag form, which §4 names explicitly.
+pub fn command(hint: &str) -> Result<String> {
+    from_env(std::env::var("EDITOR").ok().as_deref(), hint)
+}
+
+/// The decision, separated from the reading.
+///
+/// Not a flourish: `std::env::set_var` is unsound while another thread reads the
+/// environment, and the test harness is threaded — `std::env::temp_dir` alone
+/// reads `TMPDIR`, and a neighbouring test calls it. Passing the value in is
+/// what lets the empty and untrimmed cases be tested at all without a test that
+/// is racy by construction. The absence itself is tested through the binary, in
+/// a process of its own, which is where it belongs anyway.
+pub fn from_env(value: Option<&str>, hint: &str) -> Result<String> {
+    match value {
+        // Set but empty is unset: a caller who exported it to nothing gets the
+        // same answer as one who never exported it, rather than `sh` being
+        // handed a bare file name to execute.
+        Some(v) if !v.trim().is_empty() => Ok(v.trim().to_string()),
+        // Nothing is guessed. An editor picked on the caller's behalf would open
+        // something they never asked for, on a file they are about to commit.
+        _ => Err(
+            CliError::new(9, "EDITOR is not set, and there is no editor to open")
+                .with_hint(hint.to_string()),
+        ),
+    }
+}
+
+/// Runs the editor on `file` and waits for it.
+///
+/// Through `sh -c`, like the verifiers, and for the same reason: `$EDITOR` is a
+/// command line and not a program name — `code -w`, `emacsclient -nw` and
+/// `vim -f` are all ordinary values of it — so splitting it here would mean
+/// reimplementing word splitting and quoting badly. `sh` is already a hard
+/// dependency of `done`, and `verify::find_sh` already knows where to find one
+/// on Windows.
+pub fn open(editor: &str, cwd: &Path, file: &Path, hint: &str) -> Result<()> {
+    let sh = verify::find_sh()?;
+    let command = format!("{editor} {}", sh_quote(&file.to_string_lossy()));
+    // stdio is inherited: the editor is the foreground process for as long as it
+    // runs, and capturing any of the three would leave a full-screen editor
+    // drawing into a pipe.
+    let status = std::process::Command::new(&sh)
+        .current_dir(cwd)
+        .arg("-c")
+        .arg(&command)
+        .status()
+        .map_err(|e| {
+            CliError::new(9, format!("cannot run the editor: {e}")).with_hint(hint.to_string())
+        })?;
+    if status.success() {
+        return Ok(());
+    }
+    let code = match status.code() {
+        Some(c) => c.to_string(),
+        None => "a signal".to_string(),
+    };
+    Err(CliError::new(
+        9,
+        format!("the editor exited {code}, so nothing was written"),
+    )
+    .with_hint(hint.to_string()))
+}
+
+/// Single quotes, with the one character they cannot hold spliced out. The path
+/// is ours, but it sits under a temporary directory the environment chooses.
+pub fn sh_quote(s: &str) -> String {
+    format!("'{}'", s.replace('\'', r"'\''"))
+}
+
+/// A scratch file outside `.ank/`, carrying `label` and the `.md` extension so
+/// that an editor opens it with the right mode and the caller recognises it in
+/// a message. Never inside `.ank/`: a stray `.md` there is a corpus fault, and a
+/// crash mid-edit would leave one.
+pub fn scratch_path(label: &str) -> PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    std::env::temp_dir().join(format!(
+        "ank-edit-{}-{}-{label}.md",
+        std::process::id(),
+        SEQ.fetch_add(1, Ordering::Relaxed)
+    ))
+}
+
+/// What came back is not an entity, said with the code the flag form would have
+/// used for the same complaint.
+///
+/// The split is not cosmetic. §4 gives 1 to a malformed invocation and 7 to a
+/// missing prerequisite, and the flag form already answers an empty scope with 7
+/// — so an editor path that answered 1 to the same corpus would make the exit
+/// code depend on how the entity was typed rather than on what is wrong with it.
+/// A caller branching on the code would be reading the input method.
+pub fn invalid_entity(e: ank_core::Error, what: &str, hint: &str) -> CliError {
+    use ank_core::Error::*;
+    let code = match e {
+        // The entity parsed and does not hold together: the same class of thing
+        // `--scope` and `--criteria` are refused for on the flag path.
+        EmptyScope | InvalidGlob(_) | CriteriaByWithoutCriteria => 7,
+        // Malformed: nothing here is a field the caller failed to supply.
+        _ => 1,
+    };
+    CliError::new(code, format!("{what}: {e}")).with_hint(hint.to_string())
+}
+
+/// Names the scratch file in a refusal, so that the text survives the message.
+///
+/// Every path that fails after the editor has run goes through here, because the
+/// alternative is a verb that answers a typo by discarding the twenty minutes
+/// around it.
+pub fn kept(e: CliError, scratch: &Path) -> CliError {
+    CliError {
+        message: format!(
+            "{} (the edited text is kept at {})",
+            e.message,
+            scratch.display()
+        ),
+        ..e
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_quoted_path_survives_the_shell() {
+        assert_eq!(sh_quote("/tmp/a b.md"), "'/tmp/a b.md'");
+        // The one character single quotes cannot hold. Left unhandled, a
+        // temporary directory with an apostrophe in it would end the quoting and
+        // hand the rest of the path to the shell as words.
+        assert_eq!(sh_quote("/tmp/o'brien.md"), r"'/tmp/o'\''brien.md'");
+        // Backslashes are literal inside single quotes, which is what makes a
+        // Windows path survive `sh -c` unchanged.
+        assert_eq!(sh_quote(r"C:\Users\a\x.md"), r"'C:\Users\a\x.md'");
+    }
+
+    #[test]
+    fn the_scratch_file_is_outside_the_corpus_and_carries_its_label() {
+        let p = scratch_path("TASK-000000000001");
+        let text = p.display().to_string();
+        assert!(text.contains("TASK-000000000001"), "{text}");
+        assert!(text.ends_with(".md"), "{text}");
+        assert!(!text.contains(".ank"), "never inside the corpus: {text}");
+        // Two calls in one process must not collide: an editor left open on the
+        // first would otherwise be writing into the second's file.
+        assert_ne!(p, scratch_path("TASK-000000000001"));
+    }
+
+    #[test]
+    fn an_unset_editor_is_an_environment_failure_that_names_the_retry() {
+        let err = from_env(None, "EDITOR=vi ank edit 039e").unwrap_err();
+        assert_eq!(err.code, 9);
+        assert_eq!(err.hint.as_deref(), Some("EDITOR=vi ank edit 039e"));
+
+        // Exported to nothing is the same answer as never exported, rather than
+        // `sh` being handed a bare file name to execute.
+        assert_eq!(
+            from_env(Some(""), "EDITOR=vi ank edit 039e")
+                .unwrap_err()
+                .code,
+            9
+        );
+        assert_eq!(
+            from_env(Some("   "), "EDITOR=vi ank edit 039e")
+                .unwrap_err()
+                .code,
+            9
+        );
+
+        // A command line, not a program name, and the surrounding blanks a shell
+        // profile leaves behind are not part of it.
+        assert_eq!(
+            from_env(Some(" vim -f "), "ank new task --title x").unwrap(),
+            "vim -f"
+        );
+    }
+}

--- a/crates/ank-cli/src/main.rs
+++ b/crates/ank-cli/src/main.rs
@@ -33,6 +33,7 @@ mod commands;
 mod context;
 mod done;
 mod edit;
+mod editor;
 mod graph;
 mod human;
 mod index;

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -242,6 +242,33 @@ impl Repo {
     }
 }
 
+/// An editor that fills a `new` template in, rather than replacing it.
+///
+/// It has to transform: the id is minted by `new` before the editor runs and is
+/// refused if it comes back changed, so the wholesale `cp` that serves `edit`
+/// cannot serve here.
+///
+/// A shell function, and not `sed -i`, because `-i` is where the three
+/// platforms part company: it takes a mandatory backup suffix on the BSD sed
+/// macOS ships, so `sed -i -e ...` consumes `-e` as the suffix there and the
+/// suite would pass on two runners and fail on the third. Redirecting into a
+/// second file and moving it is POSIX everywhere. The path arrives as `$1`
+/// because `sh -c 'f; f <path>'` binds it — which is also what makes this read
+/// like an editor rather than a fixture.
+fn editor_filling(title: &str, scope: &str, body: &str) -> String {
+    format!(
+        r#"f() {{ sed -e "s|^title:.*|title: {title}|" -e "s|^scope: .*|scope: [\"{scope}\"]|" "$1" > "$1.new"; printf "%s\n" "" "{body}" >> "$1.new"; mv "$1.new" "$1"; }}; f"#
+    )
+}
+
+/// The same, plus one arbitrary substitution — for the tests that need to move
+/// a field the template does not invite anyone to touch.
+fn editor_filling_and(title: &str, scope: &str, extra: &str) -> String {
+    format!(
+        r#"f() {{ sed -e "s|^title:.*|title: {title}|" -e "s|^scope: .*|scope: [\"{scope}\"]|" -e "{extra}" "$1" > "$1.new"; mv "$1.new" "$1"; }}; f"#
+    )
+}
+
 impl Drop for Repo {
     fn drop(&mut self) {
         let _ = std::fs::remove_dir_all(&self.0);
@@ -2425,4 +2452,258 @@ fn an_editor_that_exits_non_zero_leaves_the_entity_untouched() {
         stderr(&out)
     );
     assert_eq!(r.task_text(ID), before);
+}
+
+// ---------------------------------------------------------------------------
+// new, interactive
+// ---------------------------------------------------------------------------
+//
+// The `git commit` pattern: no flags, an editor (§4). The flag form is what
+// SKILL.md teaches and what an agent uses, and the tests that matter most here
+// are the ones asserting nothing about it moved.
+
+/// The entities a repository holds, read off the disk rather than through the
+/// tool: what has to be true is the state of the corpus, not `find`'s agreement
+/// with itself.
+fn entity_files(r: &Repo, sub: &str) -> Vec<String> {
+    let dir = r.0.join(".ank").join(sub);
+    let mut v: Vec<String> = std::fs::read_dir(&dir)
+        .map(|rd| {
+            rd.filter_map(|e| e.ok())
+                .map(|e| e.file_name().to_string_lossy().to_string())
+                .filter(|n| n.ends_with(".md"))
+                .collect()
+        })
+        .unwrap_or_default();
+    v.sort();
+    v
+}
+
+#[test]
+fn new_task_without_flags_opens_a_template_and_writes_what_comes_back() {
+    let r = Repo::new();
+    let editor = editor_filling("A task typed in an editor", "crates/**", "The reasoning.");
+
+    let out = r.ank_edit("claude-code@ank", &["new", "task"], Some(&editor));
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    assert!(
+        stdout(&out).contains("created TASK-")
+            && stdout(&out).contains("A task typed in an editor"),
+        "{}",
+        stdout(&out)
+    );
+
+    let files = entity_files(&r, "tasks");
+    assert_eq!(files.len(), 1, "exactly one task: {files:?}");
+    let text = std::fs::read_to_string(r.0.join(".ank/tasks").join(&files[0])).unwrap();
+
+    // The guidance rides in YAML comments and the parser drops them. A template
+    // whose help text reached the corpus would put it in every `show` forever.
+    assert!(!text.contains('#'), "the comments are stripped: {text}");
+    assert!(text.contains("title: A task typed in an editor"), "{text}");
+    assert!(
+        text.contains("  - crates/**"),
+        "canonical block scope: {text}"
+    );
+    // Derived, not typed: the template never asks for a slug.
+    assert!(text.contains("slug: a-task-typed-in-an-editor"), "{text}");
+    assert!(
+        text.ends_with("The reasoning.\n"),
+        "the body survives: {text}"
+    );
+    assert!(
+        text.contains("status: open") && text.contains("version: 1"),
+        "{text}"
+    );
+}
+
+#[test]
+fn new_adr_without_flags_opens_a_template_and_writes_what_comes_back() {
+    let r = Repo::new();
+    // The constraint is the ADR's mandatory field, and the template leaves it an
+    // empty block for the caller to fill.
+    let editor = editor_filling_and(
+        "A decision typed in an editor",
+        "docs/**",
+        r"s|^  $|  Do not do X.|",
+    );
+
+    let out = r.ank_edit("marie@laptop", &["new", "adr"], Some(&editor));
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+
+    let files = entity_files(&r, "adr");
+    assert_eq!(files.len(), 1, "exactly one adr: {files:?}");
+    let text = std::fs::read_to_string(r.0.join(".ank/adr").join(&files[0])).unwrap();
+    assert!(text.contains("Do not do X."), "{text}");
+    // Never born accepted and never born anchored: ratification is a signed
+    // commit produced by `accept`, and an ADR that arrived ratified would bind
+    // before anyone agreed to it.
+    assert!(text.contains("status: proposed"), "{text}");
+    assert!(!text.contains("ratified:"), "{text}");
+}
+
+/// The clause that keeps the interactive form from being the hole in the wall:
+/// it refuses what the flag form refuses, in the flag form's words and with the
+/// flag form's code.
+#[test]
+fn a_template_saved_untouched_is_refused_and_creates_nothing() {
+    let r = Repo::new();
+
+    let out = r.ank_edit("claude-code@ank", &["new", "task"], Some("true"));
+    assert_eq!(
+        code(&out),
+        7,
+        "the same code the flag form gives an empty scope: {}",
+        stderr(&out)
+    );
+    let err = stderr(&out);
+    assert!(err.contains("empty scope"), "says why: {err}");
+    assert!(
+        err.contains("ank new task --title"),
+        "names the flag form: {err}"
+    );
+    assert!(
+        entity_files(&r, "tasks").is_empty(),
+        "nothing is created: {:?}",
+        entity_files(&r, "tasks")
+    );
+}
+
+/// §4 requires this one by name: `$EDITOR` unset is an environment failure, and
+/// what it names as the way through is the flag form.
+#[test]
+fn new_without_an_editor_names_the_flag_form() {
+    let r = Repo::new();
+
+    let out = r.ank_edit("claude-code@ank", &["new", "task"], None);
+    assert_eq!(code(&out), 9, "{}", stderr(&out));
+    let err = stderr(&out);
+    assert!(err.contains("EDITOR is not set"), "{err}");
+    assert_eq!(
+        err.lines().nth(1).map(str::trim),
+        Some(r#"-> ank new task --title "<t>" --scope "<glob>""#),
+        "{err}"
+    );
+
+    let out = r.ank_edit("marie@laptop", &["new", "adr"], None);
+    assert_eq!(code(&out), 9, "{}", stderr(&out));
+    assert!(stderr(&out).contains("--constraint"), "{}", stderr(&out));
+    assert!(entity_files(&r, "tasks").is_empty());
+}
+
+/// The property the whole trigger rule was chosen for. A script that forgot
+/// `--scope` has to stop, not sit in an editor waiting for somebody who is not
+/// there — so a partial invocation stays the flag form and fails as it always
+/// did, with an editor set and willing.
+#[test]
+fn the_flag_form_is_untouched_by_the_interactive_one() {
+    let r = Repo::new();
+    // An editor that would happily create a valid entity if it were ever run.
+    // Reaching it is the failure this test exists to catch.
+    let editor = editor_filling("Should never be created", "src/**", "x");
+
+    let out = r.ank_edit(
+        "claude-code@ank",
+        &["new", "task", "--title", "Half an invocation"],
+        Some(&editor),
+    );
+    assert_eq!(code(&out), 7, "{}", stderr(&out));
+    assert!(
+        stderr(&out).contains("a scope is required"),
+        "{}",
+        stderr(&out)
+    );
+    assert!(
+        entity_files(&r, "tasks").is_empty(),
+        "the editor was reached: {:?}",
+        entity_files(&r, "tasks")
+    );
+
+    // And the complete flag form still writes exactly what it always wrote.
+    let out = r.ank_edit(
+        "claude-code@ank",
+        &["new", "task", "--title", "Scripted", "--scope", "src/**"],
+        Some(&editor),
+    );
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    let files = entity_files(&r, "tasks");
+    assert_eq!(files.len(), 1, "{files:?}");
+    let text = std::fs::read_to_string(r.0.join(".ank/tasks").join(&files[0])).unwrap();
+    assert!(text.contains("title: Scripted"), "{text}");
+    assert!(text.contains("  - src/**"), "{text}");
+}
+
+/// The id hashes the act of creation (§3) and the file name carries it. Letting
+/// the caller choose one would let them collide with an entity that exists, or
+/// mint a reference nothing can resolve.
+#[test]
+fn a_template_that_comes_back_with_another_id_is_refused() {
+    let r = Repo::new();
+    let editor = editor_filling_and(
+        "Renamed",
+        "src/**",
+        r"s|^id: TASK-.*|id: TASK-000000000009|",
+    );
+
+    let out = r.ank_edit("claude-code@ank", &["new", "task"], Some(&editor));
+    assert_eq!(code(&out), 6, "{}", stderr(&out));
+    assert!(
+        stderr(&out).contains("cannot be chosen"),
+        "{}",
+        stderr(&out)
+    );
+    assert!(entity_files(&r, "tasks").is_empty());
+}
+
+/// Reaching the editor does not mean nothing was said. A flag that is not one of
+/// the mandatory ones carries into the template rather than being dropped.
+#[test]
+fn the_flags_that_were_given_are_carried_into_the_template() {
+    let r = Repo::new().with_verifiers("verifiers:\n  unit:\n    run: 'true'\n    timeout: 1m\n");
+    let editor = editor_filling("Pre-filled", "src/**", "x");
+
+    let out = r.ank_edit(
+        "claude-code@ank",
+        &[
+            "new",
+            "task",
+            "--criteria",
+            "The binary answers.",
+            "--verify",
+            "unit",
+        ],
+        Some(&editor),
+    );
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    let files = entity_files(&r, "tasks");
+    assert_eq!(files.len(), 1, "{files:?}");
+    let text = std::fs::read_to_string(r.0.join(".ank/tasks").join(&files[0])).unwrap();
+    assert!(text.contains("The binary answers."), "{text}");
+    assert!(text.contains("verify: [unit]"), "{text}");
+    // Set by the creator, because that is who typed it — the same thing the flag
+    // form records.
+    assert!(text.contains("criteria_by: creator"), "{text}");
+}
+
+/// The references are resolved at the point of creation, exactly as the flag
+/// form resolves `--blocked-by`: an unknown one would otherwise surface in
+/// `check`, long afterwards, as a corpus error nobody can attribute to the act.
+#[test]
+fn a_blocker_that_does_not_exist_is_refused_at_creation() {
+    let r = Repo::new();
+    let editor = editor_filling_and(
+        "Blocked on nothing",
+        "src/**",
+        r"s|^blocked_by: .*|blocked_by: [TASK-000000000404]|",
+    );
+
+    let out = r.ank_edit("claude-code@ank", &["new", "task"], Some(&editor));
+    assert_eq!(code(&out), 7, "{}", stderr(&out));
+    let err = stderr(&out);
+    assert!(err.contains("TASK-000000000404"), "{err}");
+    assert!(
+        err.contains("ank find"),
+        "the exact command to run next: {err}"
+    );
+    assert!(entity_files(&r, "tasks").is_empty());
 }


### PR DESCRIPTION
The `git commit` pattern: no `-m`, an editor. `ank new task` and `ank new adr` with none of their mandatory flags open a pre-filled template in `$EDITOR`, validate what comes back, and refuse to write an entity that would fail validation.

## The trigger rule is the decision worth reviewing

**All the mandatory flags absent, not some.** §4 says it two ways — "`new` without its mandatory flags" in the prose, "no flags" in the commands block — and this reading satisfies both:

| invocation | form |
|---|---|
| `ank new task` | editor |
| `ank new task --criteria "..."` | editor, criteria pre-filled |
| `ank new task --title "x"` | flag form, exits 7 on the missing scope |
| `ank new adr --title "x" --scope "s/**"` | flag form, exits 7 on the missing constraint |

The difference is the whole point. A build that forgot `--scope` has to stop, not sit in `vi` waiting for somebody who is not there. Mutating the rule from all-absent to any-absent broke the flag-form test **and** `the_whole_agent_loop_runs_through_the_binary`, written three tasks ago — the scripted-path regression, caught by a test that predates this work.

## Two more decisions

**The template is a real entity file in canonical form**, not an editable subset. A second surface for the same data is exactly the drift ADR-63b59c5c26f7 exists to prevent. Guidance rides in YAML comments inside the frontmatter, where the parser strips it and nobody has to remember to. It never goes below the second fence: the body is markdown, `#` there is a heading, and a tool that deleted those lines would eat the reasoning it just asked for.

**Every check on the way back has a counterpart on the flag path** — title, scope, status, `blocked_by` resolution, verifier names, and the id, which is minted by `new` and refused if it comes back changed. An interactive form that validated less would not be a convenience, it would be the way to write the entity `new` refuses. That extends to the exit codes: `editor::invalid_entity` gives an empty scope the same 7 the flag form gives it, so the code reports what is wrong rather than how the entity was typed.

The editor plumbing moves out of `edit.rs` into a shared `editor.rs`. Two callers needing identical answers about quoting, exit codes and where the text went is the pair that drifts the first time only one is fixed.

## Verification

Eight tests through the binary. Four mutations, four caught: the trigger rule, the id refusal, the guidance placement, and the blocker resolution.

The test editor is a POSIX shell function rather than `sed -i`. BSD sed on macOS takes a mandatory backup suffix, so `sed -i -e ...` consumes `-e` as the suffix there — the suite would have passed on two runners and failed on the third.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169ygCoGJmmYUWgDvWTYMkF