### PR TITLE
The getting-started guide reaches for the verb where it reached for the file

### DIFF
--- a/.ank/tasks/TASK-31fcf8b27aa2.md
+++ b/.ank/tasks/TASK-31fcf8b27aa2.md
@@ -1,0 +1,23 @@
+---
+id: TASK-31fcf8b27aa2
+type: task
+slug: the-guide-still-says-init-does-not-write-the-git
+title: The guide still says init does not write the gitignore rule, and it does
+created: 2026-08-09T15:53:53Z
+author: claude-code@ank
+status: open
+scope:
+  - docs/getting-started.md
+blocked_by: []
+done_criteria: |
+  docs/getting-started.md no longer tells the reader to run 'echo .ank/index.db >> .gitignore', and no longer says init does not write the rule. The count in 'Two edits to make now' matches what follows it. What the page says about init writing .gitignore agrees with the init output it shows earlier on the same page. No other file changes, and cargo test stays green.
+criteria_by: creator
+schema: 2
+version: 1
+---
+
+Found while executing TASK-7af1cd875d9a and left out of it, because that task's criterion is about config.yml and this is a different staleness in the same file.
+
+The page shows 'wrote .gitignore' in the ank init output, and then thirty lines later says init 'does not yet write the rule for you' and asks the reader to append it by hand. Both cannot be true. Measured on a fresh repository with the binary at d0ccc24: init writes a .gitignore containing '.ank/index.db', which is also what section 9 of the specification says it does.
+
+So the second of the page's 'Two edits to make now' is not an edit anyone has to make, and the count is wrong with it. A reader who follows the instruction gets a duplicate line rather than an error, which is why this has survived: it costs nothing visible and quietly teaches that the tool does less than it does.

--- a/.ank/tasks/TASK-7af1cd875d9a.md
+++ b/.ank/tasks/TASK-7af1cd875d9a.md
@@ -5,15 +5,19 @@ slug: the-getting-started-guide-still-tells-the-reader
 title: The getting-started guide still tells the reader to open config.yml
 created: 2026-08-09T15:17:35Z
 author: claude-code@ank
-status: in_progress
+status: done
 scope:
   - docs/getting-started.md
 blocked_by: [TASK-797d64113614]
 done_criteria: |
   docs/getting-started.md no longer instructs anyone to open .ank/config.yml, and the two error blocks it quotes match what the binary prints: the default-branch refusal names 'ank config default_branch <name>', and the undeclared-verifier refusal names 'ank config verifiers.<name>.run'. The section that adds a default branch and the one that declares verifiers both go through the verb. No other file changes, and cargo test stays green.
 criteria_by: creator
+proof:
+  - type: test
+    ref: "31322378253"
+    criteria: d7104c9fd1d4
 schema: 2
-version: 3
+version: 4
 ---
 
 Fallout of TASK-797d64113614, found while changing the hints and left out of it because the guide is outside that task's scope.
@@ -24,3 +28,4 @@ The guide addresses a human, and a human with an editor keeps every power they h
 
 ## Log
 - 2026-08-09T15:53:42Z claude-code@ank — Verified every command and output against a fresh scratch repository rather than composing them, which is what the page's own opening promises. The verb writes exactly the YAML the guide already showed: 'verifiers: {}' is promoted to a block, roles and identities are untouched, and no-jwt's run comes back double-quoted because it opens with '!'. Found a second staleness in the same file and left it out: 'init does not yet write the rule for you' at line 98 contradicts 'wrote .gitignore' in the init output at line 64, and init does write '.ank/index.db' -- confirmed on the scratch repo. That makes 'Two edits to make now' wrong too. Outside this criterion, filed separately.
+- 2026-08-09T15:58:15Z claude-code@ank — done, proof test:31322378253

--- a/.ank/tasks/TASK-7af1cd875d9a.md
+++ b/.ank/tasks/TASK-7af1cd875d9a.md
@@ -5,7 +5,7 @@ slug: the-getting-started-guide-still-tells-the-reader
 title: The getting-started guide still tells the reader to open config.yml
 created: 2026-08-09T15:17:35Z
 author: claude-code@ank
-status: open
+status: in_progress
 scope:
   - docs/getting-started.md
 blocked_by: [TASK-797d64113614]
@@ -13,7 +13,7 @@ done_criteria: |
   docs/getting-started.md no longer instructs anyone to open .ank/config.yml, and the two error blocks it quotes match what the binary prints: the default-branch refusal names 'ank config default_branch <name>', and the undeclared-verifier refusal names 'ank config verifiers.<name>.run'. The section that adds a default branch and the one that declares verifiers both go through the verb. No other file changes, and cargo test stays green.
 criteria_by: creator
 schema: 2
-version: 1
+version: 3
 ---
 
 Fallout of TASK-797d64113614, found while changing the hints and left out of it because the guide is outside that task's scope.
@@ -21,3 +21,6 @@ Fallout of TASK-797d64113614, found while changing the hints and left out of it 
 The guide reproduces two error messages verbatim -- lines 90-92 and 163-164 as of this filing -- and both are the text the binary stopped printing when ADR-e64dfaafd578 was executed. It also says 'Open .ank/config.yml and add one line' at line 82 and points at the file again at line 151.
 
 The guide addresses a human, and a human with an editor keeps every power they had (ADR-e64dfaafd578). So this is not a correctness rule being broken; it is a guide quoting output that no longer exists, which is the kind of staleness a reader has no way to detect. The fix is to quote what the binary now prints and to reach for the verb where the guide currently reaches for the file.
+
+## Log
+- 2026-08-09T15:53:42Z claude-code@ank — Verified every command and output against a fresh scratch repository rather than composing them, which is what the page's own opening promises. The verb writes exactly the YAML the guide already showed: 'verifiers: {}' is promoted to a block, roles and identities are untouched, and no-jwt's run comes back double-quoted because it opens with '!'. Found a second staleness in the same file and left it out: 'init does not yet write the rule for you' at line 98 contradicts 'wrote .gitignore' in the init output at line 64, and init does write '.ank/index.db' -- confirmed on the scratch repo. That makes 'Two edits to make now' wrong too. Outside this criterion, filed separately.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -79,9 +79,11 @@ keeps everything already in it.
 
 Two edits to make now, before the first real command.
 
-**Name your default branch.** Open `.ank/config.yml` and add one line:
+**Name your default branch.** `.ank/config.yml` is written through the CLI
+rather than by hand:
 
-    default_branch: main
+    $ ank config default_branch main
+    default_branch (unset) -> main
 
 Without it, Ank looks for `refs/remotes/origin/HEAD`, and a repository with no
 remote has none. It refuses rather than guessing:
@@ -89,7 +91,7 @@ remote has none. It refuses rather than guessing:
     $ ank accept 06d2
     error[9]: default branch indeterminable (default_branch absent from .ank/config.yml, refs/remotes/origin/HEAD absent)
       -> git remote set-head origin -a
-      -> or add "default_branch: <name>" to .ank/config.yml
+      -> or ank config default_branch <name>
 
 **Ignore the index.** `.ank/index.db` is a derived SQLite cache, rebuildable
 from the files and safe to delete at any time. It does not belong in git, and
@@ -148,7 +150,16 @@ constraint ratified on a feature branch would bind on that branch alone.
 ## Declare a verifier, then the task that uses it
 
 A task names verifiers; it never carries a shell command. The definitions live
-in `.ank/config.yml`, under the repository's own review:
+in `.ank/config.yml`, under the repository's own review, and they go in through
+the same verb — writing a `run` for a name the file does not carry is how a
+verifier is declared:
+
+    $ ank config verifiers.auth-tests.run "sh tests/auth.sh"
+    verifiers.auth-tests.run (unset) -> sh tests/auth.sh
+    $ ank config verifiers.no-jwt.run "! grep -rq jwt.verify src/auth/"
+    verifiers.no-jwt.run (unset) -> ! grep -rq jwt.verify src/auth/
+
+which is what the file then carries:
 
     verifiers:
       auth-tests:
@@ -156,12 +167,26 @@ in `.ank/config.yml`, under the repository's own review:
       no-jwt:
         run: "! grep -rq jwt.verify src/auth/"
 
+`ank config --unset verifiers.no-jwt` takes one back out. Reading a key says
+where the value comes from — this repository, or a default the tool resolved:
+
+    $ ank config verifiers.auth-tests.run
+    sh tests/auth.sh
+    $ ank config verifiers.auth-tests.timeout
+    10m (default)
+
+The distinction is the reason writing is line surgery rather than a round-trip
+through a YAML serializer. Your comments, blank lines, key order and quoting
+survive a write, and a key you never set is never written out: an unset key
+follows the tool, a written one is pinned here, and a serializer would quietly
+convert every one of the first kind into the second.
+
 Declare them first. A task that names a verifier `config.yml` does not know is
 refused at creation:
 
     $ ank new task --title "Migrate auth" --scope "src/auth/**" --verify auth-tests
     error[7]: no verifier 'auth-tests' in .ank/config.yml
-      -> declare it under verifiers: in .ank/config.yml
+      -> ank config verifiers.auth-tests.run "<command>"
 
 With the definitions in place:
 


### PR DESCRIPTION
TASK-7af1cd875d9a — the fallout of ADR-e64dfaafd578 that PR #61 left out, because the guide sits outside TASK-797d64113614's scope.

The page told the reader to open `.ank/config.yml` in two places, and quoted two error blocks the binary stopped printing when the hints changed.

## What changed

**Setting the default branch** now goes through the verb, and the refusal below it quotes the second arrow the binary prints today:

```
$ ank config default_branch main
default_branch (unset) -> main
```

**Declaring verifiers** likewise — writing a `run` for a name the file does not carry is how one is declared:

```
$ ank config verifiers.auth-tests.run "sh tests/auth.sh"
verifiers.auth-tests.run (unset) -> sh tests/auth.sh
$ ank config verifiers.no-jwt.run "! grep -rq jwt.verify src/auth/"
verifiers.no-jwt.run (unset) -> ! grep -rq jwt.verify src/auth/
```

and the refusal at creation names the command instead of the file:

```
$ ank new task --title "Migrate auth" --scope "src/auth/**" --verify auth-tests
error[7]: no verifier 'auth-tests' in .ank/config.yml
  -> ank config verifiers.auth-tests.run "<command>"
```

## Measured, not composed

The page opens by promising that every command and every output on it was run against a fresh repository, so every block here was. The verb writes exactly the YAML the guide already showed: `verifiers: {}` is promoted to a block mapping, `roles` and `identities` are untouched, and no-jwt's `run` comes back double-quoted because it opens with `!`.

## One addition rather than a correction

Why the writing is line surgery, which is the non-obvious half and the reason `ank config verifiers.auth-tests.timeout` prints `10m (default)`: an unset key follows the tool, a written one is pinned here, and a serializer would quietly convert every key of the first kind into the second.

## Left out on purpose

The page says `init` "does not yet write the rule for you" about `.gitignore`, thirty lines after showing `wrote .gitignore` in its own `init` output. Both cannot be true — measured on a fresh repository, `init` writes `.ank/index.db` into it, which is also what §9 says. That makes "Two edits to make now" wrong with it.

Different staleness, different criterion: **TASK-31fcf8b27aa2**.

## Verification

`cargo test --workspace`, `cargo fmt --check`, `ank check` — all green. No file outside `docs/getting-started.md` and `.ank/` changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012kHgSHnrDGvrSAmRAz9S58
