### PR TITLE
The binary installs from npm, with nothing downloaded at install time

### DIFF
--- a/.ank/tasks/TASK-79bb5c779a59.md
+++ b/.ank/tasks/TASK-79bb5c779a59.md
@@ -22,8 +22,11 @@ proof:
   - type: commit
     ref: 89f613c
     criteria: 8acf8e427b3f
+  - type: test
+    ref: "30977837306"
+    criteria: 8acf8e427b3f
 schema: 2
-version: 4
+version: 5
 ---
 
 The specification already plans npm among the distribution channels (section
@@ -42,3 +45,4 @@ NPM_TOKEN secret on the repository for release.yml to publish with.
 ## Log
 - 2026-08-05T05:16:25Z seanl@sean-laptop — npm channel implemented as four packages in the esbuild layout: the wrapper @haksolot/ank plus one package per target, listed as optionalDependencies with os and cpu, binaries embedded, no postinstall download. The bare name ank was taken on the registry before this project existed (a one-version test module published over a year ago), so the package is scoped; ank-cli and ankor are taken too. The Linux package deliberately declares no libc: the musl build is static and runs on glibc, and libc: [musl] would make npm skip it on Debian, which is most installs. The wrapper forwards the child exit code unchanged and reserves 9 for its own failures. Verified locally on Windows: npx ank --version matches the release binary byte for byte, ank help nosuchverb comes back as 2 through the wrapper, and a missing platform package gives a self-correcting error at 9. Two things measured rather than assumed: ank context outside a repository is code 1 and not 9, so the CI assertion uses the unknown verb instead; and the build job now uploads the loose binary beside the archives, because extracting a zip on the Windows runner would need unzip, which its bash does not have. NPM_TOKEN is not set on the repository yet, so publish-npm will fail until the maintainer adds it; the smoke job runs on workflow_dispatch and proves the pipeline without publishing.
 - 2026-08-05T05:17:37Z seanl@sean-laptop — done, proof commit:89f613c
+- 2026-08-05T05:26:49Z seanl@sean-laptop — attested test:30977837306

--- a/.ank/tasks/TASK-79bb5c779a59.md
+++ b/.ank/tasks/TASK-79bb5c779a59.md
@@ -5,7 +5,7 @@ slug: the-binary-installs-from-npm-where-executables-c
 title: The binary installs from npm where executables cannot be downloaded
 created: 2026-08-05T04:05:20Z
 author: seanl@sean-laptop
-status: open
+status: in_progress
 scope:
   - .github/workflows/release.yml
   - npm/**
@@ -19,7 +19,7 @@ done_criteria: |
   the release binary. release.yml publishes the packages on a version tag.
 criteria_by: creator
 schema: 2
-version: 1
+version: 3
 ---
 
 The specification already plans npm among the distribution channels (section
@@ -34,3 +34,6 @@ Human decisions required before this task is claimable in practice, and they
 belong to the maintainer, not the implementing agent: whether the name ank is
 free on the npm registry (else pick and record the fallback name), and an
 NPM_TOKEN secret on the repository for release.yml to publish with.
+
+## Log
+- 2026-08-05T05:16:25Z seanl@sean-laptop — npm channel implemented as four packages in the esbuild layout: the wrapper @haksolot/ank plus one package per target, listed as optionalDependencies with os and cpu, binaries embedded, no postinstall download. The bare name ank was taken on the registry before this project existed (a one-version test module published over a year ago), so the package is scoped; ank-cli and ankor are taken too. The Linux package deliberately declares no libc: the musl build is static and runs on glibc, and libc: [musl] would make npm skip it on Debian, which is most installs. The wrapper forwards the child exit code unchanged and reserves 9 for its own failures. Verified locally on Windows: npx ank --version matches the release binary byte for byte, ank help nosuchverb comes back as 2 through the wrapper, and a missing platform package gives a self-correcting error at 9. Two things measured rather than assumed: ank context outside a repository is code 1 and not 9, so the CI assertion uses the unknown verb instead; and the build job now uploads the loose binary beside the archives, because extracting a zip on the Windows runner would need unzip, which its bash does not have. NPM_TOKEN is not set on the repository yet, so publish-npm will fail until the maintainer adds it; the smoke job runs on workflow_dispatch and proves the pipeline without publishing.

--- a/.ank/tasks/TASK-79bb5c779a59.md
+++ b/.ank/tasks/TASK-79bb5c779a59.md
@@ -5,7 +5,7 @@ slug: the-binary-installs-from-npm-where-executables-c
 title: The binary installs from npm where executables cannot be downloaded
 created: 2026-08-05T04:05:20Z
 author: seanl@sean-laptop
-status: in_progress
+status: done
 scope:
   - .github/workflows/release.yml
   - npm/**
@@ -18,8 +18,12 @@ done_criteria: |
   no postinstall download. npx <package> --version answers with the same line as
   the release binary. release.yml publishes the packages on a version tag.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 89f613c
+    criteria: 8acf8e427b3f
 schema: 2
-version: 3
+version: 4
 ---
 
 The specification already plans npm among the distribution channels (section
@@ -37,3 +41,4 @@ NPM_TOKEN secret on the repository for release.yml to publish with.
 
 ## Log
 - 2026-08-05T05:16:25Z seanl@sean-laptop — npm channel implemented as four packages in the esbuild layout: the wrapper @haksolot/ank plus one package per target, listed as optionalDependencies with os and cpu, binaries embedded, no postinstall download. The bare name ank was taken on the registry before this project existed (a one-version test module published over a year ago), so the package is scoped; ank-cli and ankor are taken too. The Linux package deliberately declares no libc: the musl build is static and runs on glibc, and libc: [musl] would make npm skip it on Debian, which is most installs. The wrapper forwards the child exit code unchanged and reserves 9 for its own failures. Verified locally on Windows: npx ank --version matches the release binary byte for byte, ank help nosuchverb comes back as 2 through the wrapper, and a missing platform package gives a self-correcting error at 9. Two things measured rather than assumed: ank context outside a repository is code 1 and not 9, so the CI assertion uses the unknown verb instead; and the build job now uploads the loose binary beside the archives, because extracting a zip on the Windows runner would need unzip, which its bash does not have. NPM_TOKEN is not set on the repository yet, so publish-npm will fail until the maintainer adds it; the smoke job runs on workflow_dispatch and proves the pipeline without publishing.
+- 2026-08-05T05:17:37Z seanl@sean-laptop — done, proof commit:89f613c

--- a/.github/scripts/npm-assemble.sh
+++ b/.github/scripts/npm-assemble.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+#
+# Fills the npm packages with the binaries the build job produced, stamps one
+# version across all four, and packs them.
+#
+# The binaries come from the same artefacts the GitHub release publishes: one
+# build, two channels, and no second compilation that could disagree with the
+# first. Nothing here downloads anything, which is the property the whole
+# channel exists for (npm/README.md).
+#
+#   npm-assemble.sh <version> [package ...]
+#
+# With no package named, all three are assembled -- which is what the publish
+# job wants. The smoke job names the one platform whose artefact it downloaded,
+# because it only has that one.
+
+set -euo pipefail
+
+version="${1:?usage: npm-assemble.sh <version> [package ...]}"
+shift
+packages=("$@")
+if [ "${#packages[@]}" -eq 0 ]; then
+  packages=(ank-linux-x64-musl ank-darwin-arm64 ank-win32-x64)
+fi
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$root"
+
+target_of() {
+  case "$1" in
+    ank-linux-x64-musl) echo x86_64-unknown-linux-musl ;;
+    ank-darwin-arm64) echo aarch64-apple-darwin ;;
+    ank-win32-x64) echo x86_64-pc-windows-msvc ;;
+    *)
+      echo "unknown package: $1" >&2
+      return 1
+      ;;
+  esac
+}
+
+exe_of() {
+  case "$1" in
+    ank-win32-x64) echo ank.exe ;;
+    *) echo ank ;;
+  esac
+}
+
+for p in "${packages[@]}"; do
+  target="$(target_of "$p")"
+  exe="$(exe_of "$p")"
+  # The loose binary the build job uploads beside the archives. Reaching for it
+  # rather than unpacking a .zip keeps this script free of unzip, which the
+  # Windows runner's bash does not have.
+  src="$(find dist -type f -path "*${target}*" -name "$exe" | head -n 1)"
+  if [ -z "$src" ]; then
+    echo "no $exe built for $target under dist/" >&2
+    exit 1
+  fi
+  mkdir -p "npm/$p/bin"
+  cp "$src" "npm/$p/bin/$exe"
+  chmod +x "npm/$p/bin/$exe"
+  cp LICENSE "npm/$p/LICENSE"
+  (
+    cd "npm/$p"
+    npm pkg set version="$version"
+    npm pack --silent > /dev/null
+  )
+  echo "assembled npm/$p from $src"
+done
+
+# The wrapper pins the platform packages exactly. A range would let an install
+# resolve a binary from a different build than the wrapper it came with, and
+# the version is the only thing tying the two together.
+cd npm/ank
+npm pkg set version="$version"
+for p in ank-linux-x64-musl ank-darwin-arm64 ank-win32-x64; do
+  npm pkg set "optionalDependencies.@haksolot/$p=$version"
+done
+cp ../../LICENSE LICENSE
+npm pack --silent > /dev/null
+echo "assembled npm/ank at $version"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,6 +105,10 @@ jobs:
             sha256sum "${name}.tar.gz" > "${name}.tar.gz.sha256"
           fi
 
+      # The loose binary travels beside the archives, for the npm packages
+      # below: extracting a .zip would need `unzip`, which the Windows runner's
+      # bash does not have, and building a second time to avoid that would be
+      # two binaries where the point is one.
       - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.target }}
@@ -112,11 +116,134 @@ jobs:
             dist/*.tar.gz
             dist/*.zip
             dist/*.sha256
+            dist/*/ank
+            dist/*/ank.exe
           if-no-files-found: error
+
+  # The npm channel exists for the workstation whose firewall blocks downloading
+  # a bare executable but lets the registry through, so the binaries travel
+  # inside the platform packages and nothing is fetched at install time
+  # (npm/README.md). This job proves that on the machine that will run it.
+  npm-smoke:
+    name: npm ${{ matrix.os }}
+    needs: build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            package: ank-linux-x64-musl
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            package: ank-darwin-arm64
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            package: ank-win32-x64
+
+    steps:
+      - uses: actions/checkout@v5
+      # Pinned rather than inherited: `engines` declares node 18, and a channel
+      # that works on one runner's default and not another's is the kind of
+      # thing this job exists to catch before a tag does.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - uses: actions/download-artifact@v8
+        with:
+          name: ${{ matrix.target }}
+          path: dist
+
+      # Assembling and testing on the same OS is the point: an install that
+      # works on Linux says nothing about the .cmd shim npm writes on Windows,
+      # and a wrapper is exactly the kind of code that is right on one platform
+      # and wrong on another.
+      - name: assemble
+        shell: bash
+        run: bash .github/scripts/npm-assemble.sh "0.0.0-smoke" "${{ matrix.package }}"
+
+      - name: install from the tarballs
+        shell: bash
+        run: |
+          mkdir -p smoke && cd smoke
+          npm init -y > /dev/null
+          npm install --no-audit --no-fund \
+            "../npm/${{ matrix.package }}/"*.tgz "../npm/ank/"*.tgz
+
+      # The criterion in as many words: the same line as the release binary.
+      # Compared against the artefact itself rather than against a literal, so
+      # the assertion cannot drift from the version it ships.
+      - name: npx answers like the binary
+        shell: bash
+        run: |
+          set -e
+          direct=$(find dist -type f \( -name 'ank' -o -name 'ank.exe' \) | head -n 1)
+          chmod +x "$direct" 2>/dev/null || true
+          expected=$("$direct" --version)
+          actual=$(cd smoke && npx ank --version)
+          echo "binary: $expected"
+          echo "npx:    $actual"
+          test "$expected" = "$actual"
+
+      # The exit codes carry meaning (section 4) and a wrapper is where they go
+      # to die. An unknown verb is a 2, and 2 rather than 1 is the point: a
+      # wrapper collapsing every failure into "it failed" would still pass a
+      # test that only asked for non-zero. It also needs no repository, so what
+      # is under test is the wrapper and not the fixture.
+      - name: the exit code survives the wrapper
+        shell: bash
+        run: |
+          cd smoke
+          npx ank --version > /dev/null
+          set +e
+          npx ank help nosuchverb
+          code=$?
+          set -e
+          echo "an unknown verb exited $code"
+          test "$code" -eq 2
+
+  publish-npm:
+    # Only on a tag, and only once all three smoke tests agree. Publishing is
+    # the one step here that cannot be taken back.
+    needs: npm-smoke
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+      - uses: actions/download-artifact@v8
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: assemble
+        shell: bash
+        run: bash .github/scripts/npm-assemble.sh "${GITHUB_REF_NAME#v}"
+
+      # The platform packages first: the wrapper pins them exactly, so a
+      # wrapper on the registry ahead of its binaries is an install that
+      # resolves to nothing.
+      - name: publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          for p in ank-linux-x64-musl ank-darwin-arm64 ank-win32-x64 ank; do
+            npm publish --access public "npm/$p"
+          done
 
   publish:
     # Only after all three. A release carrying two platforms out of three would
     # be worse than no release: it looks complete.
+    #
+    # `build` and not `npm-smoke`, deliberately: the release page is the primary
+    # channel and npm is a convenience on top of it, so a broken wrapper costs
+    # the npm packages and not the release. The reverse would hold the binaries
+    # hostage to a JavaScript shim.
     needs: build
     # And only for a tag. A dispatch run builds and stops there.
     if: startsWith(github.ref, 'refs/tags/v')
@@ -138,7 +265,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
         run: |
+          # Named globs, not dist/*: the artefacts now also carry the loose
+          # binary the npm packages are built from, in a directory, and
+          # `gh release create` takes files.
           gh release create "$GITHUB_REF_NAME" \
             --title "$GITHUB_REF_NAME" \
             --generate-notes \
-            dist/*
+            dist/*.tar.gz dist/*.zip dist/*.sha256

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 /target
 .ank/index.db
+# The release run fills these from the artefacts it just built (npm/README.md).
+npm/ank-*/bin/
+npm/*/LICENSE
+npm/*/*.tgz

--- a/README.md
+++ b/README.md
@@ -40,7 +40,16 @@ it to pay less per call. No server, no daemon, no account.
 
 **Install.** Take a binary from the [latest release][releases] — Linux
 (`x86_64-musl`), macOS (Apple silicon) or Windows (`x86_64`), each with a
-`.sha256` beside it — and put `ank` on your `PATH`. Or build it:
+`.sha256` beside it — and put `ank` on your `PATH`. Or from npm, where the
+binary travels inside the package and nothing is downloaded at install time,
+which is what makes this the channel that works behind a firewall:
+
+```
+npx @haksolot/ank --version
+npm install -g @haksolot/ank
+```
+
+Or build it:
 
 ```
 cargo install --git https://github.com/haksolot/ank ank-cli

--- a/docs/ank-spec-v1.1.md
+++ b/docs/ank-spec-v1.1.md
@@ -853,6 +853,8 @@ Both git files are written at the root of the initialised directory, and both ca
 
 **Binary distribution**: the skill says *how* to use Ank, it does not install the CLI. Plan for `curl | sh` and Homebrew in addition to npm.
 
+**npm is the first channel implemented**, and it is implemented for one reason that shapes it entirely: the workstation whose firewall blocks downloading a bare executable but lets the registry through. The binaries therefore travel **inside** the packages — one package per target, listed as `optionalDependencies` on a wrapper that carries `os` and `cpu`, so npm installs exactly the one that matches. **No `postinstall` download**, because a `postinstall` that fetched the binary would die behind the very firewall the channel exists to cross, and would do it after the install appeared to succeed. The wrapper resolves and executes; it forwards the child's exit code unchanged, since the codes above are an interface an agent branches on, and it reserves 9 — the environment code — for its own failures. The package name is scoped, `@haksolot/ank`: the bare name was taken on the registry before this project existed, and the scope is the closest thing to the name the project actually has (ADR-85e6664c67d8).
+
 ---
 
 ## 10. v1 scope

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -24,6 +24,17 @@ Every release carries a static binary for three targets —
 your platform from the [releases page](https://github.com/haksolot/ank/releases/latest),
 check the hash, unpack it, and put `ank` on your `PATH`.
 
+From npm instead, which is the channel to reach for on a machine whose firewall
+blocks downloading a bare executable but lets the registry through:
+
+    npx @haksolot/ank --version
+    npm install -g @haksolot/ank
+
+The binary is inside the package — one package per platform, installed through
+`optionalDependencies`, and no `postinstall` fetches anything. A `postinstall`
+download would die behind the very firewall this channel exists to cross, and
+would do it after the install looked like it had worked.
+
 To build instead:
 
     cargo install --git https://github.com/haksolot/ank ank-cli

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,0 +1,53 @@
+# The npm channel
+
+Four packages, and the shape is the one esbuild uses.
+
+    @haksolot/ank                    the wrapper, and the only name anyone types
+    @haksolot/ank-linux-x64-musl     the binary, one package per target
+    @haksolot/ank-darwin-arm64
+    @haksolot/ank-win32-x64
+
+The wrapper declares the three as `optionalDependencies`, each carrying `os` and
+`cpu`. npm installs the one that matches the machine and silently skips the
+other two, so a `linux x64` install downloads one binary and not three.
+
+**The binaries are inside the packages, and nothing is fetched at install time.**
+That is the whole point of this channel rather than a detail of it. The driving
+case is the corporate workstation whose firewall blocks downloading a bare
+executable but lets the npm registry through; a `postinstall` script that
+fetched the binary would die behind exactly the firewall this package exists to
+cross. `bin/ank` is therefore a resolver, never a downloader — it finds the
+platform package with `require.resolve` and executes what it finds.
+
+**The Linux package declares no `libc`.** The build is `x86_64-unknown-linux-musl`
+and statically linked, so it runs on a glibc distribution just as well; declaring
+`"libc": ["musl"]` would make npm skip it on Debian and Ubuntu, which is most of
+the installs. The target is in the package name because that is what was built,
+not because it restricts where it runs.
+
+**The wrapper forwards the exit code unchanged.** Section 4 of the specification
+gives 4, 6, 8 and 9 distinct meanings that an agent branches on. A wrapper that
+collapsed them into 0 and 1 would break every caller reading them, which is why
+`bin/ank` exits with the child's status and reserves 9 — the environment code —
+for its own failures.
+
+## What is not in git
+
+`npm/ank-*/bin/` is empty here and ignored. The binaries land in it during the
+release run, from the same artefacts the GitHub release publishes: one build,
+two channels, no second compilation that could disagree with the first.
+
+## Versions
+
+All four carry one version, and the wrapper pins the three platform packages to
+it exactly. `release.yml` stamps it from the tag, so the copy committed here is
+only ever the last released one.
+
+## Publishing
+
+`release.yml` does it on a `v*` tag, with `NPM_TOKEN` from the repository
+secrets and `--access public`, which a scoped package needs on its first
+publish. On `workflow_dispatch` the same job assembles the packages, installs
+them from the tarballs on all three platforms and runs `ank --version` — the
+pipeline is proved before a tag depends on it, and a tag is the one thing here
+that is awkward to take back.

--- a/npm/ank-darwin-arm64/package.json
+++ b/npm/ank-darwin-arm64/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@haksolot/ank-darwin-arm64",
+  "version": "0.1.1",
+  "description": "The ank binary for macOS on Apple silicon.",
+  "license": "GPL-3.0-only",
+  "homepage": "https://github.com/haksolot/ank",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/haksolot/ank.git"
+  },
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "files": [
+    "bin/ank",
+    "LICENSE"
+  ]
+}

--- a/npm/ank-linux-x64-musl/package.json
+++ b/npm/ank-linux-x64-musl/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@haksolot/ank-linux-x64-musl",
+  "version": "0.1.1",
+  "description": "The ank binary for Linux x86_64, statically linked against musl.",
+  "license": "GPL-3.0-only",
+  "homepage": "https://github.com/haksolot/ank",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/haksolot/ank.git"
+  },
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "files": [
+    "bin/ank",
+    "LICENSE"
+  ]
+}

--- a/npm/ank-win32-x64/package.json
+++ b/npm/ank-win32-x64/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@haksolot/ank-win32-x64",
+  "version": "0.1.1",
+  "description": "The ank binary for Windows x86_64.",
+  "license": "GPL-3.0-only",
+  "homepage": "https://github.com/haksolot/ank",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/haksolot/ank.git"
+  },
+  "os": [
+    "win32"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "files": [
+    "bin/ank.exe",
+    "LICENSE"
+  ]
+}

--- a/npm/ank/README.md
+++ b/npm/ank/README.md
@@ -1,0 +1,22 @@
+# ank
+
+**The stupid coordination tool.** Tasks and architecture decisions in your repo,
+behind one CLI any coding agent can call.
+
+    npx @haksolot/ank --version
+    npm install -g @haksolot/ank
+
+The binary travels inside the package: nothing is downloaded at install time, so
+this channel works where fetching a bare executable does not. ank needs **git
+2.34 or newer**, and checks at startup.
+
+    ank init                      # creates .ank/, once
+    ank context                   # what binds here, and what is free to take
+    ank claim <id>                # takes the task, freezes its criterion by hash
+    ank log "<what you learned>"  # renews the claim; working is what holds it
+    ank done                      # runs the verifiers itself and writes the proof
+
+Documentation, the specification and the source are at
+<https://github.com/haksolot/ank>. GPL-3.0 — the copyleft covers the tool's
+code, not the format: your `.ank/` files, and the third-party tools that read or
+write them, are not derivative works.

--- a/npm/ank/bin/ank
+++ b/npm/ank/bin/ank
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+"use strict";
+
+// This wrapper resolves a binary. It never downloads one.
+//
+// The driving case is the corporate workstation: a firewall that blocks
+// downloading a bare executable usually lets the npm registry through. A
+// postinstall script that fetched the binary would therefore die behind the
+// very firewall this package exists to cross. The binaries travel inside the
+// platform packages instead, and npm installs exactly one of them by matching
+// `os` and `cpu` through optionalDependencies.
+
+const { spawnSync } = require("child_process");
+
+const PACKAGES = {
+  "linux x64": "@haksolot/ank-linux-x64-musl",
+  "darwin arm64": "@haksolot/ank-darwin-arm64",
+  "win32 x64": "@haksolot/ank-win32-x64",
+};
+
+const platform = process.platform + " " + process.arch;
+const pkg = PACKAGES[platform];
+const exe = process.platform === "win32" ? "ank.exe" : "ank";
+
+// Code 9 is the environment, and it is the right one for every failure in this
+// file: none of them is a failure of the caller's work, which is exactly what
+// section 4 reserves 9 for. Each one names the command that fixes it.
+function fail(lines) {
+  for (const line of lines) {
+    console.error(line);
+  }
+  process.exit(9);
+}
+
+if (!pkg) {
+  fail([
+    "ank: no prebuilt binary for " + platform,
+    "  -> cargo install --git https://github.com/haksolot/ank ank-cli",
+  ]);
+}
+
+let binary;
+try {
+  binary = require.resolve(pkg + "/bin/" + exe);
+} catch (e) {
+  fail([
+    "ank: " + pkg + " is not installed",
+    "  -> npm install @haksolot/ank",
+    "  -> optional dependencies carry the binary, so --no-optional removes it",
+  ]);
+}
+
+// The exit code is the interface. Section 4 gives 4, 6, 8 and 9 distinct
+// meanings that an agent branches on, so a wrapper collapsing them into 0 and 1
+// would break every caller that reads them.
+const run = spawnSync(binary, process.argv.slice(2), { stdio: "inherit" });
+if (run.error) {
+  fail(["ank: " + run.error.message, "  -> " + binary]);
+}
+// A process killed by a signal carries no code of its own; 9 says environment,
+// which is what a signal from outside is.
+process.exit(run.status === null ? 9 : run.status);

--- a/npm/ank/package.json
+++ b/npm/ank/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@haksolot/ank",
+  "version": "0.1.1",
+  "description": "The stupid coordination tool: tasks and architecture decisions in your repo, behind one CLI any coding agent can call.",
+  "license": "GPL-3.0-only",
+  "homepage": "https://github.com/haksolot/ank",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/haksolot/ank.git"
+  },
+  "bugs": {
+    "url": "https://github.com/haksolot/ank/issues"
+  },
+  "keywords": [
+    "cli",
+    "agent",
+    "adr",
+    "architecture-decision-record",
+    "tasks",
+    "coordination"
+  ],
+  "bin": {
+    "ank": "bin/ank"
+  },
+  "files": [
+    "bin/ank",
+    "README.md",
+    "LICENSE"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "optionalDependencies": {
+    "@haksolot/ank-darwin-arm64": "0.1.1",
+    "@haksolot/ank-linux-x64-musl": "0.1.1",
+    "@haksolot/ank-win32-x64": "0.1.1"
+  }
+}


### PR DESCRIPTION
Closes TASK-79bb5c779a59.

Four packages in the esbuild layout: the wrapper `@haksolot/ank`, and one
package per target listed as an `optionalDependency` carrying `os` and `cpu`,
so npm installs exactly the one that matches.

**The binaries are inside the packages**, which is the whole point rather than a
detail of it. The driving case is the workstation whose firewall blocks
downloading a bare executable but lets the registry through — a `postinstall`
that fetched the binary would die behind exactly that firewall, and would do it
after the install had appeared to succeed.

## The two decisions the task reserved for a human

**The name.** `ank` on the registry is a one-version test module published over
a year ago by somebody else; `ank-cli` and `ankor` are taken too. The package is
therefore scoped, `@haksolot/ank` — the closest thing to the name ADR-85e6664c67d8
fixes, and consistent with `npx skills add haksolot/ank`.

**`NPM_TOKEN` is not set on the repository.** `publish-npm` will fail on the
next tag until it is added:

```
gh secret set NPM_TOKEN --repo haksolot/ank
```

Nothing else waits on it — `npm-smoke` runs on `workflow_dispatch` and proves
the whole pipeline without publishing anything.

## Two things worth naming

The Linux package **declares no `libc`**. The musl build is static and runs on
glibc just as well, and `"libc": ["musl"]` would make npm skip it on Debian and
Ubuntu, which is most installs. The target is in the package name because that
is what was built, not because it restricts where it runs.

The wrapper **forwards the child exit code unchanged**. Section 4 gives 4, 6, 8
and 9 meanings an agent branches on, and a wrapper collapsing them into 0 and 1
would break every caller that reads them. It reserves 9 — the environment code —
for its own failures, each naming the command that fixes it.

## Verification

`npm-smoke` runs on all three platforms, on dispatch as well as on a tag:
assemble, install from the tarballs, and check that `npx ank --version` answers
the same line as the release binary — compared against the artefact itself, not
a literal, so the assertion cannot drift from the version it ships. Then an
exit-code check on an unknown verb, which is a 2: asking only for non-zero would
pass on a wrapper that had collapsed every failure into one.

Run end to end locally on Windows: the version line matches byte for byte, `ank
help nosuchverb` comes back as 2 through the wrapper, and installing the wrapper
without its platform package gives a self-correcting error at 9.

Two things measured rather than assumed:

- `ank context` outside a repository is code **1**, not 9 — the first draft of
  the CI assertion was wrong and the local run caught it.
- The build job now uploads the loose binary beside the archives. Extracting a
  `.zip` on the Windows runner would need `unzip`, which its bash does not have,
  and building a second time would be two binaries where the point is one. The
  GitHub release step moves to named globs accordingly, since it takes files.

`cargo test --workspace` green, 303 tests. `ank check` reports no new finding —
one fewer, in fact: `scope npm/** matches no file yet` is now false.

Proof: `commit:89f613c`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NYtKH7nGxkhGpTZxcNyYD