### PR TITLE
The documentation splits by audience

### DIFF
--- a/.ank/tasks/TASK-143c90665ed4.md
+++ b/.ank/tasks/TASK-143c90665ed4.md
@@ -1,0 +1,25 @@
+---
+id: TASK-143c90665ed4
+type: task
+slug: the-readme-still-describes-two-command-surfaces
+title: The README still describes two command surfaces
+created: 2026-08-04T04:28:37Z
+author: seanl@sean-laptop
+status: open
+scope:
+  - README.md
+blocked_by: []
+done_criteria: |
+  The status section of README.md describes one command surface, counts the verbs the binary actually dispatches, and names no agent surface and no human surface. Whatever number it states is derived from ank help rather than written by hand, or it states no number at all.
+criteria_by: creator
+schema: 2
+version: 1
+---
+
+ADR-c656cbcc33a9 dissolved the split between an agent surface and a human one: every verb is available to every caller, and the CLI refuses on state, never on identity. The specification followed in revision i, and skill/SKILL.md restates the freeze as a freeze on its own content.
+
+The README did not follow. It still reads 'Thirteen verbs work end to end -- the eight of the agent surface (context, claim, show, log, done, new, find, release), the five of the human one (check, review, accept, close, attest), plus init and help', which is the shape the ADR withdrew, named in the two categories it withdrew them under.
+
+The count is wrong as well as the shape: ank help lists eighteen verbs plus init and help. amend, status, edit, graph and scope arrived after the sentence was written and are absent from it.
+
+This is the same defect as TASK-b495234f192c one level out. That task is about an installed SKILL.md teaching against a ratified ADR; this is about the first page of the repository doing it, to a reader who has no CLAUDE.md to correct them. Found while routing the documentation by audience (TASK-e32dc98faceb), whose criterion covered the routing and not this paragraph.

--- a/.ank/tasks/TASK-c1783c841710.md
+++ b/.ank/tasks/TASK-c1783c841710.md
@@ -1,0 +1,24 @@
+---
+id: TASK-c1783c841710
+type: task
+slug: ank-init-does-not-gitignore-the-derived-index
+title: ank init does not gitignore the derived index
+created: 2026-08-04T04:17:32Z
+author: seanl@sean-laptop
+status: open
+scope:
+  - crates/ank-cli/src/init.rs
+  - crates/ank-cli/tests/cli.rs
+blocked_by: []
+done_criteria: |
+  After ank init in a fresh git repository, .ank/index.db is ignored by git, asserted through the binary: init runs, a command that builds the index runs, and git reports the file as ignored rather than untracked. Re-running init duplicates nothing, and an existing .gitignore keeps its content.
+criteria_by: creator
+schema: 2
+version: 1
+---
+
+Section 6 of the specification calls index.db derived, disposable and gitignored. init writes .gitattributes, the config, the refspec and the AGENTS.md pointer, and writes no ignore rule at all -- so the third of those three adjectives is true of no repository init produces. This repository is not the counterexample: its own .gitignore carries the line by hand, written before init existed to write it, which is exactly why the gap survived.
+
+Found on 2026-08-03 by walking the newcomer path of TASK-e32dc98faceb in a scratch repository. The first git add -A after a done committed .ank/index.db, along with a warning about its line endings -- a binary file, tracked, that every command rewrites. Nothing in the walk announced it; the file simply appeared in the commit.
+
+The fix belongs with the other four effects of init and is the same shape as the .gitattributes one: an idempotent line added to a file that may already exist, ensure_line already does it. What deserves a decision is the path -- a root .gitignore, or .ank/.gitignore next to the file it concerns.

--- a/.ank/tasks/TASK-e32dc98faceb.md
+++ b/.ank/tasks/TASK-e32dc98faceb.md
@@ -5,7 +5,7 @@ slug: the-documentation-splits-by-audience
 title: The documentation splits by audience
 created: 2026-08-01T18:30:10Z
 author: seanl@sean-laptop
-status: open
+status: in_progress
 scope:
   - docs/**
   - README.md
@@ -14,7 +14,12 @@ done_criteria: |
   docs/getting-started.md takes a newcomer from install to a first claim and a first done without reading the specification. docs/format.md documents the file format and canonical form for third-party tools and points at the specification as the source of truth instead of restating it. README.md routes the documents by audience. The specification stops serving as tutorial.
 criteria_by: creator
 schema: 2
-version: 1
+version: 5
 ---
 
 The specification stays the single source of truth per ADR-63b59c5c26f7; the two new documents point at it and never restate normative content. Blocked by the spec revision so the newcomer document does not teach a surface about to change.
+
+## Log
+- 2026-08-04T04:15:29Z seanl@sean-laptop — Walked the newcomer path in a scratch repo rather than writing it from the spec, and two first-run refusals only that walk would have found. In a fresh local-only repository accept exits 9: default_branch is absent from the config init writes, and refs/remotes/origin/HEAD does not exist without a remote, so the very first accept fails until the key is added by hand. And new --verify <name> refuses at creation time (code 7) when the verifier is not declared in config.yml, so declaring the verifier precedes creating the task that names it. getting-started.md orders the steps around both.
+- 2026-08-04T04:17:39Z seanl@sean-laptop — The walk also turned up a defect outside this scope, filed as TASK-c1783c841710: init writes no ignore rule, so .ank/index.db lands in the first commit of every repository it creates, while section 6 calls the index gitignored. This repository hides it -- its own .gitignore carries the line by hand. getting-started.md documents the behaviour as it is and tells the reader to add the line.
+- 2026-08-04T04:24:07Z seanl@sean-laptop — Three readings the criterion left open, decided and written into the documents rather than left implicit. First, 'stops serving as tutorial' is a change of role, not a deletion: the argued examples in sections 3, 4 and 5 are what a normative document owes a reader who has to revise it, and cutting them would weaken the source of truth to satisfy a clause about routing. The spec now carries a 'Who this document is for' section that says it is not a tutorial and names the two documents that are, and the README no longer sends a newcomer to it. Second, format.md documents the field order, the emission rules and the quoting predicate -- none of which the specification enumerates, since section 3 states canonical form as a property -- and defers every rule it depends on with a section pointer plus a stated precedence: where the two disagree, the specification is right and format.md is a bug. Third, getting-started.md quotes real output only. Every block in it was produced by a scratch repository, which is how the two first-run refusals were found.

--- a/.ank/tasks/TASK-e32dc98faceb.md
+++ b/.ank/tasks/TASK-e32dc98faceb.md
@@ -17,8 +17,11 @@ proof:
   - type: commit
     ref: 5b65a90
     criteria: 2d79b3ea378f
+  - type: test
+    ref: "30877806179"
+    criteria: 2d79b3ea378f
 schema: 2
-version: 6
+version: 7
 ---
 
 The specification stays the single source of truth per ADR-63b59c5c26f7; the two new documents point at it and never restate normative content. Blocked by the spec revision so the newcomer document does not teach a surface about to change.
@@ -28,3 +31,4 @@ The specification stays the single source of truth per ADR-63b59c5c26f7; the two
 - 2026-08-04T04:17:39Z seanl@sean-laptop — The walk also turned up a defect outside this scope, filed as TASK-c1783c841710: init writes no ignore rule, so .ank/index.db lands in the first commit of every repository it creates, while section 6 calls the index gitignored. This repository hides it -- its own .gitignore carries the line by hand. getting-started.md documents the behaviour as it is and tells the reader to add the line.
 - 2026-08-04T04:24:07Z seanl@sean-laptop — Three readings the criterion left open, decided and written into the documents rather than left implicit. First, 'stops serving as tutorial' is a change of role, not a deletion: the argued examples in sections 3, 4 and 5 are what a normative document owes a reader who has to revise it, and cutting them would weaken the source of truth to satisfy a clause about routing. The spec now carries a 'Who this document is for' section that says it is not a tutorial and names the two documents that are, and the README no longer sends a newcomer to it. Second, format.md documents the field order, the emission rules and the quoting predicate -- none of which the specification enumerates, since section 3 states canonical form as a property -- and defers every rule it depends on with a section pointer plus a stated precedence: where the two disagree, the specification is right and format.md is a bug. Third, getting-started.md quotes real output only. Every block in it was produced by a scratch repository, which is how the two first-run refusals were found.
 - 2026-08-04T04:24:37Z seanl@sean-laptop — done, proof commit:5b65a90
+- 2026-08-04T04:31:55Z seanl@sean-laptop — attested test:30877806179

--- a/.ank/tasks/TASK-e32dc98faceb.md
+++ b/.ank/tasks/TASK-e32dc98faceb.md
@@ -5,7 +5,7 @@ slug: the-documentation-splits-by-audience
 title: The documentation splits by audience
 created: 2026-08-01T18:30:10Z
 author: seanl@sean-laptop
-status: in_progress
+status: done
 scope:
   - docs/**
   - README.md
@@ -13,8 +13,12 @@ blocked_by: [TASK-ff1c20395929]
 done_criteria: |
   docs/getting-started.md takes a newcomer from install to a first claim and a first done without reading the specification. docs/format.md documents the file format and canonical form for third-party tools and points at the specification as the source of truth instead of restating it. README.md routes the documents by audience. The specification stops serving as tutorial.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 5b65a90
+    criteria: 2d79b3ea378f
 schema: 2
-version: 5
+version: 6
 ---
 
 The specification stays the single source of truth per ADR-63b59c5c26f7; the two new documents point at it and never restate normative content. Blocked by the spec revision so the newcomer document does not teach a surface about to change.
@@ -23,3 +27,4 @@ The specification stays the single source of truth per ADR-63b59c5c26f7; the two
 - 2026-08-04T04:15:29Z seanl@sean-laptop — Walked the newcomer path in a scratch repo rather than writing it from the spec, and two first-run refusals only that walk would have found. In a fresh local-only repository accept exits 9: default_branch is absent from the config init writes, and refs/remotes/origin/HEAD does not exist without a remote, so the very first accept fails until the key is added by hand. And new --verify <name> refuses at creation time (code 7) when the verifier is not declared in config.yml, so declaring the verifier precedes creating the task that names it. getting-started.md orders the steps around both.
 - 2026-08-04T04:17:39Z seanl@sean-laptop — The walk also turned up a defect outside this scope, filed as TASK-c1783c841710: init writes no ignore rule, so .ank/index.db lands in the first commit of every repository it creates, while section 6 calls the index gitignored. This repository hides it -- its own .gitignore carries the line by hand. getting-started.md documents the behaviour as it is and tells the reader to add the line.
 - 2026-08-04T04:24:07Z seanl@sean-laptop — Three readings the criterion left open, decided and written into the documents rather than left implicit. First, 'stops serving as tutorial' is a change of role, not a deletion: the argued examples in sections 3, 4 and 5 are what a normative document owes a reader who has to revise it, and cutting them would weaken the source of truth to satisfy a clause about routing. The spec now carries a 'Who this document is for' section that says it is not a tutorial and names the two documents that are, and the README no longer sends a newcomer to it. Second, format.md documents the field order, the emission rules and the quoting predicate -- none of which the specification enumerates, since section 3 states canonical form as a property -- and defers every rule it depends on with a section pointer plus a stated precedence: where the two disagree, the specification is right and format.md is a bug. Third, getting-started.md quotes real output only. Every block in it was produced by a scratch repository, which is how the two first-run refusals were found.
+- 2026-08-04T04:24:37Z seanl@sean-laptop — done, proof commit:5b65a90

--- a/README.md
+++ b/README.md
@@ -112,9 +112,26 @@ Still missing before v1: binaries for the three platforms and the installable
 skill. `ank find` scans the index rather than querying FTS5, which is a
 performance gap and not a behavioural one.
 
-- **The specification is the source of truth**: [`docs/ank-spec-v1.1.md`](docs/ank-spec-v1.1.md)
-- **The development plan**: `.ank/tasks/` (a DAG through `blocked_by`), the
-  decisions in `.ank/adr/`
+## Documentation
+
+Four documents, and which one you want depends on what you are about to do.
+
+- **You want to use it.** [`docs/getting-started.md`](docs/getting-started.md)
+  takes you from install to a first claim and a first `done`, with real output
+  at every step. It assumes nothing and does not send you to the specification.
+- **You are writing a tool that reads or writes `.ank/`.**
+  [`docs/format.md`](docs/format.md) has the field order, the emission rules,
+  the two hashes and the conformance suite — the mechanical half, for a second
+  implementation.
+- **You want to know why it is shaped this way, or you need the normative
+  answer.** [`docs/ank-spec-v1.1.md`](docs/ank-spec-v1.1.md) is the source of
+  truth. It argues the design and settles every question the other two defer to
+  it; it is not a tutorial, and the two documents above exist so that it does
+  not have to be one.
+- **You are an agent working on this repository.**
+  [`CLAUDE.md`](CLAUDE.md) has the conventions, and the section below has the
+  loop. The development plan itself lives in `.ank/` — a DAG of tasks through
+  `blocked_by`, and the decisions in `.ank/adr/` — reached through the CLI.
 
 ## For agents working on this repository
 
@@ -154,7 +171,7 @@ Detailed conventions are in [`CLAUDE.md`](CLAUDE.md).
 
     crates/ank-core   parser and data model — the reference implementation of the format
     crates/ank-cli    the `ank` binary — thirteen verbs, plus init and help
-    docs/             the specification, source of truth
+    docs/             the specification (source of truth), getting started, the format
     .ank/             Ank's own development plan, in the Ank format
     skill/            the bootstrap skill for agents
 

--- a/docs/ank-spec-v1.1.md
+++ b/docs/ank-spec-v1.1.md
@@ -3,6 +3,24 @@
 Status: working draft, arbitration revision
 Last revised: 1 August 2026
 
+## Who this document is for
+
+This is the normative document and the source of truth: every question the
+other two defer to it is settled here, and where any of them disagrees with
+this one, this one is right.
+
+It is not a tutorial, and it no longer stands in for one. A reader who wants to
+install Ank and finish a first task reads [getting-started.md](getting-started.md);
+a reader implementing a tool that reads or writes `.ank/` reads
+[format.md](format.md), which carries the mechanical half — field order,
+emission rules, conformance suite — and points back here for every rule it
+depends on. Both are written so that this document does not have to teach.
+
+What is here instead is the argument. Sections state a decision, the
+alternatives rejected, and what the decision costs, because a specification
+that records only its conclusions cannot be revised by anyone who was not in
+the room.
+
 ## Decisions settled in this revision
 
 Settled relative to v1: orientation and constraints reconciled (§5) · immutability anchored by hash, verifiable without making the CLI a gatekeeper (§3, §8) · nominal execution model, one worktree per agent (§7) · claims on git refs from level 0 onward, one ref per task (§7) · Ank never commits, except `accept` (§12) · return after TTL expiry, and a TTL ceiling (§3) · `verify` becomes a list (§3) · `proof` becomes an append-only list, with `attest` as the one write allowed after `done` (§3, §10) · log format fixed as an append-only section of the task file (§3) · index lifecycle fixed (§6) · verifier timeout fixed (§4) · `--reason` mandatory on `release` (§4) · `check` signals extended (§4) · identity, default roles and signature verification specified (§8).

--- a/docs/format.md
+++ b/docs/format.md
@@ -26,7 +26,7 @@ run against.
       allowed_signers     public keys allowed to ratify (§8), versioned
       tasks/TASK-<hex>.md
       adr/ADR-<hex>.md
-      index.db            derived, disposable, gitignored — never a source of truth
+      index.db            derived, disposable, belongs in .gitignore — never a source of truth
 
 Flat, deliberately: attachment happens through the `scope` field, not through
 location (§3). A file's name is its id; nothing resolves through the directory

--- a/docs/format.md
+++ b/docs/format.md
@@ -1,0 +1,275 @@
+# The file format
+
+For anyone writing a tool that reads or writes `.ank/` — an editor plugin, an
+exporter, a linter, a second implementation.
+
+The format is the specification, and the CLI is a reference implementation of
+it rather than a gatekeeper. Nothing here needs `ank` to be installed or asks
+your tool to call it.
+
+**This document is not normative.** Section 3 of
+[the specification](ank-spec-v1.1.md) is, and where the two disagree the
+specification is right and this page is a bug. What you will find here instead
+is the mechanical half a writer has to reproduce exactly — the field order, the
+emission rules, the quoting predicate — which the specification states as
+properties rather than as a list, plus a pointer to the section that argues each
+one.
+
+Two things settle a disagreement in practice, in this order: the specification,
+then `crates/ank-core/tests/golden/`, which is the suite your implementation can
+run against.
+
+## Layout
+
+    .ank/
+      config.yml          repository settings and named verifiers
+      allowed_signers     public keys allowed to ratify (§8), versioned
+      tasks/TASK-<hex>.md
+      adr/ADR-<hex>.md
+      index.db            derived, disposable, gitignored — never a source of truth
+
+Flat, deliberately: attachment happens through the `scope` field, not through
+location (§3). A file's name is its id; nothing resolves through the directory
+tree.
+
+**Identifiers** are `TASK-` or `ADR-` followed by exactly 12 hexadecimal
+characters, lowercase on output and accepted in either case on input. They hash
+the act of creation — timestamp, identity, title, entropy — never the content,
+so they survive every edit (§3). A tool that resolves short prefixes must
+require at least 4 hex characters and must fail on an ambiguous one, listing the
+candidates. Guessing is the one behaviour the format rules out by name.
+
+## The shape of a file
+
+Markdown with YAML frontmatter, UTF-8 without BOM, LF line endings:
+
+    ---
+    <frontmatter>
+    ---
+    <body>
+
+The delimiters are exact: the file begins with `---\n`, and the frontmatter ends
+at the first `\n---\n`. Everything after that separator is the body, kept
+verbatim, byte for byte. The body is free-form markdown, with one convention
+carved out below.
+
+**Unknown fields are rejected**, not ignored. That is what turns a typo like
+`priorty:` into an error instead of a silent loss, and it is the reason the
+`schema` rule in the next section exists at all.
+
+## Fields, in canonical order
+
+Canonical form is a **fixed field order**, and a serializer that emits the right
+fields in the wrong order produces a non-canonical file. The order is not
+alphabetical and not negotiable; it is this.
+
+### Task
+
+| # | Field | Emission | Notes |
+|---|---|---|---|
+| 1 | `id` | bare | `TASK-<12 hex>` |
+| 2 | `type` | bare | always `task` |
+| 3 | `slug` | scalar | optional, omitted when absent; cosmetic, never resolved on |
+| 4 | `title` | scalar | |
+| 5 | `created` | scalar | ISO 8601, always UTC with the `Z` suffix |
+| 6 | `author` | scalar | optional; absent means the entity predates the field |
+| 7 | `status` | bare | `open` \| `in_progress` \| `done` \| `closed` |
+| 8 | `scope` | block sequence | mandatory, never empty; globs |
+| 9 | `blocked_by` | flow list | always emitted, `[]` when empty |
+| 10 | `done_criteria` | literal block | optional |
+| 11 | `criteria_by` | bare | `creator` \| `claimer`; invalid without `done_criteria` |
+| 12 | `verify` | flow list | omitted when empty |
+| 13 | `proof` | block sequence of maps | omitted when empty |
+| 14 | `schema` | integer | |
+| 15 | `version` | integer | |
+
+A `proof` entry emits its own keys in order: `type`, `ref`, then `tree`,
+`criteria` and `verifier`, each omitted when absent. `type` is one of `test`,
+`commit`, `human-review`, `assertion`.
+
+### ADR
+
+| # | Field | Emission | Notes |
+|---|---|---|---|
+| 1 | `id` | bare | `ADR-<12 hex>` |
+| 2 | `type` | bare | always `adr` |
+| 3 | `slug` | scalar | optional |
+| 4 | `title` | scalar | |
+| 5 | `created` | scalar | ISO 8601, UTC |
+| 6 | `author` | scalar | optional |
+| 7 | `status` | bare | `proposed` \| `accepted` \| `superseded` |
+| 8 | `scope` | block sequence | mandatory, never empty |
+| 9 | `constraint` | literal block | mandatory |
+| 10 | `see` | scalar | optional |
+| 11 | `supersedes` | bare | optional, an entity id |
+| 12 | `ratified` | scalar | optional; set by `accept` (see below) |
+| 13 | `schema` | integer | |
+| 14 | `version` | integer | |
+
+**Optional fields are omitted, never emitted empty.** An entity with no author
+serialises without the key at all. Writing `author:` with nothing after it would
+change every older file on its first rewrite, and the round-trip guarantee below
+forbids that.
+
+## Emission rules
+
+**Literal blocks** carry the multi-line fields — `done_criteria` and
+`constraint`. Two spaces of indent, and the chomping indicator records whether
+the value ends in a newline: `|` when it does, `|-` when it does not.
+
+    done_criteria: |
+      Auth integration tests pass, and no reference to
+      jwt.verify remains in src/auth/
+
+**Flow lists** carry references: `blocked_by: [TASK-51c2a7f0b3d9]`,
+`verify: [auth-tests, no-jwt]`.
+
+**Block sequences** carry `scope` and `proof`, two spaces of indent:
+
+    scope:
+      - src/auth/**
+      - src/middleware/session.ts
+
+**Scalars are emitted bare when that is unambiguous and quoted otherwise**,
+conservatively — when in doubt, quote. The reference implementation emits a
+scalar bare only when all of these hold: it is non-empty; it contains no
+newline, no `": "` and no `" #"`; it does not end in `:` or a space; it does not
+begin with any of
+
+    - ? : # & * ! | > ' " % @ ` [ ] { } ,
+
+or a space; it is not one of `null`, `~`, `true`, `false`, `yes`, `no`; and it
+does not parse as a number. Otherwise it is double-quoted, with `\`, `"` and
+newline escaped. Reproducing this predicate exactly is what makes a third-party
+writer round-trip.
+
+## The round-trip guarantee
+
+    serialize(parse(x)) == x, byte for byte, when x is in canonical form
+
+Valid but non-canonical input — another acceptable YAML form, superfluous
+quotes, CRLF — is read correctly and **normalised on first rewrite** (§3). That
+is what lets a human or a third-party tool write a file without knowing the
+canonical form, without making that form an authoritative variant.
+
+**CRLF is read, never written.** A parser must accept it; a serializer must not
+produce it. A `---\r\n` diagnosed as "missing frontmatter" sends the reader
+looking for a delimiter that is right there, so normalise line endings before
+splitting, not after. `ank init` writes a `.gitattributes` carrying
+`.ank/** text eol=lf`, because on Windows git would otherwise convert back on
+every checkout what the tool has just normalised.
+
+## Reading a version you do not know
+
+`schema` is the format version, and a tool declares **a range of versions it
+reads**, not a single one.
+
+Older is a promise the format keeps: every field introduced after version 1 is
+optional at parse time, and its absence means "written before this existed"
+rather than "invalid". A corpus is never migrated by a tool that refuses to read
+it.
+
+Newer is refused, and refused **on the version rather than on the first field it
+does not recognise**. Since unknown fields are rejected, a tool that checked
+only its own version would report a file one version newer as *unknown field
+`author`*, and its reader would go hunting for a typo. Naming the version says
+the one true thing: this file is newer than this tool. The argument is in §3.
+
+## The log
+
+One convention inside the body, and the only one: a `## Log` section at the end
+of a task file, append-only, one line per entry.
+
+    ## Log
+    - 2026-07-26T14:02Z claude-code@host-3 — jwt.verify removed from session.ts
+
+Appending at the end is what makes a log entry a one-line git diff. The log is a
+**work trace, not proof**: nothing authoritative is anchored in it, which is why
+there is no chained hash over it (§3). A tool may parse it, and may append to
+it; it should not reorder or rewrite it.
+
+## What is derived, and must never be stored
+
+A file says less than the corpus does, on purpose. Four things are computed at
+read time and have no field:
+
+- **Blocked.** A task is blocked if and only if at least one of its
+  `blocked_by` is not `done`. `closed` does not unblock. There is no `blocked`
+  status to go stale.
+- **Reverse edges.** What a task unblocks is derived by walking `blocked_by`
+  across the corpus. A stored reverse edge is a second copy that can disagree
+  with the first.
+- **The claim.** Never in the file. See below.
+- **The index.** `index.db` is a cache rebuilt from the files; deleting it is
+  always safe.
+
+## What lives outside the files
+
+A tool that reads only `.ank/` sees the durable state and none of the
+coordination. Two things are deliberately elsewhere, and both matter if your
+tool intends to say anything about them.
+
+**Claims are git refs**, one per task, at `refs/ank/claims/<task-id>`. The ref
+has two states and the record it points at says which: a `claim` (holder,
+expiry, the frozen criterion hash, the hash of applicable constraints) or a
+`completed` record (commit, branch, identity, timestamp) written by `done`. A
+task that is `in_progress` in the file with no ref behind it is simply one whose
+claim expired — legal, and re-claimable (§7).
+
+**The ratification anchor is a commit message.** `accept` writes `ratified:` into
+the ADR *and* produces a commit whose subject is `ratify <id>` and whose body
+carries `constraint+scope: <hash>`. The copy in the commit is the one that
+counts, because the copy in the file is written by whoever writes the file. A
+verifier walks the ADR's own path history with `--full-history` and takes the
+first such commit (§3).
+
+## The two hashes
+
+Both are SHA-256 over normalised text, displayed as the first 12 hex characters,
+and a verifier accepts the short form or the full one.
+
+**Normalisation** is what makes a hash insensitive to editing noise without ever
+tolerating a change of meaning: CRLF becomes LF, trailing whitespace is stripped
+from each line, trailing blank lines are removed.
+
+- **The criterion freeze**, recorded by `claim`: `hash(normalize(done_criteria))`.
+- **The ratification anchor**, recorded by `accept`: the normalised `constraint`,
+  a newline, then each `scope` glob trimmed and followed by a newline — hashed
+  as one buffer.
+
+Freezing is verifiable, not defended (§2). Your tool can rewrite any field in
+any file; what it cannot do is make the recorded hash agree afterwards.
+
+## Concurrency
+
+`version` is an integer incremented on every write, and it is an intra-tree
+compare-and-swap: read, compare, write, under a file lock, with the write done
+atomically (write-then-rename). It protects one working tree — a human and an
+agent sharing a checkout. Between clones, git's own compare-and-swap at push
+time is what arbitrates (§7).
+
+## Conformance
+
+`crates/ank-core/tests/golden/` is a reusable suite, and it is small enough to
+port in an afternoon:
+
+- `valid/` — every file must parse, and re-serialising it must reproduce the
+  input byte for byte **once line endings are normalised**. One file,
+  `TASK-c71f0e5a9b23.md`, is in CRLF on purpose and must come back in LF; that
+  is the only file for which the assertion is against the normalised input
+  rather than the bytes on disk.
+- `invalid/` — every file must be **rejected with the right error**, not merely
+  rejected. The nine cases each name a distinct failure: no frontmatter, a bad
+  id, an unknown schema, an unknown field, a bad status, a type mismatch, an
+  empty scope, an invalid glob, and `criteria_by` without a criterion.
+
+The second half is where a permissive implementation is caught. Accepting a file
+the format rejects is the failure mode that spreads, because the corpus it
+writes still looks fine until something else reads it.
+
+## Where to go next
+
+- [ank-spec-v1.1.md](ank-spec-v1.1.md) — the specification. §3 for the data
+  model and canonical form, §6 for storage, §7 for the coordination plane, §8
+  for identity and ratification.
+- [getting-started.md](getting-started.md) — if you also want to use the tool.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,317 @@
+# Getting started
+
+By the end of this page your repository holds one binding constraint, one
+finished task, and a proof that Ank wrote after running the verification
+itself. It takes about ten minutes, and nothing here asks you to read the
+specification.
+
+Every command and every output below was run against a fresh repository. Where
+the tool refuses, the refusal is shown as it appears.
+
+## What you need
+
+- **git 2.34 or newer.** Not a convenience: claims live in git refs, and Ank
+  checks the version at startup.
+- **`sh`.** Verifiers run under `sh -c` on all three operating systems. On
+  Windows it comes with Git for Windows, so requiring git makes it free.
+- **Rust 1.95 or newer**, to build. There are no published binaries yet.
+
+## Install
+
+    git clone https://github.com/haksolot/ank
+    cd ank
+    cargo build --release
+
+The binary is `target/release/ank`. Put it on your `PATH`, then check it
+answers:
+
+    $ ank --version
+    ank 0.1.1 (bc59636)
+
+It prints the version and the commit it was built from. That second half
+matters the first time you suspect the binary in your hand is older than the
+behaviour you are reading about.
+
+## Initialise a repository
+
+From the root of a git repository:
+
+    $ ank init
+    created .ank/tasks .ank/adr
+    wrote .ank/config.yml
+    wrote .gitattributes
+    pointer added to AGENTS.md
+    refspec added: +refs/ank/*:refs/ank/*
+
+Five effects, and re-running changes nothing — `init` is idempotent and says
+`already initialised, nothing to do`. The `.gitattributes` line keeps `.ank/`
+in LF on checkout: on Windows git would otherwise convert back to CRLF
+everything the tool has just written, on every clone. The refspec is what makes
+claims travel, since hosts do not fetch non-standard refs on their own.
+
+Two edits to make now, before the first real command.
+
+**Name your default branch.** Open `.ank/config.yml` and add one line:
+
+    default_branch: main
+
+Without it, Ank looks for `refs/remotes/origin/HEAD`, and a repository with no
+remote has none. It refuses rather than guessing:
+
+    $ ank accept 06d2
+    error[9]: default branch indeterminable (default_branch absent from .ank/config.yml, refs/remotes/origin/HEAD absent)
+      -> git remote set-head origin -a
+      -> or add "default_branch: <name>" to .ank/config.yml
+
+**Ignore the index.** `.ank/index.db` is a derived SQLite cache, rebuildable
+from the files and safe to delete at any time. It does not belong in git, and
+`init` does not yet write the rule for you:
+
+    echo '.ank/index.db' >> .gitignore
+
+## The two kinds of file
+
+Flat in `.ank/`, markdown with YAML frontmatter, and only two of them.
+
+An **ADR** is a decision that constrains code. Its `constraint` is the one
+field injected into an agent's context, so it is short and imperative; the body
+holds the reasoning and costs nothing at injection time.
+
+A **task** is a unit of work. Its `done_criteria` says what would prove it
+finished.
+
+Both carry a `scope`: a list of globs, and the only thing that joins the two
+kinds. There is no epic, no parent, no label. "Everything about the auth
+migration" is answered by `ank context src/auth/`. The full field list is in
+[format.md](format.md); you do not need it to work through this page.
+
+## Write the first constraint
+
+    $ ank new adr --title "Opaque sessions rather than stateless JWT" \
+        --scope "src/auth/**" \
+        --constraint "Do not introduce self-contained JWTs for user auth. Every session goes through the Redis store."
+    created ADR-06d29e727d24 Opaque sessions rather than stateless JWT
+
+It is created `proposed`, which means visible but not binding. Promotion goes
+through one command, and that command is the only one in the tool that makes a
+git commit:
+
+    $ git add -A && git commit -m "adr: opaque sessions"
+    $ ank accept 06d2
+    accepted ADR-06d29e727d24 -> 9c45c50
+
+Short prefixes work everywhere an id is accepted; an ambiguous one is an error
+listing the candidates, never a guess. The commit it produced carries the hash
+of `constraint` and `scope` at acceptance:
+
+    ratify ADR-06d29e727d24
+
+    constraint+scope: c5d4f3478ad5
+    by: you@laptop
+
+That hash is the anchor. Editing the constraint afterwards does not change it,
+which is how `ank check` notices. Sign your commits and list the key in
+`.ank/allowed_signers` if you want the anchor to be verifiable by others; with
+no signing configured, `check` says so rather than pretending.
+
+`accept` runs on the default branch only, and there is no flag around it. A
+constraint ratified on a feature branch would bind on that branch alone.
+
+## Declare a verifier, then the task that uses it
+
+A task names verifiers; it never carries a shell command. The definitions live
+in `.ank/config.yml`, under the repository's own review:
+
+    verifiers:
+      auth-tests:
+        run: sh tests/auth.sh
+      no-jwt:
+        run: "! grep -rq jwt.verify src/auth/"
+
+Declare them first. A task that names a verifier `config.yml` does not know is
+refused at creation:
+
+    $ ank new task --title "Migrate auth" --scope "src/auth/**" --verify auth-tests
+    error[7]: no verifier 'auth-tests' in .ank/config.yml
+      -> declare it under verifiers: in .ank/config.yml
+
+With the definitions in place:
+
+    $ ank new task --title "Migrate auth to opaque sessions" \
+        --scope "src/auth/**" \
+        --criteria "The auth tests pass and no reference to jwt.verify remains in src/auth/" \
+        --verify auth-tests --verify no-jwt
+    created TASK-820d259af6a7 Migrate auth to opaque sessions
+
+A composite criterion is mechanised by several verifiers, not by one that
+covers half of it. All of them must pass.
+
+## Orientation
+
+`ank context` is the first call, and the only one you have to remember. With no
+argument it covers the whole repository; with a path it covers that perimeter.
+
+    $ ank context src/auth/
+
+    CONSTRAINTS (1 active)
+      ADR-06d2  Do not introduce self-contained JWTs for user auth. Every session goes through the Redis store.
+
+    TASKS (1)
+      TASK-820d  [open] Migrate auth to opaque sessions
+
+    > ank claim TASK-820d to start
+
+Constraints come first and are never truncated once you are working. The output
+ends with the next command, as every output here does.
+
+## Claim
+
+    $ ank claim 820d
+    claimed TASK-820d259af6a7 migrate-auth-to-opaque-sessions -> HEAD
+
+Three things happened. The task moved to `in_progress`. A claim ref appeared at
+`refs/ank/claims/TASK-820d259af6a7`, which is what arbitrates two people or two
+agents reaching for the same task — git's compare-and-swap, one winner. And the
+`done_criteria` was frozen: its hash went into the claim record, where the
+file's editor cannot reach it.
+
+The freeze is the rule worth internalising. Editing the criterion to make the
+work fit does not unblock anything; `done` compares against the recorded hash
+and refuses, and `check` reports the divergence. If the criterion is genuinely
+wrong, hand the task back — `ank release --reason "<why>"` — and say so.
+
+`claim` also sets HEAD, so the following commands need no id. One claim at a
+time, per person and per agent.
+
+Run `ank context` again and the output inverts: no other task, the full
+criterion, and the constraints matching this task's scope.
+
+    $ ank context
+
+    TASK-820d  Migrate auth to opaque sessions
+
+    DONE_CRITERIA
+      The auth tests pass and no reference to jwt.verify remains in src/auth/
+
+    CONSTRAINTS (1 active)
+      ADR-06d2  Do not introduce self-contained JWTs for user auth. Every session goes through the Redis store.
+
+`ank show 820d` gives you the entity whole — frontmatter, body and log — which
+is where the reasoning behind a task lives.
+
+## Work, and log what you learn
+
+    $ ank log "jwt.verify removed from session.ts"
+    logged on TASK-820d259af6a7
+
+The log is a work trace, not proof. Write to it when you discover something,
+not when you finish: it renews the claim, so working is what keeps the lock and
+there is no heartbeat command to remember. A claim lasts 30 minutes by default;
+if it expires because a build ran long, the task stays `in_progress` and you
+re-acquire silently, provided nobody took it over.
+
+`ank log 820d` with no message reads the log back instead of writing, and needs
+no claim.
+
+## Finish
+
+    $ ank done
+    running: auth-tests ... ok (0.1s)
+    running: no-jwt ... ok (0.1s)
+    proof recorded: auth-tests@94a1f671c577 -> local/e3b0c44298fc@9c45c50  (scope/b623b24a5777)
+    proof recorded: no-jwt@791cc818d0ad -> local/e3b0c44298fc@9c45c50  (scope/b623b24a5777)
+    TASK-820d259af6a7 -> done
+
+This is the point of the tool. Ank ran the verifiers itself and wrote what
+actually ran: one proof entry each, carrying the hash of the verifier
+definition that executed, the HEAD commit, and a hash of the scope files'
+content at that moment. Nobody reported their own result. Never set
+`status: done` by hand — a status written by the party being measured measures
+nothing.
+
+A task with no `verify` takes the other branch, and `--proof` becomes
+mandatory:
+
+    $ ank done
+    error[5]: proof required to move TASK-0ff108d8e2ca to done
+      -> ank done --proof test:<ci-run-ref>
+
+The proof types are `commit`, `test`, `human-review` and `assertion`, in
+descending order of what they guarantee. `commit:<sha>` is checked with git.
+`assertion:"..."` guarantees nothing and is marked weak, which is what keeps it
+from quietly becoming the default path.
+
+If a verifier fails or times out, the transition is refused and the task stays
+where it is.
+
+## Commit, and what `check` says until you do
+
+**Ank never commits, except `accept`.** Everything else writes files and leaves
+them in your working tree, so the corpus travels through your normal review
+like any other change.
+
+Before you commit, `check` has something to say:
+
+    $ ank check
+    signal: TASK-820d259af6a7: finished on another branch, main has not caught up
+    signal: allowed_signers: no ratification key declared: permissions are advisory, not enforced (§8)
+    check: ok — 1 tasks, 1 adr, 2 signal(s)
+
+The first signal is the mechanism doing its job. `status: done` lives in the
+file, therefore on your branch alone until the merge, and during all that time
+the task would look free to everyone else. The claim ref is not deleted at
+`done`: it becomes a completion ref, and anyone who tries to claim the task is
+refused with the commit and the branch named. Commit, and the ref is pruned:
+
+    $ git add -A && git commit -m "TASK-820d is done"
+    $ ank check
+    signal: allowed_signers: no ratification key declared: permissions are advisory, not enforced (§8)
+    pruned refs/ank/claims/TASK-820d259af6a7
+    check: ok — 1 tasks, 1 adr, 1 signal(s)
+
+`check` is what you put in CI. It validates parsing, byte-for-byte round-trip,
+`blocked_by` references, frozen fields against their anchors, and it prunes the
+coordination plane. **Exit 8 means findings; signals exit 0** — a signal is
+something a reader should see, not a failure.
+
+## When a command refuses
+
+The exit code carries the meaning so a script can route without parsing
+anything, and the message always ends with the exact command to run next.
+
+| Code | Meaning |
+|---|---|
+| 2 | entity not found, or ambiguous prefix |
+| 3 | version conflict — re-read and retry |
+| 4 | task unavailable — held by someone else, or finished on another branch |
+| 5 | proof missing or invalid |
+| 6 | illegal transition, or a frozen field diverged |
+| 7 | missing prerequisite — no criterion, task blocked, `accept` off the default branch |
+| 8 | `check` found something |
+| 9 | environment — git too old, `sh` missing, default branch indeterminable |
+
+Code 9 is the one to read carefully: it says the environment is broken, not
+that your work is wrong. Fix the machine, not the code.
+
+## Handing the loop to an agent
+
+    npx skills add haksolot/ank
+
+That installs the skill, not the binary. The skill teaches one page: the loop
+`context → claim → show → log → done`, the three off-loop verbs `new`, `find`
+and `release`, and the rules that are not negotiable. It is loaded on every
+session, which is why its content is deliberately small.
+
+One convention it carries is worth knowing before you see an agent follow it:
+**`.ank/` is opaque to an agent, the way `.git/` is.** Reading goes through
+`ank show`, `ank find` and `ank context`; writing goes through the verbs. The
+CLI knows what the files do not — the context budget, the frozen criterion, who
+holds which claim. A human with an editor keeps every power they had.
+
+## Where to go next
+
+- [format.md](format.md) — the file format and canonical form, for anyone
+  writing a tool that reads or writes `.ank/`.
+- [ank-spec-v1.1.md](ank-spec-v1.1.md) — the specification, and the source of
+  truth for everything above. It argues the design; it is not a tutorial.
+- `ank help` lists every verb, `ank help <verb>` answers about one.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -236,10 +236,12 @@ mandatory:
     error[5]: proof required to move TASK-0ff108d8e2ca to done
       -> ank done --proof test:<ci-run-ref>
 
-The proof types are `commit`, `test`, `human-review` and `assertion`, in
-descending order of what they guarantee. `commit:<sha>` is checked with git.
-`assertion:"..."` guarantees nothing and is marked weak, which is what keeps it
-from quietly becoming the default path.
+The proof types are `commit`, `test`, `human-review` and `assertion`, and what
+separates them is not local versus hosted but **who controls the environment**.
+A CI reference is out of the agent's reach and guarantees the most;
+`commit:<sha>` is checked with git; a local test proves what ran in a tree the
+agent could have altered; `assertion:"..."` guarantees nothing and is marked
+weak, which is what keeps it from quietly becoming the default path.
 
 If a verifier fails or times out, the transition is refused and the task stays
 where it is.


### PR DESCRIPTION
`TASK-e32dc98faceb`. The specification was the only document, so it was also
the tutorial, the format reference and the routing table.

**`docs/getting-started.md`** takes a newcomer from install to a first claim
and a first `done`. Every command and every output in it was run against a
scratch repository rather than written from the specification, which is what
turned up two first-run refusals:

- `accept` exits 9 in a fresh local-only repository — `default_branch` is
  absent from the config `init` writes, and `refs/remotes/origin/HEAD` does not
  exist without a remote.
- `new --verify <name>` refuses at creation time when `config.yml` does not
  declare the verifier, so the declaration has to come first.

The page orders its steps around both, and documents a third gap as it stands:
`init` writes no ignore rule, so `.ank/index.db` lands in the first commit.
Filed separately as `TASK-c1783c841710`.

**`docs/format.md`** serves the tool author: field order, emission rules, the
quoting predicate, the two hashes, and the golden suite as a portable
conformance harness. None of it restates the specification — §3 states
canonical form as a property rather than enumerating it — and every rule it
depends on carries a section pointer plus a stated precedence: where the two
disagree, the specification is right and `format.md` is the bug.

**The specification stops serving as tutorial by role, not by deletion.** Its
argued examples are what a normative document owes a reader who has to revise
it. It now opens by saying it is not a tutorial and naming the two documents
that are, and `README.md` routes all four by audience.

Proof is `commit:5b65a90`. `ank check` is at its baseline seven signals plus
the expected "finished on another branch" until this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017UvAwksjf2DR3hxebZq6Kz