### PR TITLE
The palette closes, show is painted, and one status reads the same everywhere

### DIFF
--- a/.ank/tasks/TASK-20acb18f7013.md
+++ b/.ank/tasks/TASK-20acb18f7013.md
@@ -1,0 +1,91 @@
+---
+id: TASK-20acb18f7013
+type: task
+slug: show-paints-the-entity-it-prints-and-a-pipe-stil
+title: show paints the entity it prints, and a pipe still receives it byte for byte
+created: 2026-08-09T03:08:44Z
+author: seanl@sean-laptop
+status: in_progress
+scope:
+  - docs/ank-spec-v1.1.md
+  - crates/ank-cli/src/style.rs
+  - crates/ank-cli/src/paint.rs
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/src/commands.rs
+  - crates/ank-cli/src/main.rs
+  - crates/ank-cli/tests/cli.rs
+blocked_by: [TASK-bfe1cbd9ec42]
+done_criteria: |
+  Section 4 of docs/ank-spec-v1.1.md says, before the code moves, that show paints the entity it renders and adds, removes and moves no character -- the escapes are zero width, so stripping them yields the bytes a pipe receives -- and its palette table gains the elements the painting uses: the --- fences and the frontmatter keys dim, the id and supersedes values yellow, the status value the colour of its own marker, a markdown heading in the body bold, and the timestamp and author of a log entry dim.
+  
+  The painting lives in one module that contains no escape sequence of its own and calls only style.rs accessors, so "every escape byte is written in style.rs and nowhere else" stays literally true, and a test reads the crate's own sources and finds the escape literal in style.rs alone. The first act of the painter is to return its input untouched when style is off, so no defect in the scan can reach a pipe even if the scan is wrong.
+  
+  The frontmatter region is bounded by the rule ank_core's split_frontmatter already uses and not by a heuristic of its own, so scanner and parser cannot disagree about where the body starts, and a file that is not canonical is returned untouched. A log line is rebuilt from its parsed parts rather than sliced, so the em-dash is never cut. ank log's own listing moves in the same change, because show and log print the same line and one fact must not acquire two shapes. --json still receives the unpainted text.
+  
+  The invariant is asserted rather than assumed. Over fixtures carrying a block scalar whose own text contains a "status:" line and a log-shaped line, a sequence, a --- inside the body, a quoted title, and a message containing the same em-dash separator its prefix uses: stripping the SGR sequences from the painted form yields the input byte for byte, painting with PLAIN yields the input byte for byte, and every fixture is asserted free of escape sequences before the comparison, so the equality cannot hold by mutual destruction. No escape run nests inside another. show_prints_the_entity_verbatim and show_on_an_adr_stays_verbatim_and_adds_nothing pass with no edit. A test drives show itself at COLOR and asserts its stripped output equals its PLAIN output. styled_surface gains the ADR case so the pipe suite covers the block-scalar path, and the rest of that suite stays green with no edit.
+criteria_by: creator
+schema: 2
+version: 3
+---
+
+## Why
+
+`ank show` writes the entity with a single `write!(out, "{text}")`. On a real
+task file -- YAML frontmatter, block scalars, a `## Log` and its timestamped
+entries -- that is a uniform wall of text, and the only styled thing on screen
+is the `BLOCKED BY` / `UNBLOCKS` sections show appends itself.
+
+## What is not available, and why
+
+Re-laying it out is not on the table, and not because it would be hard.
+
+`ank show <id>` returns the entity byte for byte: ADR-01b6dd05f0db says so, and
+skill/SKILL.md says so under a frozen revision hash. Nothing may be added,
+removed or moved.
+
+Laying it out only at a terminal is the option ADR-0c8ab846d262 examined and
+rejected in writing: it gives one corpus two shapes, and turns "what did the
+agent see" into a question with two answers.
+
+What is left is colour, and colour is enough. Escapes carry no width, so the
+painted form strips back to the byte sequence that exists today. A pipe -- which
+is what every agent reads through -- is unchanged, and the guarantee holds
+exactly where it was ever asserted. A human at a terminal gets hierarchy.
+
+## Why the painter is its own module
+
+TASK-b288bc31e2d7 named style.rs up front and was closed for it. The painter has
+to know what a log line is, and knowing that means reaching for
+ank_core::LogEntry -- while style.rs opens by claiming, in its own module doc,
+no dependency direct or transitive, and by promising that a reader asking "can
+ank put an escape sequence in my pipe" reads that file and no other. Eighty
+lines of YAML-and-markdown scanning would end both claims.
+
+Nothing is lost. TASK-4601ed18d84e's rule is that every escape *byte* is written
+in style.rs, and a module that emits none of its own and calls only accessors
+satisfies it literally -- which is why this criterion asks for a test that reads
+the sources and proves it, instead of leaving it as an architectural intention.
+
+## The traps the scan has to survive
+
+A block scalar (`constraint: |`, `done_criteria: |`) whose continuation lines are
+indented, are not keys, and whose text may itself contain a line reading
+`status: something` or a line shaped like a log entry. A sequence (`scope:`)
+whose items begin with `  - `. A `---` inside the body, which must not be read as
+a fence. A quoted title containing a colon. The em-dash separating a log entry's
+author from its message, which is three bytes and must never be sliced through --
+so the line is rebuilt from its parsed parts rather than cut.
+
+And the trap in the test rather than the code: `undo_sgr` strips escapes from
+both sides of the comparison, so a fixture that already contained one would make
+the equality hold by mutual destruction. Every fixture is asserted escape-free
+before it is trusted.
+
+## Log
+- 2026-08-09T03:21:50Z seanl@sean-laptop — Verified through the binary rather than only in unit tests: the freshly built ank and the published 0.1.3 print byte-identical output for `ank show TASK-4601` into a pipe, 2799 bytes each, with zero escape bytes. That is the guarantee stated as a comparison against the thing it promises not to change, not as an assertion about our own new code.
+
+Falsified the negative guarantee too. Forcing style::COLOR unconditionally in dispatch turns 17 integration tests red, including all four that guard the pipe. So the escape-free-pipe suite can fail, which is what makes it worth anything.
+
+Two things the design surfaced that the first attempt at this task would have shipped wrong. First, ank log prints the same lines show does, through LogEntry::format_line -- painting them under one verb and not the other would have manufactured the exact one-fact-two-shapes defect the sibling task exists to remove, so log_read moves through the same painter. Second, undo_sgr strips escapes from both sides of the comparison, so a fixture that already carried one would make the equality hold by mutual destruction; every fixture is now asserted escape-free first, and the same hole was open in context.rs's own test and is now closed.
+
+The source-scan test failed on itself first, which was the right kind of embarrassing: it looks for the escape opener as it appears in source, and writing that needle as a literal put the needle in the file it forbids. Assembled from two pieces now.

--- a/.ank/tasks/TASK-20acb18f7013.md
+++ b/.ank/tasks/TASK-20acb18f7013.md
@@ -5,7 +5,7 @@ slug: show-paints-the-entity-it-prints-and-a-pipe-stil
 title: show paints the entity it prints, and a pipe still receives it byte for byte
 created: 2026-08-09T03:08:44Z
 author: seanl@sean-laptop
-status: in_progress
+status: done
 scope:
   - docs/ank-spec-v1.1.md
   - crates/ank-cli/src/style.rs
@@ -24,8 +24,12 @@ done_criteria: |
   
   The invariant is asserted rather than assumed. Over fixtures carrying a block scalar whose own text contains a "status:" line and a log-shaped line, a sequence, a --- inside the body, a quoted title, and a message containing the same em-dash separator its prefix uses: stripping the SGR sequences from the painted form yields the input byte for byte, painting with PLAIN yields the input byte for byte, and every fixture is asserted free of escape sequences before the comparison, so the equality cannot hold by mutual destruction. No escape run nests inside another. show_prints_the_entity_verbatim and show_on_an_adr_stays_verbatim_and_adds_nothing pass with no edit. A test drives show itself at COLOR and asserts its stripped output equals its PLAIN output. styled_surface gains the ADR case so the pipe suite covers the block-scalar path, and the rest of that suite stays green with no edit.
 criteria_by: creator
+proof:
+  - type: test
+    ref: "31292287284"
+    criteria: 1c0ab394df44
 schema: 2
-version: 3
+version: 4
 ---
 
 ## Why
@@ -89,3 +93,4 @@ Falsified the negative guarantee too. Forcing style::COLOR unconditionally in di
 Two things the design surfaced that the first attempt at this task would have shipped wrong. First, ank log prints the same lines show does, through LogEntry::format_line -- painting them under one verb and not the other would have manufactured the exact one-fact-two-shapes defect the sibling task exists to remove, so log_read moves through the same painter. Second, undo_sgr strips escapes from both sides of the comparison, so a fixture that already carried one would make the equality hold by mutual destruction; every fixture is now asserted escape-free first, and the same hole was open in context.rs's own test and is now closed.
 
 The source-scan test failed on itself first, which was the right kind of embarrassing: it looks for the escape opener as it appears in source, and writing that needle as a literal put the needle in the file it forbids. Assembled from two pieces now.
+- 2026-08-09T03:25:59Z seanl@sean-laptop — done, proof test:31292287284

--- a/.ank/tasks/TASK-a015e74735c5.md
+++ b/.ank/tasks/TASK-a015e74735c5.md
@@ -5,7 +5,7 @@ slug: one-coordination-string-whichever-verb-prints-it
 title: One coordination string, whichever verb prints it
 created: 2026-08-09T02:58:32Z
 author: seanl@sean-laptop
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/src/context.rs
   - crates/ank-cli/src/commands.rs
@@ -17,7 +17,7 @@ done_criteria: |
   find, scope, graph and show's edge sections present a task's coordination with the same string context already prints: [claimed:who] for a live claim, [status expired:who] for a lapsed one, [finished:sha on branch] for a task finished elsewhere, and [status] otherwise. The string is built in one place -- context's marker logic, split so that the listing verbs and context call the same function rather than each formatting their own -- and the coordination map is read once per invocation through the enumeration context already performs, never once per row. find keeps the marker on the row the caller holds and derives it from that same map instead of calling held_by, so the ref enumeration is performed once and not twice. An ADR carries no claim ref and its listing is unchanged. a_listing_marks_the_row_the_caller_holds stays green with no edit, width neutrality included, and that is verified rather than assumed. A test through the binary claims a task and asserts that context and find print the same status string for it, which is the defect this task closes.
 criteria_by: creator
 schema: 2
-version: 1
+version: 3
 ---
 
 ## Why
@@ -47,3 +47,12 @@ in_progress` will return rows that display `[claimed:who]`. That is already
 true of `context`, and it is the right split: the filter is about the data, the
 marker is about the coordination. Recorded here so it is not re-read later as a
 defect.
+
+## Log
+- 2026-08-09T03:36:22Z seanl@sean-laptop — The machine surface nearly moved, and a test caught it. Edge.status feeds both the human line and --json, so replacing it with the bracketed marker changed what a parser reads. Edge now carries both: status stays the stored word for --json, marker is what the human line prints. The rule is worth stating plainly -- a human listing learning to say something better is not a reason for the machine surface to move.
+
+Falsified the new cross-verb test by reverting find alone to the index's word: it fails and names the verb that drifted ("`ank find Example` does not say [claimed:...]"). A test asserting five verbs agree is worthless if it cannot tell which one stopped agreeing.
+
+Confirmed on the live corpus rather than only on a fixture. Published 0.1.3 prints "* TASK-a015 [in_progress] ..." for this very task; the built binary prints "* TASK-a015 [claimed:seanl@sean-laptop] ...".
+
+On cost: find and scope already called held_by, which enumerates refs/ank/claims/* and reads a record per ref, then discarded everything but the caller's own. They now call context::coordination instead, which is the same enumeration keeping its answers, so both listings pay one read where they used to pay one read and a discard. graph and show's edges gained a read they did not have; both are proportional to the coordination in flight, not to the corpus.

--- a/.ank/tasks/TASK-a015e74735c5.md
+++ b/.ank/tasks/TASK-a015e74735c5.md
@@ -1,0 +1,49 @@
+---
+id: TASK-a015e74735c5
+type: task
+slug: one-coordination-string-whichever-verb-prints-it
+title: One coordination string, whichever verb prints it
+created: 2026-08-09T02:58:32Z
+author: seanl@sean-laptop
+status: open
+scope:
+  - crates/ank-cli/src/context.rs
+  - crates/ank-cli/src/commands.rs
+  - crates/ank-cli/src/graph.rs
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/tests/cli.rs
+blocked_by: [TASK-bfe1cbd9ec42]
+done_criteria: |
+  find, scope, graph and show's edge sections present a task's coordination with the same string context already prints: [claimed:who] for a live claim, [status expired:who] for a lapsed one, [finished:sha on branch] for a task finished elsewhere, and [status] otherwise. The string is built in one place -- context's marker logic, split so that the listing verbs and context call the same function rather than each formatting their own -- and the coordination map is read once per invocation through the enumeration context already performs, never once per row. find keeps the marker on the row the caller holds and derives it from that same map instead of calling held_by, so the ref enumeration is performed once and not twice. An ADR carries no claim ref and its listing is unchanged. a_listing_marks_the_row_the_caller_holds stays green with no edit, width neutrality included, and that is verified rather than assumed. A test through the binary claims a task and asserts that context and find print the same status string for it, which is the defect this task closes.
+criteria_by: creator
+schema: 2
+version: 1
+---
+
+## Why
+
+`context` reads the claim refs and prints `[claimed:sean@pc]`. `find`, `scope`,
+`graph` and `show`'s edge sections read the SQLite index and print
+`[in_progress]`. Same task, same moment, two strings. TASK-bfe1cbd9ec42 makes
+them the same colour; this makes them the same text.
+
+## The cost is already paid, which is why this is worth doing
+
+The obvious objection is that a listing should not spawn git plumbing per row.
+It will not, and it does not today either.
+
+`find` already calls `held_by` (commands.rs), which enumerates
+refs/ank/claims/* and reads a record per ref -- then discards every one of them
+except the caller's own. `context::coordination` performs the same enumeration
+with one cat-file per existing ref, and keeps the answers. Substituting the
+second for the first is at equal cost or less, and it yields both facts a
+listing needs -- who holds the row, and what the row's coordination is -- from
+one read instead of one read and a discard.
+
+## What deliberately does not change
+
+`--status` filters on the status stored in the index. So `ank find --status
+in_progress` will return rows that display `[claimed:who]`. That is already
+true of `context`, and it is the right split: the filter is about the data, the
+marker is about the coordination. Recorded here so it is not re-read later as a
+defect.

--- a/.ank/tasks/TASK-a015e74735c5.md
+++ b/.ank/tasks/TASK-a015e74735c5.md
@@ -5,7 +5,7 @@ slug: one-coordination-string-whichever-verb-prints-it
 title: One coordination string, whichever verb prints it
 created: 2026-08-09T02:58:32Z
 author: seanl@sean-laptop
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/src/context.rs
   - crates/ank-cli/src/commands.rs
@@ -16,8 +16,12 @@ blocked_by: [TASK-bfe1cbd9ec42]
 done_criteria: |
   find, scope, graph and show's edge sections present a task's coordination with the same string context already prints: [claimed:who] for a live claim, [status expired:who] for a lapsed one, [finished:sha on branch] for a task finished elsewhere, and [status] otherwise. The string is built in one place -- context's marker logic, split so that the listing verbs and context call the same function rather than each formatting their own -- and the coordination map is read once per invocation through the enumeration context already performs, never once per row. find keeps the marker on the row the caller holds and derives it from that same map instead of calling held_by, so the ref enumeration is performed once and not twice. An ADR carries no claim ref and its listing is unchanged. a_listing_marks_the_row_the_caller_holds stays green with no edit, width neutrality included, and that is verified rather than assumed. A test through the binary claims a task and asserts that context and find print the same status string for it, which is the defect this task closes.
 criteria_by: creator
+proof:
+  - type: test
+    ref: "31292788779"
+    criteria: 8c8940087415
 schema: 2
-version: 3
+version: 4
 ---
 
 ## Why
@@ -56,3 +60,4 @@ Falsified the new cross-verb test by reverting find alone to the index's word: i
 Confirmed on the live corpus rather than only on a fixture. Published 0.1.3 prints "* TASK-a015 [in_progress] ..." for this very task; the built binary prints "* TASK-a015 [claimed:seanl@sean-laptop] ...".
 
 On cost: find and scope already called held_by, which enumerates refs/ank/claims/* and reads a record per ref, then discarded everything but the caller's own. They now call context::coordination instead, which is the same enumeration keeping its answers, so both listings pay one read where they used to pay one read and a discard. graph and show's edges gained a read they did not have; both are proportional to the coordination in flight, not to the corpus.
+- 2026-08-09T03:39:44Z seanl@sean-laptop — done, proof test:31292788779

--- a/.ank/tasks/TASK-b288bc31e2d7.md
+++ b/.ank/tasks/TASK-b288bc31e2d7.md
@@ -1,0 +1,62 @@
+---
+id: TASK-b288bc31e2d7
+type: task
+slug: show-paints-the-entity-it-prints-and-a-pipe-stil
+title: show paints the entity it prints, and a pipe still receives it byte for byte
+created: 2026-08-09T02:58:15Z
+author: seanl@sean-laptop
+status: open
+scope:
+  - docs/ank-spec-v1.1.md
+  - crates/ank-cli/src/style.rs
+  - crates/ank-cli/src/human.rs
+blocked_by: [TASK-bfe1cbd9ec42]
+done_criteria: |
+  Section 4 of docs/ank-spec-v1.1.md says, before the code moves, that show paints the entity it renders and adds, removes and moves no character, so the byte-for-byte guarantee ADR-01b6dd05f0db states holds for every reader that parses; and its palette table gains the elements that painting uses: the frontmatter fences and keys dim, the value of id yellow, the value of status the colour of its own marker, a markdown heading in the body bold, and the timestamp and author of a log entry dim. A single new method on Style in crates/ank-cli/src/style.rs performs the painting, so every escape byte is still written in style.rs and nowhere else, and human::show calls it in place of writing the text raw. The invariant is asserted rather than assumed: on a fixture carrying a block scalar, a sequence, a --- inside the body, a heading and a log entry with its em-dash, stripping the SGR sequences from the painted form yields the input byte for byte, and painting with PLAIN yields the input byte for byte. show_prints_the_entity_verbatim and show_on_an_adr_stays_verbatim_and_adds_nothing pass with no edit. A test drives show itself at COLOR and asserts its stripped output equals its PLAIN output. The pipe suite through the binary stays green with no edit, show being already in styled_surface, and that is verified rather than assumed.
+criteria_by: creator
+schema: 2
+version: 1
+---
+
+## Why
+
+`ank show` writes the entity with a single `write!(out, "{text}")`. On a real
+task file -- YAML frontmatter, block scalars, a `## Log` and its timestamped
+entries -- that is a uniform wall of text, and the only styled thing on screen
+is the `BLOCKED BY` / `UNBLOCKS` sections show appends itself.
+
+## What is not available, and why
+
+Re-laying it out is not on the table, and not because it would be hard.
+
+`ank show <id>` returns the entity byte for byte: ADR-01b6dd05f0db says so, and
+skill/SKILL.md says so under a frozen revision hash. Nothing may be added,
+removed or moved.
+
+Laying it out only at a terminal is the option ADR-0c8ab846d262 examined and
+rejected in writing: it gives one corpus two shapes, and turns "what did the
+agent see" into a question with two answers.
+
+What is left is colour, and colour is enough. Escapes carry no width, so the
+painted form strips back to the byte sequence that exists today. A pipe -- which
+is what every agent reads through -- is unchanged, and the guarantee holds
+exactly where it was ever asserted. A human at a terminal gets hierarchy.
+
+## Where the scanner lives
+
+On Style, in style.rs, rather than in human.rs. Two reasons, and the second is
+the load-bearing one: TASK-4601ed18d84e's criterion says every escape byte is
+written in style.rs and nowhere else, and a scanner that emits escapes belongs
+where that sentence can stay literally true; and the strip-equality invariant is
+then a unit test of the module that owns it, rather than a test that has to
+stand up a repository to reach show.
+
+## The traps the scan has to survive
+
+A block scalar (`constraint: |`) whose continuation lines are indented and are
+not keys. A sequence (`scope:`) whose items begin with `  - `. A `---` inside
+the body, which must not be read as a fence once the frontmatter region has
+closed. A quoted title containing a colon. And the em-dash separating a log
+entry's author from its message, which is multi-byte and must never be sliced
+through -- so every cut point is found on an ASCII pattern or by searching for
+the separator whole.

--- a/.ank/tasks/TASK-b288bc31e2d7.md
+++ b/.ank/tasks/TASK-b288bc31e2d7.md
@@ -5,17 +5,22 @@ slug: show-paints-the-entity-it-prints-and-a-pipe-stil
 title: show paints the entity it prints, and a pipe still receives it byte for byte
 created: 2026-08-09T02:58:15Z
 author: seanl@sean-laptop
-status: open
+status: closed
 scope:
   - docs/ank-spec-v1.1.md
   - crates/ank-cli/src/style.rs
   - crates/ank-cli/src/human.rs
+  - crates/ank-cli/src/paint.rs
+  - crates/ank-cli/src/main.rs
+  - crates/ank-cli/src/commands.rs
+  - crates/ank-cli/src/context.rs
+  - crates/ank-cli/tests/cli.rs
 blocked_by: [TASK-bfe1cbd9ec42]
 done_criteria: |
   Section 4 of docs/ank-spec-v1.1.md says, before the code moves, that show paints the entity it renders and adds, removes and moves no character, so the byte-for-byte guarantee ADR-01b6dd05f0db states holds for every reader that parses; and its palette table gains the elements that painting uses: the frontmatter fences and keys dim, the value of id yellow, the value of status the colour of its own marker, a markdown heading in the body bold, and the timestamp and author of a log entry dim. A single new method on Style in crates/ank-cli/src/style.rs performs the painting, so every escape byte is still written in style.rs and nowhere else, and human::show calls it in place of writing the text raw. The invariant is asserted rather than assumed: on a fixture carrying a block scalar, a sequence, a --- inside the body, a heading and a log entry with its em-dash, stripping the SGR sequences from the painted form yields the input byte for byte, and painting with PLAIN yields the input byte for byte. show_prints_the_entity_verbatim and show_on_an_adr_stays_verbatim_and_adds_nothing pass with no edit. A test drives show itself at COLOR and asserts its stripped output equals its PLAIN output. The pipe suite through the binary stays green with no edit, show being already in styled_surface, and that is verified rather than assumed.
 criteria_by: creator
 schema: 2
-version: 1
+version: 3
 ---
 
 ## Why
@@ -60,3 +65,7 @@ closed. A quoted title containing a colon. And the em-dash separating a log
 entry's author from its message, which is multi-byte and must never be sliced
 through -- so every cut point is found on an ASCII pattern or by searching for
 the separator whole.
+
+## Log
+- 2026-08-09T03:07:47Z seanl@sean-laptop — amended: +scope crates/ank-cli/src/paint.rs, +scope crates/ank-cli/src/main.rs, +scope crates/ank-cli/src/commands.rs, +scope crates/ank-cli/src/context.rs, +scope crates/ank-cli/tests/cli.rs
+- 2026-08-09T03:08:17Z seanl@sean-laptop — closed: Superseded by a task whose criterion is complete. This one named the module up front -- "a single new method on Style in style.rs" -- and that turned out to prejudge the design badly: the painter has to know what a log line is, which means reaching for ank_core::LogEntry, and style.rs states in its own module doc that it has no dependency, direct or transitive. Worse, the criterion was silent on ank log, which prints the very same log lines through format_line. Painting them under show and not under log would have created the one-fact-two-shapes defect that the sibling task exists to remove. A criterion that ships a defect it did not think to forbid is the wrong criterion, not a criterion to work around.

--- a/.ank/tasks/TASK-bfe1cbd9ec42.md
+++ b/.ank/tasks/TASK-bfe1cbd9ec42.md
@@ -5,7 +5,7 @@ slug: every-status-a-listing-prints-carries-a-colour-a
 title: Every status a listing prints carries a colour, and in_progress is not missing from the table
 created: 2026-08-09T02:57:52Z
 author: seanl@sean-laptop
-status: in_progress
+status: done
 scope:
   - docs/ank-spec-v1.1.md
   - crates/ank-cli/src/style.rs
@@ -13,8 +13,12 @@ blocked_by: []
 done_criteria: |
   Section 4 of docs/ank-spec-v1.1.md declares one colour for every status the CLI can print, and it declares it before the code moves: [open] blue, [in_progress] cyan alongside [claimed:...], [proposed] magenta, [accepted] green and [superseded] dim stated rather than left implied by the transition-word rule, and [blocked] struck from the table because nothing emits it. state_sgr in crates/ank-cli/src/style.rs is the only function that changes, it returns a colour for every one of those states, and no status the CLI prints reaches a reader unstyled. [open expired:who] is still yellow. Every escape byte is still written in style.rs and nowhere else. The table test in style.rs enumerates the new table state by state rather than spot-checking it, and asserts through the status and landed accessors both, so a second table that happened to agree today would not pass. The whole integration suite through the binary stays green with no edit: no escape sequence reaches a pipe, and the colour of a status is unit-tested because a spawned binary writes to a pipe and can never observe it.
 criteria_by: creator
+proof:
+  - type: test
+    ref: "31291756290"
+    criteria: 0e4bf5f40617
 schema: 2
-version: 3
+version: 4
 ---
 
 ## Why
@@ -62,3 +66,4 @@ task, because it means `find`, `scope` and `graph` reading the claim refs.
 The model-driven test is the one that matters. It reads the variants through a match rather than a typed array, so adding a variant to TaskStatus or AdrStatus stops it compiling. A bare list would have gone stale in silence, and going stale in silence is precisely how in_progress came to be absent from the table: TASK-4601ed18d84e verified the palette covered every verb, and nothing verified it covered every status.
 
 Also struck [blocked] from section 4. It was in the table and in state_sgr and nothing has ever emitted it -- blocked is derived from blocked_by at read time, never stored, so no listing can print it. A dead row in a table that is meant to be checkable is worse than an omission.
+- 2026-08-09T03:10:11Z seanl@sean-laptop — done, proof test:31291756290

--- a/.ank/tasks/TASK-bfe1cbd9ec42.md
+++ b/.ank/tasks/TASK-bfe1cbd9ec42.md
@@ -1,0 +1,64 @@
+---
+id: TASK-bfe1cbd9ec42
+type: task
+slug: every-status-a-listing-prints-carries-a-colour-a
+title: Every status a listing prints carries a colour, and in_progress is not missing from the table
+created: 2026-08-09T02:57:52Z
+author: seanl@sean-laptop
+status: in_progress
+scope:
+  - docs/ank-spec-v1.1.md
+  - crates/ank-cli/src/style.rs
+blocked_by: []
+done_criteria: |
+  Section 4 of docs/ank-spec-v1.1.md declares one colour for every status the CLI can print, and it declares it before the code moves: [open] blue, [in_progress] cyan alongside [claimed:...], [proposed] magenta, [accepted] green and [superseded] dim stated rather than left implied by the transition-word rule, and [blocked] struck from the table because nothing emits it. state_sgr in crates/ank-cli/src/style.rs is the only function that changes, it returns a colour for every one of those states, and no status the CLI prints reaches a reader unstyled. [open expired:who] is still yellow. Every escape byte is still written in style.rs and nowhere else. The table test in style.rs enumerates the new table state by state rather than spot-checking it, and asserts through the status and landed accessors both, so a second table that happened to agree today would not pass. The whole integration suite through the binary stays green with no edit: no escape sequence reaches a pipe, and the colour of a status is unit-tested because a spawned binary writes to a pipe and can never observe it.
+criteria_by: creator
+schema: 2
+version: 3
+---
+
+## Why
+
+TASK-4601ed18d84e verified that the palette covered every verb. Nobody verified
+that it covered every status, and it does not.
+
+state_sgr falls through to None on three states. Two of them are deliberate --
+section 4 says `[open] | default` in as many words -- but the third is not:
+`in_progress` appears nowhere, not in the table and not in the code. So one
+task renders cyan `[claimed:who]` under `context`, which reads the claim refs,
+and unstyled `[in_progress]` under `find`, `scope`, `graph` and `show`'s edge
+sections, which read the index. One fact, two colours, decided by which verb
+the reader happened to type.
+
+## What is being decided, and what is not
+
+Giving `[open]` a colour is a change to section 4, not a patch to a table in
+the code: ADR-0c8ab846d262 binds the palette to the specification, and the
+specification is what moves first. No new ADR is needed -- 0c8a already decided
+that colour is a property of the reader, and this only fills in the table it
+governs.
+
+Blue and magenta are the two remaining base colours. Spending them here closes
+the palette: after this, no status is without a colour and no base colour is
+unassigned, which is a property a reader can check rather than a list they have
+to remember.
+
+## Consequence to expect, not to fix
+
+`release` prints `released TASK-x -> open` through landed(), which reads the
+same table. Its `open` becomes blue. That is section 4's rule holding -- the
+state a transition lands on takes exactly the colour its bracketed marker takes
+-- and not a regression to undo.
+
+## Follow-on
+
+`[in_progress]` and `[claimed:who]` will still be two different strings after
+this task; only their colour is unified here. Unifying the text is its own
+task, because it means `find`, `scope` and `graph` reading the claim refs.
+
+## Log
+- 2026-08-09T03:03:45Z seanl@sean-laptop — Falsified the two table tests before trusting them: dropping the `open` arm from state_sgr turns both red with the message each was written to give -- "the marker [open] is not the colour section 4 gives it" and "open reaches a reader with no colour". Restored, 325 green.
+
+The model-driven test is the one that matters. It reads the variants through a match rather than a typed array, so adding a variant to TaskStatus or AdrStatus stops it compiling. A bare list would have gone stale in silence, and going stale in silence is precisely how in_progress came to be absent from the table: TASK-4601ed18d84e verified the palette covered every verb, and nothing verified it covered every status.
+
+Also struck [blocked] from section 4. It was in the table and in state_sgr and nothing has ever emitted it -- blocked is derived from blocked_by at read time, never stored, so no listing can print it. A dead row in a table that is meant to be checkable is worse than an omission.

--- a/crates/ank-cli/src/commands.rs
+++ b/crates/ank-cli/src/commands.rs
@@ -854,7 +854,12 @@ pub fn find(
     // indistinguishable from any other claimed one — `[claimed:who]` says who,
     // and the reader has to recognise their own identity to answer "is that
     // mine".
-    let held = held_by(&repo.root, identity)?.map(|(id, _, _)| id);
+    // One read of the coordination plane, and it answers both questions this
+    // listing has: which row the caller holds, and what every row's marker
+    // says. It replaces the enumeration `held_by` already performed here and
+    // threw all but one answer away, so the listing pays no more than before.
+    let coord = crate::context::coordination(&repo.root, &mut Vec::new())?;
+    let held = crate::context::held_in(&coord, identity);
     for r in &hits[..shown] {
         let short = shorts
             .get(&r.id)
@@ -865,7 +870,10 @@ pub fn find(
             "{}{}  {} {}",
             marker_of(&held, &r.id),
             style.id(&short),
-            style.status(&format!("[{}]", r.status)),
+            style.status(&crate::context::marker_for(
+                &r.status,
+                crate::context::coordination_of(&coord, &r.id)
+            )),
             r.title
         );
     }
@@ -967,7 +975,10 @@ pub fn scope(inv: &Invocation, repo: &Repo, identity: &str, out: &mut dyn Write)
         return Ok(0);
     }
     let style = inv.style();
-    let held = held_by(&repo.root, identity)?.map(|(id, _, _)| id);
+    // One read, both answers, exactly as in `find`: the two listings print the
+    // same rows and must print them with the same words.
+    let coord = crate::context::coordination(&repo.root, &mut Vec::new())?;
+    let held = crate::context::held_in(&coord, identity);
     for (label, group) in [("ADR", &adrs), ("TASKS", &tasks)] {
         if group.is_empty() {
             continue;
@@ -987,7 +998,10 @@ pub fn scope(inv: &Invocation, repo: &Repo, identity: &str, out: &mut dyn Write)
                 "{}{}  {} {}",
                 marker_of(&held, &r.id),
                 style.id(&short),
-                style.status(&format!("[{}]", r.status)),
+                style.status(&crate::context::marker_for(
+                    &r.status,
+                    crate::context::coordination_of(&coord, &r.id)
+                )),
                 r.title
             );
         }

--- a/crates/ank-cli/src/commands.rs
+++ b/crates/ank-cli/src/commands.rs
@@ -1184,8 +1184,11 @@ fn log_read(inv: &Invocation, store: &Store, id: &EntityId, out: &mut dyn Write)
     let _ = writeln!(out);
     for e in &entries {
         // The section's own formatter, so the printed line and the stored line
-        // cannot drift into two shapes for one thing.
-        let _ = writeln!(out, "{}", e.format_line());
+        // cannot drift into two shapes for one thing — and painted through the
+        // same function `show` uses, for the same reason applied to the two
+        // verbs: `show` prints this line too, and one line must not read one
+        // way here and another there.
+        let _ = writeln!(out, "{}", crate::paint::log_line(e, inv.style()));
     }
     Ok(0)
 }

--- a/crates/ank-cli/src/context.rs
+++ b/crates/ank-cli/src/context.rs
@@ -84,7 +84,13 @@ impl Coordination {
 /// is right to call it a hard error, because it is about to write there;
 /// `context` is a reader, and refusing to describe the corpus because one ref
 /// is damaged would be the opposite of degrading gracefully.
-fn coordination(
+///
+/// Shared with the listing verbs rather than kept here: `find`, `scope`, `graph`
+/// and `show` present the same tasks and must present them with the same words.
+/// A listing has no channel for a warning and passes an empty vector — `check`
+/// is what reports a damaged ref, and a reader must not fail for having nothing
+/// to say about one.
+pub(crate) fn coordination(
     cwd: &std::path::Path,
     warnings: &mut Vec<String>,
 ) -> Result<HashMap<EntityId, Coordination>> {
@@ -332,10 +338,7 @@ pub fn build(
 
     // HEAD is derived, never stored: the task on which this agent holds a
     // claim that has not lapsed.
-    let head = coord.iter().find_map(|(id, state)| match state {
-        Coordination::Claimed { holder, .. } if holder == identity => Some(id.clone()),
-        _ => None,
-    });
+    let head = held_in(&coord, identity);
 
     match head {
         Some(id) => build_execution(&store, repo, &index, &shorts, &coord, id, warnings),
@@ -600,7 +603,20 @@ fn build_execution(
 // ---------------------------------------------------------------------------
 
 fn marker(t: &TaskLine) -> String {
-    match &t.coordination {
+    marker_for(&t.status, &t.coordination)
+}
+
+/// The bracketed marker a row carries, from its stored status and what the
+/// coordination plane says about it.
+///
+/// One function for every verb that prints one. `context` reads the claim refs
+/// and used to be the only listing that did, so the same task read
+/// `[claimed:who]` here and `[in_progress]` under `find`, `scope`, `graph` and
+/// `show` — one fact wearing two words, chosen by whichever verb the reader
+/// happened to type. The words are the file's and the ref's, and the ref is the
+/// one that knows whether anybody is actually on it.
+pub(crate) fn marker_for(status: &str, coordination: &Coordination) -> String {
+    match coordination {
         Coordination::Claimed { holder, .. } => format!("[claimed:{holder}]"),
         Coordination::Finished { commit, branch } => {
             let c: String = commit.chars().take(7).collect();
@@ -612,9 +628,34 @@ fn marker(t: &TaskLine) -> String {
         // A lapsed claim leaves the file `in_progress` and the task takeable.
         // Saying so is the point: the log tells the next agent where the
         // previous one stopped.
-        Coordination::Lapsed { holder } => format!("[{} expired:{holder}]", t.status),
-        Coordination::Free => format!("[{}]", t.status),
+        Coordination::Lapsed { holder } => format!("[{status} expired:{holder}]"),
+        Coordination::Free => format!("[{status}]"),
     }
+}
+
+/// The plane says nothing about most entities: no ADR carries a claim ref, and
+/// neither does a task nobody has touched.
+static FREE: Coordination = Coordination::Free;
+
+/// What the coordination plane says about one id, or `Free` when it says
+/// nothing.
+pub(crate) fn coordination_of<'a>(
+    map: &'a HashMap<EntityId, Coordination>,
+    id: &EntityId,
+) -> &'a Coordination {
+    map.get(id).unwrap_or(&FREE)
+}
+
+/// The task this identity holds, out of a coordination map already read.
+///
+/// HEAD is derived, never stored. Shared so that a listing marking the caller's
+/// own row and `context` switching to execution mode cannot disagree about
+/// whose task it is.
+pub(crate) fn held_in(map: &HashMap<EntityId, Coordination>, identity: &str) -> Option<EntityId> {
+    map.iter().find_map(|(id, state)| match state {
+        Coordination::Claimed { holder, .. } if holder == identity => Some(id.clone()),
+        _ => None,
+    })
 }
 
 /// The end-of-loop message (§5). A normal state, not an error: an agent in a

--- a/crates/ank-cli/src/context.rs
+++ b/crates/ank-cli/src/context.rs
@@ -1355,30 +1355,7 @@ After a blank one."
         );
     }
 
-    /// Strip the SGR sequences back out of a styled render and what is left has
-    /// to be the unstyled render, exactly.
-    ///
-    /// This is the invariant the whole of §4's colour rule rests on, and it is
-    /// stronger than looking at the two outputs: it fails on a doubled paint, on
-    /// an escape landing inside a padded column, on a header styled in one mode
-    /// and not the other, and on the budget spending itself on invisible bytes
-    /// so that a terminal truncates the log one entry earlier than a pipe.
-    fn undo_sgr(s: &str) -> String {
-        let mut out = String::with_capacity(s.len());
-        let mut it = s.chars();
-        while let Some(c) = it.next() {
-            if c == '\x1b' {
-                for c in it.by_ref() {
-                    if c == 'm' {
-                        break;
-                    }
-                }
-            } else {
-                out.push(c);
-            }
-        }
-        out
-    }
+    use crate::style::undo_sgr;
 
     #[test]
     fn colour_changes_the_bytes_and_never_the_content() {
@@ -1396,6 +1373,13 @@ After a blank one."
         ] {
             let plain = render(&view, budget, crate::style::PLAIN);
             let painted = render(&view, budget, crate::style::COLOR);
+            // Asserted before the comparison below: `undo_sgr` strips from both
+            // sides, so a render already carrying an escape would make the
+            // equality hold by mutual destruction.
+            assert!(
+                !plain.contains('\x1b'),
+                "the plain render is not escape-free"
+            );
             assert_ne!(plain, painted, "nothing was painted at all");
             assert!(painted.contains('\x1b'));
             assert_eq!(

--- a/crates/ank-cli/src/graph.rs
+++ b/crates/ank-cli/src/graph.rs
@@ -86,6 +86,9 @@ pub fn run(inv: &Invocation, repo: &Repo, out: &mut dyn Write) -> Result<i32> {
     // also means no root, which would otherwise print a header and nothing
     // under it — so what has not been drawn is drawn flat at the end.
     let style = inv.style();
+    // Read once for the whole forest, never per node: a task claimed by someone
+    // reads the same here as it does under `context`, `find` and `scope`.
+    let coord = context::coordination(&repo.root, &mut Vec::new())?;
     let mut drawn: HashSet<&EntityId> = HashSet::new();
     for root in &roots {
         draw(
@@ -94,6 +97,7 @@ pub fn run(inv: &Invocation, repo: &Repo, out: &mut dyn Write) -> Result<i32> {
             &row_of,
             &shorts,
             &outside_count,
+            &coord,
             "",
             None,
             &mut drawn,
@@ -109,7 +113,7 @@ pub fn run(inv: &Invocation, repo: &Repo, out: &mut dyn Write) -> Result<i32> {
             let _ = writeln!(
                 out,
                 "  {}",
-                line(&row.id, &row_of, &shorts, &outside_count, style)
+                line(&row.id, &row_of, &shorts, &outside_count, &coord, style)
             );
         }
     }
@@ -144,6 +148,7 @@ fn draw<'a>(
     row_of: &HashMap<&'a EntityId, &'a Row>,
     shorts: &HashMap<EntityId, String>,
     outside: &HashMap<&'a EntityId, usize>,
+    coord: &HashMap<EntityId, context::Coordination>,
     prefix: &str,
     last: Option<bool>,
     drawn: &mut HashSet<&'a EntityId>,
@@ -161,7 +166,7 @@ fn draw<'a>(
         let _ = writeln!(
             out,
             "{prefix}{connector}{} (cycle)",
-            line(id, row_of, shorts, outside, style)
+            line(id, row_of, shorts, outside, coord, style)
         );
         return;
     }
@@ -170,7 +175,7 @@ fn draw<'a>(
     let _ = writeln!(
         out,
         "{prefix}{connector}{}{mark}",
-        line(id, row_of, shorts, outside, style)
+        line(id, row_of, shorts, outside, coord, style)
     );
     if repeat {
         return;
@@ -193,6 +198,7 @@ fn draw<'a>(
             row_of,
             shorts,
             outside,
+            coord,
             &child_prefix,
             Some(i + 1 == children.len()),
             drawn,
@@ -209,6 +215,7 @@ fn line<'a>(
     row_of: &HashMap<&'a EntityId, &'a Row>,
     shorts: &HashMap<EntityId, String>,
     outside: &HashMap<&'a EntityId, usize>,
+    coord: &HashMap<EntityId, context::Coordination>,
     style: crate::style::Style,
 ) -> String {
     let short = shorts.get(id).cloned().unwrap_or_else(|| id.to_string());
@@ -218,7 +225,10 @@ fn line<'a>(
     let mut s = format!(
         "{}  {} {}",
         style.id(&short),
-        style.status(&format!("[{}]", row.status)),
+        style.status(&context::marker_for(
+            &row.status,
+            context::coordination_of(coord, id)
+        )),
         row.title
     );
     // Never silently a root. A task held up by something the perimeter excludes

--- a/crates/ank-cli/src/human.rs
+++ b/crates/ank-cli/src/human.rs
@@ -2298,7 +2298,11 @@ pub fn show(inv: &Invocation, repo: &Repo, out: &mut dyn Write) -> Result<i32> {
             json_str(&text)
         );
     } else if !inv.quiet() {
-        let _ = write!(out, "{text}");
+        // Painted here and not above: `--json` carries the entity as data and
+        // must keep receiving `text` itself. `cli::dispatch` already forces the
+        // style to PLAIN under `--json`, so this is the second of two
+        // independent guards rather than the only one.
+        let _ = write!(out, "{}", crate::paint::entity(&text, inv.style()));
         if let Some((blocked_by, unblocks)) = &edges {
             edge_section(out, "BLOCKED BY", blocked_by, inv.style());
             edge_section(out, "UNBLOCKS", unblocks, inv.style());
@@ -4285,6 +4289,51 @@ mod tests {
             out,
             std::fs::read_to_string(t.store().path_of(&id)).unwrap()
         );
+    }
+
+    /// The end-to-end half of the painter's invariant. `paint`'s own tests
+    /// prove the scan; this proves the wiring — that `show` calls it, that
+    /// calling it moved nothing, and that `--json` was left out of it.
+    #[test]
+    fn show_paints_the_entity_and_moves_nothing() {
+        let t = Temp::new();
+        t.write(&task("000000000001", TaskStatus::Open, &[]));
+        t.write(&adr("00000000aaaa", AdrStatus::Accepted, &["src/**"]));
+        let repo = t.repo();
+
+        let render = |args: &[&str], style: crate::style::Style| {
+            let argv: Vec<String> = args.iter().map(|a| a.to_string()).collect();
+            let mut inv = crate::cli::parse(&argv).unwrap();
+            inv.style = style;
+            let mut out = Vec::new();
+            show(&inv, &repo, &mut out).unwrap();
+            String::from_utf8(out).unwrap()
+        };
+
+        // Qualified: both entities live in this repo, and a bare `0000` is
+        // ambiguous across the two kinds.
+        for id in ["TASK-0000", "ADR-0000"] {
+            let plain = render(&["show", id], crate::style::PLAIN);
+            let painted = render(&["show", id], crate::style::COLOR);
+            // Asserted before the comparison: `undo_sgr` strips both sides.
+            assert!(
+                !plain.contains('\x1b'),
+                "the plain render carries an escape"
+            );
+            assert_ne!(painted, plain, "show did not paint {id}");
+            assert_eq!(
+                crate::style::undo_sgr(&painted),
+                plain,
+                "colour moved the content of {id}"
+            );
+        }
+
+        // The style is forced to COLOR here rather than left to dispatch, which
+        // would have set it to PLAIN: what is under test is that `show` itself
+        // keeps the machine surface out of the painting, not that something
+        // upstream happens to.
+        let json = render(&["show", "TASK-0000", "--json"], crate::style::COLOR);
+        assert!(!json.contains('\x1b'), "--json was painted: {json}");
     }
 
     #[test]

--- a/crates/ank-cli/src/human.rs
+++ b/crates/ank-cli/src/human.rs
@@ -2320,7 +2320,13 @@ pub fn show(inv: &Invocation, repo: &Repo, out: &mut dyn Write) -> Result<i32> {
 struct Edge {
     id: EntityId,
     short: String,
+    /// The stored status, and only ever that: it is what `--json` carries, and
+    /// the machine surface does not move because a human listing learned to say
+    /// something better.
     status: Option<String>,
+    /// What the human line prints — the stored status seen through the
+    /// coordination plane, brackets included.
+    marker: Option<String>,
     title: Option<String>,
 }
 
@@ -2337,6 +2343,10 @@ fn edges_of(repo: &Repo, task: &Task) -> Result<(Vec<Edge>, Vec<Edge>)> {
     let ids: Vec<EntityId> = all.iter().map(|r| r.id.clone()).collect();
     let shorts = crate::context::short_ids(&ids);
     let row_of: HashMap<&EntityId, &crate::index::Row> = all.iter().map(|r| (&r.id, r)).collect();
+    // The same coordination every other listing reads, so a blocker that is
+    // claimed says so here too instead of reading `[in_progress]` at a reader
+    // who has just been told `[claimed:who]` by `context`.
+    let coord = crate::context::coordination(&repo.root, &mut Vec::new())?;
 
     let edge = |id: &EntityId| -> Edge {
         let row = row_of.get(id);
@@ -2344,6 +2354,11 @@ fn edges_of(repo: &Repo, task: &Task) -> Result<(Vec<Edge>, Vec<Edge>)> {
             id: id.clone(),
             short: shorts.get(id).cloned().unwrap_or_else(|| id.to_string()),
             status: row.map(|r| r.status.clone()),
+            // The whole marker, brackets included, because it is the marker
+            // that varies and not just the word inside it.
+            marker: row.map(|r| {
+                crate::context::marker_for(&r.status, crate::context::coordination_of(&coord, id))
+            }),
             title: row.map(|r| r.title.clone()),
         }
     };
@@ -2380,13 +2395,13 @@ fn edge_section(out: &mut dyn Write, heading: &str, edges: &[Edge], style: crate
         } else {
             crate::style::glyph::BRANCH
         };
-        match (&e.status, &e.title) {
-            (Some(status), Some(title)) => {
+        match (&e.marker, &e.title) {
+            (Some(marker), Some(title)) => {
                 let _ = writeln!(
                     out,
                     "{connector}{}  {} {title}",
                     style.id(&e.short),
-                    style.status(&format!("[{status}]"))
+                    style.status(marker)
                 );
             }
             _ => {

--- a/crates/ank-cli/src/main.rs
+++ b/crates/ank-cli/src/main.rs
@@ -19,6 +19,7 @@ mod config;
 mod git;
 mod identity;
 mod init;
+mod paint;
 mod repo;
 mod store;
 mod style;

--- a/crates/ank-cli/src/paint.rs
+++ b/crates/ank-cli/src/paint.rs
@@ -1,0 +1,392 @@
+//! The entity `show` prints, lit for a reader at a terminal (§4).
+//!
+//! `show` is the one command that does not summarise: it returns the entity
+//! byte for byte (ADR-01b6dd05f0db). This module keeps that true and still
+//! gives a human hierarchy, by emitting nothing but escape sequences. An escape
+//! occupies no column, so stripping the escapes from what this writes yields
+//! the byte sequence `show` wrote before it existed — same characters, same
+//! order, nothing aligned, nothing re-indented. The file is not re-laid-out for
+//! a human: ADR-0c8ab846d262 already refused to give one corpus two shapes.
+//!
+//! **No escape sequence is written here.** The palette stays in
+//! [`crate::style`] and this module only calls its accessors, so the rule
+//! TASK-4601ed18d84e set — every escape byte is written in `style.rs` and
+//! nowhere else — is literally true and is asserted by a test that reads the
+//! crate's own sources.
+//!
+//! **Presentation only.** Nothing here is ever parsed, written to disk, or fed
+//! to §5's attention budget. A painted string reaching `Store::write` would be
+//! a corrupted corpus, and `#![allow(dead_code)]` at the crate root means a
+//! misuse would not warn.
+
+use crate::style::Style;
+use ank_core::log::LOG_HEADER;
+use ank_core::LogEntry;
+
+/// A serialized entity, painted.
+///
+/// Returns its input untouched when the style is off, and that early return is
+/// the load-bearing line of the module: a pipe is safe by construction rather
+/// than by the scan below being correct. No defect in the scan can reach an
+/// agent, because the scan does not run for one.
+pub fn entity(text: &str, style: Style) -> String {
+    if !style.enabled() {
+        return text.to_string();
+    }
+
+    // The frontmatter bound is ank_core's, replicated rather than invented:
+    // `parse::split_frontmatter` strips `---\n` and takes the *first*
+    // `\n---\n`. Using the same rule is what stops the painter and the parser
+    // disagreeing about where the body starts — and it means a `---` in the
+    // body is outside the region and can never be read as a fence.
+    let Some(rest) = text.strip_prefix("---\n") else {
+        return text.to_string();
+    };
+    let Some(end) = rest.find("\n---\n") else {
+        return text.to_string();
+    };
+    let (frontmatter, body) = text.split_at("---\n".len() + end + "\n---\n".len());
+
+    let mut out = String::with_capacity(text.len() + 256);
+    for chunk in frontmatter.split_inclusive('\n') {
+        let (content, terminator) = split_terminator(chunk);
+        out.push_str(&frontmatter_line(content, style));
+        out.push_str(terminator);
+    }
+    let mut in_log = false;
+    let mut in_code = false;
+    for chunk in body.split_inclusive('\n') {
+        let (content, terminator) = split_terminator(chunk);
+        out.push_str(&body_line(content, style, &mut in_log, &mut in_code));
+        out.push_str(terminator);
+    }
+    out
+}
+
+/// One `## Log` line, painted: the addressing recedes, the message does not.
+///
+/// `log_line(e, PLAIN) == e.format_line()`, always — `log` prints through here
+/// too, because the two verbs print the same line and one line must not have
+/// two shapes.
+pub fn log_line(e: &LogEntry, style: Style) -> String {
+    let line = e.format_line();
+    if !style.enabled() {
+        return line;
+    }
+    // The prefix is the whole line but its message, derived by length rather
+    // than by searching for the separator: the message is a suffix of the
+    // formatted line by construction, so this cannot drift if ank_core ever
+    // changes what the separator is, and the cut is a character boundary
+    // whatever the message contains — including another em-dash.
+    let cut = line.len() - e.message.len();
+    format!("{}{}", style.key(&line[..cut]), &line[cut..])
+}
+
+/// Splits a chunk from `split_inclusive` into its content and its terminator,
+/// so that a missing final newline and a lone `\r` both survive untouched.
+fn split_terminator(chunk: &str) -> (&str, &str) {
+    if let Some(c) = chunk.strip_suffix("\r\n") {
+        return (c, "\r\n");
+    }
+    if let Some(c) = chunk.strip_suffix('\n') {
+        return (c, "\n");
+    }
+    (chunk, "")
+}
+
+fn frontmatter_line(content: &str, style: Style) -> String {
+    if content == "---" {
+        return style.key(content);
+    }
+    let Some((key, rest)) = key_split(content) else {
+        return content.to_string();
+    };
+    let value = rest.trim_start();
+    if value.is_empty() {
+        // `scope:`, `proof:`, `blocked_by:` with nothing on the line. Only the
+        // key is there to paint.
+        return format!("{}{}", style.key(key), rest);
+    }
+    let painted = match key {
+        // §4 gives identifiers one colour wherever they appear.
+        "id:" | "supersedes:" => style.id(value),
+        // Through `landed`, not `green`: the same table `[done]` reads, so the
+        // status at the top of a file and the marker in a listing are one fact
+        // seen twice and cannot drift into two colours.
+        "status:" => style.landed(value),
+        _ => value.to_string(),
+    };
+    let padding = &rest[..rest.len() - value.len()];
+    format!("{}{}{}", style.key(key), padding, painted)
+}
+
+/// A frontmatter key and the rest of its line, or `None` when the line is not a
+/// key at all.
+///
+/// The test is entirely positional, and that is what lets this module do
+/// without a state machine: in canonical output every key sits at column 0, and
+/// every block-scalar continuation, sequence item and nested key is indented by
+/// at least two (`parse::emit_block`, `emit_scope`). So a `done_criteria` whose
+/// own text contains a line reading `status: done` is indented, is therefore
+/// not a key, and is left alone.
+fn key_split(content: &str) -> Option<(&str, &str)> {
+    if !content.starts_with(|c: char| c.is_ascii_lowercase()) {
+        return None;
+    }
+    for (i, c) in content.char_indices() {
+        // ASCII throughout, so `split_at` is always on a character boundary.
+        if c == ':' {
+            return Some(content.split_at(i + 1));
+        }
+        if !(c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_') {
+            return None;
+        }
+    }
+    None
+}
+
+fn body_line(content: &str, style: Style, in_log: &mut bool, in_code: &mut bool) -> String {
+    // A fenced block is emitted whole. No entity in the corpus carries one
+    // today; this is what stops a `# comment` inside a shell example being
+    // bolded the day one does.
+    if content.trim_start().starts_with("```") {
+        *in_code = !*in_code;
+        return content.to_string();
+    }
+    if *in_code {
+        return content.to_string();
+    }
+    if is_heading(content) {
+        // The same test `parse_log` applies, so `show` and `log` agree about
+        // where the log section starts and where a later heading ends it.
+        *in_log = content.trim_end() == LOG_HEADER;
+        return style.header(content);
+    }
+    if *in_log {
+        if let Some(e) = LogEntry::parse_line(content) {
+            return log_line(&e, style);
+        }
+    }
+    content.to_string()
+}
+
+/// An ATX heading: one to six `#` followed by a space.
+fn is_heading(content: &str) -> bool {
+    let hashes = content.bytes().take_while(|b| *b == b'#').count();
+    (1..=6).contains(&hashes) && content.as_bytes().get(hashes) == Some(&b' ')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::style::{undo_sgr, COLOR, PLAIN};
+
+    /// A task carrying every shape the scan has to survive: a block scalar
+    /// whose own text contains a `status:` line and a log-shaped line, a
+    /// sequence, a quoted title with a colon, a `---` in the body, and a log
+    /// entry whose message contains the same separator its prefix uses.
+    fn task() -> String {
+        concat!(
+            "---\n",
+            "id: TASK-000000000001\n",
+            "type: task\n",
+            "title: \"A title: with a colon\"\n",
+            "status: done\n",
+            "scope:\n",
+            "  - crates/ank-cli/src/paint.rs\n",
+            "done_criteria: |\n",
+            "  The file says status: open and nothing here is a key.\n",
+            "  - 2026-08-08T10:00:00Z someone@host — this is not a log entry\n",
+            "supersedes: ADR-000000000002\n",
+            "schema: 2\n",
+            "---\n",
+            "## Context\n",
+            "\n",
+            "Prose, and a rule below that is not a fence:\n",
+            "\n",
+            "---\n",
+            "\n",
+            "## Log\n",
+            "- 2026-08-08T10:00:00Z claude-code@ank — a message — with a separator\n",
+            "- 2026-08-08T11:00:00Z claude-code@ank — plain\n",
+        )
+        .to_string()
+    }
+
+    fn adr() -> String {
+        concat!(
+            "---\n",
+            "id: ADR-000000000002\n",
+            "type: adr\n",
+            "status: accepted\n",
+            "constraint: |\n",
+            "  A constraint that mentions --- and status: proposed inside itself.\n",
+            "---\n",
+            "## Decision\n",
+            "\n",
+            "Text.\n"
+        )
+        .to_string()
+    }
+
+    /// No trailing newline, and no frontmatter at all: both must come back
+    /// exactly as they went in.
+    fn oddities() -> Vec<String> {
+        vec![
+            "not an entity at all\n".to_string(),
+            "---\nid: TASK-000000000001\nunterminated frontmatter\n".to_string(),
+            "---\nid: TASK-000000000001\n---\nbody with no final newline".to_string(),
+        ]
+    }
+
+    fn fixtures() -> Vec<String> {
+        let mut all = vec![task(), adr()];
+        all.extend(oddities());
+        all
+    }
+
+    #[test]
+    fn plain_is_the_identity_for_every_shape() {
+        for t in fixtures() {
+            assert_eq!(entity(&t, PLAIN), t, "PLAIN moved something");
+        }
+    }
+
+    #[test]
+    fn colour_changes_the_bytes_and_never_the_content() {
+        for t in fixtures() {
+            // Asserted before the comparison: `undo_sgr` strips from both
+            // sides, so a fixture carrying an escape of its own would make the
+            // equality below hold by mutual destruction.
+            assert!(!t.contains('\x1b'), "the fixture is not escape-free");
+            let painted = entity(&t, COLOR);
+            assert_eq!(undo_sgr(&painted), t, "colour moved the content");
+        }
+    }
+
+    #[test]
+    fn a_real_entity_is_actually_painted() {
+        // The other direction of the test above, which would otherwise pass on
+        // a function that returned its input.
+        for t in [task(), adr()] {
+            let painted = entity(&t, COLOR);
+            assert_ne!(painted, t, "nothing was painted at all");
+        }
+    }
+
+    #[test]
+    fn a_file_that_is_not_canonical_is_returned_untouched() {
+        for t in oddities().iter().take(2) {
+            assert_eq!(entity(t, COLOR), *t);
+        }
+    }
+
+    #[test]
+    fn every_run_closes_and_none_nests() {
+        // `undo_sgr` equality alone would not catch a nested paint: the inner
+        // reset clears the outer attribute, so a terminal silently drops it
+        // while the stripped text still matches.
+        for t in [task(), adr()] {
+            let painted = entity(&t, COLOR);
+            let mut open = false;
+            let mut it = painted.chars();
+            while let Some(c) = it.next() {
+                if c != '\x1b' {
+                    continue;
+                }
+                let mut sgr = String::new();
+                for c in it.by_ref() {
+                    if c == 'm' {
+                        break;
+                    }
+                    sgr.push(c);
+                }
+                let is_reset = sgr == "[0";
+                assert_ne!(
+                    is_reset, !open,
+                    "a run opened inside another, or closed twice"
+                );
+                open = !is_reset;
+            }
+            assert!(!open, "a run was left open");
+        }
+    }
+
+    #[test]
+    fn a_block_scalar_is_never_read_as_frontmatter() {
+        let painted = entity(&task(), COLOR);
+        for line in painted.lines() {
+            if line.contains("nothing here is a key") || line.contains("not a log entry") {
+                assert!(
+                    !line.contains('\x1b'),
+                    "a block scalar was painted: {line:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn a_rule_in_the_body_is_not_a_fence() {
+        let painted = entity(&task(), COLOR);
+        // The two frontmatter fences are painted; the body's rule is not, so
+        // exactly two of the three `---` lines carry an escape.
+        let fences = painted
+            .lines()
+            .filter(|l| l.contains("---") && l.contains('\x1b'))
+            .count();
+        assert_eq!(fences, 2, "the body's rule was read as a fence");
+    }
+
+    #[test]
+    fn the_status_value_reads_the_marker_table() {
+        let painted = entity(&task(), COLOR);
+        assert!(
+            painted.contains(&COLOR.landed("done")),
+            "the status value is not painted from the marker table"
+        );
+    }
+
+    #[test]
+    fn a_log_line_survives_its_em_dash() {
+        for line in task().lines().filter(|l| l.starts_with("- 2026")) {
+            let e = LogEntry::parse_line(line).expect("fixture is a log line");
+            // The round-trip the painter relies on: it rebuilds the line from
+            // the parsed parts rather than slicing near the em-dash.
+            assert_eq!(e.format_line(), line);
+            assert_eq!(log_line(&e, PLAIN), line);
+            assert_eq!(undo_sgr(&log_line(&e, COLOR)), line);
+            // The message keeps its own separator and stays out of the dim run.
+            assert!(log_line(&e, COLOR).ends_with(&e.message));
+        }
+    }
+
+    /// The rule TASK-4601ed18d84e set, turned from an intention into an
+    /// assertion: `style.rs` is the only source file that writes an escape.
+    #[test]
+    fn style_is_the_only_module_that_writes_an_escape() {
+        let src = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        // The opener as it appears in source, not the byte itself — no source
+        // file contains a literal escape. The bracket is part of the needle on
+        // purpose: it is what distinguishes *writing* a sequence from merely
+        // looking for one, which several test modules legitimately do.
+        //
+        // Assembled rather than written whole, so this test's own source does
+        // not contain the thing it forbids. It failed on itself first.
+        let needle = String::from("\\") + "x1b[";
+        for entry in std::fs::read_dir(&src).expect("src is readable") {
+            let path = entry.expect("entry").path();
+            if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+                continue;
+            }
+            if path.file_name().and_then(|f| f.to_str()) == Some("style.rs") {
+                continue;
+            }
+            let text = std::fs::read_to_string(&path).expect("source is readable");
+            assert!(
+                !text.contains(needle.as_str()),
+                "{} writes an escape sequence; the palette is style.rs and nowhere else",
+                path.display()
+            );
+        }
+    }
+}

--- a/crates/ank-cli/src/style.rs
+++ b/crates/ank-cli/src/style.rs
@@ -1,7 +1,7 @@
 //! ANSI styling, and the whole of it (§4, ADR-962c25797569).
 //!
 //! Every escape sequence this binary can emit is written here, in one table of
-//! six codes. That is deliberate: color is presentation, and presentation
+//! eight codes. That is deliberate: color is presentation, and presentation
 //! scattered across twelve verb modules is presentation nobody can audit. A
 //! reader asking "can `ank` put an escape sequence in my pipe" reads this file
 //! and no other.
@@ -76,7 +76,7 @@ impl Style {
         }
     }
 
-    // The six codes, and the whole of them.
+    // The eight codes, and the whole of them.
 
     pub fn bold(&self, s: &str) -> String {
         self.paint("1", s)
@@ -95,6 +95,12 @@ impl Style {
     }
     pub fn cyan(&self, s: &str) -> String {
         self.paint("36", s)
+    }
+    pub fn blue(&self, s: &str) -> String {
+        self.paint("34", s)
+    }
+    pub fn magenta(&self, s: &str) -> String {
+        self.paint("35", s)
     }
 
     // Semantic names for the elements §4 names. A call site says what it is
@@ -192,8 +198,17 @@ fn state_sgr(state: &str) -> Option<&'static str> {
     }
     match state.split(':').next().unwrap_or(state) {
         "done" | "finished" | "accepted" => Some("32"),
-        "claimed" => Some("36"),
-        "closed" | "blocked" | "superseded" => Some("2"),
+        // One state seen twice: `in_progress` is what the file says, `claimed`
+        // is what the ref says. A reader who sees them in two colours has to
+        // learn that they are the same fact; a reader who sees one colour does
+        // not.
+        "claimed" | "in_progress" => Some("36"),
+        "closed" | "superseded" => Some("2"),
+        "open" => Some("34"),
+        "proposed" => Some("35"),
+        // Nothing else is a status. Returning None here is not a default for a
+        // state the table forgot -- it is the answer for a string that is not a
+        // state at all, and §4 is now checkable against that.
         _ => None,
     }
 }
@@ -291,6 +306,8 @@ mod tests {
         assert_eq!(s.green("x"), "\x1b[32mx\x1b[0m");
         assert_eq!(s.yellow("x"), "\x1b[33mx\x1b[0m");
         assert_eq!(s.cyan("x"), "\x1b[36mx\x1b[0m");
+        assert_eq!(s.blue("x"), "\x1b[34mx\x1b[0m");
+        assert_eq!(s.magenta("x"), "\x1b[35mx\x1b[0m");
         // Every sequence closes. An unreset attribute bleeds into the prompt.
         for painted in [
             s.header("h"),
@@ -318,8 +335,8 @@ mod tests {
             "done",
             "accepted",
             "claimed",
+            "in_progress",
             "closed",
-            "blocked",
             "superseded",
             "open",
             "proposed",
@@ -349,30 +366,94 @@ mod tests {
         }
     }
 
+    /// The table of §4, enumerated rather than sampled.
+    ///
+    /// Expectations are built from the raw accessors, never from an escape
+    /// literal, for the reason `a_landing_state_carries_the_colour_its_marker_carries`
+    /// gives: a literal keeps passing when the meaning underneath it has moved.
     #[test]
     fn the_status_table_is_the_one_section_4_declares() {
         let s = COLOR;
-        assert_eq!(s.status("[done]"), s.green("[done]"));
-        assert_eq!(
-            s.status("[finished:abc1234 on main]"),
-            s.green("[finished:abc1234 on main]")
-        );
-        assert_eq!(s.status("[accepted]"), s.green("[accepted]"));
-        assert_eq!(s.status("[claimed:who@host]"), s.cyan("[claimed:who@host]"));
-        assert_eq!(s.status("[closed]"), s.dim("[closed]"));
-        assert_eq!(s.status("[blocked]"), s.dim("[blocked]"));
-        // Expired wins over the status it expired from, and `[open]` is the
-        // one marker that stays the terminal's own colour.
-        assert_eq!(
-            s.status("[open expired:who@host]"),
-            s.yellow("[open expired:who@host]")
-        );
+        let table: [(&str, fn(&Style, &str) -> String); 10] = [
+            ("open", Style::blue),
+            ("in_progress", Style::cyan),
+            ("claimed:who@host", Style::cyan),
+            ("done", Style::green),
+            ("finished:abc1234 on main", Style::green),
+            ("closed", Style::dim),
+            ("proposed", Style::magenta),
+            ("accepted", Style::green),
+            ("superseded", Style::dim),
+            ("open expired:who@host", Style::yellow),
+        ];
+        for (state, expected) in table {
+            let marker = format!("[{state}]");
+            assert_eq!(
+                s.status(&marker),
+                expected(&s, &marker),
+                "the marker [{state}] is not the colour §4 gives it"
+            );
+            assert_eq!(
+                s.landed(state),
+                expected(&s, state),
+                "the landing {state} is not the colour §4 gives it"
+            );
+        }
+        // Expired wins over the status it expired from, whichever that is —
+        // which is why it is tested from both ends and not only from `open`.
         assert_eq!(
             s.status("[done expired:who@host]"),
             s.yellow("[done expired:who@host]")
         );
-        assert_eq!(s.status("[open]"), "[open]");
-        assert_eq!(s.status("[proposed]"), "[proposed]");
+        // `blocked` is not a status. §4 struck it from the table because it is
+        // derived from `blocked_by` at read time and no entity is ever stored
+        // carrying it, so nothing can print it and it has nothing to colour.
+        assert_eq!(s.status("[blocked]"), "[blocked]");
+    }
+
+    /// The property §4 now states: nothing a listing prints is left at the
+    /// terminal's default.
+    ///
+    /// Driven off the model's own enumerations rather than a list typed here,
+    /// through a match that stops compiling when a variant is added. A bare
+    /// array would have gone stale in silence — which is exactly how
+    /// `in_progress` came to be missing from the table for as long as it was.
+    #[test]
+    fn every_status_the_model_can_hold_has_a_colour() {
+        use ank_core::{AdrStatus, TaskStatus};
+
+        fn task(v: TaskStatus) -> &'static str {
+            match v {
+                TaskStatus::Open
+                | TaskStatus::InProgress
+                | TaskStatus::Done
+                | TaskStatus::Closed => v.as_str(),
+            }
+        }
+        fn adr(v: AdrStatus) -> &'static str {
+            match v {
+                AdrStatus::Proposed | AdrStatus::Accepted | AdrStatus::Superseded => v.as_str(),
+            }
+        }
+
+        let s = COLOR;
+        for state in [
+            task(TaskStatus::Open),
+            task(TaskStatus::InProgress),
+            task(TaskStatus::Done),
+            task(TaskStatus::Closed),
+            adr(AdrStatus::Proposed),
+            adr(AdrStatus::Accepted),
+            adr(AdrStatus::Superseded),
+        ] {
+            let marker = format!("[{state}]");
+            assert_ne!(
+                s.status(&marker),
+                marker,
+                "{state} reaches a reader with no colour"
+            );
+            assert_ne!(s.landed(state), state, "{state} lands with no colour");
+        }
     }
 
     #[test]

--- a/crates/ank-cli/src/style.rs
+++ b/crates/ank-cli/src/style.rs
@@ -213,6 +213,38 @@ fn state_sgr(state: &str) -> Option<&'static str> {
     }
 }
 
+/// Strip the SGR sequences back out of a styled render.
+///
+/// The inverse of the painting, and it lives here because this module owns the
+/// escapes: what strips them and what writes them must agree, and they cannot
+/// agree from two files. Every caller uses it the same way — strip the coloured
+/// render and it has to equal the plain one, exactly — which is the invariant
+/// the whole of §4's colour rule rests on. It is stronger than comparing the
+/// two outputs by eye: it fails on a doubled paint, on an escape landing inside
+/// a padded column, on a header styled in one mode and not the other, and on a
+/// budget spending itself on invisible bytes.
+///
+/// **A caller must assert its input carries no escape of its own first.** This
+/// strips from both sides of a comparison, so a fixture that already contained
+/// one would make the equality hold by mutual destruction.
+#[cfg(test)]
+pub(crate) fn undo_sgr(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut it = s.chars();
+    while let Some(c) = it.next() {
+        if c == '\x1b' {
+            for c in it.by_ref() {
+                if c == 'm' {
+                    break;
+                }
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
 /// The rule of §4, evaluated once per process.
 ///
 /// Three conditions, in the order that costs least: a terminal, then an

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -3767,6 +3767,46 @@ fn a_listing_marks_the_row_the_caller_holds() {
     }
 }
 
+/// One fact, one string, whichever verb prints it.
+///
+/// `context` reads the claim refs and every other listing read the index, so a
+/// claimed task said `[claimed:who]` under one verb and `[in_progress]` under
+/// four others — one state wearing two words, chosen by whichever verb the
+/// reader happened to type. Asserted through the binary because the divergence
+/// was between whole commands and not inside one function: each of these opens
+/// the corpus its own way, and only running them proves they agree.
+#[test]
+fn every_verb_says_the_same_thing_about_a_claimed_task() {
+    let r = color_fixture();
+
+    // `color_fixture` leaves ID claimed by claude-code@ank, and the marker
+    // names the holder whoever is asking — so a stranger reads the same words.
+    let held = format!("[claimed:{}]", "claude-code@ank");
+
+    for args in [
+        vec!["context"],
+        vec!["find", "Example"],
+        vec!["scope", "src"],
+        vec!["graph"],
+        // The reverse edge of the task ID blocks: `show` reaches ID through
+        // another task's `BLOCKED BY`, which is the fourth listing that used to
+        // print the index's word instead.
+        vec!["show", "TASK-000000000002"],
+    ] {
+        let said = stdout(&r.ank("someone-else@ank", &args));
+        assert!(
+            said.contains(&held),
+            "`ank {}` does not say {held}: {said}",
+            args.join(" ")
+        );
+        assert!(
+            !said.contains("[in_progress]"),
+            "`ank {}` still prints the index's word: {said}",
+            args.join(" ")
+        );
+    }
+}
+
 /// The transition grammar of §4, walked through the binary.
 ///
 /// Every one of these lines was bare before TASK-4601ed18d84e, and none of them

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -3636,6 +3636,10 @@ fn styled_surface() -> Vec<Vec<&'static str>> {
         vec!["find", "Example"],
         vec!["find", "nothing-matches-this"],
         vec!["show", ID],
+        // The ADR too: its `constraint` is a block scalar, which is the shape
+        // the entity painter has to walk past without touching, and a task's
+        // `show` alone never reaches it.
+        vec!["show", "ADR-0000000000ab"],
         vec!["log", ID],
         vec!["graph"],
         vec!["scope", "src"],

--- a/docs/ank-spec-v1.1.md
+++ b/docs/ank-spec-v1.1.md
@@ -537,10 +537,12 @@ The palette is small on purpose, and it is bounded here rather than in the code 
 |---|---|
 | section headers: `CONSTRAINTS`, `PROPOSED`, `TASKS`, `DONE_CRITERIA`, `LOG`, `BLOCKED BY`, `UNBLOCKS` | bold |
 | identifiers: `TASK-8ebd`, `ADR-962c` | yellow |
-| `[open]` | default |
-| `[claimed:…]`, `[… expired:…]` | cyan, yellow |
-| `[done]`, `[finished:… on …]` | green |
-| `[closed]`, `[blocked]` | dim |
+| `[open]` | blue |
+| `[in_progress]`, `[claimed:…]` | cyan |
+| `[… expired:…]` | yellow |
+| `[done]`, `[finished:… on …]`, `[accepted]` | green |
+| `[closed]`, `[superseded]` | dim |
+| `[proposed]` | magenta |
 | a transition word that advanced the corpus: `created`, `claimed`, `logged`, `attested`, `amended`, `accepted` | green |
 | a transition word that gave something up: `released`, `closed`, `superseded`, `pruned` | dim |
 | the state a transition landed on: `-> done`, `-> open`, `-> closed` | as its marker above |
@@ -549,6 +551,18 @@ The palette is small on purpose, and it is bounded here rather than in the code 
 | `warning:` and `check`'s `signal:` tag | yellow |
 | a verifier's `ok` / `FAILED` | green / red |
 | the trailing next-command line, `> ank …` | bold |
+
+**Every status carries a color, and every base color is spent.** A task is
+`open`, `in_progress`, `done` or `closed`; an ADR is `proposed`, `accepted` or
+`superseded`; and the two sets read from one table, because `find` and `scope`
+list them side by side and a reader should not have to know which kind a row is
+before knowing what its color means. `in_progress` takes the color `[claimed:…]`
+carries, because they are one state seen twice — from the index, and from
+the ref that claimed it. Nothing is left at the terminal's default, and that is
+what makes the table checkable rather than memorable: a status with no color is
+now a defect, where before it was an omission somebody had to notice. `blocked`
+is absent because it is not a status — it is derived from `blocked_by` at read
+time (§3), and no entity is ever stored carrying it.
 
 **A transition reads the same whichever verb produced it.** Every verb that changes state confirms it in one shape — the word for what happened, the identifier it happened to, and where the entity landed — and the color follows that shape rather than the verb. The word carries the direction, the identifier is yellow like every other identifier, and the landing state takes exactly the color its bracketed marker takes in a listing: `-> done` and `[done]` are the same fact seen twice, and a reader who has learned one has learned the other. This is why the rule is stated as a grammar and not as a list of verbs — `attested` is legible to someone who has only ever run `claim`.
 

--- a/docs/ank-spec-v1.1.md
+++ b/docs/ank-spec-v1.1.md
@@ -551,6 +551,28 @@ The palette is small on purpose, and it is bounded here rather than in the code 
 | `warning:` and `check`'s `signal:` tag | yellow |
 | a verifier's `ok` / `FAILED` | green / red |
 | the trailing next-command line, `> ank …` | bold |
+| the `---` fences and the frontmatter keys of the entity `show` prints | dim |
+| the `id` and `supersedes` values of that frontmatter | yellow |
+| its `status` value | as its marker above |
+| a markdown heading in its body | bold |
+| the `- <timestamp> <who>` prefix of a log entry, under `show` and under `log` | dim |
+
+**`show` paints the entity and moves nothing.** ADR-01b6dd05f0db returns the
+entity byte for byte, and that stays exactly true: an escape sequence occupies
+no column, so stripping the escapes from what `show` writes yields the byte
+sequence it wrote before, character for character, in the same order. Nothing is
+added, removed, aligned or re-indented. The file is not re-laid-out for a human,
+because ADR-0c8ab846d262 already refused to give one corpus two shapes — what
+changes is which of those bytes are lit, and only for a reader who is at a
+terminal. Every reader that parses gets what it always got.
+
+The `status` value is painted from the same table its bracketed marker reads, so
+`status: done` at the top of a file and `[done]` in a listing are one fact seen
+twice, which is the rule the transition grammar below already states. A log
+entry's prefix recedes for the reason `status`'s labels do: the timestamp and
+the author are addressing, and the message is what the reader came for. The
+prefix is painted the same way under `log`, because the two verbs print the same
+line and a line printed twice must not have two shapes.
 
 **Every status carries a color, and every base color is spent.** A task is
 `open`, `in_progress`, `done` or `closed`; an ADR is `proposed`, `accepted` or


### PR DESCRIPTION
Three tasks, each anchored on its own green CI run.

## What was wrong

Two of these were visible; the third was the actual defect and nobody had seen it.

`ank show` wrote the entity with a single `write!`, so a real task file arrived as a uniform wall of text. `[open]` carried no colour — deliberate, section 4 said `default` in as many words. But **`in_progress` appeared nowhere**: not in the specification table, not in `state_sgr`. One claimed task therefore read `[claimed:who]` under `context`, which resolves the claim refs, and `[in_progress]` under `find`, `scope`, `graph` and `show`s edge sections, which read the index. One state, two words and two colours, chosen by whichever verb the reader happened to type.

TASK-4601ed18d84e had verified the palette covered every *verb*. Nothing had verified it covered every *status*.

## What changed

**TASK-bfe1cbd9ec42 — the palette closes.** `[open]` blue, `[in_progress]` cyan beside `[claimed:...]`, `[proposed]` magenta, `[accepted]` and `[superseded]` stated rather than implied. `[blocked]` struck: it sat in the table and in the code and nothing has ever emitted it, because blocked is derived from `blocked_by` at read time and no entity is stored carrying it. Blue and magenta were the two remaining base colours, so the palette is now closed — a property a reader can check instead of a list to remember, and a new test checks it off `TaskStatus` and `AdrStatus` through a match, so adding a variant stops compilation rather than shipping unpainted.

**TASK-20acb18f7013 — `show` paints the entity.** Escapes only, no character added, removed or moved. Re-laying it out was never available: ADR-01b6dd05f0db returns the entity byte for byte and `skill/SKILL.md` repeats it under a frozen revision hash, and laying it out only at a terminal is the option ADR-0c8ab846d262 examined and rejected in writing. The painter is its own module, writes no escape of its own, and returns its input untouched when style is off — so a pipe is safe by construction rather than by the scan being correct. `ank log` moves with it, because it prints the same lines through the same formatter.

**TASK-a015e74735c5 — one coordination string.** The four listings now build their marker through `context::marker_for`, the function `context` already used. It costs nothing new: `find` and `scope` already enumerated `refs/ank/claims/*` through `held_by` and discarded every answer but the callers own.

## How it was verified

- The built binary and the published 0.1.3 print **byte-identical** output for `ank show` into a pipe: 2799 bytes each, zero escapes.
- Forcing `style::COLOR` unconditionally in dispatch turns **17 integration tests red**, so the escape-free-pipe guarantee is asserted by tests that can fail.
- A test reads the crates own sources and asserts the escape opener appears in `style.rs` alone — turning TASK-4601ed18d84es architectural rule into an assertion. It failed on itself first: written as a literal, the needle was in the file it forbids.
- The cross-verb test was falsified by reverting `find` alone; it fails naming the verb that drifted.
- Confirmed on the live corpus, not only on fixtures: 0.1.3 prints `[in_progress]` for TASK-a015e74735c5, the built binary prints `[claimed:seanl@sean-laptop]`.

## Two near-misses worth recording

`--json` almost moved: `Edge` carried one field for both the human line and the machine surface, and putting the marker in it changed what a parser reads. Caught by an existing test, fixed by giving the two readers their own field.

The strip-equality test could have passed vacuously: `undo_sgr` strips escapes from both sides, so a fixture already carrying one would make the equality hold by mutual destruction. Every fixture is now asserted escape-free first, and the same hole was open in `context.rs` and is now closed.

The first attempt at the `show` task was closed rather than worked around: its criterion named `style.rs` up front and was silent on `ank log`, and a criterion that ships a defect it did not think to forbid is the wrong criterion.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKySiQLuzuMBYZrbY7JNpa