### PR TITLE
A README that says what ank is and what it does

### DIFF
--- a/.ank/tasks/TASK-143c90665ed4.md
+++ b/.ank/tasks/TASK-143c90665ed4.md
@@ -5,15 +5,16 @@ slug: the-readme-still-describes-two-command-surfaces
 title: The README still describes two command surfaces
 created: 2026-08-04T04:28:37Z
 author: seanl@sean-laptop
-status: open
+status: in_progress
 scope:
   - README.md
+  - docs/getting-started.md
 blocked_by: []
 done_criteria: |
   The status section of README.md describes one command surface, counts the verbs the binary actually dispatches, and names no agent surface and no human surface. Whatever number it states is derived from ank help rather than written by hand, or it states no number at all.
 criteria_by: creator
 schema: 2
-version: 1
+version: 7
 ---
 
 ADR-c656cbcc33a9 dissolved the split between an agent surface and a human one: every verb is available to every caller, and the CLI refuses on state, never on identity. The specification followed in revision i, and skill/SKILL.md restates the freeze as a freeze on its own content.
@@ -23,3 +24,10 @@ The README did not follow. It still reads 'Thirteen verbs work end to end -- the
 The count is wrong as well as the shape: ank help lists eighteen verbs plus init and help. amend, status, edit, graph and scope arrived after the sentence was written and are absent from it.
 
 This is the same defect as TASK-b495234f192c one level out. That task is about an installed SKILL.md teaching against a ratified ADR; this is about the first page of the repository doing it, to a reader who has no CLAUDE.md to correct them. Found while routing the documentation by audience (TASK-e32dc98faceb), whose criterion covered the routing and not this paragraph.
+
+## Log
+- 2026-08-04T05:32:35Z seanl@sean-laptop — Three claims in the status section are false, not one, and the walk to check the verb count is what found the other two. Binaries ship: release v0.1.1 (2026-08-03) carries ank-0.1.1 for aarch64-apple-darwin, x86_64-pc-windows-msvc and x86_64-unknown-linux-musl, each with a .sha256, while the README still says there are none and sends the reader to cargo build --release. The skill is installable and installed -- npx skills add haksolot/ank is in SKILL.md and this session loaded it -- while the README lists it as missing before v1. And the verb count: ank help lists eighteen verbs plus init and help, not thirteen, split across an agent surface and a human one that ADR-c656cbcc33a9 withdrew. docs/getting-started.md repeats the binaries error, since I wrote it yesterday from the README rather than from the releases page.
+- 2026-08-04T05:32:44Z seanl@sean-laptop — amended: +scope docs/getting-started.md
+- 2026-08-04T05:32:45Z seanl@sean-laptop — Scope amended to add docs/getting-started.md: the install section there carries the same false claim about binaries, and correcting the README while leaving the page the README routes newcomers to would fix the sentence and not the defect. The criterion is untouched and still concerns the README's status section; the getting-started correction is the same fact, one document over.
+- 2026-08-04T05:33:39Z seanl@sean-laptop — A fourth false claim in the same paragraph: the README says ank find scans the index rather than querying FTS5, calling it a performance gap. index.rs creates a virtual table with fts5 and find runs a MATCH against it ranked by bm25 with positional weights. The whole 'still missing before v1' paragraph describes a state the repository left behind, which is the same failure as the verb count one sentence earlier -- a status section written once and never re-derived.
+- 2026-08-04T05:37:43Z seanl@sean-laptop — Rewrote rather than patched, at the human's request: the README read austere for a project that is not. The shape is now a hero with three badges, a Quick start that installs and runs the loop before it explains anything, the two entity examples and one context output as the hook, the four ideas, a routing table by audience, then status and contributor detail last. Three verifications rather than assertions: cargo install --git https://github.com/haksolot/ank ank-cli was run into a scratch root and produced ank 0.1.1 (8e4b1fe); the release assets were read from the API rather than assumed, giving the three exact target triples; and the three badge URLs were fetched and answer 200, so none of them renders as a broken image. On the criterion's number: the section states none. The first sentence asks for a count and the second licenses its absence, and a README cannot derive at read time -- what it can do is stop carrying a hand-written figure that rots, which is the defect this task was filed for. It says instead that every verb the specification specifies ships and names the test that compares the two lists in both directions.

--- a/.ank/tasks/TASK-143c90665ed4.md
+++ b/.ank/tasks/TASK-143c90665ed4.md
@@ -17,8 +17,11 @@ proof:
   - type: commit
     ref: 399a61a
     criteria: 236c353fbdee
+  - type: test
+    ref: "30881665912"
+    criteria: 236c353fbdee
 schema: 2
-version: 8
+version: 9
 ---
 
 ADR-c656cbcc33a9 dissolved the split between an agent surface and a human one: every verb is available to every caller, and the CLI refuses on state, never on identity. The specification followed in revision i, and skill/SKILL.md restates the freeze as a freeze on its own content.
@@ -36,3 +39,4 @@ This is the same defect as TASK-b495234f192c one level out. That task is about a
 - 2026-08-04T05:33:39Z seanl@sean-laptop — A fourth false claim in the same paragraph: the README says ank find scans the index rather than querying FTS5, calling it a performance gap. index.rs creates a virtual table with fts5 and find runs a MATCH against it ranked by bm25 with positional weights. The whole 'still missing before v1' paragraph describes a state the repository left behind, which is the same failure as the verb count one sentence earlier -- a status section written once and never re-derived.
 - 2026-08-04T05:37:43Z seanl@sean-laptop — Rewrote rather than patched, at the human's request: the README read austere for a project that is not. The shape is now a hero with three badges, a Quick start that installs and runs the loop before it explains anything, the two entity examples and one context output as the hook, the four ideas, a routing table by audience, then status and contributor detail last. Three verifications rather than assertions: cargo install --git https://github.com/haksolot/ank ank-cli was run into a scratch root and produced ank 0.1.1 (8e4b1fe); the release assets were read from the API rather than assumed, giving the three exact target triples; and the three badge URLs were fetched and answer 200, so none of them renders as a broken image. On the criterion's number: the section states none. The first sentence asks for a count and the second licenses its absence, and a README cannot derive at read time -- what it can do is stop carrying a hand-written figure that rots, which is the defect this task was filed for. It says instead that every verb the specification specifies ships and names the test that compares the two lists in both directions.
 - 2026-08-04T05:38:42Z seanl@sean-laptop — done, proof commit:399a61a
+- 2026-08-04T05:48:41Z seanl@sean-laptop — attested test:30881665912

--- a/.ank/tasks/TASK-143c90665ed4.md
+++ b/.ank/tasks/TASK-143c90665ed4.md
@@ -5,7 +5,7 @@ slug: the-readme-still-describes-two-command-surfaces
 title: The README still describes two command surfaces
 created: 2026-08-04T04:28:37Z
 author: seanl@sean-laptop
-status: in_progress
+status: done
 scope:
   - README.md
   - docs/getting-started.md
@@ -13,8 +13,12 @@ blocked_by: []
 done_criteria: |
   The status section of README.md describes one command surface, counts the verbs the binary actually dispatches, and names no agent surface and no human surface. Whatever number it states is derived from ank help rather than written by hand, or it states no number at all.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 399a61a
+    criteria: 236c353fbdee
 schema: 2
-version: 7
+version: 8
 ---
 
 ADR-c656cbcc33a9 dissolved the split between an agent surface and a human one: every verb is available to every caller, and the CLI refuses on state, never on identity. The specification followed in revision i, and skill/SKILL.md restates the freeze as a freeze on its own content.
@@ -31,3 +35,4 @@ This is the same defect as TASK-b495234f192c one level out. That task is about a
 - 2026-08-04T05:32:45Z seanl@sean-laptop — Scope amended to add docs/getting-started.md: the install section there carries the same false claim about binaries, and correcting the README while leaving the page the README routes newcomers to would fix the sentence and not the defect. The criterion is untouched and still concerns the README's status section; the getting-started correction is the same fact, one document over.
 - 2026-08-04T05:33:39Z seanl@sean-laptop — A fourth false claim in the same paragraph: the README says ank find scans the index rather than querying FTS5, calling it a performance gap. index.rs creates a virtual table with fts5 and find runs a MATCH against it ranked by bm25 with positional weights. The whole 'still missing before v1' paragraph describes a state the repository left behind, which is the same failure as the verb count one sentence earlier -- a status section written once and never re-derived.
 - 2026-08-04T05:37:43Z seanl@sean-laptop — Rewrote rather than patched, at the human's request: the README read austere for a project that is not. The shape is now a hero with three badges, a Quick start that installs and runs the loop before it explains anything, the two entity examples and one context output as the hook, the four ideas, a routing table by audience, then status and contributor detail last. Three verifications rather than assertions: cargo install --git https://github.com/haksolot/ank ank-cli was run into a scratch root and produced ank 0.1.1 (8e4b1fe); the release assets were read from the API rather than assumed, giving the three exact target triples; and the three badge URLs were fetched and answer 200, so none of them renders as a broken image. On the criterion's number: the section states none. The first sentence asks for a count and the second licenses its absence, and a README cannot derive at read time -- what it can do is stop carrying a hand-written figure that rots, which is the defect this task was filed for. It says instead that every verb the specification specifies ships and names the test that compares the two lists in both directions.
+- 2026-08-04T05:38:42Z seanl@sean-laptop — done, proof commit:399a61a

--- a/.ank/tasks/TASK-39495d6db583.md
+++ b/.ank/tasks/TASK-39495d6db583.md
@@ -5,7 +5,7 @@ slug: the-project-has-no-mark-of-its-own
 title: The project has no mark of its own
 created: 2026-08-04T05:42:12Z
 author: seanl@sean-laptop
-status: in_progress
+status: done
 scope:
   - assets/**
   - README.md
@@ -13,8 +13,12 @@ blocked_by: []
 done_criteria: |
   README.md shows a project mark above the title, centred, and it renders on github.com in both the light and the dark theme rather than only one. The mark is committed to the repository rather than hotlinked, no rendering depends on inline SVG in markdown, and the rendered result is checked on github.com rather than assumed.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 93471f5
+    criteria: d1209c92242d
 schema: 2
-version: 2
+version: 4
 ---
 
 Asked for by the maintainer on 2026-08-04, with a pixelarticons anchor as the mark. Filed as its own task rather than folded into TASK-143c90665ed4: that one is done, its proof anchors commit 399a61a, and amend refuses a done task for the same reason -- the criterion it was measured against said nothing about a mark.
@@ -22,3 +26,7 @@ Asked for by the maintainer on 2026-08-04, with a pixelarticons anchor as the ma
 Two constraints decide the implementation and neither is a matter of taste. GitHub strips inline <svg> from rendered markdown, so the element cannot simply be pasted into the file; the mark has to be committed and referenced through <img>. And an SVG referenced that way is an isolated document, so fill=currentColor resolves to black and the mark disappears against the dark theme. The pattern that answers both is <picture> with a prefers-color-scheme source, which is what GitHub documents.
 
 ADR-d3a8dcf38817 forbids no emojis clause covers emojis in prose; a committed vector mark is not one, and the constraint is untouched.
+
+## Log
+- 2026-08-04T05:45:00Z seanl@sean-laptop — Both halves checked on github.com rather than assumed, which is what the criterion asked for. The rendered README on the branch comes back wrapped in GitHub's own <themed-picture data-catalyst-inline=true>, so the picture element survived sanitisation and the relative srcset resolved to /haksolot/ank/raw/<branch>/assets/ank-dark.svg. Both files serve 200 as image/svg+xml. Seen in a browser: the dark variant renders light against the dark theme, centred above the title with the three badges below it, and the light variant renders dark on white. Inline <svg> in the markdown would have been stripped and shown nothing, which is the failure this shape avoids.
+- 2026-08-04T05:45:00Z seanl@sean-laptop — done, proof commit:93471f5

--- a/.ank/tasks/TASK-39495d6db583.md
+++ b/.ank/tasks/TASK-39495d6db583.md
@@ -17,8 +17,11 @@ proof:
   - type: commit
     ref: 93471f5
     criteria: d1209c92242d
+  - type: test
+    ref: "30881665912"
+    criteria: d1209c92242d
 schema: 2
-version: 4
+version: 5
 ---
 
 Asked for by the maintainer on 2026-08-04, with a pixelarticons anchor as the mark. Filed as its own task rather than folded into TASK-143c90665ed4: that one is done, its proof anchors commit 399a61a, and amend refuses a done task for the same reason -- the criterion it was measured against said nothing about a mark.
@@ -30,3 +33,4 @@ ADR-d3a8dcf38817 forbids no emojis clause covers emojis in prose; a committed ve
 ## Log
 - 2026-08-04T05:45:00Z seanl@sean-laptop — Both halves checked on github.com rather than assumed, which is what the criterion asked for. The rendered README on the branch comes back wrapped in GitHub's own <themed-picture data-catalyst-inline=true>, so the picture element survived sanitisation and the relative srcset resolved to /haksolot/ank/raw/<branch>/assets/ank-dark.svg. Both files serve 200 as image/svg+xml. Seen in a browser: the dark variant renders light against the dark theme, centred above the title with the three badges below it, and the light variant renders dark on white. Inline <svg> in the markdown would have been stripped and shown nothing, which is the failure this shape avoids.
 - 2026-08-04T05:45:00Z seanl@sean-laptop — done, proof commit:93471f5
+- 2026-08-04T05:48:41Z seanl@sean-laptop — attested test:30881665912

--- a/.ank/tasks/TASK-39495d6db583.md
+++ b/.ank/tasks/TASK-39495d6db583.md
@@ -1,0 +1,24 @@
+---
+id: TASK-39495d6db583
+type: task
+slug: the-project-has-no-mark-of-its-own
+title: The project has no mark of its own
+created: 2026-08-04T05:42:12Z
+author: seanl@sean-laptop
+status: in_progress
+scope:
+  - assets/**
+  - README.md
+blocked_by: []
+done_criteria: |
+  README.md shows a project mark above the title, centred, and it renders on github.com in both the light and the dark theme rather than only one. The mark is committed to the repository rather than hotlinked, no rendering depends on inline SVG in markdown, and the rendered result is checked on github.com rather than assumed.
+criteria_by: creator
+schema: 2
+version: 2
+---
+
+Asked for by the maintainer on 2026-08-04, with a pixelarticons anchor as the mark. Filed as its own task rather than folded into TASK-143c90665ed4: that one is done, its proof anchors commit 399a61a, and amend refuses a done task for the same reason -- the criterion it was measured against said nothing about a mark.
+
+Two constraints decide the implementation and neither is a matter of taste. GitHub strips inline <svg> from rendered markdown, so the element cannot simply be pasted into the file; the mark has to be committed and referenced through <img>. And an SVG referenced that way is an isolated document, so fill=currentColor resolves to black and the mark disappears against the dark theme. The pattern that answers both is <picture> with a prefers-color-scheme source, which is what GitHub documents.
+
+ADR-d3a8dcf38817 forbids no emojis clause covers emojis in prose; a committed vector mark is not one, and the constraint is untouched.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="assets/ank-dark.svg">
+    <img src="assets/ank.svg" alt="" width="88" height="88">
+  </picture>
+</p>
+
 <h1 align="center">ank</h1>
 
 <p align="center">
@@ -200,6 +207,7 @@ crates/ank-core   parser and data model — the reference implementation of the 
 crates/ank-cli    the `ank` binary
 docs/             the specification, getting started, the format
 skill/            the bootstrap skill for agents
+assets/           the project mark, one file per theme
 .ank/             ank's own development plan, in the ank format
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,62 @@
-# ank
+<h1 align="center">ank</h1>
 
-**The stupid coordination tool — tasks and architecture decisions as files in your repo, readable by any coding agent.**
+<p align="center">
+  <strong>The stupid coordination tool</strong><br>
+  Tasks and architecture decisions as files in your repo, readable by any coding agent.
+</p>
+
+<p align="center">
+  <a href="https://github.com/haksolot/ank/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/haksolot/ank/actions/workflows/ci.yml/badge.svg"></a>
+  <a href="https://github.com/haksolot/ank/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/haksolot/ank"></a>
+  <a href="LICENSE"><img alt="Licence" src="https://img.shields.io/badge/licence-GPL--3.0-blue"></a>
+</p>
+
+---
 
 An agent that spawns on your codebase can read every line of it. It cannot read
 your tracker, your wiki, or the thread where you decided six months ago that
 sessions must never be self-contained JWTs. So it writes plausible code that
-violates a rule nobody wrote down where it could be found.
+breaks a rule nobody wrote down where it could be found.
 
 Ank puts that layer in the repository, attached to the code it constrains, in a
-format an agent consumes in one call and under 2000 tokens.
+format an agent consumes in one call and under 2000 tokens. No server, no
+daemon, no account — two kinds of file and a CLI.
+
+## Quick start
+
+**Install.** Take a binary from the [latest release][releases] — Linux
+(`x86_64-musl`), macOS (Apple silicon) or Windows (`x86_64`), each with a
+`.sha256` beside it — and put `ank` on your `PATH`. Or build it:
+
+```
+cargo install --git https://github.com/haksolot/ank ank-cli
+```
+
+Ank needs **git 2.34 or newer**: claims are git refs, and it checks at startup.
+
+**Run the loop.** In any git repository:
+
+```
+ank init                      # creates .ank/, once
+ank context                   # what binds here, and what is free to take
+ank claim <id>                # takes the task, freezes its criterion by hash
+ank log "<what you learned>"  # renews the claim; working is what holds it
+ank done                      # runs the verifiers itself and writes the proof
+```
+
+**Hand it to an agent.**
+
+```
+npx skills add haksolot/ank
+```
+
+[**Getting started**](docs/getting-started.md) walks all of that with real
+output, including the two refusals a fresh repository will give you.
 
 ## What it looks like
 
-Two kinds of file, flat, in `.ank/`. A decision that constrains code:
+A decision that constrains code, and a unit of work with what would prove it
+finished. Both are markdown with YAML frontmatter, flat in `.ank/`:
 
 ```yaml
 ---
@@ -28,8 +72,6 @@ constraint: |
 ---
 ```
 
-And a unit of work, with what would prove it finished:
-
 ```yaml
 ---
 id: TASK-8f3a91c2d4e7
@@ -38,7 +80,7 @@ title: Migrate auth to opaque sessions
 status: open
 scope:
   - src/auth/**
-blocked_by: [TASK-51c2a7f0]
+blocked_by: [TASK-51c2a7f0b3d9]
 done_criteria: |
   Auth integration tests pass, and no reference to
   jwt.verify remains in src/auth/
@@ -63,7 +105,7 @@ TASKS (2)
 > ank claim 51c2 to start
 ```
 
-## The four ideas
+## Why it works this way
 
 **Scope, not hierarchy.** Constraints and work are two independent planes,
 joined only by a list of globs. An agent gets what binds it without traversing
@@ -78,7 +120,7 @@ own result, because an agent that reports its own result can simply be wrong.
 **Freezing is verifiable, not defended.** The CLI cannot stop anyone from
 editing a file, and it does not pretend to. Every frozen field is anchored by a
 hash in something the editor does not control — the claim record, the signed
-ratification commit — and `check` compares. Editing a criterion to unblock
+ratification commit — and `ank check` compares. Editing a criterion to unblock
 yourself does not unblock anything; it makes the divergence visible.
 
 **Git does the hard parts.** Claims are git refs, so the compare-and-swap that
@@ -95,100 +137,78 @@ nothing to run. That is what "stupid" means here.
 - **Not a security boundary.** The guardrails protect against an agent drifting,
   not against a malicious actor.
 
-## Status: pre-v1, and the CLI runs
-
-Thirteen verbs work end to end — the eight of the agent surface (`context`,
-`claim`, `show`, `log`, `done`, `new`, `find`, `release`), the five of the human
-one (`check`, `review`, `accept`, `close`, `attest`), plus `init` and `help`.
-There are no published binaries yet: build from source with
-`cargo build --release`.
-
-This repository is built by dogfooding its own format. The development plan
-lives in [`.ank/`](.ank/), and the tool now reads, claims and closes its own
-tasks — the last several were closed by `ank done`, which ran the verifiers and
-wrote the proofs itself. The corpus is validated by `ank check` on every CI run.
-
-Still missing before v1: binaries for the three platforms and the installable
-skill. `ank find` scans the index rather than querying FTS5, which is a
-performance gap and not a behavioural one.
-
 ## Documentation
 
-Four documents, and which one you want depends on what you are about to do.
+| If you want to | Read |
+|---|---|
+| use it, from install to a first finished task | [Getting started](docs/getting-started.md) |
+| write a tool that reads or writes `.ank/` | [The file format](docs/format.md) |
+| know why it is shaped this way, or need the normative answer | [The specification](docs/ank-spec-v1.1.md) |
+| work on ank itself | [CLAUDE.md](CLAUDE.md), and the section below |
 
-- **You want to use it.** [`docs/getting-started.md`](docs/getting-started.md)
-  takes you from install to a first claim and a first `done`, with real output
-  at every step. It assumes nothing and does not send you to the specification.
-- **You are writing a tool that reads or writes `.ank/`.**
-  [`docs/format.md`](docs/format.md) has the field order, the emission rules,
-  the two hashes and the conformance suite — the mechanical half, for a second
-  implementation.
-- **You want to know why it is shaped this way, or you need the normative
-  answer.** [`docs/ank-spec-v1.1.md`](docs/ank-spec-v1.1.md) is the source of
-  truth. It argues the design and settles every question the other two defer to
-  it; it is not a tutorial, and the two documents above exist so that it does
-  not have to be one.
-- **You are an agent working on this repository.**
-  [`CLAUDE.md`](CLAUDE.md) has the conventions, and the section below has the
-  loop. The development plan itself lives in `.ank/` — a DAG of tasks through
-  `blocked_by`, and the decisions in `.ank/adr/` — reached through the CLI.
+The specification is the source of truth. It argues the design and settles every
+question the other documents defer to it; it is not a tutorial, and the first two
+exist so that it does not have to be one.
 
-## For agents working on this repository
+## Status
 
-Build it once, then let it drive:
+Pre-v1, and the CLI runs on Linux, macOS and Windows.
 
-    cargo build --release        # target/release/ank
+**One command surface.** Every verb is available to every caller, and ank refuses
+on state — a claim held elsewhere, a blocked task, a missing proof — never on who
+is asking. `ank help` prints them all in one flat listing; `ank help <verb>`
+answers about one — which is why no number appears here. Every verb the
+specification specifies ships today, and `crates/ank-cli/tests/skill.rs` compares
+the two lists in both directions, so a verb that stops shipping fails the suite
+unless it is declared missing there, by name and with its task.
 
-1. `ank context` — what constrains the perimeter and what is claimable, in one
-   call. Run it before anything else; run it again with a claim held and it
-   switches to execution mode, giving the criterion and the constraints in full.
-2. `ank claim <id>` — takes the task. It refuses, with the reason and the next
-   command, if the task is held, finished on another branch, blocked, or has no
-   criterion to be measured against.
-3. `ank log "<message>"` — record what you learned. It renews the claim.
-4. `ank done` — runs the declared verifiers itself and writes the proofs. Never
-   set `status: done` by hand: the point of the tool is that nobody declares
-   themselves finished.
+What an agent is *taught* is a smaller set, and that is what is frozen: the loop
+above, plus `new`, `find` and `release`. The freeze is on `skill/SKILL.md`, which
+is loaded on every session and therefore costs tokens on every call — not on the
+dispatch table. An agent that types `ank graph` gets the graph; it was simply
+never told the verb existed, and being untold is not being refused.
 
-`ank check` validates the corpus (parse, byte-for-byte round-trip, `blocked_by`
-references) and must stay green after any edit to `.ank/`.
+This repository is built by dogfooding its own format. The development plan lives
+in `.ank/` — a DAG of tasks through `blocked_by`, and the decisions in
+`.ank/adr/` — and the tool reads, claims and closes its own tasks. `ank check`
+validates the corpus on every CI run.
 
-`.ank/` is opaque to an agent, the way `.git/` is (ADR-01b6dd05f0db): reach it
-with `ank show <id>` for an entity whole, `ank find` to list, `ank context` to
-learn what binds. The tool knows what the files do not — the context budget, the
-frozen criterion, who holds which claim — and a `PreToolUse` hook in
-[`.claude/`](.claude/) refuses the direct route rather than trusting anyone to
-remember. A human with an editor keeps every power they had; `check` remains
-what notices.
+## Working on ank
 
-That was already the rule for writing, and for a sharper reason: `claim` and
-`done` write to git refs and run verifiers, so editing the files by hand skips
-both. Reading joined it once there was nothing left the CLI could not serve.
+```
+cargo build --release        # target/release/ank
+cargo test                   # full suite, format conformance included
+cargo fmt --check
+ank check                    # validates .ank/: parse, round-trip, references
+```
 
-Detailed conventions are in [`CLAUDE.md`](CLAUDE.md).
-
-## Layout
-
-    crates/ank-core   parser and data model — the reference implementation of the format
-    crates/ank-cli    the `ank` binary — thirteen verbs, plus init and help
-    docs/             the specification (source of truth), getting started, the format
-    .ank/             Ank's own development plan, in the Ank format
-    skill/            the bootstrap skill for agents
-
-## Development
-
-    cargo test                  # full suite, format conformance included
-    cargo fmt --check
-    ank check                   # validates .ank/: parse, round-trip, references
+`.ank/` is opaque to an agent, the way `.git/` is: reach it with `ank show <id>`
+for an entity whole, `ank find` to list, `ank context` to learn what binds. The
+tool knows what the files do not — the context budget, the frozen criterion, who
+holds which claim — and a `PreToolUse` hook in [`.claude/`](.claude/) refuses the
+direct route rather than trusting anyone to remember. A human with an editor
+keeps every power they had; `ank check` remains what notices.
 
 `crates/ank-core/tests/golden/` is the format conformance suite, reusable by any
 third-party tool: `valid/` must round-trip byte for byte once normalised,
-`invalid/` must be rejected with the expected error. One valid file is in CRLF
-on purpose and must come back in LF — the format is read in either and written
-in one.
+`invalid/` must be rejected with the expected error. One valid file is in CRLF on
+purpose and must come back in LF — the format is read in either and written in
+one.
+
+```
+crates/ank-core   parser and data model — the reference implementation of the format
+crates/ank-cli    the `ank` binary
+docs/             the specification, getting started, the format
+skill/            the bootstrap skill for agents
+.ank/             ank's own development plan, in the ank format
+```
+
+Conventions for agents are in [CLAUDE.md](CLAUDE.md).
 
 ## Licence
 
 GPL-3.0 — see [LICENSE](LICENSE). The copyleft covers the tool's code, not the
 format: your `.ank/` files, and the third-party tools that read or write them,
 are not derivative works.
+
+[releases]: https://github.com/haksolot/ank/releases/latest

--- a/assets/ank-dark.svg
+++ b/assets/ank-dark.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="img" aria-label="ank" shape-rendering="crispEdges" fill="#e6edf3"><path d="M10 2h4v2h-4zm0 6h4v2h-4zM8 4h2v4H8zm6 0h2v4h-2z"/><path d="M11 9h2v12h-2z"/><path d="M5 20h14v2H5zm-2-8h2v8H3zm16 0h2v8h-2zM5 12h2v2H5zm12 0h2v2h-2z"/></svg>

--- a/assets/ank.svg
+++ b/assets/ank.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="img" aria-label="ank" shape-rendering="crispEdges" fill="#1f2328"><path d="M10 2h4v2h-4zm0 6h4v2h-4zM8 4h2v4H8zm6 0h2v4h-2z"/><path d="M11 9h2v12h-2z"/><path d="M5 20h14v2H5zm-2-8h2v8H3zm16 0h2v8h-2zM5 12h2v2H5zm12 0h2v2h-2z"/></svg>

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,16 +14,22 @@ the tool refuses, the refusal is shown as it appears.
   checks the version at startup.
 - **`sh`.** Verifiers run under `sh -c` on all three operating systems. On
   Windows it comes with Git for Windows, so requiring git makes it free.
-- **Rust 1.95 or newer**, to build. There are no published binaries yet.
+- **Rust 1.95 or newer**, only if you build from source.
 
 ## Install
 
-    git clone https://github.com/haksolot/ank
-    cd ank
-    cargo build --release
+Every release carries a static binary for three targets —
+`x86_64-unknown-linux-musl`, `aarch64-apple-darwin` and
+`x86_64-pc-windows-msvc` — each with a `.sha256` beside it. Take the archive for
+your platform from the [releases page](https://github.com/haksolot/ank/releases/latest),
+check the hash, unpack it, and put `ank` on your `PATH`.
 
-The binary is `target/release/ank`. Put it on your `PATH`, then check it
-answers:
+To build instead:
+
+    cargo install --git https://github.com/haksolot/ank ank-cli
+
+That puts `ank` in `~/.cargo/bin`. From a clone, `cargo build --release` leaves
+it at `target/release/ank`. Either way, check it answers:
 
     $ ank --version
     ank 0.1.1 (bc59636)


### PR DESCRIPTION
`TASK-143c90665ed4`, plus the rewrite the maintainer asked for in the same pass.

## Four false claims, not one

Checking the verb count turned up three more in the same paragraph.

| The README said | Actually |
|---|---|
| thirteen verbs, eight of an agent surface and five of a human one | `ank help` lists eighteen verbs plus `init` and `help`, on one surface — `ADR-c656cbcc33a9` withdrew the split |
| "There are no published binaries yet: build from source" | v0.1.1 ships `x86_64-unknown-linux-musl`, `aarch64-apple-darwin`, `x86_64-pc-windows-msvc`, each with a `.sha256` |
| "Still missing before v1: ... the installable skill" | `npx skills add haksolot/ank` works and is how this repo's own agent loads it |
| "`ank find` scans the index rather than querying FTS5" | `find` runs a `MATCH` against an FTS5 virtual table, ranked by `bm25` |

**The status section now states no number at all.** The criterion allows that
explicitly, and it is the only shape that cannot rot: a README derives nothing at
read time. It says instead that every verb the specification specifies ships, and
names the test that compares the two lists in both directions.

## The rewrite

The page opened on an argument and buried the install five sections down, which
reads austere for a project that is not.

- A hero with three badges — CI, latest release, licence. All three URLs were
  fetched and answer 200, so none renders broken.
- **Quick start first**: install, the five-command loop, `npx skills add`. You can
  be running before you have read a paragraph of design.
- The two entity examples and one `ank context` output kept as the hook.
- The four ideas kept, and "that is what stupid means here" with them.
- The four documents routed by audience in a table.
- Contributor detail moved below the fold.

## Verified rather than written

- `cargo install --git https://github.com/haksolot/ank ank-cli` was run into a
  scratch root and produced `ank 0.1.1 (8e4b1fe)`.
- Release asset names come from the API, not from memory.
- Badge URLs return 200.

`docs/getting-started.md` carried the same false claim about binaries — I wrote it
yesterday from the README rather than from the releases page — so its install
section is corrected here. That is why the scope was amended to include it.

Proof is `commit:399a61a`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017UvAwksjf2DR3hxebZq6Kz