### PR TITLE
ank --version names the skill it was built alongside

### DIFF
--- a/.ank/tasks/TASK-ecda4070354f.md
+++ b/.ank/tasks/TASK-ecda4070354f.md
@@ -17,8 +17,11 @@ proof:
   - type: commit
     ref: 1b655c2
     criteria: 0ebd573cf48c
+  - type: test
+    ref: "30954352678"
+    criteria: 0ebd573cf48c
 schema: 2
-version: 4
+version: 5
 ---
 
 TASK-548c518cb705 made the binary say what it is. TASK-b495234f192c made the skill say which revision it is. Neither says anything about the other, so telling a stale installed skill from a current one still needs a third value from somewhere -- the repository, a release note, a person who remembers.
@@ -32,3 +35,4 @@ The design question for whoever claims this: where the value belongs. ank --vers
 ## Log
 - 2026-08-04T21:42:22Z seanl@sean-laptop — Decided where the value belongs: the existing single line of `ank --version`, extended to `ank <ver> (<commit>, skill <rev>)`. `ank status` was the other candidate and is out on the criterion itself -- it runs after startup, so it needs a resolved repository, and the reader this exists for holds a binary and a SKILL.md and nothing else. Keeping one line also leaves section 4's shape untouched: the specification edit says what the line contains, not that it grew a second line.
 - 2026-08-04T21:54:37Z seanl@sean-laptop — done, proof commit:1b655c2
+- 2026-08-04T22:54:31Z seanl@sean-laptop — attested test:30954352678

--- a/.ank/tasks/TASK-ecda4070354f.md
+++ b/.ank/tasks/TASK-ecda4070354f.md
@@ -5,7 +5,7 @@ slug: nothing-connects-the-binary-s-identity-to-the-sk
 title: Nothing connects the binary's identity to the skill's
 created: 2026-08-04T05:17:24Z
 author: seanl@sean-laptop
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/src/**
   - crates/ank-cli/tests/cli.rs
@@ -13,8 +13,12 @@ blocked_by: []
 done_criteria: |
   A reader holding only the binary and the installed skill can tell whether the two agree, with no repository and no network. The binary prints the SKILL.md revision it was built alongside, that value is derived at build time from skill/SKILL.md rather than typed, and tests/skill.rs proves the printed value and the file agree. Asserted through the binary.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 1b655c2
+    criteria: 0ebd573cf48c
 schema: 2
-version: 3
+version: 4
 ---
 
 TASK-548c518cb705 made the binary say what it is. TASK-b495234f192c made the skill say which revision it is. Neither says anything about the other, so telling a stale installed skill from a current one still needs a third value from somewhere -- the repository, a release note, a person who remembers.
@@ -27,3 +31,4 @@ The design question for whoever claims this: where the value belongs. ank --vers
 
 ## Log
 - 2026-08-04T21:42:22Z seanl@sean-laptop — Decided where the value belongs: the existing single line of `ank --version`, extended to `ank <ver> (<commit>, skill <rev>)`. `ank status` was the other candidate and is out on the criterion itself -- it runs after startup, so it needs a resolved repository, and the reader this exists for holds a binary and a SKILL.md and nothing else. Keeping one line also leaves section 4's shape untouched: the specification edit says what the line contains, not that it grew a second line.
+- 2026-08-04T21:54:37Z seanl@sean-laptop — done, proof commit:1b655c2

--- a/.ank/tasks/TASK-ecda4070354f.md
+++ b/.ank/tasks/TASK-ecda4070354f.md
@@ -5,7 +5,7 @@ slug: nothing-connects-the-binary-s-identity-to-the-sk
 title: Nothing connects the binary's identity to the skill's
 created: 2026-08-04T05:17:24Z
 author: seanl@sean-laptop
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/src/**
   - crates/ank-cli/tests/cli.rs
@@ -14,7 +14,7 @@ done_criteria: |
   A reader holding only the binary and the installed skill can tell whether the two agree, with no repository and no network. The binary prints the SKILL.md revision it was built alongside, that value is derived at build time from skill/SKILL.md rather than typed, and tests/skill.rs proves the printed value and the file agree. Asserted through the binary.
 criteria_by: creator
 schema: 2
-version: 1
+version: 3
 ---
 
 TASK-548c518cb705 made the binary say what it is. TASK-b495234f192c made the skill say which revision it is. Neither says anything about the other, so telling a stale installed skill from a current one still needs a third value from somewhere -- the repository, a release note, a person who remembers.
@@ -24,3 +24,6 @@ Closing it is cheap because both halves exist. The build script already stamps t
 What that buys is the check the original failure needed: an agent that has loaded a SKILL.md and can run ank --version compares two strings it already holds and learns, offline, that its instructions predate its tool.
 
 The design question for whoever claims this: where the value belongs. ank --version prints one line and section 4 says so in as many words, so a second line is a specification change before it is a code change (ADR-63b59c5c26f7). ank status is the other candidate and answers where am I, which is arguably the same question.
+
+## Log
+- 2026-08-04T21:42:22Z seanl@sean-laptop — Decided where the value belongs: the existing single line of `ank --version`, extended to `ank <ver> (<commit>, skill <rev>)`. `ank status` was the other candidate and is out on the criterion itself -- it runs after startup, so it needs a resolved repository, and the reader this exists for holds a binary and a SKILL.md and nothing else. Keeping one line also leaves section 4's shape untouched: the specification edit says what the line contains, not that it grew a second line.

--- a/crates/ank-cli/Cargo.toml
+++ b/crates/ank-cli/Cargo.toml
@@ -17,6 +17,14 @@ description = "The Ank CLI: one surface, refusing on state and never on identity
 name = "ank"
 path = "src/main.rs"
 
+# No new crate: `ank-core` is already a dependency below, and the skill revision
+# the build script stamps in has to be the *same* hash the frozen fields use
+# (§4). A second implementation of the freeze hash inside `build.rs` would be a
+# second thing to get wrong, and it would be wrong silently — the value it
+# printed would still look like a revision.
+[build-dependencies]
+ank-core = { path = "../ank-core" }
+
 [dependencies]
 ank-core = { path = "../ank-core" }
 # Already in the tree through ank-core: no new crate enters here.

--- a/crates/ank-cli/build.rs
+++ b/crates/ank-cli/build.rs
@@ -1,4 +1,5 @@
-//! Embeds the commit the binary was built from (§4).
+//! Embeds the commit the binary was built from, and the revision of the
+//! `skill/SKILL.md` it was built alongside (§4).
 //!
 //! `rev-parse` and `symbolic-ref`, and nothing else: both are on the list of
 //! commands ADR-b8884edcebe3 allows, their output is a sha or a path and stable
@@ -25,13 +26,24 @@
 //! With no git and no checkout, nothing is emitted and Cargo falls back to
 //! watching the package — the right behaviour for a tarball, where the answer is
 //! `unknown` however often it is recomputed.
+//!
+//! The skill revision is watched the same way and for the same reason: the file
+//! it is derived from is outside this package, so nothing Cargo watches by
+//! default would notice it moving (TASK-ecda4070354f).
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+/// The skill whose revision is stamped in, relative to this package.
+const SKILL: &str = "../../skill/SKILL.md";
+
 fn main() {
     let dir = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".into());
     println!("cargo:rustc-env=ANK_COMMIT={}", commit(&dir));
+    println!("cargo:rustc-env=ANK_SKILL={}", skill_revision(&dir));
+    if PathBuf::from(&dir).join(SKILL).is_file() {
+        println!("cargo:rerun-if-changed={SKILL}");
+    }
     for path in watched(&dir) {
         println!("cargo:rerun-if-changed={path}");
     }
@@ -56,6 +68,41 @@ fn git(dir: &str, args: &[&str]) -> Option<String> {
 /// commit it does not know is worse than one that admits it.
 fn commit(dir: &str) -> String {
     git(dir, &["rev-parse", "--short", "HEAD"]).unwrap_or_else(|| "unknown".into())
+}
+
+/// The revision of the skill this binary was built alongside: the short freeze
+/// hash of `SKILL.md`'s body, which is the value the file declares under
+/// `metadata.revision` (§4).
+///
+/// Derived here rather than typed anywhere, which is the whole point: a number
+/// kept by hand drifts the first time somebody edits the body and forgets it,
+/// and a stale marker is worse than none because it answers confidently.
+///
+/// The body, not the whole file — the frontmatter carries the revision itself,
+/// and hashing it would make the value an input to its own computation. The
+/// split is the entity format's own delimiters, on text with line endings
+/// unified first: `.gitattributes` covers `.ank/**` and not `skill/`, so a
+/// Windows checkout of this file can legitimately be CRLF.
+///
+/// `unknown` when there is no `skill/` to read — a published crate, a vendored
+/// dependency — for the same reason the commit is. A file that is present and
+/// unreadable as a skill is a different case and fails loudly: it is a defect in
+/// the tree, not a build without a checkout.
+fn skill_revision(dir: &str) -> String {
+    let path = PathBuf::from(dir).join(SKILL);
+    if !path.is_file() {
+        return "unknown".into();
+    }
+    let text = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("{}: {e}", path.display()))
+        .replace("\r\n", "\n");
+    let rest = text
+        .strip_prefix("---\n")
+        .unwrap_or_else(|| panic!("{}: must open with frontmatter", path.display()));
+    let end = rest
+        .find("\n---\n")
+        .unwrap_or_else(|| panic!("{}: frontmatter must be closed", path.display()));
+    ank_core::freeze_hash_short(&rest[end + "\n---\n".len()..])
 }
 
 /// The files whose change can change the answer, and no others.

--- a/crates/ank-cli/src/cli.rs
+++ b/crates/ank-cli/src/cli.rs
@@ -684,10 +684,23 @@ pub fn help(inv: &Invocation, out: &mut dyn Write) -> Result<i32> {
 // Dispatch
 // ---------------------------------------------------------------------------
 
-/// What the binary is, on one line (§4): the crate version, and the commit
-/// `build.rs` stamped in. `unknown` where there was no checkout to ask.
+/// What the binary is, on one line (§4): the crate version, the commit
+/// `build.rs` stamped in, and the revision of the `SKILL.md` it was built
+/// alongside. `unknown` where there was no checkout, or no `skill/`, to ask.
+///
+/// The third value is the one a reader can act on with nothing else in hand
+/// (TASK-ecda4070354f). The commit places the binary against the repository,
+/// which is a thing to go and look at; the skill revision is compared against
+/// `metadata.revision` in the file the agent has already loaded, so a stale
+/// instruction set announces itself offline instead of costing an
+/// investigation.
 pub fn version_line() -> String {
-    format!("ank {} ({})", env!("CARGO_PKG_VERSION"), env!("ANK_COMMIT"))
+    format!(
+        "ank {} ({}, skill {})",
+        env!("CARGO_PKG_VERSION"),
+        env!("ANK_COMMIT"),
+        env!("ANK_SKILL")
+    )
 }
 
 fn not_implemented(spec: &CommandSpec) -> CliError {

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -1051,10 +1051,23 @@ fn the_stamp_follows_a_commit_that_changes_no_file() {
     std::fs::create_dir_all(dir.join("src")).unwrap();
     std::fs::copy(&script, dir.join("build.rs")).unwrap();
     // An empty `[workspace]` so the fixture is not adopted by any workspace it
-    // happens to sit under, and no dependencies so the build needs no registry.
+    // happens to sit under, and the one build-dependency the real script has:
+    // it hashes SKILL.md with `ank_core::freeze_hash_short` (TASK-ecda4070354f),
+    // and the fixture drives the real script rather than a copy of its logic, so
+    // it has to build like the real one. By path, and the builds below are
+    // `--offline`, so this still needs no registry beyond the cache the
+    // workspace build has already warmed.
+    let core = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../ank-core")
+        .to_string_lossy()
+        .replace('\\', "/");
     std::fs::write(
         dir.join("Cargo.toml"),
-        "[workspace]\n\n[package]\nname = \"stamp\"\nversion = \"0.0.0\"\nedition = \"2021\"\n",
+        format!(
+            "[workspace]\n\n[package]\nname = \"stamp\"\nversion = \"0.0.0\"\n\
+             edition = \"2021\"\n\n[build-dependencies]\n\
+             ank-core = {{ path = \"{core}\" }}\n"
+        ),
     )
     .unwrap();
     std::fs::write(
@@ -1085,7 +1098,7 @@ fn the_stamp_follows_a_commit_that_changes_no_file() {
     let build_and_read = || {
         let out = Command::new(&cargo)
             .current_dir(&dir)
-            .args(["run", "-q"])
+            .args(["run", "-q", "--offline"])
             .env("CARGO_TARGET_DIR", dir.join("target"))
             .output()
             .expect("cargo must be on PATH");
@@ -1154,14 +1167,22 @@ fn the_version_answers_before_anything_can_stop_it() {
         said.contains('(') && said.ends_with(')'),
         "and the commit it was built from: {said}"
     );
-    // Empty parentheses would satisfy the shape and answer nothing.
-    let commit = said
+    // Empty parentheses would satisfy the shape and answer nothing. The commit
+    // is the first value inside them; the skill revision beside it is
+    // TASK-ecda4070354f's and is asserted against the file itself in
+    // tests/skill.rs, which is the only place that comparison means anything.
+    let inside = said
         .rsplit_once('(')
         .and_then(|(_, c)| c.strip_suffix(')'))
         .unwrap_or("");
+    let commit = inside.split(',').next().unwrap_or("").trim();
     assert!(
         commit.len() >= 4,
         "a sha or the word `unknown`, never a blank: {said}"
+    );
+    assert!(
+        inside.contains("skill "),
+        "and the skill revision it was built alongside: {said}"
     );
 
     // Nowhere in particular: no `.ank/`, no git repository, no config. This is

--- a/crates/ank-cli/tests/skill.rs
+++ b/crates/ank-cli/tests/skill.rs
@@ -308,3 +308,72 @@ fn the_skill_says_which_revision_it_is() {
          \"{actual}\""
     );
 }
+
+// ---------------------------------------------------------------------------
+// Whether the two halves agree (TASK-ecda4070354f)
+// ---------------------------------------------------------------------------
+
+/// The `skill <rev>` token of `ank --version`, or `None` if the line does not
+/// carry one.
+fn printed_skill_revision() -> Option<String> {
+    let out = Command::new(env!("CARGO_BIN_EXE_ank"))
+        .arg("--version")
+        .output()
+        .expect("the binary must have been built");
+    assert!(out.status.success(), "ank --version must succeed");
+    let said = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    let (_, after) = said.split_once("skill ")?;
+    Some(
+        after
+            .chars()
+            .take_while(char::is_ascii_alphanumeric)
+            .collect(),
+    )
+}
+
+/// **The binary and the skill can be compared with nothing else in hand.**
+///
+/// The two markers existed and said nothing about each other: TASK-548c518cb705
+/// made the binary name its commit, TASK-b495234f192c made the skill name its
+/// revision, and telling a stale installed skill from a current one still needed
+/// a third value from somewhere — the repository, a release note, a person who
+/// remembers.
+///
+/// What closes it is that the printed value is *derived* at build time from
+/// `skill/SKILL.md` rather than typed. A stamp somebody maintains by hand would
+/// reproduce the original failure one edit later, and would reproduce it
+/// confidently.
+///
+/// Through the binary, because the claim is about what an agent holding only
+/// that binary can read — a unit test on the formatting would pass on a build
+/// whose stamp was never taken.
+#[test]
+fn the_binary_names_the_skill_revision_it_was_built_alongside() {
+    let (front, body) = split_skill(&skill());
+    let declared = declared_revision(&front).expect("SKILL.md declares no metadata.revision");
+
+    let printed = printed_skill_revision().unwrap_or_else(|| {
+        panic!(
+            "`ank --version` names no skill revision, so a reader holding the \
+             binary and the skill cannot tell whether the two agree"
+        )
+    });
+
+    assert_ne!(
+        printed, "unknown",
+        "the build found no skill/SKILL.md to hash: this suite runs from the \
+         repository, where it is there to be read"
+    );
+    assert_eq!(
+        printed,
+        ank_core::freeze_hash_short(&body),
+        "the binary was built alongside a different SKILL.md than the one in \
+         this tree: rebuild, and if it persists the stamp is not being derived \
+         from the file"
+    );
+    assert_eq!(
+        printed, declared,
+        "the binary and the file disagree on the revision: whichever is stale, \
+         the comparison this exists for would mislead its reader"
+    );
+}

--- a/docs/ank-spec-v1.1.md
+++ b/docs/ank-spec-v1.1.md
@@ -421,7 +421,7 @@ ank check [<path>]
 ank init [<path>]           (§9)
 ank help [<verb>]           (§9)
 
-ank --version               (the build itself: version and commit, no verb, no repository)
+ank --version               (the build itself: version, commit and skill revision, no verb, no repository)
 ```
 
 **This block is the whole dispatch table**, and that is a property worth stating rather than assuming: `attest`, `init` and `help` were reachable in the binary while appearing nowhere here, so a reader comparing the two documents could not tell which one was wrong (TASK-5c868c20472f). `init` and `help` are specified in §9 and listed here only so the list is complete; `ank help` prints this order, minus whatever is not yet implemented, which is what ADR-c656cbcc33a9 requires of it.
@@ -444,13 +444,15 @@ The rule is not cosmetic, and it is written down because its absence was not obv
 
 Global flags, deliberately limited to three: `--json`, `--quiet`, `--repo <path>`. Every global flag is a memorisation cost. `--json` is available on every command without exception: full scriptability is an invariant, not an option.
 
-**`ank --version` is not a fourth global flag**, and the limit above is untouched. The three modify a verb; this one replaces it — there is no `ank check --version`, and asking for the build while also asking for something else is not a question anyone has. It prints the crate version and the commit the binary was built from, on one line, and exits 0.
+**`ank --version` is not a fourth global flag**, and the limit above is untouched. The three modify a verb; this one replaces it — there is no `ank check --version`, and asking for the build while also asking for something else is not a question anyone has. It prints the crate version, the commit the binary was built from and the revision of the `skill/SKILL.md` it was built alongside, on one line, and exits 0.
 
 It answers **before the foundation**, like `help` and for a sharper reason: the caller who needs it is the one holding an artifact they cannot identify. A version that required a resolved repository, a git of 2.34 and a readable `config.yml` would fall silent in exactly the situation it exists for. Outside any git repository, in a directory with no `.ank/`, it still prints and still exits 0.
 
 The commit is embedded at build time through `rev-parse`, which §8's plumbing rule already allows, and is `unknown` when the build had no checkout to ask — a source tarball, a vendored dependency. Naming the absence beats inventing a value, and it beats the silence that made TASK-1ea38a17d854 cost an investigation to conclude that the binary in hand predated the feature being measured for.
 
 **What the stamp guarantees, and on which builds.** It names the commit the build script last ran at, and the script reruns whenever the commit moves — including a commit that changes no source file, which is the case that catches a binary quietly left behind. It does not depend on the source having changed. The files a commit moves are located through `rev-parse --git-path` rather than assumed at `.git/`, so a linked worktree and a packed ref are covered rather than hoped for; on a detached HEAD the sha lives in the HEAD file, which is watched on its own account. A release, built from a fresh checkout, is exact by construction. The stamp is not a claim about the working tree: uncommitted edits are invisible to it, and a binary built from a dirty tree names the commit it was based on, not the code it contains (TASK-0b26c8b5bfc5).
+
+**The skill revision, and what it lets a reader do offline.** The third value is `skill <rev>`, where `<rev>` is the short form of the same freeze hash that anchors a frozen `done_criteria` (§3), taken over the body of `skill/SKILL.md` — the same value that file declares under `metadata.revision`, computed at build time from the file rather than typed. An agent has both halves in hand and nothing else: the skill is loaded into its context, the binary is on its `PATH`. Comparing the two strings tells it, with no repository and no network, whether the instructions it is following predate the tool it is holding. That is the check TASK-1ea38a17d854 needed and did not have, and the case that motivated it was measured (TASK-b495234f192c): an installed `SKILL.md` two commits behind a tree that had just withdrawn the invitation to read `.ank/` by hand. The hash covers the body and not the frontmatter, so the revision the frontmatter carries does not change its own input. It is `unknown` on a build with no `skill/` to read, for the same reason and with the same honesty as the commit.
 
 ### Exit codes
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -32,11 +32,15 @@ That puts `ank` in `~/.cargo/bin`. From a clone, `cargo build --release` leaves
 it at `target/release/ank`. Either way, check it answers:
 
     $ ank --version
-    ank 0.1.1 (bc59636)
+    ank 0.1.1 (bc59636, skill 605f771e1955)
 
-It prints the version and the commit it was built from. That second half
-matters the first time you suspect the binary in your hand is older than the
-behaviour you are reading about.
+It prints the version, the commit it was built from, and the revision of the
+skill it was built alongside. The commit matters the first time you suspect the
+binary in your hand is older than the behaviour you are reading about. The
+revision answers the same question about the other half: it is the value
+`skill/SKILL.md` carries under `metadata.revision`, so an agent that has loaded
+that file can compare two strings it already holds and see that its
+instructions predate its tool.
 
 ## Initialise a repository
 


### PR DESCRIPTION
Closes TASK-ecda4070354f.

## The gap

`ank --version` named the commit (TASK-548c518cb705). `skill/SKILL.md` named its revision (TASK-b495234f192c). Neither said anything about the other, so telling a stale installed skill from a current one still needed a third value from somewhere — the repository, a release note, a person who remembers. The reader who needs that check has none of them.

## What it does now

```
$ ank --version
ank 0.1.1 (bc59636, skill 605f771e1955)
```

The third value is what `skill/SKILL.md` declares under `metadata.revision`. An agent holds both halves already — the skill is in its context, the binary is on its `PATH` — so it compares two strings and learns, offline and with no repository, whether its instructions predate its tool.

## Decisions

**On the line, not under it.** The task body left this open. `ank status` was the other candidate and is out on the criterion itself: it runs after startup, so it needs a resolved repository. Keeping one line also leaves §4's shape intact — the specification edit says what the line contains, not that it grew a second one. Specification first, then the code (ADR-63b59c5c26f7).

**Derived, never typed.** `build.rs` hashes the body of `SKILL.md` with `ank_core::freeze_hash_short` — the same freeze hash that anchors a frozen `done_criteria`, not a second implementation of it. The body only: the frontmatter carries the revision, and hashing it would make the value an input to its own computation. `unknown` where there is no `skill/` to read, for the same reason the commit is.

**The watch.** `SKILL.md` is outside this package, so nothing Cargo watches by default would notice it moving. It is named in `rerun-if-changed` alongside the git paths.

**The stamp fixture** now declares the same build-dependency. It drives the real `build.rs` rather than a copy of its logic, so it has to build like the real one; by path, with `--offline` cargo invocations, so it still needs no registry beyond the cache the workspace build has already warmed.

## Verification

- `tests/skill.rs` runs `ank --version` **through the binary**, parses the token and compares it against both the declared revision and a fresh hash of the body.
- The negative direction was measured, not assumed: with a probe line appended to `SKILL.md` the test fails naming both values (`685a7227df28` vs `605f771e1955`), and the printed stamp followed the edit and came back.
- `cargo test --workspace` green (291 tests), `cargo fmt --check` clean, `ank check` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GSAsvw8NC3uXoXYpuwBpUK