### PR TITLE
init writes the ignore rule for the index it derives

### DIFF
--- a/.ank/tasks/TASK-c1783c841710.md
+++ b/.ank/tasks/TASK-c1783c841710.md
@@ -5,7 +5,7 @@ slug: ank-init-does-not-gitignore-the-derived-index
 title: ank init does not gitignore the derived index
 created: 2026-08-04T04:17:32Z
 author: seanl@sean-laptop
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/src/init.rs
   - crates/ank-cli/tests/cli.rs
@@ -14,7 +14,7 @@ done_criteria: |
   After ank init in a fresh git repository, .ank/index.db is ignored by git, asserted through the binary: init runs, a command that builds the index runs, and git reports the file as ignored rather than untracked. Re-running init duplicates nothing, and an existing .gitignore keeps its content.
 criteria_by: creator
 schema: 2
-version: 1
+version: 4
 ---
 
 Section 6 of the specification calls index.db derived, disposable and gitignored. init writes .gitattributes, the config, the refspec and the AGENTS.md pointer, and writes no ignore rule at all -- so the third of those three adjectives is true of no repository init produces. This repository is not the counterexample: its own .gitignore carries the line by hand, written before init existed to write it, which is exactly why the gap survived.
@@ -22,3 +22,7 @@ Section 6 of the specification calls index.db derived, disposable and gitignored
 Found on 2026-08-03 by walking the newcomer path of TASK-e32dc98faceb in a scratch repository. The first git add -A after a done committed .ank/index.db, along with a warning about its line endings -- a binary file, tracked, that every command rewrites. Nothing in the walk announced it; the file simply appeared in the commit.
 
 The fix belongs with the other four effects of init and is the same shape as the .gitattributes one: an idempotent line added to a file that may already exist, ensure_line already does it. What deserves a decision is the path -- a root .gitignore, or .ank/.gitignore next to the file it concerns.
+
+## Log
+- 2026-08-04T17:14:03Z seanl@sean-laptop — Decision on the path, which the body left open: root .gitignore with the line '.ank/index.db', not .ank/.gitignore with 'index.db'. Three reasons. (1) Symmetry: init already writes a root .gitattributes for the same class of reason, and a user asking what init did to their repo finds every effect at root plus .ank/. (2) ADR-01b6 makes .ank/ opaque to agents and a PreToolUse hook enforces it -- an ignore rule living inside .ank/ could not be read by the agent debugging why index.db is tracked. At root it is plain to everyone. (3) It reuses ensure_line unchanged, and it is the line this repository already carries by hand. Checked that a stray file at the top of .ank/ would have been inert anyway: index::scan and store::list_ids both read only tasks/ and adr/, so the choice was not forced by the tool. Also confirmed the pattern stays correct under 'ank init <subdir>': a path-bearing gitignore pattern is anchored to the directory holding the file.
+- 2026-08-04T17:22:43Z seanl@sean-laptop — Proved the new integration test bites rather than passing vacuously, by mutating the fix twice. Dropping the write and the report line together fails at the 'wrote .gitignore' assertion, which only proves the report changed; keeping the report true and dropping the write alone fails at git check-ignore -v with 'git does not consider the index ignored' -- so the assertion that carries the criterion is load-bearing on its own. The test also asserts the index file exists before asking git about it, and that status still sees .ank/config.yml, because both assertions would otherwise pass on an empty repository. Second find, outside the scope globs: docs/getting-started.md prints init's output verbatim and calls it 'Five effects', so it went stale the moment a sixth was added. Updated there too -- a transcript in a guide is an assertion about the binary, and nothing tests it (no doc-transcript test exists in this repo).

--- a/.ank/tasks/TASK-c1783c841710.md
+++ b/.ank/tasks/TASK-c1783c841710.md
@@ -5,7 +5,7 @@ slug: ank-init-does-not-gitignore-the-derived-index
 title: ank init does not gitignore the derived index
 created: 2026-08-04T04:17:32Z
 author: seanl@sean-laptop
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/src/init.rs
   - crates/ank-cli/tests/cli.rs
@@ -13,8 +13,12 @@ blocked_by: []
 done_criteria: |
   After ank init in a fresh git repository, .ank/index.db is ignored by git, asserted through the binary: init runs, a command that builds the index runs, and git reports the file as ignored rather than untracked. Re-running init duplicates nothing, and an existing .gitignore keeps its content.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 5007a44
+    criteria: fbb035486527
 schema: 2
-version: 4
+version: 5
 ---
 
 Section 6 of the specification calls index.db derived, disposable and gitignored. init writes .gitattributes, the config, the refspec and the AGENTS.md pointer, and writes no ignore rule at all -- so the third of those three adjectives is true of no repository init produces. This repository is not the counterexample: its own .gitignore carries the line by hand, written before init existed to write it, which is exactly why the gap survived.
@@ -26,3 +30,4 @@ The fix belongs with the other four effects of init and is the same shape as the
 ## Log
 - 2026-08-04T17:14:03Z seanl@sean-laptop — Decision on the path, which the body left open: root .gitignore with the line '.ank/index.db', not .ank/.gitignore with 'index.db'. Three reasons. (1) Symmetry: init already writes a root .gitattributes for the same class of reason, and a user asking what init did to their repo finds every effect at root plus .ank/. (2) ADR-01b6 makes .ank/ opaque to agents and a PreToolUse hook enforces it -- an ignore rule living inside .ank/ could not be read by the agent debugging why index.db is tracked. At root it is plain to everyone. (3) It reuses ensure_line unchanged, and it is the line this repository already carries by hand. Checked that a stray file at the top of .ank/ would have been inert anyway: index::scan and store::list_ids both read only tasks/ and adr/, so the choice was not forced by the tool. Also confirmed the pattern stays correct under 'ank init <subdir>': a path-bearing gitignore pattern is anchored to the directory holding the file.
 - 2026-08-04T17:22:43Z seanl@sean-laptop — Proved the new integration test bites rather than passing vacuously, by mutating the fix twice. Dropping the write and the report line together fails at the 'wrote .gitignore' assertion, which only proves the report changed; keeping the report true and dropping the write alone fails at git check-ignore -v with 'git does not consider the index ignored' -- so the assertion that carries the criterion is load-bearing on its own. The test also asserts the index file exists before asking git about it, and that status still sees .ank/config.yml, because both assertions would otherwise pass on an empty repository. Second find, outside the scope globs: docs/getting-started.md prints init's output verbatim and calls it 'Five effects', so it went stale the moment a sixth was added. Updated there too -- a transcript in a guide is an assertion about the binary, and nothing tests it (no doc-transcript test exists in this repo).
+- 2026-08-04T17:24:20Z seanl@sean-laptop — done, proof commit:5007a44

--- a/crates/ank-cli/src/init.rs
+++ b/crates/ank-cli/src/init.rs
@@ -2,13 +2,18 @@
 //!
 //! A narrow, fixed perimeter: create `.ank/`, write `config.yml`, add the
 //! `refs/ank/*` refspec, place a pointer in `AGENTS.md`, and write a
-//! `.gitattributes`.
+//! `.gitattributes` and a `.gitignore`.
 //!
-//! That last point is not cosmetic. On Windows `core.autocrlf=true` is the
+//! Neither git file is cosmetic. On Windows `core.autocrlf=true` is the
 //! default, and without `.gitattributes` git converts back to CRLF on every
 //! checkout what the tool has just written in LF — making any fresh clone
-//! unreadable. Fixing it only in Ank's own repository would have left it
-//! broken for every user.
+//! unreadable. Without `.gitignore`, §6 calls the index derived, disposable
+//! and gitignored while no repository `init` produces is any of the third:
+//! the first `git add -A` commits a binary file that every command rewrites.
+//! Fixing either one only in Ank's own repository would have left it broken
+//! for every user — which is precisely how the second survived, since this
+//! repository carries the ignore line by hand, written before `init` existed
+//! to write it.
 
 use crate::cli::{CliError, Invocation, Result};
 use crate::{config, git, repo};
@@ -17,6 +22,10 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 
 pub const GITATTRIBUTES_LINE: &str = ".ank/** text eol=lf";
+/// Root-relative on purpose: a `gitignore` pattern holding a `/` is anchored
+/// to the directory of the file that carries it, so this stays correct when
+/// `init` runs on a subdirectory rather than on the repository root.
+pub const GITIGNORE_LINE: &str = ".ank/index.db";
 pub const REFSPEC: &str = "+refs/ank/*:refs/ank/*";
 const AGENTS_POINTER: &str = "This repo uses Ank: tasks and decisions live in `.ank/`.";
 
@@ -41,6 +50,7 @@ pub struct Report {
     pub created_dirs: bool,
     pub wrote_config: bool,
     pub wrote_gitattributes: bool,
+    pub wrote_gitignore: bool,
     pub wrote_agents_pointer: bool,
     pub added_refspec: bool,
 }
@@ -58,6 +68,9 @@ impl Report {
         }
         if self.wrote_gitattributes {
             v.push("wrote .gitattributes".to_string());
+        }
+        if self.wrote_gitignore {
+            v.push("wrote .gitignore".to_string());
         }
         if self.wrote_agents_pointer {
             v.push("pointer added to AGENTS.md".to_string());
@@ -99,6 +112,9 @@ pub fn init_at(root: &Path) -> Result<Report> {
 
     let ga = root.join(".gitattributes");
     report.wrote_gitattributes = ensure_line(&ga, GITATTRIBUTES_LINE)?;
+
+    let gi = root.join(".gitignore");
+    report.wrote_gitignore = ensure_line(&gi, GITIGNORE_LINE)?;
 
     let agents = root.join("AGENTS.md");
     report.wrote_agents_pointer = ensure_line(&agents, AGENTS_POINTER)?;
@@ -182,7 +198,7 @@ mod tests {
     }
 
     #[test]
-    fn init_produces_all_five_effects() {
+    fn init_produces_all_six_effects() {
         let t = Temp::new_repo();
         let r = init_at(&t.0).unwrap();
 
@@ -197,6 +213,10 @@ mod tests {
         assert!(r.wrote_gitattributes);
         let ga = fs::read_to_string(t.0.join(".gitattributes")).unwrap();
         assert!(ga.contains(GITATTRIBUTES_LINE), "{ga}");
+
+        assert!(r.wrote_gitignore);
+        let gi = fs::read_to_string(t.0.join(".gitignore")).unwrap();
+        assert!(gi.contains(GITIGNORE_LINE), "{gi}");
 
         assert!(r.wrote_agents_pointer);
         assert!(fs::read_to_string(t.0.join("AGENTS.md"))
@@ -234,6 +254,26 @@ mod tests {
         assert!(s.starts_with("# Notes\n\nAlready here.\n"), "{s:?}");
         assert!(s.contains(AGENTS_POINTER));
         assert!(!ensure_line(&f, AGENTS_POINTER).unwrap(), "second pass");
+    }
+
+    /// A `.gitignore` is a file the user curates, far more often than a
+    /// `.gitattributes` is. Appending to it must leave every rule already
+    /// there intact, and must not grow a second copy of ours on re-init.
+    #[test]
+    fn an_existing_gitignore_keeps_its_content() {
+        let t = Temp::new_repo();
+        let gi = t.0.join(".gitignore");
+        fs::write(&gi, "/target\nnode_modules/\n").unwrap();
+
+        init_at(&t.0).unwrap();
+        let s = fs::read_to_string(&gi).unwrap();
+        assert!(s.starts_with("/target\nnode_modules/\n"), "{s:?}");
+        assert!(s.contains(GITIGNORE_LINE), "{s:?}");
+
+        let second = init_at(&t.0).unwrap();
+        assert!(!second.wrote_gitignore);
+        let s = fs::read_to_string(&gi).unwrap();
+        assert_eq!(s.lines().filter(|l| l.trim() == GITIGNORE_LINE).count(), 1);
     }
 
     /// The test the original bug was asking for: a repository initialised,

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -1857,6 +1857,108 @@ fn init_runs_where_there_is_no_ank_directory_yet() {
     let _ = std::fs::remove_dir_all(&dir);
 }
 
+/// §6 calls the index derived, disposable and gitignored. The first two were
+/// true of what `init` produced; the third was true of no repository it had
+/// ever produced, because it wrote no ignore rule at all. This repository was
+/// not the counterexample -- it carries the line by hand, written before
+/// `init` existed to write it, which is exactly how the gap survived.
+///
+/// Through the binary end to end, and deliberately not by reading
+/// `.gitignore`: what has to be true is that *git* treats the file as ignored,
+/// and a line present in a file it does not consult would satisfy any
+/// assertion about the file's content while proving nothing.
+#[test]
+fn an_initialised_repo_leaves_the_index_ignored_and_never_untracked() {
+    let dir = std::env::temp_dir().join(format!("ank-cli-ignore-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+
+    let git = |args: &[&str]| -> Output {
+        Command::new("git")
+            .current_dir(&dir)
+            .args(args)
+            .output()
+            .expect("git must be installed: it is a hard dependency")
+    };
+    assert!(git(&["init", "-q", "-b", "main"]).status.success());
+
+    // A `.gitignore` the user curated first: `init` has to append to it, not
+    // replace it, and that is only observable when there is something to lose.
+    std::fs::write(dir.join(".gitignore"), "/target\n").unwrap();
+
+    let init = || -> Output {
+        Command::new(ANK)
+            .arg("init")
+            .arg(&dir)
+            .env("ANK_AGENT", "claude-code@ank")
+            .current_dir(std::env::temp_dir())
+            .output()
+            .expect("the binary must have been built")
+    };
+    let out = init();
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    assert!(
+        stdout(&out).contains("wrote .gitignore"),
+        "{}",
+        stdout(&out)
+    );
+
+    // A command that builds the index, so the file under test actually exists.
+    let out = Command::new(ANK)
+        .args(["find", "--status", "open"])
+        .arg("--repo")
+        .arg(&dir)
+        .env("ANK_AGENT", "claude-code@ank")
+        .current_dir(std::env::temp_dir())
+        .output()
+        .unwrap();
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    assert!(
+        dir.join(".ank/index.db").exists(),
+        "nothing built the index, so the assertion below would pass vacuously"
+    );
+
+    // Ignored, positively: `check-ignore` names a rule that matches.
+    let ci = git(&["check-ignore", "-v", ".ank/index.db"]);
+    assert!(
+        ci.status.success(),
+        "git does not consider the index ignored: {}{}",
+        String::from_utf8_lossy(&ci.stdout),
+        String::from_utf8_lossy(&ci.stderr)
+    );
+
+    // And untracked, negatively: `status` must not offer it. `-uall` because
+    // the default collapses an untracked directory to its name, which would
+    // hide the very path in question behind `.ank/`.
+    let st = git(&["status", "--porcelain", "-uall"]);
+    let st = String::from_utf8_lossy(&st.stdout).replace('\\', "/");
+    assert!(
+        !st.contains("index.db"),
+        "the index is still offered for commit:\n{st}"
+    );
+    // The fixture is sound only if `status` sees the rest of `.ank/`.
+    assert!(
+        st.contains(".ank/config.yml"),
+        "empty status proves nothing:\n{st}"
+    );
+
+    // The user's own rule survived, and a second init adds nothing.
+    let gi = std::fs::read_to_string(dir.join(".gitignore")).unwrap();
+    assert!(gi.starts_with("/target\n"), "{gi:?}");
+
+    let out = init();
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    assert!(
+        !stdout(&out).contains("wrote .gitignore"),
+        "re-init rewrote it: {}",
+        stdout(&out)
+    );
+    let again = std::fs::read_to_string(dir.join(".gitignore")).unwrap();
+    assert_eq!(gi, again, "re-init changed .gitignore");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
 /// The bug this exists for, end to end and through the binary: a corpus that a
 /// Windows clone handed back in CRLF was entirely unreadable, and every entity
 /// was reported as "missing frontmatter" -- a diagnostic that sends the reader

--- a/docs/ank-spec-v1.1.md
+++ b/docs/ank-spec-v1.1.md
@@ -644,7 +644,7 @@ In orientation mode, where the agent is not writing code yet, truncation is acce
   allowed_signers   # public keys allowed to ratify (§8), versioned
   tasks/TASK-<id>.md
   adr/ADR-<id>.md
-  index.db          # derived, disposable, gitignored
+  index.db          # derived, disposable, gitignored by init (§9)
 ```
 
 **Flat tree.** Attachment happens through `scope`, not through location. One entity can constrain several modules; a tree mirroring the code would force a single parent and break at the first refactor.
@@ -830,7 +830,9 @@ The `skills` CLI handles multi-agent detection (Claude Code, Codex, Cursor, Open
 
 **`ank help` is one flat listing** (ADR-c656cbcc33a9): every verb, in the order of §4, with no headings and no grouping. The loop is what SKILL.md teaches, not what the binary prints — a heading printed by the CLI is a claim about who a verb is for, and that is the claim §4 withdraws. The order carries what a heading would have said, since §4 puts the loop first, and it carries it without asserting a category. `ank help <verb>` answers about that verb alone: its usage, its flags with their value placeholders, and the globals. An unknown verb is a **code 2** and never a fallback to the general listing — an agent that asked about one verb and received all sixteen has to work out that its question went unanswered.
 
-`ank init` keeps a narrow perimeter: create `.ank/`, write `config.yml`, add the `refs/ank/*` refspec (§7), place a pointer in `AGENTS.md`.
+`ank init` keeps a narrow perimeter: create `.ank/`, write `config.yml`, add the `refs/ank/*` refspec (§7), place a pointer in `AGENTS.md`, write a `.gitattributes` (§2) and a `.gitignore` (§6).
+
+Both git files are written at the root of the initialised directory, and both carry a single line added idempotently to whatever is already there. The `.gitignore` line is `.ank/index.db`: §6 calls the index derived, disposable and gitignored, and the third adjective is only true of a repository where something wrote the rule. It goes at the root rather than inside `.ank/` for the same reason `.gitattributes` does — one place to look for what `init` changed — and because ADR-01b6dd05f0db makes `.ank/` opaque to agents, so a rule hidden there could not be read by the agent asking why the index is tracked.
 
 **Binary distribution**: the skill says *how* to use Ank, it does not install the CLI. Plan for `curl | sh` and Homebrew in addition to npm.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -46,14 +46,21 @@ From the root of a git repository:
     created .ank/tasks .ank/adr
     wrote .ank/config.yml
     wrote .gitattributes
+    wrote .gitignore
     pointer added to AGENTS.md
     refspec added: +refs/ank/*:refs/ank/*
 
-Five effects, and re-running changes nothing — `init` is idempotent and says
+Six effects, and re-running changes nothing — `init` is idempotent and says
 `already initialised, nothing to do`. The `.gitattributes` line keeps `.ank/`
 in LF on checkout: on Windows git would otherwise convert back to CRLF
-everything the tool has just written, on every clone. The refspec is what makes
-claims travel, since hosts do not fetch non-standard refs on their own.
+everything the tool has just written, on every clone. The `.gitignore` line is
+`.ank/index.db`, the derived SQLite index: it is rebuilt from the files
+whenever it is missing, so committing it would only track a binary that every
+command rewrites. The refspec is what makes claims travel, since hosts do not
+fetch non-standard refs on their own.
+
+Both git files are appended to, never replaced — an existing `.gitignore`
+keeps everything already in it.
 
 Two edits to make now, before the first real command.
 


### PR DESCRIPTION
Closes TASK-c1783c841710.

## The bug

Section 6 of the specification calls `index.db` derived, disposable and
gitignored. `init` wrote `.gitattributes`, the config, the refspec and the
`AGENTS.md` pointer, and no ignore rule at all -- so the third of those three
adjectives was true of no repository `init` produced. The first `git add -A`
in a fresh repo committed a binary file that every command rewrites.

This repository was not the counterexample: it carries the line by hand,
written before `init` existed to write it, which is exactly how the gap
survived.

## The path, which the task left open

Root `.gitignore` with `.ank/index.db`, not `.ank/.gitignore` with `index.db`:

- symmetric with `.gitattributes`, so there is one place to look for what
  `init` changed;
- readable by every agent -- ADR-01b6dd05f0db makes `.ank/` opaque, and a rule
  hidden there could not be read by whoever is asking why the index is tracked;
- a `gitignore` pattern holding a slash is anchored to the directory of the
  file carrying it, so the line stays correct under `ank init <subdir>`.

The choice was not forced by the tool: `index::scan` and `store::list_ids`
read only `tasks/` and `adr/`, so a file at the top of `.ank/` would have been
inert either way.

## Order

Specification first (§6 and §9), then the code. No format change, so no
goldens are involved.

## The test

The criterion says "asserted through the binary", and the test deliberately
does not read `.gitignore`: what has to be true is that *git* treats the file
as ignored, and a line in a file git never consults would satisfy any
assertion about content while proving nothing. Both directions are checked --
`check-ignore -v` names a matching rule, `status --porcelain -uall` does not
offer the path -- and each is guarded against passing vacuously.

Verified the test bites, by mutating the fix twice. Dropping the write and the
report line together fails only at the report assertion, which proves nothing
about the ignore. Keeping the report true and dropping the write alone fails
at `check-ignore`, so the assertion carrying the criterion is load-bearing on
its own.

## Outside the scope globs, fixed anyway

`docs/getting-started.md` prints `init`'s output verbatim and called it "Five
effects", so it went stale on the sixth. Nothing tests that transcript.

## Checks

`cargo test` green, `cargo fmt --check` clean, `ank check` exit 0. The one new
signal is `finished on another branch, main has not caught up`, which clears
on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KDo3iBf2PJSF7HMDdzG5Yd
