### PR TITLE
An installed SKILL.md says which revision it is

### DIFF
--- a/.ank/tasks/TASK-b495234f192c.md
+++ b/.ank/tasks/TASK-b495234f192c.md
@@ -5,7 +5,7 @@ slug: a-stale-installed-skill-teaches-the-opposite-of
 title: A stale installed skill teaches the opposite of a binding ADR
 created: 2026-08-03T04:10:01Z
 author: seanl@sean-laptop
-status: in_progress
+status: done
 scope:
   - skill/**
   - crates/ank-cli/tests/skill.rs
@@ -14,8 +14,24 @@ done_criteria: |
   An agent or a human can tell which revision of SKILL.md is installed without a copy of the repository to diff against. Whatever carries that marker is asserted by tests/skill.rs, and the decision on whether the marker is compatible with the freeze of section 4 is recorded in the task before it is implemented.
 criteria_by: creator
 verify: [cargo-test, fmt-check, check-repo]
+proof:
+  - type: test
+    ref: local/f7bde20eb195@0543719
+    tree: scope/494eb5ee3219
+    criteria: 630bbd66bd22
+    verifier: cargo-test@f14aeab36e1b
+  - type: test
+    ref: local/e3b0c44298fc@0543719
+    tree: scope/494eb5ee3219
+    criteria: 630bbd66bd22
+    verifier: fmt-check@5ca6d10bcd55
+  - type: test
+    ref: local/011669e05a3b@0543719
+    tree: scope/494eb5ee3219
+    criteria: 630bbd66bd22
+    verifier: check-repo@5734e9cf9d3d
 schema: 2
-version: 4
+version: 5
 ---
 
 Measured on 2026-08-02. The SKILL.md installed at ~/.claude/skills/ank is byte-identical to the blob at commit a004ac7 (2026-07-31 10:18). The repository moved twice after it, the same day: 830d069 at 19:15 added the eighth verb, 7429cdd at 19:16 replaced the third non-negotiable rule.
@@ -36,3 +52,4 @@ Related: TASK-548c518cb705, the same inability to interrogate an artifact, on th
 ## Log
 - 2026-08-04T05:14:13Z seanl@sean-laptop — The freeze decision, recorded before implementing as the criterion requires. A revision marker is NOT a succession, and the reasoning is that the strict reading of section 4 was never the operative one. The sentence 'this is the entire content of SKILL.md, and that content is frozen' follows a two-line loop block, while the shipped file is 69 lines with a name and a description in frontmatter. Read literally the file has been violating its own freeze since it existed, which is an argument that the literal reading is not what was ratified rather than an argument that the file is wrong. The operative reading is in the next clause of the same paragraph: growing WHAT IT TEACHES costs an ADR superseding ADR-c656cbcc33a9, and the reason given is the token budget paid on every session. That is also exactly what tests/skill.rs enforces, in three assertions -- the eight loop verbs are present, no verb outside the loop is named, and the file stays under 80 lines and 700 words. A fingerprint touches none of the three. Contrast with the case that did need a decision: show entered the loop and grew what an agent is taught. A marker teaches no verb and names no command.
 - 2026-08-04T05:14:27Z seanl@sean-laptop — The carrier, decided from the Agent Skills standard rather than invented: frontmatter metadata, which the specification defines as an arbitrary key-value map for properties it does not define, and whose own worked example is metadata.version. So the marker sits where name and description sit -- in the file's metadata, not in its instructions -- and it is standard-sanctioned rather than an unknown key some loader may reject. Claude Code's own frontmatter reference lists no version field, which is what ruled out a bare top-level key. The value is a content hash of the body, not a date and not a hand-kept semantic version. A hand-kept number drifts the first time somebody edits the body and forgets it; a hash cannot, because the test recomputes it. And a date would not have caught the failure this task was filed for: a004ac7 at 10:18 and 7429cdd at 19:16 shipped on the same day, so a date-stamped stale copy would have looked current. The hash is ank_core::freeze_hash_short, the same normalised SHA-256 every other anchor in this project uses -- which also makes the marker survive a CRLF checkout, since .gitattributes covers .ank/ only and skill/ is not exempt on Windows.
+- 2026-08-04T05:18:43Z seanl@sean-laptop — done, proof test:local/f7bde20eb195@0543719 test:local/e3b0c44298fc@0543719 test:local/011669e05a3b@0543719

--- a/.ank/tasks/TASK-b495234f192c.md
+++ b/.ank/tasks/TASK-b495234f192c.md
@@ -30,8 +30,11 @@ proof:
     tree: scope/494eb5ee3219
     criteria: 630bbd66bd22
     verifier: check-repo@5734e9cf9d3d
+  - type: test
+    ref: "30880317460"
+    criteria: 630bbd66bd22
 schema: 2
-version: 5
+version: 6
 ---
 
 Measured on 2026-08-02. The SKILL.md installed at ~/.claude/skills/ank is byte-identical to the blob at commit a004ac7 (2026-07-31 10:18). The repository moved twice after it, the same day: 830d069 at 19:15 added the eighth verb, 7429cdd at 19:16 replaced the third non-negotiable rule.
@@ -53,3 +56,4 @@ Related: TASK-548c518cb705, the same inability to interrogate an artifact, on th
 - 2026-08-04T05:14:13Z seanl@sean-laptop — The freeze decision, recorded before implementing as the criterion requires. A revision marker is NOT a succession, and the reasoning is that the strict reading of section 4 was never the operative one. The sentence 'this is the entire content of SKILL.md, and that content is frozen' follows a two-line loop block, while the shipped file is 69 lines with a name and a description in frontmatter. Read literally the file has been violating its own freeze since it existed, which is an argument that the literal reading is not what was ratified rather than an argument that the file is wrong. The operative reading is in the next clause of the same paragraph: growing WHAT IT TEACHES costs an ADR superseding ADR-c656cbcc33a9, and the reason given is the token budget paid on every session. That is also exactly what tests/skill.rs enforces, in three assertions -- the eight loop verbs are present, no verb outside the loop is named, and the file stays under 80 lines and 700 words. A fingerprint touches none of the three. Contrast with the case that did need a decision: show entered the loop and grew what an agent is taught. A marker teaches no verb and names no command.
 - 2026-08-04T05:14:27Z seanl@sean-laptop — The carrier, decided from the Agent Skills standard rather than invented: frontmatter metadata, which the specification defines as an arbitrary key-value map for properties it does not define, and whose own worked example is metadata.version. So the marker sits where name and description sit -- in the file's metadata, not in its instructions -- and it is standard-sanctioned rather than an unknown key some loader may reject. Claude Code's own frontmatter reference lists no version field, which is what ruled out a bare top-level key. The value is a content hash of the body, not a date and not a hand-kept semantic version. A hand-kept number drifts the first time somebody edits the body and forgets it; a hash cannot, because the test recomputes it. And a date would not have caught the failure this task was filed for: a004ac7 at 10:18 and 7429cdd at 19:16 shipped on the same day, so a date-stamped stale copy would have looked current. The hash is ank_core::freeze_hash_short, the same normalised SHA-256 every other anchor in this project uses -- which also makes the marker survive a CRLF checkout, since .gitattributes covers .ank/ only and skill/ is not exempt on Windows.
 - 2026-08-04T05:18:43Z seanl@sean-laptop — done, proof test:local/f7bde20eb195@0543719 test:local/e3b0c44298fc@0543719 test:local/011669e05a3b@0543719
+- 2026-08-04T05:21:50Z seanl@sean-laptop — attested test:30880317460

--- a/.ank/tasks/TASK-b495234f192c.md
+++ b/.ank/tasks/TASK-b495234f192c.md
@@ -5,7 +5,7 @@ slug: a-stale-installed-skill-teaches-the-opposite-of
 title: A stale installed skill teaches the opposite of a binding ADR
 created: 2026-08-03T04:10:01Z
 author: seanl@sean-laptop
-status: open
+status: in_progress
 scope:
   - skill/**
   - crates/ank-cli/tests/skill.rs
@@ -15,7 +15,7 @@ done_criteria: |
 criteria_by: creator
 verify: [cargo-test, fmt-check, check-repo]
 schema: 2
-version: 1
+version: 4
 ---
 
 Measured on 2026-08-02. The SKILL.md installed at ~/.claude/skills/ank is byte-identical to the blob at commit a004ac7 (2026-07-31 10:18). The repository moved twice after it, the same day: 830d069 at 19:15 added the eighth verb, 7429cdd at 19:16 replaced the third non-negotiable rule.
@@ -32,3 +32,7 @@ The repository side is healthy and should not be touched on account of this: ski
 The hard question belongs to whoever claims this, and the criterion asks for the answer to be written down rather than assumed: section 4 says "this is the entire content of SKILL.md, and that content is frozen", which read strictly covers any addition, including a version marker in the frontmatter. The enforcement as written -- eight verbs present, 80 lines, 700 words, nothing taught outside the loop -- would not object. Whether that gap is licence or oversight is a decision, and if it is a succession then it costs an ADR superseding ADR-c656cbcc33a9 and a signature.
 
 Related: TASK-548c518cb705, the same inability to interrogate an artifact, on the binary rather than the skill.
+
+## Log
+- 2026-08-04T05:14:13Z seanl@sean-laptop — The freeze decision, recorded before implementing as the criterion requires. A revision marker is NOT a succession, and the reasoning is that the strict reading of section 4 was never the operative one. The sentence 'this is the entire content of SKILL.md, and that content is frozen' follows a two-line loop block, while the shipped file is 69 lines with a name and a description in frontmatter. Read literally the file has been violating its own freeze since it existed, which is an argument that the literal reading is not what was ratified rather than an argument that the file is wrong. The operative reading is in the next clause of the same paragraph: growing WHAT IT TEACHES costs an ADR superseding ADR-c656cbcc33a9, and the reason given is the token budget paid on every session. That is also exactly what tests/skill.rs enforces, in three assertions -- the eight loop verbs are present, no verb outside the loop is named, and the file stays under 80 lines and 700 words. A fingerprint touches none of the three. Contrast with the case that did need a decision: show entered the loop and grew what an agent is taught. A marker teaches no verb and names no command.
+- 2026-08-04T05:14:27Z seanl@sean-laptop — The carrier, decided from the Agent Skills standard rather than invented: frontmatter metadata, which the specification defines as an arbitrary key-value map for properties it does not define, and whose own worked example is metadata.version. So the marker sits where name and description sit -- in the file's metadata, not in its instructions -- and it is standard-sanctioned rather than an unknown key some loader may reject. Claude Code's own frontmatter reference lists no version field, which is what ruled out a bare top-level key. The value is a content hash of the body, not a date and not a hand-kept semantic version. A hand-kept number drifts the first time somebody edits the body and forgets it; a hash cannot, because the test recomputes it. And a date would not have caught the failure this task was filed for: a004ac7 at 10:18 and 7429cdd at 19:16 shipped on the same day, so a date-stamped stale copy would have looked current. The hash is ank_core::freeze_hash_short, the same normalised SHA-256 every other anchor in this project uses -- which also makes the marker survive a CRLF checkout, since .gitattributes covers .ank/ only and skill/ is not exempt on Windows.

--- a/.ank/tasks/TASK-ecda4070354f.md
+++ b/.ank/tasks/TASK-ecda4070354f.md
@@ -1,0 +1,26 @@
+---
+id: TASK-ecda4070354f
+type: task
+slug: nothing-connects-the-binary-s-identity-to-the-sk
+title: Nothing connects the binary's identity to the skill's
+created: 2026-08-04T05:17:24Z
+author: seanl@sean-laptop
+status: open
+scope:
+  - crates/ank-cli/src/**
+  - crates/ank-cli/tests/cli.rs
+blocked_by: []
+done_criteria: |
+  A reader holding only the binary and the installed skill can tell whether the two agree, with no repository and no network. The binary prints the SKILL.md revision it was built alongside, that value is derived at build time from skill/SKILL.md rather than typed, and tests/skill.rs proves the printed value and the file agree. Asserted through the binary.
+criteria_by: creator
+schema: 2
+version: 1
+---
+
+TASK-548c518cb705 made the binary say what it is. TASK-b495234f192c made the skill say which revision it is. Neither says anything about the other, so telling a stale installed skill from a current one still needs a third value from somewhere -- the repository, a release note, a person who remembers.
+
+Closing it is cheap because both halves exist. The build script already stamps the commit through rev-parse; hashing skill/SKILL.md in the same place costs one more line and no new dependency, and the value is derived rather than kept, which is the property that made the marker itself worth having.
+
+What that buys is the check the original failure needed: an agent that has loaded a SKILL.md and can run ank --version compares two strings it already holds and learns, offline, that its instructions predate its tool.
+
+The design question for whoever claims this: where the value belongs. ank --version prints one line and section 4 says so in as many words, so a second line is a specification change before it is a code change (ADR-63b59c5c26f7). ank status is the other candidate and answers where am I, which is arguably the same question.

--- a/crates/ank-cli/tests/skill.rs
+++ b/crates/ank-cli/tests/skill.rs
@@ -4,9 +4,10 @@
 //! permanently, on every session, in every repository that installs it. That is
 //! what makes its content the thing actually frozen (ADR-c656cbcc33a9) -- the
 //! dispatch table refuses nobody, and the loop exists because this file teaches
-//! it and teaches nothing else. Two properties are therefore worth a test
-//! rather than a habit: that it carries the whole loop, and that it stays small
-//! enough to be worth loading.
+//! it and teaches nothing else. Three properties are therefore worth a test
+//! rather than a habit: that it carries the whole loop, that it stays small
+//! enough to be worth loading, and that a copy in the wild says which revision
+//! it is.
 //!
 //! This file exists because the task's declared verifier is `cargo-test`. A
 //! criterion nothing executes is a criterion nobody checked, and a proof that
@@ -234,4 +235,76 @@ fn the_skill_teaches_nothing_beyond_the_loop() {
              frozen at"
         );
     }
+}
+
+// ---------------------------------------------------------------------------
+// Which revision is installed (TASK-b495234f192c)
+// ---------------------------------------------------------------------------
+
+/// Frontmatter and body, split on the same delimiters the entity format uses.
+/// A second rule for a second file is a second thing to get wrong.
+///
+/// Line endings are unified first: `.gitattributes` covers `.ank/**` and not
+/// `skill/`, so a Windows checkout of this file can legitimately be CRLF and
+/// the closing delimiter is then `\r\n---\r\n`.
+fn split_skill(text: &str) -> (String, String) {
+    let lf = text.replace("\r\n", "\n");
+    let rest = lf
+        .strip_prefix("---\n")
+        .expect("SKILL.md must open with frontmatter")
+        .to_string();
+    let end = rest
+        .find("\n---\n")
+        .expect("SKILL.md frontmatter must be closed");
+    (
+        rest[..end].to_string(),
+        rest[end + "\n---\n".len()..].to_string(),
+    )
+}
+
+/// The value the frontmatter declares under `metadata.revision`, unquoted.
+fn declared_revision(front: &str) -> Option<String> {
+    front.lines().find_map(|l| {
+        let v = l.trim().strip_prefix("revision:")?;
+        Some(v.trim().trim_matches('"').to_string())
+    })
+}
+
+/// **A copy in the wild says which revision it is.** Measured on 2026-08-02:
+/// the SKILL.md installed at `~/.claude/skills/ank` was byte-identical to the
+/// blob at a004ac7, two commits and nine hours behind a tree that had just
+/// withdrawn the invitation to read `.ank/` by hand (ADR-01b6dd05f0db). It was
+/// not merely old, it instructed against a ratified decision -- and it carried
+/// nothing by which its reader or its owner could have noticed.
+///
+/// The marker is a hash of the body rather than a version anyone keeps by hand,
+/// for two reasons. A hand-kept number drifts the first time somebody edits the
+/// body and forgets it, whereas this one cannot: the assertion below recomputes
+/// it. And a date would not have caught the case above -- a004ac7 at 10:18 and
+/// 7429cdd at 19:16 shipped on the same day, so a date-stamped stale copy would
+/// have looked current.
+///
+/// It sits in `metadata`, which the Agent Skills standard defines as an
+/// arbitrary map for properties the standard does not itself define, so it is
+/// metadata about the file and not part of what the file teaches. That is the
+/// whole of the freeze (ADR-c656cbcc33a9), and the three assertions above are
+/// the enforcement -- none of them moves because of a fingerprint.
+#[test]
+fn the_skill_says_which_revision_it_is() {
+    let text = skill();
+    let (front, body) = split_skill(&text);
+
+    let declared = declared_revision(&front).unwrap_or_else(|| {
+        panic!(
+            "SKILL.md declares no metadata.revision, so an installed copy \
+             identifies itself to nobody"
+        )
+    });
+    let actual = ank_core::freeze_hash_short(&body);
+
+    assert_eq!(
+        declared, actual,
+        "SKILL.md was edited without its revision: set metadata.revision to \
+         \"{actual}\""
+    );
 }

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: ank
 description: Read a repository's tasks and binding constraints, claim work, and finish it with proof. Use when working in a repo that has a .ank/ directory.
+metadata:
+  revision: "605f771e1955"
 ---
 
 # ank


### PR DESCRIPTION
`TASK-b495234f192c`.

Measured on 2026-08-02: the `SKILL.md` installed at `~/.claude/skills/ank` was
byte-identical to the blob at `a004ac7`, two commits and nine hours behind a
tree that had just withdrawn the invitation to read `.ank/` by hand. It was not
merely old — it instructed against a ratified decision (`ADR-01b6dd05f0db`) —
and it carried nothing by which its reader or its owner could have noticed.

## The freeze question, settled before implementing

**Not a succession.** §4's "this is the entire content of SKILL.md, and that
content is frozen" follows a two-line loop block, while the shipped file is 69
lines with a `name` and a `description` in frontmatter. Read literally, the file
has been violating its own freeze since it existed — which argues that the
literal reading is not what was ratified, not that the file is wrong.

The operative reading is in the next clause of the same paragraph: growing **what
it teaches** costs an ADR superseding `ADR-c656cbcc33a9`, and the reason given is
the token budget paid on every session. That is exactly what `tests/skill.rs`
enforces, in three assertions — the eight loop verbs present, no verb outside the
loop named, one page. A fingerprint moves none of them. Contrast the case that
did need a decision: `show` entering the loop grew what an agent is taught.

## The carrier and the value

`metadata.revision`, taken from the Agent Skills standard rather than invented —
the standard defines `metadata` as an arbitrary map for properties it does not
itself define, and its own worked example is `metadata.version`. Claude Code's
frontmatter reference lists no `version` field, which is what ruled out a bare
top-level key some loader might reject.

The value is a hash of the body, and both alternatives were rejected on evidence:

- **A hand-kept version** drifts the first time somebody edits the body and
  forgets it. This one cannot — the test recomputes it and its failure message
  names the value to paste.
- **A date** would not have caught the case this task was filed for. `a004ac7` at
  10:18 and `7429cdd` at 19:16 shipped on the same day, so a date-stamped stale
  copy would have looked current.

The hash is `ank_core::freeze_hash_short`, the same normalised SHA-256 every
other anchor in the project uses. That also makes the marker survive a CRLF
checkout: `.gitattributes` covers `.ank/**` and not `skill/`.

## What remains

`TASK-ecda4070354f`. A bare hash identifies a revision; it does not date one, so
telling stale from current still needs a reference value the reader may not have.
The binary was built alongside the file and could say so — `TASK-548c518cb705`
already gave it a voice.

Proof: `ank done` ran `cargo-test`, `fmt-check` and `check-repo` itself, three
proof entries, each with its verifier definition hashed in. No `--proof` was
passed and none would have been accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017UvAwksjf2DR3hxebZq6Kz