### PR TITLE
Let --body read the body from stdin with -

### DIFF
--- a/.ank/tasks/TASK-8e7c8e7724ee.md
+++ b/.ank/tasks/TASK-8e7c8e7724ee.md
@@ -5,7 +5,7 @@ slug: let-body-read-from-stdin-with-so-multi-paragraph
 title: Let --body read from stdin with '-' so multi-paragraph bodies bypass shell quoting
 created: 2026-08-06T17:27:41Z
 author: seanl@sean-laptop
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/src/**
   - crates/ank-cli/tests/**
@@ -14,7 +14,7 @@ done_criteria: |
   With text piped to stdin, 'ank new task ... --body -' creates the entity with the piped text as its body, and 'ank show <id>' returns that body byte-for-byte. Verified through the binary: an integration test pipes a multi-paragraph body containing double quotes, single quotes and blank lines, then asserts the show output; a unit test on the parsing function alone does not satisfy this criterion. When --body - is given and stdin is empty, new fails with a self-correcting error naming the flag.
 criteria_by: creator
 schema: 2
-version: 1
+version: 3
 ---
 
 Observed friction, not speculation: writing a six-paragraph body through a shell flag means fighting quoting and escaping with no editor, and it is the single most painful step of the whole creation path. The interactive form of new and 'ank edit' cover the human at a keyboard; an agent driving the CLI from a shell has no good channel for long prose.
@@ -27,3 +27,6 @@ Decisions left to the implementer, to settle in the body of the work or in a log
 - Behaviour when stdin is a terminal: blocking on a silent read is hostile; refusing with the exact fix command matches the self-correcting-errors style rule.
 
 The canonical form is untouched: this changes how a value enters the CLI, not how it is serialised. No spec change required.
+
+## Log
+- 2026-08-11T00:57:34Z seanl@sean-laptop — Implemented in body_of, which now takes the entity kind so the refusal can name the flag form to retype. Three decisions settled. (1) Trailing newline: absorbed, not stored. The existing trim() runs on the piped text exactly as it ran on a flag value, so a heredoc and a flag produce the same file byte for byte; the integration test pins it by creating the same body through both channels and comparing. Storing the newline verbatim would have made the input channel visible in the corpus. (2) The same spelling on --criteria is left out: the flag is read in three places here plus claim, so giving it to new alone would be an inconsistency, and giving it to all of them is a surface question of its own rather than something that falls out for free. (3) Nothing to read is refused with code 9, as an unset EDITOR is, for the empty pipe and for a terminal alike: the prose channel the caller named is unavailable, and there is one fix for both. Noticed on the way, not fixed here: this very message could not be typed starting with two dashes, because there is no end-of-flags separator.

--- a/.ank/tasks/TASK-8e7c8e7724ee.md
+++ b/.ank/tasks/TASK-8e7c8e7724ee.md
@@ -5,7 +5,7 @@ slug: let-body-read-from-stdin-with-so-multi-paragraph
 title: Let --body read from stdin with '-' so multi-paragraph bodies bypass shell quoting
 created: 2026-08-06T17:27:41Z
 author: seanl@sean-laptop
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/src/**
   - crates/ank-cli/tests/**
@@ -13,8 +13,12 @@ blocked_by: []
 done_criteria: |
   With text piped to stdin, 'ank new task ... --body -' creates the entity with the piped text as its body, and 'ank show <id>' returns that body byte-for-byte. Verified through the binary: an integration test pipes a multi-paragraph body containing double quotes, single quotes and blank lines, then asserts the show output; a unit test on the parsing function alone does not satisfy this criterion. When --body - is given and stdin is empty, new fails with a self-correcting error naming the flag.
 criteria_by: creator
+proof:
+  - type: test
+    ref: "31447913949"
+    criteria: 7fe846651701
 schema: 2
-version: 3
+version: 4
 ---
 
 Observed friction, not speculation: writing a six-paragraph body through a shell flag means fighting quoting and escaping with no editor, and it is the single most painful step of the whole creation path. The interactive form of new and 'ank edit' cover the human at a keyboard; an agent driving the CLI from a shell has no good channel for long prose.
@@ -30,3 +34,4 @@ The canonical form is untouched: this changes how a value enters the CLI, not ho
 
 ## Log
 - 2026-08-11T00:57:34Z seanl@sean-laptop — Implemented in body_of, which now takes the entity kind so the refusal can name the flag form to retype. Three decisions settled. (1) Trailing newline: absorbed, not stored. The existing trim() runs on the piped text exactly as it ran on a flag value, so a heredoc and a flag produce the same file byte for byte; the integration test pins it by creating the same body through both channels and comparing. Storing the newline verbatim would have made the input channel visible in the corpus. (2) The same spelling on --criteria is left out: the flag is read in three places here plus claim, so giving it to new alone would be an inconsistency, and giving it to all of them is a surface question of its own rather than something that falls out for free. (3) Nothing to read is refused with code 9, as an unset EDITOR is, for the empty pipe and for a terminal alike: the prose channel the caller named is unavailable, and there is one fix for both. Noticed on the way, not fixed here: this very message could not be typed starting with two dashes, because there is no end-of-flags separator.
+- 2026-08-11T01:03:18Z seanl@sean-laptop — done, proof test:31447913949

--- a/.ank/tasks/TASK-b8a12d60686d.md
+++ b/.ank/tasks/TASK-b8a12d60686d.md
@@ -1,0 +1,43 @@
+---
+id: TASK-b8a12d60686d
+type: task
+slug: init-accepts-repo-and-writes-somewhere-else
+title: init accepts --repo and writes somewhere else
+created: 2026-08-11T00:57:53Z
+author: seanl@sean-laptop
+status: open
+scope:
+  - crates/ank-cli/src/init.rs
+  - crates/ank-cli/src/cli.rs
+  - crates/ank-cli/tests/**
+blocked_by: []
+done_criteria: |
+  ank init --repo <path> either initialises <path>, or refuses --repo by name; it never writes into the current repository while a --repo naming another was given. The choice is written into section 4 of docs/ank-spec-v1.1.md before the code moves. Verified through the binary: an integration test runs init with --repo pointing at a second, empty git repository from inside a first one, and asserts that the first is untouched -- no AGENTS.md pointer, no .ank/, no refspec added.
+criteria_by: creator
+schema: 2
+version: 1
+---
+
+Measured, not supposed. Running `ank init --repo <scratch>` from a checkout of
+this repository initialised *this* repository instead: it appended the pointer
+paragraph to AGENTS.md here, reported `pointer added to AGENTS.md` and
+`refspec added`, and left the scratch directory empty. The next command in the
+same scratch directory then answered `no .ank/ found`, which is the only reason
+the misdirection was noticed at all.
+
+The cause is in `init::run`: the target is `inv.positionals.first()` or `cwd`,
+and `--repo` is never consulted. Dispatch routes `init` before the foundation
+that resolves `--repo` for every other verb, and rightly so -- init precedes the
+existence of the repository -- but routing early is not a reason to drop a
+global flag.
+
+Two things make this worse than a flag quietly ignored. `init` writes, so the
+silence lands as edits in a repository the caller did not name, in a file
+(AGENTS.md) they were not editing. And section 4 makes `--repo` legal on every
+verb without exception, which is the property ADR-c656cbcc33a9 leans on: a
+global that means something everywhere except one verb is a global nobody can
+rely on.
+
+Either behaviour is defensible and one has to be chosen in the specification
+first: `--repo` names the target, or `--repo` on `init` is refused by name. What
+is not defensible is accepting it and writing somewhere else.

--- a/crates/ank-cli/src/cli.rs
+++ b/crates/ank-cli/src/cli.rs
@@ -342,7 +342,10 @@ pub const COMMANDS: &[CommandSpec] = &[
             flag("--body"),
         ],
         refuses: &[refuses(9, "no --title or --scope and $EDITOR is unset, so there is nothing to open")],
-        notes: &["a scope is mandatory: an entity attached to nothing is invisible"],
+        notes: &[
+            "a scope is mandatory: an entity attached to nothing is invisible",
+            "--body - reads the body from stdin, so a long one needs no shell quoting",
+        ],
         owner_task: None,
     },
     CommandSpec {

--- a/crates/ank-cli/src/commands.rs
+++ b/crates/ank-cli/src/commands.rs
@@ -34,7 +34,7 @@ use ank_core::{
     append_log, parse_entity, serialize_entity, Adr, AdrStatus, CriteriaBy, Entity, EntityId,
     EntityKind, LogEntry, Task, TaskStatus, SCHEMA_VERSION,
 };
-use std::io::Write;
+use std::io::{IsTerminal, Read, Write};
 use std::path::Path;
 
 /// One line per result, as for `context` (§4).
@@ -134,7 +134,7 @@ pub fn new(
                 proof: Vec::new(),
                 schema: SCHEMA_VERSION,
                 version: 1,
-                body: body_of(inv),
+                body: body_of(inv, kind)?,
             })
         }
         EntityKind::Adr => {
@@ -167,7 +167,7 @@ pub fn new(
                 ratified: None,
                 schema: SCHEMA_VERSION,
                 version: 1,
-                body: body_of(inv),
+                body: body_of(inv, kind)?,
             })
         }
     };
@@ -309,7 +309,7 @@ fn skeleton(
             proof: Vec::new(),
             schema: SCHEMA_VERSION,
             version: 1,
-            body: body_of(inv),
+            body: body_of(inv, kind)?,
         }),
         EntityKind::Adr => Entity::Adr(Adr {
             id: id.clone(),
@@ -328,7 +328,7 @@ fn skeleton(
             ratified: None,
             schema: SCHEMA_VERSION,
             version: 1,
-            body: body_of(inv),
+            body: body_of(inv, kind)?,
         }),
     })
 }
@@ -732,11 +732,66 @@ fn supersedes_of(inv: &Invocation, store: &Store) -> Result<Option<EntityId>> {
 ///
 /// Absent or blank leaves the body empty, which is a task with no reasoning
 /// attached: allowed, and visible for what it is.
-fn body_of(inv: &Invocation) -> String {
-    match inv.value("--body") {
-        Some(text) if !text.trim().is_empty() => format!("\n{}\n", text.trim()),
-        _ => String::new(),
+///
+/// `--body -` reads the prose from stdin instead, the Unix convention (`cat`,
+/// `diff`, `kubectl apply -f -`). It is the answer to observed friction and not
+/// a convenience: a six-paragraph body typed as a shell argument is a fight with
+/// quoting and escaping, and it was the most painful step of the creation path.
+/// A heredoc has neither problem. The cost is one reserved spelling — a body
+/// that is literally `-` can no longer be written as a flag value, which is a
+/// body nobody wants — and no new flag, so nothing SKILL.md teaches moves.
+///
+/// The trailing newline every heredoc ends with is absorbed by the canonical
+/// form rather than stored: the trim below is what already ran for a flag value,
+/// and the two spellings have to produce the same file or the channel would be
+/// visible in the corpus. Everything inside survives byte for byte — blank
+/// lines, quotes of both kinds, indentation.
+fn body_of(inv: &Invocation, kind: EntityKind) -> Result<String> {
+    let piped;
+    let text = match inv.value("--body") {
+        Some("-") => {
+            piped = read_body_from_stdin(kind)?;
+            piped.as_str()
+        }
+        Some(text) => text,
+        None => "",
+    };
+    Ok(match text.trim() {
+        "" => String::new(),
+        trimmed => format!("\n{trimmed}\n"),
+    })
+}
+
+/// The body, read whole from stdin, for `--body -`.
+///
+/// **Nothing to read is refused, never accepted as an empty body.** The caller
+/// said where the prose is; if it is not there, the entity they get would be the
+/// one thing `--body` exists to prevent — a task with no reasoning, written
+/// silently. A terminal is the same failure one step earlier, and refusing it is
+/// what keeps `--body -` from sitting on a silent `read` waiting for a heredoc
+/// nobody is going to type.
+///
+/// Code 9 for both, as `$EDITOR` unset is (§4): the prose channel the caller
+/// named is unavailable, which is not a fault in the task and not a fault in the
+/// corpus. One code, because there is one fix.
+fn read_body_from_stdin(kind: EntityKind) -> Result<String> {
+    let hint = format!("printf '%s' \"<the body>\" | {} --body -", flag_form(kind));
+    if std::io::stdin().is_terminal() {
+        return Err(CliError::new(
+            9,
+            "--body - reads the body from stdin, and stdin is a terminal: pipe it, \
+             or drop the flag and let $EDITOR open",
+        )
+        .with_hint(hint));
     }
+    let mut text = String::new();
+    std::io::stdin()
+        .read_to_string(&mut text)
+        .map_err(|e| CliError::new(9, format!("--body -: cannot read stdin: {e}")))?;
+    if text.trim().is_empty() {
+        return Err(CliError::new(9, "--body - read nothing on stdin").with_hint(hint));
+    }
+    Ok(text)
 }
 
 /// A short, readable handle. Never an identifier: the id is what references

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -17,8 +17,9 @@
 //! spawn the binary even if we wanted one.
 
 use std::ffi::OsStr;
+use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Output};
+use std::process::{Command, Output, Stdio};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::OnceLock;
 
@@ -274,6 +275,33 @@ impl Repo {
             .current_dir(std::env::temp_dir())
             .output()
             .expect("the binary must have been built")
+    }
+
+    /// The same invocation, with `text` on stdin.
+    ///
+    /// Piped rather than redirected from a file, because a pipe is what the
+    /// caller `--body -` exists for actually has: a heredoc, or the output of
+    /// another command. `Command::output` would close stdin outright, which is
+    /// the empty case and not this one.
+    fn ank_stdin(&self, agent: &str, args: &[&str], text: &str) -> Output {
+        let mut child = ank_command()
+            .args(args)
+            .arg("--repo")
+            .arg(&self.0)
+            .env("ANK_AGENT", agent)
+            .current_dir(std::env::temp_dir())
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("the binary must have been built");
+        child
+            .stdin
+            .take()
+            .expect("stdin was piped")
+            .write_all(text.as_bytes())
+            .expect("the child reads its stdin");
+        child.wait_with_output().expect("the process must exit")
     }
 
     /// The same invocation with extra environment variables set.
@@ -2780,6 +2808,152 @@ fn an_unattested_task_is_not_reported_until_the_default_branch_carries_it() {
         said.contains("no test proof") && said.contains(UNATTESTED),
         "the default branch caught up and nothing was reported:\n{said}"
     );
+}
+
+/// The body that is painful to type as a flag arrives on stdin instead.
+///
+/// The prose here is the whole point of the test, so it is the prose that hurts:
+/// six lines, blank lines between them, and quotes of both kinds. Written as a
+/// shell argument this is a fight with escaping — which is the friction
+/// TASK-8e7c8e7724ee measured, not a hypothesis about one.
+///
+/// Asserted through `ank show` and not by reading the file, because `show` is
+/// what an agent receives: what has to survive the pipe is the body a reader
+/// gets back, byte for byte.
+#[test]
+fn a_body_piped_on_stdin_reaches_show_byte_for_byte() {
+    let r = Repo::new();
+
+    // A heredoc's trailing newline is absorbed by the canonical form, so the
+    // text below is what `show` must return verbatim, and the pipe carries one
+    // more newline than that.
+    const BODY: &str = "Observed friction, not speculation: writing a body \
+                        through a shell flag means \"fighting\" quoting.\n\
+                        \n\
+                        The '-' convention is the established Unix answer, and \
+                        it costs nothing on the surface.\n\
+                        \n\
+                        - a bullet, indented\n\
+                        - and a second one, with an apostrophe it doesn't need";
+
+    let out = r.ank_stdin(
+        "claude-code@ank",
+        &[
+            "new",
+            "task",
+            "--title",
+            "A piped task",
+            "--scope",
+            "src/**",
+            "--criteria",
+            "A verifiable criterion.",
+            "--body",
+            "-",
+        ],
+        &format!("{BODY}\n"),
+    );
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    let id = stdout(&out)
+        .split_whitespace()
+        .nth(1)
+        .expect("created <id> <title>")
+        .to_string();
+
+    let shown = stdout(&r.ank("claude-code@ank", &["show", &id]));
+    let (_, after) = shown
+        .split_once("\n---\n\n")
+        .expect("show prints the frontmatter, then the body");
+    let body = after
+        .split("BLOCKED BY")
+        .next()
+        .expect("split yields at least one part");
+    assert_eq!(
+        body.trim_end_matches('\n'),
+        BODY,
+        "the piped body reached the entity changed:\n{shown}"
+    );
+
+    // And the two channels write the same file: a body that carried its origin
+    // into the corpus would be a second spelling of the same field.
+    let out = r.ank(
+        "claude-code@ank",
+        &[
+            "new",
+            "task",
+            "--title",
+            "A flagged task",
+            "--scope",
+            "src/**",
+            "--body",
+            BODY,
+        ],
+    );
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    let twin = stdout(&out).split_whitespace().nth(1).unwrap().to_string();
+    assert_eq!(
+        r.task_text(&id).split_once("---\n\n").unwrap().1,
+        r.task_text(&twin).split_once("---\n\n").unwrap().1,
+        "the pipe and the flag must produce the same body"
+    );
+}
+
+/// `--body -` with nothing on stdin refuses, and names the flag it refuses on.
+///
+/// Accepting it would write the one entity `--body` exists to prevent — a task
+/// with no reasoning, created silently by a pipeline that produced nothing. The
+/// hint has to carry the flag, since the flag is what the caller has to fix.
+#[test]
+fn body_from_an_empty_stdin_is_refused_and_names_the_flag() {
+    let r = Repo::new();
+
+    let out = r.ank_stdin(
+        "claude-code@ank",
+        &[
+            "new",
+            "task",
+            "--title",
+            "An empty task",
+            "--scope",
+            "src/**",
+            "--body",
+            "-",
+        ],
+        "",
+    );
+    let said = format!("{}{}", stdout(&out), stderr(&out));
+    assert_eq!(code(&out), 9, "{said}");
+    assert!(said.contains("--body -"), "the flag is not named:\n{said}");
+    assert!(
+        said.contains("ank new task") && said.contains("| "),
+        "the refusal must name the command to run next:\n{said}"
+    );
+
+    // Nothing was written: a refusal that left a half-made entity behind would
+    // cost more than the one it refused.
+    let out = r.ank("claude-code@ank", &["find", "--status", "open"]);
+    assert!(
+        !stdout(&out).contains("An empty task"),
+        "the refused task was created anyway:\n{}",
+        stdout(&out)
+    );
+
+    // Whitespace alone is the same emptiness, and the one a heredoc actually
+    // produces when the variable it interpolates is unset.
+    let out = r.ank_stdin(
+        "claude-code@ank",
+        &[
+            "new",
+            "task",
+            "--title",
+            "A blank task",
+            "--scope",
+            "src/**",
+            "--body",
+            "-",
+        ],
+        "\n\n   \n",
+    );
+    assert_eq!(code(&out), 9, "{}{}", stdout(&out), stderr(&out));
 }
 
 /// A task created through the binary needs no hand finishing.


### PR DESCRIPTION
Closes TASK-8e7c8e7724ee, anchored on CI run 31447913949.

Writing a six-paragraph body as a shell argument is a fight with quoting and
escaping, and it was the most painful step of the creation path. `-` is the Unix
answer and costs one reserved spelling: no new flag, and nothing SKILL.md
teaches moves, `new` being off-loop.

The three decisions the task left to the implementer:

- **Trailing newline: absorbed, not stored.** The `trim()` that already ran on a
  flag value runs on the piped text, so a heredoc and a flag produce the same
  file byte for byte. The integration test pins it by creating the same body
  through both channels and comparing.
- **`--criteria -` left out.** The flag is read in three places in `new` plus
  `claim`, so giving it to `new` alone would be an inconsistency and giving it
  to all of them is a surface question of its own -- it does not fall out of
  this code path for free.
- **Nothing to read is refused with code 9**, as an unset `$EDITOR` is, for the
  empty pipe and for a terminal alike. Accepting it would write the one entity
  `--body` exists to prevent: a task with no reasoning, created silently by a
  pipeline that produced nothing.

Verified through the binary: an integration test pipes a multi-paragraph body
with double quotes, single quotes, blank lines and indentation, then asserts the
`ank show` output.

Found while dogfooding this and filed separately as TASK-b8a12d60686d:
`ank init --repo <path>` ignores the flag and initialises the current
repository instead, writing the AGENTS.md pointer into a repository the caller
did not name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RYLJW2CXtQn1zCLRLcqZ7