### PR TITLE
The repository is its own Claude Code plugin and marketplace

### DIFF
--- a/.ank/tasks/TASK-e1671f747e47.md
+++ b/.ank/tasks/TASK-e1671f747e47.md
@@ -5,7 +5,7 @@ slug: the-repository-is-its-own-claude-code-plugin-and
 title: The repository is its own Claude Code plugin and marketplace
 created: 2026-08-08T16:16:45Z
 author: seanl@sean-laptop
-status: open
+status: in_progress
 scope:
   - .claude-plugin/**
   - README.md
@@ -21,7 +21,7 @@ done_criteria: |
   README.md names the two commands a user runs. cargo test and ank check stay green.
 criteria_by: creator
 schema: 2
-version: 1
+version: 3
 ---
 
 First of the channels opened by ADR-e3cb36646d77, and the one that proves the
@@ -51,3 +51,6 @@ repository the layer this project just chose to retire in its own.
 The version field is a fourth place where 0.1.2 is written by hand, beside the
 two Cargo.toml and the npm package.json files. Noted as debt, not fixed here; a
 task that unifies the stamping is a separate one.
+
+## Log
+- 2026-08-08T16:35:40Z seanl@sean-laptop — Verified through the CLI, not by reading: claude plugin validate passes on the working copy, claude plugin install ank@ank from a local marketplace add succeeds, and claude plugin details reports Skills (1) ank -- the frontmatter name, not a directory basename -- with no ignored-directory warning. Measured cost: ~58 tokens always-on, ~1.1k on invoke. skill/SKILL.md was not touched: ank --version still prints skill 605f771e1955 from both the installed binary and the tree. One thing validate does not do: with both manifests present it reports only the marketplace one, so the plugin manifest is proved by the install succeeding, not by validate.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "name": "ank",
+  "description": "The ank skill, served from the repository that carries the tool.",
+  "owner": {
+    "name": "haksolot",
+    "url": "https://github.com/haksolot"
+  },
+  "plugins": [
+    {
+      "name": "ank",
+      "source": "./",
+      "description": "Read a repository's tasks and binding constraints, claim work, and finish it with proof."
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "ank",
+  "description": "Tasks and architecture decisions in your repo, behind one CLI any coding agent can call.",
+  "version": "0.1.2",
+  "author": {
+    "name": "haksolot",
+    "url": "https://github.com/haksolot"
+  },
+  "homepage": "https://github.com/haksolot/ank",
+  "repository": "https://github.com/haksolot/ank",
+  "license": "GPL-3.0-only",
+  "keywords": [
+    "adr",
+    "architecture-decision-record",
+    "tasks",
+    "coordination",
+    "agent"
+  ],
+  "skills": ["./skill"]
+}

--- a/README.md
+++ b/README.md
@@ -78,6 +78,17 @@ That installs the skill, not the binary. The skill is one plain markdown file,
 [`skill/SKILL.md`](skill/SKILL.md): where that command does not fit, copy it by
 hand into whatever your agent loads.
 
+Claude Code can take it as a plugin instead, this repository serving as its own
+marketplace:
+
+```
+/plugin marketplace add haksolot/ank
+/plugin install ank@ank
+```
+
+Same file either way — the plugin points at `skill/SKILL.md` where it already
+lives, and there is no second copy to fall behind it.
+
 [**Getting started**](docs/getting-started.md) walks all of that with real
 output, including the two refusals a fresh repository will give you.
 


### PR DESCRIPTION
## Which task does this close

TASK-e1671f747e47

## What it does, and why this way

Two manifests at `.claude-plugin/`, and no copy of the skill anywhere. `plugin.json` declares `"skills": ["./skill"]` -- a skill path may name a directory that holds `SKILL.md` directly, so the manifest reaches the file where it already lives, under the path the freeze in `build.rs` and three ratified ADR scopes are anchored on. The invocation name comes from the frontmatter `name`, so it stays `ank` whatever the install directory is called. `marketplace.json` lists one plugin whose `source` is `"./"`: the repository is its own catalogue, which is what `ADR-e3cb36646d77` (proposed) asks for when it refuses satellite repositories -- a second copy of `skill/SKILL.md` has no anchor and drifts with nothing turning red.

Verified by running, not by reading. `claude plugin validate` passes; `claude plugin marketplace add` against the checkout then `claude plugin install ank@ank` then `claude plugin details` reports `Skills (1) ank` with no ignored-directory warning, at ~58 tokens always-on and ~1.1k on invoke. The local marketplace was removed afterwards. `skill/SKILL.md` is untouched: `ank --version` still prints skill `605f771e1955`.

`.claude-plugin/` is not `.claude/` -- TASK-10b8a29fd853 removes the latter and its hook, and this directory stays. The plugin ships no hook on purpose.

## The three gates

- [x] `cargo fmt --check`
- [x] `cargo test --workspace`
- [x] `cargo run -q --bin ank -- check` -- `ok, 100 tasks, 19 adr, 27 signals`, exit 0

## Before you open it

- [x] The behaviour the `done_criteria` describes was exercised through the real `claude plugin` CLI, not through a manifest read
- [x] `status:` was not edited by hand
- [x] The MSRV number was not edited
- [x] English everywhere, no emojis

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XszrHRiKJWjAM4At7YwYkg
