### PR TITLE
The npm package is a pi package, skill included

### DIFF
--- a/.ank/tasks/TASK-20b23cd4fb16.md
+++ b/.ank/tasks/TASK-20b23cd4fb16.md
@@ -5,7 +5,7 @@ slug: the-npm-package-is-a-pi-package-skill-included
 title: The npm package is a pi package, skill included
 created: 2026-08-08T16:17:02Z
 author: seanl@sean-laptop
-status: open
+status: in_progress
 scope:
   - npm/**
   - .github/scripts/npm-assemble.sh
@@ -23,7 +23,7 @@ done_criteria: |
   cargo test and ank check stay green.
 criteria_by: creator
 schema: 2
-version: 1
+version: 3
 ---
 
 The pi route, and the one that carries discovery: a package published with the
@@ -52,3 +52,6 @@ Note that pi does not put the binary on PATH when it installs an npm package: it
 loads resources. The skill's Install section already tells a reader the skill is
 not the binary, so nothing there needs to change -- and must not, since that body
 is frozen and TASK-e70d28a5fba8 already holds the pen on it.
+
+## Log
+- 2026-08-08T16:54:00Z seanl@sean-laptop — Verified locally end to end. npm-assemble.sh copies skill/SKILL.md into npm/ank/skills/ank/SKILL.md; npm publish --dry-run lists it at 3.2kB among five files; the tarball assertion matches sha256 9e4161fb... on both sides. Negative direction proved too: repacked with skills/ removed, the same assertion exits 1, so the step fails when the skill is absent rather than passing vacuously. pi accepts the package -- pi install ./npm/ank succeeds and pi list shows it -- but pi could not be made to print its resolved skills on this machine, so what is proved is that the manifest is accepted, not that the skill loads. Two findings outside this criterion. First, npm 11.14.1 refuses the dry-run the smoke job runs: 0.0.0-smoke is a prerelease and needs --tag, and even 0.0.0 is refused as lower than the published 0.1.2. CI passes today on the runner's npm 10, so this is latent, and it fails closed. Second, git checkout -- npm/ to undo the version stamping also reverts hand edits to the same file; assemble in a throwaway tree or restore the version field alone.

--- a/.ank/tasks/TASK-ace80749fd5c.md
+++ b/.ank/tasks/TASK-ace80749fd5c.md
@@ -1,0 +1,48 @@
+---
+id: TASK-ace80749fd5c
+type: task
+slug: the-release-dry-run-passes-on-an-npm-that-would
+title: The release dry-run passes on an npm that would refuse it
+created: 2026-08-08T16:55:44Z
+author: seanl@sean-laptop
+status: open
+scope:
+  - .github/workflows/release.yml
+  - .github/scripts/npm-assemble.sh
+blocked_by: []
+done_criteria: |
+  The npm-smoke job's dry-run passes on an npm that refuses an unpublishable
+  version. Established by running the job's own command on npm 11 before the fix
+  and seeing it fail, and after the fix and seeing it pass, on all three runners.
+  The version the smoke job assembles and the flags it passes are chosen so the
+  dry-run exercises the same argument publish-npm passes, with no new flag that
+  publish-npm does not also carry. cargo test and ank check stay green.
+criteria_by: creator
+schema: 2
+version: 1
+---
+
+Found while adding the pi skill to the wrapper (TASK-20b23cd4fb16), by running
+the smoke job's own commands locally rather than trusting the green tick.
+
+The job assembles at 0.0.0-smoke and runs:
+
+    npm publish --dry-run --access public "./npm/ank"
+
+npm 11.14.1 refuses it: "You must specify a tag using --tag when publishing a
+prerelease version." Assembling at 0.0.0 instead moves the refusal rather than
+removing it -- "Cannot implicitly apply the latest tag because previously
+published version 0.1.2 is higher". The runners use the npm bundled with node 22,
+which does not enforce either, so CI is green today and the trap is dated rather
+than absent.
+
+It fails closed, which is the only good news here: a smoke job that cannot dry-run
+blocks publish-npm and no tag is spent. The cost is a red release on the day node
+22's bundled npm moves, discovered at the moment someone tags, which is precisely
+the situation the dry-run step was added to prevent -- v0.1.2 shipped no packages
+because nothing had ever run the publish argument.
+
+The shape of the fix is the constraint. Adding --tag to the dry-run and not to
+publish-npm would make the smoke job test a command nobody runs, which is how the
+v0.1.2 defect happened in the first place. Either both carry it, or the assembled
+version is one npm will accept unflagged. Decide that first, then write it once.

--- a/.github/scripts/npm-assemble.sh
+++ b/.github/scripts/npm-assemble.sh
@@ -77,5 +77,17 @@ for p in ank-linux-x64-musl ank-darwin-arm64 ank-win32-x64; do
   npm pkg set "optionalDependencies.@haksolot/$p=$version"
 done
 cp ../../LICENSE LICENSE
+
+# pi reads a package's skills from its pi.skills path, and its convention is
+# skills/<name>/SKILL.md. The source is skill/SKILL.md at the repository root,
+# where the freeze lives: build.rs hashes it into `ank --version` and
+# tests/skill.rs holds the file to that hash. A second copy committed beside it
+# would have no such anchor and would drift with nothing turning red, which is
+# what ADR-e3cb36646d77 refuses. So the copy is made here, from the one file, on
+# every run, and .gitignore keeps it out of the tree -- the same arrangement as
+# LICENSE on the line above. The release smoke job is what checks it arrived.
+mkdir -p skills/ank
+cp ../../skill/SKILL.md skills/ank/SKILL.md
+
 npm pack --silent > /dev/null
 echo "assembled npm/ank at $version"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,6 +163,25 @@ jobs:
         shell: bash
         run: bash .github/scripts/npm-assemble.sh "0.0.0-smoke" "${{ matrix.package }}"
 
+      # The wrapper is also the pi package, and a pi package is its skill: with
+      # skills/ank/SKILL.md missing, `pi install npm:@haksolot/ank` installs a
+      # binary and teaches nothing, while every other assertion in this job
+      # still passes. The copy is made at assembly time and never committed
+      # (npm-assemble.sh), so nothing else in the repository can notice it went
+      # missing. Read out of the tarball rather than off the disk, because the
+      # tarball is what the registry receives -- a `files` entry that stopped
+      # matching would leave the file on disk and out of the package.
+      - name: the wrapper carries the skill
+        shell: bash
+        run: |
+          set -e
+          tgz=$(ls npm/ank/*.tgz | head -n 1)
+          packed=$(tar -xzOf "$tgz" package/skills/ank/SKILL.md | sha256sum | cut -d' ' -f1)
+          source=$(sha256sum skill/SKILL.md | cut -d' ' -f1)
+          echo "packed: $packed"
+          echo "source: $source"
+          test "$packed" = "$source"
+
       # The argument publish-npm passes, run on every dispatch and every tag,
       # with the one flag that stops short of the registry. This is the step
       # that was missing when v0.1.2 shipped no packages: the smoke job proved

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 npm/ank-*/bin/
 npm/*/LICENSE
 npm/*/*.tgz
+# And this one from skill/SKILL.md, which is the only copy that exists in git.
+npm/ank/skills/

--- a/npm/ank/package.json
+++ b/npm/ank/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haksolot/ank",
-  "version": "0.1.2",
+  "version": "0.0.0",
   "description": "The stupid coordination tool: tasks and architecture decisions in your repo, behind one CLI any coding agent can call.",
   "license": "GPL-3.0-only",
   "homepage": "https://github.com/haksolot/ank",
@@ -17,13 +17,20 @@
     "adr",
     "architecture-decision-record",
     "tasks",
-    "coordination"
+    "coordination",
+    "pi-package"
   ],
   "bin": {
     "ank": "bin/ank"
   },
+  "pi": {
+    "skills": [
+      "./skills"
+    ]
+  },
   "files": [
     "bin/ank",
+    "skills/",
     "README.md",
     "LICENSE"
   ],
@@ -31,8 +38,8 @@
     "node": ">=18"
   },
   "optionalDependencies": {
-    "@haksolot/ank-darwin-arm64": "0.1.2",
-    "@haksolot/ank-linux-x64-musl": "0.1.2",
-    "@haksolot/ank-win32-x64": "0.1.2"
+    "@haksolot/ank-darwin-arm64": "0.0.0",
+    "@haksolot/ank-linux-x64-musl": "0.0.0",
+    "@haksolot/ank-win32-x64": "0.0.0"
   }
 }


### PR DESCRIPTION
## Which task does this close

TASK-20b23cd4fb16. It also adds TASK-ace80749fd5c, found while verifying this one -- the file landed in the same commit rather than its own.

## What it does, and why this way

pi resolves a package's skills from its `pi.skills` manifest key, and pi.dev/packages lists what carries the `pi-package` keyword **and is published to npm**. Both go on the wrapper rather than into a package of their own, so `pi install npm:@haksolot/ank` delivers the binary and the skill together.

The skill is copied at assembly time and never committed: `npm-assemble.sh` writes `npm/ank/skills/ank/SKILL.md` from `skill/SKILL.md` on every run, `.gitignore` keeps it out of the tree -- the arrangement `LICENSE` already has one line above. That is what `ADR-e3cb36646d77` (proposed) allows and why it allows only that: the source is frozen by hash and a copy living in git beside it would drift with nothing turning red.

Nothing in the repository can notice that copy going missing, so the smoke job is where it is checked. The new step reads the file out of the **packed tarball**, not off the disk -- a `files` entry that stopped matching would leave it in place and out of the package -- and compares sha256 against the source. Verified both ways locally: it passes on the real tarball, and repacked with `skills/` removed it exits 1 rather than passing vacuously.

`npm publish --dry-run` lists the skill at 3.2kB among five files. `pi install ./npm/ank` succeeds and `pi list` shows it. What that does **not** prove is the skill resolving: pi could not be made to print its resolved resources on this machine, so the manifest is accepted and the shape used is the documented convention, nothing stronger.

`skill/SKILL.md` untouched -- `ank --version` still prints skill `605f771e1955`.

Visibility on pi.dev/packages follows only at the next tag: the gallery indexes the registry.

## The three gates

- [x] `cargo fmt --check`
- [x] `cargo test --workspace`
- [x] `cargo run -q --bin ank -- check` -- exit 0

## Before you open it

- [x] The criterion was exercised by running `npm-assemble.sh`, `npm pack` and the assertion itself, in both the passing and the failing direction
- [x] `status:` was not edited by hand
- [x] The MSRV number was not edited
- [x] English everywhere, no emojis

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XszrHRiKJWjAM4At7YwYkg
