### PR TITLE
config.yml is written through the CLI: the decision, and the task that executes it

### DIFF
--- a/.ank/adr/ADR-e64dfaafd578.md
+++ b/.ank/adr/ADR-e64dfaafd578.md
@@ -1,0 +1,119 @@
+---
+id: ADR-e64dfaafd578
+type: adr
+slug: config-yml-is-written-through-the-cli-and-the-wr
+title: config.yml is written through the CLI, and the writer touches nothing else
+created: 2026-08-09T06:37:07Z
+author: seanl@sean-laptop
+status: proposed
+scope:
+  - crates/ank-cli/src/config.rs
+  - crates/ank-cli/src/init.rs
+  - crates/ank-cli/src/cli.rs
+  - docs/**
+constraint: |
+  .ank/config.yml is read and written through the ank CLI. Reading is
+  `ank config <key>`; writing is `ank config <key> <value>` and
+  `ank config --unset <key>`, with nested values addressed by dotted path
+  (`verifiers.<name>.run`). The key set stays closed: a key the parser does not
+  know is refused by name, never written.
+  
+  The writer changes no byte it was not asked to change. Comments, blank lines,
+  key order and quoting style survive a write untouched, and every key other than
+  the one named is byte-identical afterwards. The `run` of a verifier is never
+  rewritten by a write that did not name it: that string is hashed into every
+  proof that verifier has ever produced.
+  
+  `config` runs without a parsed configuration, as `init` and `help` do. The
+  caller who most needs it is the one whose config.yml does not load.
+  
+  This constrains the agent, not the human: a human with an editor keeps every
+  power they had, and the file stays reviewable text in the repository.
+schema: 2
+version: 1
+---
+
+## Context
+
+ADR-01b6dd05f0db closed `.ank/` to agents: entities are read and written through
+the CLI, never by opening the file. Its body enumerates the writing verbs -- new,
+claim, log, done, release, attest, close, accept -- and says nothing about
+`config.yml`, because `config.yml` is not an entity. The gap was not argued; it
+was simply out of frame.
+
+Ank's own error messages are where it shows. Six sites tell the caller to open
+the file:
+
+- `or add "default_branch: <name>" to .ank/config.yml` -- git.rs, status.rs,
+  context.rs, human.rs;
+- `add it under verifiers: in .ank/config.yml` -- done.rs, on a task declaring a
+  verifier the configuration does not have;
+- `declare it under verifiers: in .ank/config.yml` -- commands.rs, on `--verify`
+  at `new` and at `amend`.
+
+These are the only errors in the CLI that name a file to edit instead of a
+command to run, and section 4 calls that shape out by name: a self-correcting
+error carries the exact command, never generic help. They are not wrong today --
+there is no command to name.
+
+One writer exists: `init` writes the default file if it is absent, and never
+touches it again. Everything after that is a hand edit.
+
+## Decision
+
+`config.yml` stops being a hand-edited file for the same reason entities did.
+The tool knows things the file does not -- which keys exist, what a duration
+means, that an unknown key is refused rather than ignored -- and a caller
+guessing at YAML is a caller who finds out at the next command, in the form of
+every command failing at once.
+
+The shape is `git config`'s, and deliberately: a flat key and a value, with
+dotted paths for what is nested. It is the shape the parser's own error messages
+already use -- `verifiers.<name>.timeout` appears verbatim in config.rs today --
+and it needs no second vocabulary.
+
+## Why the byte guarantee is in the constraint and not left to taste
+
+There is no serializer. `Config` derives `Deserialize` and nothing else, and the
+only configuration text this program has ever produced is the literal `init`
+writes. A writer built the obvious way -- parse, mutate, re-serialize -- would
+drop every comment and blank line, and would reorder `verifiers`, `roles` and
+`identities`, which are `BTreeMap`s and would come back alphabetical.
+
+That is the visible damage. The invisible damage is worse. `definition_hash` is
+`sha256(run.trim() + NUL + timeout_in_seconds)`, and it is stored in every proof
+that verifier ever produced. Re-quoting or reflowing a `run` scalar changes the
+hash, and `check` then reports "verifier X changed since the proof" on every
+historical task in the corpus -- a corpus-wide false signal produced by a
+formatting change nobody asked for. A useful corollary: `timeout: 600s` and
+`timeout: 10m` hash identically, so a timeout's spelling is free where a `run`'s
+is not.
+
+So the guarantee is not a nicety about respecting the user's comments. It is
+what keeps the coordination plane honest, and it belongs where it binds.
+
+## Why `config` runs without a configuration
+
+`startup` loads `config.yml` for every verb but `init` and `help`, so a file
+that does not parse makes every command exit 1 -- including `check`, and
+including the command that would fix it. The exemption already has its reasoning
+written in the dispatcher, about `help`: the caller most in need of it is the
+one whose environment is wrong. A configuration verb that a broken configuration
+disables is a verb that works only when it is not needed.
+
+## Rejected
+
+**Extending `init`** with flags. `init` is a one-shot bootstrap with a perimeter
+fixed by section 9, and it is idempotent by assertion: it will not redo anything,
+including correcting a key. It cannot serve a read-and-write use case without
+becoming a different verb under an old name.
+
+**Extending `edit`** to the configuration. `edit` opens an entity and validates
+frontmatter on the way back; `config.yml` has no id, no version, no frozen
+fields and no CAS. It would be one verb doing two unrelated things.
+
+**Leaving it to the human.** That is the status quo, and it is defensible for a
+human -- who keeps the editor either way. It is not defensible for an agent,
+which ADR-01b6dd05f0db already established has no route into `.ank/` but the
+CLI. Today that route stops at the configuration, and the six hints above are
+the CLI telling an agent to do what the CLI forbids it to do.

--- a/.ank/adr/ADR-e64dfaafd578.md
+++ b/.ank/adr/ADR-e64dfaafd578.md
@@ -20,9 +20,10 @@ constraint: |
   
   The writer changes no byte it was not asked to change. Comments, blank lines,
   key order and quoting style survive a write untouched, and every key other than
-  the one named is byte-identical afterwards. The `run` of a verifier is never
-  rewritten by a write that did not name it: that string is hashed into every
-  proof that verifier has ever produced.
+  the one named is byte-identical afterwards. The file is never round-tripped
+  through a serializer, and no default is ever materialised into it: an unset key
+  stays unset, or absence becomes an assertion the next release contradicts. A
+  form the surgery cannot edit safely is refused by name, never guessed at.
   
   `config` runs without a parsed configuration, as `init` and `help` do. The
   caller who most needs it is the one whose config.yml does not load.
@@ -30,7 +31,7 @@ constraint: |
   This constrains the agent, not the human: a human with an editor keeps every
   power they had, and the file stays reviewable text in the repository.
 schema: 2
-version: 1
+version: 2
 ---
 
 ## Context
@@ -80,14 +81,25 @@ writes. A writer built the obvious way -- parse, mutate, re-serialize -- would
 drop every comment and blank line, and would reorder `verifiers`, `roles` and
 `identities`, which are `BTreeMap`s and would come back alphabetical.
 
-That is the visible damage. The invisible damage is worse. `definition_hash` is
-`sha256(run.trim() + NUL + timeout_in_seconds)`, and it is stored in every proof
-that verifier ever produced. Re-quoting or reflowing a `run` scalar changes the
-hash, and `check` then reports "verifier X changed since the proof" on every
-historical task in the corpus -- a corpus-wide false signal produced by a
-formatting change nobody asked for. A useful corollary: `timeout: 600s` and
-`timeout: 10m` hash identically, so a timeout's spelling is free where a `run`'s
-is not.
+That is the visible damage, and it is not the argument. The argument is that a
+round-trip turns absence into assertion. Every field of the wire struct carries
+a serde default and none of them would be skipped on the way out, so a
+serializer materialises the lot: `context_budget: 8000`, `claim_ttl_max: 2h`, a
+`timeout: 10m` on every verifier that omitted one, and empty maps for
+`verifiers`, `roles` and `identities`. An unset key means "follows the tool"; a
+written one means "pinned here". The day a default moves, every repository that
+ever ran one `ank config` is silently holding the old value, and nothing
+anywhere says so.
+
+The proof hashes are safer than they look, and the measurement is worth keeping
+because the wrong version of it is persuasive. `definition_hash` is
+`sha256(run.trim() + NUL + timeout_in_seconds)` over the **resolved** values of
+the parsed struct, not over the YAML text. So `run: cargo test` and
+`run: "cargo test"` hash identically, and re-quoting alone would not disturb a
+single historical proof. What does disturb one is a restyle that changes the
+resolved string -- a block scalar becoming a folded one, where the newlines
+differ -- which is exactly the form the surgery refuses to touch rather than
+guess at. The timeout is hashed in seconds, so `600s` and `10m` agree too.
 
 So the guarantee is not a nicety about respecting the user's comments. It is
 what keeps the coordination plane honest, and it belongs where it binds.

--- a/.ank/tasks/TASK-797d64113614.md
+++ b/.ank/tasks/TASK-797d64113614.md
@@ -25,7 +25,7 @@ done_criteria: |
   
   `ank config <key>` prints the value in effect, a resolved default included and marked as one. `ank config <key> <value>` writes it. `ank config --unset <key>` removes it. Nested values are addressed by dotted path, `verifiers.<name>.run` and `verifiers.<name>.timeout`. A key the parser does not know is refused by name, with the set it does know, and nothing is written.
   
-  The writer changes no byte it was not asked to change, and that is asserted rather than claimed: over a config.yml carrying comments, blank lines, verifiers declared out of alphabetical order, and a `run` whose value needs quoting, writing one key leaves every other line byte-identical, and verify::definition_hash of every verifier the write did not name is unchanged. A write that would produce a config.yml the parser cannot read fails and leaves the file as it was.
+  The writer changes no byte it was not asked to change, and that is asserted rather than claimed. Over a config.yml carrying comments, blank lines, verifiers declared out of alphabetical order, a quoted `run`, a verifier with no timeout and the line terminators the working tree actually has: writing one key leaves the file byte-identical once the changed line is spliced back, and setting a key that was absent and then unsetting it returns the file byte for byte. No default is ever materialised: a key the file did not carry is still absent after a write to another key. verify::definition_hash is unchanged for every verifier the write did not name. A `run` the surgery cannot edit safely -- a block or folded scalar -- is refused by name with what to do instead, never rewritten. A write that would produce a config.yml the parser cannot read fails and leaves the file as it was.
   
   `ank config` runs without a parsed configuration, as `init` and `help` do, demonstrated through the binary on a config.yml carrying an unknown key: the verb that exists to fix the file is the one verb the broken file does not stop.
   
@@ -34,7 +34,7 @@ done_criteria: |
   skill/SKILL.md does not change and the flat listing stays flat. cargo test, cargo fmt --check and ank check stay green, and crates/ank-cli/tests/skill.rs holds section 4's order against ank help with no edit beyond the new verb's place.
 criteria_by: creator
 schema: 2
-version: 1
+version: 2
 ---
 
 ## Why
@@ -64,16 +64,26 @@ alone. An absent key is appended; a nested one is addressed under its parent.
 
 ## The trap that makes this non-negotiable
 
-`verify::definition_hash` is `sha256(run.trim() + NUL + timeout_in_seconds)`,
-and it is stored in every proof its verifier ever produced. Re-quoting or
-reflowing a `run` scalar changes that hash, and `check` then reports
-"verifier X changed since the proof" on every historical task -- a corpus-wide
-false signal caused by a formatting change nobody asked for.
+Not the proof hashes, which are the plausible answer and the wrong one. It is
+worth writing down which, because the wrong version persuades.
 
-Two corollaries worth having in hand. `run.trim()` means leading and trailing
-whitespace on `run` is insignificant. And the timeout is hashed in seconds, so
-`600s` and `10m` hash identically: a timeout's spelling is free, a `run`'s is
-not.
+`verify::definition_hash` is `sha256(run.trim() + NUL + timeout_in_seconds)`
+over the **resolved** values of the parsed struct, not over the YAML text. So
+`run: cargo test` and `run: "cargo test"` hash identically, and re-quoting alone
+disturbs no historical proof. The timeout is hashed in seconds, so `600s` and
+`10m` agree too. What does move the hash is a restyle that changes the resolved
+string -- a block scalar becoming folded, where the newlines differ -- which is
+why those forms are refused rather than edited.
+
+The real trap is that a round-trip turns absence into assertion. Every field of
+the wire struct carries a serde default and none would be skipped on the way
+out, so a serializer writes the lot into the file: `context_budget: 8000`,
+`claim_ttl_max: 2h`, a `timeout: 10m` on every verifier that omitted one, and
+empty maps for `verifiers`, `roles` and `identities`. An unset key means
+"follows the tool"; a written one means "pinned here". The day a default moves,
+every repository that ever ran one `ank config` holds the old value silently.
+That is why the criterion asks for a key the file did not carry to still be
+absent after a write to another key.
 
 ## The exemption, and why it is load-bearing
 
@@ -95,3 +105,7 @@ four verbs turned the suite red on placement alone.
 `skill/SKILL.md` must not change. Nothing here is taught to an agent by the
 skill, the exclusion test in `skill.rs` is where that is held, and any edit to
 that file forces a revision bump and a rebuild for no gain.
+
+BLOCKED BY (0)
+
+UNBLOCKS (0)

--- a/.ank/tasks/TASK-797d64113614.md
+++ b/.ank/tasks/TASK-797d64113614.md
@@ -1,0 +1,97 @@
+---
+id: TASK-797d64113614
+type: task
+slug: ank-config-writes-the-file-the-errors-currently
+title: ank config writes the file the errors currently tell you to open
+created: 2026-08-09T06:37:37Z
+author: seanl@sean-laptop
+status: open
+scope:
+  - docs/ank-spec-v1.1.md
+  - crates/ank-cli/src/cli.rs
+  - crates/ank-cli/src/config.rs
+  - crates/ank-cli/src/main.rs
+  - crates/ank-cli/src/done.rs
+  - crates/ank-cli/src/commands.rs
+  - crates/ank-cli/src/git.rs
+  - crates/ank-cli/src/status.rs
+  - crates/ank-cli/src/context.rs
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/tests/cli.rs
+  - crates/ank-cli/tests/skill.rs
+blocked_by: []
+done_criteria: |
+  Section 4 of docs/ank-spec-v1.1.md declares `ank config` before the code moves -- in the Commands block, in its place in the order, with its flags -- and section 9 states that config.yml is written through it rather than by hand.
+  
+  `ank config <key>` prints the value in effect, a resolved default included and marked as one. `ank config <key> <value>` writes it. `ank config --unset <key>` removes it. Nested values are addressed by dotted path, `verifiers.<name>.run` and `verifiers.<name>.timeout`. A key the parser does not know is refused by name, with the set it does know, and nothing is written.
+  
+  The writer changes no byte it was not asked to change, and that is asserted rather than claimed: over a config.yml carrying comments, blank lines, verifiers declared out of alphabetical order, and a `run` whose value needs quoting, writing one key leaves every other line byte-identical, and verify::definition_hash of every verifier the write did not name is unchanged. A write that would produce a config.yml the parser cannot read fails and leaves the file as it was.
+  
+  `ank config` runs without a parsed configuration, as `init` and `help` do, demonstrated through the binary on a config.yml carrying an unknown key: the verb that exists to fix the file is the one verb the broken file does not stop.
+  
+  The six hints that today say to open the file name the command instead: done's absent verifier, new's and amend's unknown --verify, and the four sites that ask for default_branch.
+  
+  skill/SKILL.md does not change and the flat listing stays flat. cargo test, cargo fmt --check and ank check stay green, and crates/ank-cli/tests/skill.rs holds section 4's order against ank help with no edit beyond the new verb's place.
+criteria_by: creator
+schema: 2
+version: 1
+---
+
+## Why
+
+Execution of ADR-e64dfaafd578, which is named here rather than in `blocked_by`
+because that field takes task identifiers only -- an ADR there is reported by
+`check` as an entity that does not exist. Read the ADR first: it carries the
+argument, and this carries the work.
+
+The short version: six error messages tell the caller to open `.ank/config.yml`,
+and they are the only errors in the CLI that name a file to edit instead of a
+command to run. ADR-01b6dd05f0db closed `.ank/` to agents and stopped at the
+configuration, so those six are the tool instructing an agent to do what the
+tool forbids.
+
+## Text surgery, not a serializer
+
+There is no serializer to reach for. `Config` derives `Deserialize` and nothing
+else, and the only configuration text this program has ever produced is the
+literal `init` writes when the file is absent.
+
+Building one is the wrong move, not a shortcut avoided. A parse-mutate-serialize
+writer drops every comment and blank line, and returns `verifiers`, `roles` and
+`identities` alphabetised, because they are `BTreeMap`s. So the write is
+line-oriented: find the key, replace its value, leave the rest of the file
+alone. An absent key is appended; a nested one is addressed under its parent.
+
+## The trap that makes this non-negotiable
+
+`verify::definition_hash` is `sha256(run.trim() + NUL + timeout_in_seconds)`,
+and it is stored in every proof its verifier ever produced. Re-quoting or
+reflowing a `run` scalar changes that hash, and `check` then reports
+"verifier X changed since the proof" on every historical task -- a corpus-wide
+false signal caused by a formatting change nobody asked for.
+
+Two corollaries worth having in hand. `run.trim()` means leading and trailing
+whitespace on `run` is insignificant. And the timeout is hashed in seconds, so
+`600s` and `10m` hash identically: a timeout's spelling is free, a `run`'s is
+not.
+
+## The exemption, and why it is load-bearing
+
+`startup` loads the configuration for every verb but `init` and `help`. A
+config.yml that does not parse therefore fails every command at exit 1 --
+`check` included -- so an ordinary `ank config` would be disabled by exactly the
+file it exists to repair. It joins the two exemptions, and the reasoning already
+written in the dispatcher for `help` is the same one: the caller who most needs
+it is the one whose environment is wrong.
+
+## What the surface costs
+
+Section 4's Commands block is parsed by `crates/ank-cli/tests/skill.rs`, so the
+verb must be declared there, in the position it will occupy in `COMMANDS`, or
+three tests refuse the commit. The count assertion in `cli.rs` and the ordering
+test go with them. Precedent says the position is what fires: three of the last
+four verbs turned the suite red on placement alone.
+
+`skill/SKILL.md` must not change. Nothing here is taught to an agent by the
+skill, the exclusion test in `skill.rs` is where that is held, and any edit to
+that file forces a revision bump and a rebuild for no gain.


### PR DESCRIPTION
Files one ADR (`proposed`) and one task (`open`). No code changes.

## The gap

ADR-01b6dd05f0db closed `.ank/` to agents: entities are read and written through the CLI, never by opening the file. Its body enumerates the writing verbs — `new`, `claim`, `log`, `done`, `release`, `attest`, `close`, `accept` — and says nothing about `config.yml`, because `config.yml` is not an entity. The gap was never argued; it was simply out of frame.

**It shows in ank''s own error messages.** Six sites tell the caller to open the file:

| site | hint |
|---|---|
| `git.rs`, `status.rs`, `context.rs`, `human.rs` | `or add "default_branch: <name>" to .ank/config.yml` |
| `done.rs` | `add it under verifiers: in .ank/config.yml` |
| `commands.rs` (×2, `--verify` at `new` and `amend`) | `declare it under verifiers: in .ank/config.yml` |

These are the only errors in the CLI that name a file to edit instead of a command to run — the shape §4 calls out by name — and they are the tool instructing an agent to do the one thing the tool forbids it. They are not wrong today: there is no command to name.

One writer exists. `init` writes the default file if it is absent and never touches it again. Everything after that is a hand edit.

## The decision — ADR-e64dfaafd578

`config.yml` stops being a hand-edited file, in `git config`''s shape: a flat key and a value, `--unset`, dotted paths for what is nested. That is the vocabulary `config.rs` already uses in its own error messages — `verifiers.<name>.timeout` appears there verbatim — so it needs no second one.

### Why byte preservation is in the constraint

There is no serializer. `Config` derives `Deserialize` and nothing else, and the only configuration text ank has ever produced is the literal `init` writes. A parse-mutate-serialize writer would drop every comment and blank line, and return `verifiers`, `roles` and `identities` alphabetised, being `BTreeMap`s.

**That is the visible damage, and it is not the argument.** The argument is that a round-trip turns *absence into assertion*. Every field of the wire struct carries a serde default and none would be skipped on the way out, so a serializer materialises the lot: `context_budget: 8000`, `claim_ttl_max: 2h`, a `timeout: 10m` on every verifier that omitted one, empty maps for `verifiers`/`roles`/`identities`. An unset key means "follows the tool"; a written one means "pinned here". The day a default moves, every repository that ever ran one `ank config` holds the old value and nothing anywhere says so.

**A correction worth recording, because the wrong version is persuasive.** These entities first argued that a round-trip would invalidate historical proofs by re-quoting a verifier''s `run`. Measured against `verify.rs:72`, it would not: `definition_hash` is `sha256(run.trim() + NUL + timeout_in_seconds)` over the **resolved** values of the parsed struct, not over the YAML text, so `run: cargo test` and `run: "cargo test"` hash identically. Only a restyle that changes the resolved string moves the hash — a block scalar becoming folded — which is a form the surgery refuses rather than edits. The claim was corrected in both entities before this PR was ready.

### Why `config` runs without a parsed configuration

`startup` loads `config.yml` for every verb but `init` and `help`, so a file that does not parse fails every command at exit 1 — `check` included — and an ordinary `ank config` would be disabled by exactly the file it exists to repair. The dispatcher already carries that reasoning for `help`: the caller most in need of it is the one whose environment is wrong. Note the exemption is from the *config load*, not from `startup` as a whole: ADR-b8884edcebe3 requires git to be checked at startup and scopes `crates/ank-cli/**`.

Rejected in the ADR: extending `init` (one-shot, idempotent by assertion, perimeter fixed by §9), extending `edit` (entity-shaped: id, version, frozen fields, CAS — none of which `config.yml` has), and leaving it to the human (defensible for a human, who keeps the editor either way; not for an agent, which has no route into `.ank/` but the CLI).

## The task — TASK-797d64113614

Carries the work. Spec first, as ADR-63b59c5c26f7 requires: §4''s Commands block is *parsed* by `crates/ank-cli/tests/skill.rs`, so the verb must be declared there in the position it will occupy in `COMMANDS`, or three tests refuse the commit. Precedent says placement is what fires — three of the last four verbs turned the suite red on it alone.

The criterion pins the guarantee as assertions rather than claims: writing one key leaves the file byte-identical once the changed line is spliced back; setting a key that was absent and then unsetting it returns the file byte for byte; a key the file did not carry is still absent after a write to another key; `definition_hash` is unchanged for every verifier the write did not name; and a `run` the surgery cannot edit safely is refused by name rather than rewritten.

It names the ADR in its body rather than in `blocked_by`, which takes task identifiers only — `check` reports an ADR there as an entity that does not exist.

## After merging

The ADR lands `proposed` and binds nobody. **`ank accept ADR-e64dfaafd578` is yours to run**, signed, on `main` — I have not run it and will not.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKySiQLuzuMBYZrbY7JNpa