### PR TITLE
Three tasks for the repository's public surface

### DIFF
--- a/.ank/tasks/TASK-5112b7151220.md
+++ b/.ank/tasks/TASK-5112b7151220.md
@@ -1,0 +1,52 @@
+---
+id: TASK-5112b7151220
+type: task
+slug: contributing-and-conduct-are-written-down-and-th
+title: Contributing and conduct are written down, and the fork case is named
+created: 2026-08-05T18:35:59Z
+author: seanl@sean-laptop
+status: open
+scope:
+  - CONTRIBUTING.md
+  - CODE_OF_CONDUCT.md
+  - README.md
+blocked_by: []
+done_criteria: |
+  CONTRIBUTING.md exists and names the three gates ci.yml actually runs
+  (cargo fmt --check, cargo test --workspace, cargo run -q --bin ank -- check),
+  the English-only rule, the specification-then-goldens-then-code order for any
+  format change, the prohibition on editing status: or the MSRV number by hand,
+  and the fork caveat: a contributor without push access to refs/ank/* runs at
+  level 0, so the claim is local and invisible upstream, and coordination
+  happens in the issue or the PR. CODE_OF_CONDUCT.md is Contributor Covenant
+  2.1 with a reachable contact. README.md links both. cargo test --workspace
+  and ank check stay green.
+criteria_by: creator
+schema: 2
+version: 1
+---
+
+The contribution model of this repository is the ank loop, and the rules a
+contributor has to know are already ratified: English everywhere
+(ADR-d3a8dcf38817), the specification before the goldens before the code
+(ADR-63b5), .ank/ reached through the CLI and never by opening the files
+(ADR-01b6dd05f0db), one command surface (ADR-c656cbcc33a9). CONTRIBUTING.md
+points at them and at docs/getting-started.md; it does not restate them
+loosely, because a second, looser copy of a rule is how the two drift apart.
+
+Two rules deserve to be spelled out because getting them wrong looks like
+making CI pass. Never edit status: by hand -- ank done runs the verifiers and
+writes the proof, and an agent that grades itself can simply be wrong. Never
+edit the MSRV number to unblock a build: the floor is a consequence of a
+dependency, it was measured by walking toolchains against the tree, and
+re-measuring means re-running that walk, not editing ci.yml until it turns
+green.
+
+The fork paragraph is the one nothing states today. Claims are git refs under
+refs/ank/claims/*, pushed to a shared remote at level 1 (section 7). A
+contributor working from a fork has no push access to the upstream ref
+namespace, so they run at level 0: the claim is real and it is local, and no
+one upstream can see it. That is the design working as specified, not a
+defect, and it means outside coordination belongs in the issue or the pull
+request. Saying so costs a paragraph; leaving it unsaid costs someone a
+duplicated effort they had every reason to think was announced.

--- a/.ank/tasks/TASK-90442c8f0ca2.md
+++ b/.ank/tasks/TASK-90442c8f0ca2.md
@@ -1,0 +1,51 @@
+---
+id: TASK-90442c8f0ca2
+type: task
+slug: the-issue-and-pull-request-forms-ask-for-what-th
+title: The issue and pull request forms ask for what the errors already carry
+created: 2026-08-05T18:36:22Z
+author: seanl@sean-laptop
+status: open
+scope:
+  - .github/ISSUE_TEMPLATE/**
+  - .github/pull_request_template.md
+blocked_by: [TASK-bc162e1464ef]
+done_criteria: |
+  A bug form asks for the exact command, its exit code, ank --version and
+  git --version. A second form covers a divergence between the binary and
+  docs/ank-spec-v1.1.md and asks which section. A config.yml routes security
+  reports to the private advisory form rather than to a public issue. A pull
+  request template lists the three gates and asks which task the change closes.
+  gh api repos/haksolot/ank/community/profile reports issue_template and
+  pull_request_template no longer null.
+criteria_by: creator
+schema: 2
+version: 1
+---
+
+The forms ask for what the tool already produces, so a report arrives
+classifiable instead of needing a round trip.
+
+The exit code first. The codes carry meaning (section 4) and they are the
+fastest triage available: 9 is the environment, 7 a missing prerequisite, 5 a
+verifier that failed, 4 a refusal on state, 2 an unknown verb. A reporter who
+gives the number has already narrowed the search before anyone reads the
+prose. The exact command next, verbatim, because every refusal in this tool
+already prints the command to run next -- if that line was wrong or missing,
+it is itself the defect, and it cannot be recovered from a paraphrase.
+
+The two versions after that: ank --version names the build and the skill
+revision it was built alongside, and git --version matters because the
+minimum is 2.34 and claims are git refs.
+
+A divergence between the binary and the specification is its own form because
+it is its own kind of report. The specification is the source of truth, so
+the question is not only what the binary did but which section it disagrees
+with -- and the answer decides whether the fix is in the code or in the
+document.
+
+The config.yml matters more than it looks: without it, the natural place to
+report a vulnerability is a public issue, which is exactly the wrong place.
+It links to the private advisory form instead. That is why this task is
+blocked by the security policy task -- the link has to exist before something
+points at it.

--- a/.ank/tasks/TASK-bc162e1464ef.md
+++ b/.ank/tasks/TASK-bc162e1464ef.md
@@ -1,0 +1,51 @@
+---
+id: TASK-bc162e1464ef
+type: task
+slug: the-threat-model-becomes-a-security-policy
+title: The threat model becomes a security policy
+created: 2026-08-05T18:35:37Z
+author: seanl@sean-laptop
+status: open
+scope:
+  - SECURITY.md
+blocked_by: []
+done_criteria: |
+  SECURITY.md exists at the root and states the threat model as section 1
+  and README.md already state it: ank protects against drift, not against an
+  adversary, it is not a security boundary, and the roles in config.yml are
+  advisory. It names the signed ratification commit as the single hard line of
+  authority and states what that signature does not prove. It records that
+  verifiers live in a repository-controlled file, so ank done on a PR from a
+  fork executes nothing the repository did not accept. It names which version
+  is supported and routes reports to GitHub private vulnerability reporting,
+  which is enabled on the repository. No sentence in it contradicts
+  docs/ank-spec-v1.1.md.
+criteria_by: creator
+schema: 2
+version: 1
+---
+
+The project published its first package to a registry with v0.1.2, so it is
+now something strangers install before they know anything about how it is
+built. A security policy is what answers them, and here it cannot be
+boilerplate: the specification takes a position and a generic policy would
+contradict the source of truth.
+
+Section 1 protects against drift, not against an adversary. README.md says in
+as many words that ank is not a security boundary. Section 8 says the
+signature proves access to an authorised key, not human intent -- an agent on
+a developer machine with signing unlocked can produce a valid signed commit,
+and the defence there is operational (a ratification key behind a passphrase
+or hardware, distinct from the everyday key), never cryptographic. With no
+signing configured at all, the hard line is gone and nothing replaces it;
+check displays that rather than hiding it, because a verification that
+degrades to success is not a verification.
+
+One property is worth stating as the real one: verifiers are named in
+config.yml and never inline, precisely because a task may arrive through a PR
+from a fork. An inline command would be arbitrary code execution triggered by
+ank done. Git had this problem with hooks and solved it the same way.
+
+Reports go to GitHub private vulnerability reporting, which has to be enabled
+on the repository before the file names it. A policy pointing at a channel
+that does not exist is worse than no policy.


### PR DESCRIPTION
The repository is published but says nothing about how to contribute to it, what it does and does not defend against, or what a report should carry. These three tasks name that gap in the order it has to be filled.

- **TASK-bc162e1464ef** — the threat model becomes `SECURITY.md`: ank protects against drift, not against an adversary, and the signed ratification commit is the single hard line of authority. It also opens the private reporting channel the issue forms need.
- **TASK-90442c8f0ca2** — the issue and pull request forms ask for what the errors already carry. Blocked by the security task, because its `config.yml` has to route reports somewhere that exists.
- **TASK-5112b7151220** — `CONTRIBUTING.md` written against the three gates `ci.yml` runs, and the fork case named: without push access to `refs/ank/*`, a claim is local and invisible upstream.

Corpus only, no code change. `ank check` exits 0. The three new scopes report `matches no file yet`, which is the expected state before the work starts, and the burst signal fires because the three were filed in one sitting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WE5eDrYhsgFff27UtW7Wjb