### PR TITLE
ank log with an id and no message reads instead of writing

### DIFF
--- a/.ank/tasks/TASK-a6af1fca65bc.md
+++ b/.ank/tasks/TASK-a6af1fca65bc.md
@@ -5,7 +5,7 @@ slug: ank-log-with-an-id-and-no-message-reads-instead
 title: ank log with an id and no message reads instead of writing
 created: 2026-08-01T18:30:09Z
 author: seanl@sean-laptop
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/**
 blocked_by: [TASK-ff1c20395929]
@@ -13,7 +13,10 @@ done_criteria: |
   ank log <id> with no message prints the log section of the task, newest first, and requires no claim. ank log with a message keeps writing and renewing the claim. An argument that resolves to an entity id is a read, anything else is a message; a message that also resolves to an id is an error naming both readings. The binary is what the test invokes.
 criteria_by: creator
 schema: 2
-version: 1
+version: 3
 ---
 
 Dissolves the one place the git intuition was betrayed, without renaming the verb: git log reads, and now so does ank log when given only an id.
+
+## Log
+- 2026-08-03T22:28:46Z seanl@sean-laptop — The disambiguation of the read form: only a successful resolve is a read, so an ambiguous prefix is a message like any other string. One question, one answer, predictable without running it -- the alternative (ambiguous is an error) adds a second question an agent cannot answer from the argument alone. Read prints through LogEntry::format_line so the printed line and the stored line stay one shape.

--- a/.ank/tasks/TASK-a6af1fca65bc.md
+++ b/.ank/tasks/TASK-a6af1fca65bc.md
@@ -5,18 +5,23 @@ slug: ank-log-with-an-id-and-no-message-reads-instead
 title: ank log with an id and no message reads instead of writing
 created: 2026-08-01T18:30:09Z
 author: seanl@sean-laptop
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/**
 blocked_by: [TASK-ff1c20395929]
 done_criteria: |
   ank log <id> with no message prints the log section of the task, newest first, and requires no claim. ank log with a message keeps writing and renewing the claim. An argument that resolves to an entity id is a read, anything else is a message; a message that also resolves to an id is an error naming both readings. The binary is what the test invokes.
 criteria_by: creator
+proof:
+  - type: test
+    ref: "30858885207"
+    criteria: 94553a371c03
 schema: 2
-version: 3
+version: 4
 ---
 
 Dissolves the one place the git intuition was betrayed, without renaming the verb: git log reads, and now so does ank log when given only an id.
 
 ## Log
 - 2026-08-03T22:28:46Z seanl@sean-laptop — The disambiguation of the read form: only a successful resolve is a read, so an ambiguous prefix is a message like any other string. One question, one answer, predictable without running it -- the alternative (ambiguous is an error) adds a second question an agent cannot answer from the argument alone. Read prints through LogEntry::format_line so the printed line and the stored line stay one shape.
+- 2026-08-03T22:32:45Z seanl@sean-laptop — done, proof test:30858885207

--- a/crates/ank-cli/src/cli.rs
+++ b/crates/ank-cli/src/cli.rs
@@ -181,7 +181,9 @@ pub const COMMANDS: &[CommandSpec] = &[
         name: "log",
         subcommands: &[],
         max_positionals: 2,
-        positional_help: "[<id>] <message>",
+        // Both optional, and what is given decides which of the two things the
+        // verb does: an id alone reads, a message writes (§4).
+        positional_help: "[<id>] [<message>]",
         flags: &[],
         owner_task: None,
     },

--- a/crates/ank-cli/src/commands.rs
+++ b/crates/ank-cli/src/commands.rs
@@ -14,6 +14,8 @@
 //!   as effective as a badly bounded `context`.
 //! - **`log`** requires holding the claim and renews the TTL by writing.
 //!   Working is what keeps the lock; there is no heartbeat verb to memorise.
+//!   Given nothing but an id it reads instead, and then asks for no claim at
+//!   all: `git log` reads, and this is what stops the borrowed name from lying.
 //! - **`release`** requires a reason, because it is the delegation mechanism
 //!   between agents: the reason reaches the next holder through the log.
 //! - **`scope`** makes glob resolution observable before an entity is written
@@ -1035,6 +1037,15 @@ fn check_matches_head(store: &Store, given: Option<&String>, head: &EntityId) ->
     Ok(())
 }
 
+/// `log [<id>] [<message>]` (§4). `git log` reads, and so does this one when it
+/// is given nothing but an id — the one place the git intuition was betrayed,
+/// closed without renaming the verb.
+///
+/// **The disambiguation is stated, not inferred**: an argument that resolves to
+/// an entity id is a read, anything else is a message. "It resolved" is the
+/// whole test, so an argument that fails to resolve for any reason at all —
+/// absent, too short, ambiguous — is a message. A rule with one question has one
+/// answer, and an agent can predict it without running it.
 pub fn log(
     inv: &Invocation,
     repo: &Repo,
@@ -1042,24 +1053,105 @@ pub fn log(
     identity: &str,
     out: &mut dyn Write,
 ) -> Result<i32> {
-    // `log [<id>] <message>`: the message is always the last positional, so one
-    // argument is the message and two are an id and a message.
-    let (given, message) = match inv.positionals.as_slice() {
-        [message] => (None, message.clone()),
-        [id, message] => (Some(id), message.clone()),
-        _ => {
-            return Err(CliError::new(1, "log expects a message")
-                .with_hint("ank log \"<what you just did>\""))
+    let store = Store::new(&repo.ank);
+    match inv.positionals.as_slice() {
+        [one] => match store.resolve(one) {
+            Ok(id) => log_read(inv, &store, &id, out),
+            Err(_) => log_write(inv, repo, cfg, identity, &store, None, one, out),
+        },
+        [given, message] => {
+            // The one invocation the rule above cannot decide: the message sits
+            // where a message goes and still names an entity. Both readings are
+            // live, so neither is picked (§4).
+            if let Ok(other) = store.resolve(message) {
+                return Err(CliError::new(
+                    1,
+                    format!(
+                        "{message} reads two ways: the log of {other} to print, \
+                         or a message to write on {given}"
+                    ),
+                )
+                .with_hint(format!("ank log {other}")));
+            }
+            log_write(inv, repo, cfg, identity, &store, Some(given), message, out)
         }
+        _ => Err(
+            CliError::new(1, "log expects a message to write or an id to read")
+                .with_hint("ank log \"<what you just did>\""),
+        ),
+    }
+}
+
+/// The task's log section, newest first, and no claim asked for: printing what
+/// somebody else recorded takes nothing from them (§4). The file is append-only,
+/// so the entry a reader came for is the last line of it — reversing is what
+/// makes the answer start with it.
+fn log_read(inv: &Invocation, store: &Store, id: &EntityId, out: &mut dyn Write) -> Result<i32> {
+    let Entity::Task(task) = store.load(id)?.entity else {
+        return Err(
+            CliError::new(1, format!("{id} is not a task, and only a task has a log"))
+                .with_hint(format!("ank show {id}")),
+        );
     };
+    let entries: Vec<LogEntry> = ank_core::parse_log(&task.body).into_iter().rev().collect();
+
+    if inv.json() {
+        let items: Vec<String> = entries
+            .iter()
+            .map(|e| {
+                format!(
+                    "{{\"timestamp\":{},\"who\":{},\"message\":{}}}",
+                    json_string(&e.timestamp),
+                    json_string(&e.who),
+                    json_string(&e.message)
+                )
+            })
+            .collect();
+        let _ = writeln!(
+            out,
+            "{{\"task\":\"{id}\",\"entries\":[{}]}}",
+            items.join(",")
+        );
+        return Ok(0);
+    }
+    if inv.quiet() {
+        return Ok(0);
+    }
+
+    let _ = writeln!(out, "{id}  {}", task.title);
+    if entries.is_empty() {
+        // Named rather than left blank: an empty answer and an answer about the
+        // wrong task look identical otherwise.
+        let _ = writeln!(out, "\nno log entry yet");
+        return Ok(0);
+    }
+    let _ = writeln!(out);
+    for e in &entries {
+        // The section's own formatter, so the printed line and the stored line
+        // cannot drift into two shapes for one thing.
+        let _ = writeln!(out, "{}", e.format_line());
+    }
+    Ok(0)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn log_write(
+    inv: &Invocation,
+    repo: &Repo,
+    cfg: &Config,
+    identity: &str,
+    store: &Store,
+    given: Option<&String>,
+    message: &str,
+    out: &mut dyn Write,
+) -> Result<i32> {
     if message.trim().is_empty() {
         return Err(CliError::new(1, "an empty log entry records nothing")
             .with_hint("ank log \"<what you just did>\""));
     }
 
-    let store = Store::new(&repo.ank);
     let (id, witness, record) = head_of(&repo.root, identity)?;
-    check_matches_head(&store, given, &id)?;
+    check_matches_head(store, given, &id)?;
 
     let loaded = store.load(&id)?;
     let base_version = version_of(&loaded.entity);

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -1580,6 +1580,140 @@ fn the_whole_agent_loop_runs_through_the_binary() {
     assert!(ctx.contains("needs staging access"), "{ctx}");
 }
 
+/// `git log` reads, and now so does `ank log` given nothing but an id (§4).
+///
+/// Through the binary because the criterion says so, and because what has to be
+/// true is a property of the process: a read that took the claim path would
+/// still pass a module test run under the holder's identity, and fail for every
+/// caller who is not it.
+#[test]
+fn log_with_an_id_and_no_message_reads_and_asks_for_no_claim() {
+    let r = Repo::new();
+    r.seed_task(ID, Some("A verifiable criterion."));
+
+    // An empty log is an answer, not a blank. Read here by an agent that holds
+    // nothing, before any claim exists at all.
+    let out = r.ank("marie@laptop", &["log", ID]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    assert!(
+        stdout(&out).contains("no log entry yet"),
+        "{}",
+        stdout(&out)
+    );
+
+    assert_eq!(code(&r.ank("claude-code@ank", &["claim", ID])), 0);
+    assert_eq!(code(&r.ank("claude-code@ank", &["log", "first thing"])), 0);
+    assert_eq!(code(&r.ank("claude-code@ank", &["log", "second thing"])), 0);
+
+    // Still `marie@laptop`, who holds no claim on anything: the claim is what
+    // writing needs, never reading.
+    let before = r.task_text(ID);
+    let out = r.ank("marie@laptop", &["log", ID]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    let text = stdout(&out);
+    let newest = text
+        .find("second thing")
+        .unwrap_or_else(|| panic!("the newer entry is missing:\n{text}"));
+    let oldest = text
+        .find("first thing")
+        .unwrap_or_else(|| panic!("the older entry is missing:\n{text}"));
+    assert!(newest < oldest, "newest first (§4):\n{text}");
+    assert_eq!(
+        r.task_text(ID),
+        before,
+        "a read that writes is not a read: {text}"
+    );
+    assert!(
+        r.claim_ref(ID).is_some(),
+        "reading neither takes nor drops the holder's claim"
+    );
+
+    // Scriptable like every other verb, and the same order.
+    let out = r.ank("marie@laptop", &["log", ID, "--json"]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    let j = stdout(&out);
+    assert!(
+        j.starts_with(&format!("{{\"task\":\"{ID}\",\"entries\":[")),
+        "{j}"
+    );
+    assert!(
+        j.find("second thing").unwrap() < j.find("first thing").unwrap(),
+        "{j}"
+    );
+
+    // Only a task has a log, and the refusal names the verb that does answer.
+    const ADR: &str = "ADR-0000000000ab";
+    r.seed_adr(ADR, "Do not do X.", "src/**");
+    let out = r.ank("marie@laptop", &["log", ADR]);
+    assert_eq!(code(&out), 1, "{}", stderr(&out));
+    assert!(
+        stderr(&out).contains(&format!("ank show {ADR}")),
+        "{}",
+        stderr(&out)
+    );
+}
+
+/// The disambiguation of §4, exercised on all three of its branches. It is
+/// stated rather than inferred precisely so that it can be asserted this way:
+/// one question — does the argument resolve — and one answer.
+#[test]
+fn log_decides_between_reading_and_writing_by_what_resolves() {
+    const OTHER: &str = "TASK-000000000002";
+    let r = Repo::new();
+    r.seed_task(ID, Some("A verifiable criterion."));
+    r.seed_task(OTHER, Some("Another verifiable criterion."));
+    assert_eq!(code(&r.ank("claude-code@ank", &["claim", ID])), 0);
+
+    // Shaped like an id, resolving to nothing: a message.
+    let out = r.ank("claude-code@ank", &["log", "TASK-000000000009"]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    assert!(
+        r.task_text(ID).contains("TASK-000000000009"),
+        "{}",
+        r.task_text(ID)
+    );
+
+    // An ambiguous prefix resolves to no single entity, so it is a message too.
+    // "It resolved" is the whole test, and a second question — did it nearly
+    // resolve — would be one an agent has to guess the answer to.
+    let out = r.ank("claude-code@ank", &["log", "TASK-00000000000"]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    assert!(
+        r.task_text(ID)
+            .lines()
+            .any(|l| l.ends_with("TASK-00000000000")),
+        "{}",
+        r.task_text(ID)
+    );
+
+    // A message that also resolves: refused, naming both readings, writing
+    // neither.
+    let before = r.task_text(ID);
+    let out = r.ank("claude-code@ank", &["log", ID, OTHER]);
+    assert_eq!(code(&out), 1, "{}", stderr(&out));
+    let e = stderr(&out);
+    assert!(e.contains(OTHER), "the read it could have been: {e}");
+    assert!(e.contains(ID), "the write it could have been: {e}");
+    assert_eq!(r.task_text(ID), before, "a refusal writes nothing");
+
+    // The redundant write form is untouched when the message is a message.
+    let out = r.ank("claude-code@ank", &["log", ID, "a real message"]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    assert!(r.task_text(ID).contains("a real message"));
+
+    // And an id alone reads even for the agent holding it: what decides is the
+    // argument, not who is asking.
+    let out = r.ank("claude-code@ank", &["log", ID]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    assert!(stdout(&out).contains("a real message"), "{}", stdout(&out));
+    assert_eq!(
+        stdout(&out).matches("a real message").count(),
+        1,
+        "reading appended an entry: {}",
+        stdout(&out)
+    );
+}
+
 #[test]
 fn init_runs_where_there_is_no_ank_directory_yet() {
     // The one verb that precedes the foundation. Kept here because the reason


### PR DESCRIPTION
`git log` reads, and now so does `ank log` when it is given nothing but an id — the last behaviour §4 specifies that the binary did not have. TASK-a6af1fca65bc.

**The read.** `ank log <id>` prints the task's log section, newest first, and asks for no claim: printing what somebody else recorded takes nothing from them. The file is append-only, so the entry a reader came for is its last line, and reversing is what puts it first. It prints through `LogEntry::format_line`, the same formatter the write appends with — two shapes for one line is what drifts when only one of them is fixed.

**The disambiguation is stated rather than inferred**, and "it resolved" is the whole test. An argument that resolves to an entity id is a read; anything else is a message, including an argument that fails to resolve for any reason at all — absent, too short, ambiguous. Making a near-miss its own error would add a second question the caller cannot answer from the argument alone, and a rule an agent cannot predict without running it is not a rule it can be taught.

The one invocation the rule cannot decide is a message that also resolves — `ank log <id> <other-id>`. Both readings are live, so neither is picked: the refusal names them both and writes nothing.

**Unchanged:** `log` with a message still writes and still renews the claim, the redundant `log <id> <message>` form still requires the id to match HEAD, and SKILL.md is untouched (its content is frozen by ADR-c656cbcc33a9).

Tested through the binary, as the criterion requires and because it is the process that carries the property: a read that took the claim path would still pass a module test run under the holder's identity, and fail for every caller who is not it. Four mutations — no reversal, a claim demanded for the read, the ambiguity refusal dropped, an id alone still writing — all four caught.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0184mrBck5YotradGk8EGYJ9