### PR TITLE
SKILL.md teaches planning, and says that what an agent reads is never styled

### DIFF
--- a/.ank/tasks/TASK-21031b516bb2.md
+++ b/.ank/tasks/TASK-21031b516bb2.md
@@ -5,7 +5,7 @@ slug: skill-md-states-that-what-an-agent-reads-is-neve
 title: SKILL.md states that what an agent reads is never styled
 created: 2026-08-08T18:41:15Z
 author: claude-code@ank
-status: open
+status: in_progress
 scope:
   - skill/SKILL.md
   - crates/ank-cli/tests/skill.rs
@@ -14,5 +14,13 @@ done_criteria: |
   SKILL.md carries the guarantee in one sentence: the output an agent reads is plain bytes, because colour is emitted only at a terminal and never in a pipe or under --json, so there is nothing to configure and no second surface to prefer. The ceiling of ADR-e17e1bbd93ff still holds (at most 140 lines, 1200 words), metadata.revision is regenerated, and ank --version reports the same hash. A test in crates/ank-cli/tests/skill.rs fails if the sentence leaves.
 criteria_by: creator
 schema: 2
-version: 1
+version: 3
 ---
+## Log
+- 2026-08-09T05:05:27Z seanl@sean-laptop — Falsified the test before trusting it: removing the sentence turns it red naming the first token it cannot find. Asserted by what the sentence must establish -- terminal, pipe, --json -- rather than by its wording, which is the lesson TASK-e70d28a5fba8 paid for one task ago: a test pinned to an exact phrase fails on a correct rewrite and reports it as a removal.
+
+Placed with the non-negotiable rules rather than in a section of its own. It is not a verb and not a flag; it is a fact about the input an agent is holding while it reads everything else, which is the same register as "the criterion is frozen at claim" and ".ank/ is opaque".
+
+Worth naming why this is worth a line of a permanently loaded file at all, since every line there costs every session. The guarantee was written down in the specification, in two ADRs and in the code, and in none of the places an agent actually reads. An agent that does not know the rule can reasonably suspect its input of carrying escape sequences, and every repair it then reaches for -- stripping output, hunting for a --no-color flag that deliberately does not exist, preferring --json for cleanliness rather than for parsing -- is wasted work built on a guess. One line removes the class.
+
+109 lines and 847 words against the ceiling of 140 and 1200, and both SKILL.md tasks together added 37 lines to it.

--- a/.ank/tasks/TASK-21031b516bb2.md
+++ b/.ank/tasks/TASK-21031b516bb2.md
@@ -5,7 +5,7 @@ slug: skill-md-states-that-what-an-agent-reads-is-neve
 title: SKILL.md states that what an agent reads is never styled
 created: 2026-08-08T18:41:15Z
 author: claude-code@ank
-status: in_progress
+status: done
 scope:
   - skill/SKILL.md
   - crates/ank-cli/tests/skill.rs
@@ -13,8 +13,12 @@ blocked_by: [TASK-8ebd6e02f125]
 done_criteria: |
   SKILL.md carries the guarantee in one sentence: the output an agent reads is plain bytes, because colour is emitted only at a terminal and never in a pipe or under --json, so there is nothing to configure and no second surface to prefer. The ceiling of ADR-e17e1bbd93ff still holds (at most 140 lines, 1200 words), metadata.revision is regenerated, and ank --version reports the same hash. A test in crates/ank-cli/tests/skill.rs fails if the sentence leaves.
 criteria_by: creator
+proof:
+  - type: test
+    ref: "31295939470"
+    criteria: e413b412f48a
 schema: 2
-version: 3
+version: 4
 ---
 ## Log
 - 2026-08-09T05:05:27Z seanl@sean-laptop — Falsified the test before trusting it: removing the sentence turns it red naming the first token it cannot find. Asserted by what the sentence must establish -- terminal, pipe, --json -- rather than by its wording, which is the lesson TASK-e70d28a5fba8 paid for one task ago: a test pinned to an exact phrase fails on a correct rewrite and reports it as a removal.
@@ -24,3 +28,4 @@ Placed with the non-negotiable rules rather than in a section of its own. It is 
 Worth naming why this is worth a line of a permanently loaded file at all, since every line there costs every session. The guarantee was written down in the specification, in two ADRs and in the code, and in none of the places an agent actually reads. An agent that does not know the rule can reasonably suspect its input of carrying escape sequences, and every repair it then reaches for -- stripping output, hunting for a --no-color flag that deliberately does not exist, preferring --json for cleanliness rather than for parsing -- is wasted work built on a guess. One line removes the class.
 
 109 lines and 847 words against the ceiling of 140 and 1200, and both SKILL.md tasks together added 37 lines to it.
+- 2026-08-09T05:08:57Z seanl@sean-laptop — done, proof test:31295939470

--- a/.ank/tasks/TASK-e70d28a5fba8.md
+++ b/.ank/tasks/TASK-e70d28a5fba8.md
@@ -5,7 +5,7 @@ slug: skill-md-teaches-planning-and-the-freeze-moves-t
 title: SKILL.md teaches planning, and the freeze moves to the new content
 created: 2026-08-05T04:05:45Z
 author: seanl@sean-laptop
-status: in_progress
+status: done
 scope:
   - skill/SKILL.md
   - crates/ank-cli/tests/skill.rs
@@ -21,8 +21,12 @@ done_criteria: |
   teaches-nothing-beyond exclusion list. metadata.revision is regenerated and
   matches the skill hash ank --version reports.
 criteria_by: creator
+proof:
+  - type: test
+    ref: "31295730272"
+    criteria: ef2a2ab1897e
 schema: 2
-version: 5
+version: 6
 ---
 
 Execution of ADR-e17e1bbd93ff, in the order the project imposes: specification
@@ -44,3 +48,4 @@ Landed at 105 lines and 803 words against a ceiling of 140 and 1200. Left short 
 Also corrected the citations. Section 4 and section 9 still credited ADR-c656cbcc33a9 for the one-surface clause and the flat help listing, and that ADR is superseded -- ADR-e17e1bbd93ff carries both forward unchanged. Citing a superseded decision as the authority is how a reader ends up at the wrong constraint.
 
 Two things worth their own tasks, neither in this perimeter. commit.gpgsign is global here, so the throwaway git repos the integration fixtures build sign their commits: eight tests died in Repo::new when the local gpg agent's pinentry timed out, none reaching an assertion. Signing a fixture commit proves nothing and makes the suite depend on a developer's agent being unlocked, which is why CI is green -- it has no key. And this claim lapsed while that was being sorted out, which is the TTL working as designed; re-claimed against an unchanged criterion, so the freeze hash matched.
+- 2026-08-09T05:02:22Z seanl@sean-laptop — done, proof test:31295730272

--- a/.ank/tasks/TASK-e70d28a5fba8.md
+++ b/.ank/tasks/TASK-e70d28a5fba8.md
@@ -5,7 +5,7 @@ slug: skill-md-teaches-planning-and-the-freeze-moves-t
 title: SKILL.md teaches planning, and the freeze moves to the new content
 created: 2026-08-05T04:05:45Z
 author: seanl@sean-laptop
-status: open
+status: in_progress
 scope:
   - skill/SKILL.md
   - crates/ank-cli/tests/skill.rs
@@ -22,7 +22,7 @@ done_criteria: |
   matches the skill hash ank --version reports.
 criteria_by: creator
 schema: 2
-version: 2
+version: 3
 ---
 
 Execution of ADR-e17e1bbd93ff, in the order the project imposes: specification

--- a/.ank/tasks/TASK-e70d28a5fba8.md
+++ b/.ank/tasks/TASK-e70d28a5fba8.md
@@ -22,7 +22,7 @@ done_criteria: |
   matches the skill hash ank --version reports.
 criteria_by: creator
 schema: 2
-version: 3
+version: 5
 ---
 
 Execution of ADR-e17e1bbd93ff, in the order the project imposes: specification
@@ -35,3 +35,12 @@ authority ends.
 
 ## Log
 - 2026-08-05T04:06:58Z seanl@sean-laptop — amended: -blocked_by ADR-e17e1bbd93ff
+- 2026-08-09T04:59:32Z seanl@sean-laptop — Falsified both new tests rather than trusting them. Rewriting the description as `ank accept` turns two tests red at once, which is the point: described-and-never-invited is one rule and neither half asserts it alone. And the planning test's limit was measured instead of assumed -- deleting the explanatory paragraph for a verb leaves it green, because the summary block at the top still names the verb; deleting the name from both places turns it red. That is the same standard the_skill_carries_the_whole_loop has always held, and the doc comment now says so instead of leaving a reader to discover it.
+
+Rewrote the accept description test after the falsification exposed it as brittle. It had asserted the exact string with its backticks, so it failed on the rewording too -- for the wrong reason, and with a message claiming the file never names accept when it plainly did. It now asserts the three things the description has to say: accept, signed, default branch. A test that cannot tell a rewrite from a removal is a test nobody trusts twice.
+
+Landed at 105 lines and 803 words against a ceiling of 140 and 1200. Left short deliberately: the ceiling exists to notice drift, and filling it now would leave nothing to notice.
+
+Also corrected the citations. Section 4 and section 9 still credited ADR-c656cbcc33a9 for the one-surface clause and the flat help listing, and that ADR is superseded -- ADR-e17e1bbd93ff carries both forward unchanged. Citing a superseded decision as the authority is how a reader ends up at the wrong constraint.
+
+Two things worth their own tasks, neither in this perimeter. commit.gpgsign is global here, so the throwaway git repos the integration fixtures build sign their commits: eight tests died in Repo::new when the local gpg agent's pinentry timed out, none reaching an assertion. Signing a fixture commit proves nothing and makes the suite depend on a developer's agent being unlocked, which is why CI is green -- it has no key. And this claim lapsed while that was being sorted out, which is the TTL working as designed; re-claimed against an unchanged criterion, so the freeze hash matched.

--- a/crates/ank-cli/tests/skill.rs
+++ b/crates/ank-cli/tests/skill.rs
@@ -301,6 +301,35 @@ fn the_skill_teaches_nothing_beyond_what_is_frozen() {
     }
 }
 
+/// **What an agent reads is plain bytes, and the skill says so**
+/// (TASK-21031b516bb2).
+///
+/// The guarantee existed and was written down everywhere except the one file
+/// every agent actually loads. That gap has a cost the others do not: an agent
+/// that does not know the rule can reasonably suspect its input of carrying
+/// escape sequences, and the repairs it would then reach for -- stripping
+/// output, hunting for a `--no-color` that does not exist, preferring `--json`
+/// for cleanliness rather than for parsing -- are all wasted work built on a
+/// guess. Saying it once costs one line of a permanently loaded file and
+/// removes the whole class.
+///
+/// Asserted by what the sentence has to establish rather than by its exact
+/// wording, for the reason `the_skill_describes_accept_without_inviting_it`
+/// records: a test pinned to one phrasing fails on a correct rewrite, and
+/// reports it as a removal.
+#[test]
+fn the_skill_states_that_what_an_agent_reads_is_never_styled() {
+    let text = skill();
+    for token in ["terminal", "pipe", "--json"] {
+        assert!(
+            text.contains(token),
+            "SKILL.md does not say {token:?}: an agent that cannot read the \
+             guarantee has to guess whether its input is styled, and every \
+             repair it reaches for from that guess is wasted"
+        );
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Which revision is installed (TASK-b495234f192c)
 // ---------------------------------------------------------------------------

--- a/crates/ank-cli/tests/skill.rs
+++ b/crates/ank-cli/tests/skill.rs
@@ -2,12 +2,12 @@
 //!
 //! `skill/SKILL.md` is not documentation: it is loaded into an agent's context
 //! permanently, on every session, in every repository that installs it. That is
-//! what makes its content the thing actually frozen (ADR-c656cbcc33a9) -- the
-//! dispatch table refuses nobody, and the loop exists because this file teaches
-//! it and teaches nothing else. Three properties are therefore worth a test
-//! rather than a habit: that it carries the whole loop, that it stays small
-//! enough to be worth loading, and that a copy in the wild says which revision
-//! it is.
+//! what makes its content the thing actually frozen (ADR-e17e1bbd93ff) -- the
+//! dispatch table refuses nobody, and the two modes exist because this file
+//! teaches them and teaches nothing else. Four properties are therefore worth a
+//! test rather than a habit: that it carries the whole loop, that it carries
+//! the planning that fills the loop, that it stays small enough to be worth
+//! loading, and that a copy in the wild says which revision it is.
 //!
 //! This file exists because the task's declared verifier is `cargo-test`. A
 //! criterion nothing executes is a criterion nobody checked, and a proof that
@@ -181,11 +181,17 @@ fn help_prints_section_4s_order() {
     );
 }
 
-/// The loop, and the content of SKILL.md is frozen at exactly these
-/// (ADR-c656cbcc33a9).
+/// The loop and what is off it: how work gets done (ADR-e17e1bbd93ff).
 const LOOP_VERBS: [&str; 8] = [
     "context", "claim", "show", "log", "done", "new", "find", "release",
 ];
+
+/// Planning: how the work that gets done comes to exist (ADR-e17e1bbd93ff).
+///
+/// `new adr` is spelled out rather than covered by `new`, because the whole
+/// point of the addition is the path from noticing an architectural problem to
+/// recording one — and `ank new task` alone does not carry it.
+const PLANNING_VERBS: [&str; 5] = ["review", "graph", "check", "amend", "new adr"];
 
 #[test]
 fn the_skill_carries_the_whole_loop() {
@@ -199,39 +205,97 @@ fn the_skill_carries_the_whole_loop() {
     }
 }
 
-/// One page, and the budget is the reason: §9 puts the loop and the mental
-/// model here, and sends flag detail to `ank help`, loaded on demand.
-/// The number is a ceiling to notice drift, not a target to fill.
+/// The half ADR-e17e1bbd93ff added. An agent taught only the loop can execute
+/// work and cannot propose a decision, correct a graph, or notice the corpus
+/// has gone incoherent -- which is the gap that ADR names and this asserts is
+/// closed.
+///
+/// **What this checks is that the verb is named, not that it is explained**,
+/// exactly as `the_skill_carries_the_whole_loop` has always done: the summary
+/// block at the top of the file satisfies it on its own. That is the right
+/// standard here, because the property being protected is the one the ADR
+/// states -- "a verb it does not name is a verb that does not come up" (§11) --
+/// and it was measured: deleting the explanatory paragraph alone leaves this
+/// green, deleting the name from both places turns it red.
+#[test]
+fn the_skill_carries_the_planning_mode() {
+    let text = skill();
+    for verb in PLANNING_VERBS {
+        assert!(
+            text.contains(&format!("ank {verb}")),
+            "SKILL.md never shows `ank {verb}`: planning is frozen content \
+             now, not an optional extra"
+        );
+    }
+}
+
+/// **`accept` is described and never invited** (ADR-e17e1bbd93ff).
+///
+/// The two halves are one rule and neither works alone. The skill must say what
+/// `accept` is, so a planning agent knows where its own authority ends rather
+/// than discovering the boundary by hitting it; and it must never show the
+/// command form, because showing a command is how a file that is loaded
+/// permanently invites it to be run.
+/// The description is asserted by the three things it has to say rather than by
+/// one exact phrase: a test pinned to `` `accept` `` with its backticks fails
+/// on a rewording that is perfectly correct, and a test that cannot tell a
+/// rewrite from a removal is a test nobody trusts twice.
+#[test]
+fn the_skill_describes_accept_without_inviting_it() {
+    let text = skill();
+    for token in ["accept", "signed", "default branch"] {
+        assert!(
+            text.contains(token),
+            "SKILL.md does not say {token:?} about `accept`: an agent that \
+             cannot see the one hard authority line will find it by hitting it"
+        );
+    }
+    // The other half is `the_skill_teaches_nothing_beyond_what_is_frozen`,
+    // which keeps `ank accept` out. Described, never invited -- and neither
+    // assertion means anything without the other.
+}
+
+/// The budget is the reason: §9 puts the loop, the planning that fills it and
+/// the mental model behind both here, and sends flag detail to `ank help`,
+/// loaded on demand. The number is a ceiling to notice drift, not a target to
+/// fill.
+///
+/// It moved from 80/700 to 140/1200 with ADR-e17e1bbd93ff, and moved because a
+/// decision said so — which is the only way it is allowed to move. A ceiling
+/// raised to accommodate whatever was just written is not a ceiling.
 #[test]
 fn the_skill_stays_within_one_page() {
     let text = skill();
     let lines = text.lines().count();
     let words = text.split_whitespace().count();
     assert!(
-        lines <= 80,
+        lines <= 140,
         "SKILL.md is {lines} lines: it is loaded permanently, so growth costs \
          every session in every repo. Move detail to `ank help`."
     );
-    assert!(words <= 700, "SKILL.md is {words} words, over one page");
+    assert!(words <= 1200, "SKILL.md is {words} words, over the ceiling");
 }
 
 /// These verbs run for whoever types them -- nothing here is refused to an
-/// agent (ADR-c656cbcc33a9). What this asserts is narrower and is the whole of
+/// agent (ADR-e17e1bbd93ff). What this asserts is narrower and is the whole of
 /// the freeze: SKILL.md does not *teach* them. Naming one as a thing to run
 /// would grow what every session pays for, by habit rather than by decision,
 /// which is how a permanently loaded file actually grows.
 ///
-/// `show` is absent from this list because it was moved into the loop by
-/// decision and with the reason recorded, back when the loop was still called a
-/// surface. That is what the list is for -- everything else still costs a
-/// succession.
+/// The list shrinks only by decision, and it has twice. `show` left it when it
+/// moved into the loop, back when the loop was still called a surface;
+/// `review`, `check` and `amend` left it with ADR-e17e1bbd93ff, which bought
+/// planning with a raised ceiling and said so. `accept` is the interesting
+/// survivor: the skill now *describes* it, and still must not show the command,
+/// so it stays here while `the_skill_describes_accept_without_inviting_it`
+/// holds the other half. Everything remaining costs a succession.
 #[test]
-fn the_skill_teaches_nothing_beyond_the_loop() {
+fn the_skill_teaches_nothing_beyond_what_is_frozen() {
     let text = skill();
-    for verb in ["accept", "review", "close", "attest", "check"] {
+    for verb in ["accept", "close", "attest", "edit", "status", "scope"] {
         assert!(
             !text.contains(&format!("ank {verb}")),
-            "SKILL.md shows `ank {verb}`, which is outside the loop it is \
+            "SKILL.md shows `ank {verb}`, which is outside the content it is \
              frozen at"
         );
     }

--- a/docs/ank-spec-v1.1.md
+++ b/docs/ank-spec-v1.1.md
@@ -275,18 +275,23 @@ The symmetric risk — an agent going off the rails and flooding the repository 
 
 ## 4. CLI surface
 
-**Ank exposes one surface** (ADR-c656cbcc33a9). Every verb is available to every caller, and the CLI refuses on state, never on identity. Git has more than a hundred commands, every one of them reachable by anybody who types it, and stays learnable because of what a newcomer is taught first — not because the porcelain sorts callers into classes. Ank borrows that shape.
+**Ank exposes one surface** (ADR-e17e1bbd93ff, superseding ADR-c656cbcc33a9). Every verb is available to every caller, and the CLI refuses on state, never on identity. Git has more than a hundred commands, every one of them reachable by anybody who types it, and stays learnable because of what a newcomer is taught first — not because the porcelain sorts callers into classes. Ank borrows that shape.
 
-The memorisation budget is real; it is simply not the binary's job. It is spent on documentation, and it is enforced where it operates: what an agent is taught is the loop, and the content of what teaches it is frozen. What a human may type is everything.
+The memorisation budget is real; it is simply not the binary's job. It is spent on documentation, and it is enforced where it operates: what an agent is taught is the loop and the planning that fills it, and the content of what teaches it is frozen. What a human may type is everything.
 
-### The loop, and the freeze on SKILL.md
+### What the skill teaches, and the freeze on SKILL.md
 
 ```
 Loop:        context → claim → show → log → done
 Off-loop:    new, find, release
+Planning:    new adr, amend, review, graph, check, find --status open
 ```
 
-**This is the entire content of SKILL.md, and that content is frozen.** SKILL.md is loaded permanently (§9), so the surface an agent reads about is the one that costs tokens on every call; growing what it teaches costs an ADR superseding ADR-c656cbcc33a9, exactly as growing a verb list once did. The freeze constrains the documentation, not the dispatch table: an agent that runs `ank graph` gets the graph; it was simply never told the verb existed, and being untold is not being refused.
+**This is the entire content of SKILL.md, and that content is frozen** (ADR-e17e1bbd93ff). SKILL.md is loaded permanently (§9), so what it teaches is what costs tokens on every call, for every agent, including the ones that only loop; growing it costs an ADR superseding ADR-e17e1bbd93ff, exactly as growing a verb list once did. The freeze constrains the documentation, not the dispatch table: an agent that runs `ank scope` gets the answer; it was simply never told the verb existed, and being untold is not being refused.
+
+**Two modes, because an agent that can only execute is half an agent.** The loop is how work gets done; planning is how the work that gets done comes to exist — deciding which tasks should exist, in what order, under which constraints. ADR-c656cbcc33a9 taught the loop alone, and an agent taught by it could not propose a decision, correct a graph, or notice that the corpus had gone incoherent: `ank new adr` was never mentioned, so an agent seeing an architectural problem had no documented path from the observation to a recorded ADR. Planning is the highest-leverage activity in the corpus, and a badly shaped backlog wastes more downstream than the teaching costs upstream. The ceiling moves with the content — **at most 140 lines and 1200 words**, up from 80 and 700 — and stays a ceiling to notice drift, not a target to fill.
+
+**`accept` is described and never invited.** The skill says what it is — a human act, signed, on the default branch only — so that a planning agent knows where its own authority ends, and it never shows the command as something to run. That is the one hard authority line in the system (§8, §12), and describing it is what makes it legible rather than mysterious. `close` and `attest` stay outside for the ordinary reason: nothing has decided they are worth what every session pays for them.
 
 That distinction is the whole revision. ADR-3859eb46bdc3 froze an *agent surface* at these same eight verbs and sent everything else to a human side, but the split it protected was never a boundary — the CLI told callers apart by `$ANK_AGENT`, a variable the caller sets itself (§8). A wall whose bricks are self-declared identity is a sign, not a wall. What the freeze actually protected was the token budget, and that protection moves here, where it holds without pretending to be a check.
 
@@ -294,7 +299,7 @@ That distinction is the whole revision. ADR-3859eb46bdc3 froze an *agent surface
 
 ### The rest of the surface
 
-These verbs serve human ergonomics: the ratification queue, corpus health, the plan revisions a human makes on somebody else's task. They are outside the loop because SKILL.md does not teach them, and outside is not withheld — none of the refusals below consults who is calling.
+These verbs are the rest of the surface. Four of them — `review`, `check`, `amend` and `graph` — are what the planning mode above teaches, and the others are outside what the skill teaches rather than withheld from anyone: none of the refusals below consults who is calling, and an agent that types one gets its answer.
 
 ```
 review    ratification queue, pending proposals, corpus health
@@ -983,9 +988,9 @@ Skills install from repositories rather than npm packages: the identifier is `ow
 
 The `skills` CLI handles multi-agent detection (Claude Code, Codex, Cursor, OpenCode, and many others) and creates links from each agent to a canonical copy — exactly the desired design, already maintained by a third party.
 
-**Token economy.** These files are loaded permanently, which is why the content of SKILL.md is frozen (§4): it carries the loop and the mental model, nothing else, and growing that costs a superseding ADR. Flag details and the rest of the surface stay in `ank help`, loaded on demand.
+**Token economy.** These files are loaded permanently, which is why the content of SKILL.md is frozen (§4): it carries the loop, the planning that fills it, and the mental model behind both — nothing else, and growing that costs a superseding ADR. Flag details and the rest of the surface stay in `ank help`, loaded on demand.
 
-**`ank help` is one flat listing** (ADR-c656cbcc33a9): every verb, in the order of §4, with no headings and no grouping. The loop is what SKILL.md teaches, not what the binary prints — a heading printed by the CLI is a claim about who a verb is for, and that is the claim §4 withdraws. The order carries what a heading would have said, since §4 puts the loop first, and it carries it without asserting a category. `ank help <verb>` answers about that verb alone: its usage, its flags with their value placeholders, and the globals. An unknown verb is a **code 2** and never a fallback to the general listing — an agent that asked about one verb and received all sixteen has to work out that its question went unanswered.
+**`ank help` is one flat listing** (ADR-e17e1bbd93ff): every verb, in the order of §4, with no headings and no grouping. What SKILL.md teaches is not what the binary prints — a heading printed by the CLI is a claim about who a verb is for, and that is the claim §4 withdraws. The order carries what a heading would have said, since §4 puts the loop first, and it carries it without asserting a category. `ank help <verb>` answers about that verb alone: its usage, its flags with their value placeholders, and the globals. An unknown verb is a **code 2** and never a fallback to the general listing — an agent that asked about one verb and received all sixteen has to work out that its question went unanswered.
 
 `ank init` keeps a narrow perimeter: create `.ank/`, write `config.yml`, add the `refs/ank/*` refspec (§7), place a pointer in `AGENTS.md`, write a `.gitattributes` (§2) and a `.gitignore` (§6).
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -2,7 +2,7 @@
 name: ank
 description: Read a repository's tasks and binding constraints, claim work, and finish it with proof. Use when working in a repo that has a .ank/ directory.
 metadata:
-  revision: "92b32ac69f22"
+  revision: "975e5ca25da1"
 ---
 
 # ank
@@ -91,6 +91,10 @@ ends is part of planning well.
   directly. `ank show <id>` gives you an entity whole, `ank find` lists,
   `ank context` binds — the CLI knows the budget, the freeze and who holds what;
   the files do not.
+
+- **What you read is never styled.** Colour is emitted only when a human is at
+  a terminal, never into a pipe, a file or `--json`, so the bytes reaching you
+  are plain: there is nothing to configure and no second surface to prefer.
 
 Exit codes carry meaning: `4` unavailable, `6` a frozen field diverged, `8`
 findings, `9` environment. Errors always name the exact next command.

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -2,16 +2,18 @@
 name: ank
 description: Read a repository's tasks and binding constraints, claim work, and finish it with proof. Use when working in a repo that has a .ank/ directory.
 metadata:
-  revision: "605f771e1955"
+  revision: "92b32ac69f22"
 ---
 
 # ank
 
 Tasks and architecture decisions live as files in `.ank/`, attached to the code
-they constrain. Eight verbs, and `context` is the one you start with.
+they constrain. Two modes: executing work, and shaping the work that exists.
+`context` starts both.
 
     Loop:      ank context -> ank claim <id> -> ank show <id> -> ank log "<msg>" -> ank done
     Off-loop:  ank new, ank find, ank release --reason "<r>"
+    Planning:  ank new adr, ank amend, ank review, ank graph, ank check
 
 ## The loop
 
@@ -41,10 +43,42 @@ agent that grades itself can simply be wrong.
 entity attached to nothing is invisible. A subtask you discover is a new task
 with a `blocked_by`, never a softened criterion.
 
-**`ank find <query>`** — search titles, scopes and criteria.
+**`ank find <query>`** — search titles, scopes and criteria. `ank find --status
+open` lists what remains, with no query to invent.
 
 **`ank release --reason "<why>"`** — stuck, or wrong about the approach. Say so
 and hand the task back rather than letting the claim lapse in silence.
+
+## Planning
+
+Deciding which tasks should exist, in what order, under which constraints. This
+is what produces the work everyone else loops on, so a badly shaped backlog
+costs more downstream than any single task does.
+
+**`ank new adr --title "<t>" --scope "<glob>" --constraint "<rule>"`** — a
+decision, not a task. Write one when you hit something the corpus should be held
+to afterwards, rather than something you merely have to do now. It lands
+`proposed`, which binds nobody until it is ratified.
+
+**`ank amend <id>`** — the two fields a plan actually changes: `blocked_by` and
+`scope`. It adds and removes explicitly and never takes a replacement list, so
+nothing is dropped by being forgotten. It will not touch `done_criteria` — that
+is `release --reason`.
+
+**`ank review`** — the ratification queue and the health of the corpus: what is
+proposed and waiting, and which scopes have gone dead and want closing.
+
+**`ank graph`** — the `blocked_by` DAG as text, indented under what blocks it.
+What is genuinely a root, and what only looked like one in a flat list.
+
+**`ank check`** — the mechanical invariants: parse, round-trip, references,
+frozen fields, orphaned claims. Exit `8` means findings, and findings are for
+reading, not for silencing.
+
+**`accept` is not yours to run.** It is what turns a proposed ADR into a binding
+one, and it is a human act: signed, on the default branch, with no way around
+it. Propose the decision, then say it is waiting. Knowing where your authority
+ends is part of planning well.
 
 ## Rules that are not negotiable
 


### PR DESCRIPTION
The pair that closes ADR-e17e1bbd93ff. Two tasks, each anchored on its own green CI run.

## TASK-e70d28a5fba8 — the freeze moves to the new content

ADR-c656cbcc33a9 froze SKILL.md on the loop alone. An agent taught only by that file could execute work and could not propose a decision, correct a graph, or notice the corpus had gone incoherent: `ank new adr` was never mentioned, so an agent seeing an architectural problem had no documented path from the observation to a recorded ADR.

Specification first, as the project requires. Section 4 now states two modes and the ceiling that goes with them — 140 lines and 1200 words, up from 80 and 700, moved because a decision said so and not to accommodate what was just written. SKILL.md grows the planning section: `ank new adr`, `ank amend`, `ank review`, `ank graph`, `ank check`, and `ank find --status open` for what remains.

**`accept` is described and never invited**, which is one rule needing two tests. The skill says what it is — a human act, signed, default branch only — so a planning agent knows where its own authority ends; `the_skill_teaches_nothing_beyond_what_is_frozen` keeps the command form out. Neither assertion means anything without the other, and rewriting the description as `ank accept` was measured to turn both red.

The exclusion list shrinks by decision rather than by habit: `review`, `check` and `amend` leave it, `accept`, `close` and `attest` stay, and `edit`, `status` and `scope` join it explicitly instead of being outside it by silence.

Citations corrected along the way. Sections 4 and 9 still credited ADR-c656cbcc33a9 for the one-surface clause and the flat `help` listing, and that ADR is superseded — ADR-e17e1bbd93ff carries both forward unchanged. Citing a superseded decision as the authority is how a reader ends up at the wrong constraint.

## TASK-21031b516bb2 — the guarantee an agent could not read

> **What you read is never styled.** Colour is emitted only when a human is at a terminal, never into a pipe, a file or `--json`, so the bytes reaching you are plain: there is nothing to configure and no second surface to prefer.

The guarantee was written down in the specification, in ADR-962c25797569 and ADR-0c8ab846d262, and in the code — and in none of the places an agent actually reads. That gap costs more than the others: an agent that does not know the rule can reasonably suspect its input of carrying escape sequences, and every repair it reaches for from that suspicion is wasted work built on a guess — stripping output, hunting for a `--no-color` flag that deliberately does not exist, preferring `--json` for cleanliness rather than for parsing.

It sits with the non-negotiable rules rather than in a section of its own: it is not a verb and not a flag, it is a fact about the input an agent holds while reading everything else.

## On the tests

Every new assertion was falsified before being trusted, and one of them was rewritten because falsifying it exposed a defect in the test rather than in the file.

The `accept` description test originally asserted the exact string with its backticks. Rewording it to `ank accept` did turn it red — for the wrong reason, with a message claiming the file never names `accept` while it plainly did. It now asserts the three things the description has to establish: `accept`, `signed`, `default branch`. The styling test was written to that standard from the start, and the reasoning is recorded in both doc comments: a test that cannot tell a rewrite from a removal is a test nobody trusts twice.

The planning test's limit was measured rather than assumed. Deleting the explanatory paragraph for a verb leaves it green, because the summary block still names the verb; deleting the name from both places turns it red. That is the same standard `the_skill_carries_the_whole_loop` has always held — the property being protected is that a verb is named, since "a verb it does not name is a verb that does not come up" — and the doc comment says so instead of leaving a reader to discover it.

## Budget

**109 lines and 847 words**, against a ceiling of 140 and 1200. Left short deliberately: the ceiling exists to notice drift, and filling it now would leave nothing to notice.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKySiQLuzuMBYZrbY7JNpa