### PR TITLE
Turn signing off where the fixture is built, not where it commits

### DIFF
--- a/.ank/tasks/TASK-40a972e98a9a.md
+++ b/.ank/tasks/TASK-40a972e98a9a.md
@@ -5,7 +5,7 @@ slug: a-test-fixture-signs-nothing-and-does-not-have-t
 title: A test fixture signs nothing, and does not have to be reminded
 created: 2026-08-09T05:24:34Z
 author: seanl@sean-laptop
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/tests/cli.rs
   - crates/ank-cli/src/claim.rs
@@ -19,7 +19,7 @@ done_criteria: |
   No test fixture inherits the developer's signing configuration. Every throwaway repository a test builds turns signing off in its own config at creation -- commit and tag both -- rather than at each call that commits, and the per-call `-c commit.gpgsign=false` repetitions are removed in the same change, because a guard that survives only where somebody remembered it is the defect and not the fix. The suite passes with `commit.gpgsign=true` and `tag.gpgsign=true` set globally and no gpg agent reachable at all, which is the condition that produced the failure and the only condition that proves the fix: a developer with a locked or absent key runs the same green suite CI does. Verified by running the suite through the binary under that environment, not by reading the call sites.
 criteria_by: creator
 schema: 2
-version: 1
+version: 3
 ---
 
 ## What happened
@@ -61,3 +61,16 @@ Not by reading the call sites. Set `commit.gpgsign=true` and `tag.gpgsign=true`
 globally, make the agent unreachable, and run the suite: that is the condition
 that produced the failure, and the only one that shows a developer with a locked
 key now runs the same green suite CI does.
+
+## Log
+- 2026-08-10T04:59:28Z claude-code@ank — Every throwaway repository now turns signing off in its own config at creation -- commit.gpgsign and tag.gpgsign both -- and all nine per-call -c commit.gpgsign=false repetitions are gone with it. Eight fixture creation points: claim.rs, context.rs, done.rs, git.rs (three: the Temp, the worktree fixture, the nested inner repo), human.rs, init.rs, plus the stamp fixture in tests/cli.rs, which is the one repository in that file that commits without being a Repo.
+
+tests/cli.rs already had the environment neutralised by TASK-97437c25ddda, which was the same defect rediscovered and filed narrower. It now says the same thing in the repository's own config as well. That is deliberate belt and braces: the environment is what makes inheritance impossible, the config is what a reader looking at the fixture can see.
+
+One site is load-bearing rather than cosmetic and is marked as such: the forged ratification in human.rs commits unsigned on purpose and asserts Signature::Absent. Its guarantee moved from the call to the fixture, so the comment moved with it.
+
+Measured. The criterion's condition -- commit.gpgsign and tag.gpgsign true globally, the key unusable, agent unreachable -- is green across the workspace: 385 tests. The fix is what carries it: with the two config lines removed from claim.rs alone, five of its tests fail under that same environment with 'gpg failed to sign the data'.
+
+The boundary, stated rather than glossed. Under a harsher reading -- the gpg binary itself absent, not merely the agent -- one test still fails, human::tests::this_repositorys_own_ratifications_are_signed. It is not a fixture and inherits no signing configuration: it verifies this repository's real history, and it fails because ank reports an uncheckable signature as Absent. That is TASK-f4ed2020c964, filed before this work started, and it is not fixed here.
+
+commands.rs also builds a fixture and is outside this task's scope; it never commits, so it has nothing to turn off.

--- a/.ank/tasks/TASK-40a972e98a9a.md
+++ b/.ank/tasks/TASK-40a972e98a9a.md
@@ -5,7 +5,7 @@ slug: a-test-fixture-signs-nothing-and-does-not-have-t
 title: A test fixture signs nothing, and does not have to be reminded
 created: 2026-08-09T05:24:34Z
 author: seanl@sean-laptop
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/tests/cli.rs
   - crates/ank-cli/src/claim.rs
@@ -18,8 +18,12 @@ blocked_by: []
 done_criteria: |
   No test fixture inherits the developer's signing configuration. Every throwaway repository a test builds turns signing off in its own config at creation -- commit and tag both -- rather than at each call that commits, and the per-call `-c commit.gpgsign=false` repetitions are removed in the same change, because a guard that survives only where somebody remembered it is the defect and not the fix. The suite passes with `commit.gpgsign=true` and `tag.gpgsign=true` set globally and no gpg agent reachable at all, which is the condition that produced the failure and the only condition that proves the fix: a developer with a locked or absent key runs the same green suite CI does. Verified by running the suite through the binary under that environment, not by reading the call sites.
 criteria_by: creator
+proof:
+  - type: test
+    ref: "31357441443"
+    criteria: fbf229fba05a
 schema: 2
-version: 3
+version: 4
 ---
 
 ## What happened
@@ -74,3 +78,4 @@ Measured. The criterion's condition -- commit.gpgsign and tag.gpgsign true globa
 The boundary, stated rather than glossed. Under a harsher reading -- the gpg binary itself absent, not merely the agent -- one test still fails, human::tests::this_repositorys_own_ratifications_are_signed. It is not a fixture and inherits no signing configuration: it verifies this repository's real history, and it fails because ank reports an uncheckable signature as Absent. That is TASK-f4ed2020c964, filed before this work started, and it is not fixed here.
 
 commands.rs also builds a fixture and is outside this task's scope; it never commits, so it has nothing to turn off.
+- 2026-08-10T05:14:19Z claude-code@ank — done, proof test:31357441443

--- a/crates/ank-cli/src/claim.rs
+++ b/crates/ank-cli/src/claim.rs
@@ -1097,6 +1097,9 @@ mod tests {
             t.porcelain(&["config", "user.email", "test@ank.local"]);
             t.porcelain(&["config", "user.name", "Test"]);
             t.porcelain(&["config", "core.autocrlf", "false"]);
+            // Signing off at creation, not at each commit (TASK-40a972e98a9a).
+            t.porcelain(&["config", "commit.gpgsign", "false"]);
+            t.porcelain(&["config", "tag.gpgsign", "false"]);
             t
         }
 
@@ -1113,7 +1116,7 @@ mod tests {
 
         fn commit_all(&self, message: &str) -> String {
             self.porcelain(&["add", "-A"]);
-            self.porcelain(&["-c", "commit.gpgsign=false", "commit", "-qm", message]);
+            self.porcelain(&["commit", "-qm", message]);
             git::run(&self.0, &["rev-parse", "HEAD"]).unwrap()
         }
 

--- a/crates/ank-cli/src/context.rs
+++ b/crates/ank-cli/src/context.rs
@@ -1198,6 +1198,10 @@ After a blank one."
                 vec!["config", "user.email", "test@ank.local"],
                 vec!["config", "user.name", "Test"],
                 vec!["config", "core.autocrlf", "false"],
+                // Signing off at creation, not at each commit
+                // (TASK-40a972e98a9a).
+                vec!["config", "commit.gpgsign", "false"],
+                vec!["config", "tag.gpgsign", "false"],
             ] {
                 let st = Command::new("git")
                     .current_dir(&t.0)
@@ -1239,10 +1243,7 @@ After a blank one."
 
         fn commit(&self) {
             std::fs::write(self.0.join("seed.txt"), "x").unwrap();
-            for args in [
-                vec!["add", "-A"],
-                vec!["-c", "commit.gpgsign=false", "commit", "-qm", "seed"],
-            ] {
+            for args in [vec!["add", "-A"], vec!["commit", "-qm", "seed"]] {
                 let st = Command::new("git")
                     .current_dir(&self.0)
                     .args(&args)

--- a/crates/ank-cli/src/done.rs
+++ b/crates/ank-cli/src/done.rs
@@ -526,6 +526,10 @@ mod tests {
                 vec!["config", "user.email", "test@ank.local"],
                 vec!["config", "user.name", "Test"],
                 vec!["config", "core.autocrlf", "false"],
+                // Signing off at creation, not at each commit
+                // (TASK-40a972e98a9a).
+                vec!["config", "commit.gpgsign", "false"],
+                vec!["config", "tag.gpgsign", "false"],
             ] {
                 assert!(Command::new("git")
                     .current_dir(&t.0)
@@ -545,10 +549,7 @@ mod tests {
         }
 
         fn commit(&self) {
-            for args in [
-                vec!["add", "-A"],
-                vec!["-c", "commit.gpgsign=false", "commit", "-qm", "seed"],
-            ] {
+            for args in [vec!["add", "-A"], vec!["commit", "-qm", "seed"]] {
                 Command::new("git")
                     .current_dir(&self.0)
                     .args(&args)

--- a/crates/ank-cli/src/git.rs
+++ b/crates/ank-cli/src/git.rs
@@ -593,6 +593,9 @@ mod tests {
             t.porcelain(&["config", "user.email", "test@ank.local"]);
             t.porcelain(&["config", "user.name", "Test"]);
             t.porcelain(&["config", "core.autocrlf", "false"]);
+            // Signing off at creation, not at each commit (TASK-40a972e98a9a).
+            t.porcelain(&["config", "commit.gpgsign", "false"]);
+            t.porcelain(&["config", "tag.gpgsign", "false"]);
             t
         }
 
@@ -614,7 +617,7 @@ mod tests {
             std::fs::create_dir_all(full.parent().unwrap()).unwrap();
             std::fs::write(&full, content).unwrap();
             self.porcelain(&["add", "-A"]);
-            self.porcelain(&["-c", "commit.gpgsign=false", "commit", "-qm", "step"]);
+            self.porcelain(&["commit", "-qm", "step"]);
             run(&self.0, &["rev-parse", "HEAD"]).unwrap()
         }
     }
@@ -878,9 +881,12 @@ mod tests {
         git(&main, &["init", "-q", "-b", "main"]);
         git(&main, &["config", "user.email", "t@ank.local"]);
         git(&main, &["config", "user.name", "T"]);
+        // Signing off at creation, not at each commit (TASK-40a972e98a9a).
+        git(&main, &["config", "commit.gpgsign", "false"]);
+        git(&main, &["config", "tag.gpgsign", "false"]);
         std::fs::write(main.join("seed.txt"), "x").unwrap();
         git(&main, &["add", "-A"]);
-        git(&main, &["-c", "commit.gpgsign=false", "commit", "-qm", "s"]);
+        git(&main, &["commit", "-qm", "s"]);
         let wt = dir.join("wt");
         git(
             &main,
@@ -904,6 +910,8 @@ mod tests {
         let inner = main.join("inner");
         std::fs::create_dir_all(&inner).unwrap();
         git(&inner, &["init", "-q", "-b", "main"]);
+        git(&inner, &["config", "commit.gpgsign", "false"]);
+        git(&inner, &["config", "tag.gpgsign", "false"]);
         let from_inner = common_dir(&inner);
         assert!(from_inner.is_some());
         assert_ne!(from_inner, from_main);

--- a/crates/ank-cli/src/human.rs
+++ b/crates/ank-cli/src/human.rs
@@ -2472,6 +2472,11 @@ mod tests {
                 vec!["config", "user.email", "test@ank.local"],
                 vec!["config", "user.name", "Test"],
                 vec!["config", "core.autocrlf", "false"],
+                // Signing off at creation, not at each commit
+                // (TASK-40a972e98a9a). `accept` passes `-S`, which outranks
+                // this, so the fixtures that sign for real still do.
+                vec!["config", "commit.gpgsign", "false"],
+                vec!["config", "tag.gpgsign", "false"],
             ] {
                 assert!(Command::new("git")
                     .current_dir(&t.0)
@@ -2512,10 +2517,7 @@ mod tests {
             .unwrap();
         }
         fn commit(&self, msg: &str) {
-            for args in [
-                vec!["add", "-A"],
-                vec!["-c", "commit.gpgsign=false", "commit", "-qm", msg],
-            ] {
+            for args in [vec!["add", "-A"], vec!["commit", "-qm", msg]] {
                 Command::new("git")
                     .current_dir(&self.0)
                     .args(&args)
@@ -3909,9 +3911,9 @@ mod tests {
         t.write(&Entity::Adr(b));
         for args in [
             vec!["add", "-A"],
+            // Unsigned on purpose: the fixture turns signing off at creation,
+            // and this commit asserting `Absent` is what depends on it.
             vec![
-                "-c",
-                "commit.gpgsign=false",
                 "commit",
                 "-qm",
                 &format!("ratify ADR-00000000bbbb\n\nconstraint+scope: {anchor}"),

--- a/crates/ank-cli/src/init.rs
+++ b/crates/ank-cli/src/init.rs
@@ -187,7 +187,20 @@ mod tests {
                 .expect("git must be installed: it is a hard dependency")
                 .success();
             assert!(ok, "git init failed in {}", p.display());
-            Temp(p)
+            let t = Temp(p);
+            // Signing off at creation, not at each commit (TASK-40a972e98a9a).
+            for args in [
+                ["config", "commit.gpgsign", "false"],
+                ["config", "tag.gpgsign", "false"],
+            ] {
+                let st = Command::new("git")
+                    .current_dir(&t.0)
+                    .args(args)
+                    .status()
+                    .expect("git must be installed: it is a hard dependency");
+                assert!(st.success(), "git {args:?}");
+            }
+            t
         }
     }
 
@@ -306,7 +319,7 @@ blocked_by: []\nschema: 1\nversion: 1\n---\n\nBody.\n";
             assert!(st.success(), "git {args:?}");
         };
         run(&["add", "-A"]);
-        run(&["-c", "commit.gpgsign=false", "commit", "-qm", "init"]);
+        run(&["commit", "-qm", "init"]);
 
         let clone = t.0.with_extension("clone");
         let st = Command::new("git")

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -105,6 +105,14 @@ impl Repo {
         r.git(&["config", "user.email", "test@ank.local"]);
         r.git(&["config", "user.name", "Test"]);
         r.git(&["config", "core.autocrlf", "false"]);
+        // Belt and braces, and deliberately so (TASK-40a972e98a9a). The
+        // environment above already puts the machine's configuration out of
+        // reach; this says the same thing in the repository's own config, where
+        // a reader looking at the fixture can see it. `tag.gpgsign` because
+        // nothing tags today and the first thing that does should not have to
+        // rediscover any of this.
+        r.git(&["config", "commit.gpgsign", "false"]);
+        r.git(&["config", "tag.gpgsign", "false"]);
         std::fs::write(
             r.0.join(".ank/config.yml"),
             "schema: 1\nclaim_ttl_max: 2h\ndefault_branch: main\n",
@@ -1283,6 +1291,10 @@ fn the_stamp_follows_a_commit_that_changes_no_file() {
     git(&["init", "-q", "-b", "main"]);
     git(&["config", "user.email", "test@ank.local"]);
     git(&["config", "user.name", "Test"]);
+    // The one fixture in this file that commits without being a `Repo`
+    // (TASK-40a972e98a9a).
+    git(&["config", "commit.gpgsign", "false"]);
+    git(&["config", "tag.gpgsign", "false"]);
     git(&["add", "-A"]);
     git(&["commit", "-qm", "seed"]);
 


### PR DESCRIPTION
Closes TASK-40a972e98a9a, anchored on CI run 31357441443.

`-c commit.gpgsign=false` was repeated at nine call sites across the test
modules of `claim.rs`, `context.rs`, `done.rs`, `git.rs`, `human.rs` and
`init.rs`. A guard applied per call holds wherever it was remembered, and the
places it was forgotten are not random: they are the newest ones. The count only
grows.

It moves into the repository's own config, at creation, beside `user.email`,
`user.name` and `core.autocrlf` -- eight fixture creation points, including the
two in `git.rs` that are not the `Temp` (the worktree fixture and the nested
inner repository) and the stamp fixture in `tests/cli.rs`, which is the one
repository in that file that commits without being a `Repo`. `tag.gpgsign` too:
nothing tags today, and the next thing that does should not have to rediscover
this.

`tests/cli.rs` already had its environment neutralised by TASK-97437c25ddda --
the same defect, rediscovered and filed narrower while this one sat open. It now
says the same thing in the repository's own config as well. That is deliberate
belt and braces: the environment is what makes inheritance impossible, the
config is what a reader looking at the fixture can see.

One site is load-bearing rather than cosmetic, and the comment moved with the
guarantee: the forged ratification in `human.rs` commits unsigned on purpose and
asserts `Signature::Absent`. What made that true was the flag on the call; what
makes it true now is the fixture.

**Measured under the condition the criterion names** -- `commit.gpgsign` and
`tag.gpgsign` true globally, the signing key unusable, no agent able to answer.
The whole workspace is green there: 385 tests. And the fix is what carries it,
not a leftover: with the two config lines removed from `claim.rs` alone, five of
its tests fail under that same environment with `gpg failed to sign the data`.

The boundary, stated rather than glossed. Under a harsher reading -- the gpg
binary itself absent, not merely the agent -- one test still fails,
`human::tests::this_repositorys_own_ratifications_are_signed`. It is not a
fixture and inherits no signing configuration: it verifies this repository's
real history, and it fails because ank reports an uncheckable signature as
`Absent` rather than `Unchecked`. That is TASK-f4ed2020c964, filed before this
work started and not fixed here.

`commands.rs` builds a fixture too and is outside this task's scope; it never
commits, so it has nothing to turn off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011AmDYxTF8HUGoMTY6Yuwzc