### PR TITLE
Read the claim's second hash at done, so the warning section 7 promises exists

### DIFF
--- a/.ank/tasks/TASK-2eefcdd80124.md
+++ b/.ank/tasks/TASK-2eefcdd80124.md
@@ -1,0 +1,36 @@
+---
+id: TASK-2eefcdd80124
+type: task
+slug: three-verbs-put-non-json-on-stdout-while-json-is
+title: Three verbs put non-JSON on stdout while --json is set
+created: 2026-08-09T17:11:56Z
+author: claude-code@ank
+status: open
+scope:
+  - crates/ank-cli/src/done.rs
+  - crates/ank-cli/src/commands.rs
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/src/cli.rs
+  - crates/ank-cli/tests/cli.rs
+blocked_by: []
+done_criteria: |
+  Under --json, every verb writes exactly one JSON document to standard output and nothing else. Measured through the binary on the three known sites -- done progress lines, and the takeover warnings of log and amend -- by capturing stdout alone and requiring it to start with a brace and to contain no line outside the document. A test walks the verbs rather than naming these three, so a line added later to a fourth is caught. What moves off stdout goes to standard error, keeping the information rather than dropping it. cargo test and ank check stay green.
+criteria_by: creator
+schema: 2
+version: 1
+---
+
+Found while executing TASK-bfa325e55424, which put its own warning on standard error rather than beside these.
+
+Section 4 says --json is data, and that it stays byte-for-byte what a caller's parser already reads. Three verbs contradict it, and cli.rs already knows: the comment on the style gate names them -- done's progress lines, and the takeover warnings of log and amend -- and treats the situation as a given rather than as a defect.
+
+Measured on a scratch repository with the binary at 5f825cd. Running `ank done <id> --json` put this on standard output:
+
+    running: ok ... ok (0.1s)
+    {"task": "TASK-ff695a8a0a39", "status": "done", ...}
+
+A caller parsing stdout as JSON fails on the first line. The failure is not subtle, which is probably why it has survived: anyone who hit it worked around it by reading the last line, and a workaround that works is a defect nobody files.
+
+The information itself is worth keeping -- progress on a long verifier run is exactly what a human wants -- so the fix is to move it to standard error, not to suppress it under --json. That is what TASK-bfa325e55424 did for the constraint-drift warning, and doing the same here would leave one rule instead of two.
+
+The test should walk the surface rather than name the three sites, for the reason TASK-8dd89053fa33 was filed: a criterion that enumerates instances gets satisfied exactly, and the fourth site is added outside it.

--- a/.ank/tasks/TASK-bfa325e55424.md
+++ b/.ank/tasks/TASK-bfa325e55424.md
@@ -5,15 +5,19 @@ slug: done-never-warns-on-constraint-drift-though-the
 title: done never warns on constraint drift, though the claim freezes the hash for it
 created: 2026-08-06T23:24:36Z
 author: seanl@sean-laptop
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/**
 blocked_by: []
 done_criteria: |
   ank done warns when the constraints hash frozen at claim differs from the constraints applicable to the task scope at completion, and a test drives that warning through the binary.
 criteria_by: creator
+proof:
+  - type: test
+    ref: "31325809143"
+    criteria: 24d1a0ddd0a9
 schema: 2
-version: 3
+version: 4
 ---
 
 The claim record carries two hashes: the frozen done_criteria and a hash of the
@@ -57,3 +61,4 @@ No spec change: section 7 line 881 already promised this in as many words -- 'a 
 Put on stderr rather than beside done's 'running:' lines, which is a deliberate departure from the neighbours: those lines already make 'done --json' unparseable, contradicting section 4, and adding a second line to stdout would deepen that defect rather than avoid it. Filed nothing for it here because it is a different fault in a different verb, but it is real and it is now the only thing standing between done and a clean --json.
 
 Measured that the test bites: with the call removed, done_warns_when_a_constraint_landed... fails with 'done completed in silence, which is the whole defect'. The control test matters as much -- a warning that fired on every done would be one nobody reads on the done that matters. The fixture accepts a real ADR with a real signature, because bearing_on counts accepted ADRs only and a proposed one would have left the hash where it was, passing on a binary that never looked.
+- 2026-08-09T17:15:49Z claude-code@ank — done, proof test:31325809143

--- a/.ank/tasks/TASK-bfa325e55424.md
+++ b/.ank/tasks/TASK-bfa325e55424.md
@@ -5,7 +5,7 @@ slug: done-never-warns-on-constraint-drift-though-the
 title: done never warns on constraint drift, though the claim freezes the hash for it
 created: 2026-08-06T23:24:36Z
 author: seanl@sean-laptop
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/**
 blocked_by: []
@@ -13,7 +13,7 @@ done_criteria: |
   ank done warns when the constraints hash frozen at claim differs from the constraints applicable to the task scope at completion, and a test drives that warning through the binary.
 criteria_by: creator
 schema: 2
-version: 1
+version: 3
 ---
 
 The claim record carries two hashes: the frozen done_criteria and a hash of the
@@ -48,3 +48,12 @@ Two things the implementation must not get wrong:
   on the output. Asserting that a hash comparison function returns false proves
   nothing about the path done actually takes - that is precisely how two earlier
   defects in this repo passed green unit tests.
+
+## Log
+- 2026-08-09T17:10:54Z claude-code@ank — Read the claim record's second hash in done, on stderr, warning and never blocking.
+
+No spec change: section 7 line 881 already promised this in as many words -- 'a constraint accepted while the agent works changes that hash, and done WARNS, never blocks, inviting a re-read of ank context; check reports the same case'. The specification was right and the code was half-written, which is the opposite of the last two tasks. check had it (human.rs, with a comment reading 'done warns; so does this'), done never read ClaimRecord.constraints at all.
+
+Put on stderr rather than beside done's 'running:' lines, which is a deliberate departure from the neighbours: those lines already make 'done --json' unparseable, contradicting section 4, and adding a second line to stdout would deepen that defect rather than avoid it. Filed nothing for it here because it is a different fault in a different verb, but it is real and it is now the only thing standing between done and a clean --json.
+
+Measured that the test bites: with the call removed, done_warns_when_a_constraint_landed... fails with 'done completed in silence, which is the whole defect'. The control test matters as much -- a warning that fired on every done would be one nobody reads on the done that matters. The fixture accepts a real ADR with a real signature, because bearing_on counts accepted ADRs only and a proposed one would have left the hash where it was, passing on a binary that never looked.

--- a/crates/ank-cli/src/done.rs
+++ b/crates/ank-cli/src/done.rs
@@ -142,6 +142,12 @@ pub fn run(
     // credibility the anchor has already withdrawn.
     check_frozen_criteria(&id, &criteria, claim_record)?;
 
+    // The claim record's other hash, and until now the decorative one. Before
+    // anything runs for the same reason: an agent told a new rule landed over
+    // these files should hear it before it spends a minute on verifiers, not
+    // after the transition is already written.
+    warn_on_constraint_drift(&store, repo, &task, claim_record, inv.style());
+
     let declared: Vec<String> = task.verify.clone();
     let proofs = if declared.is_empty() {
         let usage = ProofUsage {
@@ -277,6 +283,55 @@ fn resolve_head(
 
 /// The freeze, checked at the point of use. The CLI is not a gatekeeper: the
 /// hash lives in the claim record, which the file's editor does not control.
+/// A constraint accepted while the claim was held (§7, TASK-bfa325e55424).
+///
+/// The claim record carries two hashes. The criteria freeze is checked above
+/// and refuses; this is the other one, and §7 says exactly what it is for: it
+/// closes the long-work window, because a constraint accepted while the agent
+/// works changes what applies to its scope, and `done` warns — inviting a
+/// re-read of `ank context`.
+///
+/// Half of that was true. `check` reported the case and `done` never read
+/// `ClaimRecord.constraints` at all, so the field was written at every claim,
+/// carried for the whole life of the ref, and consulted only by a verb the
+/// agent is not required to run. The window it left open is the one the design
+/// already judged worth closing: claim, work for an hour, a rule lands over the
+/// scope meanwhile, and the transition completes in silence.
+///
+/// **It warns and never blocks.** A constraint that landed after the work
+/// started does not necessarily concern work already finished, and refusing
+/// would punish exactly the case §7 singles out.
+///
+/// **On standard error**, unlike the `running:` lines beside it. Those already
+/// make `done --json` unparseable, which §4 forbids and which is a defect of
+/// its own; adding a second line to stdout would deepen it to say something no
+/// parser asked for.
+///
+/// A constraint set that cannot be computed says nothing rather than guessing:
+/// this is an advisory read, and failing a `done` over it would be the blocking
+/// this is explicitly not.
+fn warn_on_constraint_drift(
+    store: &Store,
+    repo: &Repo,
+    task: &ank_core::Task,
+    claim: &ClaimRecord,
+    style: crate::style::Style,
+) {
+    let Ok(applicable) = claim::applicable_constraints(store, repo, task) else {
+        return;
+    };
+    if claim::constraints_hash(&applicable) == claim.constraints {
+        return;
+    }
+    let style = style.on_stderr();
+    eprintln!(
+        "{} constraints over this scope changed while the claim was held ({} bind it now)",
+        style.yellow("warning:"),
+        applicable.len()
+    );
+    eprintln!("  -> ank context");
+}
+
 fn check_frozen_criteria(id: &EntityId, criteria: &str, claim: &ClaimRecord) -> Result<()> {
     if criteria.trim().is_empty() {
         return Err(CliError::new(7, format!("{id} has no done_criteria")).with_hint("ank context"));

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -4936,3 +4936,103 @@ fn help_answers_about_config_the_way_it_answers_about_every_verb() {
     assert!(listing.contains("ank config <key> [<value>]"), "{listing}");
     assert!(listing.contains("--unset"), "{listing}");
 }
+
+// ---------------------------------------------------------------------------
+// Constraint drift at done (TASK-bfa325e55424)
+// ---------------------------------------------------------------------------
+//
+// Through the binary, and the task said why in advance: asserting that a hash
+// comparison returns false proves nothing about the path `done` actually takes,
+// and that is precisely how two earlier defects in this repo passed green unit
+// tests. So the fixture accepts a real constraint, with a real signature, over
+// a scope a real claim already froze.
+
+/// A repository where a task is claimed and one constraint can be landed over
+/// its scope afterwards.
+fn drift_fixture(task: &str) -> Repo {
+    let r = Repo::new().with_verifiers("verifiers:\n  ok:\n    run: git --version\n");
+    r.enable_signing();
+    std::fs::create_dir_all(r.0.join("src")).unwrap();
+    std::fs::write(r.0.join("src/main.rs"), "fn main() {}\n").unwrap();
+    r.seed_task_with(task, Some("A verifiable criterion."), &["ok"]);
+    r.git(&["add", "-A"]);
+    r.git(&["-c", "commit.gpgsign=false", "commit", "-qm", "seed"]);
+    r
+}
+
+#[test]
+fn done_warns_when_a_constraint_landed_over_the_scope_while_the_claim_was_held() {
+    const TASK: &str = "TASK-0000000000dd";
+    const ADR: &str = "ADR-0000000000ce";
+    let r = drift_fixture(TASK);
+
+    // The claim freezes the constraints applicable to `src/**` -- none yet.
+    let out = r.ank("claude-code@ank", &["claim", TASK]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+
+    // A rule lands over those files while the work is in progress. Accepted for
+    // real: `bearing_on` counts accepted ADRs and nothing else, so a proposed
+    // one would leave the hash where it was and this test would pass on a
+    // binary that never looked.
+    r.seed_adr(ADR, "Every session goes through the store.", "src/**");
+    r.git(&["add", "-A"]);
+    r.git(&["-c", "commit.gpgsign=false", "commit", "-qm", "adr"]);
+    let out = r.ank("marie@laptop", &["accept", ADR]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+
+    let out = r.ank("claude-code@ank", &["done", TASK]);
+
+    // It warns, and it does not block: a rule that landed after the work
+    // started does not necessarily concern work already finished, and refusing
+    // would punish exactly the case §7 singles out.
+    assert_eq!(code(&out), 0, "done was blocked: {}", stderr(&out));
+    assert!(
+        stdout(&out).contains("-> done"),
+        "the transition did not happen: {}",
+        stdout(&out)
+    );
+
+    let err = stderr(&out);
+    assert!(
+        err.contains("constraints over this scope changed"),
+        "done completed in silence, which is the whole defect: {err}"
+    );
+    assert!(
+        err.contains("ank context"),
+        "the warning names no next command: {err}"
+    );
+
+    // On stderr and not on stdout: the `running:` lines already make
+    // `done --json` unparseable, and a second line there would deepen a defect
+    // rather than avoid it.
+    assert!(
+        !stdout(&out).contains("constraints over this scope"),
+        "the warning reached stdout: {}",
+        stdout(&out)
+    );
+}
+
+#[test]
+fn done_says_nothing_when_the_constraints_did_not_move() {
+    // The control, and it is what makes the test above mean anything: a warning
+    // that fires on every `done` would be a warning nobody reads on the one
+    // that matters.
+    const TASK: &str = "TASK-0000000000de";
+    const ADR: &str = "ADR-0000000000cf";
+    let r = drift_fixture(TASK);
+
+    // Accepted *before* the claim, so it is inside the frozen hash.
+    r.seed_adr(ADR, "Every session goes through the store.", "src/**");
+    r.git(&["add", "-A"]);
+    r.git(&["-c", "commit.gpgsign=false", "commit", "-qm", "adr"]);
+    assert_eq!(code(&r.ank("marie@laptop", &["accept", ADR])), 0);
+
+    assert_eq!(code(&r.ank("claude-code@ank", &["claim", TASK])), 0);
+    let out = r.ank("claude-code@ank", &["done", TASK]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    assert!(
+        !stderr(&out).contains("constraints over this scope changed"),
+        "warned with nothing to warn about: {}",
+        stderr(&out)
+    );
+}


### PR DESCRIPTION
TASK-bfa325e55424.

The claim record carries two hashes: the frozen `done_criteria`, and a hash of the constraints applicable to the task's scope at pickup. §7 says exactly what the second is for:

> a constraint accepted while the agent works changes that hash, and `done` **warns** — never blocks, since a new constraint does not necessarily concern work already done — inviting a re-read of `ank context`; `check` reports the same case.

Half of that was true. `check` reported it, under a comment reading *"`done` warns; so does this"*. `done` never read `ClaimRecord.constraints` at all — the field was written at every claim, carried for the whole life of the ref, and consulted only by a verb the agent is not required to run.

The window that left open is the one the design already judged worth closing: claim, work for an hour, a rule lands over the scope meanwhile, and the transition completes in silence. The agent never learns there is a new rule over the files it just touched.

**No specification changed here**, and that is the difference from the last three PRs. §7 was right and the code was half-written; this makes the mechanism real rather than decorative.

## Shape

```
$ ank done TASK-0000000000dd
warning: constraints over this scope changed while the claim was held (1 binds it now)
  -> ank context
running: ok ... ok (0.1s)
TASK-0000000000dd -> done
```

- **Warns, never blocks.** A constraint that landed after the work started does not necessarily concern work already finished; refusing would punish exactly the case §7 singles out.
- **Before the verifiers run**, so an agent told a new rule covers these files hears it before spending a minute on them rather than after the transition is written.
- **On standard error** — a deliberate departure from the `running:` lines beside it. Those already make `ank done --json` unparseable, which contradicts §4; a second line on stdout would deepen that defect rather than avoid it.

## Measured, and filed

`ank done --json` on a scratch repository:

```
running: ok ... ok (0.1s)
{"task":"TASK-ff695a8a0a39","status":"done",...}
```

A caller parsing stdout fails on the first line. `cli.rs` already names the three sites (`done`'s progress, the takeover warnings of `log` and `amend`) and treats it as a given. Different fault, three other verbs, its own criterion: **TASK-2eefcdd80124**.

## The tests drive the binary

The task said why in advance: asserting that a hash comparison returns false proves nothing about the path `done` actually takes, and that is how two earlier defects in this repo passed green unit tests.

The fixture accepts a **real ADR with a real signature**, because `bearing_on` counts accepted ADRs and nothing else — a proposed one would have left the hash where it was and passed on a binary that never looked.

The control test carries as much weight as the positive one: a warning that fired on every `done` would be a warning nobody reads on the `done` that matters.

**It bites**: with the call removed, the test fails with `done completed in silence, which is the whole defect`.

## Verification

`cargo test --workspace` (256 unit + 93 integration + 11 skill + 20 core), `cargo fmt --check`, `ank check` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012kHgSHnrDGvrSAmRAz9S58
