### PR TITLE
The README leads with the CLI, a configurable budget and no single harness

### DIFF
--- a/.ank/adr/ADR-962c25797569.md
+++ b/.ank/adr/ADR-962c25797569.md
@@ -5,7 +5,7 @@ slug: short-flags-and-tty-color-are-presentation-and-t
 title: Short flags and TTY color are presentation, and the machine surface is unchanged
 created: 2026-08-05T04:04:15Z
 author: seanl@sean-laptop
-status: proposed
+status: accepted
 scope:
   - crates/ank-cli/src/cli.rs
   - docs/**
@@ -18,8 +18,9 @@ constraint: |
   is a terminal and NO_COLOR is unset. Piped output and --json stay
   byte-for-byte identical to the uncolored output of today: what agents ingest
   does not change, and the golden corpus does not move.
+ratified: 8eaa5ddd4d60
 schema: 2
-version: 1
+version: 2
 ---
 
 ## Context

--- a/.ank/adr/ADR-962c25797569.md
+++ b/.ank/adr/ADR-962c25797569.md
@@ -1,0 +1,45 @@
+---
+id: ADR-962c25797569
+type: adr
+slug: short-flags-and-tty-color-are-presentation-and-t
+title: Short flags and TTY color are presentation, and the machine surface is unchanged
+created: 2026-08-05T04:04:15Z
+author: seanl@sean-laptop
+status: proposed
+scope:
+  - crates/ank-cli/src/cli.rs
+  - docs/**
+constraint: |
+  Every long flag keeps its form. Short forms are single-dash, single-letter
+  mappings declared in the specification, section 4, before any code moves:
+  one table, one letter per long flag where a letter is available, no bundling
+  (-st is an error naming the two flags to type), and no verb abbreviation.
+  Color is hand-written ANSI, no new dependency. It is emitted only when stdout
+  is a terminal and NO_COLOR is unset. Piped output and --json stay
+  byte-for-byte identical to the uncolored output of today: what agents ingest
+  does not change, and the golden corpus does not move.
+schema: 2
+version: 1
+---
+
+## Context
+
+The CLI has no short flags and no styling. That is fine for agents, which read
+plain bytes from a pipe, and austere for the human who types ank find
+--type task --status open several times a day and reads walls of unmarked text.
+
+## Decision
+
+Ergonomics for the human hand and eye, with a hard guarantee for the machine:
+presentation only. Detection is stdout-is-a-TTY plus NO_COLOR, nothing else —
+no --color flag grows the surface. The short-form table lives in the
+specification first, so the grammar stays the specification and the parser
+stays its implementation. Bundling is refused rather than guessed: the
+self-correcting error names the exact flags to type separately.
+
+## Rejected
+
+Verb abbreviations and prefix matching (the verbs are the teachable surface,
+and eight of them are frozen into SKILL.md); a color crate (the binary stays
+static and the dependency rule stands); color in pipes with a --color=always
+escape (an agent one misconfiguration away from ANSI in its context window).

--- a/.ank/adr/ADR-bcb18aecb7e1.md
+++ b/.ank/adr/ADR-bcb18aecb7e1.md
@@ -5,7 +5,7 @@ slug: a-read-only-local-viewer-opens-ank-in-the-browse
 title: A read-only local viewer opens .ank in the browser, without a server
 created: 2026-08-05T04:04:29Z
 author: seanl@sean-laptop
-status: proposed
+status: accepted
 scope:
   - docs/**
 constraint: |
@@ -18,8 +18,9 @@ constraint: |
   ADR-01b6dd05f0db, which constrains agents, not tools: nothing in it goes
   through the CLI, and nothing in it is available to an agent as a route around
   the CLI.
+ratified: 2a48845ea581
 schema: 2
-version: 2
+version: 3
 ---
 
 ## Context

--- a/.ank/adr/ADR-bcb18aecb7e1.md
+++ b/.ank/adr/ADR-bcb18aecb7e1.md
@@ -1,0 +1,48 @@
+---
+id: ADR-bcb18aecb7e1
+type: adr
+slug: a-read-only-local-viewer-opens-ank-in-the-browse
+title: A read-only local viewer opens .ank in the browser, without a server
+created: 2026-08-05T04:04:29Z
+author: seanl@sean-laptop
+status: proposed
+scope:
+  - docs/**
+constraint: |
+  The read-only web view deferred by the specification, section 10, is reopened
+  with this shape and no other: a single self-contained HTML page, no backend,
+  no network, no account, no build server at view time. It reads .ank/ live
+  through the browser File System Access API, read-only — it never writes a
+  file, a ref, or a claim. It parses the format as the specification defines it
+  and holds no state of its own. It is a third-party reader in the sense of
+  ADR-01b6dd05f0db, which constrains agents, not tools: nothing in it goes
+  through the CLI, and nothing in it is available to an agent as a route around
+  the CLI.
+schema: 2
+version: 2
+---
+
+## Context
+
+The specification, section 10, deferred a read-only web view "to reopen only if
+non-developers must read the board". That condition is now met: the board needs
+to be readable by someone who will not learn a CLI, and needs views a terminal
+does not give — a browsable DAG, filters, a board by status.
+
+## Decision
+
+Live over snapshot: an export command would freeze the board at export time and
+grow the CLI surface; a page that opens the repository folder through the File
+System Access API reads the same files the CLI reads, at the moment of viewing.
+The known cost is browser support — the File System Access API means
+Chromium-based browsers today — and it is accepted for a local developer-side
+tool.
+
+The GPL note in the README already states that third-party tools reading .ank/
+are not derivative works; this viewer simply lives in-tree, under viewer/, and
+is held to the same reading the licence promises others.
+
+## Sequencing
+
+This ADR is the framing decision only. Implementation tasks are created after
+acceptance, blocked on nothing else; none exist yet by design.

--- a/.ank/adr/ADR-c656cbcc33a9.md
+++ b/.ank/adr/ADR-c656cbcc33a9.md
@@ -5,7 +5,7 @@ slug: the-help-is-a-flat-listing-and-the-loop-is-taugh
 title: The help is a flat listing, and the loop is taught rather than printed
 created: 2026-08-01T23:07:04Z
 author: seanl@sean-laptop
-status: accepted
+status: superseded
 scope:
   - crates/ank-cli/**
   - skill/**
@@ -15,7 +15,7 @@ constraint: |
 supersedes: ADR-9ede1ffd04e2
 ratified: 7fd54c01c3e0
 schema: 2
-version: 2
+version: 3
 ---
 
 ADR-9ede1ffd04e2 dissolved the split between an agent surface and a human one, and kept one residue of it: a help that presents the loop first and the rest layered. This supersedes it to remove that residue, and changes nothing else.

--- a/.ank/adr/ADR-e17e1bbd93ff.md
+++ b/.ank/adr/ADR-e17e1bbd93ff.md
@@ -1,0 +1,60 @@
+---
+id: ADR-e17e1bbd93ff
+type: adr
+slug: the-skill-teaches-planning-as-well-as-the-loop
+title: The skill teaches planning as well as the loop
+created: 2026-08-05T04:03:55Z
+author: seanl@sean-laptop
+status: proposed
+scope:
+  - skill/SKILL.md
+  - crates/ank-cli/tests/skill.rs
+  - docs/**
+constraint: |
+  The CLI exposes one surface: every verb is available to every caller, and the
+  CLI refuses on state, never on identity. The only hard authority line is the
+  signed ratification commit produced by accept. ank help stays one flat listing
+  of every verb, in the order of section 4, with no headings and no grouping.
+  The verbs themselves do not change.
+  
+  What changes is the content of the freeze. SKILL.md teaches two modes, and its
+  content remains frozen by revision hash. The loop: context, claim, show, log,
+  done, with new, find and release off-loop. Planning: ank new adr, ank amend,
+  ank review, ank graph, ank check, ank find --status open to list what remains,
+  and the fact that accept is human, signed, and runs only on the default
+  branch — the skill teaches what accept is, never that an agent should run it.
+  The size ceiling moves with the content: at most 140 lines and 1200 words,
+  a ceiling to notice drift, not a target to fill.
+supersedes: ADR-c656cbcc33a9
+schema: 2
+version: 1
+---
+
+## Context
+
+ADR-c656cbcc33a9 froze SKILL.md on the loop alone: an agent taught only by that
+file can execute work, but cannot propose a decision, amend a graph, or check
+the coherence of the corpus. ank new adr is never mentioned; an agent that sees
+an architectural problem has no documented path from the observation to a
+recorded ADR. Planning — deciding what tasks should exist, in what order, under
+which constraints — is exactly the activity that produces what other agents
+then loop on, and it was untaught.
+
+## The argument any addition to SKILL.md has to beat
+
+The spec (section 4) states it: SKILL.md is loaded permanently, so every word
+costs tokens on every call, for every agent, including the ones that only loop.
+The addition is accepted here with eyes open. Planning is the highest-leverage
+activity in the corpus — a badly shaped backlog wastes more tokens downstream
+than the teaching costs upstream — and the alternative (a second, separately
+loaded skill) was considered and rejected by the maintainer in favour of one
+file that tells the whole truth. The ceiling moves from 80 lines / 700 words to
+140 lines / 1200 words, and stays a ceiling to notice drift, not a target to
+fill.
+
+## What does not move
+
+One surface, refusal on state never identity, the flat help listing, and the
+verb set are all carried over unchanged from ADR-c656cbcc33a9. accept remains
+outside what the skill invites an agent to do: it is described (human, signed,
+default branch only) so a planning agent knows where its own authority ends.

--- a/.ank/adr/ADR-e17e1bbd93ff.md
+++ b/.ank/adr/ADR-e17e1bbd93ff.md
@@ -5,7 +5,7 @@ slug: the-skill-teaches-planning-as-well-as-the-loop
 title: The skill teaches planning as well as the loop
 created: 2026-08-05T04:03:55Z
 author: seanl@sean-laptop
-status: proposed
+status: accepted
 scope:
   - skill/SKILL.md
   - crates/ank-cli/tests/skill.rs
@@ -26,8 +26,9 @@ constraint: |
   The size ceiling moves with the content: at most 140 lines and 1200 words,
   a ceiling to notice drift, not a target to fill.
 supersedes: ADR-c656cbcc33a9
+ratified: ddcb4b4ec828
 schema: 2
-version: 1
+version: 2
 ---
 
 ## Context

--- a/.ank/tasks/TASK-10b8a29fd853.md
+++ b/.ank/tasks/TASK-10b8a29fd853.md
@@ -1,0 +1,31 @@
+---
+id: TASK-10b8a29fd853
+type: task
+slug: the-dogfooding-hook-leaves-and-the-docs-stop-nam
+title: The dogfooding hook leaves, and the docs stop naming it
+created: 2026-08-05T04:05:28Z
+author: seanl@sean-laptop
+status: open
+scope:
+  - .claude/**
+  - README.md
+  - CLAUDE.md
+blocked_by: []
+done_criteria: |
+  The .claude/ directory (settings.json and hooks/deny-ank-direct-access.mjs) is
+  removed from the tree. README.md and CLAUDE.md no longer mention a PreToolUse
+  hook. The constraint of ADR-01b6dd05f0db is untouched and remains what binds
+  agents; the ratified file is not edited, and ank check stays green.
+criteria_by: creator
+schema: 2
+version: 1
+---
+
+Maintainer decision. The .claude/ directory is not a leftover bypass — it is
+the harness-side enforcement layer added with ADR-01b6dd05f0db, refusing
+Read/Write/Edit/Glob/Grep aimed at .ank/ — and the maintainer chose to remove
+it anyway. Enforcement becomes advisory: the constraint is still served by ank
+context at the top of every session, still binds every agent, and ank check
+remains what notices. The ADR body's mention of a hook stays as written —
+ratified content is anchored by hash and historical context is not falsified
+by the layer being retired later.

--- a/.ank/tasks/TASK-591d1726c305.md
+++ b/.ank/tasks/TASK-591d1726c305.md
@@ -5,7 +5,7 @@ slug: the-readme-sells-a-hard-limit-one-harness-and-fi
 title: The README sells a hard limit, one harness, and files before the CLI
 created: 2026-08-05T04:04:50Z
 author: seanl@sean-laptop
-status: in_progress
+status: done
 scope:
   - README.md
 blocked_by: []
@@ -19,8 +19,12 @@ done_criteria: |
   leads with the CLI as the single surface: .ank/ opaque like .git/ is stated in
   the pitch, not only in the contributor section.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: e2ae46c
+    criteria: b4d5574535d3
 schema: 2
-version: 3
+version: 4
 ---
 
 Three defects in positioning, one file.
@@ -43,3 +47,4 @@ two claims sit 180 lines apart and the second one must win, from the top.
 
 ## Log
 - 2026-08-05T04:32:12Z seanl@sean-laptop — README rewritten on the three positioning defects. Budget: the under-2000-tokens gloss becomes context_budget in config.yml, 8000 characters by default, stated as an optimisation. Harnesses: the skills CLI is credited with detecting Claude Code, Codex, Cursor and OpenCode as spec section 9 says, and skill/SKILL.md is named as one plain markdown file to copy by hand where npx does not fit. Surface: the pitch now states .ank/ opaque like .git/, the What it looks like section leads with ank context output and the files follow it, and the sample identity is pi@host-3, matching the spec's own neutral sample. The hook sentence in the contributor section is left alone: it belongs to TASK-10b8. Full suite green, 299 tests.
+- 2026-08-05T04:33:55Z seanl@sean-laptop — done, proof commit:e2ae46c

--- a/.ank/tasks/TASK-591d1726c305.md
+++ b/.ank/tasks/TASK-591d1726c305.md
@@ -1,0 +1,42 @@
+---
+id: TASK-591d1726c305
+type: task
+slug: the-readme-sells-a-hard-limit-one-harness-and-fi
+title: The README sells a hard limit, one harness, and files before the CLI
+created: 2026-08-05T04:04:50Z
+author: seanl@sean-laptop
+status: open
+scope:
+  - README.md
+blocked_by: []
+done_criteria: |
+  The README presents the context budget as a configurable optimisation —
+  context_budget in config.yml, 8000 characters by default, roughly 2000
+  tokens — never as a fixed property of the format. It names several harnesses
+  (Claude Code, Codex, Cursor, OpenCode, as the specification section 9 does)
+  and says the skill is a plain markdown file that can be copied by hand. The
+  sample identity claimed:claude-code@host-3 becomes vendor-neutral. The pitch
+  leads with the CLI as the single surface: .ank/ opaque like .git/ is stated in
+  the pitch, not only in the contributor section.
+criteria_by: creator
+schema: 2
+version: 1
+---
+
+Three defects in positioning, one file.
+
+Under 2000 tokens (line 29) is a prose gloss of a configurable default
+(DEFAULT_CONTEXT_BUDGET = 8000 characters, config.rs:15) hardened into what
+reads as a hardcoded limit. Nothing in the code breaks at any budget; say
+optimisation, name the knob.
+
+Several readers flagged an apparent dependency on one ecosystem: the README
+mentions only .claude/, CLAUDE.md, a claude-code@host-3 sample identity, and
+npx skills add as the only install path, while the tool is agnostic to the
+agent and the harness, and the specification (section 9) names Claude Code,
+Codex, Cursor, OpenCode.
+
+The tagline sells tasks and decisions as files in your repo while line 192
+says the opposite — .ank/ is opaque, like .git/, reached only through the CLI.
+The whole point is one common CLI surface, not organised files to grep. The
+two claims sit 180 lines apart and the second one must win, from the top.

--- a/.ank/tasks/TASK-591d1726c305.md
+++ b/.ank/tasks/TASK-591d1726c305.md
@@ -5,7 +5,7 @@ slug: the-readme-sells-a-hard-limit-one-harness-and-fi
 title: The README sells a hard limit, one harness, and files before the CLI
 created: 2026-08-05T04:04:50Z
 author: seanl@sean-laptop
-status: open
+status: in_progress
 scope:
   - README.md
 blocked_by: []
@@ -20,7 +20,7 @@ done_criteria: |
   the pitch, not only in the contributor section.
 criteria_by: creator
 schema: 2
-version: 1
+version: 3
 ---
 
 Three defects in positioning, one file.
@@ -40,3 +40,6 @@ The tagline sells tasks and decisions as files in your repo while line 192
 says the opposite — .ank/ is opaque, like .git/, reached only through the CLI.
 The whole point is one common CLI surface, not organised files to grep. The
 two claims sit 180 lines apart and the second one must win, from the top.
+
+## Log
+- 2026-08-05T04:32:12Z seanl@sean-laptop — README rewritten on the three positioning defects. Budget: the under-2000-tokens gloss becomes context_budget in config.yml, 8000 characters by default, stated as an optimisation. Harnesses: the skills CLI is credited with detecting Claude Code, Codex, Cursor and OpenCode as spec section 9 says, and skill/SKILL.md is named as one plain markdown file to copy by hand where npx does not fit. Surface: the pitch now states .ank/ opaque like .git/, the What it looks like section leads with ank context output and the files follow it, and the sample identity is pi@host-3, matching the spec's own neutral sample. The hook sentence in the contributor section is left alone: it belongs to TASK-10b8. Full suite green, 299 tests.

--- a/.ank/tasks/TASK-79bb5c779a59.md
+++ b/.ank/tasks/TASK-79bb5c779a59.md
@@ -1,0 +1,36 @@
+---
+id: TASK-79bb5c779a59
+type: task
+slug: the-binary-installs-from-npm-where-executables-c
+title: The binary installs from npm where executables cannot be downloaded
+created: 2026-08-05T04:05:20Z
+author: seanl@sean-laptop
+status: open
+scope:
+  - .github/workflows/release.yml
+  - npm/**
+  - docs/**
+blocked_by: []
+done_criteria: |
+  An npm package installs the release binary for the three existing targets
+  (linux x86_64-musl, macOS arm64, windows x86_64) through platform packages
+  listed as optionalDependencies, with the binaries embedded in the packages —
+  no postinstall download. npx <package> --version answers with the same line as
+  the release binary. release.yml publishes the packages on a version tag.
+criteria_by: creator
+schema: 2
+version: 1
+---
+
+The specification already plans npm among the distribution channels (section
+10: curl | sh, Homebrew, Scoop/winget, npm); nothing is implemented. The
+driving case is the corporate workstation: a firewall that blocks downloading
+a bare executable usually lets the npm registry through, so the binaries must
+travel inside the platform packages (the esbuild layout), never be fetched by
+a postinstall script — a postinstall download dies behind the same firewall
+the package exists to cross.
+
+Human decisions required before this task is claimable in practice, and they
+belong to the maintainer, not the implementing agent: whether the name ank is
+free on the npm registry (else pick and record the fallback name), and an
+NPM_TOKEN secret on the repository for release.yml to publish with.

--- a/.ank/tasks/TASK-8ebd6e02f125.md
+++ b/.ank/tasks/TASK-8ebd6e02f125.md
@@ -1,0 +1,35 @@
+---
+id: TASK-8ebd6e02f125
+type: task
+slug: color-on-a-terminal-bytes-unchanged-in-a-pipe
+title: Color on a terminal, bytes unchanged in a pipe
+created: 2026-08-05T04:06:09Z
+author: seanl@sean-laptop
+status: open
+scope:
+  - crates/ank-cli/src/cli.rs
+  - crates/ank-cli/src/context.rs
+  - crates/ank-cli/src/status.rs
+  - docs/**
+blocked_by: []
+done_criteria: |
+  Output is colored — hand-written ANSI, no new dependency — only when stdout is
+  a terminal and NO_COLOR is unset. Captured in a pipe, every command's output
+  is byte-for-byte identical to today's, and the existing golden corpus does not
+  move. --json is never colored. Behaviour is tested through the binary,
+  including the piped case.
+criteria_by: creator
+schema: 2
+version: 2
+---
+
+Execution of ADR-962c25797569, presentation half. The guarantee that matters
+is negative: agents read pipes, and a pipe must never see an escape sequence.
+TTY detection goes through what the tree already has (libc is present as a
+transitive dependency; if a direct dependency became necessary the ADR's
+no-new-dependency line wins and the feature shrinks). Restraint over
+decoration: status markers, section headers, the error line — not a theme
+engine.
+
+## Log
+- 2026-08-05T04:06:58Z seanl@sean-laptop — amended: -blocked_by ADR-962c25797569

--- a/.ank/tasks/TASK-b5ad06f134f6.md
+++ b/.ank/tasks/TASK-b5ad06f134f6.md
@@ -1,0 +1,34 @@
+---
+id: TASK-b5ad06f134f6
+type: task
+slug: a-blocker-finished-on-another-branch-still-block
+title: A blocker finished on another branch still blocks in silence
+created: 2026-08-05T04:04:56Z
+author: seanl@sean-laptop
+status: open
+scope:
+  - crates/ank-cli/src/claim.rs
+  - docs/**
+blocked_by: []
+done_criteria: |
+  When a blocked_by names a task carrying a completion ref, the code 7 refusal
+  from claim names the commit and the branch — blocked by <id>, finished on
+  <branch> (commit <sha>), not merged here yet — instead of the bare blocked-by
+  message. The specification section 7 documents the behaviour. The behaviour is
+  tested through the binary, not only through the function.
+criteria_by: creator
+schema: 2
+version: 1
+---
+
+check_blockers() builds its status map from task files in the local working
+tree only and never consults refs/ank/claims/*. A blocker finished on another
+branch — completion ref present, done not yet merged here — therefore still
+reads as not done, and the dependent claim is refused with a message that
+hides the one fact the agent needs.
+
+The refusal itself stays: claiming on top of unmerged work is the real risk,
+and ADR-bcf222a31525 built the completion ref precisely so this window is
+visible. What is missing is the information, not the permission. The fix
+extends to blockers the same answer claim already gives for the task itself
+(finished_elsewhere, claim.rs:667-682).

--- a/.ank/tasks/TASK-d79dc424c63d.md
+++ b/.ank/tasks/TASK-d79dc424c63d.md
@@ -1,0 +1,39 @@
+---
+id: TASK-d79dc424c63d
+type: task
+slug: two-sessions-on-one-machine-are-one-agent-by-acc
+title: Two sessions on one machine are one agent by accident
+created: 2026-08-05T04:05:04Z
+author: seanl@sean-laptop
+status: open
+scope:
+  - crates/ank-cli/src/identity.rs
+  - crates/ank-cli/src/claim.rs
+  - docs/**
+blocked_by: []
+done_criteria: |
+  claim by an identity that already holds a live claim on another task prints a
+  warning naming that claim and its task. getting-started documents that each
+  concurrent session sets its own ANK_AGENT. Both behaviours are tested through
+  the binary.
+criteria_by: creator
+schema: 2
+version: 1
+---
+
+Observed while dogfooding: a task claimed in one terminal follows you into a
+second terminal — status shows the same claim, log renews it. The cause is the
+identity default: ANK_AGENT unset means user@host (identity.rs:14-19), so two
+sessions on one machine are indistinguishable and silently share and renew
+each other's claims. Nothing is broken in the refs — the model just cannot
+tell the sessions apart.
+
+Deliberately not fixed by binding identity to the session: a PID or TTY in the
+identity would break resuming a claim after a restart, and identity is
+declared, never proof (spec, section on ANK_AGENT). What can be fixed is the
+silence: one claim per agent is the convention, so claiming a second task
+under an identity that already holds one deserves a warning naming it — the
+one-terminal user learns nothing new, the two-terminal user learns exactly
+what is happening and the doc tells them the fix: set ANK_AGENT per session.
+Parallel agents each with their own identity remain fully supported; that is
+the design, one ref per task.

--- a/.ank/tasks/TASK-e70d28a5fba8.md
+++ b/.ank/tasks/TASK-e70d28a5fba8.md
@@ -1,0 +1,37 @@
+---
+id: TASK-e70d28a5fba8
+type: task
+slug: skill-md-teaches-planning-and-the-freeze-moves-t
+title: SKILL.md teaches planning, and the freeze moves to the new content
+created: 2026-08-05T04:05:45Z
+author: seanl@sean-laptop
+status: open
+scope:
+  - skill/SKILL.md
+  - crates/ank-cli/tests/skill.rs
+  - docs/ank-spec-v1.1.md
+blocked_by: []
+done_criteria: |
+  The specification section 4 is rewritten first: the freeze and its content as
+  ADR-e17e1bbd93ff defines them. SKILL.md then grows the planning section — ank
+  new adr, ank amend, ank review, ank graph, ank check, ank find --status open,
+  and accept described as human, signed, default branch only, never as a verb
+  the skill invites an agent to run. The skill.rs tests move to the new ceiling
+  (at most 140 lines, 1200 words) and the new frozen content, including the
+  teaches-nothing-beyond exclusion list. metadata.revision is regenerated and
+  matches the skill hash ank --version reports.
+criteria_by: creator
+schema: 2
+version: 2
+---
+
+Execution of ADR-e17e1bbd93ff, in the order the project imposes: specification
+first, then the taught file, then the tests that freeze it. The exclusion test
+(the_skill_teaches_nothing_beyond_the_loop) does not disappear — it moves:
+accept, close and attest stay excluded as invitations, while review, graph,
+check, amend and new adr become taught. The wording for accept must thread the
+needle the ADR describes: an agent knows what accept is and where its own
+authority ends.
+
+## Log
+- 2026-08-05T04:06:58Z seanl@sean-laptop — amended: -blocked_by ADR-e17e1bbd93ff

--- a/.ank/tasks/TASK-f3e92656b5df.md
+++ b/.ank/tasks/TASK-f3e92656b5df.md
@@ -1,0 +1,32 @@
+---
+id: TASK-f3e92656b5df
+type: task
+slug: every-long-flag-gains-a-declared-short-form
+title: Every long flag gains a declared short form
+created: 2026-08-05T04:06:02Z
+author: seanl@sean-laptop
+status: open
+scope:
+  - crates/ank-cli/src/cli.rs
+  - docs/ank-spec-v1.1.md
+blocked_by: []
+done_criteria: |
+  The short-form table lives in the specification section 4 before the parser
+  moves. The parser accepts -s open and -s=open wherever --status is legal, and
+  refuses bundling (-st) with a self-correcting error naming the exact flags to
+  type separately. ank help <verb> shows both forms. Behaviour is tested through
+  the binary.
+criteria_by: creator
+schema: 2
+version: 2
+---
+
+Execution of ADR-962c25797569, grammar half. The parser is hand-rolled
+precisely for character-level control (cli.rs module header), so the change is
+in one place: FlagSpec grows a short letter, parse() learns single-dash, and
+the COMMANDS table stays the single source help renders from. One letter per
+long flag where a letter is available; collisions within a verb are resolved
+in the specification table, not improvised in code.
+
+## Log
+- 2026-08-05T04:06:58Z seanl@sean-laptop — amended: -blocked_by ADR-962c25797569

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 <p align="center">
   <strong>The stupid coordination tool</strong><br>
-  Tasks and architecture decisions as files in your repo, readable by any coding agent.
+  Tasks and architecture decisions in your repo, behind one CLI any coding agent can call.
 </p>
 
 <p align="center">
@@ -25,9 +25,16 @@ your tracker, your wiki, or the thread where you decided six months ago that
 sessions must never be self-contained JWTs. So it writes plausible code that
 breaks a rule nobody wrote down where it could be found.
 
-Ank puts that layer in the repository, attached to the code it constrains, in a
-format an agent consumes in one call and under 2000 tokens. No server, no
-daemon, no account — two kinds of file and a CLI.
+Ank puts that layer in the repository, attached to the code it constrains, and
+serves it through one command surface. `ank context` answers what binds here in
+a single call; `.ank/` itself is opaque to an agent, the way `.git/` is —
+`ank show` for an entity whole, `ank find` to list, `ank context` to learn what
+binds. Not a directory to grep, a CLI to call.
+
+What comes back is sized by a budget you set: `context_budget` in
+`config.yml`, 8000 characters by default — roughly 2000 tokens. It is an
+optimisation, not a property of the format: raise it on a wide perimeter, lower
+it to pay less per call. No server, no daemon, no account.
 
 ## Quick start
 
@@ -51,19 +58,43 @@ ank log "<what you learned>"  # renews the claim; working is what holds it
 ank done                      # runs the verifiers itself and writes the proof
 ```
 
-**Hand it to an agent.**
+**Hand it to an agent.** The `skills` CLI detects what you run — Claude Code,
+Codex, Cursor, OpenCode and others — and links each one to a single copy:
 
 ```
 npx skills add haksolot/ank
 ```
+
+That installs the skill, not the binary. The skill is one plain markdown file,
+[`skill/SKILL.md`](skill/SKILL.md): where that command does not fit, copy it by
+hand into whatever your agent loads.
 
 [**Getting started**](docs/getting-started.md) walks all of that with real
 output, including the two refusals a fresh repository will give you.
 
 ## What it looks like
 
-A decision that constrains code, and a unit of work with what would prove it
-finished. Both are markdown with YAML frontmatter, flat in `.ank/`:
+An agent asks what applies where it is about to work, and gets only that:
+
+```
+$ ank context src/auth/
+
+CONSTRAINTS (2 active)
+  ADR-3c7e  Do not introduce self-contained JWTs for user auth.
+            Every session goes through the Redis store.
+  ADR-8b41  Rate limiting mandatory on every public endpoint.
+
+TASKS (2)
+  TASK-8f3a  [claimed:pi@host-3] Migrate auth to opaque sessions
+  TASK-51c2  [open] Add secret rotation
+
+> ank claim 51c2 to start
+```
+
+Behind it, two kinds of entity: a decision that constrains code, and a unit of
+work with what would prove it finished. Both are markdown with YAML
+frontmatter, flat in `.ank/` — written through `ank new` and the verbs, read
+through `ank show`:
 
 ```yaml
 ---
@@ -93,23 +124,6 @@ done_criteria: |
   jwt.verify remains in src/auth/
 verify: [auth-tests, no-jwt]
 ---
-```
-
-An agent asks what applies where it is about to work, and gets only that:
-
-```
-$ ank context src/auth/
-
-CONSTRAINTS (2 active)
-  ADR-3c7e  Do not introduce self-contained JWTs for user auth.
-            Every session goes through the Redis store.
-  ADR-8b41  Rate limiting mandatory on every public endpoint.
-
-TASKS (2)
-  TASK-8f3a  [claimed:claude-code@host-3] Migrate auth to opaque sessions
-  TASK-51c2  [open] Add secret rotation
-
-> ank claim 51c2 to start
 ```
 
 ## Why it works this way


### PR DESCRIPTION
Closes TASK-591d1726c305.

Three positioning defects, one file.

**The budget was sold as a hard limit.** `under 2000 tokens` was a prose gloss
of a configurable default (`DEFAULT_CONTEXT_BUDGET = 8000` characters,
`config.rs:15`) hardened into what read as a hardcoded property of the format.
It now names the knob: `context_budget` in `config.yml`, 8000 characters by
default, roughly 2000 tokens, and says plainly that it is an optimisation to
raise or lower.

**One harness looked like a dependency.** Several readers flagged it. The skill
block now credits the `skills` CLI with detecting Claude Code, Codex, Cursor and
OpenCode, as section 9 of the specification does, says it installs the skill and
not the binary, and names `skill/SKILL.md` as one plain markdown file to copy by
hand where `npx` does not fit. The sample identity `claimed:claude-code@host-3`
becomes `claimed:pi@host-3`, the neutral sample the specification already uses.

**The tagline contradicted line 192.** `files in your repo` sat 180 lines above
`.ank/ is opaque, like .git/`, and the second one has to win. The pitch now
states it from the top, and `What it looks like` leads with the output of
`ank context`, the two file shapes following as what sits behind it.

The `PreToolUse` hook sentence in the contributor section is deliberately
untouched: it belongs to TASK-10b8.

`cargo test --workspace` green, 299 tests. `ank check` reports no new finding.

Proof: `commit:e2ae46c`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NYtKH7nGxkhGpTZxcNyYD