### PR TITLE
Add `ank config`, so the errors stop naming a file agents may not open

### DIFF
--- a/.ank/tasks/TASK-797d64113614.md
+++ b/.ank/tasks/TASK-797d64113614.md
@@ -5,7 +5,7 @@ slug: ank-config-writes-the-file-the-errors-currently
 title: ank config writes the file the errors currently tell you to open
 created: 2026-08-09T06:37:37Z
 author: seanl@sean-laptop
-status: in_progress
+status: done
 scope:
   - docs/ank-spec-v1.1.md
   - crates/ank-cli/src/cli.rs
@@ -33,8 +33,12 @@ done_criteria: |
   
   skill/SKILL.md does not change and the flat listing stays flat. cargo test, cargo fmt --check and ank check stay green, and crates/ank-cli/tests/skill.rs holds section 4's order against ank help with no edit beyond the new verb's place.
 criteria_by: creator
+proof:
+  - type: test
+    ref: "31321129580"
+    criteria: cf1c5f75f83a
 schema: 2
-version: 5
+version: 6
 ---
 
 ## Why
@@ -113,3 +117,4 @@ UNBLOCKS (0)
 ## Log
 - 2026-08-09T14:50:22Z claude-code@ank — Located the hint sites the criterion names: done.rs:322 (absent verifier), commands.rs:601 and :676 (new's and amend's unknown --verify, two separate functions check_verifiers and verifiers_of), and four default_branch sites -- context.rs:330, git.rs:504, human.rs:319, status.rs:127. That is seven call sites, not six; the criterion says 'six hints' and then enumerates seven. Fixing all seven. Placement decided: config goes after check and before init in section 4's Commands block, since it shares the startup exemption with init and help. --unset takes -u, which is free, because section 4's short-form table lists letterless flags only where a letter collided.
 - 2026-08-09T15:17:23Z claude-code@ank — Spec, code, tests and the seven hint sites are in. Two findings beyond the criterion. First: the criterion says 'new's and amend's unknown --verify'; amend takes no --verify at all. The two sites are both new's -- the flag form (verifiers_of) and the verify: filled into the EDITOR template (check_verifiers). Both now go through one shared undeclared_verifier. Second: two places still reproduced the replaced text verbatim. Section 7 of the spec showed the old default-branch error, fixed here since the spec is in scope. docs/getting-started.md still tells the reader to open .ank/config.yml in two places and quotes both stale errors -- out of scope, filed separately rather than folded in. Also updated the task template's guidance line, which named the file as the place verifiers are declared.
+- 2026-08-09T15:29:33Z claude-code@ank — done, proof test:31321129580

--- a/.ank/tasks/TASK-797d64113614.md
+++ b/.ank/tasks/TASK-797d64113614.md
@@ -5,7 +5,7 @@ slug: ank-config-writes-the-file-the-errors-currently
 title: ank config writes the file the errors currently tell you to open
 created: 2026-08-09T06:37:37Z
 author: seanl@sean-laptop
-status: open
+status: in_progress
 scope:
   - docs/ank-spec-v1.1.md
   - crates/ank-cli/src/cli.rs
@@ -34,7 +34,7 @@ done_criteria: |
   skill/SKILL.md does not change and the flat listing stays flat. cargo test, cargo fmt --check and ank check stay green, and crates/ank-cli/tests/skill.rs holds section 4's order against ank help with no edit beyond the new verb's place.
 criteria_by: creator
 schema: 2
-version: 2
+version: 5
 ---
 
 ## Why
@@ -109,3 +109,7 @@ that file forces a revision bump and a rebuild for no gain.
 BLOCKED BY (0)
 
 UNBLOCKS (0)
+
+## Log
+- 2026-08-09T14:50:22Z claude-code@ank — Located the hint sites the criterion names: done.rs:322 (absent verifier), commands.rs:601 and :676 (new's and amend's unknown --verify, two separate functions check_verifiers and verifiers_of), and four default_branch sites -- context.rs:330, git.rs:504, human.rs:319, status.rs:127. That is seven call sites, not six; the criterion says 'six hints' and then enumerates seven. Fixing all seven. Placement decided: config goes after check and before init in section 4's Commands block, since it shares the startup exemption with init and help. --unset takes -u, which is free, because section 4's short-form table lists letterless flags only where a letter collided.
+- 2026-08-09T15:17:23Z claude-code@ank — Spec, code, tests and the seven hint sites are in. Two findings beyond the criterion. First: the criterion says 'new's and amend's unknown --verify'; amend takes no --verify at all. The two sites are both new's -- the flag form (verifiers_of) and the verify: filled into the EDITOR template (check_verifiers). Both now go through one shared undeclared_verifier. Second: two places still reproduced the replaced text verbatim. Section 7 of the spec showed the old default-branch error, fixed here since the spec is in scope. docs/getting-started.md still tells the reader to open .ank/config.yml in two places and quotes both stale errors -- out of scope, filed separately rather than folded in. Also updated the task template's guidance line, which named the file as the place verifiers are declared.

--- a/.ank/tasks/TASK-7af1cd875d9a.md
+++ b/.ank/tasks/TASK-7af1cd875d9a.md
@@ -1,0 +1,23 @@
+---
+id: TASK-7af1cd875d9a
+type: task
+slug: the-getting-started-guide-still-tells-the-reader
+title: The getting-started guide still tells the reader to open config.yml
+created: 2026-08-09T15:17:35Z
+author: claude-code@ank
+status: open
+scope:
+  - docs/getting-started.md
+blocked_by: [TASK-797d64113614]
+done_criteria: |
+  docs/getting-started.md no longer instructs anyone to open .ank/config.yml, and the two error blocks it quotes match what the binary prints: the default-branch refusal names 'ank config default_branch <name>', and the undeclared-verifier refusal names 'ank config verifiers.<name>.run'. The section that adds a default branch and the one that declares verifiers both go through the verb. No other file changes, and cargo test stays green.
+criteria_by: creator
+schema: 2
+version: 1
+---
+
+Fallout of TASK-797d64113614, found while changing the hints and left out of it because the guide is outside that task's scope.
+
+The guide reproduces two error messages verbatim -- lines 90-92 and 163-164 as of this filing -- and both are the text the binary stopped printing when ADR-e64dfaafd578 was executed. It also says 'Open .ank/config.yml and add one line' at line 82 and points at the file again at line 151.
+
+The guide addresses a human, and a human with an editor keeps every power they had (ADR-e64dfaafd578). So this is not a correctness rule being broken; it is a guide quoting output that no longer exists, which is the kind of staleness a reader has no way to detect. The fix is to quote what the binary now prints and to reach for the verb where the guide currently reaches for the file.

--- a/crates/ank-cli/src/cli.rs
+++ b/crates/ank-cli/src/cli.rs
@@ -198,6 +198,7 @@ pub const SHORT_FORMS: &[(&str, char)] = &[
     ("--proof", 'p'),
     ("--status", 's'),
     ("--type", 't'),
+    ("--unset", 'u'),
     ("--verify", 'v'),
 ];
 
@@ -497,6 +498,30 @@ pub const COMMANDS: &[CommandSpec] = &[
         flags: &[],
         refuses: &[],
         notes: &["exit 8 means findings; a signal alone leaves it 0"],
+        owner_task: None,
+    },
+    // After `check` and before `init`: §4's order. It sits beside the verb
+    // that writes `config.yml` in the first place, which is the reading §9
+    // states -- what `init` writes, `config` maintains.
+    CommandSpec {
+        name: "config",
+        summary: "reads and writes .ank/config.yml: the key alone reads, a value writes, --unset removes",
+        subcommands: &[],
+        max_positionals: 2,
+        positional_help: "<key> [<value>]",
+        flags: &[switch("--unset")],
+        refuses: &[
+            refuses(
+                1,
+                "a key the parser does not know, or a value in a form the surgery cannot edit safely",
+            ),
+            refuses(7, "verifiers.<name>.timeout on a verifier that is not declared"),
+        ],
+        notes: &[
+            "keys: schema context_budget claim_ttl_max default_branch verifiers.<name>.run verifiers.<name>.timeout",
+            "a resolved default prints marked as one; --json carries value and source as separate fields",
+            "--unset verifiers.<name> removes a whole verifier, which is what makes declaring one reversible",
+        ],
         owner_task: None,
     },
     CommandSpec {
@@ -880,7 +905,7 @@ fn globals_line(with_short: bool) -> String {
 /// literals and none of them needs it today, which is precisely why it is
 /// written rather than assumed: the day a verb or a flag carries a quote, the
 /// output stays parseable instead of becoming a bug in whatever consumes it.
-fn json_str(s: &str) -> String {
+pub fn json_str(s: &str) -> String {
     let mut out = String::from("\"");
     for c in s.chars() {
         match c {
@@ -1135,16 +1160,26 @@ fn dispatch(
         style
     };
 
-    // Two verbs run without the foundation. `init` precedes the existence of
+    // Three verbs run without the foundation. `init` precedes the existence of
     // the repository. `help` describes the surface rather than acting on it,
     // and the caller most in need of it is the one whose environment is wrong:
     // making `ank help` demand a `.ank/`, a git of 2.34, and a readable
     // `config.yml` would withhold the explanation exactly when it is needed.
+    // `config` is the third and the sharpest case of the same reasoning
+    // (ADR-e64dfaafd578): `startup` loads `config.yml` for every other verb, so
+    // an unreadable one fails all of them — `check` included — and the verb
+    // that exists to repair the file would be disabled by exactly the file it
+    // repairs. It resolves the repository, because the file it edits lives in
+    // one, and nothing else.
     if inv.command == "init" {
         return crate::init::run(&inv, cwd, out);
     }
     if inv.command == "help" {
         return help(&inv, out);
+    }
+    if inv.command == "config" {
+        let repo = crate::repo::resolve(inv.repo(), cwd)?;
+        return crate::config::run(&inv, &repo, out);
     }
 
     let s = startup(&inv, cwd)?;
@@ -1255,7 +1290,7 @@ mod tests {
         // counting.
         assert_eq!(
             COMMANDS.len(),
-            20,
+            21,
             "every verb of §4, plus init and help from §9. The surface is \
              complete, so this number moves only when §4 does"
         );
@@ -1328,8 +1363,8 @@ mod tests {
         // opposite direction: `init`, `claim` and `context` are the verbs
         // routed today, and all must be clear of it.
         for routed in [
-            "init", "help", "claim", "context", "done", "log", "release", "new", "find", "attest",
-            "amend", "show", "edit",
+            "init", "help", "config", "claim", "context", "done", "log", "release", "new", "find",
+            "attest", "amend", "show", "edit",
         ] {
             assert_eq!(
                 spec_of(routed).unwrap().owner_task,

--- a/crates/ank-cli/src/commands.rs
+++ b/crates/ank-cli/src/commands.rs
@@ -376,7 +376,7 @@ const TASK_GUIDANCE: &str = "\
 # done_criteria  what makes this verifiably done, in one testable sentence.
 #                Leave it out and whoever claims the task sets it instead.
 # blocked_by     ids that must be done first, as [ID, ID].
-# verify         verifiers declared in .ank/config.yml, as [name, name].
+# verify         verifiers declared by ank config, as [name, name].
 ";
 
 const ADR_GUIDANCE: &str = "\
@@ -590,22 +590,32 @@ fn resolve_blockers(store: &Store, ids: &[EntityId], hint: &str) -> Result<()> {
     Ok(())
 }
 
+/// The next command for a `--verify` naming a verifier that is not declared.
+///
+/// It names the command that declares one rather than the file to open
+/// (ADR-e64dfaafd578): a hint telling an agent to edit `.ank/config.yml` is the
+/// tool instructing it to do what ADR-01b6dd05f0db forbids. The names already
+/// declared come first when there are any, because a typo is the likelier of
+/// the two mistakes and the list settles it in one line.
+fn undeclared_verifier(name: &str, cfg: &Config) -> CliError {
+    let mut known: Vec<&str> = cfg.verifiers.keys().map(|s| s.as_str()).collect();
+    known.sort_unstable();
+    let declare = format!("ank config verifiers.{name}.run \"<command>\"");
+    let hint = if known.is_empty() {
+        declare
+    } else {
+        format!("declared: {}\n  -> or {declare}", known.join(" "))
+    };
+    CliError::new(7, format!("no verifier '{name}' in .ank/config.yml")).with_hint(hint)
+}
+
 /// The `verify` names, checked against `config.yml` the way `verifiers_of`
 /// checks the flag.
 fn check_verifiers(names: &[String], cfg: &Config) -> Result<()> {
     for name in names {
-        if cfg.verifier(name.trim()).is_none() {
-            let mut known: Vec<&str> = cfg.verifiers.keys().map(|s| s.as_str()).collect();
-            known.sort_unstable();
-            let hint = if known.is_empty() {
-                "declare it under verifiers: in .ank/config.yml".to_string()
-            } else {
-                format!("declared in .ank/config.yml: {}", known.join(" "))
-            };
-            return Err(
-                CliError::new(7, format!("no verifier '{name}' in .ank/config.yml"))
-                    .with_hint(hint),
-            );
+        let name = name.trim();
+        if cfg.verifier(name).is_none() {
+            return Err(undeclared_verifier(name, cfg));
         }
     }
     Ok(())
@@ -670,17 +680,7 @@ fn verifiers_of(inv: &Invocation, cfg: &Config) -> Result<Vec<String>> {
     for raw in inv.values("--verify") {
         let name = raw.trim();
         if cfg.verifier(name).is_none() {
-            let mut known: Vec<&str> = cfg.verifiers.keys().map(|s| s.as_str()).collect();
-            known.sort_unstable();
-            let hint = if known.is_empty() {
-                "declare it under verifiers: in .ank/config.yml".to_string()
-            } else {
-                format!("declared in .ank/config.yml: {}", known.join(" "))
-            };
-            return Err(
-                CliError::new(7, format!("no verifier '{name}' in .ank/config.yml"))
-                    .with_hint(hint),
-            );
+            return Err(undeclared_verifier(name, cfg));
         }
         if !out.iter().any(|v| v == name) {
             out.push(name.to_string());
@@ -2126,5 +2126,55 @@ mod tests {
         );
         assert!(slugify(&"long title ".repeat(20)).len() <= 48);
         assert!(slugify("!!!").is_empty(), "nothing readable is nothing");
+    }
+
+    /// Both routes into a `verify` name reach one refusal, and it names a
+    /// command (ADR-e64dfaafd578).
+    ///
+    /// The flag form is exercised through the binary in `tests/cli.rs`. This
+    /// one covers the other route -- a `verify:` filled into the `$EDITOR`
+    /// template, which `check_verifiers` guards -- and the shared
+    /// `undeclared_verifier` is what makes the two answer alike rather than a
+    /// second copy of the message that would drift.
+    #[test]
+    fn an_undeclared_verifier_names_the_command_that_declares_one() {
+        let empty =
+            crate::config::parse(&crate::config::default_yaml(), Path::new("config.yml")).unwrap();
+        let err = check_verifiers(&["nope".to_string()], &empty).unwrap_err();
+        assert_eq!(err.code, 7);
+        assert_eq!(
+            err.hint.as_deref(),
+            Some("ank config verifiers.nope.run \"<command>\""),
+            "a hint that names the file is the tool telling an agent to do \
+             what ADR-01b6dd05f0db forbids"
+        );
+
+        // With verifiers already declared, the names come first -- a typo is
+        // the likelier of the two mistakes -- and the command still follows.
+        let declared = crate::config::parse(
+            "schema: 1\nverifiers:\n  cargo-test:\n    run: cargo test\n",
+            Path::new("config.yml"),
+        )
+        .unwrap();
+        let err = check_verifiers(&["nope".to_string()], &declared).unwrap_err();
+        let hint = err.hint.unwrap();
+        assert!(hint.contains("declared: cargo-test"), "{hint}");
+        assert!(hint.contains("ank config verifiers.nope.run"), "{hint}");
+        assert!(!hint.contains(".ank/config.yml"), "{hint}");
+
+        // And `verifiers_of`, the flag route, is the same refusal.
+        let argv: Vec<String> = [
+            "new", "task", "--title", "T", "--scope", "s/**", "--verify", "nope",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+        let inv = crate::cli::parse(&argv).unwrap();
+        assert_eq!(
+            verifiers_of(&inv, &empty).unwrap_err().hint,
+            check_verifiers(&["nope".to_string()], &empty)
+                .unwrap_err()
+                .hint
+        );
     }
 }

--- a/crates/ank-cli/src/config.rs
+++ b/crates/ank-cli/src/config.rs
@@ -5,9 +5,11 @@
 //! verifiers. An unknown `schema` is cleanly refused rather than misread:
 //! that is the counterpart of "the format is the specification".
 
-use crate::cli::CliError;
+use crate::cli::{CliError, Invocation};
 use serde::Deserialize;
 use std::collections::BTreeMap;
+use std::io::Write;
+use std::ops::Range;
 use std::path::Path;
 use std::time::Duration;
 
@@ -210,6 +212,976 @@ identities: {}
     .to_string()
 }
 
+// ---------------------------------------------------------------------------
+// `ank config` (§4, ADR-e64dfaafd578)
+// ---------------------------------------------------------------------------
+//
+// Text surgery, and never a round-trip through a serializer. `Config` derives
+// `Deserialize` and nothing else, and building the other half would be the
+// wrong move rather than a shortcut avoided: a parse-mutate-serialize writer
+// drops every comment and blank line, returns `verifiers`, `roles` and
+// `identities` alphabetised because they are `BTreeMap`s, and -- the reason
+// this is not a matter of taste -- writes out every field carrying a serde
+// default. An unset key means "follows the tool"; a written one means "pinned
+// here". So a round-trip turns absence into assertion, and every repository
+// that ever ran one `ank config` silently holds the old value the day a default
+// moves.
+//
+// The writer therefore finds the line, replaces the span the value occupies,
+// and leaves every other byte alone.
+
+/// The keys this verb addresses, spelled the way §4's table spells them.
+pub const KEYS: &[&str] = &[
+    "schema",
+    "context_budget",
+    "claim_ttl_max",
+    "default_branch",
+    "verifiers.<name>.run",
+    "verifiers.<name>.timeout",
+];
+
+/// A dotted path, resolved against the closed key set.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Key {
+    /// A scalar at the root of the document.
+    Top {
+        name: &'static str,
+        /// Emitted verbatim: the field holds a number, and quoting one would
+        /// store a string the parser refuses.
+        numeric: bool,
+        default: Option<String>,
+    },
+    /// `verifiers.<name>.run` or `.timeout`.
+    Field {
+        verifier: String,
+        field: &'static str,
+        default: Option<String>,
+    },
+    /// `verifiers.<name>`: legal for `--unset` alone, which is what makes
+    /// declaring a verifier reversible.
+    Block { verifier: String },
+}
+
+fn unknown_key(path: &str) -> CliError {
+    CliError::new(1, format!("unknown key '{path}'")).with_hint(format!("keys: {}", KEYS.join(" ")))
+}
+
+fn structured(name: &str) -> CliError {
+    CliError::new(
+        1,
+        format!("'{name}' has a structured value, which ank config does not address"),
+    )
+    .with_hint(format!(
+        "edit .ank/config.yml by hand: {name} is a mapping of lists, not a scalar"
+    ))
+}
+
+/// A `run` written as a block or folded scalar. Refused rather than rewritten:
+/// its resolved string depends on line structure a one-line replacement would
+/// flatten, and `verify::definition_hash` is taken over the resolved value, so
+/// flattening it moves a hash that anchors historical proofs.
+fn blocky(name: &str) -> CliError {
+    CliError::new(
+        1,
+        format!("'{name}' is a block or folded scalar, which ank config does not rewrite"),
+    )
+    .with_hint(
+        "edit .ank/config.yml by hand: flattening it would move the verifier's definition hash",
+    )
+}
+
+fn flow_mapping(name: &str) -> CliError {
+    CliError::new(
+        1,
+        format!("'{name}' is written as a non-empty flow mapping, which ank config does not edit"),
+    )
+    .with_hint("edit .ank/config.yml by hand, or write it as a block mapping")
+}
+
+fn undeclared(verifier: &str) -> CliError {
+    CliError::new(7, format!("verifier '{verifier}' is not declared"))
+        .with_hint(format!("ank config verifiers.{verifier}.run \"<command>\""))
+}
+
+fn whole_block(verifier: &str) -> CliError {
+    CliError::new(
+        1,
+        format!("'verifiers.{verifier}' is a whole verifier, not a value: --unset removes it"),
+    )
+    .with_hint(format!("ank config verifiers.{verifier}.run"))
+}
+
+fn resolve_key(path: &str) -> Result<Key> {
+    let segs: Vec<&str> = path.split('.').collect();
+    if segs.iter().any(|s| s.is_empty()) {
+        return Err(unknown_key(path));
+    }
+    match segs.as_slice() {
+        ["schema"] => Ok(Key::Top {
+            name: "schema",
+            numeric: true,
+            default: None,
+        }),
+        ["context_budget"] => Ok(Key::Top {
+            name: "context_budget",
+            numeric: true,
+            default: Some(DEFAULT_CONTEXT_BUDGET.to_string()),
+        }),
+        ["claim_ttl_max"] => Ok(Key::Top {
+            name: "claim_ttl_max",
+            numeric: false,
+            default: Some(DEFAULT_CLAIM_TTL_MAX.to_string()),
+        }),
+        // No default: absent, the resolution falls back to
+        // refs/remotes/origin/HEAD and fails rather than guessing (§7).
+        ["default_branch"] => Ok(Key::Top {
+            name: "default_branch",
+            numeric: false,
+            default: None,
+        }),
+        ["roles", ..] => Err(structured("roles")),
+        ["identities", ..] => Err(structured("identities")),
+        ["verifiers"] => Err(
+            CliError::new(1, "'verifiers' is a mapping: address one by name")
+                .with_hint("ank config verifiers.<name>.run \"<command>\""),
+        ),
+        ["verifiers", name] => Ok(Key::Block {
+            verifier: (*name).to_string(),
+        }),
+        ["verifiers", name, "run"] => Ok(Key::Field {
+            verifier: (*name).to_string(),
+            field: "run",
+            default: None,
+        }),
+        ["verifiers", name, "timeout"] => Ok(Key::Field {
+            verifier: (*name).to_string(),
+            field: "timeout",
+            default: Some(DEFAULT_VERIFIER_TIMEOUT.to_string()),
+        }),
+        ["verifiers", _, other] => Err(CliError::new(
+            1,
+            format!("unknown verifier field '{other}'"),
+        )
+        .with_hint("ank config verifiers.<name>.run   or   ank config verifiers.<name>.timeout")),
+        ["verifiers", _, _, _, ..] => Err(CliError::new(
+            1,
+            format!(
+                "'{path}': a verifier whose name contains '.' cannot be addressed by a dotted path"
+            ),
+        )
+        .with_hint("edit .ank/config.yml by hand, or rename the verifier")),
+        _ => Err(unknown_key(path)),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Lines, kept exactly as they were read
+// ---------------------------------------------------------------------------
+
+/// One physical line and the terminator it carried.
+///
+/// Each line keeps its own, rather than the file keeping one: §3 forbids ank to
+/// *write* CRLF and says nothing about rewriting a CRLF checkout in place, and
+/// a writer that normalised terminators would rewrite every line of such a file
+/// to change one key.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Line {
+    text: String,
+    eol: String,
+}
+
+fn split_lines(text: &str) -> Vec<Line> {
+    let mut out = Vec::new();
+    let mut rest = text;
+    loop {
+        match rest.find('\n') {
+            Some(i) => {
+                let raw = &rest[..i];
+                let (body, eol) = match raw.strip_suffix('\r') {
+                    Some(b) => (b, "\r\n"),
+                    None => (raw, "\n"),
+                };
+                out.push(Line {
+                    text: body.to_string(),
+                    eol: eol.to_string(),
+                });
+                rest = &rest[i + 1..];
+            }
+            None => {
+                if !rest.is_empty() {
+                    out.push(Line {
+                        text: rest.to_string(),
+                        eol: String::new(),
+                    });
+                }
+                return out;
+            }
+        }
+    }
+}
+
+fn join_lines(lines: &[Line]) -> String {
+    let mut s = String::new();
+    for l in lines {
+        s.push_str(&l.text);
+        s.push_str(&l.eol);
+    }
+    s
+}
+
+/// The terminator a line appended to this file should carry.
+fn dominant_eol(lines: &[Line]) -> String {
+    if lines.iter().any(|l| l.eol == "\r\n") {
+        "\r\n".to_string()
+    } else {
+        "\n".to_string()
+    }
+}
+
+/// Gives the last line a terminator, so that appending after it does not join
+/// the two. Only the last line can be unterminated.
+fn terminate_last(lines: &mut [Line], eol: &str) {
+    if let Some(last) = lines.last_mut() {
+        if last.eol.is_empty() {
+            last.eol = eol.to_string();
+        }
+    }
+}
+
+/// Removes whole lines, terminator included.
+///
+/// Removing the last line of a file that had no trailing newline leaves the
+/// previous line's terminator in place, and that is the faithful reading rather
+/// than an oversight: that byte was in the file, the caller asked for the key
+/// below it, and clearing it would delete a byte nobody named. The absence of a
+/// trailing newline is only preserved when the line carrying it survives.
+fn remove_lines(lines: &mut Vec<Line>, r: Range<usize>) {
+    lines.drain(r);
+}
+
+// ---------------------------------------------------------------------------
+// Reading the structure: enough YAML to find a line, and no more
+// ---------------------------------------------------------------------------
+
+/// The indentation of a line that carries content.
+///
+/// `None` for a blank line or one holding only a comment. Neither belongs to a
+/// block, and reporting them at indent 0 would close every block a comment
+/// happens to sit in.
+fn content_indent(text: &str) -> Option<usize> {
+    let n = text.len() - text.trim_start_matches(' ').len();
+    let rest = &text[n..];
+    if rest.trim().is_empty() || rest.starts_with('#') {
+        return None;
+    }
+    Some(n)
+}
+
+/// A quoted scalar at the head of `s`: its value, and the bytes it occupies.
+fn read_quoted(s: &str, quote: char) -> Option<(String, usize)> {
+    let bytes = s.as_bytes();
+    let mut out = String::new();
+    let mut i = quote.len_utf8();
+    while i < bytes.len() {
+        let b = bytes[i];
+        if quote == '"' && b == b'\\' {
+            let n = *bytes.get(i + 1)? as char;
+            out.push(match n {
+                'n' => '\n',
+                't' => '\t',
+                'r' => '\r',
+                other => other,
+            });
+            i += 2;
+            continue;
+        }
+        if quote == '"' && b == b'"' {
+            return Some((out, i + 1));
+        }
+        if quote == '\'' && b == b'\'' {
+            if bytes.get(i + 1) == Some(&b'\'') {
+                out.push('\'');
+                i += 2;
+                continue;
+            }
+            return Some((out, i + 1));
+        }
+        let ch = s[i..].chars().next()?;
+        out.push(ch);
+        i += ch.len_utf8();
+    }
+    None
+}
+
+/// The key a line declares, and the byte offset just past its colon.
+///
+/// Quoted keys are read as keys: `identities` carries `"marie@laptop": human`,
+/// and a scan stopping at the first colon would find one inside the quotes.
+fn key_of(text: &str) -> Option<(String, usize)> {
+    let indent = text.len() - text.trim_start_matches(' ').len();
+    let rest = &text[indent..];
+    let first = rest.chars().next()?;
+    let (name, mut at) = if first == '"' || first == '\'' {
+        let (v, len) = read_quoted(rest, first)?;
+        (v, indent + len)
+    } else {
+        let i = rest.find(':')?;
+        (rest[..i].trim_end().to_string(), indent + i)
+    };
+    let bytes = text.as_bytes();
+    while bytes.get(at) == Some(&b' ') {
+        at += 1;
+    }
+    if bytes.get(at) != Some(&b':') {
+        return None;
+    }
+    // `key: value` and `key:`, never `key:value` -- YAML requires the space.
+    match bytes.get(at + 1) {
+        None | Some(b' ') => Some((name, at + 1)),
+        _ => None,
+    }
+}
+
+/// What a value occupies on its line, as a byte range into it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ValueSpan {
+    start: usize,
+    end: usize,
+    /// The quote the value already carried, so a rewrite keeps its style.
+    quote: Option<char>,
+    /// `|` or `>`.
+    blocky: bool,
+    value: String,
+}
+
+fn value_span(text: &str, after_colon: usize) -> ValueSpan {
+    let bytes = text.as_bytes();
+    let mut start = after_colon;
+    while bytes.get(start) == Some(&b' ') {
+        start += 1;
+    }
+    let empty = ValueSpan {
+        start,
+        end: start,
+        quote: None,
+        blocky: false,
+        value: String::new(),
+    };
+    let rest = &text[start..];
+    let Some(first) = rest.chars().next() else {
+        return empty;
+    };
+    if first == '#' {
+        return empty;
+    }
+    if first == '|' || first == '>' {
+        return ValueSpan {
+            start,
+            end: text.len(),
+            quote: None,
+            blocky: true,
+            value: String::new(),
+        };
+    }
+    if first == '"' || first == '\'' {
+        if let Some((v, len)) = read_quoted(rest, first) {
+            return ValueSpan {
+                start,
+                end: start + len,
+                quote: Some(first),
+                blocky: false,
+                value: v,
+            };
+        }
+    }
+    // A plain scalar ends where the comment after it begins: in YAML a `#`
+    // preceded by whitespace opens one, and a `#` that is not part of the
+    // value.
+    let end_rel = rest.find(" #").unwrap_or(rest.len());
+    let plain = rest[..end_rel].trim_end();
+    ValueSpan {
+        start,
+        end: start + plain.len(),
+        quote: None,
+        blocky: false,
+        value: plain.to_string(),
+    }
+}
+
+/// The block hanging under the key on line `parent`.
+///
+/// `range` ends one past the block's last line **of content**, which is the
+/// distinction insertion needs: a comment between the last verifier and the
+/// next top-level key conventionally introduces what follows it, so a new entry
+/// goes above the comment and not below it.
+struct Block {
+    range: Range<usize>,
+    /// The indentation the children use; `None` when the block is empty.
+    indent: Option<usize>,
+}
+
+fn block_under(lines: &[Line], parent: usize, parent_indent: usize) -> Block {
+    let mut indent: Option<usize> = None;
+    let mut last_content = parent;
+    for (i, line) in lines.iter().enumerate().skip(parent + 1) {
+        let Some(n) = content_indent(&line.text) else {
+            continue;
+        };
+        match indent {
+            None => {
+                if n <= parent_indent {
+                    break;
+                }
+                indent = Some(n);
+            }
+            Some(c) if n < c => break,
+            Some(_) => {}
+        }
+        last_content = i;
+    }
+    Block {
+        range: parent + 1..last_content + 1,
+        indent,
+    }
+}
+
+/// The line declaring `name` at exactly `indent`, within `range`.
+fn find_key(lines: &[Line], range: Range<usize>, indent: usize, name: &str) -> Option<usize> {
+    range.into_iter().find(|&i| {
+        content_indent(&lines[i].text) == Some(indent)
+            && key_of(&lines[i].text).is_some_and(|(k, _)| k == name)
+    })
+}
+
+/// The `verifiers:` line, the block under it, and the indentation of the
+/// entries it holds.
+fn verifiers_block(lines: &[Line]) -> Option<(usize, Block)> {
+    let vi = find_key(lines, 0..lines.len(), 0, "verifiers")?;
+    let block = block_under(lines, vi, 0);
+    Some((vi, block))
+}
+
+/// The line declaring verifier `name`, and the block of its own fields.
+fn locate_verifier(lines: &[Line], name: &str) -> Option<(usize, usize, Block)> {
+    let (_, block) = verifiers_block(lines)?;
+    let child = block.indent?;
+    let i = find_key(lines, block.range.clone(), child, name)?;
+    Some((i, child, block_under(lines, i, child)))
+}
+
+// ---------------------------------------------------------------------------
+// Rendering a value back
+// ---------------------------------------------------------------------------
+
+/// Plain scalars YAML resolves to something other than a string. A branch
+/// called `no` written plain would be stored as a boolean, and the point of the
+/// verb is that the value the caller typed is the value stored.
+fn resolves_to_non_string(s: &str) -> bool {
+    const WORDS: [&str; 10] = [
+        "true", "false", "yes", "no", "on", "off", "null", "~", "y", "n",
+    ];
+    let lower = s.to_ascii_lowercase();
+    WORDS.contains(&lower.as_str()) || s.parse::<i64>().is_ok() || s.parse::<f64>().is_ok()
+}
+
+fn plain_safe(s: &str) -> bool {
+    const INDICATORS: &str = "-?:,[]{}#&*!|>'\"%@`";
+    !s.is_empty()
+        && s.trim() == s
+        && !s.chars().any(char::is_control)
+        && !s.starts_with(|c| INDICATORS.contains(c))
+        && !s.contains(": ")
+        && !s.ends_with(':')
+        && !s.contains(" #")
+        && !resolves_to_non_string(s)
+}
+
+fn double_quoted(s: &str) -> String {
+    let mut out = String::from("\"");
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\t' => out.push_str("\\t"),
+            '\r' => out.push_str("\\r"),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+/// The value as it will be written. A string key keeps the quoting style it
+/// already had, which is what makes "quoting style survives a write" true of
+/// the edited key as well as of its neighbours.
+fn render_value(value: &str, numeric: bool, keep: Option<char>) -> String {
+    if numeric {
+        return value.to_string();
+    }
+    match keep {
+        Some('"') => double_quoted(value),
+        Some('\'') if !value.contains('\n') => format!("'{}'", value.replace('\'', "''")),
+        _ if plain_safe(value) => value.to_string(),
+        _ => double_quoted(value),
+    }
+}
+
+/// Puts `rendered` where `span` was, and nowhere else on the line.
+fn splice(line: &mut Line, span: &ValueSpan, rendered: &str) {
+    let head = line.text[..span.start].to_string();
+    let tail = line.text[span.end..].to_string();
+    // `key:` carries no space before an absent value, and one has to appear.
+    let sep = if span.start == span.end && !head.ends_with(' ') {
+        " "
+    } else {
+        ""
+    };
+    line.text = format!("{head}{sep}{rendered}{tail}");
+}
+
+// ---------------------------------------------------------------------------
+// Reading and writing one key
+// ---------------------------------------------------------------------------
+
+/// The value in effect, in the shape both surfaces print.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Value {
+    /// Carried by the file.
+    Set(String),
+    /// Absent, and the tool resolves one.
+    Default(String),
+    /// Absent, with nothing to resolve.
+    Unset,
+}
+
+impl Value {
+    fn display(&self) -> String {
+        match self {
+            Value::Set(v) => v.clone(),
+            Value::Default(v) => format!("{v} (default)"),
+            Value::Unset => "(unset)".to_string(),
+        }
+    }
+
+    fn source(&self) -> &'static str {
+        match self {
+            Value::Set(_) => "file",
+            Value::Default(_) => "default",
+            Value::Unset => "unset",
+        }
+    }
+
+    fn json(&self) -> String {
+        match self {
+            Value::Set(v) | Value::Default(v) => crate::cli::json_str(v),
+            Value::Unset => "null".to_string(),
+        }
+    }
+}
+
+fn from_default(d: &Option<String>) -> Value {
+    match d {
+        Some(v) => Value::Default(v.clone()),
+        None => Value::Unset,
+    }
+}
+
+fn scalar_at(line: &Line, name: &str) -> Result<Value> {
+    let (_, after) = key_of(&line.text).expect("the line was found by its key");
+    let span = value_span(&line.text, after);
+    if span.blocky {
+        return Err(blocky(name));
+    }
+    if span.start == span.end {
+        return Ok(Value::Unset);
+    }
+    Ok(Value::Set(span.value))
+}
+
+/// Read from the text and not from a parsed [`Config`]: this verb runs on a
+/// file that does not parse, and a reader that needed the parse would go silent
+/// exactly where it is needed (§4).
+fn read_key(lines: &[Line], key: &Key) -> Result<Value> {
+    match key {
+        Key::Block { verifier } => Err(whole_block(verifier)),
+        Key::Top { name, default, .. } => match find_key(lines, 0..lines.len(), 0, name) {
+            Some(i) => scalar_at(&lines[i], name),
+            None => Ok(from_default(default)),
+        },
+        Key::Field {
+            verifier,
+            field,
+            default,
+        } => {
+            // A timeout resolved for a verifier that is not declared would be a
+            // value in effect for something that will never run.
+            let Some((_, _, inner)) = locate_verifier(lines, verifier) else {
+                return Ok(Value::Unset);
+            };
+            match inner
+                .indent
+                .and_then(|g| find_key(lines, inner.range.clone(), g, field))
+            {
+                Some(j) => scalar_at(&lines[j], &format!("verifiers.{verifier}.{field}")),
+                None => Ok(from_default(default)),
+            }
+        }
+    }
+}
+
+/// What a write reports as the state before and after it.
+///
+/// Not [`read_key`], because a whole verifier has no value to read and is still
+/// the thing `--unset` removes: reporting `declared -> (unset)` is the honest
+/// answer, and refusing to observe it would make the removal unreportable.
+fn observe(lines: &[Line], key: &Key) -> Result<Value> {
+    match key {
+        Key::Block { verifier } => Ok(match locate_verifier(lines, verifier) {
+            Some(_) => Value::Set("declared".to_string()),
+            None => Value::Unset,
+        }),
+        other => read_key(lines, other),
+    }
+}
+
+fn write_key(lines: &mut Vec<Line>, key: &Key, value: &str) -> Result<()> {
+    match key {
+        Key::Block { verifier } => Err(whole_block(verifier)),
+        Key::Top { name, numeric, .. } => match find_key(lines, 0..lines.len(), 0, name) {
+            Some(i) => {
+                let (_, after) = key_of(&lines[i].text).expect("found by its key");
+                let span = value_span(&lines[i].text, after);
+                if span.blocky {
+                    return Err(blocky(name));
+                }
+                let rendered = render_value(value, *numeric, span.quote);
+                splice(&mut lines[i], &span, &rendered);
+                Ok(())
+            }
+            None => {
+                let eol = dominant_eol(lines);
+                terminate_last(lines, &eol);
+                let rendered = render_value(value, *numeric, None);
+                lines.push(Line {
+                    text: format!("{name}: {rendered}"),
+                    eol,
+                });
+                Ok(())
+            }
+        },
+        Key::Field {
+            verifier, field, ..
+        } => write_field(lines, verifier, field, value),
+    }
+}
+
+fn write_field(lines: &mut Vec<Line>, verifier: &str, field: &str, value: &str) -> Result<()> {
+    let eol = dominant_eol(lines);
+    let rendered = render_value(value, false, None);
+
+    let Some(vi) = find_key(lines, 0..lines.len(), 0, "verifiers") else {
+        // Only `run` declares a verifier: a timeout with no command names one
+        // that cannot run, and the file would not parse.
+        if field != "run" {
+            return Err(undeclared(verifier));
+        }
+        terminate_last(lines, &eol);
+        lines.push(Line {
+            text: "verifiers:".to_string(),
+            eol: eol.clone(),
+        });
+        lines.push(Line {
+            text: format!("  {verifier}:"),
+            eol: eol.clone(),
+        });
+        lines.push(Line {
+            text: format!("    run: {rendered}"),
+            eol,
+        });
+        return Ok(());
+    };
+
+    let (_, after) = key_of(&lines[vi].text).expect("found by its key");
+    let span = value_span(&lines[vi].text, after);
+    if span.blocky {
+        return Err(blocky("verifiers"));
+    }
+    if !span.value.is_empty() && span.value != "{}" {
+        return Err(flow_mapping("verifiers"));
+    }
+
+    // `verifiers: {}` is what `init` writes, and the first verifier declared
+    // into it turns the key into a block mapping. That byte is the parent of
+    // the key being written, not a byte beside it (§4) -- and without it the
+    // file `init` produces could never receive a verifier at all.
+    if span.value == "{}" {
+        if field != "run" {
+            return Err(undeclared(verifier));
+        }
+        let head = lines[vi].text[..span.start].trim_end().to_string();
+        let tail = lines[vi].text[span.end..].to_string();
+        lines[vi].text = format!("{head}{tail}");
+        lines.insert(
+            vi + 1,
+            Line {
+                text: format!("  {verifier}:"),
+                eol: eol.clone(),
+            },
+        );
+        lines.insert(
+            vi + 2,
+            Line {
+                text: format!("    run: {rendered}"),
+                eol,
+            },
+        );
+        return Ok(());
+    }
+
+    let block = block_under(lines, vi, 0);
+    let child = block.indent.unwrap_or(2);
+    match find_key(lines, block.range.clone(), child, verifier) {
+        Some(i) => {
+            let inner = block_under(lines, i, child);
+            let grand = inner.indent.unwrap_or(child + 2);
+            match find_key(lines, inner.range.clone(), grand, field) {
+                Some(j) => {
+                    let (_, after) = key_of(&lines[j].text).expect("found by its key");
+                    let span = value_span(&lines[j].text, after);
+                    if span.blocky {
+                        return Err(blocky(&format!("verifiers.{verifier}.{field}")));
+                    }
+                    let rendered = render_value(value, false, span.quote);
+                    splice(&mut lines[j], &span, &rendered);
+                    Ok(())
+                }
+                None => {
+                    let at = inner.range.end;
+                    if at == lines.len() {
+                        terminate_last(lines, &eol);
+                    }
+                    lines.insert(
+                        at,
+                        Line {
+                            text: format!("{}{field}: {rendered}", " ".repeat(grand)),
+                            eol,
+                        },
+                    );
+                    Ok(())
+                }
+            }
+        }
+        None => {
+            if field != "run" {
+                return Err(undeclared(verifier));
+            }
+            // A new verifier goes at the end of the block, indented the way the
+            // ones already there are rather than the way this file would have
+            // been written from scratch.
+            let grand = first_grandchild_indent(lines, &block, child).unwrap_or(child + 2);
+            let at = block.range.end;
+            if at == lines.len() {
+                terminate_last(lines, &eol);
+            }
+            lines.insert(
+                at,
+                Line {
+                    text: format!("{}{verifier}:", " ".repeat(child)),
+                    eol: eol.clone(),
+                },
+            );
+            lines.insert(
+                at + 1,
+                Line {
+                    text: format!("{}run: {rendered}", " ".repeat(grand)),
+                    eol,
+                },
+            );
+            Ok(())
+        }
+    }
+}
+
+fn first_grandchild_indent(lines: &[Line], block: &Block, child: usize) -> Option<usize> {
+    for i in block.range.clone() {
+        if content_indent(&lines[i].text) == Some(child) && key_of(&lines[i].text).is_some() {
+            return block_under(lines, i, child).indent;
+        }
+    }
+    None
+}
+
+fn unset_key(lines: &mut Vec<Line>, key: &Key) -> Result<()> {
+    match key {
+        Key::Top { name, .. } => {
+            if let Some(i) = find_key(lines, 0..lines.len(), 0, name) {
+                remove_lines(lines, i..i + 1);
+            }
+            Ok(())
+        }
+        Key::Field {
+            verifier, field, ..
+        } => {
+            if *field == "run" {
+                return Err(CliError::new(
+                    1,
+                    format!("verifiers.{verifier}.run is required: a verifier with no command is not one"),
+                )
+                .with_hint(format!("ank config --unset verifiers.{verifier}")));
+            }
+            let Some((_, _, inner)) = locate_verifier(lines, verifier) else {
+                return Ok(());
+            };
+            if let Some(j) = inner
+                .indent
+                .and_then(|g| find_key(lines, inner.range.clone(), g, field))
+            {
+                remove_lines(lines, j..j + 1);
+            }
+            Ok(())
+        }
+        Key::Block { verifier } => {
+            let Some((vi, block)) = verifiers_block(lines) else {
+                return Ok(());
+            };
+            let Some(child) = block.indent else {
+                return Ok(());
+            };
+            let Some(i) = find_key(lines, block.range.clone(), child, verifier) else {
+                return Ok(());
+            };
+            let inner = block_under(lines, i, child);
+            remove_lines(lines, i..inner.range.end.max(i + 1));
+
+            // The last verifier removed leaves `verifiers:` with no children,
+            // which is not an empty map but a parse error -- so the key goes
+            // back to the `{}` `init` writes. The counterpart of the promotion
+            // above, and forced by the same rule.
+            if block_under(lines, vi, 0).indent.is_none() {
+                let (_, after) = key_of(&lines[vi].text).expect("found by its key");
+                let span = value_span(&lines[vi].text, after);
+                splice(&mut lines[vi], &span, "{}");
+            }
+            Ok(())
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The verb
+// ---------------------------------------------------------------------------
+
+/// `ank config <key> [<value>] [--unset]` (§4).
+///
+/// Runs without the foundation, as `init` and `help` do: `startup` loads
+/// `config.yml` for every other verb, so a file that does not parse fails all
+/// of them, `check` included. A verb that exists to repair the file and is
+/// disabled by exactly the file it repairs is not a verb.
+pub fn run(inv: &Invocation, repo: &crate::repo::Repo, out: &mut dyn Write) -> Result<i32> {
+    let path = repo.config_path();
+    let unset = inv.has("--unset");
+
+    let Some(raw_key) = inv.positionals.first() else {
+        return Err(
+            CliError::new(1, "config expects a key").with_hint(format!("keys: {}", KEYS.join(" ")))
+        );
+    };
+    let key = resolve_key(raw_key)?;
+    let value = inv.positionals.get(1);
+
+    if unset && value.is_some() {
+        return Err(CliError::new(1, "--unset takes no value")
+            .with_hint(format!("ank config --unset {raw_key}")));
+    }
+
+    let text = std::fs::read_to_string(&path).map_err(|e| {
+        if e.kind() == std::io::ErrorKind::NotFound {
+            CliError::new(1, format!("{} not found", path.display())).with_hint("ank init")
+        } else {
+            CliError::new(1, format!("{}: {e}", path.display()))
+        }
+    })?;
+    let lines = split_lines(&text);
+
+    if !unset && value.is_none() {
+        // `read_key` is what refuses a whole verifier here: reading one as a
+        // value is not a thing, and only `--unset` addresses it.
+        let before = read_key(&lines, &key)?;
+        if inv.json() {
+            let _ = writeln!(
+                out,
+                "{{\"key\":{},\"value\":{},\"source\":{}}}",
+                crate::cli::json_str(raw_key),
+                before.json(),
+                crate::cli::json_str(before.source())
+            );
+        } else if !inv.quiet() {
+            let _ = writeln!(out, "{}", before.display());
+        }
+        return Ok(0);
+    }
+
+    let before = observe(&lines, &key)?;
+    let mut edited = lines.clone();
+    match value {
+        Some(v) => write_key(&mut edited, &key, v)?,
+        None => unset_key(&mut edited, &key)?,
+    }
+    let after_text = join_lines(&edited);
+    let after = observe(&edited, &key)?;
+
+    // Differential, and it has to be (§4): the write is refused when it
+    // *introduces* a parse failure, never when it is performed on a file that
+    // already had one -- which is the file this verb exists for.
+    let mut warning = None;
+    if let Err(e) = parse(&after_text, &path) {
+        if parse(&text, &path).is_ok() {
+            return Err(CliError::new(
+                1,
+                format!(
+                    "refused: the write would leave {} unreadable",
+                    path.display()
+                ),
+            )
+            .with_hint(format!("{}\n  -> ank config {raw_key}", e.message)));
+        }
+        warning = Some(e.message);
+    }
+
+    let changed = after_text != text;
+    if changed {
+        std::fs::write(&path, &after_text)
+            .map_err(|e| CliError::new(1, format!("{}: {e}", path.display())))?;
+    }
+
+    if inv.json() {
+        let _ = writeln!(
+            out,
+            "{{\"key\":{},\"previous\":{},\"value\":{},\"changed\":{}}}",
+            crate::cli::json_str(raw_key),
+            before.json(),
+            after.json(),
+            changed
+        );
+    } else if !inv.quiet() {
+        if changed {
+            let _ = writeln!(out, "{raw_key} {} -> {}", before.display(), after.display());
+        } else {
+            let _ = writeln!(out, "{raw_key} {} (unchanged)", after.display());
+        }
+        if let Some(w) = warning {
+            let _ = writeln!(
+                out,
+                "{} {} still does not parse: {w}",
+                inv.style().yellow("warning:"),
+                path.display()
+            );
+        }
+    }
+    Ok(0)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -328,5 +1300,461 @@ identities:
         assert_eq!(cfg.context_budget, DEFAULT_CONTEXT_BUDGET);
         assert_eq!(cfg.claim_ttl_max, Duration::from_secs(7200));
         assert_eq!(cfg.roles["human"].can, vec!["*".to_string()]);
+    }
+
+    // -----------------------------------------------------------------------
+    // The writer (§4, ADR-e64dfaafd578)
+    // -----------------------------------------------------------------------
+
+    /// Every awkward form the criterion names, in one file: comments on their
+    /// own line and after a value, blank lines, verifiers out of alphabetical
+    /// order, a quoted `run`, and a verifier carrying no `timeout`.
+    ///
+    /// One fixture rather than one per property, deliberately: a writer that
+    /// survives each awkwardness alone and mangles them together would pass
+    /// six narrow tests, and that combination is what a real `config.yml` is.
+    const FIXTURE: &str = "\
+# The configuration of this repository, reviewed like code.
+schema: 1
+
+context_budget: 4000   # tokens, not lines
+claim_ttl_max: 2h
+
+verifiers:
+  # Out of alphabetical order on purpose: a serializer would sort these.
+  fmt-check:
+    run: \"cargo fmt --check\"
+  cargo-test:
+    run: cargo test --workspace -q
+    timeout: 30m
+
+roles:
+  agent:
+    can: [context, claim]
+    cannot: [delete]
+identities: {}
+";
+
+    fn edit(text: &str, key: &str, value: Option<&str>) -> Result<String> {
+        let k = resolve_key(key)?;
+        let mut lines = split_lines(text);
+        match value {
+            Some(v) => write_key(&mut lines, &k, v)?,
+            None => unset_key(&mut lines, &k)?,
+        }
+        Ok(join_lines(&lines))
+    }
+
+    fn read(text: &str, key: &str) -> Result<Value> {
+        read_key(&split_lines(text), &resolve_key(key)?)
+    }
+
+    /// `after` with the lines that moved put back as they were.
+    ///
+    /// This is the assertion the criterion asks for, and it is stronger than
+    /// comparing the two texts: it proves that *nothing else* moved, including
+    /// the bytes a diff would show as unchanged context.
+    fn splice_back(before: &str, after: &str, expected_moves: usize) -> String {
+        let b = split_lines(before);
+        let mut a = split_lines(after);
+        assert_eq!(
+            a.len(),
+            b.len(),
+            "the line count changed, so this was not a value replacement"
+        );
+        let moved: Vec<usize> = (0..a.len()).filter(|&i| a[i] != b[i]).collect();
+        assert_eq!(moved.len(), expected_moves, "lines that moved: {moved:?}");
+        for i in moved {
+            a[i] = b[i].clone();
+        }
+        join_lines(&a)
+    }
+
+    /// `verify::definition_hash` for every verifier the file declares.
+    fn hashes(text: &str) -> BTreeMap<String, String> {
+        parse(text, p())
+            .unwrap()
+            .verifiers
+            .iter()
+            .map(|(n, v)| (n.clone(), crate::verify::definition_hash(v)))
+            .collect()
+    }
+
+    #[test]
+    fn a_file_read_and_written_back_unedited_is_byte_identical() {
+        // The floor everything else stands on: if the split and the join are
+        // not each other's inverse, no assertion below means anything.
+        for text in [
+            FIXTURE,
+            &FIXTURE.replace('\n', "\r\n"),
+            "schema: 1",           // no trailing newline
+            "\n\n# only comments", // no key at all
+            "",
+        ] {
+            assert_eq!(join_lines(&split_lines(text)), text);
+        }
+    }
+
+    #[test]
+    fn writing_one_key_moves_one_line_and_leaves_every_other_byte() {
+        let after = edit(FIXTURE, "claim_ttl_max", Some("4h")).unwrap();
+        assert!(after.contains("claim_ttl_max: 4h"));
+        assert_eq!(splice_back(FIXTURE, &after, 1), FIXTURE);
+
+        // A value followed by a comment keeps the comment, and the column it
+        // sat at: the caller asked for the value, not for the line.
+        let after = edit(FIXTURE, "context_budget", Some("9000")).unwrap();
+        assert!(
+            after.contains("context_budget: 9000   # tokens, not lines"),
+            "{after}"
+        );
+        assert_eq!(splice_back(FIXTURE, &after, 1), FIXTURE);
+
+        // Nested, and the two neighbours of the edited line are untouched.
+        let after = edit(FIXTURE, "verifiers.cargo-test.timeout", Some("45m")).unwrap();
+        assert!(after.contains("    timeout: 45m"), "{after}");
+        assert_eq!(splice_back(FIXTURE, &after, 1), FIXTURE);
+    }
+
+    #[test]
+    fn the_quoting_style_of_the_edited_key_survives_the_edit() {
+        // `fmt-check` carries a double-quoted run. Rewriting it plain would be
+        // a correct YAML value and a gratuitous restyle of a reviewed file.
+        let after = edit(
+            FIXTURE,
+            "verifiers.fmt-check.run",
+            Some("cargo fmt -- --check"),
+        )
+        .unwrap();
+        assert!(after.contains("run: \"cargo fmt -- --check\""), "{after}");
+        assert_eq!(splice_back(FIXTURE, &after, 1), FIXTURE);
+
+        // And an unquoted one stays unquoted where it safely can.
+        let after = edit(FIXTURE, "verifiers.cargo-test.run", Some("cargo test -q")).unwrap();
+        assert!(after.contains("run: cargo test -q"), "{after}");
+    }
+
+    #[test]
+    fn a_value_that_would_change_meaning_unquoted_is_quoted() {
+        // A branch called `no` is a string, and YAML plain-resolves it to
+        // false. The parser would then refuse the file, which is a refusal
+        // nobody could act on -- so it is written as what it is.
+        let after = edit(FIXTURE, "default_branch", Some("no")).unwrap();
+        assert!(after.contains("default_branch: \"no\""), "{after}");
+        assert_eq!(parse(&after, p()).unwrap().default_branch.unwrap(), "no");
+
+        // A number stays a number: quoting `context_budget` would store a
+        // string the parser refuses.
+        let after = edit(FIXTURE, "context_budget", Some("12000")).unwrap();
+        assert_eq!(parse(&after, p()).unwrap().context_budget, 12000);
+
+        // A run holding a `#` is not truncated into a comment.
+        let after = edit(
+            FIXTURE,
+            "verifiers.cargo-test.run",
+            Some("sh -c 'echo # x'"),
+        )
+        .unwrap();
+        assert_eq!(
+            parse(&after, p())
+                .unwrap()
+                .verifier("cargo-test")
+                .unwrap()
+                .run,
+            "sh -c 'echo # x'"
+        );
+    }
+
+    #[test]
+    fn no_default_is_ever_materialised() {
+        // The trap this whole design exists for. A serializer would write
+        // `default_branch`, a `timeout` onto `fmt-check`, and `{}` for every
+        // empty map -- turning "follows the tool" into "pinned here", so the
+        // day a default moves the repository silently holds the old value.
+        let after = edit(FIXTURE, "claim_ttl_max", Some("4h")).unwrap();
+        assert!(
+            !after.contains("default_branch"),
+            "a key the file did not carry was written: {after}"
+        );
+        let fmt_block = after
+            .split("fmt-check:")
+            .nth(1)
+            .unwrap()
+            .split("cargo-test:")
+            .next()
+            .unwrap();
+        assert!(
+            !fmt_block.contains("timeout"),
+            "fmt-check acquired a timeout it never declared: {fmt_block}"
+        );
+        // And the parser still resolves the defaults, which is the point: the
+        // value is in effect without being written down.
+        let cfg = parse(&after, p()).unwrap();
+        assert_eq!(cfg.default_branch, None);
+        assert_eq!(
+            cfg.verifier("fmt-check").unwrap().timeout,
+            Duration::from_secs(600)
+        );
+    }
+
+    #[test]
+    fn the_definition_hash_of_every_verifier_the_write_did_not_name_is_unchanged() {
+        let before = hashes(FIXTURE);
+
+        // A write elsewhere in the file moves nothing.
+        let after = edit(FIXTURE, "claim_ttl_max", Some("4h")).unwrap();
+        assert_eq!(hashes(&after), before);
+
+        // A write to one verifier moves that one and no other.
+        let after = edit(FIXTURE, "verifiers.cargo-test.timeout", Some("45m")).unwrap();
+        let now = hashes(&after);
+        assert_eq!(now["fmt-check"], before["fmt-check"]);
+        assert_ne!(now["cargo-test"], before["cargo-test"]);
+
+        // Declaring a new verifier disturbs neither of the two already there.
+        let after = edit(FIXTURE, "verifiers.audit.run", Some("cargo audit")).unwrap();
+        let now = hashes(&after);
+        assert_eq!(now["fmt-check"], before["fmt-check"]);
+        assert_eq!(now["cargo-test"], before["cargo-test"]);
+    }
+
+    #[test]
+    fn quoting_alone_never_moves_a_definition_hash() {
+        // The plausible trap, and the wrong one. The hash is taken over the
+        // resolved values, so re-quoting a run and respelling a timeout in
+        // another unit disturb no historical proof -- which is why those forms
+        // are edited rather than refused, and why block scalars are not.
+        let quoted = "schema: 1\nverifiers:\n  t:\n    run: \"cargo test\"\n    timeout: 600s\n";
+        let plain = "schema: 1\nverifiers:\n  t:\n    run: cargo test\n    timeout: 10m\n";
+        assert_eq!(hashes(quoted), hashes(plain));
+    }
+
+    #[test]
+    fn a_block_or_folded_run_is_refused_by_name_and_never_rewritten() {
+        for marker in ["|", ">"] {
+            let text =
+                format!("schema: 1\nverifiers:\n  ci:\n    run: {marker}\n      cargo test\n");
+            let err = edit(&text, "verifiers.ci.run", Some("cargo test -q")).unwrap_err();
+            assert_eq!(err.code, 1);
+            assert!(
+                err.message.contains("verifiers.ci.run"),
+                "the refusal must name the key: {}",
+                err.message
+            );
+            assert!(err.hint.is_some(), "a refusal with no way out");
+
+            // Reading is refused for the same reason: there is no honest
+            // one-line rendering of it to print.
+            assert!(read(&text, "verifiers.ci.run").is_err());
+        }
+    }
+
+    #[test]
+    fn setting_a_key_that_was_absent_and_unsetting_it_returns_the_file() {
+        // Both shapes of insertion: a top-level scalar appended at the end,
+        // and a whole verifier block added inside another block.
+        for (key, value) in [
+            ("default_branch", "main"),
+            ("verifiers.audit.run", "cargo audit"),
+        ] {
+            let with = edit(FIXTURE, key, Some(value)).unwrap();
+            assert_ne!(with, FIXTURE, "{key} was not written at all");
+            parse(&with, p()).unwrap_or_else(|e| panic!("{key}: {}", e.message));
+            let back = edit(&with, unset_target(key), None).unwrap();
+            assert_eq!(back, FIXTURE, "{key} did not come back out cleanly");
+        }
+    }
+
+    /// A verifier is removed as a whole, which is the counterpart of declaring
+    /// one by writing its `run`.
+    fn unset_target(key: &str) -> &str {
+        match key {
+            "verifiers.audit.run" => "verifiers.audit",
+            other => other,
+        }
+    }
+
+    #[test]
+    fn a_new_verifier_lands_at_the_end_of_the_block_with_the_indentation_it_finds() {
+        let after = edit(FIXTURE, "verifiers.audit.run", Some("cargo audit")).unwrap();
+        assert!(
+            after.contains("  audit:\n    run: cargo audit\n"),
+            "{after}"
+        );
+        // At the end of `verifiers`, not at the end of the file: `roles` and
+        // `identities` still follow it, and in that order.
+        let at = |needle: &str| after.find(needle).unwrap();
+        assert!(at("audit:") > at("cargo-test:"));
+        assert!(at("audit:") < at("roles:"));
+
+        // Adding a field to a verifier that has none lands inside its block.
+        let after = edit(FIXTURE, "verifiers.fmt-check.timeout", Some("5m")).unwrap();
+        assert!(
+            after.contains("    run: \"cargo fmt --check\"\n    timeout: 5m\n"),
+            "{after}"
+        );
+        assert_eq!(
+            parse(&after, p())
+                .unwrap()
+                .verifier("fmt-check")
+                .unwrap()
+                .timeout,
+            Duration::from_secs(300)
+        );
+    }
+
+    #[test]
+    fn the_empty_flow_mapping_init_writes_can_receive_a_verifier_and_give_it_back() {
+        // Without the promotion, the file `ank init` produces could never
+        // receive a verifier at all -- and it is the file every new repository
+        // starts from.
+        let base = default_yaml();
+        let with = edit(&base, "verifiers.cargo-test.run", Some("cargo test")).unwrap();
+        let cfg = parse(&with, p()).unwrap();
+        assert_eq!(cfg.verifier("cargo-test").unwrap().run, "cargo test");
+        assert!(
+            with.contains("verifiers:\n  cargo-test:\n    run: cargo test\n"),
+            "{with}"
+        );
+        // `roles` was directly below `verifiers: {}` and is untouched.
+        assert_eq!(cfg.roles["human"].can, vec!["*".to_string()]);
+
+        // And the demotion is its exact inverse: `verifiers:` with no children
+        // is not an empty map but a parse error, so the key goes back to `{}`.
+        let back = edit(&with, "verifiers.cargo-test", None).unwrap();
+        assert_eq!(back, base);
+        parse(&back, p()).unwrap();
+    }
+
+    #[test]
+    fn a_crlf_checkout_keeps_its_terminators_on_every_line() {
+        // §3 forbids ank to *write* CRLF and says nothing about rewriting one
+        // in place. A writer that normalised would rewrite every line of the
+        // file to change one key, which is the opposite of what this is for.
+        let crlf = FIXTURE.replace('\n', "\r\n");
+        let after = edit(&crlf, "claim_ttl_max", Some("4h")).unwrap();
+        assert!(!after.contains("\n\n"), "an LF slipped in: {after:?}");
+        assert_eq!(after.matches("\r\n").count(), crlf.matches("\r\n").count());
+        assert_eq!(splice_back(&crlf, &after, 1), crlf);
+
+        // A key appended to such a file arrives with the file's terminator,
+        // not with the one this platform would have used.
+        let after = edit(&crlf, "default_branch", Some("main")).unwrap();
+        assert!(after.ends_with("default_branch: main\r\n"), "{after:?}");
+        assert_eq!(edit(&after, "default_branch", None).unwrap(), crlf);
+    }
+
+    #[test]
+    fn a_file_with_no_trailing_newline_is_terminated_before_a_key_is_appended() {
+        // Otherwise the appended key joins the last line and the file means
+        // something else entirely.
+        let text = "schema: 1\nclaim_ttl_max: 2h";
+        let after = edit(text, "default_branch", Some("main")).unwrap();
+        assert_eq!(
+            after,
+            "schema: 1\nclaim_ttl_max: 2h\ndefault_branch: main\n"
+        );
+
+        // Removing the last line keeps the terminator of the one above it:
+        // that byte was in the file, and the caller named the key below it.
+        let text = "schema: 1\ndefault_branch: main";
+        assert_eq!(edit(text, "default_branch", None).unwrap(), "schema: 1\n");
+
+        // A key removed from the middle leaves the ending as it found it.
+        let text = "schema: 1\ndefault_branch: main\nclaim_ttl_max: 2h";
+        assert_eq!(
+            edit(text, "default_branch", None).unwrap(),
+            "schema: 1\nclaim_ttl_max: 2h"
+        );
+    }
+
+    #[test]
+    fn reading_marks_a_resolved_default_and_names_an_absence() {
+        assert_eq!(read(FIXTURE, "claim_ttl_max").unwrap().display(), "2h");
+        assert_eq!(
+            read(FIXTURE, "verifiers.fmt-check.timeout")
+                .unwrap()
+                .display(),
+            "10m (default)",
+            "the timeout in effect is the tool's, and the reader has to be told which"
+        );
+        assert_eq!(
+            read(FIXTURE, "default_branch").unwrap().display(),
+            "(unset)"
+        );
+        // A timeout resolved for a verifier that is not declared would be a
+        // value in effect for something that will never run.
+        assert_eq!(
+            read(FIXTURE, "verifiers.nope.timeout").unwrap(),
+            Value::Unset
+        );
+        assert_eq!(
+            read(FIXTURE, "verifiers.fmt-check.run").unwrap(),
+            Value::Set("cargo fmt --check".to_string()),
+            "a quoted value reads unquoted"
+        );
+    }
+
+    #[test]
+    fn the_key_set_is_closed_and_every_refusal_names_what_it_refused() {
+        // Unknown: the set it does know, and nothing written.
+        let err = edit(FIXTURE, "budget_context", Some("10")).unwrap_err();
+        assert_eq!(err.code, 1);
+        assert!(err.message.contains("budget_context"), "{}", err.message);
+        let hint = err.hint.unwrap();
+        for key in KEYS {
+            assert!(hint.contains(key), "{key} missing from: {hint}");
+        }
+
+        // Structured, and known to the parser: refused by name rather than
+        // guessed at, which is a different message from "no such key".
+        for key in ["roles", "roles.agent.can", "identities"] {
+            let err = edit(FIXTURE, key, Some("x")).unwrap_err();
+            assert!(err.message.contains("structured"), "{}", err.message);
+        }
+
+        // A whole verifier is addressable by --unset alone.
+        let err = read(FIXTURE, "verifiers.cargo-test").unwrap_err();
+        assert!(err.hint.unwrap().contains("verifiers.cargo-test.run"));
+        assert!(edit(FIXTURE, "verifiers.cargo-test", Some("x")).is_err());
+        assert!(edit(FIXTURE, "verifiers.cargo-test", None).is_ok());
+
+        // A timeout cannot declare a verifier: it would name one that has no
+        // command to run, and the file would not parse.
+        let err = edit(FIXTURE, "verifiers.nope.timeout", Some("5m")).unwrap_err();
+        assert_eq!(err.code, 7);
+        assert_eq!(
+            err.hint.as_deref(),
+            Some("ank config verifiers.nope.run \"<command>\"")
+        );
+
+        // And `run` cannot be removed on its own, for the same reason.
+        let err = edit(FIXTURE, "verifiers.cargo-test.run", None).unwrap_err();
+        assert_eq!(
+            err.hint.as_deref(),
+            Some("ank config --unset verifiers.cargo-test")
+        );
+    }
+
+    #[test]
+    fn unsetting_a_key_the_file_does_not_carry_changes_nothing() {
+        assert_eq!(edit(FIXTURE, "default_branch", None).unwrap(), FIXTURE);
+        assert_eq!(edit(FIXTURE, "verifiers.nope", None).unwrap(), FIXTURE);
+        assert_eq!(
+            edit(FIXTURE, "verifiers.fmt-check.timeout", None).unwrap(),
+            FIXTURE
+        );
+    }
+
+    #[test]
+    fn a_quoted_key_is_read_as_a_key_and_not_scanned_through() {
+        // `identities` carries `"marie@laptop": human`, and a scan stopping at
+        // the first colon would find one inside the quotes.
+        assert_eq!(key_of("  \"a: b\": value").unwrap().0, "a: b".to_string());
+        assert_eq!(key_of("run: cargo test").unwrap().0, "run".to_string());
+        // YAML requires the space, so this declares no key.
+        assert!(key_of("run:cargo").is_none());
+        assert!(key_of("- item").is_none());
+        assert!(key_of("verifiers:").is_some());
     }
 }

--- a/crates/ank-cli/src/context.rs
+++ b/crates/ank-cli/src/context.rs
@@ -327,7 +327,7 @@ pub fn build(
     if git::resolve_default_branch(cfg.default_branch.as_deref(), origin.as_deref()).is_err() {
         warnings.push(
             "default branch indeterminable, completion refs kept as they are \
-             (add \"default_branch: <name>\" to .ank/config.yml)"
+             (ank config default_branch <name>)"
                 .to_string(),
         );
     }

--- a/crates/ank-cli/src/done.rs
+++ b/crates/ank-cli/src/done.rs
@@ -319,7 +319,7 @@ fn run_verifiers(
                 9,
                 format!("{id} declares verifier '{name}', absent from config.yml"),
             )
-            .with_hint("add it under verifiers: in .ank/config.yml"));
+            .with_hint(format!("ank config verifiers.{name}.run \"<command>\"")));
         };
         let outcome = verify::run(&repo.root, name, def)?;
         let _ = writeln!(

--- a/crates/ank-cli/src/git.rs
+++ b/crates/ank-cli/src/git.rs
@@ -501,7 +501,7 @@ pub fn resolve_default_branch(
     )
     .with_hint(
         "git remote set-head origin -a\n  \
-         -> or add \"default_branch: <name>\" to .ank/config.yml",
+         -> or ank config default_branch <name>",
     ))
 }
 
@@ -702,7 +702,14 @@ mod tests {
 
         let hint = err.hint.clone().unwrap();
         assert!(hint.contains("git remote set-head origin -a"), "{hint}");
-        assert!(hint.contains("\"default_branch: <name>\""), "{hint}");
+        // The second fix names the command, not the file to open: telling an
+        // agent to edit .ank/config.yml is the tool instructing it to do what
+        // ADR-01b6dd05f0db forbids (ADR-e64dfaafd578).
+        assert!(hint.contains("ank config default_branch <name>"), "{hint}");
+        assert!(
+            !hint.contains(".ank/config.yml"),
+            "the hint still points at the file: {hint}"
+        );
 
         // Rendered, the two fixes come out as two arrow lines, as in §7.
         let rendered = err.render();

--- a/crates/ank-cli/src/human.rs
+++ b/crates/ank-cli/src/human.rs
@@ -316,7 +316,7 @@ pub fn inspect(repo: &Repo, cfg: &Config, path: Option<&str>, prune: bool) -> Re
         Err(_) => report.findings.push(Finding::signal(
             "coordination",
             "default branch indeterminable, completion refs neither pruned nor judged \
-             (add \"default_branch: <name>\" to .ank/config.yml)",
+             (ank config default_branch <name>)",
         )),
     }
 

--- a/crates/ank-cli/src/status.rs
+++ b/crates/ank-cli/src/status.rs
@@ -124,7 +124,7 @@ pub fn run(
             let _ = writeln!(
                 out,
                 "{} no default branch, so completion refs are neither pruned nor \
-                 judged (add \"default_branch: <name>\" to .ank/config.yml)",
+                 judged (ank config default_branch <name>)",
                 inv.style().yellow("warning:")
             );
         }

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -248,6 +248,14 @@ impl Repo {
         c.output().expect("the binary must have been built")
     }
 
+    fn config_text(&self) -> String {
+        std::fs::read_to_string(self.0.join(".ank/config.yml")).unwrap()
+    }
+
+    fn set_config(&self, text: &str) {
+        std::fs::write(self.0.join(".ank/config.yml"), text).unwrap();
+    }
+
     /// A non-interactive editor that saves `text`.
     ///
     /// `cp` is the exact shape of one: `edit` appends the file to open as the
@@ -4088,4 +4096,372 @@ fn no_environment_makes_a_pipe_colored() {
             );
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// `ank config` (§4, ADR-e64dfaafd578)
+// ---------------------------------------------------------------------------
+//
+// Through the binary, and not only through the module, because every clause of
+// the criterion is phrased about `ank config <key>` -- and because the sharpest
+// of them is a claim about dispatch: the verb answers on a `config.yml` that
+// fails `startup`, which no unit test on the writer could reach.
+
+/// Trimmed stdout of one invocation, which is what a caller reads.
+fn said(o: &Output) -> String {
+    String::from_utf8_lossy(&o.stdout).trim().to_string()
+}
+
+fn erred(o: &Output) -> String {
+    String::from_utf8_lossy(&o.stderr).to_string()
+}
+
+/// A `config.yml` carrying every awkward form at once: comments on their own
+/// line and after a value, blank lines, verifiers out of alphabetical order, a
+/// quoted `run`, and a verifier with no `timeout`.
+const AWKWARD: &str = "\
+# Reviewed like code, and it stays reviewable.
+schema: 1
+
+claim_ttl_max: 2h   # renewed by ank log
+default_branch: main
+
+verifiers:
+  # Out of alphabetical order on purpose.
+  fmt-check:
+    run: \"cargo fmt --check\"
+  cargo-test:
+    run: cargo test --workspace -q
+    timeout: 30m
+";
+
+#[test]
+fn config_reads_the_value_in_effect_and_marks_a_resolved_default() {
+    let r = Repo::new();
+    r.set_config(AWKWARD);
+    let say = |args: &[&str]| said(&r.ank("claude-code@ank", args));
+
+    assert_eq!(say(&["config", "claim_ttl_max"]), "2h");
+    assert_eq!(say(&["config", "default_branch"]), "main");
+    // A quoted value reads as its value, not as its spelling.
+    assert_eq!(
+        say(&["config", "verifiers.fmt-check.run"]),
+        "cargo fmt --check"
+    );
+    assert_eq!(say(&["config", "verifiers.cargo-test.timeout"]), "30m");
+
+    // Absent from the file and resolved by the tool, said to be so: the
+    // difference between "the tool's value" and "this repository's value" is
+    // the whole question a reader is asking, and a release that moves a default
+    // moves the first and not the second.
+    assert_eq!(say(&["config", "context_budget"]), "8000 (default)");
+    assert_eq!(
+        say(&["config", "verifiers.fmt-check.timeout"]),
+        "10m (default)"
+    );
+
+    // Absent with nothing to resolve.
+    r.set_config("schema: 1\n");
+    assert_eq!(say(&["config", "default_branch"]), "(unset)");
+
+    // The marker is on the human surface alone: --json splits the two, which
+    // is what a script reads.
+    r.set_config(AWKWARD);
+    let json = say(&["config", "context_budget", "--json"]);
+    assert!(json.contains("\"value\":\"8000\""), "{json}");
+    assert!(json.contains("\"source\":\"default\""), "{json}");
+    let json = say(&["config", "claim_ttl_max", "--json"]);
+    assert!(json.contains("\"source\":\"file\""), "{json}");
+}
+
+#[test]
+fn config_writes_the_key_and_no_byte_beside_it() {
+    let r = Repo::new();
+    r.set_config(AWKWARD);
+
+    let out = r.ank("claude-code@ank", &["config", "claim_ttl_max", "4h"]);
+    assert!(out.status.success(), "{}", erred(&out));
+    assert_eq!(said(&out), "claim_ttl_max 2h -> 4h");
+
+    // Every line but the one named is byte-identical, comment column included.
+    let after = r.config_text();
+    let moved: Vec<(&str, &str)> = AWKWARD
+        .lines()
+        .zip(after.lines())
+        .filter(|(a, b)| a != b)
+        .collect();
+    assert_eq!(
+        moved,
+        vec![(
+            "claim_ttl_max: 2h   # renewed by ank log",
+            "claim_ttl_max: 4h   # renewed by ank log"
+        )],
+        "more than the named key moved"
+    );
+    assert_eq!(AWKWARD.lines().count(), after.lines().count());
+
+    // No default was materialised on the way: context_budget was absent and
+    // stays absent, and fmt-check still declares no timeout.
+    assert!(!after.contains("context_budget"), "{after}");
+    let fmt = after.split("fmt-check:").nth(1).unwrap();
+    assert!(!fmt.split("cargo-test:").next().unwrap().contains("timeout"));
+
+    // Nested values are addressed by dotted path, and a new verifier is
+    // declared by writing its run -- which is what the six hints now name.
+    let out = r.ank(
+        "claude-code@ank",
+        &["config", "verifiers.audit.run", "cargo audit"],
+    );
+    assert!(out.status.success(), "{}", erred(&out));
+    assert_eq!(said(&out), "verifiers.audit.run (unset) -> cargo audit");
+    assert!(r.config_text().contains("  audit:\n    run: cargo audit\n"));
+
+    // Writing what the file already says touches nothing at all.
+    let before = r.config_text();
+    let out = r.ank(
+        "claude-code@ank",
+        &["config", "verifiers.audit.run", "cargo audit"],
+    );
+    assert_eq!(said(&out), "verifiers.audit.run cargo audit (unchanged)");
+    assert_eq!(r.config_text(), before);
+}
+
+#[test]
+fn config_unset_removes_the_key_and_gives_the_file_back() {
+    let r = Repo::new();
+    r.set_config(AWKWARD);
+
+    let out = r.ank("claude-code@ank", &["config", "--unset", "default_branch"]);
+    assert!(out.status.success(), "{}", erred(&out));
+    assert_eq!(said(&out), "default_branch main -> (unset)");
+    assert!(!r.config_text().contains("default_branch"));
+
+    // Set then unset is the identity, byte for byte -- and the short form of
+    // §4's table does the same thing as the long one.
+    r.ank("claude-code@ank", &["config", "default_branch", "main"]);
+    r.ank("claude-code@ank", &["config", "-u", "default_branch"]);
+    let stripped = AWKWARD.replace("default_branch: main\n", "");
+    assert_eq!(r.config_text(), stripped);
+
+    // A whole verifier is what --unset addresses, which is what makes
+    // declaring one reversible.
+    r.set_config(AWKWARD);
+    r.ank(
+        "claude-code@ank",
+        &["config", "verifiers.audit.run", "cargo audit"],
+    );
+    let out = r.ank("claude-code@ank", &["config", "--unset", "verifiers.audit"]);
+    assert!(out.status.success(), "{}", erred(&out));
+    assert_eq!(r.config_text(), AWKWARD);
+
+    // And `run` alone is refused, naming the command that does the job.
+    let out = r.ank(
+        "claude-code@ank",
+        &["config", "--unset", "verifiers.cargo-test.run"],
+    );
+    assert_eq!(out.status.code(), Some(1));
+    assert!(
+        erred(&out).contains("ank config --unset verifiers.cargo-test"),
+        "{}",
+        erred(&out)
+    );
+    assert_eq!(r.config_text(), AWKWARD, "a refusal wrote to the file");
+}
+
+#[test]
+fn config_refuses_an_unknown_key_by_name_and_writes_nothing() {
+    let r = Repo::new();
+    r.set_config(AWKWARD);
+
+    let out = r.ank("claude-code@ank", &["config", "budget_context", "10"]);
+    assert_eq!(out.status.code(), Some(1));
+    let err = erred(&out);
+    assert!(err.contains("budget_context"), "{err}");
+    for key in [
+        "schema",
+        "context_budget",
+        "claim_ttl_max",
+        "default_branch",
+        "verifiers.<name>.run",
+        "verifiers.<name>.timeout",
+    ] {
+        assert!(err.contains(key), "{key} missing from the refusal: {err}");
+    }
+    assert_eq!(r.config_text(), AWKWARD);
+
+    // Known to the parser, structured, and refused by name rather than guessed
+    // at -- a different message from "no such key".
+    for key in ["roles", "identities", "roles.agent.can"] {
+        let out = r.ank("claude-code@ank", &["config", key, "x"]);
+        assert_eq!(out.status.code(), Some(1), "{key}");
+        assert!(erred(&out).contains("structured"), "{key}: {}", erred(&out));
+    }
+
+    // A timeout cannot declare a verifier, and the refusal names what can.
+    let out = r.ank(
+        "claude-code@ank",
+        &["config", "verifiers.nope.timeout", "5m"],
+    );
+    assert_eq!(out.status.code(), Some(7));
+    assert!(
+        erred(&out).contains("ank config verifiers.nope.run"),
+        "{}",
+        erred(&out)
+    );
+    assert_eq!(r.config_text(), AWKWARD);
+}
+
+#[test]
+fn config_refuses_a_write_that_would_leave_the_file_unreadable() {
+    let r = Repo::new();
+    r.set_config(AWKWARD);
+
+    // Each of these parses as YAML and fails the configuration's own reading:
+    // a duration in no unit it knows, and a schema it does not support.
+    for (key, value) in [("claim_ttl_max", "30w"), ("schema", "2")] {
+        let out = r.ank("claude-code@ank", &["config", key, value]);
+        assert_eq!(out.status.code(), Some(1), "{key} was accepted");
+        assert!(erred(&out).contains("unreadable"), "{key}: {}", erred(&out));
+        assert_eq!(r.config_text(), AWKWARD, "{key} left the file changed");
+    }
+
+    // A block scalar is refused before any of that: flattening it would move
+    // the definition hash that anchors historical proofs.
+    r.set_config("schema: 1\nverifiers:\n  ci:\n    run: |\n      cargo test\n");
+    let before = r.config_text();
+    let out = r.ank(
+        "claude-code@ank",
+        &["config", "verifiers.ci.run", "cargo test -q"],
+    );
+    assert_eq!(out.status.code(), Some(1));
+    assert!(erred(&out).contains("verifiers.ci.run"), "{}", erred(&out));
+    assert_eq!(r.config_text(), before);
+}
+
+#[test]
+fn config_is_the_one_verb_a_config_that_does_not_parse_does_not_stop() {
+    let r = Repo::new();
+    let broken = "schema: 1\nclaim_ttl_max: 2h\ndefault_branch: main\nbudget_context: 10\n";
+    r.set_config(broken);
+
+    // `startup` loads the configuration for every other verb, so the file
+    // fails all of them -- `check`, the one an agent would reach for, included.
+    for args in [
+        &["check"][..],
+        &["context"][..],
+        &["status"][..],
+        &["find", "anything"][..],
+    ] {
+        let out = r.ank("claude-code@ank", args);
+        assert_eq!(
+            out.status.code(),
+            Some(1),
+            "{args:?} ran on a config.yml that does not parse"
+        );
+    }
+
+    // The verb that exists to repair the file is the one the broken file does
+    // not stop. It reads,
+    let out = r.ank("claude-code@ank", &["config", "claim_ttl_max"]);
+    assert!(out.status.success(), "{}", erred(&out));
+    assert_eq!(said(&out), "2h");
+
+    // and it writes, saying that the file is still unreadable for a reason it
+    // was not asked about. Refusing here instead would be refusing exactly
+    // where the verb is needed.
+    let out = r.ank("claude-code@ank", &["config", "claim_ttl_max", "4h"]);
+    assert!(out.status.success(), "{}", erred(&out));
+    assert!(r.config_text().contains("claim_ttl_max: 4h"));
+    assert!(said(&out).contains("warning:"), "{}", said(&out));
+    assert!(said(&out).contains("budget_context"), "{}", said(&out));
+}
+
+#[test]
+fn the_errors_that_named_the_file_now_name_the_command() {
+    // ADR-01b6dd05f0db closed `.ank/` to agents and stopped at the
+    // configuration, which left these telling their caller to open a file the
+    // same tool forbids them to open (ADR-e64dfaafd578).
+    let r = Repo::new();
+
+    // `new`, on a --verify that matches nothing. The criterion calls the two
+    // verify sites "new's and amend's"; they are in fact both `new`'s -- the
+    // flag form here, and the `verify:` filled into the $EDITOR template,
+    // which `commands::check_verifiers` guards and a unit test covers. `amend`
+    // takes no --verify at all.
+    let out = r.ank(
+        "claude-code@ank",
+        &[
+            "new", "task", "--title", "T", "--scope", "src/**", "--verify", "nope",
+        ],
+    );
+    assert_eq!(out.status.code(), Some(7), "{}", erred(&out));
+    let err = erred(&out);
+    assert!(err.contains("ank config verifiers.nope.run"), "{err}");
+    assert!(
+        !err.contains("under verifiers: in .ank/config.yml"),
+        "it still tells the caller to open the file: {err}"
+    );
+
+    // `done`, on a task declaring a verifier the configuration does not.
+    let r = Repo::new().with_verifiers("verifiers:\n  ok:\n    run: git --version\n");
+    r.seed_task_with(
+        "TASK-000000000c01",
+        Some("A verifiable criterion."),
+        &["ok"],
+    );
+    r.ank("claude-code@ank", &["claim", "TASK-000000000c01"]);
+    r.set_config("schema: 1\nclaim_ttl_max: 2h\ndefault_branch: main\n");
+    let out = r.ank("claude-code@ank", &["done", "TASK-000000000c01"]);
+    assert_eq!(out.status.code(), Some(9), "{}", erred(&out));
+    assert!(
+        erred(&out).contains("ank config verifiers.ok.run"),
+        "{}",
+        erred(&out)
+    );
+
+    // The four sites that ask for a default branch. There is no
+    // `default_branch` and no `refs/remotes/origin/HEAD` to fall back on, so
+    // each of them has to name the command that sets one.
+    let r = Repo::new();
+    r.set_config("schema: 1\nclaim_ttl_max: 2h\n");
+    std::fs::write(r.0.join("seed.txt"), "x").unwrap();
+    r.git(&["add", "-A"]);
+    r.git(&["-c", "commit.gpgsign=false", "commit", "-qm", "seed"]);
+
+    r.seed_adr("ADR-000000000c02", "A binding rule.", "src/**");
+    for args in [
+        &["status"][..],
+        &["check"][..],
+        &["context"][..],
+        &["accept", "ADR-000000000c02"][..],
+    ] {
+        let out = r.ank("claude-code@ank", args);
+        let text = format!("{}{}", said(&out), erred(&out));
+        assert!(
+            text.contains("ank config default_branch"),
+            "{args:?} does not name the command: {text}"
+        );
+        assert!(
+            !text.contains("\"default_branch: <name>\""),
+            "{args:?} still quotes the line to add by hand: {text}"
+        );
+    }
+}
+
+#[test]
+fn help_answers_about_config_the_way_it_answers_about_every_verb() {
+    let r = Repo::new();
+    let text = said(&r.ank("claude-code@ank", &["help", "config"]));
+    assert!(text.contains("ank config <key> [<value>]"), "{text}");
+    // The short form of §4's table, on the surface that teaches one verb.
+    assert!(text.contains("-u, --unset"), "{text}");
+    // What it refuses, with the code -- the question is asked before the call.
+    assert!(text.contains("(1)") && text.contains("(7)"), "{text}");
+    // The key set, which is the one thing a caller cannot guess.
+    assert!(text.contains("verifiers.<name>.run"), "{text}");
+
+    // And the flat listing stays flat: one line for the verb, no heading.
+    let listing = said(&r.ank("claude-code@ank", &["help"]));
+    assert!(listing.contains("ank config <key> [<value>]"), "{listing}");
+    assert!(listing.contains("--unset"), "{listing}");
 }

--- a/docs/ank-spec-v1.1.md
+++ b/docs/ank-spec-v1.1.md
@@ -423,6 +423,7 @@ ank edit <id>
 ank graph [<path>]
 ank scope <path>
 ank check [<path>]
+ank config <key> [<value>]  [--unset]   (a value writes; the key alone reads)
 ank init [<path>]           (§9)
 ank help [<verb>]           (§9)
 
@@ -449,6 +450,48 @@ The rule is not cosmetic, and it is written down because its absence was not obv
 
 Global flags, deliberately limited to three: `--json`, `--quiet`, `--repo <path>`. Every global flag is a memorisation cost. `--json` is available on every command without exception: full scriptability is an invariant, not an option.
 
+### Configuration
+
+`.ank/config.yml` is read and written through `ank config` (ADR-e64dfaafd578). ADR-01b6dd05f0db closed `.ank/` to agents and stopped at the configuration, which left six errors telling their caller to open a file the same tool forbids them to open. This is the verb those errors name instead.
+
+```
+$ ank config claim_ttl_max
+2h
+$ ank config context_budget
+8000 (default)
+$ ank config verifiers.cargo-test.run "cargo test --workspace"
+verifiers.cargo-test.run (unset) -> cargo test --workspace
+$ ank config --unset default_branch
+default_branch main -> (unset)
+```
+
+**The key set is closed**, and it is the set the parser knows:
+
+| Key | Value |
+|---|---|
+| `schema` | the format revision of the file |
+| `context_budget` | tokens, default `8000` |
+| `claim_ttl_max` | duration, default `2h` |
+| `default_branch` | branch name; unset falls back to `refs/remotes/origin/HEAD` (§7) |
+| `verifiers.<name>.run` | the command line, §4 |
+| `verifiers.<name>.timeout` | duration, default `10m` |
+
+Nested values are addressed by dotted path, and `<name>` is any verifier name — writing `verifiers.<name>.run` for a name the file does not carry is how a verifier is declared. `verifiers.<name>` addresses the whole block and is legal for `--unset` alone, which is what makes declaring one reversible; reading it, or writing a value to it, is refused by name with `verifiers.<name>.run` to type instead. `roles` and `identities` are keys the parser knows and this verb does not address: their values are structured, the surgery below has no safe edit for them, and they are refused by name rather than guessed at. A key the parser does not know is refused by name too, with the set it does know, and nothing is written.
+
+**Reading prints the value in effect, and marks a resolved default as one.** `context_budget` on a file that does not carry it is `8000 (default)`, not `8000` — the difference between "the tool's value" and "this repository's value" is the whole question a reader is asking, and a release that moves a default moves the first and not the second. A key with no value in effect is `(unset)`. The marker is on the human surface only: `--json` carries `value` and `source` as separate fields, which is what a script reads.
+
+**Writing is text surgery, and never a round-trip through a serializer.** The file is a repository artifact, reviewed like code: comments, blank lines, key order and quoting style survive a write untouched, and every key other than the one named is byte-identical afterwards. A serializer would return `verifiers`, `roles` and `identities` alphabetised, drop every comment, and — the reason this is not a matter of taste — write out every field carrying a default. An unset key means "follows the tool"; a written one means "pinned here", and a round-trip that materialises the defaults converts every repository that ever ran one `ank config` into one that silently pins the old values the day a default moves. **No default is ever materialised**: a key the file did not carry is still absent after a write to another key.
+
+Two edits touch a byte outside the line named, and both are the parent of the key being written rather than a byte beside it: `verifiers: {}` becomes a block mapping when the first verifier is declared into it, and a block mapping becomes `verifiers: {}` when the last one is removed. Without the first, the file `ank init` writes could never receive a verifier; without the second, `verifiers:` would be left with no children, which is not an empty map but a parse error.
+
+**A form the surgery cannot edit safely is refused by name, never rewritten.** A `run` written as a block or folded scalar — `|` or `>` — is one: its resolved string depends on line structure the replacement would flatten, and `verify::definition_hash` is taken over the resolved value, so flattening it would move a hash that anchors historical proofs. The refusal names the key and says to edit the file by hand, which a human always may. Quoting alone is safe and stays safe: the hash is over the resolved string and over the timeout in seconds, so `run: cargo test` and `run: "cargo test"` hash identically, as do `600s` and `10m`.
+
+**A write that would produce a file the parser cannot read fails, and leaves the file as it was.** The result is parsed before anything is written, so the check is not a repair after the fact. The test is differential and has to be: it refuses a write that *introduces* a parse failure, not one performed on a file that already had one. A file carrying an unknown key fails every other verb, and a repair verb that refused to run on it would refuse exactly where it is needed — so on a file that did not parse to begin with, the write goes through and the parse error is reported as a warning rather than a refusal.
+
+**`ank config` runs without a parsed configuration**, as `init` and `help` do (§9). `startup` loads `config.yml` for every other verb, so a file that does not parse fails all of them — `check` included. A verb that exists to repair the file and is disabled by exactly the file it repairs is not a verb; the caller who most needs it is the one whose configuration does not load.
+
+This constrains the agent and not the human. A human with an editor keeps every power they had, and the file stays reviewable text in the repository.
+
 ### Short forms
 
 Every long flag keeps its form. Short forms are an addition and never a replacement (ADR-962c25797569): single-dash, single-letter, and this table is the whole of them.
@@ -464,6 +507,7 @@ Every long flag keeps its form. Short forms are an addition and never a replacem
 | `-p` | `--proof` | `done`, `attest` |
 | `-s` | `--status` | `find` |
 | `-t` | `--type` | `find` |
+| `-u` | `--unset` | `config` |
 | `-v` | `--verify` | `new` |
 
 **The letter is the first letter of the long flag, and one letter has one meaning in every verb.** Where several long flags begin with the same letter, exactly one takes it and the others keep only their long form. That is the whole rule, and it is worth the flags it costs: a `-s` meaning `--status` in `find` and `--scope` in `new` would not be a saving but a silent wrong answer, since `ank find -s open` would filter on a scope named `open` and return nothing at all. A short form is only useful if it can be typed without checking which verb it is being typed at.
@@ -874,8 +918,10 @@ The predicate is about the task file as it appears on the default branch (`git c
 $ ank accept 19d0
 error[9]: default branch indeterminable (default_branch absent from .ank/config.yml, refs/remotes/origin/HEAD absent)
   -> git remote set-head origin -a
-  -> or add "default_branch: <name>" to .ank/config.yml
+  -> or ank config default_branch <name>
 ```
+
+The second fix names a command rather than a line to add to a file (§4, ADR-e64dfaafd578). It is one of the four sites that ask for this key, and all four say the same thing: telling an agent to open `.ank/config.yml` is the tool instructing it to do what ADR-01b6dd05f0db forbids.
 
 Two uses depend on it, and not in the same way. `accept` **fails** with code 9: without a reference branch its branch precondition (§4) cannot be evaluated, and running anyway would produce precisely the variable-geometry ratification it exists to forbid. `claim` and `context` **degrade**: they keep completion refs, display them, and warn once. That is "degrade, do not fail" (§2) to the letter — reading does not stop because maintenance is impossible, and `claim`'s refusal on a task finished elsewhere is still delivered, which is the safe behaviour.
 
@@ -1003,6 +1049,8 @@ Three consequences, each of which was one of those five:
 The listing and the per-verb page stay two surfaces. The flat listing is unchanged — it buys its token economy by being short, and a summary line per verb is what §9 sends to `ank help <verb>` in the first place.
 
 `ank init` keeps a narrow perimeter: create `.ank/`, write `config.yml`, add the `refs/ank/*` refspec (§7), place a pointer in `AGENTS.md`, write a `.gitattributes` (§2) and a `.gitignore` (§6).
+
+**What `init` writes, `ank config` maintains** (§4). `config.yml` is written through the verb rather than by hand: it is the last thing under `.ank/` that ADR-01b6dd05f0db left an agent no route to, and the six errors that used to say "add it under `verifiers:` in `.ank/config.yml`" now name the command. `config` joins `init` and `help` as the third verb that runs without the foundation, and for the same reason those two do — the caller who needs it is the one whose environment is wrong, and a repair verb gated on the thing it repairs answers nobody.
 
 Both git files are written at the root of the initialised directory, and both carry a single line added idempotently to whatever is already there. The `.gitignore` line is `.ank/index.db`: §6 calls the index derived, disposable and gitignored, and the third adjective is only true of a repository where something wrote the rule. It goes at the root rather than inside `.ank/` for the same reason `.gitattributes` does — one place to look for what `init` changed — and because ADR-01b6dd05f0db makes `.ank/` opaque to agents, so a rule hidden there could not be read by the agent asking why the index is tracked.
 


### PR DESCRIPTION
Execution of ADR-e64dfaafd578 (TASK-797d64113614).

Six errors told their caller to open `.ank/config.yml`, and they were the only errors in the CLI naming a file to edit rather than a command to run — the tool instructing an agent to do what ADR-01b6dd05f0db forbids it. This adds the verb they now name.

## The specification moves first

Per ADR-63b59c5c26f7:

- **§4** declares `ank config` in its place in the Commands block — after `check`, before `init` — with the closed key set, the reading of a resolved default, the surgery and its refusals. `--unset` takes `-u`; the letter was free, so §4's short-form table gives it one.
- **§7**'s default-branch example stops quoting an error the binary no longer prints.
- **§9** states that what `init` writes, `config` maintains, and why the verb joins `init` and `help` outside the foundation.

`skill/SKILL.md` does not change, and the flat listing stays flat.

## Writing is line surgery, never a serializer

The plausible trap is the proof hashes, and it is the wrong one: `verify::definition_hash` is taken over the **resolved** values, so `run: cargo test` and `run: "cargo test"` hash identically, as do `600s` and `10m`.

The real trap is that a round-trip turns absence into assertion. Every field of the wire struct carries a `serde` default and none would be skipped on the way out, so a serializer writes the lot into the file. An unset key means "follows the tool"; a written one means "pinned here" — and the day a default moves, every repository that ever ran one `ank config` silently holds the old value.

So: find the line, replace the span the value occupies, leave every other byte alone. Comments, blank lines, key order and quoting style survive, and that is asserted over a fixture carrying all of them at once rather than claimed.

Two edits touch a byte outside the line named, and both are the parent of the key being written:

- `verifiers: {}` becomes a block mapping when the first verifier is declared into it. Without this, the file `ank init` writes could never receive a verifier at all.
- It goes back to `{}` when the last one is removed, because `verifiers:` with no children is a parse error and not an empty map.

A `run` written as a block or folded scalar is **refused by name**, never flattened: its resolved string depends on line structure the replacement would lose, and that would move a hash anchoring historical proofs.

## The verb runs without the foundation

The sharpest clause. `startup` loads `config.yml` for every other verb, so a file that does not parse fails all of them — `check` included. A repair verb gated on exactly the file it repairs answers nobody.

Which makes the parse check on a write **differential**: it refuses a write that *introduces* a failure, never one performed on a file that already had one. On a broken file the write goes through and the parse error is reported as a warning.

## Seven call sites, not six

The criterion says six and enumerates seven. All seven now name the command:

| Site | Was | Is |
|---|---|---|
| `done`, absent verifier | `add it under verifiers: in .ank/config.yml` | `ank config verifiers.<name>.run "<command>"` |
| `new`, `--verify` flag | `declare it under verifiers: in .ank/config.yml` | same, through one shared refusal |
| `new`, `verify:` from `$EDITOR` | idem | idem |
| `git::resolve_default_branch` | `add "default_branch: <name>" to .ank/config.yml` | `ank config default_branch <name>` |
| `context`, `check`, `status` | idem | idem |

The criterion calls two of them "new's and amend's". `amend` takes no `--verify` at all: both are `new`'s, the flag form and the template form, and they now share one `undeclared_verifier`. The task template's own guidance line named the file too, and now names the verb.

## Left out, on purpose

`docs/getting-started.md` still quotes both replaced errors and tells the reader to open the file. It is outside this task's scope, so it is **TASK-7af1cd875d9a**, blocked on this one, rather than folded in here.

## Verification

`cargo test --workspace` (254 unit + 82 integration + 11 skill + 20 core), `cargo fmt --check`, `ank check` — all green. Eight new integration tests drive the verb through the binary, including the one property no unit test could reach: that it answers on a `config.yml` which fails `startup` for every other verb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012kHgSHnrDGvrSAmRAz9S58
