### PR TITLE
The guide stops telling the reader to write a gitignore rule init already wrote

### DIFF
--- a/.ank/tasks/TASK-31fcf8b27aa2.md
+++ b/.ank/tasks/TASK-31fcf8b27aa2.md
@@ -5,7 +5,7 @@ slug: the-guide-still-says-init-does-not-write-the-git
 title: The guide still says init does not write the gitignore rule, and it does
 created: 2026-08-09T15:53:53Z
 author: claude-code@ank
-status: open
+status: in_progress
 scope:
   - docs/getting-started.md
 blocked_by: []
@@ -13,7 +13,7 @@ done_criteria: |
   docs/getting-started.md no longer tells the reader to run 'echo .ank/index.db >> .gitignore', and no longer says init does not write the rule. The count in 'Two edits to make now' matches what follows it. What the page says about init writing .gitignore agrees with the init output it shows earlier on the same page. No other file changes, and cargo test stays green.
 criteria_by: creator
 schema: 2
-version: 1
+version: 3
 ---
 
 Found while executing TASK-7af1cd875d9a and left out of it, because that task's criterion is about config.yml and this is a different staleness in the same file.
@@ -21,3 +21,6 @@ Found while executing TASK-7af1cd875d9a and left out of it, because that task's 
 The page shows 'wrote .gitignore' in the ank init output, and then thirty lines later says init 'does not yet write the rule for you' and asks the reader to append it by hand. Both cannot be true. Measured on a fresh repository with the binary at d0ccc24: init writes a .gitignore containing '.ank/index.db', which is also what section 9 of the specification says it does.
 
 So the second of the page's 'Two edits to make now' is not an edit anyone has to make, and the count is wrong with it. A reader who follows the instruction gets a duplicate line rather than an error, which is why this has survived: it costs nothing visible and quietly teaches that the tool does less than it does.
+
+## Log
+- 2026-08-09T16:05:41Z claude-code@ank — Measured the whole init section against a fresh repository rather than only the two lines the criterion names: the six-line output block, the '.gitignore' content ('.ank/index.db') and the idempotent re-run message ('already initialised, nothing to do') all match the page byte for byte. Dropped the 'Ignore the index' subsection whole -- what it said about the index being derived and rebuildable is already in the paragraph above it, so removing it loses nothing and stops the page contradicting its own init output. 'Two edits' becomes 'One edit', and the remaining one now says why default_branch is the key init leaves unset on purpose.

--- a/.ank/tasks/TASK-31fcf8b27aa2.md
+++ b/.ank/tasks/TASK-31fcf8b27aa2.md
@@ -5,15 +5,19 @@ slug: the-guide-still-says-init-does-not-write-the-git
 title: The guide still says init does not write the gitignore rule, and it does
 created: 2026-08-09T15:53:53Z
 author: claude-code@ank
-status: in_progress
+status: done
 scope:
   - docs/getting-started.md
 blocked_by: []
 done_criteria: |
   docs/getting-started.md no longer tells the reader to run 'echo .ank/index.db >> .gitignore', and no longer says init does not write the rule. The count in 'Two edits to make now' matches what follows it. What the page says about init writing .gitignore agrees with the init output it shows earlier on the same page. No other file changes, and cargo test stays green.
 criteria_by: creator
+proof:
+  - type: test
+    ref: "31322911685"
+    criteria: c098a70fe64e
 schema: 2
-version: 3
+version: 4
 ---
 
 Found while executing TASK-7af1cd875d9a and left out of it, because that task's criterion is about config.yml and this is a different staleness in the same file.
@@ -24,3 +28,4 @@ So the second of the page's 'Two edits to make now' is not an edit anyone has to
 
 ## Log
 - 2026-08-09T16:05:41Z claude-code@ank — Measured the whole init section against a fresh repository rather than only the two lines the criterion names: the six-line output block, the '.gitignore' content ('.ank/index.db') and the idempotent re-run message ('already initialised, nothing to do') all match the page byte for byte. Dropped the 'Ignore the index' subsection whole -- what it said about the index being derived and rebuildable is already in the paragraph above it, so removing it loses nothing and stops the page contradicting its own init output. 'Two edits' becomes 'One edit', and the remaining one now says why default_branch is the key init leaves unset on purpose.
+- 2026-08-09T16:09:30Z claude-code@ank — done, proof test:31322911685

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -77,10 +77,12 @@ fetch non-standard refs on their own.
 Both git files are appended to, never replaced — an existing `.gitignore`
 keeps everything already in it.
 
-Two edits to make now, before the first real command.
+One edit to make now, before the first real command.
 
-**Name your default branch.** `.ank/config.yml` is written through the CLI
-rather than by hand:
+**Name your default branch.** It is the one key `init` leaves unset on purpose:
+it runs where the reference branch is not known yet, and writing `main` there
+would be exactly the guess the tool refuses everywhere else. `.ank/config.yml`
+is written through the CLI rather than by hand:
 
     $ ank config default_branch main
     default_branch (unset) -> main
@@ -92,12 +94,6 @@ remote has none. It refuses rather than guessing:
     error[9]: default branch indeterminable (default_branch absent from .ank/config.yml, refs/remotes/origin/HEAD absent)
       -> git remote set-head origin -a
       -> or ank config default_branch <name>
-
-**Ignore the index.** `.ank/index.db` is a derived SQLite cache, rebuildable
-from the files and safe to delete at any time. It does not belong in git, and
-`init` does not yet write the rule for you:
-
-    echo '.ank/index.db' >> .gitignore
 
 ## The two kinds of file
 


### PR DESCRIPTION
TASK-31fcf8b27aa2, found while doing TASK-7af1cd875d9a (#62) and filed rather than folded in.

## The contradiction

The page showed this in its own `init` output:

```
wrote .gitignore
```

and then, thirty lines later:

> **Ignore the index.** `.ank/index.db` is a derived SQLite cache […] It does not belong in git, and `init` does not yet write the rule for you:
>
> ```
> echo '.ank/index.db' >> .gitignore
> ```

Both cannot be true. Measured on a fresh repository with the binary at `cc0c7b7`, `init` writes a `.gitignore` containing `.ank/index.db` — which is also what §9 of the specification says it does.

## The fix

The subsection goes **whole** rather than being corrected. What it said — the index is derived, rebuildable, and does not belong in git — is already in the paragraph explaining what `init` just wrote, so removing it loses nothing and leaves one statement where there were two that disagreed.

`Two edits to make now` becomes `One edit`, and the one that remains now says *why* `default_branch` is the key `init` leaves unset on purpose: `init` runs where the reference branch is not known yet, and writing `main` there would be exactly the guess the tool refuses everywhere else.

## Why it survived

Following the instruction cost nothing visible. Appending a line that is already there produces a duplicate, not an error — so the page could go on quietly teaching that the tool does less than it does. That is the shape of staleness a reader has no way to detect, and it is the reason this was worth its own task rather than a shrug.

## Measured, not assumed

As the page's opening promises. Against a fresh repository: the six-line `init` output, the `.gitignore` content, and the idempotent re-run message (`already initialised, nothing to do`) all match the page byte for byte.

## Verification

`cargo test --workspace`, `ank check` — green. One file changed outside `.ank/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012kHgSHnrDGvrSAmRAz9S58
