### PR TITLE
The release dry-run passes on an npm that would refuse it

### DIFF
--- a/.ank/tasks/TASK-8ebd6e02f125.md
+++ b/.ank/tasks/TASK-8ebd6e02f125.md
@@ -30,7 +30,7 @@ done_criteria: |
   including the piped case.
 criteria_by: creator
 schema: 2
-version: 4
+version: 7
 ---
 
 Execution of ADR-962c25797569, presentation half. The guarantee that matters
@@ -44,3 +44,5 @@ engine.
 ## Log
 - 2026-08-05T04:06:58Z seanl@sean-laptop — amended: -blocked_by ADR-962c25797569
 - 2026-08-08T18:11:16Z seanl@sean-laptop — amended: +scope crates/ank-cli/src/style.rs, +scope crates/ank-cli/src/main.rs, +scope crates/ank-cli/src/commands.rs, +scope crates/ank-cli/src/human.rs, +scope crates/ank-cli/src/done.rs, +scope crates/ank-cli/src/claim.rs, +scope crates/ank-cli/src/graph.rs, +scope crates/ank-cli/src/edit.rs, +scope crates/ank-cli/src/init.rs, +scope crates/ank-cli/tests/cli.rs
+- 2026-08-08T18:14:04Z seanl@sean-laptop — released: Reclaiming under the agent's own ANK_AGENT: taken while seanl@sean-laptop already held TASK-1613794deccf, and two live claims on one identity make HEAD ambiguous between verbs.
+- 2026-08-08T18:15:41Z claude-code@ank — Correction to the release note above: HEAD was never ambiguous between verbs. A second session finished TASK-1613794deccf at 18:12:14Z, between this session's ank status and its ank done, so done saw one remaining claim and correctly asked for a proof. The release was taken on a misread and cost nothing but this entry. The real lesson stands and is the one the claim warning names: an unset ANK_AGENT makes two sessions on one machine a single agent, and one-claim-per-agent then arbitrates between them.

--- a/.ank/tasks/TASK-ace80749fd5c.md
+++ b/.ank/tasks/TASK-ace80749fd5c.md
@@ -5,7 +5,7 @@ slug: the-release-dry-run-passes-on-an-npm-that-would
 title: The release dry-run passes on an npm that would refuse it
 created: 2026-08-08T16:55:44Z
 author: seanl@sean-laptop
-status: in_progress
+status: done
 scope:
   - .github/workflows/release.yml
   - .github/scripts/npm-assemble.sh
@@ -18,8 +18,12 @@ done_criteria: |
   dry-run exercises the same argument publish-npm passes, with no new flag that
   publish-npm does not also carry. cargo test and ank check stay green.
 criteria_by: creator
+proof:
+  - type: test
+    ref: "31271789884"
+    criteria: 2241bf3237a8
 schema: 2
-version: 2
+version: 4
 ---
 
 Found while adding the pi skill to the wrapper (TASK-20b23cd4fb16), by running
@@ -46,3 +50,7 @@ The shape of the fix is the constraint. Adding --tag to the dry-run and not to
 publish-npm would make the smoke job test a command nobody runs, which is how the
 v0.1.2 defect happened in the first place. Either both carry it, or the assembled
 version is one npm will accept unflagged. Decide that first, then write it once.
+
+## Log
+- 2026-08-08T18:36:27Z seanl@sean-laptop — Verified on the runners, both directions. The fix, dispatched on this branch as run 31271789884: 'the publish argument is a path' passes on ubuntu, macos and windows, each reporting npm 12.0.2 -- npm@latest is already past the 11 that broke it, so the pin is what keeps this honest rather than a guess about which npm the runner ships. The negative control, run 31272065545 on a throwaway branch carrying the same npm pin without --tag latest: failure on all three, at that exact step, with 'npm error You must specify a tag using --tag when publishing a prerelease version'. That branch is deleted. So the failure is demonstrated on the runners and not only on a maintainer's machine, and the fix is demonstrated against it.
+- 2026-08-08T18:36:29Z seanl@sean-laptop — done, proof test:31271789884

--- a/.ank/tasks/TASK-ace80749fd5c.md
+++ b/.ank/tasks/TASK-ace80749fd5c.md
@@ -5,7 +5,7 @@ slug: the-release-dry-run-passes-on-an-npm-that-would
 title: The release dry-run passes on an npm that would refuse it
 created: 2026-08-08T16:55:44Z
 author: seanl@sean-laptop
-status: open
+status: in_progress
 scope:
   - .github/workflows/release.yml
   - .github/scripts/npm-assemble.sh
@@ -19,7 +19,7 @@ done_criteria: |
   publish-npm does not also carry. cargo test and ank check stay green.
 criteria_by: creator
 schema: 2
-version: 1
+version: 2
 ---
 
 Found while adding the pi skill to the wrapper (TASK-20b23cd4fb16), by running

--- a/.ank/tasks/TASK-c75e2a43e712.md
+++ b/.ank/tasks/TASK-c75e2a43e712.md
@@ -1,0 +1,47 @@
+---
+id: TASK-c75e2a43e712
+type: task
+slug: a-prerelease-tag-publishes-as-latest-and-nothing
+title: A prerelease tag publishes as latest, and nothing decided that
+created: 2026-08-08T18:21:15Z
+author: seanl@sean-laptop
+status: open
+scope:
+  - .github/workflows/release.yml
+blocked_by: []
+done_criteria: |
+  A tag matching v* whose version is a prerelease does not reach the registry under
+  the latest dist-tag. What it does instead -- refuse, or publish under a
+  prerelease tag -- is decided in the specification or an ADR first, then written
+  once and passed by both npm-smoke and publish-npm, which keep passing the same
+  flags as each other. Demonstrated on a dispatch, not on a real tag.
+  cargo test and ank check stay green.
+criteria_by: creator
+schema: 2
+version: 1
+---
+
+Recorded while fixing TASK-ace80749fd5c, and deliberately not decided there.
+
+release.yml fires on push of any tag matching v*, which includes v0.2.0-rc1. The
+version reaching npm-assemble.sh is ${GITHUB_REF_NAME#v}, so such a tag publishes
+0.2.0-rc1 to the registry. Under npm 10 that landed on the latest dist-tag
+without a word, which means every user running npm install -g @haksolot/ank would
+have got a release candidate. The fix for ace8 makes that explicit rather than
+implicit -- publish now passes --tag latest -- so the behaviour is unchanged and
+now visible, which is the point at which it becomes worth a decision.
+
+The options are not equivalent and the choice is not obvious. Refusing the tag
+outright keeps the registry clean and costs the project the ability to ship a
+candidate at all. Deriving the dist-tag from the version, latest for a release
+and next for a prerelease, is the npm convention and means a candidate is
+installable by anyone who asks for it by name without touching what a bare
+install resolves to. A third answer is to narrow the workflow trigger so a
+prerelease tag builds and publishes a GitHub release without reaching npm.
+
+Whichever is chosen, the constraint that ace8 established holds: the smoke job
+and the publish job pass the same flags, or the rehearsal stops rehearsing. That
+is what made this worth separating rather than folding in -- deciding it inside
+ace8 would have changed release behaviour under cover of a compatibility fix.
+
+No prerelease tag has ever been pushed here, so nothing is broken today.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,6 +155,20 @@ jobs:
           name: ${{ matrix.target }}
           path: dist
 
+      # The node version is pinned above; the npm inside it is not, and that is
+      # the one that moved. npm 11 refuses to publish a prerelease, or a version
+      # below the one already on the registry, without an explicit --tag, where
+      # npm 10 applied "latest" silently -- so this job passed on the runner's
+      # bundled npm while the same command failed on a maintainer's machine.
+      # Taking the newest npm in both jobs makes the rehearsal use the npm the
+      # publish will use, and makes the next tightening of these rules turn a
+      # dispatch red instead of a tag.
+      - name: npm
+        shell: bash
+        run: |
+          npm install -g npm@latest
+          npm --version
+
       # Assembling and testing on the same OS is the point: an install that
       # works on Linux says nothing about the .cmd shim npm writes on Windows,
       # and a wrapper is exactly the kind of code that is right on one platform
@@ -191,11 +205,16 @@ jobs:
       # was wrong -- a bare `npm/ank` is a GitHub shorthand to npm, not a
       # folder. Tested here because a publish is not something you get to
       # retry: the tag is spent whether or not the registry accepted it.
+      #
+      # `--tag latest` is not a flag this rehearsal carries alone: publish-npm
+      # passes the same one. It names the tag npm 10 was applying implicitly, so
+      # it changes nothing about what a release does and everything about
+      # whether the command still runs on npm 11, which refuses to guess.
       - name: the publish argument is a path
         shell: bash
         run: |
-          npm publish --dry-run --access public "./npm/${{ matrix.package }}"
-          npm publish --dry-run --access public "./npm/ank"
+          npm publish --dry-run --access public --tag latest "./npm/${{ matrix.package }}"
+          npm publish --dry-run --access public --tag latest "./npm/ank"
 
       - name: install from the tarballs
         shell: bash
@@ -255,6 +274,15 @@ jobs:
           path: dist
           merge-multiple: true
 
+      # The same npm the smoke job rehearsed on. A rehearsal against one npm and
+      # a publish against another rehearses nothing, and the publish is the step
+      # that cannot be taken back.
+      - name: npm
+        shell: bash
+        run: |
+          npm install -g npm@latest
+          npm --version
+
       - name: assemble
         shell: bash
         run: bash .github/scripts/npm-assemble.sh "${GITHUB_REF_NAME#v}"
@@ -267,12 +295,18 @@ jobs:
       # before it is a directory, so `npm/ank` sent v0.1.2 to
       # ssh://git@github.com/npm/ank.git and the job died at the first package.
       # The leading `./` is what makes it a path.
+      #
+      # `--tag latest` names what npm 10 was applying without being asked, so it
+      # changes nothing a release has ever done and lets the smoke job rehearse
+      # the identical command. It does mean a prerelease tag would publish as
+      # latest rather than failing -- which is already what happens today, and is
+      # recorded as its own question rather than decided here.
       - name: publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           for p in ank-linux-x64-musl ank-darwin-arm64 ank-win32-x64 ank; do
-            npm publish --access public "./npm/$p"
+            npm publish --access public --tag latest "./npm/$p"
           done
 
   publish:


### PR DESCRIPTION
## Which task does this close

TASK-ace80749fd5c. It also files TASK-c75e2a43e712, see below.

## What it does, and why this way

The node version was pinned in both npm jobs; **the npm inside it was not**, and that is the one that moved. npm 11 refuses to publish a prerelease, or a version below the one already on the registry, without an explicit `--tag`, where npm 10 applied `latest` silently. The smoke job assembles at `0.0.0-smoke`, so its dry-run passed on the runners while the same command failed on a maintainer's machine.

Measured across six combinations on npm 11.14.1 against a copy of the wrapper: `0.0.0-smoke` unflagged fails on the prerelease rule, `0.0.0` unflagged fails as lower than the published `0.1.3`, `0.0.0-smoke --tag latest` passes, and any version above the published one passes unflagged.

Two changes, neither a flag the rehearsal carries alone:

- **Both jobs take `npm@latest`** rather than whatever node 22 bundled. A rehearsal on one npm and a publish on another rehearses nothing, and the point of this job is to fail before a tag is spent. It also means the next tightening of these rules turns a dispatch red instead of a tag.
- **Both jobs pass `--tag latest`.** It names the tag npm 10 was applying without being asked, so it changes nothing a release has ever done, and it lets the dry-run exercise the identical command.

The second makes one existing behaviour explicit rather than altering it: a tag like `v0.2.0-rc1` publishes a candidate under `latest`, which is already what happens. Deciding that inside a compatibility fix would be changing release behaviour under cover of one, so it is recorded as **TASK-c75e2a43e712** instead.

## The three gates

Run in CI rather than locally: the working copy this was written in has another session's uncommitted, non-compiling work on TASK-8ebd in it. This commit touches only `.github/workflows/release.yml` and `.ank/`, so CI runs the gates against a clean tree.

- [ ] `cargo fmt --check` -- CI
- [ ] `cargo test --workspace` -- CI
- [ ] `cargo run -q --bin ank -- check` -- CI

The change itself is verified by a `workflow_dispatch` of `release.yml` on this branch, which is the only thing that exercises these jobs at all.

## Before you open it

- [x] The failure was reproduced on npm 11 before the fix and the fix measured against it
- [x] `status:` was not edited by hand
- [x] English everywhere, no emojis

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XszrHRiKJWjAM4At7YwYkg
