### PR TITLE
A git clone of the repository installs into pi

### DIFF
--- a/.ank/tasks/TASK-58e55ec52d7d.md
+++ b/.ank/tasks/TASK-58e55ec52d7d.md
@@ -5,7 +5,7 @@ slug: a-git-clone-of-the-repository-installs-into-pi
 title: A git clone of the repository installs into pi
 created: 2026-08-08T16:17:19Z
 author: seanl@sean-laptop
-status: open
+status: in_progress
 scope:
   - package.json
   - README.md
@@ -20,7 +20,7 @@ done_criteria: |
   flow reaches this file.
 criteria_by: creator
 schema: 2
-version: 1
+version: 3
 ---
 
 The second pi route, for a user who installs from source:
@@ -50,3 +50,6 @@ knowingly: it declares one manifest key and nothing else, it pulls in no
 dependency, and it is the only way the git route works without moving
 skill/SKILL.md -- a move that would break the ADR scopes anchored on skill/**,
 the freeze hash in build.rs, and the tests that hold it.
+
+## Log
+- 2026-08-08T17:14:37Z seanl@sean-laptop — Both questions answered by running, not by reading. Question one: pi's own loader accepts a path naming a directory that holds SKILL.md directly. Its documented rule is 'if a directory contains SKILL.md, treat it as a skill root and do not recurse further', and calling loadSkillsFromDir from pi's dist against skill/ returns one skill named ank, description intact, zero diagnostics. So pi.skills is ./skill and no skills/<name>/ shape is needed. Question two: pi install ./ succeeds against this working copy, pi list shows it, and nothing is fetched -- npm install at the root is a clean no-op. Two things learned that the task body got wrong. The manifest needs no version field at all: pi installs it and npm is content, so the root manifest adds no sixth place where 0.1.2 is written by hand, which was the reason to hesitate. And private: true is weaker than assumed -- npm 11 ignores it under --dry-run and reports a successful publish of 205 files. It still blocks a real publish, but the guard that matters is that no publish flow here targets the root: every npm publish in release.yml names ./npm/<pkg>, and npm-assemble only ever npm pkg set inside npm/. The name is scoped to @haksolot/ank-pi rather than the bare ank the body proposed, because ank is an existing package on the registry owned by someone else.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@haksolot/ank-pi",
+  "private": true,
+  "description": "Pi package manifest for the ank skill. Not published: the published package is @haksolot/ank, under npm/ank.",
+  "license": "GPL-3.0-only",
+  "homepage": "https://github.com/haksolot/ank",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/haksolot/ank.git"
+  },
+  "keywords": [
+    "pi-package"
+  ],
+  "pi": {
+    "skills": [
+      "./skill"
+    ]
+  }
+}


### PR DESCRIPTION
## Which task does this close

TASK-58e55ec52d7d

## What it does, and why this way

One manifest at the root, no dependencies and no copy of the skill. It opens `pi install git:github.com/haksolot/ank`, which found nothing before: pi looks for a `pi.skills` manifest key or a conventional `skills/` directory, and a clone of this repository had neither.

The open question was the path form, settled by running pi's own code. The rule in `dist/core/skills.js` is *"if a directory contains SKILL.md, treat it as a skill root and do not recurse further"*, and calling `loadSkillsFromDir` against `skill/` returns one skill named `ank`, description intact, zero diagnostics. So the manifest names `./skill`, and no `skills/<name>/SKILL.md` shape is needed -- which is what keeps the skill where the freeze and three ADR scopes are anchored on it. `pi install ./` then succeeds, `pi list` shows it, and nothing is fetched.

Two corrections to what the task body assumed, both worth knowing:

- **No `version` field.** pi installs the manifest without one and npm is content, so the root does not become a sixth place where `0.1.2` is written by hand. That was the main reason to hesitate over a `package.json` in a Rust repo, and it does not apply.
- **`private: true` is not the guard.** npm 11 ignores it under `--dry-run` and reports a successful publish of 205 files. It still refuses a real publish, but the guard that matters is that no publish flow here targets the root: every `npm publish` in `release.yml` names `./npm/<pkg>`, and `npm-assemble.sh` only runs `npm pkg set` inside `npm/`. The name is scoped to `@haksolot/ank-pi` rather than the bare `ank` the body proposed -- `ank` is an existing registry package belonging to someone else.

`README.md` is untouched: naming the routes is TASK-207e07504dcd, blocked on this one so it can be written once, after each route has been run.

## The three gates

- [x] `cargo fmt --check`
- [x] `cargo test --workspace`
- [x] `cargo run -q --bin ank -- check` -- exit 0

## Before you open it

- [x] The path form was established by executing pi's own loader and `pi install`, not by reading the docs
- [x] `status:` was not edited by hand
- [x] The MSRV number was not edited
- [x] English everywhere, no emojis

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XszrHRiKJWjAM4At7YwYkg
