### PR TITLE
Contributing, conduct, and the forms that ask for what the errors already carry

### DIFF
--- a/.ank/tasks/TASK-5112b7151220.md
+++ b/.ank/tasks/TASK-5112b7151220.md
@@ -5,7 +5,7 @@ slug: contributing-and-conduct-are-written-down-and-th
 title: Contributing and conduct are written down, and the fork case is named
 created: 2026-08-05T18:35:59Z
 author: seanl@sean-laptop
-status: open
+status: done
 scope:
   - CONTRIBUTING.md
   - CODE_OF_CONDUCT.md
@@ -22,8 +22,12 @@ done_criteria: |
   2.1 with a reachable contact. README.md links both. cargo test --workspace
   and ank check stay green.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: ea02088c82e10efcb30a67eb3d7b32953f0cba4f
+    criteria: a136c140b168
 schema: 2
-version: 1
+version: 4
 ---
 
 The contribution model of this repository is the ank loop, and the rules a
@@ -50,3 +54,7 @@ one upstream can see it. That is the design working as specified, not a
 defect, and it means outside coordination belongs in the issue or the pull
 request. Saying so costs a paragraph; leaving it unsaid costs someone a
 duplicated effort they had every reason to think was announced.
+
+## Log
+- 2026-08-06T18:36:51Z seanl@sean-laptop — CoC contact is the maintainer on GitHub (@haksolot) plus GitHub Support for reports concerning the maintainer -- maintainer decision, no personal email published in a public repo. CONTRIBUTING points at the ADRs rather than restating them; the fork paragraph names level 0 as specified in section 7.
+- 2026-08-06T18:38:04Z seanl@sean-laptop — done, proof commit:ea02088c82e10efcb30a67eb3d7b32953f0cba4f

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,107 @@
+name: Bug report
+description: ank did something other than what it says it does
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Every refusal in ank prints the exact command to run next, and every
+        exit code carries a meaning. This form asks for what the tool already
+        gave you, so the report arrives classifiable.
+
+        A suspected vulnerability does not belong here: report it privately at
+        <https://github.com/haksolot/ank/security/advisories/new>.
+
+  - type: textarea
+    id: command
+    attributes:
+      label: The exact command, and its output
+      description: >
+        Verbatim, not a paraphrase. Ank's errors name the command to run next,
+        and if that line was wrong or missing it is itself the defect -- which
+        cannot be recovered from a summary.
+      render: shell
+      placeholder: |
+        $ ank claim TASK-8ebd
+        error[4]: TASK-8ebd6e02f125 is held by pi@host-3 until 2026-08-06T18:12:00Z
+          -> ank find --status open
+    validations:
+      required: true
+
+  - type: dropdown
+    id: exit_code
+    attributes:
+      label: Exit code
+      description: >
+        Section 4 of the specification defines these. It is the fastest triage
+        available: the number narrows the search before anyone reads the prose.
+        `echo $?` on a POSIX shell, `$LASTEXITCODE` in PowerShell.
+      options:
+        - "0 -- ok (and that is the bug: it should have refused)"
+        - "1 -- generic error"
+        - "2 -- entity not found, or ambiguous prefix"
+        - "3 -- version conflict"
+        - "4 -- task unavailable"
+        - "5 -- proof missing or invalid"
+        - "6 -- illegal transition, or frozen field modified"
+        - "7 -- missing prerequisite"
+        - "8 -- check: invariants violated"
+        - "9 -- environment unavailable"
+        - "something else, or the command never returned"
+    validations:
+      required: true
+
+  - type: input
+    id: ank_version
+    attributes:
+      label: ank --version
+      description: >
+        The whole line. It names the build and the skill revision it shipped
+        alongside.
+      placeholder: ank 0.1.2 (skill 7f3c1a9)
+    validations:
+      required: true
+
+  - type: input
+    id: git_version
+    attributes:
+      label: git --version
+      description: >
+        The minimum is 2.34, and claims are git refs -- so the git version is
+        part of the reproduction, not an afterthought.
+      placeholder: git version 2.47.1.windows.1
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - Linux
+        - macOS
+        - Windows
+        - other
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected instead
+      description: >
+        One sentence is enough. If the specification says something different
+        from the binary, open a specification divergence instead -- that form
+        asks which section.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: How to reproduce
+      description: >
+        The steps from an empty repository, if you have them. Prefer a minimal
+        throwaway repository over anything real.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,29 @@
+# Blank issues stay open: a report that fits no form is still a report, and a
+# chooser that refuses one teaches people to file it as the wrong kind.
+blank_issues_enabled: true
+
+contact_links:
+  - name: Report a vulnerability (private)
+    url: https://github.com/haksolot/ank/security/advisories/new
+    about: >
+      Never a public issue. Private vulnerability reporting is enabled on this
+      repository; SECURITY.md says what is in scope, and what section 1 already
+      answers.
+
+  - name: Read the specification first
+    url: https://github.com/haksolot/ank/blob/main/docs/ank-spec-v1.1.md
+    about: >
+      The source of truth. It settles every question the other documents defer
+      to it, including why a verb refuses on state and never on identity.
+
+  - name: Getting started
+    url: https://github.com/haksolot/ank/blob/main/docs/getting-started.md
+    about: >
+      Install to a first finished task, with real output -- including the two
+      refusals a fresh repository will give you.
+
+  - name: Contributing
+    url: https://github.com/haksolot/ank/blob/main/CONTRIBUTING.md
+    about: >
+      The three gates CI runs, the order a format change follows, and what a
+      claim does from a fork.

--- a/.github/ISSUE_TEMPLATE/spec-divergence.yml
+++ b/.github/ISSUE_TEMPLATE/spec-divergence.yml
@@ -1,0 +1,76 @@
+name: Specification divergence
+description: The binary and docs/ank-spec-v1.1.md disagree
+labels: ["spec"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        The specification is the source of truth, so this is its own kind of
+        report. The question is not only what the binary did, but which section
+        it disagrees with -- and that answer decides whether the fix belongs in
+        the code or in the document.
+
+  - type: dropdown
+    id: section
+    attributes:
+      label: Which section
+      description: >
+        [docs/ank-spec-v1.1.md](https://github.com/haksolot/ank/blob/main/docs/ank-spec-v1.1.md).
+        Pick the section that states the rule you read.
+      options:
+        - "3. Data model"
+        - "4. CLI surface"
+        - "5. Attention budget"
+        - "6. Storage and search"
+        - "7. Synchronisation"
+        - "8. Permissions"
+        - "9. Bootstrapping"
+        - "10. v1 scope"
+        - "11. Constraint lifecycle"
+        - "12. Implementation"
+        - "13. Final decisions"
+        - "somewhere else, or I could not find it"
+    validations:
+      required: true
+
+  - type: textarea
+    id: quote
+    attributes:
+      label: What the specification says
+      description: >
+        Quote the sentence, and give the heading or table it sits under. A
+        paraphrase is where two readings of the same rule start to diverge.
+    validations:
+      required: true
+
+  - type: textarea
+    id: observed
+    attributes:
+      label: What the binary does
+      description: The exact command and its output, verbatim.
+      render: shell
+    validations:
+      required: true
+
+  - type: input
+    id: ank_version
+    attributes:
+      label: ank --version
+      placeholder: ank 0.1.2 (skill 7f3c1a9)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: which_is_wrong
+    attributes:
+      label: Which one do you think is wrong
+      description: >
+        Your reading, not a verdict. The maintainer may disagree, and saying
+        which way you lean is what makes that conversation short.
+      options:
+        - The code -- the specification is right
+        - The specification -- the code is right and the document is stale
+        - Both are defensible; the text is ambiguous
+        - No opinion
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,52 @@
+<!--
+Keep this short. The task carries the reasoning, the commit carries the change,
+and this template only asks for what neither of them says.
+-->
+
+## Which task does this close
+
+<!--
+The id, from `ank find --status open`. If there is none, say why: a typo fix
+does not need one, a behaviour change does -- and a change with no task is a
+change with no frozen criterion to measure it against.
+-->
+
+TASK-
+
+## What it does, and why this way
+
+<!-- One paragraph. If a ratified ADR constrains this perimeter, name it. -->
+
+## The three gates
+
+Run locally, on your platform. CI runs the same lines on Linux, macOS and
+Windows.
+
+- [ ] `cargo fmt --check`
+- [ ] `cargo test --workspace`
+- [ ] `cargo run -q --bin ank -- check` (exit 8 means findings, and findings are
+      a failure; signals exit 0)
+
+## If this touches the format
+
+<!-- Delete this section if it does not. -->
+
+- [ ] `docs/ank-spec-v1.1.md` first -- no field exists in the code without
+      existing there
+- [ ] then `crates/ank-core/tests/golden/`
+- [ ] then the code
+
+## Before you open it
+
+- [ ] The behaviour a `done_criteria` describes is tested **through the binary**,
+      not only through the function meant to produce it
+- [ ] `status:` was not edited by hand -- `ank done` runs the verifiers and
+      writes the proof
+- [ ] The MSRV number was not edited to make a build pass -- the floor is
+      measured by walking toolchains, and a human runs the walk
+- [ ] English everywhere, no emojis
+
+Working from a fork? Your claim is local and invisible upstream ([why][fork]).
+Say here which task you took.
+
+[fork]: ../blob/main/CONTRIBUTING.md#working-from-a-fork

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,135 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**[@haksolot](https://github.com/haksolot)**, the maintainer of this repository,
+through GitHub. This is a small project with a single maintainer, so a report
+that concerns the maintainer, or that cannot wait on one person, goes to GitHub
+Support instead: <https://github.com/contact/report-abuse>.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,147 @@
+# Contributing to ank
+
+The contribution model of this repository is ank itself. The development plan
+lives in `.ank/`, work is taken with `ank claim` and finished with `ank done`,
+and the rules that bind a change are ratified ADRs served by `ank context`. This
+file points at them; it deliberately does not restate them, because a second,
+looser copy of a rule is how the two drift apart.
+
+If you have never run the tool, read [Getting started](docs/getting-started.md)
+first. If you need the normative answer to anything below, it is in
+[the specification](docs/ank-spec-v1.1.md), which is the source of truth.
+
+## The three gates
+
+`ci.yml` runs these on Linux, macOS and Windows, and a pull request is green
+when all three are:
+
+```
+cargo fmt --check
+cargo test --workspace
+cargo run -q --bin ank -- check
+```
+
+The third is the same line as the `check-repo` verifier in `.ank/config.yml`, on
+purpose: a CI that validated `.ank/` differently from `ank done` would let a
+corpus pass one and fail the other. Exit 8 means findings, and findings are a
+failure. Two further jobs build the workspace on the declared MSRV and prove
+that the minor below it fails — see the MSRV section.
+
+Run all three locally before opening a pull request. They are the same commands
+in both places.
+
+## Working the loop
+
+```
+ank context                   # what binds here, and what is free to take
+ank claim <id>                # takes the task, freezes its criterion by hash
+ank log "<what you learned>"  # renews the claim; working is what holds it
+ank done                      # runs the verifiers itself and writes the proof
+```
+
+Three things about this loop are not conventions but properties of the tool.
+
+**The criterion is frozen at claim.** Editing `done_criteria` to unblock
+yourself unblocks nothing: the hash is held in the claim record, and `ank check`
+reports the divergence (ADR-6b3f19e08a24). A subtask you discover is a new task
+with a `blocked_by`, never a softened criterion. If the criterion is wrong, say
+so with `ank release --reason "<why>"`.
+
+**Never edit `status:` by hand.** `ank done` runs the declared verifiers and
+writes the proof of what actually ran, hashed. Setting the field yourself
+produces a task that claims to be finished with nothing behind the claim, and an
+agent — or a human — that grades its own work can simply be wrong.
+
+**`.ank/` is reached through the CLI, not by opening the files**
+(ADR-01b6dd05f0db). `ank show <id>` gives an entity whole, `ank find` lists,
+`ank context` binds. This constrains agents, not people: a human with an editor
+keeps every power they had, and `ank check` remains what notices.
+
+## Working from a fork
+
+Claims are git refs under `refs/ank/claims/*`. Pushing them to a shared remote
+is level 1 in section 7 of the specification, and it is what makes a claim
+visible to anyone else.
+
+**A contributor without push access to `refs/ank/*` runs at level 0.** The claim
+is real and it is entirely local: nobody upstream can see it, and nobody
+upstream is prevented from claiming the same task. That is the design working as
+specified, not a defect — level 0 is the default mode and needs no
+configuration.
+
+The consequence is procedural. From a fork, coordination happens **in the issue
+or in the pull request**: say which task you are taking before you start, and
+say it where a maintainer can read it. `ank claim` still does its job in your
+clone — it freezes the criterion, which is the half that protects your work —
+but it announces nothing.
+
+## Changing the format
+
+The format is the specification, and `ank-core` is its reference
+implementation. Every format change happens in this order, and it is ratified
+(ADR-63b59c5c26f7):
+
+1. **the specification** — `docs/ank-spec-v1.1.md`. No field exists in the code
+   without existing there first.
+2. **the goldens** — `crates/ank-core/tests/golden/`. `valid/` must round-trip
+   byte for byte once normalised, `invalid/` must be rejected with the expected
+   error.
+3. **the code**.
+
+The round-trip is byte-identical on canonical form; valid but non-canonical
+input is read correctly and normalised on first rewrite. CRLF is read, never
+written — one golden is in CRLF on purpose and must come back in LF.
+
+## The MSRV is measured, never chosen
+
+`rust-version` is declared in both `crates/ank-cli/Cargo.toml` and
+`crates/ank-core/Cargo.toml`, and enforced by two CI jobs: `msrv` builds on the
+declared toolchain, proving it is sufficient, and `msrv-tight` requires the
+minor below it to fail, proving it is not higher than the tree needs.
+
+**Never edit that number to make a build pass.** The floor is a consequence of a
+dependency, not a target held on purpose; it was measured by walking toolchains
+upward against the tree, and re-measuring means re-running that walk:
+
+```
+cargo +<toolchain> build --workspace --locked --ignore-rust-version
+```
+
+An unexpectedly successful build names a number to lower — it does not lower it.
+If a job goes red here, read the diagnostic and open an issue or a task; the
+walk is what decides, and a human runs the walk.
+
+## English only
+
+English is the only language of the project (ADR-d3a8dcf38817): prose,
+identifiers, comments, CLI output, error messages, entity titles, bodies, slugs
+and log entries. Non-English text is a finding, not a matter of taste. The one
+exception is a string whose meaning is its literal value — an external proof
+reference, a quoted third-party message, a fixture asserting a byte sequence.
+
+## Style
+
+- **Self-correcting errors.** Every refusal prints the exact command to run
+  next, never generic help.
+- **Terse output**, in the shape of `git status`. `--json` everywhere, strictly
+  opt-in, and never colored.
+- **No emojis** in messages, documentation or comments.
+- **No new dependency without necessity.** A static binary is the goal.
+- **A criterion that talks about the binary is tested through the binary.** When
+  a `done_criteria` says "the binary does X", the test invokes the binary, not
+  only the function meant to produce X. Two real defects shipped past green unit
+  tests that way. The same rule applies to platforms: OS-dependent behaviour is
+  not verified until it has run on all three.
+
+## Reporting
+
+A suspected vulnerability goes to [private advisory
+reporting](https://github.com/haksolot/ank/security/advisories/new), never to a
+public issue — [SECURITY.md](SECURITY.md) says what is in scope and what section
+1 already answers.
+
+Anything else is an issue. The forms ask for what the tool already produces: the
+exact command, its exit code, `ank --version` and `git --version`. Exit codes
+carry meaning and they are the fastest triage available.
+
+Participation is governed by the [Code of Conduct](CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ nothing to run. That is what "stupid" means here.
 | write a tool that reads or writes `.ank/` | [The file format](docs/format.md) |
 | know why it is shaped this way, or need the normative answer | [The specification](docs/ank-spec-v1.1.md) |
 | work on ank itself | [CLAUDE.md](CLAUDE.md), and the section below |
+| open a pull request | [Contributing](CONTRIBUTING.md) |
+| report a vulnerability, or know what ank does not protect against | [Security policy](SECURITY.md) |
 
 The specification is the source of truth. It argues the design and settles every
 question the other documents defer to it; it is not a tutorial, and the first two
@@ -235,6 +237,11 @@ assets/           the project mark, one file per theme
 ```
 
 Conventions for agents are in [CLAUDE.md](CLAUDE.md).
+[CONTRIBUTING.md](CONTRIBUTING.md) has the three gates CI runs, the order a
+format change follows, and the one thing a fork has to know: without push access
+to `refs/ank/*` a claim stays local and invisible upstream, so coordination
+happens in the issue or the pull request. Participation is governed by the
+[Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## Licence
 


### PR DESCRIPTION
Closes TASK-5112b7151220 and TASK-90442c8f0ca2.

## CONTRIBUTING.md and CODE_OF_CONDUCT.md

`CONTRIBUTING.md` names the three gates `ci.yml` actually runs, the
specification-then-goldens-then-code order, the English-only rule, and the two
prohibitions that look like making CI pass: editing `status:` by hand, and
editing the MSRV number to unblock a build. It points at the ADRs rather than
restating them — a second, looser copy of a rule is how the two drift apart.

The fork paragraph is the one nothing stated. A contributor without push access
to `refs/ank/*` runs at level 0: the claim is real, local, and invisible
upstream. That is section 7 working as specified, and it means coordination
belongs in the issue or the pull request.

`CODE_OF_CONDUCT.md` is Contributor Covenant 2.1 verbatim. The contact is the
maintainer on GitHub, plus GitHub Support for a report concerning the
maintainer — a single-maintainer project has to name the second channel, and no
personal address is published in a public repository.

## The forms

The bug form asks for the exact command verbatim, the exit code as a dropdown
carrying the meanings from section 4, `ank --version` and `git --version`. A
specification divergence gets its own form, because the question is which
section disagrees and the answer decides whether the fix is in the code or in
the document. `config.yml` routes a vulnerability to the private advisory form;
blank issues stay enabled.

## Gates

- `cargo fmt --check` — green
- `cargo test --workspace` — green
- `cargo run -q --bin ank -- check` — exit 0, signals only

`gh api repos/haksolot/ank/community/profile` reads the default branch only, so
the `issue_template` / `pull_request_template` clause of TASK-90442c8f0ca2 turns
true on merge, and is verified then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)