### PR TITLE
npm publish takes a path, and the smoke job now passes the one that failed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,6 +163,21 @@ jobs:
         shell: bash
         run: bash .github/scripts/npm-assemble.sh "0.0.0-smoke" "${{ matrix.package }}"
 
+      # The argument publish-npm passes, run on every dispatch and every tag,
+      # with the one flag that stops short of the registry. This is the step
+      # that was missing when v0.1.2 shipped no packages: the smoke job proved
+      # the tarballs install, but it reached them through globs that expand to
+      # real files, and `npm pack` runs from inside the directory. Nothing
+      # anywhere gave npm the path itself, which is precisely the argument that
+      # was wrong -- a bare `npm/ank` is a GitHub shorthand to npm, not a
+      # folder. Tested here because a publish is not something you get to
+      # retry: the tag is spent whether or not the registry accepted it.
+      - name: the publish argument is a path
+        shell: bash
+        run: |
+          npm publish --dry-run --access public "./npm/${{ matrix.package }}"
+          npm publish --dry-run --access public "./npm/ank"
+
       - name: install from the tarballs
         shell: bash
         run: |
@@ -228,12 +243,17 @@ jobs:
       # The platform packages first: the wrapper pins them exactly, so a
       # wrapper on the registry ahead of its binaries is an install that
       # resolves to nothing.
+      #
+      # `./npm/$p` and not `npm/$p`: to npm, a bare `a/b` is a GitHub shorthand
+      # before it is a directory, so `npm/ank` sent v0.1.2 to
+      # ssh://git@github.com/npm/ank.git and the job died at the first package.
+      # The leading `./` is what makes it a path.
       - name: publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           for p in ank-linux-x64-musl ank-darwin-arm64 ank-win32-x64 ank; do
-            npm publish --access public "npm/$p"
+            npm publish --access public "./npm/$p"
           done
 
   publish:


### PR DESCRIPTION
`npm publish --access public "npm/ank-linux-x64-musl"` does not publish a
folder. To npm a bare `a/b` is a GitHub shorthand before it is a directory, so
it resolved a package spec, ran `git ls-remote
ssh://git@github.com/npm/ank-linux-x64-musl.git`, and exited 128. Under
`bash -e` the loop stopped at the first of the four.

That is the only reason v0.1.2 did not leave a half-published version on the
registry: the wrapper pins its platform packages exactly, so a wrapper on npm
ahead of its binaries is an install that resolves to nothing. The registry is
untouched -- all four `@haksolot/*` return 404. The GitHub release v0.1.2 is
complete and unaffected, since `publish` needs `build` and not `npm-smoke`,
which is the split the workflow chose on purpose.

The leading `./` is the whole fix. The second half of this PR is why it took a
tag to find out.

`npm-smoke` proved the tarballs install and that the exit codes survive the
wrapper, on all three platforms, and it proved nothing about the command that
ships them. It reaches the packages through globs that expand to real files,
and `npm-assemble.sh` runs `npm pack` from inside each directory -- so no step
anywhere handed npm the path, which is the argument that was wrong. The job
was built to catch a wrapper right on one platform and wrong on another. This
was neither: it was wrong everywhere, in the one job no dispatch reaches.

The argument `publish-npm` passes is now passed by `npm-smoke` too, on every
dispatch and every tag, with `--dry-run` -- which stops short of the registry
and needs no token. Verified locally: `npm publish --dry-run npm/ank` exits
128 on the git spec, `npm publish --dry-run ./npm/ank` packs
`@haksolot/ank@0.1.2`.

Once this is in, v0.1.2 is replayed: the tag and its release are deleted and
re-cut on this commit, so npm and the release page carry the same number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FWoUy5ngMfxsUrRxUHuoLj