### PR TITLE
Every long flag gains a declared short form

### DIFF
--- a/.ank/tasks/TASK-f3e92656b5df.md
+++ b/.ank/tasks/TASK-f3e92656b5df.md
@@ -5,7 +5,7 @@ slug: every-long-flag-gains-a-declared-short-form
 title: Every long flag gains a declared short form
 created: 2026-08-05T04:06:02Z
 author: seanl@sean-laptop
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/src/cli.rs
   - docs/ank-spec-v1.1.md
@@ -17,8 +17,12 @@ done_criteria: |
   type separately. ank help <verb> shows both forms. Behaviour is tested through
   the binary.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 81c0501
+    criteria: 9ed5d10705f8
 schema: 2
-version: 4
+version: 5
 ---
 
 Execution of ADR-962c25797569, grammar half. The parser is hand-rolled
@@ -31,3 +35,4 @@ in the specification table, not improvised in code.
 ## Log
 - 2026-08-05T04:06:58Z seanl@sean-laptop — amended: -blocked_by ADR-962c25797569
 - 2026-08-05T05:48:55Z seanl@sean-laptop — Short-form table written into specification section 4 before any parser change, ADR-962c25797569. The rule is mechanical rather than negotiated: the letter is the first letter of the long flag, without exception, and where several long flags share one, exactly one takes it and the others keep only their long form. Ten letters: -j -q -r globally, then -b -c -l -p -s -t -v. That is what leaves --scope, --title, --ttl, --reason, --constraint, --supersedes and --body long-only, and section 4 names each one with the letter that would have been its. A -s meaning --status under find and --scope under new would be a silent wrong answer, not a saving: ank find -s open would filter on a scope named open and return nothing. One table in cli.rs rather than a letter beside each declaration, since --scope and --criteria are each declared in three CommandSpecs. Two consequences handled: a short flag that names a real flag the verb does not take gets its own message rather than unknown flag, and a single-dash argument containing whitespace is refused as the positional it is, naming the -- escape, because ank log '-1 rebuilt' used to be a message and is now a flag. Tested through the binary, six tests, with the negative control run: the branch disabled, three of them fail.
+- 2026-08-05T05:49:22Z seanl@sean-laptop — done, proof commit:81c0501

--- a/.ank/tasks/TASK-f3e92656b5df.md
+++ b/.ank/tasks/TASK-f3e92656b5df.md
@@ -5,7 +5,7 @@ slug: every-long-flag-gains-a-declared-short-form
 title: Every long flag gains a declared short form
 created: 2026-08-05T04:06:02Z
 author: seanl@sean-laptop
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/src/cli.rs
   - docs/ank-spec-v1.1.md
@@ -18,7 +18,7 @@ done_criteria: |
   the binary.
 criteria_by: creator
 schema: 2
-version: 2
+version: 4
 ---
 
 Execution of ADR-962c25797569, grammar half. The parser is hand-rolled
@@ -30,3 +30,4 @@ in the specification table, not improvised in code.
 
 ## Log
 - 2026-08-05T04:06:58Z seanl@sean-laptop — amended: -blocked_by ADR-962c25797569
+- 2026-08-05T05:48:55Z seanl@sean-laptop — Short-form table written into specification section 4 before any parser change, ADR-962c25797569. The rule is mechanical rather than negotiated: the letter is the first letter of the long flag, without exception, and where several long flags share one, exactly one takes it and the others keep only their long form. Ten letters: -j -q -r globally, then -b -c -l -p -s -t -v. That is what leaves --scope, --title, --ttl, --reason, --constraint, --supersedes and --body long-only, and section 4 names each one with the letter that would have been its. A -s meaning --status under find and --scope under new would be a silent wrong answer, not a saving: ank find -s open would filter on a scope named open and return nothing. One table in cli.rs rather than a letter beside each declaration, since --scope and --criteria are each declared in three CommandSpecs. Two consequences handled: a short flag that names a real flag the verb does not take gets its own message rather than unknown flag, and a single-dash argument containing whitespace is refused as the positional it is, naming the -- escape, because ank log '-1 rebuilt' used to be a message and is now a flag. Tested through the binary, six tests, with the negative control run: the branch disabled, three of them fail.

--- a/.ank/tasks/TASK-f3e92656b5df.md
+++ b/.ank/tasks/TASK-f3e92656b5df.md
@@ -21,8 +21,11 @@ proof:
   - type: commit
     ref: 81c0501
     criteria: 9ed5d10705f8
+  - type: test
+    ref: "30979320605"
+    criteria: 9ed5d10705f8
 schema: 2
-version: 5
+version: 6
 ---
 
 Execution of ADR-962c25797569, grammar half. The parser is hand-rolled
@@ -36,3 +39,4 @@ in the specification table, not improvised in code.
 - 2026-08-05T04:06:58Z seanl@sean-laptop — amended: -blocked_by ADR-962c25797569
 - 2026-08-05T05:48:55Z seanl@sean-laptop — Short-form table written into specification section 4 before any parser change, ADR-962c25797569. The rule is mechanical rather than negotiated: the letter is the first letter of the long flag, without exception, and where several long flags share one, exactly one takes it and the others keep only their long form. Ten letters: -j -q -r globally, then -b -c -l -p -s -t -v. That is what leaves --scope, --title, --ttl, --reason, --constraint, --supersedes and --body long-only, and section 4 names each one with the letter that would have been its. A -s meaning --status under find and --scope under new would be a silent wrong answer, not a saving: ank find -s open would filter on a scope named open and return nothing. One table in cli.rs rather than a letter beside each declaration, since --scope and --criteria are each declared in three CommandSpecs. Two consequences handled: a short flag that names a real flag the verb does not take gets its own message rather than unknown flag, and a single-dash argument containing whitespace is refused as the positional it is, naming the -- escape, because ank log '-1 rebuilt' used to be a message and is now a flag. Tested through the binary, six tests, with the negative control run: the branch disabled, three of them fail.
 - 2026-08-05T05:49:22Z seanl@sean-laptop — done, proof commit:81c0501
+- 2026-08-05T05:53:28Z seanl@sean-laptop — attested test:30979320605

--- a/crates/ank-cli/src/cli.rs
+++ b/crates/ank-cli/src/cli.rs
@@ -130,6 +130,49 @@ const fn multi(name: &'static str) -> FlagSpec {
 /// than declaring them per command, which would leave room to forget one.
 pub const GLOBAL_FLAGS: &[FlagSpec] = &[switch("--json"), switch("--quiet"), flag("--repo")];
 
+/// The short forms of §4 (ADR-962c25797569), and the whole of them.
+///
+/// One table rather than a letter beside each declaration: `--scope` and
+/// `--criteria` are declared in three [`CommandSpec`]s each, and three
+/// declarations of one letter are three chances for two of them to disagree.
+/// Here a letter can only mean one thing, which is exactly the property §4
+/// claims for it.
+///
+/// The letter is the first letter of the long flag, without exception. Where
+/// several long flags share one, exactly one takes it and the others keep only
+/// their long form — a `-s` that meant `--status` under `find` and `--scope`
+/// under `new` would not be a saving but a silent wrong answer.
+pub const SHORT_FORMS: &[(&str, char)] = &[
+    ("--json", 'j'),
+    ("--quiet", 'q'),
+    ("--repo", 'r'),
+    ("--blocked-by", 'b'),
+    ("--criteria", 'c'),
+    ("--limit", 'l'),
+    ("--proof", 'p'),
+    ("--status", 's'),
+    ("--type", 't'),
+    ("--verify", 'v'),
+];
+
+/// The short form of a long flag, if §4 gave it one.
+pub fn short_of(long: &str) -> Option<char> {
+    SHORT_FORMS
+        .iter()
+        .find(|(name, _)| *name == long)
+        .map(|(_, c)| *c)
+}
+
+/// The long flag a letter stands for, anywhere. Whether that flag is legal on
+/// the verb being parsed is a separate question, and asking it separately is
+/// what lets the error say "not for this verb" instead of "no such flag".
+fn long_of(c: char) -> Option<&'static str> {
+    SHORT_FORMS
+        .iter()
+        .find(|(_, letter)| *letter == c)
+        .map(|(name, _)| *name)
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct CommandSpec {
     pub name: &'static str,
@@ -403,6 +446,83 @@ impl Invocation {
 // Parsing
 // ---------------------------------------------------------------------------
 
+/// `name=value` split, for both forms: `--status=open` and `-s=open` reach it
+/// with the dashes already accounted for by the caller.
+fn split_inline(arg: &str) -> (String, Option<String>) {
+    match arg.split_once('=') {
+        Some((n, v)) => (n.to_string(), Some(v.to_string())),
+        None => (arg.to_string(), None),
+    }
+}
+
+/// A single-dash argument, resolved to the long flag it names (§4).
+///
+/// Bundling is refused rather than parsed. Accepting `-st` forces a decision
+/// about `-sopen` — is that three flags, or `-s` with a value? — and every
+/// answer to that is a guess about what the caller meant. The refusal costs one
+/// round trip and names exactly what to type instead; a guess costs a wrong
+/// answer that looks right.
+fn short_flag(spec: &CommandSpec, arg: &str) -> Result<(String, String, Option<String>)> {
+    // No flag contains whitespace, so this one is a positional that starts with
+    // a dash -- `ank log "-1 rebuilt the index"`. Saying so beats reporting it
+    // as a bundle of nine unknown letters, and it is a fact rather than a guess
+    // about intent. Single-dash arguments became flags the day short forms did,
+    // and that is the one consequence a caller has to be told rather than left
+    // to discover.
+    if arg.contains(char::is_whitespace) {
+        return Err(
+            CliError::new(1, format!("'{arg}' is not a flag: it contains a space"))
+                .with_hint(format!("ank {} -- \"{arg}\"", spec.name)),
+        );
+    }
+
+    let (letters, inline) = split_inline(&arg[1..]);
+    let chars: Vec<char> = letters.chars().collect();
+
+    if chars.len() > 1 {
+        return Err(bundled(spec, &chars, &letters));
+    }
+
+    let unknown = |typed: &str| {
+        CliError::new(1, format!("unknown flag '{typed}' for '{}'", spec.name))
+            .with_hint(format!("valid flags: {}", known_flags(spec).join(" ")))
+    };
+
+    // `-` alone never reaches here, and `-=v` leaves nothing to resolve.
+    let Some(c) = chars.first() else {
+        return Err(unknown(arg));
+    };
+    let typed = format!("-{c}");
+    let Some(long) = long_of(*c) else {
+        return Err(unknown(&typed));
+    };
+    Ok((typed, long.to_string(), inline))
+}
+
+/// `-st`, and the two flags to type instead.
+///
+/// A letter that names nothing on this verb is reported as itself: naming a
+/// flag the caller could type separately would be advice about a command that
+/// would refuse too.
+fn bundled(spec: &CommandSpec, chars: &[char], letters: &str) -> CliError {
+    let mut parts: Vec<String> = Vec::new();
+    for c in chars {
+        match long_of(*c).and_then(|long| find_flag(spec, long)) {
+            Some(fs) if fs.takes_value => parts.push(format!("-{c} <v>")),
+            Some(_) => parts.push(format!("-{c}")),
+            None => {
+                return CliError::new(1, format!("unknown flag '-{c}' for '{}'", spec.name))
+                    .with_hint(format!("valid flags: {}", known_flags(spec).join(" ")))
+            }
+        }
+    }
+    CliError::new(1, format!("'-{letters}' bundles short flags")).with_hint(format!(
+        "ank {} {}",
+        spec.name,
+        parts.join(" ")
+    ))
+}
+
 pub fn parse(argv: &[String]) -> Result<Invocation> {
     let Some(first) = argv.first() else {
         return Err(CliError::new(1, "no command").with_hint("ank context"));
@@ -454,54 +574,70 @@ pub fn parse(argv: &[String]) -> Result<Invocation> {
             continue;
         }
 
-        if !terminated && arg.starts_with("--") {
-            let (name, inline) = match arg.split_once('=') {
-                Some((n, v)) => (n.to_string(), Some(v.to_string())),
-                None => (arg.clone(), None),
-            };
+        // `typed` is what the caller wrote and `name` is the long flag it
+        // names; they differ only for a short form. Every error below quotes
+        // `typed`, because an agent that typed `-s` is helped by an error about
+        // `-s` and not about a flag it never wrote.
+        let named: Option<(String, String, Option<String>)> = if terminated {
+            None
+        } else if arg.starts_with("--") {
+            let (name, inline) = split_inline(arg);
+            Some((name.clone(), name, inline))
+        } else if arg.starts_with('-') && arg.len() > 1 {
+            Some(short_flag(spec, arg)?)
+        } else {
+            None
+        };
 
-            let Some(fs) = find_flag(spec, &name) else {
-                return Err(
-                    CliError::new(1, format!("unknown flag '{name}' for '{}'", spec.name))
-                        .with_hint(format!("valid flags: {}", known_flags(spec).join(" "))),
-                );
-            };
+        let Some((typed, name, inline)) = named else {
+            positionals.push(arg.clone());
+            i += 1;
+            continue;
+        };
 
-            if !fs.takes_value {
-                if inline.is_some() {
-                    return Err(CliError::new(1, format!("'{name}' takes no value"))
-                        .with_hint(format!("ank {} {name}", spec.name)));
-                }
-                flags.entry(name).or_default();
-                i += 1;
-                continue;
+        let Some(fs) = find_flag(spec, &name) else {
+            // A letter that names a real flag the verb does not take is a
+            // different mistake from a letter that names nothing, and saying
+            // which one it is saves the round trip.
+            let message = if typed == name {
+                format!("unknown flag '{typed}' for '{}'", spec.name)
+            } else {
+                format!("'{typed}' is {name}, which '{}' does not take", spec.name)
+            };
+            return Err(CliError::new(1, message)
+                .with_hint(format!("valid flags: {}", known_flags(spec).join(" "))));
+        };
+
+        if !fs.takes_value {
+            if inline.is_some() {
+                return Err(CliError::new(1, format!("'{typed}' takes no value"))
+                    .with_hint(format!("ank {} {typed}", spec.name)));
             }
-
-            let value = match inline {
-                Some(v) => {
-                    i += 1;
-                    v
-                }
-                None => {
-                    let v = rest.get(i + 1).ok_or_else(|| {
-                        CliError::new(1, format!("'{name}' expects a value"))
-                            .with_hint(format!("ank {} {name} <value>", spec.name))
-                    })?;
-                    i += 2;
-                    v.clone()
-                }
-            };
-
-            let slot = flags.entry(name.clone()).or_default();
-            if !fs.repeatable {
-                slot.clear();
-            }
-            slot.push(value);
+            flags.entry(name).or_default();
+            i += 1;
             continue;
         }
 
-        positionals.push(arg.clone());
-        i += 1;
+        let value = match inline {
+            Some(v) => {
+                i += 1;
+                v
+            }
+            None => {
+                let v = rest.get(i + 1).ok_or_else(|| {
+                    CliError::new(1, format!("'{typed}' expects a value"))
+                        .with_hint(format!("ank {} {typed} <value>", spec.name))
+                })?;
+                i += 2;
+                v.clone()
+            }
+        };
+
+        let slot = flags.entry(name).or_default();
+        if !fs.repeatable {
+            slot.clear();
+        }
+        slot.push(value);
     }
 
     if positionals.len() > spec.max_positionals {
@@ -542,11 +678,21 @@ pub fn usage(spec: &CommandSpec) -> String {
 
 /// A flag as `help` shows it: the name alone says nothing about whether a value
 /// follows, and an agent that guesses wrong pays a round trip to find out.
-fn flag_display(f: &FlagSpec) -> String {
+///
+/// `with_short` is what separates the two surfaces of §9. `ank help <verb>`
+/// shows both forms, since that is the call made to learn one verb precisely.
+/// The flat listing does not, and stays byte for byte what it was: it buys its
+/// token economy by being short, and spending it on a second spelling of every
+/// flag would spend exactly what the split saves.
+fn flag_display(f: &FlagSpec, with_short: bool) -> String {
+    let name = match short_of(f.name) {
+        Some(c) if with_short => format!("-{c}, {}", f.name),
+        _ => f.name.to_string(),
+    };
     match (f.takes_value, f.repeatable) {
-        (false, _) => f.name.to_string(),
-        (true, false) => format!("{} <v>", f.name),
-        (true, true) => format!("{} <v>...", f.name),
+        (false, _) => name,
+        (true, false) => format!("{name} <v>"),
+        (true, true) => format!("{name} <v>..."),
     }
 }
 
@@ -561,10 +707,10 @@ fn flag_names(spec: &CommandSpec) -> String {
         .join(" ")
 }
 
-fn globals_line() -> String {
+fn globals_line(with_short: bool) -> String {
     GLOBAL_FLAGS
         .iter()
-        .map(flag_display)
+        .map(|f| flag_display(f, with_short))
         .collect::<Vec<_>>()
         .join(" ")
 }
@@ -597,9 +743,17 @@ fn json_of(specs: &[&CommandSpec]) -> String {
                 .iter()
                 .chain(GLOBAL_FLAGS.iter())
                 .map(|f| {
+                    // The short form is here and not only in the human listing:
+                    // `--json` is how a script reads the surface, and a mapping
+                    // it cannot see is a mapping it cannot use.
+                    let short = match short_of(f.name) {
+                        Some(c) => json_str(&format!("-{c}")),
+                        None => "null".to_string(),
+                    };
                     format!(
-                        "{{\"name\":{},\"takes_value\":{},\"repeatable\":{}}}",
+                        "{{\"name\":{},\"short\":{},\"takes_value\":{},\"repeatable\":{}}}",
                         json_str(f.name),
+                        short,
                         f.takes_value,
                         f.repeatable
                     )
@@ -644,10 +798,10 @@ pub fn help(inv: &Invocation, out: &mut dyn Write) -> Result<i32> {
         }
         let _ = writeln!(out, "{}", usage(spec));
         if !spec.flags.is_empty() {
-            let flags: Vec<String> = spec.flags.iter().map(flag_display).collect();
+            let flags: Vec<String> = spec.flags.iter().map(|f| flag_display(f, true)).collect();
             let _ = writeln!(out, "  flags:    {}", flags.join(" "));
         }
-        let _ = writeln!(out, "  global:   {}", globals_line());
+        let _ = writeln!(out, "  global:   {}", globals_line(true));
         return Ok(0);
     }
 
@@ -671,7 +825,7 @@ pub fn help(inv: &Invocation, out: &mut dyn Write) -> Result<i32> {
             let _ = writeln!(out, "{:width$}  {names}", usage(spec));
         }
     }
-    let _ = writeln!(out, "\nglobal: {}", globals_line());
+    let _ = writeln!(out, "\nglobal: {}", globals_line(false));
     let _ = writeln!(out, "ank help <verb> for one verb");
     // A trailing pointer, beside the one above it and in the same shape: not a
     // heading and not a grouping, so the flat listing ADR-c656cbcc33a9 requires

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -1601,6 +1601,200 @@ fn a_done_through_the_binary_leaves_a_completion_ref_naming_commit_and_branch() 
     );
 }
 
+// ---------------------------------------------------------------------------
+// Short forms (TASK-f3e92656b5df, ADR-962c25797569)
+// ---------------------------------------------------------------------------
+
+/// The short form is the long form, and the output proves it byte for byte.
+///
+/// Comparing the two invocations against each other rather than against an
+/// expected listing is what makes this a test of the parser: it cannot pass
+/// because `find` was taught to print something, only because both spellings
+/// reached the same flag with the same value.
+#[test]
+fn a_short_flag_is_the_long_flag_and_takes_its_value_both_ways() {
+    let r = Repo::new();
+    r.seed_task("TASK-000000000f01", Some("A criterion."));
+    r.seed_task("TASK-000000000f02", Some("A criterion."));
+    seed_done(
+        &r,
+        "TASK-000000000f03",
+        "  - type: commit\n    ref: abc1234\n",
+    );
+
+    let long = r.ank(
+        "claude-code@ank",
+        &["find", "criterion", "--status", "open"],
+    );
+    assert_eq!(code(&long), 0, "{}", stderr(&long));
+    let expected = stdout(&long);
+    assert!(
+        expected.contains("TASK-000000000f01") && !expected.contains("TASK-000000000f03"),
+        "the fixture must actually filter, or the comparison proves nothing:\n{expected}"
+    );
+
+    for argv in [
+        vec!["find", "criterion", "-s", "open"],
+        vec!["find", "criterion", "-s=open"],
+    ] {
+        let out = r.ank("claude-code@ank", &argv);
+        assert_eq!(code(&out), 0, "{argv:?}: {}", stderr(&out));
+        assert_eq!(stdout(&out), expected, "{argv:?} answered differently");
+    }
+
+    // And a global one, which is legal on every verb rather than declared per
+    // verb -- the path through the parser is the same, the table is not.
+    let out = r.ank("claude-code@ank", &["find", "criterion", "-j"]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    assert!(
+        stdout(&out).trim_start().starts_with('{'),
+        "-j is --json: {}",
+        stdout(&out)
+    );
+}
+
+/// Bundling is refused, and the refusal is the command to type instead.
+#[test]
+fn bundled_short_flags_are_refused_by_naming_the_flags_to_type_separately() {
+    let r = Repo::new();
+    r.seed_task(ID, Some("A criterion."));
+
+    let out = r.ank("claude-code@ank", &["find", "criterion", "-st", "task"]);
+    let said = stderr(&out);
+    assert_eq!(code(&out), 1, "{said}");
+    assert!(said.contains("'-st' bundles"), "{said}");
+    // The exact flags, each with its value placeholder: an error that only said
+    // "no bundling" would leave the caller to work out what to write.
+    assert!(
+        said.contains("ank find -s <v> -t <v>"),
+        "the hint is the command to run next: {said}"
+    );
+
+    // A letter that names nothing on this verb is reported as itself rather
+    // than folded into the bundling message, which would advise a command that
+    // would refuse too.
+    let out = r.ank("claude-code@ank", &["find", "criterion", "-sz"]);
+    let said = stderr(&out);
+    assert_eq!(code(&out), 1, "{said}");
+    assert!(said.contains("unknown flag '-z'"), "{said}");
+}
+
+/// A letter that is a real flag on another verb is a different mistake from a
+/// letter that is nothing, and the error says which.
+#[test]
+fn a_short_flag_the_verb_does_not_take_names_the_flag_it_stands_for() {
+    let r = Repo::new();
+    r.seed_task(ID, Some("A criterion."));
+
+    let out = r.ank("claude-code@ank", &["claim", ID, "-s", "open"]);
+    let said = stderr(&out);
+    assert_eq!(code(&out), 1, "{said}");
+    assert!(
+        said.contains("'-s' is --status") && said.contains("'claim' does not take"),
+        "{said}"
+    );
+    assert!(
+        r.task_text(ID).contains("status: open"),
+        "a refused parse claims nothing"
+    );
+
+    let out = r.ank("claude-code@ank", &["claim", ID, "-z"]);
+    let said = stderr(&out);
+    assert_eq!(code(&out), 1, "{said}");
+    assert!(said.contains("unknown flag '-z'"), "{said}");
+}
+
+/// `ank help <verb>` shows both forms; `ank help` shows what it always did.
+///
+/// The second half is the one worth a test. ADR-c656cbcc33a9 froze the flat
+/// listing, and a second spelling of every flag is exactly the kind of addition
+/// that arrives looking like an improvement.
+#[test]
+fn help_shows_both_forms_for_one_verb_and_leaves_the_flat_listing_alone() {
+    let r = Repo::new();
+
+    let one = stdout(&r.ank("claude-code@ank", &["help", "find"]));
+    assert!(one.contains("-s, --status <v>"), "{one}");
+    assert!(one.contains("-t, --type <v>"), "{one}");
+    assert!(one.contains("-j, --json"), "the globals too: {one}");
+    // `--scope` has no letter: `s` went to `--status`, and §4 says so rather
+    // than leaving a reader to wonder whether it was forgotten.
+    assert!(
+        one.contains("--scope <v>") && !one.contains(", --scope"),
+        "a flag with no short form shows none: {one}"
+    );
+
+    let all = stdout(&r.ank("claude-code@ank", &["help"]));
+    assert!(
+        all.contains("--status"),
+        "the listing still names flags: {all}"
+    );
+    assert!(
+        !all.contains("-s, ") && !all.contains("-j, "),
+        "the flat listing is unchanged: {all}"
+    );
+
+    // A script reads the mapping from --json, or it cannot use it at all.
+    let j = stdout(&r.ank("claude-code@ank", &["help", "find", "--json"]));
+    assert!(j.contains("\"name\":\"--status\",\"short\":\"-s\""), "{j}");
+    assert!(j.contains("\"name\":\"--scope\",\"short\":null"), "{j}");
+}
+
+/// A single dash is a flag now, so the escape had to become reachable.
+///
+/// `ank log "-1 rebuilt"` used to be a message and is now an argument starting
+/// with a dash. It is refused for what it is rather than reported as a bundle
+/// of unknown letters, and `--` still carries it through.
+#[test]
+fn a_positional_that_starts_with_a_dash_is_refused_by_naming_the_escape() {
+    let r = Repo::new();
+    r.seed_task(ID, Some("A criterion."));
+    assert_eq!(code(&r.ank("claude-code@ank", &["claim", ID])), 0);
+
+    let message = "-1 rebuilt the index";
+    let out = r.ank("claude-code@ank", &["log", message]);
+    let said = stderr(&out);
+    assert_eq!(code(&out), 1, "{said}");
+    assert!(
+        said.contains("is not a flag: it contains a space"),
+        "{said}"
+    );
+    assert!(
+        said.contains(&format!("ank log -- \"{message}\"")),
+        "the hint is the exact command that works: {said}"
+    );
+
+    // And it does work. Invoked directly rather than through the harness,
+    // because `--` terminates everything after it and the harness appends
+    // `--repo` last -- which is the terminator behaving exactly as specified,
+    // and worth seeing once from the caller's side.
+    let out = Command::new(ANK)
+        .args(["log", "--repo"])
+        .arg(&r.0)
+        .args(["--", message])
+        .env("ANK_AGENT", "claude-code@ank")
+        .current_dir(std::env::temp_dir())
+        .output()
+        .expect("the binary must have been built");
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    assert!(r.task_text(ID).contains(message), "{}", r.task_text(ID));
+
+    // A value keeps taking its dash verbatim, whichever form the flag took:
+    // only a positional ever needs the escape.
+    let out = r.ank("claude-code@ank", &["find", "criterion", "-s=open"]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+}
+
+/// Verbs are never abbreviated, and the short forms did not open a door to it.
+#[test]
+fn a_verb_is_never_abbreviated() {
+    let r = Repo::new();
+    let out = r.ank("claude-code@ank", &["cl", ID]);
+    let said = stderr(&out);
+    assert_eq!(code(&out), 1, "{said}");
+    assert!(said.contains("unknown command 'cl'"), "{said}");
+}
+
 /// A second claim under one identity is named, never refused (TASK-d79dc424c63d).
 ///
 /// Observed while dogfooding: a task claimed in one terminal follows you into a

--- a/docs/ank-spec-v1.1.md
+++ b/docs/ank-spec-v1.1.md
@@ -444,6 +444,51 @@ The rule is not cosmetic, and it is written down because its absence was not obv
 
 Global flags, deliberately limited to three: `--json`, `--quiet`, `--repo <path>`. Every global flag is a memorisation cost. `--json` is available on every command without exception: full scriptability is an invariant, not an option.
 
+### Short forms
+
+Every long flag keeps its form. Short forms are an addition and never a replacement (ADR-962c25797569): single-dash, single-letter, and this table is the whole of them.
+
+| Short | Long | Legal on |
+|---|---|---|
+| `-j` | `--json` | every verb |
+| `-q` | `--quiet` | every verb |
+| `-r` | `--repo` | every verb |
+| `-b` | `--blocked-by` | `new`, `amend` |
+| `-c` | `--criteria` | `claim`, `new`, `amend` |
+| `-l` | `--limit` | `context` |
+| `-p` | `--proof` | `done`, `attest` |
+| `-s` | `--status` | `find` |
+| `-t` | `--type` | `find` |
+| `-v` | `--verify` | `new` |
+
+**The letter is the first letter of the long flag, and one letter has one meaning in every verb.** Where several long flags begin with the same letter, exactly one takes it and the others keep only their long form. That is the whole rule, and it is worth the flags it costs: a `-s` meaning `--status` in `find` and `--scope` in `new` would not be a saving but a silent wrong answer, since `ank find -s open` would filter on a scope named `open` and return nothing at all. A short form is only useful if it can be typed without checking which verb it is being typed at.
+
+The long flags left without one, with the letter that would have been theirs: `--body` and `--drop-blocked-by` (`b`), `--constraint` (`c`), `--reason` (`r`), `--scope`, `--supersedes` and `--drop-scope` (`s`), `--title` and `--ttl` (`t`). The three globals take their letter ahead of everything else, because they are legal on every verb and a letter they did not hold everywhere would be a letter nobody could rely on — that is what leaves `--reason` on its long form, `r` being `--repo`'s.
+
+A short form takes its value both ways, exactly as the long form does: `ank find -s open` and `ank find -s=open`.
+
+**Bundling is refused, and the refusal names the flags to type instead.** `-st` is not `-s -t`, because a parser that accepts bundling has to decide what `-sopen` means, and every answer to that is a guess about the caller's intent:
+
+```
+$ ank find bug -st task
+error[1]: '-st' bundles short flags
+  -> ank find -s <v> -t <v>
+```
+
+**A single dash is a flag, which is what makes `--` matter.** It was already the only way to write a positional beginning with a dash; short forms make it reachable rather than theoretical, since `ank log "-1 rebuilt the index"` now names a flag where it used to name a message. An argument that begins with a dash and contains whitespace is refused as what it is — no flag contains a space — and the refusal names the escape:
+
+```
+$ ank log "-1 rebuilt the index"
+error[1]: '-1 rebuilt the index' is not a flag: it contains a space
+  -> ank log -- "-1 rebuilt the index"
+```
+
+Values are untouched by any of this. A flag's value is taken verbatim, whichever form the flag was typed in, so `ank release --reason "-x"` and `ank find bug -s=-x` both pass their dash through and only a positional ever needs escaping.
+
+**Verbs are never abbreviated.** `ank cl` is not `ank claim`, and it is `unknown command 'cl'` naming the verbs. A prefix that resolves today stops resolving the day a second verb shares it, which would make a working script break on a release that added a verb.
+
+`ank help <verb>` shows both forms; `ank help` does not, and the flat listing is unchanged (ADR-c656cbcc33a9, §9). The overview buys its token economy by staying short, and the detail is one call away for the caller who wants it.
+
 **`ank --version` is not a fourth global flag**, and the limit above is untouched. The three modify a verb; this one replaces it — there is no `ank check --version`, and asking for the build while also asking for something else is not a question anyone has. It prints the crate version, the commit the binary was built from and the revision of the `skill/SKILL.md` it was built alongside, on one line, and exits 0.
 
 It answers **before the foundation**, like `help` and for a sharper reason: the caller who needs it is the one holding an artifact they cannot identify. A version that required a resolved repository, a git of 2.34 and a readable `config.yml` would fall silent in exactly the situation it exists for. Outside any git repository, in a directory with no `.ank/`, it still prints and still exits 0.


### PR DESCRIPTION
Closes TASK-f3e92656b5df. Execution of ADR-962c25797569, grammar half.

The table lands in §4 of the specification before the parser moves, and the rule
it declares is mechanical rather than negotiated: **the short form is the first
letter of the long flag, without exception**, and where several long flags begin
with the same letter, exactly one takes it and the others keep only their long
form.

| Short | Long | Legal on |
|---|---|---|
| `-j` `-q` `-r` | `--json` `--quiet` `--repo` | every verb |
| `-b` | `--blocked-by` | `new`, `amend` |
| `-c` | `--criteria` | `claim`, `new`, `amend` |
| `-l` | `--limit` | `context` |
| `-p` | `--proof` | `done`, `attest` |
| `-s` | `--status` | `find` |
| `-t` | `--type` | `find` |
| `-v` | `--verify` | `new` |

That leaves `--scope`, `--title`, `--ttl`, `--reason`, `--constraint`,
`--supersedes` and `--body` on their long form, and §4 names each one beside the
letter that would have been its.

**The rule is worth the flags it costs.** A `-s` meaning `--status` under `find`
and `--scope` under `new` would not be a saving but a silent wrong answer:
`ank find -s open` would filter on a scope named `open` and return nothing at
all. A short form is only useful if it can be typed without checking which verb
it is being typed at. The globals take their letter ahead of everything else,
which is what puts `--reason` on its long form.

One table in `cli.rs`, not a letter beside each declaration: `--scope` and
`--criteria` are declared in three `CommandSpec`s each, and three declarations
of one letter are three chances for two of them to disagree.

## Two consequences handled rather than discovered later

A short flag naming a real flag the verb does not take says which:

```
$ ank claim TASK-x -s open
error[1]: '-s' is --status, which 'claim' does not take
```

And a single-dash argument containing whitespace is refused as the positional it
is. `ank log "-1 rebuilt the index"` used to be a message and is a flag now —
the one consequence of short forms a caller has to be told rather than left to
discover:

```
error[1]: '-1 rebuilt the index' is not a flag: it contains a space
  -> ank log -- "-1 rebuilt the index"
```

## What did not change

`ank help <verb>` shows both forms. **`ank help` does not, and its output is
byte for byte what it was** — ADR-c656cbcc33a9 froze the flat listing, and a
second spelling of every flag is exactly the kind of addition that arrives
looking like an improvement. `--json` carries the mapping, since a script that
cannot see it cannot use it.

Bundling is refused rather than parsed: accepting `-st` forces a decision about
`-sopen`, and every answer to that is a guess. The refusal names the flags to
type instead, `ank find -s <v> -t <v>`.

## Verification

Six tests through the binary, as the criterion requires. The equivalence test
compares `--status open` against `-s open` and `-s=open` **byte for byte against
each other**, so it cannot pass because `find` was taught to print something —
only because both spellings reached the same flag with the same value.

Negative control run: with the single-dash branch disabled, three of the six
fail.

`cargo test --workspace` green, 309 tests. `cargo fmt --check` clean. `ank check`
reports no new finding.

Proof: `commit:81c0501`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NYtKH7nGxkhGpTZxcNyYD