### PR TITLE
Help names every verb and says what none of them refuses

### DIFF
--- a/.ank/tasks/TASK-84cfad83c308.md
+++ b/.ank/tasks/TASK-84cfad83c308.md
@@ -1,0 +1,62 @@
+---
+id: TASK-84cfad83c308
+type: task
+slug: ank-help-verb-is-silent-on-what-the-verb-refuses
+title: ank help <verb> is silent on what the verb refuses
+created: 2026-08-07T16:59:47Z
+author: seanl@sean-laptop
+status: open
+scope:
+  - docs/ank-spec-v1.1.md
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/tests/cli.rs
+blocked_by: []
+done_criteria: |
+  docs/ank-spec-v1.1.md section 9 is rewritten first: ank help <verb> carries what the verb does and the state conditions on which it refuses, with the exit code, alongside the usage, flags and globals it already carries. The top-level flat listing stays one flat listing, unchanged. ank help amend no longer presents --criteria as an available flag. ank help done names that a proof is required on state and enumerates the four accepted proof types. ank help edit names that EDITOR is a command line run through sh, not a program name. A test in crates/ank-cli/tests/cli.rs walks every verb through the binary and fails if any flag its help lists is refused unconditionally.
+criteria_by: creator
+schema: 2
+version: 1
+---
+
+Not an implementation drift: section 9 specifies ank help <verb> as usage,
+flags with their value placeholders, and globals. The current output is
+exactly that. The gap is in the specification.
+
+Section 9 bets on a division of labour across three surfaces -- SKILL.md
+carries the mental model, ank help carries the flags, errors carry the next
+command -- and the bet is that between them a caller never needs the source.
+One session of dogfooding falsified it five times, and each recovery went
+through crates/. In another repository ank arrives as a binary and SKILL.md:
+no source, no specification. The same five become dead ends.
+
+What was needed and absent, in order of severity:
+
+amend lists --criteria among its flags while refusing it unconditionally, by
+name and by design. Help does not merely say too little there, it misinforms,
+and the refusal's own hint points at ank release, which a task that was never
+claimed cannot run. Learned by reading human.rs.
+
+done requires --proof on state, which no surface states; learned from exit 5.
+The proof grammar <type>:<ref> and its four types -- commit, human-review,
+assertion, test -- live only in done.rs, and the error gives one type by
+example rather than the set.
+
+claim --criteria overwrites an existing criterion silently and flips
+criteria_by to claimer. No surface says so; found by experiment on a scratch
+repository.
+
+EDITOR is a command line run through sh -c, not a program name. Here the
+self-correcting error is worse than incomplete: the hint EDITOR=vi suggests a
+bare binary, and a caller who follows it with a GUI editor gets no --wait, the
+editor returns immediately, ank writes the unedited file, and nothing signals
+it.
+
+The structural point is that nothing owns what a verb refuses and why. That is
+the tool's own claimed identity -- section 4 carries a whole subsection on
+refusals being on state -- documented for the reader of the document and
+nowhere for the caller of the binary.
+
+The test matters as much as the fix. Without something that fails in CI when a
+listed flag cannot succeed, this decays back within two revisions. The shape
+is the one msrv-tight already uses: a negative test that attributes the drift
+rather than leaving it for a human to notice later.

--- a/.ank/tasks/TASK-fe130d2b732c.md
+++ b/.ank/tasks/TASK-fe130d2b732c.md
@@ -1,0 +1,54 @@
+---
+id: TASK-fe130d2b732c
+type: task
+slug: the-flat-listing-names-every-verb-and-says-what
+title: The flat listing names every verb and says what none of them does
+created: 2026-08-07T17:02:44Z
+author: seanl@sean-laptop
+status: open
+scope:
+  - docs/ank-spec-v1.1.md
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/tests/cli.rs
+blocked_by: [TASK-84cfad83c308]
+done_criteria: |
+  docs/ank-spec-v1.1.md sections 4 and 9 are rewritten first: ank help carries one short description per verb, and each description states what the verb refuses wherever a refusal is what distinguishes it. The listing stays flat, in the order of section 4, with no headings and no grouping: ADR-c656cbcc33a9 and ADR-e17e1bbd93ff are not superseded and the descriptions are not a layering. ank help amend does not describe amend as changing a criterion. Each description is the one-line compression of the text ank help <verb> already carries, and a test in crates/ank-cli/tests/cli.rs walks both through the binary and fails when a verb is described in the listing as doing something its own help says it refuses.
+criteria_by: creator
+schema: 2
+version: 1
+---
+
+Raised from git's own help, which carries a one-line description per verb and
+gives a caller enough to choose one. Ank prints the verb and its flags and
+says what none of them does.
+
+Two things are stacked in git's output and only one of them is available.
+
+The grouping is settled against. The headings -- start a working area,
+collaborate -- are what ADR-c656cbcc33a9 removed, and the revision k note says
+why: revision i left a layered help whose headings were named after callers,
+layering is grouping, and a grouping printed by the binary is a claim about
+who a verb is for. The order of section 4 carries the same information without
+asserting a category. Nothing here reopens that.
+
+The description is a different axis: neither a heading nor a grouping, so it
+costs no superseding ADR. The objection left is token economy on the overview,
+and it is weak. One session spent more than twenty lines' worth of reading
+human.rs, done.rs and editor.rs, plus a scratch repository, to recover what a
+description would have carried. An economy that sends the caller to the source
+is not one.
+
+The trap is what the description says. Git's one-liners work because git's
+verbs do what they announce. Ank's design is that verbs refuse on state, so a
+description naming only a purpose becomes a fourth surface able to
+misinform -- the exact defect TASK-84cfad83c308 records on amend, where the
+flag table advertises a criterion edit the binary refuses always. 'Change a
+task's scope, blockers or criteria' would have confirmed that error rather
+than caught it. 'Change a task's scope or blockers; never its criteria' is the
+same line doing the work.
+
+So for this tool the description and the refusal are not two features. Writing
+an honest one-liner forces the refusal to be stated, which is why this is
+blocked rather than parallel: TASK-84cfad83c308 settles the per-verb text
+first, and each listing line is its compression. Written in the other order
+they are two texts that drift, and the drift is silent.


### PR DESCRIPTION
## Which task does this close

None. This adds two, it does not close one. No behaviour changes and no code
moves here -- the change is two entities under `.ank/`, which is where a
finding goes before anything is written against it.

## What it does, and why this way

Files `TASK-84cfad83c308` and `TASK-fe130d2b732c`, both found by dogfooding
rather than by review. One session needed the source five times to learn what
the binary would refuse, and every recovery went through `crates/`. In another
repository ank arrives as a binary and `SKILL.md` -- no source, no
specification -- and the same five become dead ends.

Neither is an implementation drift. Section 9 specifies `ank help <verb>` as
usage, flags and globals, and the output is exactly that. The gap is in the
specification: its division of labour across three surfaces leaves nothing
owning what a verb refuses and why, which is the tool's own claimed identity.
Section 4 spends a subsection on refusals being on state, written for the
reader of the document and nowhere for the caller of the binary.

The sharpest case is `amend`, which lists `--criteria` among its flags while
refusing it unconditionally -- help there does not say too little, it
misinforms, and the refusal's hint points at a `release` that a never-claimed
task cannot run.

The second task is the same gap on the overview and is blocked rather than
parallel. Git's listing was the prompt and stacks two things: the grouping is
settled against by ADR-c656cbcc33a9 and stays settled, while a one-line
description per verb is neither a heading nor a grouping and costs no
superseding ADR. The trap is what such a line says. Git's one-liners work
because git's verbs do what they announce; ank's refuse on state, so a
description naming only a purpose becomes a fourth surface able to mislead.
Writing an honest one-liner forces the refusal to be stated, which is why the
per-verb text is settled first and each listing line is its compression.

Both criteria put the specification first and end at a test through the
binary. Without those tests the fix decays and the drift is silent.

## The three gates

- [x] `cargo fmt --check`
- [x] `cargo test --workspace` -- 94 tests, 0 failed
- [x] `cargo run -q --bin ank -- check` -- exit 0, 0 faults, 93 tasks

## Before you open it

- [x] The behaviour a `done_criteria` describes is tested **through the binary**
- [x] `status:` was not edited by hand
- [x] The MSRV number was not edited to make a build pass
- [x] English everywhere, no emojis