### PR TITLE
0.1.2, and the npm packages carry the same number

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "ank-cli"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "ank-core",
  "hex",
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "ank-core"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "globset",
  "hex",

--- a/crates/ank-cli/Cargo.toml
+++ b/crates/ank-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ank-cli"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 # Measured on 2026-08-01 by walking toolchains upward against this tree, which
 # is the only way this number means anything: 1.78, 1.91, 1.92, 1.93 and 1.94

--- a/crates/ank-core/Cargo.toml
+++ b/crates/ank-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ank-core"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 # Measured, not assumed: see the note in ank-cli's manifest. This crate's own
 # code needs far less, but the workspace resolves one lockfile and builds as a

--- a/npm/ank-darwin-arm64/package.json
+++ b/npm/ank-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haksolot/ank-darwin-arm64",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "The ank binary for macOS on Apple silicon.",
   "license": "GPL-3.0-only",
   "homepage": "https://github.com/haksolot/ank",

--- a/npm/ank-linux-x64-musl/package.json
+++ b/npm/ank-linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haksolot/ank-linux-x64-musl",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "The ank binary for Linux x86_64, statically linked against musl.",
   "license": "GPL-3.0-only",
   "homepage": "https://github.com/haksolot/ank",

--- a/npm/ank-win32-x64/package.json
+++ b/npm/ank-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haksolot/ank-win32-x64",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "The ank binary for Windows x86_64.",
   "license": "GPL-3.0-only",
   "homepage": "https://github.com/haksolot/ank",

--- a/npm/ank/package.json
+++ b/npm/ank/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haksolot/ank",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "The stupid coordination tool: tasks and architecture decisions in your repo, behind one CLI any coding agent can call.",
   "license": "GPL-3.0-only",
   "homepage": "https://github.com/haksolot/ank",
@@ -31,8 +31,8 @@
     "node": ">=18"
   },
   "optionalDependencies": {
-    "@haksolot/ank-darwin-arm64": "0.1.1",
-    "@haksolot/ank-linux-x64-musl": "0.1.1",
-    "@haksolot/ank-win32-x64": "0.1.1"
+    "@haksolot/ank-darwin-arm64": "0.1.2",
+    "@haksolot/ank-linux-x64-musl": "0.1.2",
+    "@haksolot/ank-win32-x64": "0.1.2"
   }
 }


### PR DESCRIPTION
The bump has to land before the tag: `release.yml` names the archive from the
tag and the binary names itself from the crate version, so tagging v0.1.2 on
a tree at 0.1.1 would ship `ank-0.1.2-<target>` containing a binary answering
`ank 0.1.1`. Same reasoning as edc4fe5 for 0.1.1.

The four npm manifests move with the crates. `npm-assemble.sh` stamps the
version from the tag at publish time, so the checked-in values are never what
ships -- but the wrapper's `optionalDependencies` pin exactly, so they move
together or not at all.

What this tag is the first to do: `NPM_TOKEN` now exists on the repository, so
`publish-npm` stops being a skipped job. `@haksolot/ank` and its three
platform packages reach the registry. The scoped name is what ADR-85e6664c67d8
permits -- `ank`, `ank-cli` and `ankor` were all taken on npm before this
project existed.

Verified locally: `cargo test --workspace` green, `cargo fmt --check` clean,
`ank check` exit 0 (signals only), `ank --version` reports `ank 0.1.2`. The
npm channel itself was proven on all three runners by the `workflow_dispatch`
run 30977837306 on `npm-channel`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FWoUy5ngMfxsUrRxUHuoLj