### PR TITLE
Add ADRs and tasks: one repository carries every distribution channel

### DIFF
--- a/.ank/adr/ADR-1713af205186.md
+++ b/.ank/adr/ADR-1713af205186.md
@@ -1,0 +1,51 @@
+---
+id: ADR-1713af205186
+type: adr
+slug: an-mcp-server-is-a-decision-not-a-task
+title: An MCP server is a decision, not a task
+created: 2026-08-08T16:16:26Z
+author: seanl@sean-laptop
+status: proposed
+scope:
+  - docs/ank-spec-v1.1.md
+  - crates/**
+constraint: |
+  No MCP server, and no subset of the verbs exposed over any protocol, enters the tree while this decision is unaccepted. The design principle of specification section 2 -- shell rather than MCP, the common denominator across agents -- stands until something supersedes it. If an MCP server is ever accepted, it exposes every verb the CLI dispatches and refuses on state exactly as the CLI does, never a curated subset.
+schema: 2
+version: 1
+---
+
+A distribution plan ranked an MCP server as the highest-leverage move: one
+implementation reaching Claude Desktop, Cursor, Windsurf, OpenCode and every
+MCP-capable client. The reach is real. The shape proposed is not compatible with
+two decisions already taken, and that is why this is recorded as a decision
+rather than picked up as a task.
+
+The proposed server exposed four tools -- ank_context, ank_claim, ank_list_tasks,
+ank_done -- out of the verbs the CLI dispatches. ADR-9ede1ffd04e2 abolished the
+agent surface and the human surface: one surface, every verb available to every
+caller, refusal on state and never on identity. A four-tool server rebuilds that
+split under another protocol, and it is the worse half of it, because a caller
+reached through MCP cannot amend, cannot propose an ADR, cannot check the corpus
+-- exactly the capabilities ADR-e17e1bbd93ff judged highest-leverage and taught
+in the skill.
+
+Specification section 2 states the other half: shell rather than MCP, the common
+denominator across agents, no protocol serialisation per call. Every CLI agent
+targeted here already runs shell commands, so MCP adds a serialisation layer and
+a second dispatch path for callers that had a working route. What MCP genuinely
+adds is the client with no shell at all -- Claude Desktop is the one that matters
+-- and that is a narrower claim than the plan made.
+
+Section 10 already defers ank serve to level 2, so deferring a protocol surface
+is the established shape of this answer rather than a new one.
+
+What would have to be true to accept this: a full-surface passthrough, generated
+from the same dispatch table the CLI uses so it cannot fall behind, and a
+statement of what it does with claims -- refs/ank/claims/<id> is per clone, and
+TASK-83d6 already records that claims only arbitrate within one clone. A server
+speaking for several clients across several clones inherits that unsolved problem
+rather than avoiding it.
+
+This entry exists so the question is not re-argued from scratch. An agent that
+proposes an MCP server should be handed this ADR, not the reasoning again.

--- a/.ank/adr/ADR-e3cb36646d77.md
+++ b/.ank/adr/ADR-e3cb36646d77.md
@@ -1,0 +1,51 @@
+---
+id: ADR-e3cb36646d77
+type: adr
+slug: one-repository-carries-every-distribution-channe
+title: One repository carries every distribution channel
+created: 2026-08-08T16:15:55Z
+author: seanl@sean-laptop
+status: proposed
+scope:
+  - npm/**
+  - skill/**
+  - README.md
+  - docs/**
+constraint: |
+  Every distribution channel ank offers is carried by this repository. No satellite repository holds a skill, a plugin manifest, a marketplace catalogue or a package manifest. skill/SKILL.md is the single source: a channel either points at it by path, or receives a copy produced at release time by an assembly script and excluded from git. A second copy of the skill committed to the tree is a finding.
+schema: 2
+version: 2
+---
+
+A distribution plan proposed five satellite repositories -- one per agent
+ecosystem -- each carrying its own copy of the skill. The copy is what makes it
+wrong.
+
+skill/SKILL.md is frozen by hash. crates/ank-cli/build.rs stamps that hash into
+ank --version, crates/ank-cli/tests/skill.rs holds the file to it, and
+metadata.revision inside the file names it. A second copy in a second repository
+has no such anchor: it drifts, nothing turns red, and one day an agent is taught
+the opposite of a ratified ADR. That is not hypothetical -- TASK-b495 was
+exactly that defect, a stale installed skill contradicting a binding decision,
+and the fix was to make the binary name the revision it was built alongside. A
+satellite repository reopens the hole the fix closed.
+
+Nothing about the channels requires the split. A Claude Code plugin manifest
+takes a skills path that points at a directory containing SKILL.md directly, so
+.claude-plugin/plugin.json can name ./skill. A marketplace entry accepts a
+source that resolves to the marketplace root, so the repository lists itself. The
+skills CLI already finds skill/SKILL.md and installs it into Claude Code, Codex,
+Cursor, OpenCode and some thirty more. A pi package declares its skills in a
+package.json manifest key, which the npm wrapper and the repository root can each
+carry. Four ecosystems, one file, no copy in git.
+
+The one copy this constraint allows is the one an assembly script produces at
+release time, the way .github/scripts/npm-assemble.sh already copies LICENSE into
+each package. It is regenerated from the source on every run and gitignored, so
+it cannot drift unnoticed -- and the release smoke job is where that is checked.
+
+The single deliverable that would have justified a second repository is a demo
+project, which by nature does not belong in the tool's own tree. It was dropped
+in favour of a recording in the README: ank init is already one command in any
+repository, so a fake project buys little and has to be kept in step with the
+format forever.

--- a/.ank/tasks/TASK-1613794deccf.md
+++ b/.ank/tasks/TASK-1613794deccf.md
@@ -1,0 +1,41 @@
+---
+id: TASK-1613794deccf
+type: task
+slug: the-distribution-adr-covers-the-manifests-it-con
+title: The distribution ADR covers the manifests it constrains
+created: 2026-08-08T16:18:52Z
+author: seanl@sean-laptop
+status: open
+scope:
+  - .claude-plugin/**
+  - package.json
+blocked_by: [TASK-e1671f747e47, TASK-58e55ec52d7d]
+done_criteria: |
+  ADR-e3cb36646d77 carries .claude-plugin/** and package.json in its scope, so
+  ank context .claude-plugin/plugin.json and ank context package.json each serve
+  its constraint. ank check reports no dead scope and stays green.
+criteria_by: creator
+schema: 2
+version: 1
+---
+
+Repair of a sequencing defect in this batch, not new design.
+
+ADR-e3cb36646d77 was created naming .claude-plugin/** and package.json in its
+scope, because those are the files its constraint is about. Neither existed yet,
+and ank check reports a dead scope on an ADR as a fault, not a signal -- an ADR
+that binds nothing is a decision nobody is reading. The two paths were dropped to
+get the corpus green.
+
+They have to come back, or the constraint stops covering the manifests it exists
+for. TASK-e1671f747e47 creates .claude-plugin/, TASK-58e55ec52d7d creates
+package.json; once both are in the tree, ank amend restores the scopes and the
+coverage is real again.
+
+The criteria of those two tasks could not carry this instruction: amend refuses
+to touch done_criteria, frozen by construction, and the tasks were already
+created. A separate task with blocked_by is the route the project prescribes for
+exactly this.
+
+Worth remembering when writing an ADR ahead of the files it governs: name only
+paths that exist, and grow the scope as the files arrive.

--- a/.ank/tasks/TASK-207e07504dcd.md
+++ b/.ank/tasks/TASK-207e07504dcd.md
@@ -1,0 +1,52 @@
+---
+id: TASK-207e07504dcd
+type: task
+slug: the-install-section-names-one-command-per-agent
+title: The install section names one command per agent
+created: 2026-08-08T16:17:34Z
+author: seanl@sean-laptop
+status: open
+scope:
+  - README.md
+  - docs/getting-started.md
+blocked_by: [TASK-e1671f747e47, TASK-20b23cd4fb16, TASK-58e55ec52d7d]
+done_criteria: |
+  The README section that hands the loop to an agent names every route that works:
+  the skills CLI, the Claude Code marketplace, and both pi routes -- one command
+  each, no prose between them. docs/getting-started.md carries the same list with
+  real output, as the rest of that file does. Every command listed has been run
+  before it is written down, including npx skills add haksolot/ank --list. The
+  sentence that the skill is not the binary survives. docs/ank-spec-v1.1.md is not
+  touched. skill/SKILL.md is not touched and ank --version still prints revision
+  605f771e1955. cargo test and ank check stay green.
+criteria_by: creator
+schema: 2
+version: 1
+---
+
+Documents what the three preceding tasks build. Last of the four because a route
+that is written down before it is run is a route that does not work.
+
+README.md today names one command, npx skills add haksolot/ank, in the section
+"Hand it to an agent". It becomes a short list, one line per route:
+
+  npx skills add haksolot/ank              Claude Code, Codex, Cursor, OpenCode, and others
+  /plugin marketplace add haksolot/ank     Claude Code, as a plugin
+  pi install npm:@haksolot/ank             pi, binary and skill together
+  pi install git:github.com/haksolot/ank   pi, from source
+
+Keep the line that says the command installs the skill and not the binary; it is
+the sentence readers get wrong.
+
+One of these has never been verified: the skills CLI tries standard locations
+first -- the root, skills/, .agents/skills/ and agent-specific directories -- and
+only falls back to a recursive scan when none of them holds a skill. skill/,
+singular, is not a standard location, so this repository is served by the
+fallback. Run npx skills add haksolot/ank --list before writing the line. If the
+fallback does not find it, the cheap repair is a standard location that points at
+the same file; moving skill/SKILL.md is the expensive one and needs its own task,
+because build.rs, tests/skill.rs and the scope of three ratified ADRs including
+ADR-e17e1bbd93ff are all anchored on that path.
+
+Specification section 9 stays as written. It describes the normative bootstrap,
+not a catalogue of routes, and its note about curl and Homebrew is still true.

--- a/.ank/tasks/TASK-20b23cd4fb16.md
+++ b/.ank/tasks/TASK-20b23cd4fb16.md
@@ -1,0 +1,54 @@
+---
+id: TASK-20b23cd4fb16
+type: task
+slug: the-npm-package-is-a-pi-package-skill-included
+title: The npm package is a pi package, skill included
+created: 2026-08-08T16:17:02Z
+author: seanl@sean-laptop
+status: open
+scope:
+  - npm/**
+  - .github/scripts/npm-assemble.sh
+  - .github/workflows/release.yml
+  - .gitignore
+blocked_by: []
+done_criteria: |
+  npm/ank/package.json carries the pi-package keyword, a pi.skills key, and skills/
+  in files. .github/scripts/npm-assemble.sh copies skill/SKILL.md to
+  npm/ank/skills/ank/SKILL.md, and .gitignore excludes that path, so no copy of the
+  skill is committed. The npm-smoke job asserts the packed wrapper contains
+  skills/ank/SKILL.md byte-identical to skill/SKILL.md, and fails when it does not.
+  Verified by running npm-assemble.sh and npm publish --dry-run locally: the listing
+  shows the skill. ank --version still prints skill revision 605f771e1955.
+  cargo test and ank check stay green.
+criteria_by: creator
+schema: 2
+version: 1
+---
+
+The pi route, and the one that carries discovery: a package published with the
+pi-package keyword is listed on pi.dev/packages, which is how pi users find
+anything at all -- there is no closed marketplace to submit to.
+
+pi resolves skills from the pi.skills manifest key or, failing that, from a
+conventional skills/ directory holding <name>/SKILL.md folders. The wrapper
+package is where this belongs rather than a separate package, because then
+pi install npm:@haksolot/ank delivers the binary and the skill in one command
+instead of asking a user to install two things that must stay in step.
+
+The copy is made at assembly time, never committed. That is the shape
+ADR-e3cb36646d77 allows and the shape this script already uses: npm-assemble.sh
+copies LICENSE into each package the same way, and .gitignore already carries
+npm/ank-*/bin/, npm/*/LICENSE and npm/*/*.tgz for exactly this reason. Follow
+those three lines rather than inventing a fourth mechanism.
+
+The smoke assertion is the point of the task, not a nicety. Without it a release
+publishes a pi package with no skill in it and nothing says so -- the wrapper
+still resolves a binary, npx ank --version still passes, and the failure is
+visible only to a pi user weeks later. The job already asserts the version and
+the exit code through the wrapper; this is the third assertion of the same kind.
+
+Note that pi does not put the binary on PATH when it installs an npm package: it
+loads resources. The skill's Install section already tells a reader the skill is
+not the binary, so nothing there needs to change -- and must not, since that body
+is frozen and TASK-e70d28a5fba8 already holds the pen on it.

--- a/.ank/tasks/TASK-58e55ec52d7d.md
+++ b/.ank/tasks/TASK-58e55ec52d7d.md
@@ -1,0 +1,52 @@
+---
+id: TASK-58e55ec52d7d
+type: task
+slug: a-git-clone-of-the-repository-installs-into-pi
+title: A git clone of the repository installs into pi
+created: 2026-08-08T16:17:19Z
+author: seanl@sean-laptop
+status: open
+scope:
+  - package.json
+  - README.md
+blocked_by: []
+done_criteria: |
+  A package.json at the repository root declares the pi manifest -- private, the
+  pi-package keyword, and a pi.skills path resolving skill/SKILL.md -- with no
+  dependencies and no copy of the skill. The path form is the one pi actually
+  accepts, established by running pi install against this working copy and seeing
+  the skill load, not by reading the documentation. ank --version still prints skill
+  revision 605f771e1955, cargo test and ank check stay green, and no npm publish
+  flow reaches this file.
+criteria_by: creator
+schema: 2
+version: 1
+---
+
+The second pi route, for a user who installs from source:
+pi install git:github.com/haksolot/ank. pi clones the repository and looks for a
+manifest or a conventional skills/ directory. This repository has neither, so the
+git route finds nothing today, and a root manifest is what opens it.
+
+The open question is the path form, and it decides the file:
+
+  pi discovers skills from a manifest path, or from a conventional skills/
+  directory where it "recursively finds SKILL.md folders". Whether a manifest path
+  naming ./skill -- a directory holding SKILL.md directly, not skills/<name>/SKILL.md
+  -- is accepted is not stated. Try ./skill first. If it is refused, the fallbacks
+  are "." for the root, or the file path itself. Do not answer this from the
+  documentation; run it.
+
+pi also runs npm install when a package.json exists in a cloned package. With no
+dependencies that is a no-op, but confirm it rather than assume it.
+
+private: true, because this manifest exists to be read by pi from a clone and
+must never be publishable as a package in its own right. The published package is
+@haksolot/ank under npm/ank/, and TASK-20b23cd4fb16 is what makes that one a pi
+package too.
+
+A package.json at the root of a Rust repository is an oddity worth accepting
+knowingly: it declares one manifest key and nothing else, it pulls in no
+dependency, and it is the only way the git route works without moving
+skill/SKILL.md -- a move that would break the ADR scopes anchored on skill/**,
+the freeze hash in build.rs, and the tests that hold it.

--- a/.ank/tasks/TASK-ab3592c8c586.md
+++ b/.ank/tasks/TASK-ab3592c8c586.md
@@ -1,0 +1,41 @@
+---
+id: TASK-ab3592c8c586
+type: task
+slug: the-readme-shows-the-loop-running
+title: The README shows the loop running
+created: 2026-08-08T16:17:47Z
+author: seanl@sean-laptop
+status: open
+scope:
+  - README.md
+  - assets/**
+blocked_by: []
+done_criteria: |
+  A recording under assets/ shows the loop doing the thing the README claims: ank
+  context serving a constraint, and the work that follows respecting it. It is
+  referenced from README.md, it renders on the GitHub page in both the light and
+  the dark theme, and it is short enough to be watched without a decision -- under
+  about forty seconds. No .ank/ file is opened on screen. cargo test and ank check
+  stay green.
+criteria_by: creator
+schema: 2
+version: 1
+---
+
+The one purely promotional deliverable, and deliberately last: nothing here is
+worth showing until the install routes work.
+
+The README argues that an agent can read the code but not the tracker, and that
+ank closes the gap. The recording has to show that closing, not the CLI's
+output for its own sake: a constraint served by ank context, and a change that
+comes out different because of it. A screen of terse output proves nothing a
+reader cannot already see in the "What it looks like" section.
+
+Constraints on the recording itself. It must never show a .ank/ file being
+opened -- ADR-01b6dd05f0db is the decision the tool exists to make legible, and a
+recording that violates it teaches the opposite. It must survive GitHub's theme
+switch, the way assets/ank.svg and assets/ank-dark.svg already do through a
+picture element. Terminal recordings age badly when they show a version string or
+a hash that will be wrong next month; prefer framing that does not.
+
+Place it above the quick start, where a reader decides whether to keep reading.

--- a/.ank/tasks/TASK-e1671f747e47.md
+++ b/.ank/tasks/TASK-e1671f747e47.md
@@ -1,0 +1,53 @@
+---
+id: TASK-e1671f747e47
+type: task
+slug: the-repository-is-its-own-claude-code-plugin-and
+title: The repository is its own Claude Code plugin and marketplace
+created: 2026-08-08T16:16:45Z
+author: seanl@sean-laptop
+status: open
+scope:
+  - .claude-plugin/**
+  - README.md
+blocked_by: []
+done_criteria: |
+  The repository carries .claude-plugin/plugin.json and .claude-plugin/marketplace.json.
+  The plugin manifest declares the skill by path -- skills naming ./skill -- and
+  skill/SKILL.md is not copied, moved or duplicated; ank --version still prints
+  skill revision 605f771e1955. The marketplace entry names the repository itself as
+  its source. Verified by running, not by reading: /plugin marketplace add against
+  this working copy, then /plugin install, and the skill appears under its
+  frontmatter name ank, with claude plugin list reporting no ignored directory.
+  README.md names the two commands a user runs. cargo test and ank check stay green.
+criteria_by: creator
+schema: 2
+version: 1
+---
+
+First of the channels opened by ADR-e3cb36646d77, and the one that proves the
+whole approach: a plugin manifest can point at a skill by path, so the tool's own
+repository is also the plugin and its own marketplace.
+
+Two files, no third:
+
+  .claude-plugin/plugin.json      name ank, "skills": ["./skill"]
+  .claude-plugin/marketplace.json name ank, one plugin whose source is "./"
+
+The skills manifest key adds to the default skills/ scan rather than replacing
+it, except for a marketplace entry whose source resolves to the marketplace root
+-- which is this case, and there is no skills/ directory here anyway. The
+invocation name comes from the frontmatter name field, so it stays ank whatever
+the install directory is called; without it Claude Code falls back to a directory
+basename that is a version string changing on every update.
+
+Two traps.
+
+.claude-plugin/ is not .claude/. TASK-10b8a29fd853 removes .claude/ and its
+PreToolUse hook from the tree by maintainer decision -- enforcement becomes
+advisory. The new directory is a different one and must survive that removal. The
+plugin must not ship the hook either: shipping it would re-impose in every user's
+repository the layer this project just chose to retire in its own.
+
+The version field is a fourth place where 0.1.2 is written by hand, beside the
+two Cargo.toml and the npm package.json files. Noted as debt, not fixed here; a
+task that unifies the stamping is a separate one.


### PR DESCRIPTION
## Which task does this close

None -- this opens six. A batch of `.ank/` entities only: two ADRs and six tasks, no code, no format change.

## What it does, and why this way

A distribution plan proposed five satellite repositories, each with its own copy of `skill/SKILL.md`, plus an MCP server as the top deliverable. `ADR-e3cb36646d77` (proposed) refuses the satellites: the skill is frozen by hash -- `build.rs` stamps it into `ank --version`, `tests/skill.rs` holds the file to it -- so a copy in another repository drifts with nothing turning red, which is the defect `TASK-b495` already corrected once. Verified, not assumed: a plugin manifest takes a `skills` path naming a directory that holds `SKILL.md` directly, a marketplace entry takes a `source` resolving to the marketplace root, the skills CLI already reaches `skill/SKILL.md`, and pi reads a `pi.skills` manifest key -- four ecosystems, one file, no copy in git. `ADR-1713af205186` stays proposed on MCP: the four-tool server rebuilds under another protocol the surface split `ADR-9ede1ffd04e2` abolished, and section 2 of the specification already answers it with shell rather than MCP.

The six tasks are the channels in dependency order, with the documentation blocked on the three that build them. The sixth repairs this batch: the ADR named `.claude-plugin/**` and `package.json` before either existed, `check` reports a dead ADR scope as a fault, so the paths were dropped and a blocked task restores them -- they could not go in the other tasks' criteria, since `amend` refuses `done_criteria` unconditionally.

Nothing here touches `skill/SKILL.md`; `TASK-e70d28a5fba8` holds the pen on that file.

## The three gates

- [x] `cargo fmt --check`
- [x] `cargo test --workspace` -- 309 passed, 0 failed
- [x] `cargo run -q --bin ank -- check` -- `ok, 100 tasks, 19 adr, 29 signals`, exit 0

## Before you open it

- [x] `status:` was not edited by hand -- no task changes status here
- [x] The MSRV number was not edited
- [x] English everywhere, no emojis

Both ADRs are `proposed` and await a signed `ank accept` on the default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XszrHRiKJWjAM4At7YwYkg
