### PR TITLE
Add task: the shared-identity warning is emitted once and never again

### DIFF
--- a/.ank/tasks/TASK-21031b516bb2.md
+++ b/.ank/tasks/TASK-21031b516bb2.md
@@ -1,0 +1,18 @@
+---
+id: TASK-21031b516bb2
+type: task
+slug: skill-md-states-that-what-an-agent-reads-is-neve
+title: SKILL.md states that what an agent reads is never styled
+created: 2026-08-08T18:41:15Z
+author: claude-code@ank
+status: open
+scope:
+  - skill/SKILL.md
+  - crates/ank-cli/tests/skill.rs
+blocked_by: [TASK-8ebd6e02f125]
+done_criteria: |
+  SKILL.md carries the guarantee in one sentence: the output an agent reads is plain bytes, because colour is emitted only at a terminal and never in a pipe or under --json, so there is nothing to configure and no second surface to prefer. The ceiling of ADR-e17e1bbd93ff still holds (at most 140 lines, 1200 words), metadata.revision is regenerated, and ank --version reports the same hash. A test in crates/ank-cli/tests/skill.rs fails if the sentence leaves.
+criteria_by: creator
+schema: 2
+version: 1
+---

--- a/.ank/tasks/TASK-38b384543551.md
+++ b/.ank/tasks/TASK-38b384543551.md
@@ -1,0 +1,81 @@
+---
+id: TASK-38b384543551
+type: task
+slug: the-shared-identity-warning-is-emitted-once-and
+title: The shared-identity warning is emitted once and never again
+created: 2026-08-08T22:45:06Z
+author: seanl@sean-laptop
+status: open
+scope:
+  - crates/ank-cli/**
+blocked_by: []
+done_criteria: |
+  A second live claim held by the same identity is visible after the moment it was
+  acquired: ank status names every live claim of this identity, not only the one
+  bound to the current perimeter, and repeats the way out that claim already names.
+  Whether ank context carries it too is decided in this task and the reasoning
+  recorded, since context is loaded on every call and every word there is paid for.
+  Tested through the binary: one identity, two claims, and the assertion is on what
+  ank status prints, because a warning that never reaches stdout is not a warning.
+  --json carries the same information, and piped output stays byte-for-byte what it
+  was (ADR-962c25797569). cargo test and ank check stay green.
+criteria_by: creator
+schema: 2
+version: 1
+---
+
+Found by two sessions colliding in one working tree on 2026-08-08, and the logs
+of the tasks involved keep the sequence. Both ran with ANK_AGENT unset, so both
+were seanl@sean-laptop and ank saw one agent. At 18:12:14Z one session finished
+TASK-1613794deccf. At 18:14 the other released TASK-8ebd6e02f125, writing that
+two live claims on one identity made HEAD ambiguous between verbs. At 18:15 it
+corrected itself: the done had landed between its own ank status and its own ank
+done, so nothing had been ambiguous and the release was taken on a misread.
+
+The release cost nothing. Where the misread formed is the finding, and it is
+ank status.
+
+Measured rather than assumed. live_claims_of (claim.rs:295) has exactly one
+call site in production code: claim.rs:906, inside the claim verb. Every other
+occurrence is a test. So the warning it feeds --
+
+    {identity} already holds {id} until {expires}
+    a second session on this machine sets its own ANK_AGENT
+
+-- is printed once, at acquisition, and never again. status.rs knows a single
+claim, the one binding the current perimeter, and prints "claim <id> <...>" or
+"no claim" (135-157). A second live claim under the same identity appears
+nowhere in it.
+
+A convention that announces itself only when it is taken fades exactly as a
+session lengthens, and status is the verb a session runs when it has lost track.
+That is the whole defect: not that two sessions can share an identity, which is
+known and warned about, but that after the warning scrolls away the tool has no
+second occasion to say so, at the one place built for asking where things stand.
+
+Not TASK-e3f4b6295b23. That one asks whether skill/SKILL.md should teach the
+nominal execution model at all, and its remedies are a superseding ADR, a tool
+message, or a recorded decision to stay silent. This one is narrower and does not
+depend on it: whichever way the skill question goes, the binary is mute at the
+moment the question is asked. They can land in either order.
+
+Not TASK-83d6eefdb36e either. Two clones do not arbitrate, and that is real, but
+it is not what happened here. One clone, one refs/ank/ namespace, and the CAS in
+claim.rs did its job perfectly -- both claims were recorded, both were live, and
+that was the correct state. The defect is in what is reported, not in what is
+locked.
+
+The tension to settle, and this task deliberately does not settle it. context is
+the right place by relevance, since it is what an agent reads every turn, and the
+wrong place by budget, since it is loaded on every call and ADR-e17e1bbd93ff
+treats every word there as paid for. status is free and is not read every turn.
+Whichever is chosen, the reasoning in claim.rs:902-905 must not be contradicted:
+one claim at a time is a convention and not a lock, parallel agents with distinct
+identities are the design, so this warns and never refuses.
+
+Out of scope, named so it is not reopened cold: the git-level interference of a
+shared tree -- a branch switch aborting on another session's uncommitted work, a
+git add .ank sweeping another session's claim file into an unrelated commit.
+Section 7 already answers it by calling a shared tree a degraded mode rather than
+a design mode, and ADR-9ede1ffd04e2 puts that policy above the tool. Both
+happened during this same episode; neither is ank's to fix.

--- a/.ank/tasks/TASK-8ebd6e02f125.md
+++ b/.ank/tasks/TASK-8ebd6e02f125.md
@@ -30,7 +30,7 @@ done_criteria: |
   including the piped case.
 criteria_by: creator
 schema: 2
-version: 4
+version: 9
 ---
 
 Execution of ADR-962c25797569, presentation half. The guarantee that matters
@@ -44,3 +44,7 @@ engine.
 ## Log
 - 2026-08-05T04:06:58Z seanl@sean-laptop — amended: -blocked_by ADR-962c25797569
 - 2026-08-08T18:11:16Z seanl@sean-laptop — amended: +scope crates/ank-cli/src/style.rs, +scope crates/ank-cli/src/main.rs, +scope crates/ank-cli/src/commands.rs, +scope crates/ank-cli/src/human.rs, +scope crates/ank-cli/src/done.rs, +scope crates/ank-cli/src/claim.rs, +scope crates/ank-cli/src/graph.rs, +scope crates/ank-cli/src/edit.rs, +scope crates/ank-cli/src/init.rs, +scope crates/ank-cli/tests/cli.rs
+- 2026-08-08T18:14:04Z seanl@sean-laptop — released: Reclaiming under the agent's own ANK_AGENT: taken while seanl@sean-laptop already held TASK-1613794deccf, and two live claims on one identity make HEAD ambiguous between verbs.
+- 2026-08-08T18:15:41Z claude-code@ank — Correction to the release note above: HEAD was never ambiguous between verbs. A second session finished TASK-1613794deccf at 18:12:14Z, between this session's ank status and its ank done, so done saw one remaining claim and correctly asked for a proof. The release was taken on a misread and cost nothing but this entry. The real lesson stands and is the one the claim warning names: an unset ANK_AGENT makes two sessions on one machine a single agent, and one-claim-per-agent then arbitrates between them.
+- 2026-08-08T18:31:47Z claude-code@ank — Falsified the new tests rather than trusting them green: forcing style::COLOR unconditionally in dispatch turns 7 of 69 integration tests red, three of them the new ones. A negative guarantee asserted by a test that cannot fail is not a guarantee. Also measured: std::io::IsTerminal (stable 1.70, floor here 1.95) answers the terminal question with no dependency at all, so the libc route the task body anticipated was never needed.
+- 2026-08-08T18:41:29Z claude-code@ank — Implementation complete and locally green: 318 tests, fmt clean, ank check 0 faults. Design that mattered: the Style rides on Invocation, so parse() leaves it PLAIN (every unit test stays uncoloured with no edit) and dispatch() is the single place --json forces it back off -- which covers the three sites that print a non-JSON line while --json is set (done's 'running:', log's and amend's takeover warnings) without touching any of them. Budget accounting now counts visible characters, not bytes: otherwise a terminal would truncate the log one entry earlier than a pipe, which is the same command answering differently by who is watching. Follow-up filed as TASK-21031b516bb2 for the SKILL.md sentence, which falls outside this criterion.

--- a/.ank/tasks/TASK-8ebd6e02f125.md
+++ b/.ank/tasks/TASK-8ebd6e02f125.md
@@ -5,7 +5,7 @@ slug: color-on-a-terminal-bytes-unchanged-in-a-pipe
 title: Color on a terminal, bytes unchanged in a pipe
 created: 2026-08-05T04:06:09Z
 author: seanl@sean-laptop
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/src/cli.rs
   - crates/ank-cli/src/context.rs
@@ -29,8 +29,12 @@ done_criteria: |
   move. --json is never colored. Behaviour is tested through the binary,
   including the piped case.
 criteria_by: creator
+proof:
+  - type: test
+    ref: "31272803093"
+    criteria: 6855eba7161f
 schema: 2
-version: 9
+version: 10
 ---
 
 Execution of ADR-962c25797569, presentation half. The guarantee that matters
@@ -48,3 +52,4 @@ engine.
 - 2026-08-08T18:15:41Z claude-code@ank — Correction to the release note above: HEAD was never ambiguous between verbs. A second session finished TASK-1613794deccf at 18:12:14Z, between this session's ank status and its ank done, so done saw one remaining claim and correctly asked for a proof. The release was taken on a misread and cost nothing but this entry. The real lesson stands and is the one the claim warning names: an unset ANK_AGENT makes two sessions on one machine a single agent, and one-claim-per-agent then arbitrates between them.
 - 2026-08-08T18:31:47Z claude-code@ank — Falsified the new tests rather than trusting them green: forcing style::COLOR unconditionally in dispatch turns 7 of 69 integration tests red, three of them the new ones. A negative guarantee asserted by a test that cannot fail is not a guarantee. Also measured: std::io::IsTerminal (stable 1.70, floor here 1.95) answers the terminal question with no dependency at all, so the libc route the task body anticipated was never needed.
 - 2026-08-08T18:41:29Z claude-code@ank — Implementation complete and locally green: 318 tests, fmt clean, ank check 0 faults. Design that mattered: the Style rides on Invocation, so parse() leaves it PLAIN (every unit test stays uncoloured with no edit) and dispatch() is the single place --json forces it back off -- which covers the three sites that print a non-JSON line while --json is set (done's 'running:', log's and amend's takeover warnings) without touching any of them. Budget accounting now counts visible characters, not bytes: otherwise a terminal would truncate the log one entry earlier than a pipe, which is the same command answering differently by who is watching. Follow-up filed as TASK-21031b516bb2 for the SKILL.md sentence, which falls outside this criterion.
+- 2026-08-08T18:50:35Z claude-code@ank — done, proof test:31272803093

--- a/crates/ank-cli/src/claim.rs
+++ b/crates/ank-cli/src/claim.rs
@@ -930,11 +930,15 @@ pub fn run(
         // A warning survives `--quiet`: what it reports is not the confirmation
         // the flag is there to silence.
         for w in &warnings {
-            let _ = writeln!(out, "warning: {w}");
+            let _ = writeln!(out, "{} {w}", inv.style().yellow("warning:"));
         }
         if !inv.quiet() {
             let slug = task.slug.as_deref().unwrap_or("");
-            let _ = writeln!(out, "claimed {} {slug} -> HEAD", acquired.id);
+            let _ = writeln!(
+                out,
+                "claimed {} {slug} -> HEAD",
+                inv.style().id(&acquired.id.to_string())
+            );
         }
     }
     Ok(0)

--- a/crates/ank-cli/src/cli.rs
+++ b/crates/ank-cli/src/cli.rs
@@ -62,9 +62,20 @@ impl CliError {
 
     /// Terse rendering, `git status` style, on standard error.
     pub fn render(&self) -> String {
+        self.render_styled(crate::style::PLAIN)
+    }
+
+    /// The same line, with the `error[N]:` tag painted when §4 allows it.
+    ///
+    /// Only the tag: the message and the hint are the part a reader has to
+    /// read, and the hint is a command to copy. Painting either would be
+    /// decoration, and the hint is the last thing that should be hard to
+    /// select.
+    pub fn render_styled(&self, style: crate::style::Style) -> String {
+        let tag = style.red(&format!("error[{}]:", self.code));
         match &self.hint {
-            Some(h) => format!("error[{}]: {}\n  -> {}", self.code, self.message, h),
-            None => format!("error[{}]: {}", self.code, self.message),
+            Some(h) => format!("{tag} {}\n  -> {}", self.message, h),
+            None => format!("{tag} {}", self.message),
         }
     }
 }
@@ -414,6 +425,14 @@ pub struct Invocation {
     pub positionals: Vec<String>,
     /// Values per flag. A switch carries an empty list.
     pub flags: BTreeMap<String, Vec<String>>,
+    /// How this invocation is allowed to paint (§4).
+    ///
+    /// Not parsed — [`parse`] has no way to know what the process is attached
+    /// to and leaves it [`style::PLAIN`], which is what keeps every unit test
+    /// that builds an `Invocation` through the parser uncolored without saying
+    /// so. [`dispatch`] is what fills it in, and what forces it back off under
+    /// `--json`.
+    pub style: crate::style::Style,
 }
 
 impl Invocation {
@@ -439,6 +458,10 @@ impl Invocation {
 
     pub fn repo(&self) -> Option<&str> {
         self.value("--repo")
+    }
+
+    pub fn style(&self) -> crate::style::Style {
+        self.style
     }
 }
 
@@ -657,6 +680,7 @@ pub fn parse(argv: &[String]) -> Result<Invocation> {
         subcommand,
         positionals,
         flags,
+        style: crate::style::PLAIN,
     })
 }
 
@@ -865,11 +889,16 @@ fn not_implemented(spec: &CommandSpec) -> CliError {
 
 /// Entry point. Returns the exit code; never calls `exit` itself, so that it
 /// stays testable.
-pub fn run(argv: &[String], cwd: &std::path::Path, out: &mut dyn std::io::Write) -> i32 {
-    match dispatch(argv, cwd, out) {
+pub fn run(
+    argv: &[String],
+    cwd: &std::path::Path,
+    out: &mut dyn std::io::Write,
+    style: crate::style::Style,
+) -> i32 {
+    match dispatch(argv, cwd, out, style) {
         Ok(code) => code,
         Err(err) => {
-            eprintln!("{}", err.render());
+            eprintln!("{}", err.render_styled(style.on_stderr()));
             err.code
         }
     }
@@ -916,7 +945,12 @@ fn startup(inv: &Invocation, cwd: &std::path::Path) -> Result<Startup> {
 /// and the fall-through is the honest default rather than a placeholder: until
 /// TASK-45d18f45de2c the fall-through was total, while six module headers
 /// asserted the opposite.
-fn dispatch(argv: &[String], cwd: &std::path::Path, out: &mut dyn std::io::Write) -> Result<i32> {
+fn dispatch(
+    argv: &[String],
+    cwd: &std::path::Path,
+    out: &mut dyn std::io::Write,
+    style: crate::style::Style,
+) -> Result<i32> {
     // Before `parse`, and not as a flag on a verb (§4). `--version` replaces the
     // verb rather than modifying one, so the parser — which resolves a command
     // first and would reject this as an unknown one — never sees it. It is also
@@ -927,8 +961,20 @@ fn dispatch(argv: &[String], cwd: &std::path::Path, out: &mut dyn std::io::Write
         let _ = writeln!(out, "{}", version_line());
         return Ok(0);
     }
-    let inv = parse(argv)?;
+    let mut inv = parse(argv)?;
     let spec = spec_of(inv.command).expect("spec resolved during parsing");
+
+    // The one gate, and the reason it is one. `--json` is never colored (§4),
+    // and three verbs print an unconditional non-JSON line onto stdout while
+    // it is set — `done`'s `running:`, and the takeover warnings of `log` and
+    // `amend`. Suppressing color at each printing site would be three chances
+    // to forget one; suppressing it here makes "no escape sequence under
+    // --json" a property of the invocation rather than of the discipline.
+    inv.style = if inv.json() {
+        crate::style::PLAIN
+    } else {
+        style
+    };
 
     // Two verbs run without the foundation. `init` precedes the existence of
     // the repository. `help` describes the surface rather than acting on it,
@@ -1151,6 +1197,7 @@ mod tests {
             &argv(&["check", "--repo", "/path/that/does/not/exist"]),
             std::path::Path::new("."),
             &mut out,
+            crate::style::PLAIN,
         );
         assert_eq!(code, 1);
 
@@ -1167,6 +1214,7 @@ mod tests {
             &argv(&["check", "--repo", root.to_str().unwrap(), "--quiet"]),
             std::path::Path::new("."),
             &mut out,
+            crate::style::PLAIN,
         );
         assert!(code == 0 || code == 8, "check answered with {code}");
     }

--- a/crates/ank-cli/src/commands.rs
+++ b/crates/ank-cli/src/commands.rs
@@ -832,12 +832,19 @@ pub fn find(inv: &Invocation, repo: &Repo, cfg: &Config, out: &mut dyn Write) ->
         return Ok(0);
     }
 
+    let style = inv.style();
     for r in &hits[..shown] {
         let short = shorts
             .get(&r.id)
             .cloned()
             .unwrap_or_else(|| r.id.to_string());
-        let _ = writeln!(out, "{short}  [{}] {}", r.status, r.title);
+        let _ = writeln!(
+            out,
+            "{}  {} {}",
+            style.id(&short),
+            style.status(&format!("[{}]", r.status)),
+            r.title
+        );
     }
     if total > shown {
         // Announced, never silent. A search that quietly drops results teaches
@@ -936,17 +943,28 @@ pub fn scope(inv: &Invocation, repo: &Repo, out: &mut dyn Write) -> Result<i32> 
         let _ = writeln!(out, "nothing covers this path");
         return Ok(0);
     }
+    let style = inv.style();
     for (label, group) in [("ADR", &adrs), ("TASKS", &tasks)] {
         if group.is_empty() {
             continue;
         }
-        let _ = writeln!(out, "\n{label} ({})", group.len());
+        let _ = writeln!(
+            out,
+            "\n{}",
+            style.header(&format!("{label} ({})", group.len()))
+        );
         for r in group.iter() {
             let short = shorts
                 .get(&r.id)
                 .cloned()
                 .unwrap_or_else(|| r.id.to_string());
-            let _ = writeln!(out, "  {short}  [{}] {}", r.status, r.title);
+            let _ = writeln!(
+                out,
+                "  {}  {} {}",
+                style.id(&short),
+                style.status(&format!("[{}]", r.status)),
+                r.title
+            );
         }
     }
     Ok(0)
@@ -1118,7 +1136,7 @@ fn log_read(inv: &Invocation, store: &Store, id: &EntityId, out: &mut dyn Write)
         return Ok(0);
     }
 
-    let _ = writeln!(out, "{id}  {}", task.title);
+    let _ = writeln!(out, "{}  {}", inv.style().id(&id.to_string()), task.title);
     if entries.is_empty() {
         // Named rather than left blank: an empty answer and an answer about the
         // wrong task look identical otherwise.
@@ -1184,7 +1202,8 @@ fn log_write(
             // hour.
             let _ = writeln!(
                 out,
-                "warning: {id} was taken over while logging, the claim was not renewed"
+                "{} {id} was taken over while logging, the claim was not renewed",
+                inv.style().yellow("warning:")
             );
         }
     }

--- a/crates/ank-cli/src/context.rs
+++ b/crates/ank-cli/src/context.rs
@@ -30,6 +30,7 @@ use crate::git;
 use crate::index::{Index, Row};
 use crate::repo::Repo;
 use crate::store::Store;
+use crate::style::Style;
 use ank_core::{parse_log, Entity, EntityId, EntityKind, ScopeSet};
 use std::collections::HashMap;
 use std::io::Write;
@@ -639,16 +640,18 @@ fn end_of_loop(view: &View) -> String {
     }
 }
 
-fn constraint_block(c: &ConstraintLine) -> Vec<String> {
+fn constraint_block(c: &ConstraintLine, style: Style) -> Vec<String> {
     // Continuation lines align under the text, so a multi-line constraint
-    // reads as one rule rather than several.
+    // reads as one rule rather than several. The indent is measured on the
+    // unpainted identifier: an escape sequence has no width on screen, and
+    // counting it here would push every continuation line out by five columns.
     let indent = " ".repeat(2 + c.short.len() + 2);
     c.text
         .lines()
         .enumerate()
         .map(|(i, line)| {
             if i == 0 {
-                format!("  {}  {}", c.short, line.trim())
+                format!("  {}  {}", style.id(&c.short), line.trim())
             } else {
                 format!("{indent}{}", line.trim())
             }
@@ -656,14 +659,42 @@ fn constraint_block(c: &ConstraintLine) -> Vec<String> {
         .collect()
 }
 
+/// The cost of a block, in characters a reader actually sees.
+///
+/// Escape sequences are skipped rather than counted. The budget of §5 is about
+/// what fits in an agent's context and on a human's screen, and a styled header
+/// costs the reader exactly what the plain one did — charging it nine invisible
+/// characters would make a terminal truncate the log one entry earlier than a
+/// pipe, which is the same output differing by who is watching.
 fn chars(lines: &[String]) -> usize {
-    lines.iter().map(|l| l.chars().count() + 1).sum()
+    lines.iter().map(|l| visible_len(l) + 1).sum()
 }
 
-pub fn render(view: &View, budget: usize) -> String {
+/// Characters in `s`, ignoring SGR sequences (`ESC [ … m`).
+fn visible_len(s: &str) -> usize {
+    let mut n = 0usize;
+    let mut it = s.chars();
+    while let Some(c) = it.next() {
+        if c == '\x1b' {
+            // Consume up to and including the terminating `m`. An unterminated
+            // sequence swallows the rest, which cannot happen here: every
+            // sequence this binary writes comes from `style` and is closed.
+            for c in it.by_ref() {
+                if c == 'm' {
+                    break;
+                }
+            }
+        } else {
+            n += 1;
+        }
+    }
+    n
+}
+
+pub fn render(view: &View, budget: usize, style: Style) -> String {
     let mut out: Vec<String> = Vec::new();
     for w in &view.warnings {
-        out.push(format!("warning: {w}"));
+        out.push(format!("{} {w}", style.yellow("warning:")));
     }
 
     match &view.mode {
@@ -675,22 +706,22 @@ pub fn render(view: &View, budget: usize) -> String {
             ..
         } => {
             out.push(String::new());
-            out.push(format!("{short}  {title}"));
+            out.push(format!("{}  {title}", style.id(short)));
             if let Some(c) = criteria {
                 out.push(String::new());
-                out.push("DONE_CRITERIA".to_string());
+                out.push(style.header("DONE_CRITERIA"));
                 for line in c.lines() {
                     out.push(format!("  {}", line.trim_end()));
                 }
             }
             if !view.constraints.is_empty() {
                 out.push(String::new());
-                out.push(format!("CONSTRAINTS ({} active)", view.constraints.len()));
+                out.push(style.header(&format!("CONSTRAINTS ({} active)", view.constraints.len())));
                 // Never truncated here, budget or no budget: an agent that
                 // violates a rule it was never shown is the failure this whole
                 // design exists to prevent.
                 for c in &view.constraints {
-                    out.extend(constraint_block(c));
+                    out.extend(constraint_block(c, style));
                 }
             }
             if !log.is_empty() {
@@ -709,7 +740,7 @@ pub fn render(view: &View, budget: usize) -> String {
                 }
                 kept.reverse();
                 out.push(String::new());
-                out.push(format!("LOG ({} of {})", kept.len(), log.len()));
+                out.push(style.header(&format!("LOG ({} of {})", kept.len(), log.len())));
                 out.extend(kept);
             }
         }
@@ -737,6 +768,7 @@ pub fn render(view: &View, budget: usize) -> String {
                     cut_constraints,
                     &scope_arg,
                     view,
+                    style,
                 )) + chars(&out);
                 if size <= budget {
                     break;
@@ -765,6 +797,7 @@ pub fn render(view: &View, budget: usize) -> String {
                 cut_constraints,
                 &scope_arg,
                 view,
+                style,
             ));
         }
     }
@@ -784,13 +817,14 @@ fn orientation_lines(
     cut_constraints: usize,
     scope_arg: &str,
     view: &View,
+    style: Style,
 ) -> Vec<String> {
     let mut out = Vec::new();
     if !constraints.is_empty() || cut_constraints > 0 {
         out.push(String::new());
-        out.push(format!("CONSTRAINTS ({} active)", constraints.len()));
+        out.push(style.header(&format!("CONSTRAINTS ({} active)", constraints.len())));
         for c in constraints {
-            out.extend(constraint_block(c));
+            out.extend(constraint_block(c, style));
         }
         if cut_constraints > 0 {
             out.push(format!(
@@ -800,9 +834,9 @@ fn orientation_lines(
     }
     if !proposals.is_empty() || cut_proposals > 0 {
         out.push(String::new());
-        out.push(format!("PROPOSED ({}, non-binding)", proposals.len()));
+        out.push(style.header(&format!("PROPOSED ({}, non-binding)", proposals.len())));
         for p in proposals {
-            out.push(format!("  {}  {}", p.short, p.title));
+            out.push(format!("  {}  {}", style.id(&p.short), p.title));
         }
         if cut_proposals > 0 {
             out.push(format!("  +{cut_proposals} more"));
@@ -810,9 +844,14 @@ fn orientation_lines(
     }
     if !tasks.is_empty() {
         out.push(String::new());
-        out.push(format!("TASKS ({})", tasks.len()));
+        out.push(style.header(&format!("TASKS ({})", tasks.len())));
         for t in tasks {
-            out.push(format!("  {}  {} {}", t.short, marker(t), t.title));
+            out.push(format!(
+                "  {}  {} {}",
+                style.id(&t.short),
+                style.status(&marker(t)),
+                t.title
+            ));
         }
         if cut_tasks > 0 {
             out.push(format!(
@@ -822,11 +861,11 @@ fn orientation_lines(
     }
     out.push(String::new());
     match tasks.iter().find(|t| t.ready) {
-        Some(t) => out.push(format!("> ank claim {} to start", t.short)),
-        None if cut_tasks > 0 => out.push(format!(
+        Some(t) => out.push(style.next(&format!("> ank claim {} to start", t.short))),
+        None if cut_tasks > 0 => out.push(style.next(&format!(
             "> ank find --type task --scope {scope_arg} for the {cut_tasks} tasks not shown"
-        )),
-        None => out.push(format!("> {}", end_of_loop(view))),
+        ))),
+        None => out.push(style.next(&format!("> {}", end_of_loop(view)))),
     }
     out
 }
@@ -972,7 +1011,7 @@ pub fn run(
     if inv.json() {
         let _ = writeln!(out, "{}", render_json(&view));
     } else if !inv.quiet() {
-        let _ = write!(out, "{}", render(&view, cfg.context_budget));
+        let _ = write!(out, "{}", render(&view, cfg.context_budget, inv.style()));
     }
     // No ready task is a normal state, not an error (§5).
     Ok(0)
@@ -1218,7 +1257,7 @@ mod tests {
         // The narrow scope comes first, which is what survives truncation.
         assert_eq!(view.constraints[0].title, "No self-contained JWTs");
 
-        let text = render(&view, 8000);
+        let text = render(&view, 8000, crate::style::PLAIN);
         assert!(text.contains("CONSTRAINTS (2 active)"), "{text}");
         assert!(text.contains("PROPOSED (1, non-binding)"), "{text}");
         assert!(text.contains("TASKS (3)"), "{text}");
@@ -1252,11 +1291,62 @@ mod tests {
                 .ready
         );
 
-        let text = render(&view, 8000);
+        let text = render(&view, 8000, crate::style::PLAIN);
         assert!(
             text.contains(&format!("> ank claim {} to start", ready[0].short)),
             "{text}"
         );
+    }
+
+    /// Strip the SGR sequences back out of a styled render and what is left has
+    /// to be the unstyled render, exactly.
+    ///
+    /// This is the invariant the whole of §4's colour rule rests on, and it is
+    /// stronger than looking at the two outputs: it fails on a doubled paint, on
+    /// an escape landing inside a padded column, on a header styled in one mode
+    /// and not the other, and on the budget spending itself on invisible bytes
+    /// so that a terminal truncates the log one entry earlier than a pipe.
+    fn undo_sgr(s: &str) -> String {
+        let mut out = String::with_capacity(s.len());
+        let mut it = s.chars();
+        while let Some(c) = it.next() {
+            if c == '\x1b' {
+                for c in it.by_ref() {
+                    if c == 'm' {
+                        break;
+                    }
+                }
+            } else {
+                out.push(c);
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn colour_changes_the_bytes_and_never_the_content() {
+        let t = seeded();
+        let id = EntityId::parse("TASK-000000000001").unwrap();
+        t.claim_as(&id, "codex@host-9");
+
+        // Both modes, and a budget tight enough that truncation is in play:
+        // that is where counting an escape sequence as content would show.
+        for (view, budget) in [
+            (t.view("claude-code@ank", None), 8000),
+            (t.view("claude-code@ank", None), 400),
+            (t.view("codex@host-9", None), 8000),
+            (t.view("codex@host-9", None), 300),
+        ] {
+            let plain = render(&view, budget, crate::style::PLAIN);
+            let painted = render(&view, budget, crate::style::COLOR);
+            assert_ne!(plain, painted, "nothing was painted at all");
+            assert!(painted.contains('\x1b'));
+            assert_eq!(
+                undo_sgr(&painted),
+                plain,
+                "colour moved the content at budget {budget}"
+            );
+        }
     }
 
     #[test]
@@ -1286,7 +1376,7 @@ mod tests {
         assert!(matches!(line.coordination, Coordination::Claimed { .. }));
         assert_eq!(view.in_progress, vec!["codex@host-9".to_string()]);
 
-        let text = render(&view, 8000);
+        let text = render(&view, 8000, crate::style::PLAIN);
         assert!(text.contains("[claimed:codex@host-9]"), "{text}");
     }
 
@@ -1312,7 +1402,7 @@ mod tests {
         // for, and the display is what avoids the round trip to `claim`.
         assert_eq!(line.status, "open");
 
-        let text = render(&view, 8000);
+        let text = render(&view, 8000, crate::style::PLAIN);
         assert!(
             text.contains(&format!("[finished:{} on main]", &done.commit[..7])),
             "{text}"
@@ -1348,7 +1438,7 @@ mod tests {
         assert_eq!(view.ready_count(), 0);
         assert_eq!(view.blocked, 1);
 
-        let text = render(&view, 8000);
+        let text = render(&view, 8000, crate::style::PLAIN);
         assert!(text.contains("no ready tasks in scope"), "{text}");
         assert!(text.contains("1 blocked"), "{text}");
         assert!(text.contains("in progress by codex@host-9"), "{text}");
@@ -1385,7 +1475,7 @@ mod tests {
         );
         assert_eq!(view.constraints.len(), 2, "the task's own scope");
 
-        let text = render(&view, 8000);
+        let text = render(&view, 8000, crate::style::PLAIN);
         assert!(text.contains("DONE_CRITERIA"), "{text}");
         assert!(text.contains("A verifiable criterion."), "{text}");
         assert!(text.contains("LOG (2 of 2)"), "{text}");
@@ -1420,7 +1510,7 @@ mod tests {
 
         let view = t.view("claude-code@ank", None);
         // A budget far below the constraint's own size.
-        let text = render(&view, 200);
+        let text = render(&view, 200, crate::style::PLAIN);
         assert!(text.contains("CONSTRAINTS (1 active)"), "{text}");
         assert!(
             text.contains("A very long binding rule. A very long binding rule."),
@@ -1463,7 +1553,7 @@ mod tests {
 
         let view = t.view("claude-code@ank", None);
         assert_eq!(view.tasks.len(), 12);
-        let text = render(&view, 400);
+        let text = render(&view, 400, crate::style::PLAIN);
 
         assert!(text.contains("more tasks, ank find --type task"), "{text}");
         // The narrow constraint outlives the broad one.
@@ -1513,7 +1603,7 @@ mod tests {
         assert_eq!(view.tasks.len(), 3);
         assert_eq!(view.constraints.len(), 2);
         assert_eq!(view.finished_elsewhere, 1);
-        let text = render(&view, 8000);
+        let text = render(&view, 8000, crate::style::PLAIN);
         assert!(
             text.contains("warning: default branch indeterminable"),
             "{text}"

--- a/crates/ank-cli/src/done.rs
+++ b/crates/ank-cli/src/done.rs
@@ -160,7 +160,16 @@ pub fn run(
             )
             .with_hint("ank done"));
         }
-        run_verifiers(repo, cfg, &declared, &task.scope, &criteria, &id, out)?
+        run_verifiers(
+            repo,
+            cfg,
+            &declared,
+            &task.scope,
+            &criteria,
+            &id,
+            out,
+            inv.style(),
+        )?
     };
 
     // Durable state first, the ref second. A file written and a ref left behind
@@ -203,7 +212,12 @@ pub fn run(
                     .unwrap_or_default()
             );
         }
-        let _ = writeln!(out, "{id} -> done");
+        let _ = writeln!(
+            out,
+            "{} -> {}",
+            inv.style().id(&id.to_string()),
+            inv.style().green("done")
+        );
     }
     Ok(0)
 }
@@ -288,6 +302,7 @@ fn run_verifiers(
     criteria: &str,
     id: &EntityId,
     out: &mut dyn Write,
+    style: crate::style::Style,
 ) -> Result<Vec<Proof>> {
     let head = git::run(&repo.root, &["rev-parse", "HEAD"]).unwrap_or_default();
     let tree = scope_hash(&repo.root, scope);
@@ -308,7 +323,11 @@ fn run_verifiers(
         let _ = writeln!(
             out,
             "running: {name} ... {} ({:.1}s)",
-            if outcome.ok { "ok" } else { "FAILED" },
+            if outcome.ok {
+                style.green("ok")
+            } else {
+                style.red("FAILED")
+            },
             outcome.elapsed.as_secs_f64()
         );
         if !outcome.ok {

--- a/crates/ank-cli/src/edit.rs
+++ b/crates/ank-cli/src/edit.rs
@@ -126,7 +126,8 @@ fn write_back(
     if version_of(&after) != base_version && !inv.quiet() && !inv.json() {
         let _ = writeln!(
             out,
-            "warning: version is maintained by ank, and the edit to it was discarded"
+            "{} version is maintained by ank, and the edit to it was discarded",
+            inv.style().yellow("warning:")
         );
     }
 

--- a/crates/ank-cli/src/graph.rs
+++ b/crates/ank-cli/src/graph.rs
@@ -85,6 +85,7 @@ pub fn run(inv: &Invocation, repo: &Repo, out: &mut dyn Write) -> Result<i32> {
     // still has to draw the corpus that has one rather than hang on it. A cycle
     // also means no root, which would otherwise print a header and nothing
     // under it — so what has not been drawn is drawn flat at the end.
+    let style = inv.style();
     let mut drawn: HashSet<&EntityId> = HashSet::new();
     for root in &roots {
         draw(
@@ -97,13 +98,18 @@ pub fn run(inv: &Invocation, repo: &Repo, out: &mut dyn Write) -> Result<i32> {
             &mut drawn,
             &mut Vec::new(),
             out,
+            style,
         );
     }
     let stranded: Vec<&&Row> = nodes.iter().filter(|r| !drawn.contains(&r.id)).collect();
     if !stranded.is_empty() {
         let _ = writeln!(out, "\nin a cycle, so under no root:");
         for row in stranded {
-            let _ = writeln!(out, "  {}", line(&row.id, &row_of, &shorts, &outside_count));
+            let _ = writeln!(
+                out,
+                "  {}",
+                line(&row.id, &row_of, &shorts, &outside_count, style)
+            );
         }
     }
 
@@ -133,15 +139,24 @@ fn draw<'a>(
     drawn: &mut HashSet<&'a EntityId>,
     path: &mut Vec<&'a EntityId>,
     out: &mut dyn Write,
+    style: crate::style::Style,
 ) {
     let indent = "  ".repeat(depth);
     if path.contains(&id) {
-        let _ = writeln!(out, "{indent}{} (cycle)", line(id, row_of, shorts, outside));
+        let _ = writeln!(
+            out,
+            "{indent}{} (cycle)",
+            line(id, row_of, shorts, outside, style)
+        );
         return;
     }
     let repeat = drawn.contains(&id);
     let mark = if repeat { " (above)" } else { "" };
-    let _ = writeln!(out, "{indent}{}{mark}", line(id, row_of, shorts, outside));
+    let _ = writeln!(
+        out,
+        "{indent}{}{mark}",
+        line(id, row_of, shorts, outside, style)
+    );
     if repeat {
         return;
     }
@@ -158,6 +173,7 @@ fn draw<'a>(
             drawn,
             path,
             out,
+            style,
         );
     }
     path.pop();
@@ -168,12 +184,18 @@ fn line<'a>(
     row_of: &HashMap<&'a EntityId, &'a Row>,
     shorts: &HashMap<EntityId, String>,
     outside: &HashMap<&'a EntityId, usize>,
+    style: crate::style::Style,
 ) -> String {
     let short = shorts.get(id).cloned().unwrap_or_else(|| id.to_string());
     let Some(row) = row_of.get(id) else {
-        return short;
+        return style.id(&short);
     };
-    let mut s = format!("{short}  [{}] {}", row.status, row.title);
+    let mut s = format!(
+        "{}  {} {}",
+        style.id(&short),
+        style.status(&format!("[{}]", row.status)),
+        row.title
+    );
     // Never silently a root. A task held up by something the perimeter excludes
     // is not free to start, and drawing it flush left would say it is.
     if let Some(n) = outside.get(id) {

--- a/crates/ank-cli/src/human.rs
+++ b/crates/ank-cli/src/human.rs
@@ -1271,13 +1271,14 @@ fn render(report: &Report, inv: &Invocation, out: &mut dyn Write) {
     if inv.quiet() {
         return;
     }
+    let style = inv.style();
     for f in &report.findings {
         let tag = if f.level == Level::Fault {
-            "error"
+            style.red("error:")
         } else {
-            "signal"
+            style.yellow("signal:")
         };
-        let _ = writeln!(out, "{tag}: {}: {}", f.subject, f.message);
+        let _ = writeln!(out, "{tag} {}: {}", f.subject, f.message);
     }
     for p in &report.pruned {
         let _ = writeln!(out, "pruned {p}");
@@ -1286,9 +1287,9 @@ fn render(report: &Report, inv: &Invocation, out: &mut dyn Write) {
         out,
         "check: {} — {} tasks, {} adr, {} signal(s)",
         if report.faults() == 0 {
-            "ok".to_string()
+            style.green("ok")
         } else {
-            format!("{} fault(s)", report.faults())
+            style.red(&format!("{} fault(s)", report.faults()))
         },
         report.tasks,
         report.adrs,
@@ -1378,20 +1379,38 @@ pub fn review(inv: &Invocation, repo: &Repo, cfg: &Config, out: &mut dyn Write) 
         return Ok(report.exit_code());
     }
     if !inv.quiet() {
-        let _ = writeln!(out, "LIVE CONSTRAINTS ({})", live.len());
+        let style = inv.style();
+        let _ = writeln!(
+            out,
+            "{}",
+            style.header(&format!("LIVE CONSTRAINTS ({})", live.len()))
+        );
         for (r, n) in &live {
-            let _ = writeln!(out, "  {}  {} ({n} files)", r.id, r.title);
+            let _ = writeln!(
+                out,
+                "  {}  {} ({n} files)",
+                style.id(&r.id.to_string()),
+                r.title
+            );
         }
         if !dead.is_empty() {
-            let _ = writeln!(out, "\nDEAD SCOPES ({})", dead.len());
+            let _ = writeln!(
+                out,
+                "\n{}",
+                style.header(&format!("DEAD SCOPES ({})", dead.len()))
+            );
             for id in &dead {
-                let _ = writeln!(out, "  {id}");
+                let _ = writeln!(out, "  {}", style.id(&id.to_string()));
             }
         }
         let _ = writeln!(
             out,
             "\n{} fault(s), {} signal(s)",
-            report.faults(),
+            if report.faults() == 0 {
+                report.faults().to_string()
+            } else {
+                style.red(&report.faults().to_string())
+            },
             report.signals()
         );
     }
@@ -2071,8 +2090,9 @@ pub fn amend(inv: &Invocation, repo: &Repo, identity: &str, out: &mut dyn Write)
                 if let Some(holder) = holder {
                     let _ = writeln!(
                         out,
-                        "warning: {id} is held by {holder}, and the scope change moves \
-                         the constraints its claim anchors"
+                        "{} {id} is held by {holder}, and the scope change moves \
+                         the constraints its claim anchors",
+                        inv.style().yellow("warning:")
                     );
                 }
             }
@@ -2251,8 +2271,8 @@ pub fn show(inv: &Invocation, repo: &Repo, out: &mut dyn Write) -> Result<i32> {
     } else if !inv.quiet() {
         let _ = write!(out, "{text}");
         if let Some((blocked_by, unblocks)) = &edges {
-            edge_section(out, "BLOCKED BY", blocked_by);
-            edge_section(out, "UNBLOCKS", unblocks);
+            edge_section(out, "BLOCKED BY", blocked_by, inv.style());
+            edge_section(out, "UNBLOCKS", unblocks, inv.style());
         }
     }
     Ok(0)
@@ -2312,15 +2332,24 @@ fn edges_of(repo: &Repo, task: &Task) -> Result<(Vec<Edge>, Vec<Edge>)> {
     Ok((blocked_by, unblocks))
 }
 
-fn edge_section(out: &mut dyn Write, heading: &str, edges: &[Edge]) {
-    let _ = writeln!(out, "\n{heading} ({})", edges.len());
+fn edge_section(out: &mut dyn Write, heading: &str, edges: &[Edge], style: crate::style::Style) {
+    let _ = writeln!(
+        out,
+        "\n{}",
+        style.header(&format!("{heading} ({})", edges.len()))
+    );
     for e in edges {
         match (&e.status, &e.title) {
             (Some(status), Some(title)) => {
-                let _ = writeln!(out, "  {}  [{status}] {title}", e.short);
+                let _ = writeln!(
+                    out,
+                    "  {}  {} {title}",
+                    style.id(&e.short),
+                    style.status(&format!("[{status}]"))
+                );
             }
             _ => {
-                let _ = writeln!(out, "  {}  (no such entity)", e.short);
+                let _ = writeln!(out, "  {}  (no such entity)", style.id(&e.short));
             }
         }
     }

--- a/crates/ank-cli/src/main.rs
+++ b/crates/ank-cli/src/main.rs
@@ -21,6 +21,7 @@ mod identity;
 mod init;
 mod repo;
 mod store;
+mod style;
 
 // Verb modules. Each is filled in by its own task — see .ank/tasks/ — and each
 // adds its own arm to cli.rs::dispatch at that point; a verb whose module is
@@ -44,5 +45,9 @@ fn main() {
     let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
     let argv: Vec<String> = std::env::args().skip(1).collect();
     let mut out = std::io::stdout();
-    std::process::exit(cli::run(&argv, &cwd, &mut out));
+    // Detected here and nowhere else: this is the only place that knows what
+    // the process was actually attached to, and answering the question once
+    // keeps every verb downstream from asking it differently (§4).
+    let style = style::detect();
+    std::process::exit(cli::run(&argv, &cwd, &mut out, style));
 }

--- a/crates/ank-cli/src/status.rs
+++ b/crates/ank-cli/src/status.rs
@@ -119,8 +119,9 @@ pub fn run(
             // would read as "nothing is pending".
             let _ = writeln!(
                 out,
-                "warning: no default branch, so completion refs are neither pruned nor \
-                 judged (add \"default_branch: <name>\" to .ank/config.yml)"
+                "{} no default branch, so completion refs are neither pruned nor \
+                 judged (add \"default_branch: <name>\" to .ank/config.yml)",
+                inv.style().yellow("warning:")
             );
         }
         // A repository with no commit is the nominal state of one freshly
@@ -130,16 +131,26 @@ pub fn run(
         }
     }
 
+    let style = inv.style();
     match &claimed {
         Some((task, expires)) => {
-            let _ = writeln!(out, "claim {} {}", task.id, task.title);
+            let _ = writeln!(
+                out,
+                "claim {} {}",
+                style.id(&task.id.to_string()),
+                task.title
+            );
             let _ = writeln!(out, "  expires {expires}");
         }
         // A held claim whose task the index has lost would print nothing at
         // all, so the ref is reported on its own rather than dropped.
         None => match &held {
             Some((id, _, record)) => {
-                let _ = writeln!(out, "claim {id} (no such task in the corpus)");
+                let _ = writeln!(
+                    out,
+                    "claim {} (no such task in the corpus)",
+                    style.id(&id.to_string())
+                );
                 let _ = writeln!(out, "  expires {}", record.expires);
             }
             None => {
@@ -160,7 +171,11 @@ pub fn run(
     let _ = writeln!(
         out,
         "corpus {} fault(s), {} signal(s)",
-        report.faults(),
+        if report.faults() == 0 {
+            report.faults().to_string()
+        } else {
+            style.red(&report.faults().to_string())
+        },
         report.signals()
     );
 
@@ -173,7 +188,7 @@ pub fn run(
     } else {
         "ank context"
     };
-    let _ = writeln!(out, "\n> {next}");
+    let _ = writeln!(out, "\n{}", style.next(&format!("> {next}")));
     Ok(0)
 }
 

--- a/crates/ank-cli/src/style.rs
+++ b/crates/ank-cli/src/style.rs
@@ -1,0 +1,264 @@
+//! ANSI styling, and the whole of it (§4, ADR-962c25797569).
+//!
+//! Every escape sequence this binary can emit is written here, in one table of
+//! six codes. That is deliberate: color is presentation, and presentation
+//! scattered across twelve verb modules is presentation nobody can audit. A
+//! reader asking "can `ank` put an escape sequence in my pipe" reads this file
+//! and no other.
+//!
+//! The guarantee is negative and it is the one that matters. A [`Style`] that
+//! is off returns its input unchanged, byte for byte, so a call site reads the
+//! same whether or not color is live and cannot accidentally emit half of a
+//! sequence. Detection happens once, in `main`, and the result travels on the
+//! [`Invocation`](crate::cli::Invocation) — which is also where `--json` forces
+//! it back off, in one assignment rather than at each of the sites that print
+//! while `--json` is set.
+//!
+//! No dependency, direct or transitive: `std::io::IsTerminal` has been stable
+//! since 1.70 and the floor here is 1.95. The task that ordered this feature
+//! expected to reach for `libc`, and did not need to.
+
+use std::io::IsTerminal;
+
+/// Whether output may carry escape sequences, and the palette if it may.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Style {
+    on: bool,
+}
+
+/// Off. The default everywhere the answer has not been established, which is
+/// what makes a forgotten wiring produce plain text rather than a leak.
+pub const PLAIN: Style = Style { on: false };
+
+/// On. Produced by [`detect`] at a terminal, and by tests that assert the
+/// painting itself — nothing else constructs it.
+pub const COLOR: Style = Style { on: true };
+
+const RESET: &str = "\x1b[0m";
+
+impl Style {
+    pub fn enabled(&self) -> bool {
+        self.on
+    }
+
+    fn paint(&self, sgr: &str, s: &str) -> String {
+        if self.on {
+            format!("\x1b[{sgr}m{s}{RESET}")
+        } else {
+            s.to_string()
+        }
+    }
+
+    // The six codes, and the whole of them.
+
+    pub fn bold(&self, s: &str) -> String {
+        self.paint("1", s)
+    }
+    pub fn dim(&self, s: &str) -> String {
+        self.paint("2", s)
+    }
+    pub fn red(&self, s: &str) -> String {
+        self.paint("31", s)
+    }
+    pub fn green(&self, s: &str) -> String {
+        self.paint("32", s)
+    }
+    pub fn yellow(&self, s: &str) -> String {
+        self.paint("33", s)
+    }
+    pub fn cyan(&self, s: &str) -> String {
+        self.paint("36", s)
+    }
+
+    // Semantic names for the elements §4 names. A call site says what it is
+    // printing, not which colour it picked, so the table stays here and moving
+    // a colour is one edit rather than a grep.
+
+    /// `CONSTRAINTS (n active)`, `TASKS (n)`, `DONE_CRITERIA`, `BLOCKED BY (n)`.
+    pub fn header(&self, s: &str) -> String {
+        self.bold(s)
+    }
+
+    /// `TASK-8ebd`, `ADR-962c`. The register `git log` uses for a sha.
+    pub fn id(&self, s: &str) -> String {
+        self.yellow(s)
+    }
+
+    /// The trailing `> ank claim … to start` every output ends on.
+    pub fn next(&self, s: &str) -> String {
+        self.bold(s)
+    }
+
+    /// A bracketed status marker, styled by what it says.
+    ///
+    /// The mapping lives here rather than beside each `marker()` because two
+    /// modules build these strings — `context` and `find` — and two copies of a
+    /// colour table are two chances for `[done]` to be green in one listing and
+    /// not the other.
+    pub fn status(&self, marker: &str) -> String {
+        let inner = marker.trim_start_matches('[').trim_end_matches(']');
+        // Checked before the split: an expired marker is `[open expired:who]`,
+        // whose leading word is the status it expired from.
+        if inner.contains("expired") {
+            return self.yellow(marker);
+        }
+        match inner.split(':').next().unwrap_or(inner) {
+            "done" | "finished" | "accepted" => self.green(marker),
+            "claimed" => self.cyan(marker),
+            "closed" | "blocked" | "superseded" => self.dim(marker),
+            _ => marker.to_string(),
+        }
+    }
+
+    /// The style for standard error, derived from this one.
+    ///
+    /// A conjunction, never a substitution: stderr is styled only when it is
+    /// itself a terminal *and* stdout's rule already allowed color. Redirecting
+    /// one stream and not the other is therefore incapable of producing an
+    /// escape sequence that §4 forbids on the other.
+    pub fn on_stderr(self) -> Style {
+        if self.on && std::io::stderr().is_terminal() {
+            self
+        } else {
+            PLAIN
+        }
+    }
+}
+
+/// The rule of §4, evaluated once per process.
+///
+/// Three conditions, in the order that costs least: a terminal, then an
+/// environment that has not opted out, then — on Windows only — a console that
+/// says it understands what we are about to send.
+pub fn detect() -> Style {
+    if !std::io::stdout().is_terminal() {
+        return PLAIN;
+    }
+    if opted_out() {
+        return PLAIN;
+    }
+    if !vt_available() {
+        return PLAIN;
+    }
+    COLOR
+}
+
+/// `NO_COLOR` set to anything non-empty, or the terminal that cannot render.
+///
+/// The empty value is deliberately not an opt-out: `NO_COLOR=` is how a shell
+/// spells "unset this for the child", and reading it as "disable" would make
+/// the variable impossible to turn back off.
+fn opted_out() -> bool {
+    if std::env::var_os("NO_COLOR").is_some_and(|v| !v.is_empty()) {
+        return true;
+    }
+    std::env::var_os("TERM").is_some_and(|v| v == "dumb")
+}
+
+/// Windows: the console has to announce itself.
+///
+/// Legacy `conhost` does not interpret escape sequences unless the process
+/// enables them, and enabling them means `SetConsoleMode` through an `extern
+/// "system"` block — a third `unsafe` in this tree, for a presentation feature.
+/// The environment answers the question well enough: Windows Terminal, VS Code,
+/// PowerShell under either, git-bash, ConEmu and ANSICON all set one of these.
+/// A console that sets none is served plain text, which is the failure that
+/// costs its reader nothing.
+#[cfg(windows)]
+fn vt_available() -> bool {
+    [
+        "WT_SESSION",
+        "TERM",
+        "TERM_PROGRAM",
+        "ConEmuANSI",
+        "ANSICON",
+    ]
+    .iter()
+    .any(|key| std::env::var_os(key).is_some())
+}
+
+#[cfg(not(windows))]
+fn vt_available() -> bool {
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plain_returns_its_input_byte_for_byte() {
+        let s = PLAIN;
+        for input in [
+            "TASKS (19)",
+            "TASK-8ebd",
+            "[done]",
+            "",
+            "already \x1b[1m odd",
+        ] {
+            assert_eq!(s.bold(input), input);
+            assert_eq!(s.red(input), input);
+            assert_eq!(s.header(input), input);
+            assert_eq!(s.id(input), input);
+            assert_eq!(s.status(input), input);
+            assert_eq!(s.next(input), input);
+        }
+    }
+
+    #[test]
+    fn color_wraps_and_always_resets() {
+        let s = COLOR;
+        assert_eq!(s.bold("x"), "\x1b[1mx\x1b[0m");
+        assert_eq!(s.dim("x"), "\x1b[2mx\x1b[0m");
+        assert_eq!(s.red("x"), "\x1b[31mx\x1b[0m");
+        assert_eq!(s.green("x"), "\x1b[32mx\x1b[0m");
+        assert_eq!(s.yellow("x"), "\x1b[33mx\x1b[0m");
+        assert_eq!(s.cyan("x"), "\x1b[36mx\x1b[0m");
+        // Every sequence closes. An unreset attribute bleeds into the prompt.
+        for painted in [s.header("h"), s.id("i"), s.next("n"), s.status("[done]")] {
+            assert!(painted.ends_with(RESET), "{painted:?} did not reset");
+        }
+    }
+
+    #[test]
+    fn the_status_table_is_the_one_section_4_declares() {
+        let s = COLOR;
+        assert_eq!(s.status("[done]"), s.green("[done]"));
+        assert_eq!(
+            s.status("[finished:abc1234 on main]"),
+            s.green("[finished:abc1234 on main]")
+        );
+        assert_eq!(s.status("[accepted]"), s.green("[accepted]"));
+        assert_eq!(s.status("[claimed:who@host]"), s.cyan("[claimed:who@host]"));
+        assert_eq!(s.status("[closed]"), s.dim("[closed]"));
+        assert_eq!(s.status("[blocked]"), s.dim("[blocked]"));
+        // Expired wins over the status it expired from, and `[open]` is the
+        // one marker that stays the terminal's own colour.
+        assert_eq!(
+            s.status("[open expired:who@host]"),
+            s.yellow("[open expired:who@host]")
+        );
+        assert_eq!(
+            s.status("[done expired:who@host]"),
+            s.yellow("[done expired:who@host]")
+        );
+        assert_eq!(s.status("[open]"), "[open]");
+        assert_eq!(s.status("[proposed]"), "[proposed]");
+    }
+
+    #[test]
+    fn on_stderr_can_only_narrow() {
+        // Under `cargo test` stderr is captured, so this is the piped case and
+        // the answer is plain whichever way the base points. What is asserted
+        // is the direction: off never becomes on.
+        assert_eq!(PLAIN.on_stderr(), PLAIN);
+        assert!(!COLOR.on_stderr().enabled() || std::io::stderr().is_terminal());
+    }
+
+    #[test]
+    fn detect_is_plain_when_stdout_is_captured() {
+        // The whole feature in one assertion: the test harness pipes stdout, and
+        // a pipe is never styled.
+        assert_eq!(detect(), PLAIN);
+    }
+}

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -207,6 +207,29 @@ impl Repo {
             .expect("the binary must have been built")
     }
 
+    /// The same invocation with extra environment variables set.
+    ///
+    /// What the color rule of §4 reads, besides the terminal itself, is the
+    /// environment — so the environment has to be under the test's control
+    /// rather than inherited from whoever is running the suite. A developer
+    /// with `NO_COLOR` exported would otherwise be testing a different rule
+    /// from CI, and both would pass.
+    fn ank_env(&self, agent: &str, args: &[&str], env: &[(&str, Option<&str>)]) -> Output {
+        let mut c = Command::new(ANK);
+        c.args(args)
+            .arg("--repo")
+            .arg(&self.0)
+            .env("ANK_AGENT", agent)
+            .current_dir(std::env::temp_dir());
+        for (key, value) in env {
+            match value {
+                Some(v) => c.env(key, v),
+                None => c.env_remove(key),
+            };
+        }
+        c.output().expect("the binary must have been built")
+    }
+
     /// The same invocation with `$EDITOR` under the test's control. `None`
     /// removes it, which is the environment failure §4 specifies — and removing
     /// it rather than trusting its absence matters, because the developer
@@ -3565,4 +3588,148 @@ fn a_blocker_that_does_not_exist_is_refused_at_creation() {
         "the exact command to run next: {err}"
     );
     assert!(entity_files(&r, "tasks").is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Color: the guarantee is negative (§4, ADR-962c25797569)
+// ---------------------------------------------------------------------------
+
+/// Every verb worth styling, exercised against a corpus that actually has
+/// something to style: a claimed task, an ADR, a blocker, a finding.
+///
+/// Kept as one fixture and one list because the property under test is
+/// universal — "no verb" is the claim, so a list that quietly omits one is the
+/// hole. `--version` and `help` are in it for the same reason they answer
+/// before the foundation: they are reachable when nothing else is.
+fn styled_surface() -> Vec<Vec<&'static str>> {
+    vec![
+        vec!["context"],
+        vec!["status"],
+        vec!["find", "Example"],
+        vec!["find", "nothing-matches-this"],
+        vec!["show", ID],
+        vec!["log", ID],
+        vec!["graph"],
+        vec!["scope", "src"],
+        vec!["check"],
+        vec!["review"],
+        vec!["help"],
+        vec!["--version"],
+    ]
+}
+
+fn color_fixture() -> Repo {
+    let r = Repo::new();
+    r.seed_task(ID, Some("a criterion to freeze"));
+    r.seed_task("TASK-000000000002", Some("another criterion"));
+    r.seed_adr("ADR-0000000000ab", "a rule that binds", "src/**");
+    r.blocked("TASK-000000000002", &[ID]);
+    r.git(&["add", "-A"]);
+    r.git(&["commit", "-qm", "seed"]);
+    // A live claim: markers, warnings and the execution mode of `context` are
+    // all unreachable without one, and they are exactly what carries colour.
+    r.ank("claude-code@ank", &["claim", ID]);
+    r
+}
+
+/// The one assertion the whole feature exists to satisfy.
+///
+/// A spawned process writes to a pipe, so this suite *is* the piped case — the
+/// same shape an agent shelling out to `ank` sees. An escape byte anywhere in
+/// either stream is the defect ADR-962c25797569 forbids, and `--json` is
+/// checked beside the plain form because it is the one surface that must stay
+/// clean even at a terminal.
+#[test]
+fn no_verb_writes_an_escape_sequence_to_a_pipe() {
+    let r = color_fixture();
+
+    for base in styled_surface() {
+        for json in [false, true] {
+            let mut args = base.clone();
+            if json {
+                args.push("--json");
+            }
+            let out = r.ank("claude-code@ank", &args);
+            assert!(
+                !out.stdout.contains(&0x1b),
+                "{args:?} put an escape sequence on stdout: {:?}",
+                stdout(&out)
+            );
+            assert!(
+                !out.stderr.contains(&0x1b),
+                "{args:?} put an escape sequence on stderr: {:?}",
+                stderr(&out)
+            );
+        }
+    }
+}
+
+/// The error envelope travels the same rule, and it is the one line that does
+/// not go through the writer every verb shares.
+#[test]
+fn a_refusal_is_plain_in_a_pipe_too() {
+    let r = color_fixture();
+
+    // One refusal per stream-producing shape: an unknown entity, a held claim,
+    // and a flag error caught before any verb runs.
+    for args in [
+        vec!["claim", "TASK-00000000dead"],
+        vec!["claim", "TASK-000000000002"],
+        vec!["find", "bug", "-st", "task"],
+        vec!["context", "--limit", "not-a-number"],
+    ] {
+        let out = r.ank("someone-else@ank", &args);
+        assert_ne!(code(&out), 0, "{args:?} was supposed to refuse");
+        assert!(
+            !out.stderr.contains(&0x1b),
+            "{args:?} coloured a refusal into a pipe: {:?}",
+            stderr(&out)
+        );
+        assert!(
+            stderr(&out).starts_with("error["),
+            "{args:?} lost the envelope: {:?}",
+            stderr(&out)
+        );
+    }
+}
+
+/// The detection rule read from the other side: nothing in the environment can
+/// turn colour *on*, because the terminal test has already failed.
+///
+/// This is what catches a wiring inversion. `NO_COLOR` implemented backwards,
+/// or a Windows allowlist consulted instead of the terminal check, would leave
+/// every assertion above green and change the bytes here.
+#[test]
+fn no_environment_makes_a_pipe_colored() {
+    let r = color_fixture();
+
+    let environments: [&[(&str, Option<&str>)]; 6] = [
+        &[("NO_COLOR", None), ("TERM", None), ("WT_SESSION", None)],
+        &[("NO_COLOR", Some("1"))],
+        &[("NO_COLOR", Some(""))],
+        &[("TERM", Some("dumb"))],
+        &[("TERM", Some("xterm-256color"))],
+        // The Windows allowlist, set on every platform: it is only ever an
+        // additional condition, never a substitute for the terminal itself.
+        &[("WT_SESSION", Some("1")), ("ANSICON", Some("1"))],
+    ];
+
+    for base in styled_surface() {
+        let reference = r.ank_env(
+            "claude-code@ank",
+            &base,
+            &[("NO_COLOR", None), ("TERM", None), ("WT_SESSION", None)],
+        );
+        for env in environments {
+            let out = r.ank_env("claude-code@ank", &base, env);
+            assert!(
+                !out.stdout.contains(&0x1b),
+                "{base:?} under {env:?} coloured a pipe"
+            );
+            assert_eq!(
+                out.stdout, reference.stdout,
+                "{base:?} answered differently under {env:?}"
+            );
+        }
+    }
 }

--- a/docs/ank-spec-v1.1.md
+++ b/docs/ank-spec-v1.1.md
@@ -499,6 +499,33 @@ The commit is embedded at build time through `rev-parse`, which §8's plumbing r
 
 **The skill revision, and what it lets a reader do offline.** The third value is `skill <rev>`, where `<rev>` is the short form of the same freeze hash that anchors a frozen `done_criteria` (§3), taken over the body of `skill/SKILL.md` — the same value that file declares under `metadata.revision`, computed at build time from the file rather than typed. An agent has both halves in hand and nothing else: the skill is loaded into its context, the binary is on its `PATH`. Comparing the two strings tells it, with no repository and no network, whether the instructions it is following predate the tool it is holding. That is the check TASK-1ea38a17d854 needed and did not have, and the case that motivated it was measured (TASK-b495234f192c): an installed `SKILL.md` two commits behind a tree that had just withdrawn the invitation to read `.ank/` by hand. The hash covers the body and not the frontmatter, so the revision the frontmatter carries does not change its own input. It is `unknown` on a build with no `skill/` to read, for the same reason and with the same honesty as the commit.
 
+### Color
+
+Presentation and nothing else (ADR-962c25797569). Color is emitted when **stdout is a terminal and `NO_COLOR` is unset**, and under no other condition. There is no `--color` flag: the globals stay at three, and a flag able to force color into a pipe is a flag that eventually puts an escape sequence into an agent's context window. Detection is not a preference to be configured, it is an observation about who is reading.
+
+The guarantee bought is negative, and it is the whole point. **Captured output is byte-for-byte what it was before color existed** — a pipe, a file, a `$(...)`, a CI log, all unchanged. `--json` is never colored even at a terminal: it is the one place both conditions can hold and styling still be wrong, so the rule is stated separately rather than left to follow.
+
+`NO_COLOR` set to any non-empty value disables it, which is what a human at a terminal types to get the raw bytes; `TERM=dumb` disables it too.
+
+The palette is small on purpose, and it is bounded here rather than in the code for the same reason the short-form table is: the grammar is the specification, and the implementation is only its application. Status markers, section headers, identifiers, the error line. Nothing that carries meaning is carried by color alone — every marker still reads as `[open]` or `[done]` in a pipe.
+
+| Element | Style |
+|---|---|
+| section headers: `CONSTRAINTS`, `PROPOSED`, `TASKS`, `DONE_CRITERIA`, `LOG`, `BLOCKED BY`, `UNBLOCKS` | bold |
+| identifiers: `TASK-8ebd`, `ADR-962c` | yellow |
+| `[open]` | default |
+| `[claimed:…]`, `[… expired:…]` | cyan, yellow |
+| `[done]`, `[finished:… on …]` | green |
+| `[closed]`, `[blocked]` | dim |
+| `error[N]:` and `check`'s `error:` tag | red |
+| `warning:` and `check`'s `signal:` tag | yellow |
+| a verifier's `ok` / `FAILED` | green / red |
+| the trailing next-command line, `> ank …` | bold |
+
+The error line follows the same rule applied to its own stream: it is colored when stderr is a terminal **and** the condition above already holds, a conjunction rather than a substitution, so that no arrangement of redirections produces an escape sequence stdout's rule forbids.
+
+**On Windows the terminal must also announce itself**: one of `WT_SESSION`, `TERM`, `TERM_PROGRAM`, `ConEmuANSI` or `ANSICON` present in the environment. Legacy `conhost` does not interpret escape sequences unless the process turns them on, and turning them on means a console API call that this feature does not justify. A console announcing nothing is served plain text — the failure that costs a reader nothing, rather than the one that prints `←[1m` at them.
+
 ### Exit codes
 
 The semantics are carried by the code so that the shell can route without parsing output.


### PR DESCRIPTION
Adds TASK-38b384543551. `.ank/` only, one file, no code.

## What it records

Two sessions collided in one working tree today. Both ran with `ANK_AGENT` unset, so both were `seanl@sean-laptop` and ank saw one agent. At 18:12:14Z one finished TASK-1613794deccf; at 18:14 the other released TASK-8ebd6e02f125 believing two live claims on one identity had made HEAD ambiguous; at 18:15 it corrected itself -- the `done` had landed between its own `status` and its own `done`.

The release cost nothing. **Where the misread formed is the finding, and it is `ank status`.**

Measured: `live_claims_of` has exactly one call site in production code, `claim.rs:906` inside the `claim` verb, every other occurrence being a test. So the warning naming the shared identity and the way out of it prints once, at acquisition, and never again. `status.rs` knows a single claim, the one binding the current perimeter (135-157); a second live claim under the same identity appears nowhere in it. A convention that announces itself only when it is taken fades exactly as a session lengthens, and `status` is the verb a session runs when it has lost track.

## Why it is not the two tasks it sits beside

- **TASK-e3f4b6295b23** asks whether `skill/SKILL.md` should teach the execution model at all. This one holds whatever that answer turns out to be: the binary is mute at the moment the question gets asked. Either order.
- **TASK-83d6eefdb36e** is two clones never arbitrating. Here there was one clone, one `refs/ank/` namespace, and the CAS was right -- both claims were live and that was the true state. The defect is in what is reported, not in what is locked.

## What it leaves open, and what it fixes

Open: whether `context` carries the warning too -- right by relevance, wrong by budget under ADR-e17e1bbd93ff. Fixed: `claim.rs:902-905` warns and never refuses, because parallel agents with distinct identities are the design.

Out of scope and named so it is not reopened cold: the git-level interference of a shared tree. Section 7 already calls that a degraded mode, ADR-9ede1ffd04e2 puts the policy above the tool.

## Note on how this was committed

A single named file rather than `git add .ank`, because another session has uncommitted work in this tree -- that is the mistake that put its claim file into #50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XszrHRiKJWjAM4At7YwYkg