### PR TITLE
Add task: the shared-identity warning is emitted once and never again

### DIFF
--- a/.ank/tasks/TASK-38b384543551.md
+++ b/.ank/tasks/TASK-38b384543551.md
@@ -1,0 +1,81 @@
+---
+id: TASK-38b384543551
+type: task
+slug: the-shared-identity-warning-is-emitted-once-and
+title: The shared-identity warning is emitted once and never again
+created: 2026-08-08T22:45:06Z
+author: seanl@sean-laptop
+status: open
+scope:
+  - crates/ank-cli/**
+blocked_by: []
+done_criteria: |
+  A second live claim held by the same identity is visible after the moment it was
+  acquired: ank status names every live claim of this identity, not only the one
+  bound to the current perimeter, and repeats the way out that claim already names.
+  Whether ank context carries it too is decided in this task and the reasoning
+  recorded, since context is loaded on every call and every word there is paid for.
+  Tested through the binary: one identity, two claims, and the assertion is on what
+  ank status prints, because a warning that never reaches stdout is not a warning.
+  --json carries the same information, and piped output stays byte-for-byte what it
+  was (ADR-962c25797569). cargo test and ank check stay green.
+criteria_by: creator
+schema: 2
+version: 1
+---
+
+Found by two sessions colliding in one working tree on 2026-08-08, and the logs
+of the tasks involved keep the sequence. Both ran with ANK_AGENT unset, so both
+were seanl@sean-laptop and ank saw one agent. At 18:12:14Z one session finished
+TASK-1613794deccf. At 18:14 the other released TASK-8ebd6e02f125, writing that
+two live claims on one identity made HEAD ambiguous between verbs. At 18:15 it
+corrected itself: the done had landed between its own ank status and its own ank
+done, so nothing had been ambiguous and the release was taken on a misread.
+
+The release cost nothing. Where the misread formed is the finding, and it is
+ank status.
+
+Measured rather than assumed. live_claims_of (claim.rs:295) has exactly one
+call site in production code: claim.rs:906, inside the claim verb. Every other
+occurrence is a test. So the warning it feeds --
+
+    {identity} already holds {id} until {expires}
+    a second session on this machine sets its own ANK_AGENT
+
+-- is printed once, at acquisition, and never again. status.rs knows a single
+claim, the one binding the current perimeter, and prints "claim <id> <...>" or
+"no claim" (135-157). A second live claim under the same identity appears
+nowhere in it.
+
+A convention that announces itself only when it is taken fades exactly as a
+session lengthens, and status is the verb a session runs when it has lost track.
+That is the whole defect: not that two sessions can share an identity, which is
+known and warned about, but that after the warning scrolls away the tool has no
+second occasion to say so, at the one place built for asking where things stand.
+
+Not TASK-e3f4b6295b23. That one asks whether skill/SKILL.md should teach the
+nominal execution model at all, and its remedies are a superseding ADR, a tool
+message, or a recorded decision to stay silent. This one is narrower and does not
+depend on it: whichever way the skill question goes, the binary is mute at the
+moment the question is asked. They can land in either order.
+
+Not TASK-83d6eefdb36e either. Two clones do not arbitrate, and that is real, but
+it is not what happened here. One clone, one refs/ank/ namespace, and the CAS in
+claim.rs did its job perfectly -- both claims were recorded, both were live, and
+that was the correct state. The defect is in what is reported, not in what is
+locked.
+
+The tension to settle, and this task deliberately does not settle it. context is
+the right place by relevance, since it is what an agent reads every turn, and the
+wrong place by budget, since it is loaded on every call and ADR-e17e1bbd93ff
+treats every word there as paid for. status is free and is not read every turn.
+Whichever is chosen, the reasoning in claim.rs:902-905 must not be contradicted:
+one claim at a time is a convention and not a lock, parallel agents with distinct
+identities are the design, so this warns and never refuses.
+
+Out of scope, named so it is not reopened cold: the git-level interference of a
+shared tree -- a branch switch aborting on another session's uncommitted work, a
+git add .ank sweeping another session's claim file into an unrelated commit.
+Section 7 already answers it by calling a shared tree a degraded mode rather than
+a design mode, and ADR-9ede1ffd04e2 puts that policy above the tool. Both
+happened during this same episode; neither is ank's to fix.


### PR DESCRIPTION
Adds TASK-38b384543551. `.ank/` only, one file, no code. Replaces #52, which was branched while another session had moved HEAD in the shared checkout and therefore carried that session's colour commits too -- an instance of the very hazard this task is about.

## What it records

Two sessions collided in one working tree today. Both ran with `ANK_AGENT` unset, so both were `seanl@sean-laptop` and ank saw one agent. At 18:12:14Z one finished TASK-1613794deccf; at 18:14 the other released TASK-8ebd6e02f125 believing two live claims on one identity had made HEAD ambiguous; at 18:15 it corrected itself -- the `done` had landed between its own `status` and its own `done`.

The release cost nothing. **Where the misread formed is the finding, and it is `ank status`.**

Measured: `live_claims_of` has exactly one call site in production code, `claim.rs:906` inside the `claim` verb, every other occurrence being a test. So the warning naming the shared identity and the way out of it prints once, at acquisition, and never again. `status.rs` knows a single claim, the one binding the current perimeter (135-157); a second live claim under the same identity appears nowhere in it. A convention that announces itself only when it is taken fades exactly as a session lengthens, and `status` is the verb a session runs when it has lost track.

## Why it is not the two tasks it sits beside

- **TASK-e3f4b6295b23** asks whether `skill/SKILL.md` should teach the execution model at all. This one holds whatever that answer turns out to be: the binary is mute at the moment the question gets asked. Either order.
- **TASK-83d6eefdb36e** is two clones never arbitrating. Here there was one clone, one `refs/ank/` namespace, and the CAS was right -- both claims were live and that was the true state. The defect is in what is reported, not in what is locked.

## What it leaves open, and what it fixes

Open: whether `context` carries the warning too -- right by relevance, wrong by budget under ADR-e17e1bbd93ff. Fixed: `claim.rs:902-905` warns and never refuses, because parallel agents with distinct identities are the design.

Out of scope and named so it is not reopened cold: the git-level interference of a shared tree. Section 7 already calls that a degraded mode, ADR-9ede1ffd04e2 puts the policy above the tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XszrHRiKJWjAM4At7YwYkg