### PR TITLE
TASK-d81a05ef8e8d is done, proved by commit a45301a

### DIFF
--- a/.ank/tasks/TASK-d81a05ef8e8d.md
+++ b/.ank/tasks/TASK-d81a05ef8e8d.md
@@ -5,15 +5,19 @@ slug: ci-proves-the-msrv-is-sufficient-never-that-it-i
 title: CI proves the MSRV is sufficient, never that it is tight
 created: 2026-08-04T04:52:06Z
 author: seanl@sean-laptop
-status: in_progress
+status: done
 scope:
   - .github/workflows/ci.yml
 blocked_by: []
 done_criteria: |
   CI fails when the declared MSRV is higher than the tree actually needs, not only when it is lower. The check runs the toolchain one minor below rust-version with --ignore-rust-version and requires it to fail; a build that unexpectedly succeeds names the number to lower and the command that measured it. It runs on the platform where the floor is set, and a rustup release that has not shipped yet is an environment failure and not a passing check.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: a45301a
+    criteria: d837d5971fdc
 schema: 2
-version: 4
+version: 5
 ---
 
 The msrv job builds on the exact toolchain rust-version names, which proves the number is sufficient. Nothing proves it is tight. The floor comes from one build script in libsqlite3-sys, so the day that crate stops calling cfg_select! -- or the day the dependency is replaced -- the declared 1.95 becomes higher than the tree needs, every job stays green, and the only signal is that nobody can build ank on a toolchain that would have worked.
@@ -27,3 +31,4 @@ The design question belongs to whoever claims this. Requiring the previous minor
 ## Log
 - 2026-08-04T18:13:22Z seanl@sean-laptop — Attribution decided before implementing, which the criterion asks for, and measured rather than reasoned. Walked 1.94 locally: the workspace fails with error[E0658] 'use of unstable library feature cfg_select' in the libsqlite3-sys 0.38.1 build script, exit 101 -- exactly what the manifest comment records, so the comment is not stale. Rejected two altitudes. Requiring only a non-zero exit is what the body calls brittle: a network hiccup or a missing C compiler passes the negative test while proving nothing. Requiring E0658 specifically is too tight in the other direction -- it breaks the day the floor moves for a different reason, which is precisely the event this job exists to notice, and it would go red with a message pointing at the wrong cause. Landing on two independent gates instead. A positive control: ank-core alone builds on the previous minor (verified, exit 0 in 13s, no C dependency), so if that fails the toolchain, the network or the registry is broken and the job reports an environment failure rather than a pass. Then the negative test, required to carry a rustc diagnostic code (error[E), which separates 'the compiler rejected this tree' from 'the environment fell over' -- cargo's own infrastructure failures and a missing cc produce 'error: failed to ...' with no code. Residual gap recorded on purpose: a floor set by something that emits no E-code, a lockfile version for instance, would be read as untight and the job would say lower the number when it should not. That fails loudly and gets investigated, which is the direction to fail in; a false pass is the defect being fixed.
 - 2026-08-04T18:16:55Z seanl@sean-laptop — Falsified the job end to end rather than only unit-testing its branches, which for a negative test is the whole point. Extracted the decision step verbatim and drove it with real cargo results. Three outcomes exercised: the real tree on 1.94 fails with error[E0658] and the step passes naming the code; a simulated declared 1.96, where prev is 1.95 and genuinely does build the workspace (measured, exit 0, not stubbed), makes the step exit 1 with the number to lower and the command that measured it; a failure carrying no rustc diagnostic exits 9 as environment. So the check fails in the direction the criterion asks for and not only in the direction that was already covered. Discovered and out of this criterion: the existing msrv job hardcodes 1.95 in its name and in both commands, while the new job derives the number from the manifest. Bumping rust-version therefore leaves the sufficiency job building a toolchain the manifests no longer name, silently testing the wrong thing -- the same class of rot as this task, in the job next door. Filing it separately rather than widening a frozen criterion.
+- 2026-08-04T18:26:38Z seanl@sean-laptop — done, proof commit:a45301a


### PR DESCRIPTION
The `done` record for TASK-d81a05ef8e8d, whose work merged in #27.

The criterion is about CI behaviour, so it was proved by CI before this was
written rather than after: run 30938277406 derived 1.95 from the manifest,
installed 1.94, passed the positive control on `ank-core` in 8.86s, and had
the workspace build refused with `error[E0658]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KDo3iBf2PJSF7HMDdzG5Yd
