### PR TITLE
The path normaliser covers the positionals, not the flag values

### DIFF
--- a/.ank/tasks/TASK-8dd89053fa33.md
+++ b/.ank/tasks/TASK-8dd89053fa33.md
@@ -1,0 +1,69 @@
+---
+id: TASK-8dd89053fa33
+type: task
+slug: the-path-normaliser-covers-the-positionals-and-n
+title: The path normaliser covers the positionals and not the flag values
+created: 2026-08-07T18:03:48Z
+author: seanl@sean-laptop
+status: open
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-core/src/scope.rs
+  - crates/ank-cli/tests/cli.rs
+  - docs/ank-spec-v1.1.md
+blocked_by: []
+done_criteria: |
+  Every caller-supplied path or glob passes through ank_core::scope::normalize_path before it reaches glob matching or is written to an entity, whether it arrives as a positional argument or as a flag value. Measured through the binary: ank find --scope and ank new --scope answer identically for one directory however it is written - docs, docs/, docs\, ./docs, .\docs\ - and a form the tool will not resolve is refused with the command to run next, never answered with a silently partial set. ank new --scope stores the normalised form, never the string as typed. A test enumerates every positional and every flag that takes a path or a glob, and fails when one of them reaches matching or storage unnormalised, so that a call site added later cannot skip it. Section 4 states that the normalisation covers flag values.
+criteria_by: creator
+schema: 2
+version: 1
+---
+
+TASK-df4c39031583 found this defect, measured it, fixed it and is done. The
+normaliser it produced is ank_core::scope::normalize_path, and its doc comment
+still carries the measurement: against docs/, which five ADRs bind, docs and
+docs/ answered five, docs\ answered four, ./docs and .\docs\ answered zero.
+It names the four as the dangerous case -- what Windows tab-completion
+produces, looking like a correct answer while silently dropping a constraint
+that binds.
+
+That analysis was right and the fix works. Re-measured today through the
+binary, scope, context, check, graph and review accept all six spellings and
+return one answer.
+
+What was left behind is the flag values, and the reason is in the criterion
+rather than in the code. It reads: context, review, check and scope give the
+same answer for one directory however the path is written. Four verbs named,
+where the property was general -- the argument reaches glob matching verbatim.
+The fix satisfied the criterion exactly, the proof is real, and find --scope
+and new --scope were never routed through the normaliser because the frozen
+text did not reach them. Nobody was wrong: the criterion enumerated instances
+instead of stating the property, and the freeze then made that enumeration
+authoritative.
+
+Measured today on this corpus, with docs/ present:
+
+  ank find -t task -s open --scope docs      10 tasks
+  ank find -t task -s open --scope docs/     10 tasks
+  ank find -t task -s open --scope docs\      6 tasks
+  ank find -t task -s open --scope ./docs     none
+  ank find -t task -s open --scope .\docs\    none
+
+The six are the same six that docs/** returns: a trailing backslash silently
+narrows the query to a subtree match. Non-empty, plausible, and wrong -- the
+exact shape TASK-df4c39031583's own criterion forbids when it says never
+answered with a silently partial set. The zeros are not Windows-specific:
+./docs fails on every platform, because a flag value is matched raw against
+stored globs with no normalisation at all.
+
+new --scope is worse than a bad answer, because it persists. ank new task
+--scope '.\docs\' stores .\docs\ verbatim into the entity, where it will
+match nothing on any platform for the life of the corpus. check notices the
+consequence and misnames the cause: with docs/ present and containing a file,
+it reports scope '.\docs\' matches no file yet: work not started, or a typo.
+It is not a typo. It is the form the caller's own shell completed, which new
+accepted without a word. The tool writes something it cannot read back.
+
+The lesson for the criterion is the point of filing this rather than a patch:
+name the property, not the verbs that exhibit it, and make a test enumerate
+the surface so the next call site cannot be added outside it.


### PR DESCRIPTION
## Which task does this close

None. It files one, `TASK-8dd89053fa33`. No code moves here.

## What it does, and why this way

`TASK-df4c39031583` found this defect, measured it, fixed it and is done. Its
normaliser still carries the measurement in its doc comment and names the
dangerous case correctly: a trailing backslash is what Windows tab-completion
produces, it looks like a correct answer, and it silently drops a constraint
that binds.

Re-measured through the binary, the fix holds where it was applied: `scope`,
`context`, `check`, `graph` and `review` accept all six spellings of one
directory and return one answer.

It never reached the flag values, and the reason is in the criterion rather
than in the code. That criterion reads *context, review, check and scope give
the same answer for one directory however the path is written*. Four verbs
named, where the property was general. The fix satisfied that text exactly,
the proof is real, and `find --scope` and `new --scope` stayed outside it.

Measured today on this corpus, with `docs/` present:

| `--scope` | result |
|---|---|
| `docs` | 10 tasks |
| `docs/` | 10 tasks |
| `docs\` | **6 tasks** -- the same six `docs/**` returns |
| `./docs` | none |
| `.\docs\` | none |

The six are the shape that criterion explicitly forbids when it says *never
answered with a silently partial set*. The zeros are not Windows-specific:
`./docs` fails on every platform, because a flag value is matched raw against
the stored globs.

`new --scope` persists it. A scope typed `.\docs\` is stored verbatim and
matches nothing anywhere for the life of the corpus, while `check` reports the
consequence as *work not started, or a typo* -- when it is neither, but the
form the caller's own shell completed and `new` accepted without a word.

The new criterion states the property instead of enumerating verbs, and
requires a test that enumerates the surface so a call site added later cannot
be added outside it.

## The three gates

- [x] `cargo fmt --check`
- [x] `cargo test --workspace` -- 309 tests, 0 failed
- [x] `cargo run -q --bin ank -- check` -- exit 0, 0 faults, 94 tasks

## Before you open it

- [x] The behaviour a `done_criteria` describes is tested **through the binary**
- [x] `status:` was not edited by hand
- [x] The MSRV number was not edited to make a build pass
- [x] English everywhere, no emojis