### PR TITLE
Name the corpus when the walk crosses a git repository boundary

### DIFF
--- a/.ank/tasks/TASK-2f01baf94632.md
+++ b/.ank/tasks/TASK-2f01baf94632.md
@@ -5,7 +5,7 @@ slug: discover-crosses-the-git-boundary-in-silence
 title: discover crosses the git boundary in silence
 created: 2026-08-06T23:25:35Z
 author: seanl@sean-laptop
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/**
 blocked_by: []
@@ -13,7 +13,7 @@ done_criteria: |
   Running a verb from a directory whose nearest .ank/ lies outside the current git repository names the root it resolved, or the corpus records why staying silent is correct.
 criteria_by: creator
 schema: 2
-version: 1
+version: 3
 ---
 
 discover walks parents until it finds a .ank/, and its stopping condition is
@@ -51,3 +51,10 @@ Candidate answers, cheapest first:
 Related: TASK-35df68dd0eb3, which records multi-repository federation as
 deferred. This finding is the accidental half of that question, and it is
 actionable on its own.
+
+## Log
+- 2026-08-09T16:23:02Z claude-code@ank — Chose the first branch of the criterion -- name the resolved root -- and measured the finding first to be sure it was worth naming: from outer/inner/src, ank claim writes refs/ank/claims/<id> into outer/.git and inner/.git ends with zero ank refs. Git itself warns when you nest a checkout ('adding embedded git repository'); ank said nothing.
+
+Three design points the task left open. The warning fires only on the walk, never on an explicit --repo: that is what answers candidate answer 3, since the umbrella layout says which corpus it means once and is then never warned again. It goes to stderr, because ADR-0c8a requires --json to stay byte-for-byte what a parser reads and this is not part of any verb's answer. And the comparison is on 'rev-parse --git-common-dir' rather than --show-toplevel, because a linked worktree has a toplevel of its own but shares refs/ -- comparing toplevels would warn about a layout where the claim plane is in fact shared.
+
+Found a gap wider than this task and left it: the specification never describes the discovery walk at all. repo.rs is headed 'Repository discovery (section 6)' and section 6 covers the storage layout, atomic writes, the index and the three levels of search -- nothing about walking up to the nearest .ank/, and --repo appears only in the global flag list. So there is no spec text this change contradicts, and none it could have been written against. Filed separately.

--- a/.ank/tasks/TASK-2f01baf94632.md
+++ b/.ank/tasks/TASK-2f01baf94632.md
@@ -5,15 +5,19 @@ slug: discover-crosses-the-git-boundary-in-silence
 title: discover crosses the git boundary in silence
 created: 2026-08-06T23:25:35Z
 author: seanl@sean-laptop
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/**
 blocked_by: []
 done_criteria: |
   Running a verb from a directory whose nearest .ank/ lies outside the current git repository names the root it resolved, or the corpus records why staying silent is correct.
 criteria_by: creator
+proof:
+  - type: test
+    ref: "31323715190"
+    criteria: 45d0599d8de6
 schema: 2
-version: 3
+version: 4
 ---
 
 discover walks parents until it finds a .ank/, and its stopping condition is
@@ -58,3 +62,4 @@ actionable on its own.
 Three design points the task left open. The warning fires only on the walk, never on an explicit --repo: that is what answers candidate answer 3, since the umbrella layout says which corpus it means once and is then never warned again. It goes to stderr, because ADR-0c8a requires --json to stay byte-for-byte what a parser reads and this is not part of any verb's answer. And the comparison is on 'rev-parse --git-common-dir' rather than --show-toplevel, because a linked worktree has a toplevel of its own but shares refs/ -- comparing toplevels would warn about a layout where the claim plane is in fact shared.
 
 Found a gap wider than this task and left it: the specification never describes the discovery walk at all. repo.rs is headed 'Repository discovery (section 6)' and section 6 covers the storage layout, atomic writes, the index and the three levels of search -- nothing about walking up to the nearest .ank/, and --repo appears only in the global flag list. So there is no spec text this change contradicts, and none it could have been written against. Filed separately.
+- 2026-08-09T16:28:16Z claude-code@ank — done, proof test:31323715190

--- a/.ank/tasks/TASK-62136e8c2b69.md
+++ b/.ank/tasks/TASK-62136e8c2b69.md
@@ -1,0 +1,25 @@
+---
+id: TASK-62136e8c2b69
+type: task
+slug: section-6-never-describes-the-discovery-walk-it
+title: Section 6 never describes the discovery walk it is cited for
+created: 2026-08-09T16:23:15Z
+author: claude-code@ank
+status: open
+scope:
+  - docs/ank-spec-v1.1.md
+blocked_by: []
+done_criteria: |
+  Section 6 of docs/ank-spec-v1.1.md describes how a repository is resolved: the walk up from the working directory to the nearest .ank/, what stops it, how --repo short-circuits it, and the warning emitted when the resolved root lies outside the working directory's git repository. crates/ank-cli/src/repo.rs cites a section that answers what it claims. cargo test and ank check stay green.
+criteria_by: creator
+schema: 2
+version: 1
+---
+
+Found while executing TASK-2f01baf94632 and left out of it, whose scope is crates/ank-cli/** .
+
+repo.rs opens with 'Repository discovery (section 6)'. Section 6 covers the storage layout, the flat tree, atomic writes, the derived index and the three levels of search. It says nothing about resolution: not the walk up to the nearest .ank/, not its stopping condition, not what --repo does beyond appearing in the list of three global flags in section 4.
+
+So the behaviour every invocation depends on -- which corpus am I even in -- is specified nowhere, and a reader following the pointer in repo.rs arrives at a section that does not answer. That is also why TASK-2f01baf94632 could add a warning to that walk without contradicting a line of the specification: there was no line.
+
+The warning is now part of the behaviour and belongs in the same text: it fires only on the walk and never on an explicit --repo, it is emitted on standard error so --json stays byte-for-byte what a parser reads, and it degrades rather than failing. The comparison behind it is on the git common directory rather than the toplevel, so two worktrees of one repository do not read as two repositories.

--- a/crates/ank-cli/src/cli.rs
+++ b/crates/ank-cli/src/cli.rs
@@ -1103,11 +1103,61 @@ struct Startup {
     identity: String,
 }
 
+/// Names the corpus when the walk crossed a git repository boundary
+/// (TASK-2f01baf94632).
+///
+/// `discover` stops at the first `.ank/` and at nothing else, so from a
+/// checkout nested inside another repository it silently resolves the outer
+/// corpus. That is not merely reading the wrong files: claims are git refs
+/// (ADR-4e7c), so they land in the resolved root's repository and not in the
+/// one holding the code being changed. Measured on a fixture, the inner
+/// repository ends with no ank ref at all.
+///
+/// **Only on the walk.** `--repo` is the caller saying which corpus they mean,
+/// and warning about an answer that was asked for by name would fire forever in
+/// the one layout this behaviour makes usable — a single `.ank/` above several
+/// checkouts, scopes written as `repoA/src/**`. That layout was never designed
+/// for and is not forbidden either; naming `--repo` once is what separates it
+/// from the accident.
+///
+/// **On stderr**, and that is not incidental. It is not part of any verb's
+/// answer, and §4 requires `--json` to stay byte-for-byte what a caller's
+/// parser already reads; a line on stdout would break every one of them to say
+/// something no parser asked for. It degrades and never fails (§2): the walk
+/// succeeded, and the caller may well have meant it.
+fn warn_if_outside_repository(inv: &Invocation, repo: &crate::repo::Repo, cwd: &std::path::Path) {
+    if inv.repo().is_some() || inv.quiet() {
+        return;
+    }
+    let here = crate::git::common_dir(cwd);
+    let root = crate::git::common_dir(&repo.root);
+    if !crate::git::crosses_repository(here.as_deref(), root.as_deref()) {
+        return;
+    }
+    let style = inv.style().on_stderr();
+    let tag = style.yellow("warning:");
+    let root_display = repo.root.display();
+    match here {
+        Some(_) => eprintln!(
+            "{tag} .ank/ resolved to {root_display}, outside the git repository holding {}",
+            cwd.display()
+        ),
+        None => eprintln!(
+            "{tag} .ank/ resolved to {root_display}; {} is in no git repository",
+            cwd.display()
+        ),
+    }
+    eprintln!(
+        "  -> claims are refs and land in {root_display}: ank init here, or --repo to confirm"
+    );
+}
+
 fn startup(inv: &Invocation, cwd: &std::path::Path) -> Result<Startup> {
     let repo = crate::repo::resolve(inv.repo(), cwd)?;
     // git is a hard dependency, and its version is checked at startup
     // (ADR-b8884edcebe3).
     crate::git::ensure_usable(&repo.root)?;
+    warn_if_outside_repository(inv, &repo, cwd);
     let config = crate::config::load(&repo.config_path())?;
     let identity = crate::identity::resolve();
     Ok(Startup {
@@ -1179,6 +1229,11 @@ fn dispatch(
     }
     if inv.command == "config" {
         let repo = crate::repo::resolve(inv.repo(), cwd)?;
+        // The same hazard, and it reaches this verb too: a `config` run from a
+        // nested checkout edits the outer repository's configuration. `git` is
+        // unchecked here, which costs nothing — `common_dir` answers `None`
+        // when it cannot run, and two `None`s say nothing.
+        warn_if_outside_repository(&inv, &repo, cwd);
         return crate::config::run(&inv, &repo, out);
     }
 

--- a/crates/ank-cli/src/git.rs
+++ b/crates/ank-cli/src/git.rs
@@ -190,6 +190,66 @@ pub fn ensure_usable(cwd: &Path) -> Result<PathBuf> {
     toplevel(cwd)
 }
 
+/// The **common** git directory of the repository containing `cwd`, absolute,
+/// or `None` when `cwd` is not inside a repository at all.
+///
+/// The common directory and not the toplevel, and the difference is the whole
+/// point: a linked worktree has a toplevel of its own and shares `refs/` with
+/// the checkout that made it, so comparing toplevels would report two worktrees
+/// of one repository as two repositories. The question being asked is where a
+/// claim ref lands (§7), and that is the common directory.
+///
+/// `--path-format=absolute` rather than canonicalising the answer ourselves:
+/// `--git-common-dir` is relative when git is run from the repository root, and
+/// two paths compared without agreeing on that are two strings that differ for
+/// no reason. It has existed since git 2.31 and [`MIN_VERSION`] is 2.34.
+///
+/// Never an error. Every caller is asking a question whose answer may legibly
+/// be "there is no repository here", and a failure to run git is that answer
+/// too — this is used to decide whether to say something extra, never to
+/// refuse.
+pub fn common_dir(cwd: &Path) -> Option<PathBuf> {
+    let out = output(
+        cwd,
+        &["rev-parse", "--path-format=absolute", "--git-common-dir"],
+    )
+    .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    (!text.is_empty()).then(|| PathBuf::from(text))
+}
+
+/// Whether the resolved corpus and the working directory sit in two different
+/// git repositories (TASK-2f01baf94632).
+///
+/// `discover` walks parents until it finds a `.ank/`, and its stopping
+/// condition is the filesystem root — it never consults `.git` and never stops
+/// at a repository boundary. From `outer/inner/src` with no `inner/.ank/`, the
+/// walk reaches `outer/.ank/` and the verb runs there. Measured: a `claim` made
+/// from `inner/src` writes `refs/ank/claims/<id>` into `outer/.git`, and
+/// `inner/.git` — the repository holding the code being changed — ends with no
+/// ank ref at all. The coordination plane and the code part company, and
+/// nothing says so.
+///
+/// Pure on purpose, like [`resolve_default_branch`]: the two sources are passed
+/// in rather than read here, so every combination is testable without building
+/// two repositories on disk.
+pub fn crosses_repository(here: Option<&Path>, root: Option<&Path>) -> bool {
+    match (here, root) {
+        // Two repositories, and the claim plane is in the one the caller is not
+        // standing in.
+        (Some(a), Some(b)) => a != b,
+        // No repository here, and one where the corpus was found. Worth saying
+        // for the same reason: the refs are somewhere the caller is not.
+        (None, Some(_)) => true,
+        // The corpus is not in a repository. `ensure_usable` has already
+        // refused with code 9, and there is no second thing to say about it.
+        (_, None) => false,
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Refs, branches, reachability (§7, §12)
 // ---------------------------------------------------------------------------
@@ -758,6 +818,100 @@ mod tests {
             assert_eq!(err.code, 9);
             assert_eq!(err.hint.as_deref(), Some("git init"));
         }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The four combinations, without building two repositories on disk
+    /// (TASK-2f01baf94632).
+    ///
+    /// Pure for the reason `resolve_default_branch` is: a decision that only
+    /// exists inside a fixture is a decision tested under one layout, and the
+    /// interesting cases here are the ones nobody sets up by accident.
+    #[test]
+    fn crossing_a_repository_boundary_is_decided_from_the_two_common_dirs() {
+        let a = Path::new("/w/outer/.git");
+        let b = Path::new("/w/outer/inner/.git");
+
+        assert!(
+            crosses_repository(Some(b), Some(a)),
+            "standing in the inner repository with the corpus resolved in the \
+             outer one is the whole finding"
+        );
+        assert!(
+            !crosses_repository(Some(a), Some(a)),
+            "one repository, whichever subdirectory the caller stands in"
+        );
+        assert!(
+            crosses_repository(None, Some(a)),
+            "no repository here and refs over there is the same parting"
+        );
+        assert!(
+            !crosses_repository(Some(a), None),
+            "a corpus outside any repository is ensure_usable's code 9, and \
+             saying it twice helps nobody"
+        );
+        assert!(!crosses_repository(None, None));
+    }
+
+    /// Two worktrees of one repository are one repository.
+    ///
+    /// This is why the comparison is on the common directory and not on the
+    /// toplevel: a linked worktree has a toplevel of its own, so a toplevel
+    /// comparison would warn about a layout where the refs are in fact shared —
+    /// and a warning that fires when nothing is wrong is a warning nobody reads
+    /// the day something is.
+    #[test]
+    fn a_linked_worktree_shares_its_common_dir_with_the_checkout_that_made_it() {
+        let dir = std::env::temp_dir().join(format!("ank-common-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let main = dir.join("main");
+        std::fs::create_dir_all(&main).unwrap();
+
+        let git = |cwd: &Path, args: &[&str]| {
+            Command::new("git")
+                .current_dir(cwd)
+                .args(args)
+                .output()
+                .expect("git is a hard dependency")
+        };
+        git(&main, &["init", "-q", "-b", "main"]);
+        git(&main, &["config", "user.email", "t@ank.local"]);
+        git(&main, &["config", "user.name", "T"]);
+        std::fs::write(main.join("seed.txt"), "x").unwrap();
+        git(&main, &["add", "-A"]);
+        git(&main, &["-c", "commit.gpgsign=false", "commit", "-qm", "s"]);
+        let wt = dir.join("wt");
+        git(
+            &main,
+            &["worktree", "add", "-q", wt.to_str().unwrap(), "-b", "side"],
+        );
+
+        let from_main = common_dir(&main);
+        let from_wt = common_dir(&wt);
+        assert!(from_main.is_some() && from_wt.is_some(), "both resolved");
+        assert_eq!(
+            from_main, from_wt,
+            "a linked worktree shares refs/ with the checkout that made it, so \
+             it must not read as a second repository"
+        );
+        assert!(!crosses_repository(
+            from_wt.as_deref(),
+            from_main.as_deref()
+        ));
+
+        // And a repository nested inside another does read as a second one.
+        let inner = main.join("inner");
+        std::fs::create_dir_all(&inner).unwrap();
+        git(&inner, &["init", "-q", "-b", "main"]);
+        let from_inner = common_dir(&inner);
+        assert!(from_inner.is_some());
+        assert_ne!(from_inner, from_main);
+        assert!(crosses_repository(
+            from_inner.as_deref(),
+            from_main.as_deref()
+        ));
+
         let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -4448,6 +4448,142 @@ fn the_errors_that_named_the_file_now_name_the_command() {
     }
 }
 
+// ---------------------------------------------------------------------------
+// The git boundary (TASK-2f01baf94632)
+// ---------------------------------------------------------------------------
+//
+// Through the binary and **without `--repo`**, which is the only way to reach
+// this at all: the finding is about the walk `discover` performs from the
+// working directory, and every other test in this file short-circuits that walk
+// by naming the repository.
+
+/// Runs `ank` from `dir` with no `--repo`, so resolution is the walk.
+fn ank_walking(dir: &Path, args: &[&str]) -> Output {
+    Command::new(ANK)
+        .args(args)
+        .env("ANK_AGENT", "claude-code@ank")
+        .current_dir(dir)
+        .output()
+        .expect("the binary must have been built")
+}
+
+/// A git repository of its own, with no `.ank/`, nested inside `outer`.
+///
+/// The layout nobody sets up on purpose — a checkout cloned inside another
+/// checkout — and the one where the walk succeeds at the wrong place.
+fn nest_a_repository_in(outer: &Repo) -> PathBuf {
+    let inner = outer.0.join("inner");
+    std::fs::create_dir_all(inner.join("src")).unwrap();
+    for args in [
+        &["init", "-q", "-b", "main"][..],
+        &["config", "user.email", "t@ank.local"][..],
+        &["config", "user.name", "T"][..],
+    ] {
+        let out = Command::new("git")
+            .current_dir(&inner)
+            .args(args)
+            .output()
+            .expect("git is a hard dependency");
+        assert!(out.status.success(), "git {args:?}");
+    }
+    inner
+}
+
+#[test]
+fn a_verb_resolving_a_corpus_across_a_git_boundary_names_the_root() {
+    let outer = Repo::new();
+    let inner = nest_a_repository_in(&outer);
+    let root = outer.0.file_name().unwrap().to_string_lossy().to_string();
+
+    let out = ank_walking(&inner.join("src"), &["status"]);
+    // Degrade, do not fail (§2): the walk succeeded, and the caller may well
+    // have meant it.
+    assert!(out.status.success(), "{}", erred(&out));
+
+    let err = erred(&out);
+    assert!(err.contains("warning:"), "nothing was said at all: {err}");
+    assert!(
+        err.contains(&root),
+        "the resolved root is not named, which is the whole criterion: {err}"
+    );
+    // Claims are git refs, and that is why this is not merely reading the wrong
+    // files: the refs land in the outer repository while the code being changed
+    // is versioned by the inner one.
+    assert!(err.contains("claims"), "{err}");
+    // Both ways out, named.
+    assert!(err.contains("ank init") && err.contains("--repo"), "{err}");
+}
+
+#[test]
+fn the_boundary_warning_never_reaches_standard_output() {
+    // §4 requires --json to stay byte-for-byte what a caller's parser already
+    // reads. A line on stdout would break every one of them to say something no
+    // parser asked for -- so the warning is on stderr, and this is what holds it
+    // there.
+    let outer = Repo::new();
+    let inner = nest_a_repository_in(&outer);
+
+    for args in [
+        &["status", "--json"][..],
+        &["find", "--status", "open", "--json"][..],
+    ] {
+        let out = ank_walking(&inner.join("src"), args);
+        let stdout = String::from_utf8_lossy(&out.stdout).to_string();
+        assert!(
+            !stdout.contains("warning"),
+            "{args:?} put the warning on stdout: {stdout}"
+        );
+        assert!(
+            stdout.trim().is_empty() || stdout.trim_start().starts_with('{'),
+            "{args:?} left stdout unparseable: {stdout}"
+        );
+        // It was still said, on the stream that carries it.
+        assert!(erred(&out).contains("warning:"), "{args:?} said nothing");
+    }
+}
+
+#[test]
+fn naming_the_repository_is_what_silences_the_boundary_warning() {
+    let outer = Repo::new();
+    let inner = nest_a_repository_in(&outer);
+
+    // `--repo` is the caller saying which corpus they mean. Warning about an
+    // answer that was asked for by name would fire forever in the one layout
+    // this behaviour makes usable: a single `.ank/` above several checkouts.
+    let out = ank_walking(
+        &inner.join("src"),
+        &["status", "--repo", outer.0.to_str().unwrap()],
+    );
+    assert!(
+        !erred(&out).contains("warning:"),
+        "an explicit --repo was still warned about: {}",
+        erred(&out)
+    );
+
+    // And --quiet means no chatter, here as everywhere.
+    let out = ank_walking(&inner.join("src"), &["status", "--quiet"]);
+    assert!(!erred(&out).contains("warning:"), "{}", erred(&out));
+}
+
+#[test]
+fn an_ordinary_subdirectory_of_the_same_repository_is_not_warned_about() {
+    // The guard against a warning that fires when nothing is wrong. Walking up
+    // from a subdirectory is the nominal case -- §6 specifies it -- and a
+    // warning there would be noise nobody reads the day something is actually
+    // wrong.
+    let outer = Repo::new();
+    let deep = outer.0.join("crates").join("ank-cli").join("src");
+    std::fs::create_dir_all(&deep).unwrap();
+
+    let out = ank_walking(&deep, &["status"]);
+    assert!(out.status.success(), "{}", erred(&out));
+    assert!(
+        !erred(&out).contains("warning:"),
+        "the nominal walk was warned about: {}",
+        erred(&out)
+    );
+}
+
 #[test]
 fn help_answers_about_config_the_way_it_answers_about_every_verb() {
     let r = Repo::new();


### PR DESCRIPTION
TASK-2f01baf94632.

`discover` walks parents until it finds a `.ank/`, and its stopping condition is the filesystem root. It never consults `.git`, never stops at a repository boundary, and never says which root it settled on.

## Measured before deciding it was worth naming

A fixture: `outer/` carries the corpus, `outer/inner/` is a git repository of its own with no `.ank/`.

```
$ cd outer/inner/src && ank claim TASK-c27b930d1c74
claimed TASK-c27b930d1c74 touch-the-inner-code -> HEAD

$ git -C outer/inner for-each-ref refs/ank/     # the repo holding the code
0 refs

$ git -C outer for-each-ref refs/ank/           # the repo ank resolved
8dca2940bd1d… blob  refs/ank/claims/TASK-c27b930d1c74
```

That is what makes this more than reading the wrong files. Claims are git refs (ADR-4e7c), so the coordination plane lands in the outer repository while the code being changed is versioned by the inner one. They part company, and nothing says so. Git itself warns when a checkout is nested inside another; ank did not.

## Now

```
$ cd outer/inner/src && ank status
warning: .ank/ resolved to /w/outer, outside the git repository holding /w/outer/inner/src
  -> claims are refs and land in /w/outer: ank init here, or --repo to confirm
branch main (default main)
…
```

## Three choices the task left open

**Only on the walk.** `--repo` is the caller saying which corpus they mean. Warning about an answer that was asked for by name would fire forever in the one layout this behaviour makes usable — a single `.ank/` above several checkouts, scopes written as `repoA/src/**`. That layout was never designed for and is not forbidden either; naming `--repo` once separates it from the accident. This is what answers the task's third candidate answer without having to declare silence correct.

**On stderr.** It is not part of any verb's answer, and ADR-0c8ab846d262 requires `--json` to stay byte-for-byte what a caller's parser already reads. A line on stdout would break every one of them to say something no parser asked for. It degrades and never fails (§2): the walk succeeded, and the caller may well have meant it.

**Compared on the git common directory, not the toplevel.** A linked worktree has a toplevel of its own and shares `refs/` with the checkout that made it, so a toplevel comparison would report two worktrees of one repository as two repositories — warning where the claim plane is in fact shared. A warning that fires when nothing is wrong is a warning nobody reads the day something is.

## Tests

`crosses_repository` is pure, for the reason `resolve_default_branch` is: the two sources are passed in, so all four combinations are testable without building two repositories. A second unit test builds a real linked worktree and a real nested repository, because the common-dir claim is about git's behaviour and not about ours.

The rest is through the binary and deliberately **without `--repo`**, which is the only way to reach the walk at all — every other test in `tests/cli.rs` short-circuits it by naming the repository. Four cases: the root is named; the warning never reaches stdout and `--json` stays parseable; `--repo` and `--quiet` silence it; an ordinary subdirectory of the same repository is not warned about.

## Left out

The specification never describes the discovery walk. `repo.rs` is headed "Repository discovery (§6)", and §6 covers the storage layout, atomic writes, the index and the three levels of search — nothing about resolution, and `--repo` appears only in §4's list of three global flags. So there is no spec text this contradicts, and none it could have been written against. Out of this task's scope (`crates/ank-cli/**`): **TASK-62136e8c2b69**.

## Verification

`cargo test --workspace` (256 unit + 86 integration + 11 skill + 20 core), `cargo fmt --check`, `ank check` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012kHgSHnrDGvrSAmRAz9S58
