### PR TITLE
File TASK-40a972e98a9a: a test fixture signs nothing

### DIFF
--- a/.ank/tasks/TASK-40a972e98a9a.md
+++ b/.ank/tasks/TASK-40a972e98a9a.md
@@ -1,0 +1,63 @@
+---
+id: TASK-40a972e98a9a
+type: task
+slug: a-test-fixture-signs-nothing-and-does-not-have-t
+title: A test fixture signs nothing, and does not have to be reminded
+created: 2026-08-09T05:24:34Z
+author: seanl@sean-laptop
+status: open
+scope:
+  - crates/ank-cli/tests/cli.rs
+  - crates/ank-cli/src/claim.rs
+  - crates/ank-cli/src/context.rs
+  - crates/ank-cli/src/done.rs
+  - crates/ank-cli/src/git.rs
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/src/init.rs
+blocked_by: []
+done_criteria: |
+  No test fixture inherits the developer's signing configuration. Every throwaway repository a test builds turns signing off in its own config at creation -- commit and tag both -- rather than at each call that commits, and the per-call `-c commit.gpgsign=false` repetitions are removed in the same change, because a guard that survives only where somebody remembered it is the defect and not the fix. The suite passes with `commit.gpgsign=true` and `tag.gpgsign=true` set globally and no gpg agent reachable at all, which is the condition that produced the failure and the only condition that proves the fix: a developer with a locked or absent key runs the same green suite CI does. Verified by running the suite through the binary under that environment, not by reading the call sites.
+criteria_by: creator
+schema: 2
+version: 1
+---
+
+## What happened
+
+Eight integration tests died in `Repo::new` when the local gpg agent's pinentry
+timed out. None of them reached an assertion: the fixture could not build its
+own repository, because `commit.gpgsign` is true in the developer's global
+config and a throwaway repository in a temp directory inherits it.
+
+Signing a fixture commit proves nothing. It makes the suite depend on a
+developer's agent being unlocked, and CI is green precisely because it has no
+key -- so the failure is invisible exactly where it would be caught.
+
+## What makes this worth a task rather than a shrug
+
+The workaround already exists, and that is the finding. `-c
+commit.gpgsign=false` is repeated at roughly twenty-five call sites across
+`tests/cli.rs` and the test modules of `claim.rs`, `context.rs`, `done.rs`,
+`git.rs`, `human.rs` and `init.rs`. Somebody hit this before and patched the
+commit in front of them instead of the fixture.
+
+Three call sites do not carry it: the merge at `tests/cli.rs:2622`, and the two
+seeds at `:3660` and `:3827`. Those three are exactly the eight tests that
+failed -- `color_fixture` feeds six of them, and the other two are their own.
+
+That is the whole argument. A guard applied per call is a guard that holds
+wherever it was remembered, and the places it was forgotten are not distributed
+randomly: they are the newest ones. The count only grows.
+
+## Where it goes instead
+
+Into the repository's own config, once, where `user.email`, `user.name` and
+`core.autocrlf` already are (`tests/cli.rs:41-44`). `tag.gpgsign` too: nothing
+tags today, and the next thing that does should not have to rediscover this.
+
+## How it has to be verified
+
+Not by reading the call sites. Set `commit.gpgsign=true` and `tag.gpgsign=true`
+globally, make the agent unreachable, and run the suite: that is the condition
+that produced the failure, and the only one that shows a developer with a locked
+key now runs the same green suite CI does.


### PR DESCRIPTION
Files one task. No code changes.

## What happened

Eight integration tests died in `Repo::new` when the local gpg agent's pinentry timed out. None of them reached an assertion: `commit.gpgsign` is true in the developer's global config, and a throwaway repository in a temp directory inherits it.

Signing a fixture commit proves nothing. It makes the suite depend on a developer's agent being unlocked, and CI is green precisely because it has no key — so the failure is invisible exactly where it would be caught.

## Why it is a task and not a shrug

The workaround already exists, and that is the finding. `-c commit.gpgsign=false` is repeated at roughly twenty-five call sites, across `tests/cli.rs` and the test modules of `claim.rs`, `context.rs`, `done.rs`, `git.rs`, `human.rs` and `init.rs`. Somebody hit this before and patched the commit in front of them instead of the fixture.

Three call sites do not carry it: the merge at `tests/cli.rs:2622`, and the seeds at `:3660` and `:3827`. Those three are exactly the eight tests that failed — `color_fixture` feeds six of them, and the other two are their own.

A guard applied per call holds wherever it was remembered, and the places it was forgotten are not distributed randomly: they are the newest ones. The count only grows.

## What the criterion asks for

The setting moves into the fixture repository's own config, once, where `user.email`, `user.name` and `core.autocrlf` already live — `tag.gpgsign` alongside it, so the next thing that tags does not rediscover this — and the twenty-five repetitions go in the same change.

Verification is specified as an environment rather than a review: `commit.gpgsign=true` and `tag.gpgsign=true` set globally, no gpg agent reachable, suite green. That is the condition that produced the failure, and the only one that shows a developer with a locked key running the same green suite CI does.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKySiQLuzuMBYZrbY7JNpa