### PR TITLE
A blocker finished on another branch is named with its branch and commit

### DIFF
--- a/.ank/tasks/TASK-b5ad06f134f6.md
+++ b/.ank/tasks/TASK-b5ad06f134f6.md
@@ -5,7 +5,7 @@ slug: a-blocker-finished-on-another-branch-still-block
 title: A blocker finished on another branch still blocks in silence
 created: 2026-08-05T04:04:56Z
 author: seanl@sean-laptop
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/src/claim.rs
   - docs/**
@@ -18,7 +18,7 @@ done_criteria: |
   tested through the binary, not only through the function.
 criteria_by: creator
 schema: 2
-version: 1
+version: 3
 ---
 
 check_blockers() builds its status map from task files in the local working
@@ -32,3 +32,6 @@ and ADR-bcf222a31525 built the completion ref precisely so this window is
 visible. What is missing is the information, not the permission. The fix
 extends to blockers the same answer claim already gives for the task itself
 (finished_elsewhere, claim.rs:667-682).
+
+## Log
+- 2026-08-05T04:46:31Z seanl@sean-laptop — check_blockers now reads the ref of every active blocker, not only the task files. A blocker carrying a completion record refuses with code 7 and names branch and commit: 'is blocked by <id>, finished on <branch> (commit <sha>), not merged here yet'. It is named ahead of the first blocker in the list, since the order of blocked_by says nothing about which one matters. Found while testing: other_ready_task would have offered the blocker itself as another ready task, because its file reads open on this branch — an exact command that refuses on the spot. It now skips a candidate carrying a completion ref. Section 7 of the specification documents both. Tested through the binary with a negative control: without the ref lookup the message is the bare 'is blocked by <id>' and the test fails on the branch name.

--- a/.ank/tasks/TASK-b5ad06f134f6.md
+++ b/.ank/tasks/TASK-b5ad06f134f6.md
@@ -21,8 +21,11 @@ proof:
   - type: commit
     ref: f12ee8a
     criteria: ab7defbf6e22
+  - type: test
+    ref: "30976148653"
+    criteria: ab7defbf6e22
 schema: 2
-version: 4
+version: 5
 ---
 
 check_blockers() builds its status map from task files in the local working
@@ -40,3 +43,4 @@ extends to blockers the same answer claim already gives for the task itself
 ## Log
 - 2026-08-05T04:46:31Z seanl@sean-laptop — check_blockers now reads the ref of every active blocker, not only the task files. A blocker carrying a completion record refuses with code 7 and names branch and commit: 'is blocked by <id>, finished on <branch> (commit <sha>), not merged here yet'. It is named ahead of the first blocker in the list, since the order of blocked_by says nothing about which one matters. Found while testing: other_ready_task would have offered the blocker itself as another ready task, because its file reads open on this branch — an exact command that refuses on the spot. It now skips a candidate carrying a completion ref. Section 7 of the specification documents both. Tested through the binary with a negative control: without the ref lookup the message is the bare 'is blocked by <id>' and the test fails on the branch name.
 - 2026-08-05T04:47:06Z seanl@sean-laptop — done, proof commit:f12ee8a
+- 2026-08-05T04:50:24Z seanl@sean-laptop — attested test:30976148653

--- a/.ank/tasks/TASK-b5ad06f134f6.md
+++ b/.ank/tasks/TASK-b5ad06f134f6.md
@@ -5,7 +5,7 @@ slug: a-blocker-finished-on-another-branch-still-block
 title: A blocker finished on another branch still blocks in silence
 created: 2026-08-05T04:04:56Z
 author: seanl@sean-laptop
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/src/claim.rs
   - docs/**
@@ -17,8 +17,12 @@ done_criteria: |
   message. The specification section 7 documents the behaviour. The behaviour is
   tested through the binary, not only through the function.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: f12ee8a
+    criteria: ab7defbf6e22
 schema: 2
-version: 3
+version: 4
 ---
 
 check_blockers() builds its status map from task files in the local working
@@ -35,3 +39,4 @@ extends to blockers the same answer claim already gives for the task itself
 
 ## Log
 - 2026-08-05T04:46:31Z seanl@sean-laptop — check_blockers now reads the ref of every active blocker, not only the task files. A blocker carrying a completion record refuses with code 7 and names branch and commit: 'is blocked by <id>, finished on <branch> (commit <sha>), not merged here yet'. It is named ahead of the first blocker in the list, since the order of blocked_by says nothing about which one matters. Found while testing: other_ready_task would have offered the blocker itself as another ready task, because its file reads open on this branch — an exact command that refuses on the spot. It now skips a candidate carrying a completion ref. Section 7 of the specification documents both. Tested through the binary with a negative control: without the ref lookup the message is the bare 'is blocked by <id>' and the test fails on the branch name.
+- 2026-08-05T04:47:06Z seanl@sean-laptop — done, proof commit:f12ee8a

--- a/crates/ank-cli/src/claim.rs
+++ b/crates/ank-cli/src/claim.rs
@@ -681,6 +681,27 @@ fn finished_elsewhere(
     .with_hint(other_task_hint(other_ready))
 }
 
+/// The same fact as `finished_elsewhere`, about a blocker rather than about the
+/// task being claimed: code 7, because what refuses here is the prerequisite,
+/// not the ref.
+fn blocker_finished_elsewhere(
+    task: &EntityId,
+    blocker: &EntityId,
+    done: &CompletedRecord,
+    other_ready: Option<&str>,
+) -> CliError {
+    let commit: String = done.commit.chars().take(7).collect();
+    let where_ = match &done.branch {
+        Some(b) => format!("finished on {b} (commit {commit})"),
+        None => format!("finished on a detached HEAD (commit {commit})"),
+    };
+    CliError::new(
+        7,
+        format!("{task} is blocked by {blocker}, {where_}, not merged here yet"),
+    )
+    .with_hint(other_task_hint(other_ready))
+}
+
 fn lost_the_race(
     cwd: &Path,
     id: &EntityId,
@@ -782,7 +803,7 @@ pub fn run(
     };
 
     let ttl = resolve_ttl(inv.value("--ttl"), cfg)?;
-    let ready = other_ready_task(&store, &task).map(|id| id.to_string());
+    let ready = other_ready_task(&repo.root, &store, &task).map(|id| id.to_string());
 
     // Preconditions first, in the order of §3: no ref is touched by a claim
     // that was never going to be legal.
@@ -803,7 +824,7 @@ pub fn run(
             )
         }
     };
-    check_blockers(&store, &task)?;
+    check_blockers(&repo.root, &store, &task, ready.as_deref())?;
     task.status
         .check_transition(TaskStatus::InProgress)
         .map_err(|e| CliError::new(6, e.to_string()).with_hint(format!("ank show {}", task.id)))?;
@@ -871,11 +892,33 @@ fn status_map(store: &Store) -> Result<HashMap<EntityId, TaskStatus>> {
 
 /// A blocker that is not `done` refuses the claim with code 7 and names it.
 /// `closed` does not unblock either — the work was not carried out (§3).
-fn check_blockers(store: &Store, task: &Task) -> Result<()> {
+///
+/// A blocker finished on another branch reads, in the working tree, exactly
+/// like one nobody has started: `status_map` sees the file this branch carries
+/// and nothing else. The completion ref is the only witness of that window
+/// (ADR-bcf222a31525), so it is consulted here. The refusal itself does not
+/// move — claiming on top of unmerged work is the real risk — only what the
+/// agent is told about it, which is the answer `acquire` already gives for the
+/// claimed task itself.
+fn check_blockers(cwd: &Path, store: &Store, task: &Task, other_ready: Option<&str>) -> Result<()> {
     let map = status_map(store)?;
     let blockers = task
         .active_blockers(|id| map.get(id).copied())
         .map_err(|e| CliError::new(7, e.to_string()).with_hint("ank check"))?;
+
+    // A blocker carrying a completion ref is named ahead of the first one,
+    // wherever it sits in the list: it is the one fact the plain message hides,
+    // and the order of `blocked_by` says nothing about which blocker matters.
+    for id in &blockers {
+        if let Some(Held {
+            record: Record::Completed(c),
+            ..
+        }) = read(cwd, id)?
+        {
+            return Err(blocker_finished_elsewhere(&task.id, id, &c, other_ready));
+        }
+    }
+
     if let Some(first) = blockers.first() {
         let closed = map.get(*first) == Some(&TaskStatus::Closed);
         let why = if closed { " (closed)" } else { "" };
@@ -891,7 +934,11 @@ fn check_blockers(store: &Store, task: &Task) -> Result<()> {
 /// Same scope first, since that is what the message claims; any ready task
 /// otherwise is not offered, because pointing somewhere else entirely would be
 /// the generic help the style forbids.
-fn other_ready_task(store: &Store, task: &Task) -> Option<EntityId> {
+///
+/// A candidate carrying a completion ref is skipped: its file says `open` on
+/// this branch, and offering it would print an exact command that refuses the
+/// moment it is run — which is the generic help by another route.
+fn other_ready_task(cwd: &Path, store: &Store, task: &Task) -> Option<EntityId> {
     let map = status_map(store).ok()?;
     let mut candidates: Vec<&EntityId> = map
         .iter()
@@ -909,9 +956,19 @@ fn other_ready_task(store: &Store, task: &Task) -> Option<EntityId> {
         {
             continue;
         }
-        if scopes_intersect(&task.scope, &t.scope).unwrap_or(false) {
-            return Some(id.clone());
+        if !scopes_intersect(&task.scope, &t.scope).unwrap_or(false) {
+            continue;
         }
+        if matches!(
+            read(cwd, id),
+            Ok(Some(Held {
+                record: Record::Completed(_),
+                ..
+            }))
+        ) {
+            continue;
+        }
+        return Some(id.clone());
     }
     None
 }

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -1601,6 +1601,80 @@ fn a_done_through_the_binary_leaves_a_completion_ref_naming_commit_and_branch() 
     );
 }
 
+/// A blocker finished on another branch says which one (TASK-b5ad06f134f6).
+///
+/// Through the binary, because the defect is precisely a working tree being
+/// asked a question only the refs can answer: `check_blockers` built its status
+/// map from the files this branch carries, and on `main` the blocker's file
+/// still reads `open`. Nothing below is observable from the function — it needs
+/// a real repository holding a real completion ref for a commit `main` does not
+/// have.
+#[test]
+fn a_blocker_finished_on_another_branch_is_named_with_its_branch_and_commit() {
+    let blocker = "TASK-000000000c01";
+    let dependent = "TASK-000000000c02";
+    let r = Repo::new().with_verifiers("verifiers:\n  ok:\n    run: echo fine\n");
+    r.seed_task_with(blocker, Some("A criterion."), &["ok"]);
+    r.seed_task(dependent, Some("A criterion."));
+    r.blocked(dependent, &[blocker]);
+    r.git(&["add", "-A"]);
+    r.git(&["-c", "commit.gpgsign=false", "commit", "-qm", "seed tasks"]);
+
+    // A commit of its own on the branch, so the commit the completion record
+    // names is one `main` genuinely does not carry. Branching alone would leave
+    // HEAD on a commit both branches share, and the assertion below would pass
+    // on a repository where nothing was unmerged at all.
+    r.git(&["checkout", "-q", "-b", "feature"]);
+    std::fs::write(r.0.join("work.txt"), "y").unwrap();
+    r.git(&["add", "-A"]);
+    r.git(&["-c", "commit.gpgsign=false", "commit", "-qm", "work"]);
+    let finished_at = r.head();
+
+    assert_eq!(code(&r.ank("claude-code@ank", &["claim", blocker])), 0);
+    let out = r.ank("claude-code@ank", &["done"]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    r.git(&["add", "-A"]);
+    r.git(&["-c", "commit.gpgsign=false", "commit", "-qm", "done"]);
+
+    // Back where the work has not landed: the blocker's file says `open` again,
+    // and the ref is the only thing that remembers otherwise.
+    r.git(&["checkout", "-q", "main"]);
+    assert!(
+        r.task_text(blocker).contains("status: open"),
+        "the fixture is wrong if main already carries the done"
+    );
+
+    let out = r.ank("claude-code@ank", &["claim", dependent]);
+    let said = stderr(&out);
+    assert_eq!(code(&out), 7, "the refusal itself does not move: {said}");
+    assert!(
+        said.contains(&format!("blocked by {blocker}")),
+        "the blocker is still named: {said}"
+    );
+    assert!(
+        said.contains("finished on feature"),
+        "the branch is the half an agent cannot guess: {said}"
+    );
+    assert!(
+        said.contains(&finished_at[..7]),
+        "the commit is what makes the branch checkable: {said}"
+    );
+    assert!(
+        said.contains("not merged here yet"),
+        "and why it still blocks: {said}"
+    );
+    // The hint is never a command that refuses: the blocker carries the
+    // completion ref, so claiming it is exactly what fails.
+    assert!(
+        !said.contains(&format!("ank claim {blocker}")),
+        "offered a claim that would refuse on the spot: {said}"
+    );
+    assert!(
+        r.task_text(dependent).contains("status: open"),
+        "a refused claim moves nothing"
+    );
+}
+
 #[test]
 fn a_failing_done_through_the_binary_leaves_the_claim_intact() {
     let r = Repo::new().with_verifiers("verifiers:\n  nope:\n    run: exit 2\n");

--- a/docs/ank-spec-v1.1.md
+++ b/docs/ank-spec-v1.1.md
@@ -705,6 +705,16 @@ error[4]: TASK-8f3a finished on another branch (commit abc1234, branch feat/opaq
   -> ank claim 51c2   (another ready task in this scope)
 ```
 
+**A blocker carrying a `completed` record gets the same answer, with code 7.** The refusal itself is unchanged — `blocked_by` names work whose result this branch does not have, and claiming on top of it is the risk the ref exists to make visible — but the bare message hides the one fact that decides what to do next. `claim` therefore consults the ref of every active blocker, and a blocker finished elsewhere is named ahead of the first one in the list, wherever it sits there: the order of `blocked_by` says nothing about which blocker matters, and being told about the merged-nowhere one is the point.
+
+```
+$ ank claim 51c2
+error[7]: TASK-51c2 is blocked by TASK-8f3a, finished on feat/opaque-sessions (commit abc1234), not merged here yet
+  -> ank context
+```
+
+The hint follows the same rule as everywhere else and never names a command that would refuse on the spot: the task offered as another thing to take is one whose ref is free, not one whose file reads `open` on this branch only because a completion has not landed yet.
+
 **Pruning is conditioned on durable state, not on a TTL.** A completion ref is pruned once the task appears `done` or `closed` **on the default branch**: the information the ref carried is then present where everyone reads it, and the ref has no further use. That is what makes "ephemeral" accurate rather than decorative — the ref lives exactly as long as it is useful, three minutes or three weeks depending on how long review takes.
 
 The predicate is about the task file as it appears on the default branch (`git cat-file -p <default_branch>:.ank/tasks/TASK-<id>.md`), **and not about the reachability of the recorded commit**. The difference is not theoretical: `done` writes only to the working tree (§12), so the commit it records is the current HEAD, which is frequently already an ancestor of the default branch — an agent that branches and then runs `done` before its first commit would see its ref pruned immediately, which would reopen the very window the mechanism exists to close. The recorded commit serves the diagnostic above, never the pruning decision.


### PR DESCRIPTION
Closes TASK-b5ad06f134f6.

`check_blockers` built its status map from the task files the local working
tree carries and never consulted `refs/ank/claims/*`. A blocker whose work is
finished elsewhere — completion ref present, `done` not merged here — therefore
read as not started, and the dependent claim was refused with a message that
hid the one fact the agent needs.

**The refusal does not move.** Claiming on top of unmerged work is the real
risk, and ADR-bcf222a31525 built the completion ref precisely so this window is
visible. What was missing is the information, not the permission:

```
error[7]: TASK-51c2 is blocked by TASK-8f3a, finished on feat/opaque-sessions (commit abc1234), not merged here yet
  -> ank context
```

A blocker carrying a completion ref is named ahead of the first one in the
list, wherever it sits there: the order of `blocked_by` says nothing about
which blocker matters.

**One thing found while testing the message.** `other_ready_task` would have
offered the blocker itself as another ready task to take, because its file
reads `open` on this branch — an exact command that refuses the moment it is
run, which is the generic help the style forbids by another route. It now skips
a candidate carrying a completion ref.

Section 7 of the specification documents both.

The test drives the binary, as CLAUDE.md requires when the criterion talks
about the binary: the defect is precisely a working tree being asked a question
only the refs can answer, so nothing here is observable from the function. The
negative control was run — with the ref lookup removed, the message falls back
to the bare `is blocked by <id>` and the test fails on the branch name.

`cargo test --workspace` green, 300 tests. `cargo fmt --check` clean.
`ank check` reports no new finding.

Proof: `commit:f12ee8a`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NYtKH7nGxkhGpTZxcNyYD