### PR TITLE
CI proves the MSRV is tight, not only that it is sufficient

### DIFF
--- a/.ank/tasks/TASK-3b085be1bf6a.md
+++ b/.ank/tasks/TASK-3b085be1bf6a.md
@@ -1,0 +1,40 @@
+---
+id: TASK-3b085be1bf6a
+type: task
+slug: the-msrv-job-hardcodes-the-number-the-manifests
+title: The msrv job hardcodes the number the manifests declare
+created: 2026-08-04T18:17:37Z
+author: seanl@sean-laptop
+status: open
+scope:
+  - .github/workflows/ci.yml
+blocked_by: []
+done_criteria: |
+  The msrv job derives the toolchain it installs and builds with from rust-version in the manifests rather than naming it literally, so that bumping rust-version cannot leave the job measuring a toolchain the tree no longer declares. Asserted by changing the declared value and observing the job follow it, without editing the workflow.
+criteria_by: creator
+schema: 2
+version: 1
+---
+
+Found while implementing TASK-d81a05ef8e8d, and deliberately left out of it:
+that criterion is about the tightness of the declared MSRV, and this is the
+job next door.
+
+The msrv job names 1.95 in three places -- the job name, the rustup install,
+and the cargo +1.95 invocation -- while rust-version lives in two manifests.
+Bump the manifests and the job keeps installing and building 1.95, which is no
+longer the declared floor. It stays green while measuring a toolchain the tree
+no longer names, which is the same rot TASK-daf25ab8a9b7 corrected when the
+MSRV was an assertion nobody ran: the claim and the check drift apart, and the
+green tick is what hides it.
+
+The new msrv-tight job already derives the number from
+crates/ank-cli/Cargo.toml with a sed and one subtraction, so the shape is
+settled and the cost is a step and two env references. Doing both jobs the same
+way is also what stops the file from teaching two different habits.
+
+Worth deciding while claiming: the two manifests declare rust-version
+independently, and nothing checks they agree. Deriving from ank-cli alone, as
+msrv-tight does, is correct only while they match. Whether this task also makes
+the disagreement visible -- a line in the job, or a check finding -- or whether
+that is a third piece of work, belongs to whoever picks it up.

--- a/.ank/tasks/TASK-d81a05ef8e8d.md
+++ b/.ank/tasks/TASK-d81a05ef8e8d.md
@@ -5,7 +5,7 @@ slug: ci-proves-the-msrv-is-sufficient-never-that-it-i
 title: CI proves the MSRV is sufficient, never that it is tight
 created: 2026-08-04T04:52:06Z
 author: seanl@sean-laptop
-status: open
+status: in_progress
 scope:
   - .github/workflows/ci.yml
 blocked_by: []
@@ -13,7 +13,7 @@ done_criteria: |
   CI fails when the declared MSRV is higher than the tree actually needs, not only when it is lower. The check runs the toolchain one minor below rust-version with --ignore-rust-version and requires it to fail; a build that unexpectedly succeeds names the number to lower and the command that measured it. It runs on the platform where the floor is set, and a rustup release that has not shipped yet is an environment failure and not a passing check.
 criteria_by: creator
 schema: 2
-version: 1
+version: 4
 ---
 
 The msrv job builds on the exact toolchain rust-version names, which proves the number is sufficient. Nothing proves it is tight. The floor comes from one build script in libsqlite3-sys, so the day that crate stops calling cfg_select! -- or the day the dependency is replaced -- the declared 1.95 becomes higher than the tree needs, every job stays green, and the only signal is that nobody can build ank on a toolchain that would have worked.
@@ -23,3 +23,7 @@ That asymmetry is the same one TASK-daf25ab8a9b7 corrected in the other directio
 Found while answering TASK-973e9dc3f9ce, whose criterion was to choose between two dependency versions and to make the manifests agree with the measurement. Making the measurement continuous is a different piece of work and is not in that criterion.
 
 The design question belongs to whoever claims this. Requiring the previous minor to fail is a negative test, and negative tests are brittle in a way positive ones are not: a build that fails for an unrelated reason -- a network hiccup, a C compiler missing -- passes this check while proving nothing. The failure has to be attributed, not merely observed, and how tightly is the decision to record before implementing.
+
+## Log
+- 2026-08-04T18:13:22Z seanl@sean-laptop — Attribution decided before implementing, which the criterion asks for, and measured rather than reasoned. Walked 1.94 locally: the workspace fails with error[E0658] 'use of unstable library feature cfg_select' in the libsqlite3-sys 0.38.1 build script, exit 101 -- exactly what the manifest comment records, so the comment is not stale. Rejected two altitudes. Requiring only a non-zero exit is what the body calls brittle: a network hiccup or a missing C compiler passes the negative test while proving nothing. Requiring E0658 specifically is too tight in the other direction -- it breaks the day the floor moves for a different reason, which is precisely the event this job exists to notice, and it would go red with a message pointing at the wrong cause. Landing on two independent gates instead. A positive control: ank-core alone builds on the previous minor (verified, exit 0 in 13s, no C dependency), so if that fails the toolchain, the network or the registry is broken and the job reports an environment failure rather than a pass. Then the negative test, required to carry a rustc diagnostic code (error[E), which separates 'the compiler rejected this tree' from 'the environment fell over' -- cargo's own infrastructure failures and a missing cc produce 'error: failed to ...' with no code. Residual gap recorded on purpose: a floor set by something that emits no E-code, a lockfile version for instance, would be read as untight and the job would say lower the number when it should not. That fails loudly and gets investigated, which is the direction to fail in; a false pass is the defect being fixed.
+- 2026-08-04T18:16:55Z seanl@sean-laptop — Falsified the job end to end rather than only unit-testing its branches, which for a negative test is the whole point. Extracted the decision step verbatim and drove it with real cargo results. Three outcomes exercised: the real tree on 1.94 fails with error[E0658] and the step passes naming the code; a simulated declared 1.96, where prev is 1.95 and genuinely does build the workspace (measured, exit 0, not stubbed), makes the step exit 1 with the number to lower and the command that measured it; a failure carrying no rustc diagnostic exits 9 as environment. So the check fails in the direction the criterion asks for and not only in the direction that was already covered. Discovered and out of this criterion: the existing msrv job hardcodes 1.95 in its name and in both commands, while the new job derives the number from the manifest. Bumping rust-version therefore leaves the sufficiency job building a toolchain the manifests no longer name, silently testing the wrong thing -- the same class of rot as this task, in the job next door. Filing it separately rather than widening a frozen criterion.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,3 +107,119 @@ jobs:
       # on its own, and a resolution performed here would measure a different
       # tree from the one that ships.
       - run: cargo +1.95 build --workspace --locked
+
+  # The job above proves the declared MSRV is *sufficient*. Nothing proved it
+  # was *tight*, and the asymmetry is the one TASK-daf25ab8a9b7 corrected in the
+  # other direction: an MSRV asserted and never run rots in silence. The floor
+  # comes from one build script in libsqlite3-sys, so the day that crate stops
+  # calling `cfg_select!` — or the day the dependency is replaced — the declared
+  # number becomes higher than the tree needs, every job stays green, and the
+  # only signal is that nobody can build ank on a toolchain that would have
+  # worked.
+  #
+  # This is a negative test, and negative tests fail for free: a build that dies
+  # of a network hiccup or a missing C compiler "passes" a naive check while
+  # proving nothing. So the failure is attributed by two independent gates
+  # rather than merely observed.
+  #
+  #  1. A positive control. `ank-core` alone has no C dependency and builds on
+  #     the previous minor. If *that* fails, the toolchain, the network or the
+  #     registry is broken, and this job says so instead of reporting a floor.
+  #  2. The workspace failure has to carry a rustc diagnostic code. That is what
+  #     separates "the compiler rejected this tree" from "the environment fell
+  #     over": cargo's own infrastructure errors and a missing `cc` produce
+  #     `error: failed to ...` with no code.
+  #
+  # Deliberately not pinned to `E0658`, the code the floor currently produces.
+  # Pinning it would break the day the floor moves for another reason — exactly
+  # the event this job exists to notice — and it would go red pointing at the
+  # wrong cause. ADR: the floor is a consequence of a dependency, not a target.
+  #
+  # One platform, and ubuntu because it is the cheapest that can falsify the
+  # claim: the number is one per workspace, and `cfg_select!` is a rustc feature
+  # gate, so it fires the same on all three. If a floor ever does differ per
+  # target, the job above runs the matrix and is what catches the disagreement —
+  # this one only ever says "look again", never "lower it for me".
+  msrv-tight:
+    name: msrv is tight / ubuntu-latest
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      # Read from the manifest rather than written here. A number in two places
+      # is a number that will disagree with itself, and re-measuring means
+      # re-running the walk, never editing a constant.
+      - name: the minor below the declared MSRV
+        id: floor
+        run: |
+          declared=$(sed -n 's/^rust-version *= *"\([0-9][0-9]*\.[0-9][0-9]*\)".*/\1/p' \
+            crates/ank-cli/Cargo.toml | head -1)
+          if [ -z "$declared" ]; then
+            echo "no rust-version found in crates/ank-cli/Cargo.toml"
+            exit 9
+          fi
+          prev="${declared%%.*}.$(( ${declared#*.} - 1 ))"
+          echo "declared=$declared" >> "$GITHUB_OUTPUT"
+          echo "prev=$prev" >> "$GITHUB_OUTPUT"
+          echo "declared $declared, testing $prev"
+
+      # A toolchain that has not shipped is an environment failure and never a
+      # passing check: without this step its absence would make the build below
+      # fail, which is what the job is looking for, and the check would pass
+      # while measuring nothing at all.
+      # Through the environment rather than interpolated into the script. The
+      # value is `[0-9]+\.[0-9]+` by construction above, so nothing here is
+      # injectable — this is the habit, not the fix for a live hole.
+      - name: install the previous minor
+        env:
+          PREV: ${{ steps.floor.outputs.prev }}
+        run: |
+          rustup toolchain install "$PREV" --profile minimal \
+            || { echo "rustup has no $PREV: environment, not a result"; exit 9; }
+          cargo +"$PREV" --version \
+            || { echo "toolchain installed but unusable: environment, not a result"; exit 9; }
+
+      - name: positive control on the same toolchain
+        env:
+          PREV: ${{ steps.floor.outputs.prev }}
+        run: |
+          cargo +"$PREV" build -p ank-core --locked --ignore-rust-version \
+            || {
+              echo "ank-core does not build on $PREV."
+              echo "That is the toolchain, the network or the registry, not the MSRV:"
+              echo "the failure below would have been unattributable, so this job stops here."
+              exit 9
+            }
+
+      - name: the declared MSRV must be the lowest that works
+        env:
+          DECLARED: ${{ steps.floor.outputs.declared }}
+          PREV: ${{ steps.floor.outputs.prev }}
+        run: |
+          set +e
+          out=$(cargo +"$PREV" build --workspace --locked --ignore-rust-version 2>&1)
+          code=$?
+          set -e
+          echo "$out"
+
+          if [ "$code" -eq 0 ]; then
+            echo "::error::the declared MSRV $DECLARED is higher than this tree needs"
+            echo "$PREV builds the whole workspace. Re-walk before lowering it:"
+            echo "  cargo +$PREV build --workspace --locked --ignore-rust-version"
+            echo "then set rust-version in crates/ank-cli/Cargo.toml and"
+            echo "crates/ank-core/Cargo.toml to the lowest minor that builds and"
+            echo "passes the suite, and update the pin in this workflow."
+            exit 1
+          fi
+
+          if ! printf '%s' "$out" | grep -q 'error\[E[0-9]'; then
+            echo "::error::$PREV failed, but not with a compiler diagnostic"
+            echo "The positive control passed, so the toolchain works. A failure"
+            echo "carrying no error[E....] is not evidence the floor is real:"
+            echo "read the output above before trusting this number."
+            exit 9
+          fi
+
+          echo "$PREV is refused by the compiler, so $DECLARED is tight:"
+          printf '%s' "$out" | grep -o 'error\[E[0-9]*\]' | sort -u

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,13 @@ run on all three.
   consequence of a dependency, not a target to hold.** It moves when the
   dependency moves, `ci.yml` is what turns red, and re-measuring means re-running
   the walk with `--ignore-rust-version` — never editing the number.
+  `ci.yml` turns red in **both** directions: `msrv` builds on the declared
+  toolchain, proving it is sufficient, and `msrv-tight` requires the minor below
+  it to fail, proving it is not higher than the tree needs. The second is a
+  negative test, so it attributes the failure rather than merely observing it —
+  a positive control on `ank-core` first, then a required rustc diagnostic code.
+  A build that unexpectedly succeeds names the number to lower; it never lowers
+  it, because the walk is what decides and a human runs the walk.
 
 ## Style
 


### PR DESCRIPTION
Closes TASK-d81a05ef8e8d. Files TASK-3b085be1bf6a.

## The asymmetry

The `msrv` job builds on the exact toolchain `rust-version` names, proving the
number is **sufficient**. Nothing proved it was **tight**. The floor comes from
one build script in `libsqlite3-sys`, so the day that crate stops calling
`cfg_select!` -- or the day the dependency is replaced -- the declared number
becomes higher than the tree needs, every job stays green, and the only signal
is that nobody can build ank on a toolchain that would have worked.

Half the claim was enforced and half was still an assertion. Same rot
TASK-daf25ab8a9b7 corrected in the other direction.

## Attribution, decided before implementing

A negative test fails for free: a build that dies of a network hiccup or a
missing C compiler "passes" a naive check while proving nothing. Two
independent gates instead of a bare non-zero exit:

1. **A positive control.** `ank-core` has no C dependency and builds on the
   previous minor. If *that* fails, the toolchain, network or registry is
   broken, and the job says so rather than reporting a floor.
2. **A rustc diagnostic code is required.** That separates "the compiler
   rejected this tree" from "the environment fell over" -- cargo's own
   infrastructure errors and a missing `cc` produce `error: failed to ...`
   with no code.

Deliberately **not** pinned to `E0658`, the code the floor emits today.
Pinning it would break the day the floor moves for another reason -- exactly
the event this job exists to notice -- and it would go red naming the wrong
cause. The floor is a consequence of a dependency, not a target to hold.

## Falsified end to end

With real builds, not stubbed exit codes:

| case | build | verdict |
|---|---|---|
| the tree on 1.94 | exit 101, `error[E0658]` | passes, names the code |
| declared 1.96, prev 1.95 really builds | exit 0 | **exit 1**, names 1.95 and the command |
| failure with no diagnostic | exit 101 | exit 9, environment |

The middle row is the direction that was never covered.

The number is derived from `crates/ank-cli/Cargo.toml` rather than written in
the workflow: re-measuring means re-running the walk, never editing a
constant. The job says *look again* and never lowers the number itself -- the
walk decides, and a human runs the walk.

## Also here

TASK-3b085be1bf6a, filed rather than folded in: the existing `msrv` job
hardcodes `1.95` in three places while the manifests declare it in two, so a
bump leaves it measuring a toolchain the tree no longer names. Out of this
task's frozen criterion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KDo3iBf2PJSF7HMDdzG5Yd
