### PR TITLE
The MSRV floor is a dependency consequence, not a target

### DIFF
--- a/.ank/tasks/TASK-973e9dc3f9ce.md
+++ b/.ank/tasks/TASK-973e9dc3f9ce.md
@@ -20,8 +20,11 @@ proof:
   - type: commit
     ref: "8e15058"
     criteria: 73513b52fadc
+  - type: test
+    ref: "30878974512"
+    criteria: 73513b52fadc
 schema: 2
-version: 11
+version: 12
 ---
 
 Found by TASK-daf25ab8a9b7, which established the floor and stopped there because its criterion was to measure and record, not to move it.
@@ -42,3 +45,4 @@ The other side of the trade is in the manifest already: bundled is what keeps th
 - 2026-08-04T04:48:06Z seanl@sean-laptop — Scope amended to add CLAUDE.md, ci.yml and ank-core's manifest. The criterion's last clause requires those three to agree with the measurement afterwards, and the declared scope named only ank-cli's manifest and Cargo.lock, so the scope omitted files the work has to touch. That is what amend is for; the criterion is untouched and the claim holds. The warning it printed is correct and expected: the scope change moves the constraint set the claim anchors.
 - 2026-08-04T04:50:22Z seanl@sean-laptop — Decided: keep libsqlite3-sys where it is, MSRV stays 1.95. The alternative was measured to a floor of exactly 1.82 -- 1.81 fails on unsafe extern C, 1.82 builds -- and the full suite passes on it, so this is a trade and not a forced move, and the writing says so. Rejected on three measured costs and one expired premise. Eleven crates enter the lockfile including sqlite-wasm-rs and the wasm-bindgen stack, since the opt-out is a 0.40.0 feature; the bundled amalgamation drops from SQLite 3.53.2 to 3.51.3; and 0.40.1 carries the SAVEPOINT SQL injection fix, which index.rs does not reach but which sets the habit. The premise: stable was 1.97.1 when this task was written, so 'requires the newest stable, zero headroom' described the measuring machine, not the tree. The floor drifts backwards by itself every six weeks; the pinned position holds only while rusqlite 0.40 is refused, security releases included. Written into ank-cli's manifest with both measured rows, into CLAUDE.md, and into the msrv job of ci.yml.
 - 2026-08-04T04:52:40Z seanl@sean-laptop — done, proof commit:8e15058
+- 2026-08-04T04:56:22Z seanl@sean-laptop — attested test:30878974512

--- a/.ank/tasks/TASK-973e9dc3f9ce.md
+++ b/.ank/tasks/TASK-973e9dc3f9ce.md
@@ -5,7 +5,7 @@ slug: the-msrv-is-the-current-stable-and-one-dependenc
 title: The MSRV is the current stable, and one dependency decides it
 created: 2026-08-01T19:38:31Z
 author: seanl@sean-laptop
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/Cargo.toml
   - Cargo.lock
@@ -16,8 +16,12 @@ blocked_by: []
 done_criteria: |
   The choice between keeping libsqlite3-sys at a version that requires the current stable and pinning back to one that does not is made in writing, measured the same way the floor was: a toolchain run against the tree, not an assumption about what a version needs. Whichever way it goes, the manifests, CLAUDE.md and ci.yml agree with the measurement afterwards.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: "8e15058"
+    criteria: 73513b52fadc
 schema: 2
-version: 10
+version: 11
 ---
 
 Found by TASK-daf25ab8a9b7, which established the floor and stopped there because its criterion was to measure and record, not to move it.
@@ -37,3 +41,4 @@ The other side of the trade is in the manifest already: bundled is what keeps th
 - 2026-08-04T04:47:38Z seanl@sean-laptop — amended: +scope CLAUDE.md, +scope .github/workflows/ci.yml, +scope crates/ank-core/Cargo.toml
 - 2026-08-04T04:48:06Z seanl@sean-laptop — Scope amended to add CLAUDE.md, ci.yml and ank-core's manifest. The criterion's last clause requires those three to agree with the measurement afterwards, and the declared scope named only ank-cli's manifest and Cargo.lock, so the scope omitted files the work has to touch. That is what amend is for; the criterion is untouched and the claim holds. The warning it printed is correct and expected: the scope change moves the constraint set the claim anchors.
 - 2026-08-04T04:50:22Z seanl@sean-laptop — Decided: keep libsqlite3-sys where it is, MSRV stays 1.95. The alternative was measured to a floor of exactly 1.82 -- 1.81 fails on unsafe extern C, 1.82 builds -- and the full suite passes on it, so this is a trade and not a forced move, and the writing says so. Rejected on three measured costs and one expired premise. Eleven crates enter the lockfile including sqlite-wasm-rs and the wasm-bindgen stack, since the opt-out is a 0.40.0 feature; the bundled amalgamation drops from SQLite 3.53.2 to 3.51.3; and 0.40.1 carries the SAVEPOINT SQL injection fix, which index.rs does not reach but which sets the habit. The premise: stable was 1.97.1 when this task was written, so 'requires the newest stable, zero headroom' described the measuring machine, not the tree. The floor drifts backwards by itself every six weeks; the pinned position holds only while rusqlite 0.40 is refused, security releases included. Written into ank-cli's manifest with both measured rows, into CLAUDE.md, and into the msrv job of ci.yml.
+- 2026-08-04T04:52:40Z seanl@sean-laptop — done, proof commit:8e15058

--- a/.ank/tasks/TASK-973e9dc3f9ce.md
+++ b/.ank/tasks/TASK-973e9dc3f9ce.md
@@ -5,16 +5,19 @@ slug: the-msrv-is-the-current-stable-and-one-dependenc
 title: The MSRV is the current stable, and one dependency decides it
 created: 2026-08-01T19:38:31Z
 author: seanl@sean-laptop
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/Cargo.toml
   - Cargo.lock
+  - CLAUDE.md
+  - .github/workflows/ci.yml
+  - crates/ank-core/Cargo.toml
 blocked_by: []
 done_criteria: |
   The choice between keeping libsqlite3-sys at a version that requires the current stable and pinning back to one that does not is made in writing, measured the same way the floor was: a toolchain run against the tree, not an assumption about what a version needs. Whichever way it goes, the manifests, CLAUDE.md and ci.yml agree with the measurement afterwards.
 criteria_by: creator
 schema: 2
-version: 1
+version: 10
 ---
 
 Found by TASK-daf25ab8a9b7, which established the floor and stopped there because its criterion was to measure and record, not to move it.
@@ -24,3 +27,13 @@ The measurement: 1.78, 1.91, 1.92, 1.93 and 1.94 all fail; 1.95 is the first too
 So ank currently requires the newest stable Rust, with zero headroom, and the floor will move again whenever this dependency does. For a tool distributed as a static binary on three platforms, that is an adoption cost paid for one crate.
 
 The other side of the trade is in the manifest already: bundled is what keeps the binary static, and Windows ships no libsqlite3 to link against. An older rusqlite may cost features find depends on, or nothing at all. Nobody has run it, which is the same defect this task's parent existed to correct - so the answer comes from a toolchain run, not from a changelog.
+
+## Log
+- 2026-08-04T04:40:04Z seanl@sean-laptop — Two facts before any measurement of the alternative. First, rust-version now makes the walk refuse before it compiles: cargo +1.94 build --locked exits 101 with 'rustc 1.94.1 is not supported', which is the manifest doing its job and not the floor being measured. Every toolchain run below therefore carries --ignore-rust-version, otherwise the experiment only re-reads the number it is supposed to test. Second, the premise of this task has moved: stable is 1.97.1 (released 2026-07-14), not 1.95. The body says ank requires the newest stable with zero headroom, and that was true of the machine that measured it on 2026-08-01, whose stable was stale at 1.95. Today the floor sits two releases below stable. Re-measured on the current tree: 1.94 still fails, E0658 use of unstable library feature cfg_select in the build script of libsqlite3-sys 0.38.1. The floor of 1.95 stands.
+- 2026-08-04T04:41:22Z seanl@sean-laptop — Pinning within 0.38 buys nothing: libsqlite3-sys 0.38.0 carries the same cfg_select! call at the same line of build.rs and fails 1.94 identically, so the two published 0.38 releases are one floor. Reaching 0.37 costs a major of rusqlite -- 0.40.1 requires libsqlite3-sys ^0.38.1 by name -- and relocking on rusqlite 0.39 adds wasm-bindgen, js-sys and the wasm VFS back into the lockfile. That surface is exactly what default-features = false was written to keep out, so pinning back is not a free trade even before the toolchain answer is known.
+- 2026-08-04T04:43:19Z seanl@sean-laptop — The alternative is real and its price is now measured. rusqlite 0.39.0 with libsqlite3-sys 0.37.0 builds the workspace on 1.94, 1.93 and 1.92; the walk continues downward. What it costs is three things, none of them a matter of taste. Eleven crates enter the lockfile that are not in it today -- sqlite-wasm-rs, rsqlite-vfs, wasm-bindgen and its four satellites, js-sys, bumpalo, foldhash, once_cell, rustversion -- because opting out of sqlite-wasm-rs on wasm32 is a 0.40.0 feature, so default-features = false stops buying anything one major back. The bundled amalgamation drops from SQLite 3.53.2 to 3.51.3. And 0.40.1 is the release that fixed SQL injection through a tainted SAVEPOINT name; index.rs opens transactions through rusqlite, so declining that fix is declining a security fix in code this binary runs.
+- 2026-08-04T04:45:06Z seanl@sean-laptop — The pinned-back floor is not the lockfile floor either. libsqlite3-sys 0.37.0 fails 1.78 with 322 errors, the first being E0658 error_in_core on impl error::Error, so 1.78 is out for the alternative too and the 1.78 figure that lockfile v4 sets remains theoretical for this tree. 1.91 through 1.94 all build with the pinned pair, so what pinning back actually buys is a floor somewhere between 1.79 and 1.91, and the bisect is running to name it. Whatever it turns out to be, it is bounded above by 1.91 -- four releases below where we stand, not seventeen.
+- 2026-08-04T04:47:23Z seanl@sean-laptop — Both rows are now measured by this session rather than half inherited. Current pair, rusqlite 0.40.1 with libsqlite3-sys 0.38.1: 1.78, 1.91, 1.92, 1.93 and 1.94 all fail on cfg_select! in the build script, 1.95 builds and the suite is green. Pinned-back pair, rusqlite 0.39.0 with libsqlite3-sys 0.37.0: 1.78 fails on error_in_core, 1.81 fails on unsafe extern C with 319 errors, 1.85 through 1.94 all build, and cargo test --workspace on 1.95 is green -- 281 tests, so the older rusqlite costs nothing the code actually uses. The alternative is therefore functional, not hypothetical, and the decision is a trade rather than a forced move. Bisecting 1.82 and 1.83 to name its floor exactly.
+- 2026-08-04T04:47:38Z seanl@sean-laptop — amended: +scope CLAUDE.md, +scope .github/workflows/ci.yml, +scope crates/ank-core/Cargo.toml
+- 2026-08-04T04:48:06Z seanl@sean-laptop — Scope amended to add CLAUDE.md, ci.yml and ank-core's manifest. The criterion's last clause requires those three to agree with the measurement afterwards, and the declared scope named only ank-cli's manifest and Cargo.lock, so the scope omitted files the work has to touch. That is what amend is for; the criterion is untouched and the claim holds. The warning it printed is correct and expected: the scope change moves the constraint set the claim anchors.
+- 2026-08-04T04:50:22Z seanl@sean-laptop — Decided: keep libsqlite3-sys where it is, MSRV stays 1.95. The alternative was measured to a floor of exactly 1.82 -- 1.81 fails on unsafe extern C, 1.82 builds -- and the full suite passes on it, so this is a trade and not a forced move, and the writing says so. Rejected on three measured costs and one expired premise. Eleven crates enter the lockfile including sqlite-wasm-rs and the wasm-bindgen stack, since the opt-out is a 0.40.0 feature; the bundled amalgamation drops from SQLite 3.53.2 to 3.51.3; and 0.40.1 carries the SAVEPOINT SQL injection fix, which index.rs does not reach but which sets the habit. The premise: stable was 1.97.1 when this task was written, so 'requires the newest stable, zero headroom' described the measuring machine, not the tree. The floor drifts backwards by itself every six weeks; the pinned position holds only while rusqlite 0.40 is refused, security releases included. Written into ank-cli's manifest with both measured rows, into CLAUDE.md, and into the msrv job of ci.yml.

--- a/.ank/tasks/TASK-d81a05ef8e8d.md
+++ b/.ank/tasks/TASK-d81a05ef8e8d.md
@@ -1,0 +1,25 @@
+---
+id: TASK-d81a05ef8e8d
+type: task
+slug: ci-proves-the-msrv-is-sufficient-never-that-it-i
+title: CI proves the MSRV is sufficient, never that it is tight
+created: 2026-08-04T04:52:06Z
+author: seanl@sean-laptop
+status: open
+scope:
+  - .github/workflows/ci.yml
+blocked_by: []
+done_criteria: |
+  CI fails when the declared MSRV is higher than the tree actually needs, not only when it is lower. The check runs the toolchain one minor below rust-version with --ignore-rust-version and requires it to fail; a build that unexpectedly succeeds names the number to lower and the command that measured it. It runs on the platform where the floor is set, and a rustup release that has not shipped yet is an environment failure and not a passing check.
+criteria_by: creator
+schema: 2
+version: 1
+---
+
+The msrv job builds on the exact toolchain rust-version names, which proves the number is sufficient. Nothing proves it is tight. The floor comes from one build script in libsqlite3-sys, so the day that crate stops calling cfg_select! -- or the day the dependency is replaced -- the declared 1.95 becomes higher than the tree needs, every job stays green, and the only signal is that nobody can build ank on a toolchain that would have worked.
+
+That asymmetry is the same one TASK-daf25ab8a9b7 corrected in the other direction: an MSRV asserted and never run rots silently. Half the claim is now enforced and half is still an assertion.
+
+Found while answering TASK-973e9dc3f9ce, whose criterion was to choose between two dependency versions and to make the manifests agree with the measurement. Making the measurement continuous is a different piece of work and is not in that criterion.
+
+The design question belongs to whoever claims this. Requiring the previous minor to fail is a negative test, and negative tests are brittle in a way positive ones are not: a build that fails for an unrelated reason -- a network hiccup, a C compiler missing -- passes this check while proving nothing. The failure has to be attributed, not merely observed, and how tightly is the decision to record before implementing.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,11 @@ jobs:
   # All three platforms, because the crate that sets the floor sets it from a
   # build script, and a build script is the one place where the floor can
   # legitimately differ per target.
+  #
+  # The number is not a target held on purpose: it is what libsqlite3-sys 0.38
+  # needs. Pinning back to a version that needs less was measured and rejected
+  # in ank-cli's manifest (TASK-973e9dc3f9ce). This job is the whole enforcement
+  # — when the floor moves, it moves here first, in red.
   msrv:
     name: msrv 1.95 / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,10 +78,13 @@ run on all three.
 - Ank never commits, except `accept`.
 - No new dependency without necessity; a static binary is the goal; **the MSRV
   is 1.95**, declared in both manifests and pinned in `ci.yml`. It was measured
-  by walking toolchains against the tree — 1.78 through 1.94 all fail — and it
-  is the current stable, so there is no headroom: `libsqlite3-sys` alone sets
-  it (TASK-973e9dc3f9ce). Raising it means re-running the walk, never editing
-  the number.
+  by walking toolchains against the tree — 1.78 through 1.94 all fail — and
+  `libsqlite3-sys` alone sets it. The alternative was measured too and rejected
+  (TASK-973e9dc3f9ce): one major back the floor is 1.82, at the price of eleven
+  crates including a wasm stack this binary has no target for. **The floor is a
+  consequence of a dependency, not a target to hold.** It moves when the
+  dependency moves, `ci.yml` is what turns red, and re-measuring means re-running
+  the walk with `--ignore-rust-version` — never editing the number.
 
 ## Style
 

--- a/crates/ank-cli/Cargo.toml
+++ b/crates/ank-cli/Cargo.toml
@@ -4,10 +4,11 @@ version = "0.1.1"
 edition = "2021"
 # Measured on 2026-08-01 by walking toolchains upward against this tree, which
 # is the only way this number means anything: 1.78, 1.91, 1.92, 1.93 and 1.94
-# all fail, 1.95 is the first that compiles and passes the suite. The cause is
-# a single dependency and it is named below. Declared here so cargo refuses an
-# older toolchain by name instead of failing inside a build script, and pinned
-# in ci.yml so the claim turns something red the day it stops being true.
+# all fail, 1.95 is the first that compiles and passes the suite. Re-walked on
+# 2026-08-03 against the same pair, unchanged. The cause is a single dependency
+# and it is named below. Declared here so cargo refuses an older toolchain by
+# name instead of failing inside a build script, and pinned in ci.yml so the
+# claim turns something red the day it stops being true.
 rust-version = "1.95"
 license = "GPL-3.0-only"
 description = "The Ank CLI: one surface, refusing on state and never on identity."
@@ -40,11 +41,39 @@ hex = "0.4"
 # that floor is not the binding one and never was — the dependency is
 # seventeen minor versions above it.
 #
-# The consequence is worth stating plainly rather than discovering later: this
-# workspace requires the current stable, so it has no MSRV headroom at all, and
-# the floor moves whenever this dependency does. Whether that price is worth
-# paying for `bundled` SQLite is a dependency question, not an MSRV question,
-# and it is TASK-973e9dc3f9ce's to answer.
+# Whether to pin back to a version that asks for less was TASK-973e9dc3f9ce's
+# question, and it was answered by walking toolchains against both trees rather
+# than by reading changelogs (2026-08-03, `--ignore-rust-version` throughout,
+# since `rust-version` otherwise refuses before compiling anything):
+#
+#   rusqlite 0.40.1 / libsqlite3-sys 0.38.1   1.78 1.91 1.92 1.93 1.94 fail
+#                                             1.95 builds, suite green
+#   rusqlite 0.39.0 / libsqlite3-sys 0.37.0   1.78 1.81 fail
+#                                             1.82 .. 1.94 build, suite green
+#
+# So the alternative is real — 1.82, thirteen versions lower, and the full
+# suite passes on it, which is the part no changelog would have told us. It is
+# rejected anyway, for three measured reasons. It adds eleven crates to the
+# lockfile, `sqlite-wasm-rs`, `rsqlite-vfs`, `wasm-bindgen` and its satellites
+# among them, because opting out of `sqlite-wasm-rs` on wasm32 is a 0.40.0
+# feature and `default-features = false` buys nothing one major back. It drops
+# the bundled amalgamation from SQLite 3.53.2 to 3.51.3. And 0.40.1 is the
+# release that fixed a SQL injection through a tainted SAVEPOINT name — not
+# reachable from `index.rs`, which opens plain transactions and never names a
+# savepoint, but declining a security release to lower a build floor is a
+# habit, and the next one may be reachable.
+#
+# The premise that made this urgent has also expired. The floor was measured on
+# a machine whose stable was 1.95, so "requires the newest stable, zero
+# headroom" was a snapshot of that machine and not a property of the tree:
+# stable was already 1.97.1 by the time the question was asked. The floor drifts
+# backwards on its own every six weeks, whereas the pinned-back position holds
+# only while rusqlite 0.40 is refused — including for security — and has to be
+# renewed at every bump. A floor that requires standing still is a freeze.
+#
+# The MSRV is therefore a consequence, not a target: it is what this dependency
+# needs, it is measured and never asserted, and `ci.yml` builds on exactly that
+# toolchain so the claim turns something red the day it stops being true.
 #
 # `default-features = false` is not tidiness: the default set includes
 # `ffi-sqlite-wasm-rs`, which drags wasm-bindgen, js-sys and a wasm VFS into the


### PR DESCRIPTION
`TASK-973e9dc3f9ce`. The question was whether to keep `libsqlite3-sys` where it
is or pin back to a version that asks for less, answered the way the floor was
established: toolchains run against the tree, not changelogs.

Both rows walked on 2026-08-03, `--ignore-rust-version` throughout — without it
`rust-version` refuses before compiling and the walk only re-reads the number it
is meant to test.

| Pair | Result |
|---|---|
| `rusqlite 0.40.1` / `libsqlite3-sys 0.38.1` (current) | 1.78, 1.91, 1.92, 1.93, 1.94 fail on `cfg_select!`; **1.95** builds, suite green |
| `rusqlite 0.39.0` / `libsqlite3-sys 0.37.0` | 1.78 fails on `error_in_core`, 1.81 fails on `unsafe extern "C"`; **1.82** through 1.94 build, suite green |

**The alternative is real.** 1.82 is thirteen versions lower, and the full suite
passes on it — no feature `find` depends on is lost. This is a trade, not a
forced move, and the writing says so.

**Rejected anyway**, on three measured costs:

- Eleven crates enter the lockfile — `sqlite-wasm-rs`, `rsqlite-vfs`,
  `wasm-bindgen` and its four satellites, `js-sys`, `bumpalo`, `foldhash`,
  `once_cell`, `rustversion`. Opting out of `sqlite-wasm-rs` on wasm32 is a
  0.40.0 feature, so `default-features = false` buys nothing one major back.
- The bundled amalgamation drops from SQLite 3.53.2 to 3.51.3.
- 0.40.1 is the release that fixed a SQL injection through a tainted `SAVEPOINT`
  name. Not reachable from `index.rs`, which opens plain transactions and never
  names a savepoint — but declining a security release to lower a build floor is
  a habit, and the next one may be reachable.

**And the premise had expired.** Stable was 1.97.1 when the task was written, so
"requires the newest stable, zero headroom" described the machine that measured
the floor on 2026-08-01, not the tree. The floor drifts backwards on its own
every six weeks. The pinned-back position holds only while `rusqlite 0.40` is
refused — security releases included — and has to be renewed at every bump. A
floor that requires standing still is a freeze.

`Cargo.lock` is unchanged, which is what keeping means. The answer is written
into `ank-cli`'s manifest with both rows, into `CLAUDE.md`, and into the `msrv`
job of `ci.yml`.

Scope was amended mid-task to add `CLAUDE.md`, `ci.yml` and `ank-core`'s
manifest: the criterion's last clause names them and the declared scope did not.
The criterion is untouched.

`TASK-d81a05ef8e8d` files what this does not cover: the `msrv` job proves the
number is sufficient, and nothing proves it is tight.

Proof is `commit:8e15058`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017UvAwksjf2DR3hxebZq6Kz