### PR TITLE
0.1.3, and the plugin manifest carries the same number

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ank",
   "description": "Tasks and architecture decisions in your repo, behind one CLI any coding agent can call.",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": {
     "name": "haksolot",
     "url": "https://github.com/haksolot"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "ank-cli"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "ank-core",
  "hex",
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "ank-core"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "globset",
  "hex",

--- a/crates/ank-cli/Cargo.toml
+++ b/crates/ank-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ank-cli"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 # Measured on 2026-08-01 by walking toolchains upward against this tree, which
 # is the only way this number means anything: 1.78, 1.91, 1.92, 1.93 and 1.94

--- a/crates/ank-core/Cargo.toml
+++ b/crates/ank-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ank-core"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 # Measured, not assumed: see the note in ank-cli's manifest. This crate's own
 # code needs far less, but the workspace resolves one lockfile and builds as a

--- a/npm/ank-darwin-arm64/package.json
+++ b/npm/ank-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haksolot/ank-darwin-arm64",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "The ank binary for macOS on Apple silicon.",
   "license": "GPL-3.0-only",
   "homepage": "https://github.com/haksolot/ank",

--- a/npm/ank-linux-x64-musl/package.json
+++ b/npm/ank-linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haksolot/ank-linux-x64-musl",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "The ank binary for Linux x86_64, statically linked against musl.",
   "license": "GPL-3.0-only",
   "homepage": "https://github.com/haksolot/ank",

--- a/npm/ank-win32-x64/package.json
+++ b/npm/ank-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haksolot/ank-win32-x64",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "The ank binary for Windows x86_64.",
   "license": "GPL-3.0-only",
   "homepage": "https://github.com/haksolot/ank",

--- a/npm/ank/package.json
+++ b/npm/ank/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haksolot/ank",
-  "version": "0.0.0",
+  "version": "0.1.3",
   "description": "The stupid coordination tool: tasks and architecture decisions in your repo, behind one CLI any coding agent can call.",
   "license": "GPL-3.0-only",
   "homepage": "https://github.com/haksolot/ank",
@@ -38,8 +38,8 @@
     "node": ">=18"
   },
   "optionalDependencies": {
-    "@haksolot/ank-darwin-arm64": "0.0.0",
-    "@haksolot/ank-linux-x64-musl": "0.0.0",
-    "@haksolot/ank-win32-x64": "0.0.0"
+    "@haksolot/ank-darwin-arm64": "0.1.3",
+    "@haksolot/ank-linux-x64-musl": "0.1.3",
+    "@haksolot/ank-win32-x64": "0.1.3"
   }
 }


### PR DESCRIPTION
## Which task does this close

None -- a release preparation, the same shape as #37 for 0.1.2.

## What it does, and why this way

No code changed since 0.1.2. What 0.1.3 carries is the distribution surface: the Claude Code plugin and marketplace manifests, the npm wrapper declaring itself a pi package with the skill packed beside the binary, the root manifest that opens pi's git route, and the documentation naming all four commands. `ank --version` prints `0.1.3 (skill 605f771e1955)` -- the same skill revision as 0.1.2.

The number now lives in one more place: `.claude-plugin/plugin.json` is the fifth, beside the two `Cargo.toml` and the four npm `package.json`. The root `package.json` is deliberately **not** a sixth -- it carries no `version` field at all, pi installs it without one and npm is content.

**This also repairs `npm/ank/package.json`, which main has carried at `0.0.0` since cdedc1c.** A local run of `npm-assemble.sh` during that task stamped the smoke version into it and the cleanup afterwards restored only the platform manifest. Nothing downstream was affected -- `publish-npm` re-stamps every package from the tag before publishing -- but the committed tree said `0.0.0`.

## The three gates

- [x] `cargo fmt --check`
- [x] `cargo test --workspace`
- [x] `cargo run -q --bin ank -- check` -- exit 0

## Before you open it

- [x] `status:` was not edited by hand
- [x] The MSRV number was not edited
- [x] English everywhere, no emojis

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XszrHRiKJWjAM4At7YwYkg
