### PR TITLE
Say in section 7 that level 1 does not ship, and what that costs a second clone

### DIFF
--- a/.ank/tasks/TASK-82c3341502c1.md
+++ b/.ank/tasks/TASK-82c3341502c1.md
@@ -1,0 +1,32 @@
+---
+id: TASK-82c3341502c1
+type: task
+slug: level-1-claims-pushed-so-two-clones-arbitrate
+title: "Level 1: claims pushed, so two clones arbitrate"
+created: 2026-08-10T05:57:50Z
+author: claude-code@ank
+status: open
+scope:
+  - crates/ank-cli/**
+  - docs/**
+blocked_by: []
+done_criteria: |
+  claim, log and done push refs/ank/claims/<id> to the remote, and a test drives two clones of one repository through the binary: the second claim on a task already held in the first is refused with code 4. Offline, the claim is taken locally, marked unsynchronised, and warned about rather than refused -- degrade, do not fail. Section 7 stops saying level 1 is unimplemented in the same change, and the negative test in git.rs that guards that sentence goes with it. cargo test, cargo fmt --check and ank check stay green.
+criteria_by: creator
+schema: 2
+version: 1
+---
+
+Split out of TASK-83d6eefdb36e, which found the gap and deliberately did not pick between implementing it and writing it down. The specification now says what is true -- only level 0 ships, worktrees of one clone are arbitrated and separate clones are not -- so this task is the other exit, taken on its own terms rather than under a criterion written for both.
+
+Section 7 already describes the design and it does not need redeciding: the claim is pushed on acquisition, on every TTL renewal through log, and again when done transforms it into a completion ref. The primitive is the right one and is already the one in use locally -- a non fast-forward push fails server-side, atomically, on every host -- so what is missing is plumbing and the offline degradation path, not design.
+
+Three things make this more than adding a verb.
+
+push, fetch and ls-remote are not in the PLUMBING list in git.rs, and that is not an oversight to route around: a git subcommand is usable only if its output is stable by contract (ADR-b8884edcebe3). push signals a lost race by its exit code, which is exactly the kind of signal that rule protects, but the list is where the decision gets recorded.
+
+The cost lands on the hot path. log renews the TTL and an agent logs often; every renewal becomes a network round trip. Section 7 calls it marginal at one log every few minutes. That is a claim worth measuring rather than inheriting.
+
+Offline is the hard half. A claim taken with no remote reachable has to be marked unsynchronised and said out loud, and the wording matters more than the mechanism: the risk of a concurrent claim is displayed, not hidden.
+
+The test is named in the criterion because the criterion is about the binary: two clones of one repository, the second claim refused with code 4. A unit test over the push helper would prove the helper works and leave the property untested.

--- a/.ank/tasks/TASK-83d6eefdb36e.md
+++ b/.ank/tasks/TASK-83d6eefdb36e.md
@@ -5,7 +5,7 @@ slug: claims-only-arbitrate-within-one-clone-level-1-i
 title: "Claims only arbitrate within one clone: level 1 is unimplemented"
 created: 2026-08-06T23:24:02Z
 author: seanl@sean-laptop
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/**
   - docs/**
@@ -14,7 +14,7 @@ done_criteria: |
   The spec section 7 level-1 description and the code agree: either the push of refs/ank/* on claim, renewal and done exists in crates/ank-cli/, or section 7 states that level 1 is unimplemented and names what a second clone can therefore do.
 criteria_by: creator
 schema: 2
-version: 1
+version: 3
 ---
 
 Section 7 describes level 1 as "the same ref, pushed": the claim is pushed on
@@ -57,3 +57,14 @@ Two honest exits, and this task deliberately does not pick:
 Whichever is chosen, a criterion about the binary is tested through the binary:
 if the push lands, the test drives two clones of one repository and asserts that
 the second claim is refused with code 4.
+
+## Log
+- 2026-08-10T05:59:47Z claude-code@ank — Took the second exit and both halves of it: section 7 now says what is true, and the implementation is filed as TASK-82c3341502c1 with a criterion written for it alone rather than for either outcome.
+
+Section 7 gains a section before the level list -- what ships, and what a second clone can therefore do -- naming the two cases in the terms this task used: worktrees of one clone are arbitrated by the shared refs/ank/, separate clones are not, both agents succeed and nothing detects it later either, because check prunes on the default branch where two agents having done the same work looks like two agents having done their work. Level 1 and level 2 headings now carry 'not implemented'.
+
+Three other places said or implied the opposite and are corrected, because leaving them would have moved the lie rather than removed it. The nominal execution model offered 'clones or git worktree' as equals and now tells the reader to use worktrees while level 1 is unimplemented, with the reason. 'Why version coexists with git's CAS' claimed git's CAS protects between clones; it protects between working trees sharing a refs/ank/, and between clones once level 1 ships. The deferral table justified deferring level 2 by level 1 being enough, and now lists level 1 as deferred in its own right.
+
+A sentence saying 'not implemented' goes stale in silence, so it gets a tripwire. Every git verb the tool may run passes the PLUMBING list, and a remote-aware claim needs push, fetch or ls-remote to appear there first; a negative test in git.rs asserts none of the three is allowed and names section 7 in the failure. Measured: adding push to the list turns it red with the message that names the file and what the same change owes it. It fails the day the feature lands, not while it is absent.
+
+No code behaviour changed. 386 tests green, fmt clean, check exit 0.

--- a/.ank/tasks/TASK-83d6eefdb36e.md
+++ b/.ank/tasks/TASK-83d6eefdb36e.md
@@ -5,7 +5,7 @@ slug: claims-only-arbitrate-within-one-clone-level-1-i
 title: "Claims only arbitrate within one clone: level 1 is unimplemented"
 created: 2026-08-06T23:24:02Z
 author: seanl@sean-laptop
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/**
   - docs/**
@@ -13,8 +13,12 @@ blocked_by: []
 done_criteria: |
   The spec section 7 level-1 description and the code agree: either the push of refs/ank/* on claim, renewal and done exists in crates/ank-cli/, or section 7 states that level 1 is unimplemented and names what a second clone can therefore do.
 criteria_by: creator
+proof:
+  - type: test
+    ref: "31360794469"
+    criteria: b396da77f5b7
 schema: 2
-version: 3
+version: 4
 ---
 
 Section 7 describes level 1 as "the same ref, pushed": the claim is pushed on
@@ -68,3 +72,4 @@ Three other places said or implied the opposite and are corrected, because leavi
 A sentence saying 'not implemented' goes stale in silence, so it gets a tripwire. Every git verb the tool may run passes the PLUMBING list, and a remote-aware claim needs push, fetch or ls-remote to appear there first; a negative test in git.rs asserts none of the three is allowed and names section 7 in the failure. Measured: adding push to the list turns it red with the message that names the file and what the same change owes it. It fails the day the feature lands, not while it is absent.
 
 No code behaviour changed. 386 tests green, fmt clean, check exit 0.
+- 2026-08-10T06:15:58Z claude-code@ank — done, proof test:31360794469

--- a/crates/ank-cli/src/git.rs
+++ b/crates/ank-cli/src/git.rs
@@ -570,6 +570,28 @@ mod tests {
     use super::*;
     use std::sync::atomic::{AtomicU64, Ordering};
 
+    /// §7 says level 1 is unimplemented, and this is what keeps that sentence
+    /// from going stale in silence (TASK-83d6eefdb36e).
+    ///
+    /// Every git verb the tool may run passes [`PLUMBING`], so a claim that
+    /// crosses clones needs one of these three to appear here first. A negative
+    /// test: it fails the day the feature lands, not while it is absent, and it
+    /// names what the same change owes the specification. The specification is
+    /// the source of truth, and a source of truth that quietly stops describing
+    /// the binary is worse than one that never described it.
+    #[test]
+    fn no_remote_verb_is_allowed_while_the_spec_says_level_1_is_unimplemented() {
+        for verb in ["push", "fetch", "ls-remote"] {
+            assert!(
+                !PLUMBING.contains(&verb),
+                "`{verb}` is allowed now, so claims can reach another clone: \
+                 section 7 of docs/ank-spec-v1.1.md still says level 1 is \
+                 unimplemented and names what a second clone can do, and it has \
+                 to be rewritten in this change"
+            );
+        }
+    }
+
     struct Temp(PathBuf);
 
     impl Temp {

--- a/docs/ank-spec-v1.1.md
+++ b/docs/ank-spec-v1.1.md
@@ -869,7 +869,9 @@ A git-like model: fully functional locally, deployable progressively, never depe
 
 ### Nominal execution model
 
-The nominal case is **one working tree per agent** — clones or `git worktree` — each on its own branch. That is what local proofs already assume (a `verify` run in a tree other agents are modifying in parallel would prove nothing clean) and it is the effective practice of agent harnesses. Several agents sharing one tree works but is a degraded mode, not a design mode.
+The nominal case is **one working tree per agent**, each on its own branch. That is what local proofs already assume (a `verify` run in a tree other agents are modifying in parallel would prove nothing clean) and it is the effective practice of agent harnesses. Several agents sharing one tree works but is a degraded mode, not a design mode.
+
+**Use `git worktree`, not clones, while level 1 is unimplemented.** The two are not interchangeable here: worktrees of one repository share `refs/ank/`, so claims arbitrate between them; separate clones do not share it, and two agents will hold the same task without either being told. The reasons are below, under what ships.
 
 ### Separation of the two planes
 
@@ -933,13 +935,24 @@ Two uses depend on it, and not in the same way. `accept` **fails** with code 9: 
 
 ### Why `version` coexists with git's CAS
 
-The two cover disjoint ranges. Git's CAS protects **between clones**, at push time. The `version` field protects **inside a single working tree**. With one tree per agent that case becomes rare — but not nil: a human and an agent often share the same tree, and the field costs one integer. We keep it for the residual case, without presenting it as the main defence any more.
+The two cover disjoint ranges. Git's CAS protects **between working trees sharing a `refs/ank/`** — and, once level 1 ships, between clones at push time. The `version` field protects **inside a single working tree**. With one tree per agent that case becomes rare — but not nil: a human and an agent often share the same tree, and the field costs one integer. We keep it for the residual case, without presenting it as the main defence any more.
+
+### What ships, and what a second clone can therefore do
+
+**Only level 0 is implemented.** Levels 1 and 2 below describe where this goes; neither exists in the binary today. There is no push, no fetch and no `ls-remote` anywhere in the code: `ank init` adds the `refs/ank/*` **fetch** refspec and nothing more.
+
+The consequence is exact, and it is stated here rather than left to be discovered:
+
+- **Two working trees of one clone are arbitrated.** Every `git worktree` of a repository shares `refs/ank/`, so the compare-and-swap settles them. One agent wins, the other gets code 4.
+- **Two separate clones are not.** Each holds its own `refs/ank/claims/<id>` and neither ever learns of the other. Both agents claim the same task, both succeed, both work. Nothing detects it, and nothing detects it later either: `check` prunes on the default branch, where two agents having done the same work looks like two agents having done their work.
+
+So "one piece of work, one holder" holds **per clone, not per repository**. Until level 1 ships, an operator running several agents on one repository gets that property from `git worktree` and does not get it from clones.
 
 ### Level 0 — local
 
-No remote. Claims use the **same `refs/ank/claims/<id>` refs, locally**: a local git ref update is already atomic, and level 1 becomes literally "the same ref, pushed" — no migration, no state to convert. There is **no fallback without git**: git is a hard dependency, and an uninitialised repository exits with code 9 and the exact command. Functional without configuration, like a `git init` without a push. Default mode.
+No remote. Claims use the **same `refs/ank/claims/<id>` refs, locally**: a local git ref update is already atomic, and level 1 becomes literally "the same ref, pushed" — no migration, no state to convert. There is **no fallback without git**: git is a hard dependency, and an uninitialised repository exits with code 9 and the exact command. Functional without configuration, like a `git init` without a push. Default mode, and the only mode.
 
-### Level 1 — git remote only
+### Level 1 — git remote only (not implemented)
 
 Any existing remote, GitHub included. Zero infrastructure.
 
@@ -949,7 +962,7 @@ TTL renewal through `log` updates the local ref then pushes; at one log every fe
 
 The trade-off: latency on the order of a second, no notifications. Comfortable up to two or three agents, saturates beyond.
 
-### Level 2 — `ank serve`
+### Level 2 — `ank serve` (not implemented)
 
 A single binary, one port, one SQLite. It stores **only claims**, and broadcasts changes over SSE. Durable state keeps going through git; the daemon never owns it.
 
@@ -1087,7 +1100,8 @@ File format · one command surface, refusing on state and never on identity, wit
 | `.ank/` merge driver | The resolution rules are fixed (§7); automating them can wait for the first real conflicts. |
 | `touched` inferred from commits | Scope-drift detection. A git dependency, not blocking to get started. |
 | `enforced_by` (mechanisation) | The underlying mechanism against context inflation (see §11). Useless while the ADR corpus is small. |
-| `ank serve` (level 2) | Level 1 is enough up to three concurrent agents. |
+| Level 1 (claims pushed to a remote) | Described in §7 and not implemented. Worktrees of one clone are arbitrated today; separate clones are not. |
+| `ank serve` (level 2) | Level 1 is enough up to three concurrent agents, once level 1 exists. |
 | `ank review --coherence` (ADR corpus analysis) | Detecting contradictions and duplicates. No value on a small corpus. The ratification queue itself is in v1. |
 | Read-only web view | To reopen only if non-developers must read the board. |
 | Linear/Jira export | Management visibility. Never writing back into Ank. |
@@ -1139,7 +1153,7 @@ The rule that matters is not the enumeration but its criterion: a command enters
 
 ### Ank and git: who commits
 
-**Ank never commits, with one exception.** The writes of `new`, `log`, `done` and `release` land in the working tree and propagate at the pace of the agent's commits, together with its code — the organisational state and the code it describes travel together, which is exactly the tool's promise. Accepted consequence: at level 1, another clone sees a transition only once the commit is pushed; real-time coordination, meanwhile, goes through claims, which depend on no commit.
+**Ank never commits, with one exception.** The writes of `new`, `log`, `done` and `release` land in the working tree and propagate at the pace of the agent's commits, together with its code — the organisational state and the code it describes travel together, which is exactly the tool's promise. Accepted consequence: at level 1, another clone sees a transition only once the commit is pushed; real-time coordination, meanwhile, goes through claims, which depend on no commit. At level 0 — the only level that ships — that coordination reaches the working trees sharing one `refs/ank/`, and no further (§7).
 
 The exception is **`accept`, which produces the signed ratification commit itself**, containing only the promoted ADR's file (and, where applicable, the replaced ADR moving to `superseded`). The authority model rests on this commit; leaving it to the caller's discretion would make it optional.
 


### PR DESCRIPTION
Closes TASK-83d6eefdb36e, anchored on CI run 31360794469.

Section 7 described level 1 as "the same ref, pushed" -- pushed on acquisition,
on every TTL renewal through `log`, and again when `done` transforms it into a
completion ref. None of it exists: there is no push, no fetch and no `ls-remote`
anywhere in `crates/`, and `ank init` adds the `refs/ank/*` **fetch** refspec and
nothing more.

The task offered two exits and deliberately did not pick. Both are taken, in
order: the specification stops describing a binary that does not exist, and the
implementation is filed as TASK-82c3341502c1 under a criterion written for it
alone rather than for either outcome.

**What section 7 now says**, before the level list rather than buried in it:
worktrees of one clone are arbitrated, because every worktree shares `refs/ank/`
and the compare-and-swap settles them; separate clones are not, each holding its
own `refs/ank/claims/<id>` and neither ever learning of the other. Both agents
claim, both succeed, both work. Nothing detects it, and nothing detects it later
either -- `check` prunes on the default branch, where two agents having done the
same work looks like two agents having done their work. So "one piece of work,
one holder" holds per clone, not per repository.

Three other places said or implied the opposite, and leaving them would have
moved the lie rather than removed it. The nominal execution model offered
"clones or `git worktree`" as equals, and now tells the reader which one to use
and why. "Why `version` coexists with git's CAS" claimed that CAS protects
between clones; it protects between working trees sharing a `refs/ank/`, and
between clones once level 1 ships. The deferral table justified deferring level 2
by level 1 being enough, and now lists level 1 as deferred in its own right.

**A sentence saying "not implemented" goes stale in silence, so it gets a
tripwire.** Every git verb the tool may run passes the `PLUMBING` list, and a
remote-aware claim needs `push`, `fetch` or `ls-remote` to appear there first. A
negative test asserts none of the three is allowed and names section 7 in the
failure, so the change that implements level 1 cannot land without rewriting the
paragraph that says it has not. Measured: adding `push` to the list turns it red
with that message. It fails the day the feature arrives, never while it is
absent.

No code behaviour changed. 386 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011AmDYxTF8HUGoMTY6Yuwzc