### PR TITLE
A criterion that turns out unmeasurable has a route back

### DIFF
--- a/.ank/tasks/TASK-7c2fa14284ff.md
+++ b/.ank/tasks/TASK-7c2fa14284ff.md
@@ -5,17 +5,21 @@ slug: a-criterion-that-turns-out-unmeasurable-has-no-r
 title: A criterion that turns out unmeasurable has no route back
 created: 2026-08-07T16:36:57Z
 author: seanl@sean-laptop
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/src/human.rs
   - crates/ank-cli/src/editor.rs
   - docs/ank-spec-v1.1.md
+  - crates/ank-cli/src/claim.rs
+  - crates/ank-cli/src/edit.rs
+  - crates/ank-cli/src/cli.rs
+  - crates/ank-cli/tests/**
 blocked_by: []
 done_criteria: |
   A creator can correct a done_criteria that turned out unmeasurable, holding no claim, without the correction being recorded as the claimer's. The route is stated in docs/ank-spec-v1.1.md section 4 before the code moves, and it is exercised through the binary in crates/ank-cli/tests/cli.rs: the criterion changes, criteria_by stays creator, and ank check reports no fault. If the answer is that no such route belongs in the CLI, the specification says so and names what a creator does instead, and claim --criteria stops silently overwriting a criterion the creator already set.
 criteria_by: creator
 schema: 2
-version: 1
+version: 5
 ---
 
 Found by dogfooding TASK-90442c8f0ca2. Its criterion ended on a clause that
@@ -46,3 +50,8 @@ the two is wrong. If the position is the one the ADRs state -- immutability is
 verifiable, not defended, the CLI is not a gatekeeper, check is what notices
 -- then it is amend's refusal that is out of line, not claim's permissiveness.
 Either way the specification decides first, then the goldens, then the code.
+
+## Log
+- 2026-08-11T01:25:27Z seanl@sean-laptop — Direction settled with the maintainer: amend opens on state, claim closes. amend --criteria is allowed unless a live claim anchors the criterion, leaves criteria_by untouched, and is logged; claim --criteria stops overwriting a criterion that already exists and points at amend, so it only ever sets an absent one -- which is the case section 3 designed it for, and which keeps criteria_by:claimer meaning exactly one thing. Discovery that shrinks the work: edit.rs already implements this rule. check_frozen refuses a moved done_criteria only when live_claim_anchor finds a claim in force, and returns Ok otherwise, with the comment saying refusals are on state and never on identity. So a route through the CLI already existed -- ank edit -- and it was never scriptable and never named in the specification. amend will reuse that helper rather than restate the rule: it moves to claim.rs, where both callers can reach it.
+- 2026-08-11T01:25:34Z seanl@sean-laptop — amended: +scope crates/ank-cli/src/claim.rs, +scope crates/ank-cli/src/edit.rs, +scope crates/ank-cli/src/cli.rs, +scope crates/ank-cli/tests/**
+- 2026-08-11T01:38:28Z seanl@sean-laptop — Specification first, then the code, as ADR-63b5 orders. Section 4 now states the route: amend --criteria refused only while a live claim freezes the criterion, criteria_by untouched because an amend is not a claim, and claim --criteria sets an absent criterion and never replaces one. Revision l records it. The state test is claim::live, one function both amend and edit call, so the two cannot drift; edit had it privately and the specification said nothing about it. Two consequences beyond the criterion. SKILL.md line 65 became false the moment amend changed -- it taught that amend will not touch done_criteria, that release is the route -- so the sentence is corrected and metadata.revision bumped to 8295e2081364; this is a correction, not growth, the verbs and modes it teaches are unchanged and it stays inside the 140/1200 ceiling. And cli.rs::refused is now called by nothing, amend having been its only user: left in place, with its doc comment on the pattern, since the crate root allows dead code and deleting it would take listed and listed_flags with it. Verified through the binary on a scratch repository: the correction goes through unclaimed, is refused under a claim naming the holder, and claim --criteria refuses with amend as the next command.

--- a/.ank/tasks/TASK-7c2fa14284ff.md
+++ b/.ank/tasks/TASK-7c2fa14284ff.md
@@ -5,7 +5,7 @@ slug: a-criterion-that-turns-out-unmeasurable-has-no-r
 title: A criterion that turns out unmeasurable has no route back
 created: 2026-08-07T16:36:57Z
 author: seanl@sean-laptop
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/src/human.rs
   - crates/ank-cli/src/editor.rs
@@ -18,8 +18,12 @@ blocked_by: []
 done_criteria: |
   A creator can correct a done_criteria that turned out unmeasurable, holding no claim, without the correction being recorded as the claimer's. The route is stated in docs/ank-spec-v1.1.md section 4 before the code moves, and it is exercised through the binary in crates/ank-cli/tests/cli.rs: the criterion changes, criteria_by stays creator, and ank check reports no fault. If the answer is that no such route belongs in the CLI, the specification says so and names what a creator does instead, and claim --criteria stops silently overwriting a criterion the creator already set.
 criteria_by: creator
+proof:
+  - type: test
+    ref: "31450126438"
+    criteria: 99b7d783bbcc
 schema: 2
-version: 5
+version: 6
 ---
 
 Found by dogfooding TASK-90442c8f0ca2. Its criterion ended on a clause that
@@ -55,3 +59,4 @@ Either way the specification decides first, then the goldens, then the code.
 - 2026-08-11T01:25:27Z seanl@sean-laptop — Direction settled with the maintainer: amend opens on state, claim closes. amend --criteria is allowed unless a live claim anchors the criterion, leaves criteria_by untouched, and is logged; claim --criteria stops overwriting a criterion that already exists and points at amend, so it only ever sets an absent one -- which is the case section 3 designed it for, and which keeps criteria_by:claimer meaning exactly one thing. Discovery that shrinks the work: edit.rs already implements this rule. check_frozen refuses a moved done_criteria only when live_claim_anchor finds a claim in force, and returns Ok otherwise, with the comment saying refusals are on state and never on identity. So a route through the CLI already existed -- ank edit -- and it was never scriptable and never named in the specification. amend will reuse that helper rather than restate the rule: it moves to claim.rs, where both callers can reach it.
 - 2026-08-11T01:25:34Z seanl@sean-laptop — amended: +scope crates/ank-cli/src/claim.rs, +scope crates/ank-cli/src/edit.rs, +scope crates/ank-cli/src/cli.rs, +scope crates/ank-cli/tests/**
 - 2026-08-11T01:38:28Z seanl@sean-laptop — Specification first, then the code, as ADR-63b5 orders. Section 4 now states the route: amend --criteria refused only while a live claim freezes the criterion, criteria_by untouched because an amend is not a claim, and claim --criteria sets an absent criterion and never replaces one. Revision l records it. The state test is claim::live, one function both amend and edit call, so the two cannot drift; edit had it privately and the specification said nothing about it. Two consequences beyond the criterion. SKILL.md line 65 became false the moment amend changed -- it taught that amend will not touch done_criteria, that release is the route -- so the sentence is corrected and metadata.revision bumped to 8295e2081364; this is a correction, not growth, the verbs and modes it teaches are unchanged and it stays inside the 140/1200 ceiling. And cli.rs::refused is now called by nothing, amend having been its only user: left in place, with its doc comment on the pattern, since the crate root allows dead code and deleting it would take listed and listed_flags with it. Verified through the binary on a scratch repository: the correction goes through unclaimed, is refused under a claim naming the holder, and claim --criteria refuses with amend as the next command.
+- 2026-08-11T01:46:22Z seanl@sean-laptop — done, proof test:31450126438

--- a/crates/ank-cli/src/claim.rs
+++ b/crates/ank-cli/src/claim.rs
@@ -469,6 +469,27 @@ pub fn is_expired(claim: &ClaimRecord, now: i64, id: &EntityId) -> Result<bool> 
     Ok(now > expires + DRIFT_TOLERANCE.as_secs() as i64)
 }
 
+/// The claim in force on a task, if there is one.
+///
+/// **The one place the question "is this criterion frozen right now" is
+/// answered.** `edit` asked it first, and `amend --criteria` asks exactly the
+/// same thing (§4): the two must agree, and a rule restated in two verbs is a
+/// rule that will eventually be restated differently. A completion ref is not a
+/// claim and neither is a lapsed one — an expired claim is not in force and
+/// freezes nothing, which is the reading `log` and `done` already apply.
+///
+/// Any live claim, not this agent's: refusals are on state and never on identity
+/// (ADR-c656cbcc33a9).
+pub fn live(cwd: &Path, id: &EntityId) -> Result<Option<ClaimRecord>> {
+    let Some(Record::Claim(c)) = read(cwd, id)?.map(|h| h.record) else {
+        return Ok(None);
+    };
+    if is_expired(&c, now_secs(), id)? {
+        return Ok(None);
+    }
+    Ok(Some(c))
+}
+
 fn remaining_text(claim: &ClaimRecord, now: i64) -> String {
     match parse_utc(&claim.expires) {
         Some(e) if e > now => {
@@ -861,8 +882,32 @@ pub fn run(
 
     // Preconditions first, in the order of §3: no ref is touched by a claim
     // that was never going to be legal.
+    //
+    // **`--criteria` sets an absent criterion and never replaces one** (§4).
+    // §3 gives the flag exactly one job: a task cannot be claimed without a
+    // criterion, and the refusal below names the command that sets it and
+    // claims in the same call. Overwriting silently was a second job nobody
+    // specified, and it was the wrong one — it recorded the correction of a
+    // criterion that had turned out unmeasurable as the claimer's, which is the
+    // shape `criteria_by` exists to expose (TASK-7c2fa14284ff). Correcting an
+    // existing criterion is `amend --criteria`, which the freeze governs on
+    // state: refused while a claim is live, allowed the rest of the time.
     if let Some(c) = inv.value("--criteria") {
         if !c.trim().is_empty() {
+            let carried = task
+                .done_criteria
+                .as_deref()
+                .is_some_and(|existing| !existing.trim().is_empty());
+            if carried {
+                return Err(CliError::new(
+                    6,
+                    format!("{} already carries a done_criteria", task.id),
+                )
+                .with_hint(format!(
+                    "ank amend {} --criteria \"<verifiable criterion>\"",
+                    task.id
+                )));
+            }
             task.done_criteria = Some(ensure_trailing_newline(c));
             task.criteria_by = Some(CriteriaBy::Claimer);
         }
@@ -945,7 +990,10 @@ pub fn run(
     Ok(0)
 }
 
-fn ensure_trailing_newline(text: &str) -> String {
+/// A criterion, normalised for storage. Shared with `amend --criteria`: the two
+/// routes write the same field and have to write it identically, or the corpus
+/// would record which command was used.
+pub fn ensure_trailing_newline(text: &str) -> String {
     if text.ends_with('\n') {
         text.to_string()
     } else {

--- a/crates/ank-cli/src/cli.rs
+++ b/crates/ank-cli/src/cli.rs
@@ -273,7 +273,7 @@ pub const COMMANDS: &[CommandSpec] = &[
             refuses(4, "the task is held by another agent, or finished on another branch"),
             refuses(7, "the task is blocked, or has no done_criteria to freeze"),
         ],
-        notes: &["--criteria on a task that already has one overwrites it and records the criterion as the claimer's"],
+        notes: &["--criteria sets a criterion the task does not have, and records it as the claimer's; it never replaces one"],
         owner_task: None,
     },
     CommandSpec {
@@ -421,7 +421,7 @@ pub const COMMANDS: &[CommandSpec] = &[
     },
     CommandSpec {
         name: "amend",
-        summary: "changes blocked_by and scope on an entity that already exists",
+        summary: "changes blocked_by, scope, and a done_criteria no live claim freezes",
         subcommands: &[],
         max_positionals: 1,
         positional_help: "<id>",
@@ -430,17 +430,20 @@ pub const COMMANDS: &[CommandSpec] = &[
             multi("--drop-blocked-by"),
             multi("--scope"),
             multi("--drop-scope"),
-            // Known to the parser and not offered by `help`: it exists so the
-            // refusal can name it and point at `ank release` (§9). Listing it
-            // was the defect TASK-84cfad83c308 was filed for -- help did not
-            // merely say too little, it made an offer the verb rejects.
-            refused("--criteria"),
+            // Offered now, and it was `refused` here for as long as the verb
+            // rejected it outright (TASK-84cfad83c308: help must not make an
+            // offer the verb turns down). It stops being an offer the verb
+            // rejects the moment the verb accepts it on state (§4).
+            flag("--criteria"),
         ],
         refuses: &[refuses(
             6,
-            "--criteria: done_criteria is frozen at claim; a wrong criterion is a release",
+            "--criteria while a live claim freezes the criterion; that case is a release",
         )],
-        notes: &["adds and removes explicitly, never a replacement list, so nothing is dropped by being forgotten"],
+        notes: &[
+            "adds and removes explicitly, never a replacement list, so nothing is dropped by being forgotten",
+            "--criteria replaces the criterion outright, and leaves criteria_by where it stands",
+        ],
         owner_task: None,
     },
     CommandSpec {

--- a/crates/ank-cli/src/edit.rs
+++ b/crates/ank-cli/src/edit.rs
@@ -22,7 +22,7 @@
 //! the scratch file, because the alternative is a verb that answers a typo by
 //! discarding the twenty minutes that surrounded it.
 
-use crate::claim::{self, Record};
+use crate::claim;
 use crate::cli::{CliError, Invocation, Result};
 use crate::commands::json_string;
 use crate::editor;
@@ -267,14 +267,11 @@ fn check_frozen(repo: &Repo, before: &Entity, after: &Entity) -> Result<()> {
 }
 
 /// The hash a live claim anchors `done_criteria` at, if one is in force.
+///
+/// The state test itself lives in `claim::live`, because `amend --criteria`
+/// asks the same question and §4 states the answer once for both.
 fn live_claim_anchor(cwd: &Path, id: &EntityId) -> Result<Option<String>> {
-    let Some(Record::Claim(c)) = claim::read(cwd, id)?.map(|h| h.record) else {
-        return Ok(None);
-    };
-    if claim::is_expired(&c, claim::now_secs(), id)? {
-        return Ok(None);
-    }
-    Ok(Some(c.criteria))
+    Ok(claim::live(cwd, id)?.map(|c| c.criteria))
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/ank-cli/src/human.rs
+++ b/crates/ank-cli/src/human.rs
@@ -2058,18 +2058,22 @@ pub fn amend(inv: &Invocation, repo: &Repo, identity: &str, out: &mut dyn Write)
         CliError::new(1, "amend expects an id").with_hint("ank amend <id> --blocked-by <id>")
     })?;
 
-    // Refused by name rather than through the parser's unknown-flag path. The
-    // criterion is frozen by hash at claim, the anchor is held where the file's
-    // editor cannot reach it (ADR-6b3f19e08a24), and a verb that edited it
-    // would offer to do the one thing the freeze exists to make visible. What
-    // a wrong criterion actually calls for is a release.
-    if inv.value("--criteria").is_some() {
-        return Err(CliError::new(
-            6,
-            "done_criteria is frozen at claim and amend will not touch it",
-        )
-        .with_hint("ank release --reason \"<why the criterion is wrong>\""));
-    }
+    // Blank is refused rather than treated as a removal: a task with no
+    // criterion cannot be claimed at all (§3), so emptying the field through a
+    // flag that reads as an edit would be a state nobody asked for.
+    let criteria = match inv.value("--criteria") {
+        Some(c) if c.trim().is_empty() => {
+            return Err(CliError::new(
+                7,
+                "--criteria is empty, and a task with no done_criteria cannot be claimed",
+            )
+            .with_hint(format!(
+                "ank amend {prefix} --criteria \"<verifiable criterion>\""
+            )))
+        }
+        Some(c) => Some(claim::ensure_trailing_newline(c.trim())),
+        None => None,
+    };
 
     let store = Store::new(&repo.ank);
     let loaded = store.load_prefix(prefix)?;
@@ -2098,11 +2102,12 @@ pub fn amend(inv: &Invocation, repo: &Repo, identity: &str, out: &mut dyn Write)
         && drop_scope.is_empty()
         && add_blocked.is_empty()
         && drop_blocked.is_empty()
+        && criteria.is_none()
     {
         return Err(
             CliError::new(7, format!("nothing to amend on {id}")).with_hint(format!(
                 "ank amend {id} --blocked-by <id> | --drop-blocked-by <id> | \
-                 --scope <glob> | --drop-scope <glob>"
+                 --scope <glob> | --drop-scope <glob> | --criteria \"<c>\""
             )),
         );
     }
@@ -2149,6 +2154,43 @@ pub fn amend(inv: &Invocation, repo: &Repo, identity: &str, out: &mut dyn Write)
 
             amend_scope(&mut task.scope, &add_scope, &drop_scope, &id, &mut changes)?;
 
+            // The criterion, refused while a live claim anchors it and allowed
+            // the rest of the time (§4). A criterion under no claim is anchored
+            // by nothing: there is no freeze to respect, and `check` has nothing
+            // to notice. Under one, the refusal is the freeze doing its work,
+            // and what a criterion discovered wrong mid-work calls for is a
+            // release.
+            //
+            // The case this route exists for is the criterion that turns out
+            // *unmeasurable* rather than wrong (TASK-7c2fa14284ff). Before it,
+            // the correction had two ways in and both were wrong: a hand edit,
+            // which this verb exists to make unnecessary, or `claim --criteria`,
+            // which recorded a creator's correction as the claimer's.
+            if let Some(criteria) = criteria {
+                if let Some(held) = claim::live(&repo.root, &id)? {
+                    return Err(CliError::new(
+                        6,
+                        format!(
+                            "done_criteria is frozen by the claim {} holds on {id}",
+                            held.holder
+                        ),
+                    )
+                    .with_hint("ank release --reason \"<why the criterion is wrong>\""));
+                }
+                if task.done_criteria.as_deref() != Some(criteria.as_str()) {
+                    changes.push("done_criteria".to_string());
+                    task.done_criteria = Some(criteria);
+                    // `criteria_by` is deliberately left where it stands. It
+                    // answers whether the criterion was set at claim time by the
+                    // party the freeze constrains (§3), and an amend is not a
+                    // claim: writing `claimer` would launder a correction into
+                    // the shape the signal exists to expose, and writing
+                    // `creator` would assert something about the caller, which
+                    // nothing else on this surface does. The log entry below is
+                    // what records the amend, as it does for the other fields.
+                }
+            }
+
             if changes.is_empty() {
                 return Err(CliError::new(7, format!("{id} already reads that way"))
                     .with_hint(format!("ank show {id}")));
@@ -2193,6 +2235,17 @@ pub fn amend(inv: &Invocation, repo: &Repo, identity: &str, out: &mut dyn Write)
                 return Err(CliError::new(
                     1,
                     "blocked_by applies to a task: an ADR blocks nothing",
+                )
+                .with_hint(format!("ank amend {id} --scope <glob>")));
+            }
+            // Refused rather than dropped, for the reason `new` refuses
+            // `--verify` on an ADR: a flag silently ignored teaches the caller
+            // it worked. An ADR is measured by nothing — what it carries is a
+            // constraint, and changing that one is a succession.
+            if criteria.is_some() {
+                return Err(CliError::new(
+                    1,
+                    "done_criteria applies to a task: an ADR declares no criterion",
                 )
                 .with_hint(format!("ank amend {id} --scope <glob>")));
             }

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -3194,22 +3194,171 @@ fn amend_adds_and_removes_without_disturbing_the_rest() {
     assert_eq!(code(&out), 7, "{}", stderr(&out));
     assert!(stderr(&out).contains("no scope"), "{}", stderr(&out));
 
-    // The frozen field is refused by name, with the command that applies.
-    let out = r.ank(
-        "marie@laptop",
-        &["amend", ID, "--criteria", "Anything at all."],
-    );
-    assert_eq!(code(&out), 6, "{}", stderr(&out));
-    let err = stderr(&out);
-    assert!(err.contains("frozen"), "{err}");
-    assert!(
-        err.contains("ank release"),
-        "the command that applies: {err}"
-    );
+    // Blanking the criterion is refused: a task with no done_criteria cannot be
+    // claimed at all, so a flag that reads as an edit will not produce one.
+    let out = r.ank("marie@laptop", &["amend", ID, "--criteria", "   "]);
+    assert_eq!(code(&out), 7, "{}", stderr(&out));
     assert!(
         r.task_text(ID).contains("A verifiable criterion."),
         "the criterion did not move"
     );
+}
+
+/// A criterion that turns out unmeasurable is corrected, by a caller holding no
+/// claim, without the correction being recorded as the claimer's.
+///
+/// The case is real and is what TASK-7c2fa14284ff was filed for: a criterion
+/// ending on a clause no repository of that shape could ever satisfy. The work
+/// was right and the measurement was not, and the corrected criterion had no way
+/// back in that did not lie about who wrote it.
+#[test]
+fn a_criterion_under_no_claim_is_amended_and_stays_the_creators() {
+    let r = Repo::new();
+    r.seed_task(ID, Some("A criterion that cannot be measured."));
+
+    let out = r.ank(
+        "marie@laptop",
+        &["amend", ID, "--criteria", "A criterion that can."],
+    );
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+
+    let text = r.task_text(ID);
+    assert!(
+        text.contains("done_criteria: |\n  A criterion that can.\n"),
+        "the criterion moved: {text}"
+    );
+    assert!(
+        !text.contains("cannot be measured"),
+        "the old criterion is gone: {text}"
+    );
+    // The heart of it. `criteria_by` answers whether the criterion was set at
+    // claim time by the party the freeze constrains, and an amend is not a
+    // claim — writing `claimer` here would launder a correction into the shape
+    // the signal exists to expose.
+    assert!(
+        text.contains("criteria_by: creator"),
+        "the correction was recorded as somebody else's: {text}"
+    );
+    assert!(
+        text.contains("amended: done_criteria"),
+        "the log is what records the amend: {text}"
+    );
+
+    // And the corpus is clean afterwards: the point of the route is that it
+    // leaves nothing for `check` to report.
+    let out = r.ank("marie@laptop", &["check"]);
+    assert_eq!(code(&out), 0, "{}{}", stdout(&out), stderr(&out));
+    assert!(
+        !stdout(&out).contains("altered") && !stdout(&out).contains("claimer"),
+        "{}",
+        stdout(&out)
+    );
+
+    // Amending it to what it already says changes nothing, and says so rather
+    // than writing a version nobody asked for.
+    let out = r.ank(
+        "marie@laptop",
+        &["amend", ID, "--criteria", "A criterion that can."],
+    );
+    assert_eq!(code(&out), 7, "{}", stderr(&out));
+    assert!(
+        stderr(&out).contains("already reads that way"),
+        "{}",
+        stderr(&out)
+    );
+}
+
+/// The freeze still holds where it means something: under a live claim.
+///
+/// Through the binary and against a real claim ref, because "a live claim" is a
+/// fact about `refs/ank/claims/`, not about a struct — and because the refusal
+/// must not consult who is calling. The claimer itself is refused, which is the
+/// whole point: it is the party the freeze constrains.
+#[test]
+fn a_criterion_under_a_live_claim_is_refused_to_everyone_alike() {
+    let r = Repo::new().with_verifiers("verifiers:\n  ok:\n    run: echo fine\n");
+    r.seed_task(ID, Some("A verifiable criterion."));
+    assert_eq!(code(&r.ank("claude-code@ank", &["claim", ID])), 0);
+
+    for who in ["marie@laptop", "claude-code@ank"] {
+        let out = r.ank(who, &["amend", ID, "--criteria", "Something easier."]);
+        let err = stderr(&out);
+        assert_eq!(code(&out), 6, "{who}: {err}");
+        assert!(err.contains("frozen"), "{who}: {err}");
+        assert!(
+            err.contains("claude-code@ank"),
+            "the refusal names the holder: {who}: {err}"
+        );
+        assert!(
+            err.contains("ank release"),
+            "the command that applies: {who}: {err}"
+        );
+    }
+    assert!(
+        r.task_text(ID).contains("A verifiable criterion."),
+        "the criterion did not move"
+    );
+
+    // Released, the same call goes through: the refusal was on the claim and
+    // never on the caller.
+    assert_eq!(
+        code(&r.ank(
+            "claude-code@ank",
+            &["release", ID, "--reason", "unmeasurable"]
+        )),
+        0
+    );
+    let out = r.ank(
+        "marie@laptop",
+        &["amend", ID, "--criteria", "Something measurable."],
+    );
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    assert!(r.task_text(ID).contains("Something measurable."));
+}
+
+/// `claim --criteria` sets a criterion, and never replaces one.
+///
+/// The door `amend` used to bolt shut was standing open here, and open to the
+/// claimer -- the one party the freeze constrains. Closing it is what keeps
+/// `criteria_by: claimer` meaning exactly one thing.
+#[test]
+fn claim_criteria_sets_an_absent_criterion_and_refuses_to_replace_one() {
+    let r = Repo::new();
+    r.seed_task(ID, Some("The criterion its creator wrote."));
+
+    let out = r.ank(
+        "claude-code@ank",
+        &["claim", ID, "--criteria", "Something easier."],
+    );
+    let err = stderr(&out);
+    assert_eq!(code(&out), 6, "{err}");
+    assert!(err.contains("already carries a done_criteria"), "{err}");
+    assert!(
+        err.contains("ank amend") && err.contains("--criteria"),
+        "the refusal names the route that applies: {err}"
+    );
+    let text = r.task_text(ID);
+    assert!(text.contains("The criterion its creator wrote."), "{text}");
+    assert!(text.contains("criteria_by: creator"), "{text}");
+    // Refused before any ref was touched: the preconditions of §3 run before
+    // the claim, so nothing is left half-taken.
+    assert!(
+        r.claim_ref(ID).is_none(),
+        "a refused claim took the task anyway"
+    );
+
+    // A task carrying none is still claimed and set in one call, and that is
+    // still recorded as the claimer's.
+    const BARE: &str = "TASK-000000000009";
+    r.seed_task(BARE, None);
+    let out = r.ank(
+        "claude-code@ank",
+        &["claim", BARE, "--criteria", "A verifiable criterion."],
+    );
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    let text = r.task_text(BARE);
+    assert!(text.contains("A verifiable criterion."), "{text}");
+    assert!(text.contains("criteria_by: claimer"), "{text}");
 }
 
 #[test]

--- a/docs/ank-spec-v1.1.md
+++ b/docs/ank-spec-v1.1.md
@@ -27,6 +27,8 @@ Settled relative to v1: orientation and constraints reconciled (§5) · immutabi
 
 Every open point of v1 is settled: GPL-3.0 licence, native Windows in v1, merge driver specified but implemented in v1.1 (§13). `attest` was deferred alongside it and ships in v1: the command was written before a CI ever called it, so what remains deferred is the integration and not the verb (§10).
 
+Additions of revision l: **a criterion that turns out unmeasurable has a route back** (§4) — `amend --criteria` is refused only while a live claim freezes the criterion, which is the state test `edit` already applied without either the specification or `amend` saying so, and it leaves `criteria_by` alone, an amend being no claim · in exchange `claim --criteria` sets an absent criterion and never replaces one (§4), closing the door that recorded a creator's correction as the claimer's — the door `amend` bolted shut was standing open on `claim`, and open to the one party the freeze constrains.
+
 Additions of revision k: **`ank help` is one flat listing** (§4, §9, ADR-c656cbcc33a9, superseding ADR-9ede1ffd04e2) — revision i dissolved the split between an agent surface and a human one and left a layered `help` behind it, whose headings were still named after callers; layering is grouping, and a grouping printed by the binary is a claim about who a verb is for. The order of §4 carries the same information without asserting a category, and the loop stays where it is enforced, in the frozen content of SKILL.md.
 
 Additions of revision j: **the ratification signature is verified and not merely read** (§8, §4) — `check` was comparing the anchor in the ratification commit against the file without asking who signed the commit, so an ordinary unsigned commit whose subject read `ratify <id>` was accepted as a ratification; the four outcomes are specified, an unchecked signature is a signal and never a success, and the layout of `allowed_signers` is documented along with the fact that git enforces it only under `gpg.format = ssh`, OpenPGP leaving the match to `check` itself.
@@ -307,7 +309,7 @@ accept    promotes a proposed ADR to accepted (produces the signed commit, §8, 
           requires the default branch)
 check     mechanical invariants, exit code usable in CI
 close     closes a task that will never be done (--reason mandatory)
-amend     changes `blocked_by` and `scope` on an entity that already exists
+amend     changes `blocked_by`, `scope`, and a `done_criteria` no live claim freezes
 attest    appends a proof to a finished task: the one write §3 allows after `done`
 status    where am I: branch, claim, perimeter, queue, findings
 edit      opens an entity in the editor and validates what comes back
@@ -327,11 +329,19 @@ error[7]: accept requires the default branch (current: feat/opaque-sessions, def
   -> git switch main && ank accept 19d0
 ```
 
-**`amend` covers the two fields a plan actually changes on**, `blocked_by` and `scope`, and covers nothing else. A subtask discovered after a task was filed is a `blocked_by` added to something that already exists; a scope found to omit the files the work must touch is a scope corrected before the task can be claimed at all. Both are ordinary, both were done by hand until this verb existed, and an edit done by hand is indistinguishable in the resulting file from any other edit done by hand — which is the argument that put `attest` on this surface too.
+**`amend` covers the three fields a plan actually changes on**, `blocked_by`, `scope` and `done_criteria`, and covers nothing else. A subtask discovered after a task was filed is a `blocked_by` added to something that already exists; a scope found to omit the files the work must touch is a scope corrected before the task can be claimed at all. Both are ordinary, both were done by hand until this verb existed, and an edit done by hand is indistinguishable in the resulting file from any other edit done by hand — which is the argument that put `attest` on this surface too.
 
-It **adds and removes explicitly** and never takes a replacement list: a verb given the whole list silently drops whatever the caller forgot to repeat. It refuses a `done` or `closed` task, since §3 allows exactly one write after completion and that write is `attest`'s. It refuses the `scope` of an accepted ADR, whose `scope` is hashed into the ratification commit (§8) — changing a ratified decision is a succession, and succession has its own verb. And it refuses `done_criteria` by name rather than by omission, because the flag a caller reaches for deserves the command that actually applies: `release --reason`.
+It **adds and removes explicitly** and never takes a replacement list: a verb given the whole list silently drops whatever the caller forgot to repeat. It refuses a `done` or `closed` task, since §3 allows exactly one write after completion and that write is `attest`'s. And it refuses the `scope` of an accepted ADR, whose `scope` is hashed into the ratification commit (§8) — changing a ratified decision is a succession, and succession has its own verb.
 
 Amending the `scope` of a task under a live claim is **allowed and warned about**. The claim record anchors the hash of the constraints that scope selects (§7), so the change moves what binds the work in progress. Refusing would be wrong — a scope discovered false mid-task is exactly the situation the verb exists for — and allowing it silently would be worse.
+
+**`amend --criteria` is refused while a live claim freezes the criterion, and allowed the rest of the time.** That is the same state test `edit` already applies (below), and stating it once for both is the point: a criterion under no claim is anchored by nothing, so there is no freeze to respect and nothing for `check` to notice. Under a live claim the refusal is code 6 and names `release --reason`, which is what a criterion discovered wrong mid-work actually calls for.
+
+The route exists because a criterion can turn out **unmeasurable rather than wrong**, and that case had no continuation. Measured on this corpus: a task whose criterion ended on a clause about `gh api community/profile` reporting `issue_template`, which is `null` for any repository using an `ISSUE_TEMPLATE/` directory — the layout that task existed to produce (TASK-7c2fa14284ff). The work was finished and correct; the measurement never could be. The release was right and happened, and then the corrected criterion had two ways back in and both were wrong: a hand edit, which the tool exists to make unnecessary, or `claim --criteria`, which recorded a creator's correction as the claimer's.
+
+**`amend` does not touch `criteria_by`.** That field answers one question — was this criterion set at claim time, by the party the freeze constrains (§3) — and an amend is not a claim. Writing `claimer` there for a correction made under no claim would launder the correction into exactly the shape the signal exists to expose; writing `creator` would assert something about the caller, which no refusal and no field here does. What records the amend is the log entry, as it does for `scope` and `blocked_by`.
+
+**`claim --criteria` sets a criterion, and never replaces one.** On a task that already carries one it is refused, code 6, naming `ank amend <id> --criteria`. §3 gives the flag one job — a task cannot be claimed without a criterion, and the refusal for the empty case names the command that sets it and claims in the same call — and silently overwriting an existing one is not that job. It also keeps `criteria_by: claimer` meaning exactly one thing: nobody wrote a criterion for this task before the agent that took it.
 
 Everything else (editing fields, reordering, deleting) goes through **`ank edit`**, which is the paved road rather than a gate: it opens the same file in the same editor and validates what comes back. Below it, the direct edit remains possible, since the format is the specification and the CLI is not a gatekeeper. The actor matters there and is not decoration: ADR-01b6dd05f0db closes `.ank/` to direct reads and writes *by an agent*, and leaves **a human** with an editor every power they had. Written without the subject, that sentence reads as a general permission and hands back what the ADR withdrew.
 
@@ -356,7 +366,7 @@ With the surface no longer a boundary, verbs serving human ergonomics enter it w
 
 **`status`** answers *where am I* in one call: the branch, the active claim and its expiry, the constraints on the current perimeter, the ratification queue, completion refs the default branch has not caught up with (§7), and the corpus findings `check` would report. It **degrades with a warning** rather than failing when there is no remote or no determinable default branch — the parts that need neither are still worth printing. Terse `git status` register, and it ends with the next command to run, like every other output here.
 
-**`edit <id>`** opens the entity in the editor named by `$EDITOR`, validates the result on save, and writes it back in canonical form (§3). **A change to a frozen field is refused by naming the command that legally performs it**: `release --reason` for a `done_criteria` frozen at claim, `new adr --supersedes` for the `constraint` of a ratified ADR. An invalid result leaves the entity untouched and says why, so a mistyped frontmatter costs a re-edit and never a corrupt file. This is the argument that put `amend` and `attest` on this surface, generalised: an edit performed by hand is indistinguishable, in the resulting file, from any other edit performed by hand, and chaperoning it through the tool strengthens the invariants instead of relaxing them.
+**`edit <id>`** opens the entity in the editor named by `$EDITOR`, validates the result on save, and writes it back in canonical form (§3). **A change to a frozen field is refused by naming the command that legally performs it**: `release --reason` for a `done_criteria` frozen at claim, `new adr --supersedes` for the `constraint` of a ratified ADR. Frozen means anchored *now*: a `done_criteria` no live claim covers is not refused here, which is the same state test `amend --criteria` applies above and the reason the two agree by construction rather than by restatement. An invalid result leaves the entity untouched and says why, so a mistyped frontmatter costs a re-edit and never a corrupt file. This is the argument that put `amend` and `attest` on this surface, generalised: an edit performed by hand is indistinguishable, in the resulting file, from any other edit performed by hand, and chaperoning it through the tool strengthens the invariants instead of relaxing them.
 
 **`graph [<path>]`** prints the `blocked_by` DAG in readable text, restricted by an optional path the way `context` is, with `--json` for the raw edges. It **names the perimeter it drew** and says so explicitly when that perimeter holds no task. The ordering of §5 already walks these edges to count what a task unblocks, and this makes the same structure visible to a reader. `show` surfaces the narrow case from the same derivation: on a task it lists what that task **directly unblocks** alongside its blockers, one line each with status. Both are computed from the corpus at read time and stored nowhere — a stored reverse edge is a second copy of `blocked_by` that can disagree with the first.
 
@@ -403,7 +413,7 @@ released TASK-8f3a -> open
 
 ```
 ank context [<path>]        [--json] [--limit N]
-ank claim <id>              [--criteria <c>] [--ttl 30m]
+ank claim <id>              [--criteria <c>: sets an absent one, never replaces] [--ttl 30m]
 ank show <id>
 ank log [<id>] [<message>]  (id alone reads; a message writes)
 ank done [<id>]             [--proof <type>:<ref>]
@@ -418,6 +428,7 @@ ank accept <id>
 ank close <id> --reason <r>
 ank amend <id>              [--blocked-by <id>...] [--drop-blocked-by <id>...]
                             [--scope <glob>...] [--drop-scope <glob>...]
+                            [--criteria <c>]
 ank attest <id> --proof <type>:<ref>
 ank edit <id>
 ank graph [<path>]

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -2,7 +2,7 @@
 name: ank
 description: Read a repository's tasks and binding constraints, claim work, and finish it with proof. Use when working in a repo that has a .ank/ directory.
 metadata:
-  revision: "975e5ca25da1"
+  revision: "8295e2081364"
 ---
 
 # ank
@@ -60,10 +60,11 @@ decision, not a task. Write one when you hit something the corpus should be held
 to afterwards, rather than something you merely have to do now. It lands
 `proposed`, which binds nobody until it is ratified.
 
-**`ank amend <id>`** — the two fields a plan actually changes: `blocked_by` and
-`scope`. It adds and removes explicitly and never takes a replacement list, so
-nothing is dropped by being forgotten. It will not touch `done_criteria` — that
-is `release --reason`.
+**`ank amend <id>`** — the fields a plan actually changes: `blocked_by`, `scope`
+and `--criteria`. It adds and removes explicitly and never takes a replacement
+list, so nothing is dropped by being forgotten. It will not touch a
+`done_criteria` a live claim has frozen — under a claim, that is
+`release --reason`.
 
 **`ank review`** — the ratification queue and the health of the corpus: what is
 proposed and waiting, and which scopes have gone dead and want closing.


### PR DESCRIPTION
Closes TASK-7c2fa14284ff, anchored on CI run 31450126438.

`amend --criteria` is refused only while a live claim freezes the criterion, and
allowed the rest of the time. That is the state test `edit` already applied
privately in `check_frozen`: a criterion under no claim is anchored by nothing,
so there is no freeze to respect and nothing for `check` to notice. It moves to
`claim::live`, which both verbs now call -- a rule restated in two places is a
rule that will eventually be restated differently.

**`amend` leaves `criteria_by` alone.** The field answers whether the criterion
was set at claim time by the party the freeze constrains, and an amend is
neither a claim nor a statement about the caller. The log entry records it, as
it does for `scope` and `blocked_by`.

**In exchange, `claim --criteria` sets an absent criterion and never replaces
one.** The door `amend` bolted shut was standing open on `claim`, and open to
the claimer -- so a creator correcting a criterion that had turned out
unmeasurable had the correction laundered into `criteria_by: claimer`, the
exact shape the signal exists to expose. Section 3 gives the flag one job, and
this is that job.

The case is real and measured: the criterion of TASK-90442c8f0ca2 ended on a
clause about `gh api community/profile` reporting `issue_template`, which is
`null` for any repository using an `ISSUE_TEMPLATE/` directory -- the layout
that task existed to produce. The work was finished and correct; the
measurement never could be.

## What moved, in order

Specification first, then the code (ADR-63b59c5c26f7). Section 4 states the
route, and revision `l` records it. `SKILL.md` taught the opposite in one
sentence -- "It will not touch `done_criteria`" -- so it is corrected and
`metadata.revision` moved to match; the verbs and modes it teaches are
unchanged, so this is a correction and not the growth ADR-c656cbcc33a9 puts
behind a signature.

Three integration tests, through the binary: the correction goes through with
no claim held and `criteria_by` stays `creator` with `check` silent; a live
claim refuses both the holder and a third party alike, naming the holder; and
`claim --criteria` refuses without touching the ref.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RYLJW2CXtQn1zCLRLcqZ7