### PR TITLE
show says what a task unblocks, not only what blocks it

### DIFF
--- a/.ank/tasks/TASK-2415ddb92df8.md
+++ b/.ank/tasks/TASK-2415ddb92df8.md
@@ -5,7 +5,7 @@ slug: show-says-what-a-task-unblocks-not-only-what-blo
 title: show says what a task unblocks, not only what blocks it
 created: 2026-08-01T18:30:10Z
 author: seanl@sean-laptop
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/**
   - crates/ank-core/**
@@ -14,7 +14,10 @@ done_criteria: |
   ank show on a task lists the tasks it directly unblocks alongside its blockers, one line each with status. The list is derived from the corpus at read time and stored nowhere. The binary is what the test invokes.
 criteria_by: creator
 schema: 2
-version: 1
+version: 3
 ---
 
 The ordering of section 5 already computes the unblock count; this surfaces the same derivation where a reader can see it. Serves both audiences without touching the loop.
+
+## Log
+- 2026-08-04T03:57:59Z seanl@sean-laptop — Two decisions the criterion does not settle, both asserted in the test rather than left to be discovered. First, the reverse direction is not filtered by status: section 5 counts how many tasks a task still holds up and drops what is done, but this is a list of edges and a done task keeps its line carrying [done]. graph draws the whole edge set and show is the narrow view onto the same derivation, so filtering here would make two readings of one graph. Second, both headings print at zero: an absent heading and a heading with nothing under it are the same page, and only one of them answers what waits on this. A dangling blocked_by prints as (no such entity) rather than vanishing, since a shorter list is a wrong answer and check is what reports the fault.

--- a/.ank/tasks/TASK-2415ddb92df8.md
+++ b/.ank/tasks/TASK-2415ddb92df8.md
@@ -5,7 +5,7 @@ slug: show-says-what-a-task-unblocks-not-only-what-blo
 title: show says what a task unblocks, not only what blocks it
 created: 2026-08-01T18:30:10Z
 author: seanl@sean-laptop
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/**
   - crates/ank-core/**
@@ -13,11 +13,16 @@ blocked_by: [TASK-ff1c20395929]
 done_criteria: |
   ank show on a task lists the tasks it directly unblocks alongside its blockers, one line each with status. The list is derived from the corpus at read time and stored nowhere. The binary is what the test invokes.
 criteria_by: creator
+proof:
+  - type: test
+    ref: "30876277690"
+    criteria: e9cd9f0221f3
 schema: 2
-version: 3
+version: 4
 ---
 
 The ordering of section 5 already computes the unblock count; this surfaces the same derivation where a reader can see it. Serves both audiences without touching the loop.
 
 ## Log
 - 2026-08-04T03:57:59Z seanl@sean-laptop — Two decisions the criterion does not settle, both asserted in the test rather than left to be discovered. First, the reverse direction is not filtered by status: section 5 counts how many tasks a task still holds up and drops what is done, but this is a list of edges and a done task keeps its line carrying [done]. graph draws the whole edge set and show is the narrow view onto the same derivation, so filtering here would make two readings of one graph. Second, both headings print at zero: an absent heading and a heading with nothing under it are the same page, and only one of them answers what waits on this. A dangling blocked_by prints as (no such entity) rather than vanishing, since a shorter list is a wrong answer and check is what reports the fault.
+- 2026-08-04T04:02:00Z seanl@sean-laptop — done, proof test:30876277690

--- a/crates/ank-cli/src/human.rs
+++ b/crates/ank-cli/src/human.rs
@@ -2135,8 +2135,19 @@ fn report_amend(inv: &Invocation, id: &EntityId, changes: &[String], out: &mut d
     }
 }
 
-/// The whole entity, verbatim. Everything else in the tool summarises; this is
-/// the one command that does not.
+/// The whole entity, verbatim, and on a task the two directions of
+/// `blocked_by` (§4).
+///
+/// Everything above the sections is byte for byte what is on disk; everything
+/// else in the tool summarises, and this is still the one command that does
+/// not. The sections under it are derived from the corpus at read time and
+/// stored nowhere — a stored reverse edge is a second copy of `blocked_by` that
+/// can disagree with the first, and the copy that disagrees is the one a reader
+/// happens to open.
+///
+/// **Both headings print even at zero.** An absent heading and a heading with
+/// nothing under it would be the same page, and only one of the two is an
+/// answer to *what waits on this*.
 pub fn show(inv: &Invocation, repo: &Repo, out: &mut dyn Write) -> Result<i32> {
     let prefix = inv
         .positionals
@@ -2145,6 +2156,12 @@ pub fn show(inv: &Invocation, repo: &Repo, out: &mut dyn Write) -> Result<i32> {
     let store = Store::new(&repo.ank);
     let loaded = store.load_prefix(prefix)?;
     let text = serialize_entity(&loaded.entity);
+    // An ADR has no `blocked_by` to have two directions of, so it costs nothing
+    // and the index is never opened for one.
+    let edges = match &loaded.entity {
+        Entity::Task(t) => Some(edges_of(repo, t)?),
+        Entity::Adr(_) => None,
+    };
 
     if inv.json() {
         let state = match claim::read(&repo.root, loaded.entity.id())?.map(|h| h.record) {
@@ -2154,16 +2171,116 @@ pub fn show(inv: &Invocation, repo: &Repo, out: &mut dyn Write) -> Result<i32> {
             }
             None => "null".to_string(),
         };
+        let derived = match &edges {
+            Some((blocked_by, unblocks)) => format!(
+                ",\"blocked_by\":{},\"unblocks\":{}",
+                edges_json(blocked_by),
+                edges_json(unblocks)
+            ),
+            None => String::new(),
+        };
         let _ = writeln!(
             out,
-            "{{\"id\":\"{}\",\"coordination\":{state},\"content\":{}}}",
+            "{{\"id\":\"{}\",\"coordination\":{state}{derived},\"content\":{}}}",
             loaded.entity.id(),
             json_str(&text)
         );
     } else if !inv.quiet() {
         let _ = write!(out, "{text}");
+        if let Some((blocked_by, unblocks)) = &edges {
+            edge_section(out, "BLOCKED BY", blocked_by);
+            edge_section(out, "UNBLOCKS", unblocks);
+        }
     }
     Ok(0)
+}
+
+/// One end of a `blocked_by` edge, resolved against the corpus.
+///
+/// `status` is `None` when the reference resolves to nothing. A dangling
+/// `blocked_by` is a fault `check` reports; `show` still prints the line it
+/// could not resolve, because dropping it would produce a shorter list and a
+/// shorter list is a wrong answer to a question about what blocks this.
+struct Edge {
+    id: EntityId,
+    short: String,
+    status: Option<String>,
+    title: Option<String>,
+}
+
+/// What blocks this task, and what this task directly unblocks.
+///
+/// The reverse direction is not filtered by status: `graph` draws the whole
+/// edge set and this is the narrow view onto the same derivation, so a blocker
+/// that is already `done` and a task that is already `done` both keep their
+/// line and carry their status. The §5 ordering counts something else — how
+/// many tasks are still *held up* — and a count is not a list.
+fn edges_of(repo: &Repo, task: &Task) -> Result<(Vec<Edge>, Vec<Edge>)> {
+    let index = Index::open(&repo.ank)?;
+    let all = index.all()?;
+    let ids: Vec<EntityId> = all.iter().map(|r| r.id.clone()).collect();
+    let shorts = crate::context::short_ids(&ids);
+    let row_of: HashMap<&EntityId, &crate::index::Row> = all.iter().map(|r| (&r.id, r)).collect();
+
+    let edge = |id: &EntityId| -> Edge {
+        let row = row_of.get(id);
+        Edge {
+            id: id.clone(),
+            short: shorts.get(id).cloned().unwrap_or_else(|| id.to_string()),
+            status: row.map(|r| r.status.clone()),
+            title: row.map(|r| r.title.clone()),
+        }
+    };
+
+    // Declared order for the blockers: the frontmatter printed just above says
+    // the same thing in the same order, and two orders for one list is a
+    // difference a reader has to account for before trusting either.
+    let blocked_by: Vec<Edge> = task.blocked_by.iter().map(&edge).collect();
+
+    // The reverse direction is derived and has no declared order, so it takes
+    // the one every other listing uses.
+    let mut waiting: Vec<&crate::index::Row> = all
+        .iter()
+        .filter(|r| r.kind == EntityKind::Task && r.blocked_by.contains(&task.id))
+        .collect();
+    waiting.sort_by_key(|r| r.id.to_string());
+    let unblocks: Vec<Edge> = waiting.iter().map(|r| edge(&r.id)).collect();
+
+    Ok((blocked_by, unblocks))
+}
+
+fn edge_section(out: &mut dyn Write, heading: &str, edges: &[Edge]) {
+    let _ = writeln!(out, "\n{heading} ({})", edges.len());
+    for e in edges {
+        match (&e.status, &e.title) {
+            (Some(status), Some(title)) => {
+                let _ = writeln!(out, "  {}  [{status}] {title}", e.short);
+            }
+            _ => {
+                let _ = writeln!(out, "  {}  (no such entity)", e.short);
+            }
+        }
+    }
+}
+
+fn edges_json(edges: &[Edge]) -> String {
+    let items: Vec<String> = edges
+        .iter()
+        .map(|e| {
+            let field = |v: &Option<String>| match v {
+                Some(s) => json_str(s),
+                None => "null".to_string(),
+            };
+            format!(
+                "{{\"id\":\"{}\",\"short\":\"{}\",\"status\":{},\"title\":{}}}",
+                e.id,
+                e.short,
+                field(&e.status),
+                field(&e.title)
+            )
+        })
+        .collect();
+    format!("[{}]", items.join(","))
 }
 
 #[cfg(test)]
@@ -4013,10 +4130,31 @@ mod tests {
         t.write(&task("000000000001", TaskStatus::Open, &[]));
         let (code, out) = t.call(&["show", "0000"], "marie@laptop").unwrap();
         assert_eq!(code, 0);
+        // The entity comes first and comes whole: the derived sections are
+        // appended under it, and nothing is allowed to reformat what is above.
+        let file = std::fs::read_to_string(t.store().path_of(&id)).unwrap();
+        assert!(
+            out.starts_with(&file),
+            "byte for byte, which is what makes it a reliable read: {out}"
+        );
+        assert_eq!(
+            &out[file.len()..],
+            "\nBLOCKED BY (0)\n\nUNBLOCKS (0)\n",
+            "both headings print at zero: an absent heading is not an answer"
+        );
+    }
+
+    /// An ADR has no `blocked_by`, so `show` on one is unchanged.
+    #[test]
+    fn show_on_an_adr_stays_verbatim_and_adds_nothing() {
+        let t = Temp::new();
+        let id = EntityId::parse("ADR-00000000aaaa").unwrap();
+        t.write(&adr("00000000aaaa", AdrStatus::Accepted, &["src/**"]));
+        let (code, out) = t.call(&["show", "ADR-0000"], "marie@laptop").unwrap();
+        assert_eq!(code, 0);
         assert_eq!(
             out,
-            std::fs::read_to_string(t.store().path_of(&id)).unwrap(),
-            "byte for byte, which is what makes it a reliable read"
+            std::fs::read_to_string(t.store().path_of(&id)).unwrap()
         );
     }
 

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -721,6 +721,124 @@ fn graph_terminates_on_a_cycle_and_says_where_it_is() {
     );
 }
 
+/// `ank show` on a task says what it unblocks, not only what blocks it
+/// (TASK-2415ddb92df8).
+///
+/// The same derivation `graph` draws, narrowed to one entity. Through the
+/// binary, because the criterion is about what the process prints — and because
+/// the entity has to still come out whole above the sections, which is a
+/// property of the bytes on the pipe and of nothing else.
+///
+/// The fixture gives every clause something to be wrong about: a blocker that
+/// is already `done`, two tasks waiting on the same one, a blocker naming an
+/// entity the corpus does not hold, and a leaf with neither direction.
+#[test]
+fn show_lists_what_a_task_unblocks_alongside_its_blockers() {
+    let r = Repo::new();
+    let root = "TASK-000000000c01";
+    let mid = "TASK-000000000c02";
+    let leaf = "TASK-000000000c03";
+    let side = "TASK-000000000c04";
+    let ghost = "TASK-0000000000ff";
+    for id in [root, mid, leaf, side] {
+        r.seed_task(id, Some("A verifiable criterion."));
+    }
+    // One finished in each direction. A `done` entity keeps its line and
+    // carries its status, which is what makes the status on each line worth
+    // printing — and it is the difference between this list and §5's count,
+    // which drops what is no longer held up because it is ordering work.
+    for id in [root, side] {
+        let done = r.task_text(id).replace("status: open", "status: done");
+        std::fs::write(r.0.join(".ank/tasks").join(format!("{id}.md")), done).unwrap();
+    }
+    r.blocked(mid, &[root, ghost]);
+    r.blocked(leaf, &[mid]);
+    r.blocked(side, &[mid]);
+
+    let before = r.task_text(mid);
+    let out = r.ank("claude-code@ank", &["show", mid]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    let said = stdout(&out);
+
+    // The entity first, whole and unreformatted. `show` is still the one
+    // command that does not summarise; the sections are appended under it.
+    assert!(
+        said.starts_with(&before),
+        "the entity is no longer verbatim:\n{said}"
+    );
+    let derived = &said[before.len()..];
+
+    // One line each, with status, in both directions.
+    assert!(derived.contains("BLOCKED BY (2)"), "{said}");
+    assert!(
+        derived.contains(&format!("{root}  [done]")),
+        "a blocker keeps its line and its status once done: {said}"
+    );
+    assert!(
+        derived.contains(&format!("{ghost}  (no such entity)")),
+        "a dangling blocker is named, never dropped: {said}"
+    );
+    assert!(derived.contains("UNBLOCKS (2)"), "{said}");
+    let at = |needle: &str| derived.find(needle).unwrap_or_else(|| panic!("{said}"));
+    assert!(
+        derived.contains(&format!("{side}  [done]")),
+        "a task that waited and is now done keeps its line: the list is the edge \
+         set, not the count of what is still held up: {said}"
+    );
+    assert!(
+        at(&format!("{leaf}  [open]")) < at(&format!("{side}  [done]")),
+        "the derived direction is ordered by id, like every other listing: {said}"
+    );
+    // The two directions are not one list: `mid` is blocked by `root` and
+    // unblocks `leaf`, and neither may appear under the other heading.
+    let (blockers, unblocks) = derived.split_at(at("UNBLOCKS"));
+    assert!(!blockers.contains(leaf), "{said}");
+    assert!(!unblocks.contains(root), "{said}");
+
+    // A leaf has neither direction, and both headings still print: an absent
+    // heading and a heading with nothing under it are not the same answer.
+    let out = r.ank("claude-code@ank", &["show", leaf]);
+    let said = stdout(&out);
+    assert!(said.contains("BLOCKED BY (1)"), "{said}");
+    assert!(said.contains("UNBLOCKS (0)"), "{said}");
+
+    // Derived at read time and stored nowhere: a task that did not exist at the
+    // first read appears at the second, and the file `show` printed from is
+    // byte for byte what it was.
+    let late = "TASK-000000000c05";
+    r.seed_task(late, Some("A verifiable criterion."));
+    r.blocked(late, &[mid]);
+    let out = r.ank("claude-code@ank", &["show", mid]);
+    let said = stdout(&out);
+    assert!(
+        said.contains("UNBLOCKS (3)") && said.contains(&format!("{late}  [open]")),
+        "the reverse edge is derived, not stored: {said}"
+    );
+    assert_eq!(
+        r.task_text(mid),
+        before,
+        "show wrote the derivation into the entity it was asked to print"
+    );
+
+    // `--json` carries the same two lists, and the null of an unresolved one.
+    let out = r.ank("claude-code@ank", &["show", mid, "--json"]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    let j = stdout(&out);
+    assert!(
+        j.contains(&format!(
+            "{{\"id\":\"{root}\",\"short\":\"{root}\",\"status\":\"done\""
+        )),
+        "{j}"
+    );
+    assert!(
+        j.contains(&format!(
+            "{{\"id\":\"{ghost}\",\"short\":\"{ghost}\",\"status\":null,\"title\":null}}"
+        )),
+        "{j}"
+    );
+    assert!(j.contains("\"unblocks\":[{"), "{j}");
+}
+
 /// One directory, one answer, however it is typed (TASK-df4c39031583).
 ///
 /// Reported from a Windows shell against the real corpus. `docs` answered five


### PR DESCRIPTION
`ank show` on a task now prints, under the verbatim entity, the two directions of `blocked_by`:

```
BLOCKED BY (2)
  TASK-000000000c01  [done] Example task
  TASK-0000000000ff  (no such entity)

UNBLOCKS (2)
  TASK-000000000c03  [open] Example task
  TASK-000000000c04  [done] Example task
```

Same derivation `graph` draws, narrowed to one entity, computed at read time and stored nowhere. §4 already specified it; this is the code catching up.

Three decisions the criterion does not settle, each asserted in the test rather than left to be discovered:

- **The reverse direction is not filtered by status.** §5's ordering counts how many tasks are still *held up* and drops what is done; this is the edge set, and a task that waited and is now done keeps its line carrying `[done]`. Filtering here would give two readings of one graph.
- **Both headings print at zero.** An absent heading and a heading with nothing under it are the same page, and only one of them answers *what waits on this*.
- **A dangling `blocked_by` prints as `(no such entity)`** rather than vanishing. A shorter list is a wrong answer, and the dangling reference is a fault `check` already reports.

An ADR has no `blocked_by`, so `show` on one is byte-identical to before and never opens the index. `--json` carries the same two lists, with `null` for an unresolved end.

Tested through the binary, since the criterion is about what the process prints and about the entity still coming out whole above the sections. Four mutations run against the new code — filtering the reverse list by status, dropping the unresolved blocker, hiding an empty heading, reversing the derived order — four caught.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y8S4nmFEYMg75seSMHkuWD