### PR TITLE
The install section names one command per agent

### DIFF
--- a/.ank/tasks/TASK-207e07504dcd.md
+++ b/.ank/tasks/TASK-207e07504dcd.md
@@ -5,7 +5,7 @@ slug: the-install-section-names-one-command-per-agent
 title: The install section names one command per agent
 created: 2026-08-08T16:17:34Z
 author: seanl@sean-laptop
-status: open
+status: in_progress
 scope:
   - README.md
   - docs/getting-started.md
@@ -21,7 +21,7 @@ done_criteria: |
   605f771e1955. cargo test and ank check stay green.
 criteria_by: creator
 schema: 2
-version: 1
+version: 3
 ---
 
 Documents what the three preceding tasks build. Last of the four because a route
@@ -50,3 +50,6 @@ ADR-e17e1bbd93ff are all anchored on that path.
 
 Specification section 9 stays as written. It describes the normative bootstrap,
 not a catalogue of routes, and its note about curl and Homebrew is still true.
+
+## Log
+- 2026-08-08T17:26:40Z seanl@sean-laptop — npx skills add haksolot/ank --list answers 'Found 1 skill' and names ank with its frontmatter description. The recursive fallback does reach skill/SKILL.md even though skill/ singular is not one of the standard locations, so the expensive repair -- moving the file, and with it the freeze in build.rs and the scope of three ratified ADRs -- is not needed and the question is closed. Three of the four routes are now written from output I ran. The fourth, pi install npm:@haksolot/ank, cannot be run against the registry until v0.1.3 publishes the pi keys: what was exercised is the assembled package, not the published one. The claim stays held through the release for that reason, and done waits until the command in the documentation has actually been run as written. Two version strings kept out of the documentation on purpose: claude plugin details prints one, and quoting it would have the guide claim a release that was not out yet and go stale at the next tag.

--- a/README.md
+++ b/README.md
@@ -67,16 +67,14 @@ ank log "<what you learned>"  # renews the claim; working is what holds it
 ank done                      # runs the verifiers itself and writes the proof
 ```
 
-**Hand it to an agent.** The `skills` CLI detects what you run — Claude Code,
-Codex, Cursor, OpenCode and others — and links each one to a single copy:
+**Hand it to an agent.** Four routes, and the same file behind all of them.
+
+The `skills` CLI detects what you run — Claude Code, Codex, Cursor, OpenCode and
+some thirty more — and links each one to a single copy:
 
 ```
 npx skills add haksolot/ank
 ```
-
-That installs the skill, not the binary. The skill is one plain markdown file,
-[`skill/SKILL.md`](skill/SKILL.md): where that command does not fit, copy it by
-hand into whatever your agent loads.
 
 Claude Code can take it as a plugin instead, this repository serving as its own
 marketplace:
@@ -86,8 +84,17 @@ marketplace:
 /plugin install ank@ank
 ```
 
-Same file either way — the plugin points at `skill/SKILL.md` where it already
-lives, and there is no second copy to fall behind it.
+pi takes it from the registry, or from a clone:
+
+```
+pi install npm:@haksolot/ank
+pi install git:github.com/haksolot/ank
+```
+
+All four install the skill, not the binary — `ank` goes on your `PATH` as above.
+The skill is one plain markdown file, [`skill/SKILL.md`](skill/SKILL.md): where
+none of these fits, copy it by hand into whatever your agent loads. No route
+holds a copy of it, so no route can fall behind it.
 
 [**Getting started**](docs/getting-started.md) walks all of that with real
 output, including the two refusals a fresh repository will give you.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -348,7 +348,51 @@ that your work is wrong. Fix the machine, not the code.
 
 ## Handing the loop to an agent
 
-    npx skills add haksolot/ank
+Four routes install the same file. Pick the one your agent already understands.
+
+**The `skills` CLI**, which detects what you run — Claude Code, Codex, Cursor,
+OpenCode and some thirty more — and links each one to a single copy. Ask it what
+it found before you let it install:
+
+    $ npx skills add haksolot/ank --list
+    Source: https://github.com/haksolot/ank.git
+    Repository cloned
+    Found 1 skill
+
+    Available Skills
+    Ank
+      ank
+        Read a repository's tasks and binding constraints, claim work, and
+        finish it with proof. Use when working in a repo that has a .ank/
+        directory.
+
+Drop `--list` to install it.
+
+**Claude Code as a plugin**, this repository serving as its own marketplace:
+
+    /plugin marketplace add haksolot/ank
+    /plugin install ank@ank
+
+`claude plugin details ank` then tells you what it costs you, which is the
+question worth asking of anything loaded on every session:
+
+    Tasks and architecture decisions in your repo, behind one CLI any coding
+    agent can call.
+
+    Component inventory
+      Skills (1)  ank
+
+    Projected token cost
+      Always-on:   ~58 tok   added to every session
+
+**pi**, from the registry or from a clone:
+
+    $ pi install npm:@haksolot/ank
+    $ pi install git:github.com/haksolot/ank
+    Installed git:github.com/haksolot/ank
+
+The git route clones the repository and reads its `pi` manifest; the npm route
+takes the published package, which carries the skill beside the binary.
 
 That installs the skill, not the binary. The skill teaches one page: the loop
 `context → claim → show → log → done`, the three off-loop verbs `new`, `find`


### PR DESCRIPTION
## Which task does this close

TASK-207e07504dcd -- but the claim stays held until after v0.1.3, see below.

## What it does, and why this way

`README.md` named one route out of four. It now names all of them -- the skills CLI, the Claude Code plugin, and pi from the registry or from a clone -- and `docs/getting-started.md` carries the same list with the output each one prints.

The route that had never been verified is the first one. `skill/`, singular, is not among the standard locations the skills CLI looks in, so this repository is served by its **recursive fallback**, and nothing had ever confirmed the fallback reaches the file. It does: `npx skills add haksolot/ank --list` answers `Found 1 skill` and names `ank` with its frontmatter description. That closes the question and with it the expensive repair it would have forced -- moving `skill/SKILL.md` drags the freeze in `build.rs`, the tests that hold it, and the scope of three ratified ADRs including `ADR-e17e1bbd93ff`.

**One route is written ahead of being runnable.** `pi install npm:@haksolot/ank` needs the published package to carry the `pi` keys, and the registry still has v0.1.2, which predates them. What was exercised is the assembled package, not the published one. The criterion says every command listed has been run before it is written down, so the claim on this task stays held through the release and `ank done` waits until that command has been run as written.

Two version strings deliberately left out of the guide: `claude plugin details` prints one, and quoting it would have the documentation claim a release that was not out yet, then go stale at the next tag.

`docs/ank-spec-v1.1.md` untouched -- section 9 is the normative bootstrap, not a catalogue of routes.

## The three gates

- [x] `cargo fmt --check`
- [x] `cargo test --workspace`
- [x] `cargo run -q --bin ank -- check` -- exit 0

## Before you open it

- [x] Three of the four routes are written from output that was run; the fourth is flagged above and blocks `done`, not the merge
- [x] `status:` was not edited by hand
- [x] The MSRV number was not edited
- [x] English everywhere, no emojis

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XszrHRiKJWjAM4At7YwYkg
