### PR TITLE
Triage the two review backlogs into tasks that measure something

### DIFF
--- a/.ank/tasks/TASK-1b45f41e7b99.md
+++ b/.ank/tasks/TASK-1b45f41e7b99.md
@@ -1,0 +1,43 @@
+---
+id: TASK-1b45f41e7b99
+type: task
+slug: renewal-silently-drops-the-ttl-the-claim-was-gra
+title: Renewal silently drops the TTL the claim was granted
+created: 2026-08-11T03:41:43Z
+author: seanl@sean-laptop
+status: open
+scope:
+  - crates/ank-cli/src/commands.rs
+  - crates/ank-cli/src/claim.rs
+  - docs/ank-spec-v1.1.md
+  - crates/ank-cli/tests/**
+blocked_by: []
+done_criteria: |
+  Section 3 of docs/ank-spec-v1.1.md states what a renewal does with the TTL the claim was granted, before the code moves: either renewal reuses the granted lease, capped by claim_ttl_max at renewal time, or --ttl applies to one acquisition only and claim says what it grants. The code follows the choice. Verified through the binary: an integration test claims with a --ttl above the default, logs, and reads the expiry off refs/ank/claims/<id> with git, asserting the lease the specification now promises.
+criteria_by: creator
+schema: 2
+version: 1
+---
+
+Measured, not supposed. `claim` resolves `--ttl` against `claim_ttl_max` and
+writes the resulting expiry into the record (`resolve_ttl`). The renewal in
+`log` never reads it back: it recomputes `DEFAULT_TTL.min(cfg.claim_ttl_max)`
+(commands.rs, in the renewal block after the entry is written). So an agent
+that asked for a two-hour lease holds it exactly once, and falls back to thirty
+minutes at its first `log` -- which is to say almost immediately, since `log` is
+what the loop tells agents to run often.
+
+Nothing in the format has to move. The record carries `claimed` and `expires`,
+so the granted lease is `expires - claimed` and is recoverable from what is
+already written.
+
+Two readings are defensible and section 3 currently states neither:
+
+- The lease is a property of the claim. Renewal reuses the granted duration,
+  still capped by `claim_ttl_max` at renewal time so a lowered cap takes effect.
+- `--ttl` is for this acquisition only, and renewal deliberately returns to the
+  default. Then the flag says so, and `claim` says what it is granting.
+
+The second is defensible but has to be chosen out loud, because the current
+behaviour is the second one arrived at by omission: nothing in the code says the
+fallback is meant, and the flag reads as a lease.

--- a/.ank/tasks/TASK-1ead0e19fb73.md
+++ b/.ank/tasks/TASK-1ead0e19fb73.md
@@ -1,0 +1,43 @@
+---
+id: TASK-1ead0e19fb73
+type: task
+slug: orientation-spends-its-budget-on-constraints-and
+title: Orientation spends its budget on constraints and leaves nothing for the choice
+created: 2026-08-11T03:48:12Z
+author: seanl@sean-laptop
+status: open
+scope:
+  - docs/ank-spec-v1.1.md
+  - crates/ank-cli/src/context.rs
+  - crates/ank-cli/tests/**
+blocked_by: []
+done_criteria: |
+  Section 5 of docs/ank-spec-v1.1.md says how orientation mode allocates its budget between constraints and tasks, distinctly from execution mode, and the reasoning names what orientation is for. The measurement that settles it is recorded in the task log: what a cold ank context costs on this corpus today against what it costs with a perimeter given. The code follows, and a test through the binary asserts the allocation the specification now promises on a corpus large enough to exceed the budget.
+criteria_by: creator
+schema: 2
+version: 1
+---
+
+Observed on a cold pull of this repository, and observed again today: `ank
+context` at the root answers with twelve constraints rendered in full, several
+of them multi-paragraph, followed by one task line and `+13 more tasks`. The
+proportion is inverted for the call the loop opens with. An agent that has not
+yet chosen a perimeter receives every rule in the corpus at full length and
+almost none of the work.
+
+The two modes are not the same question and the budget does not currently
+distinguish them. In execution mode a constraint is rightly never truncated:
+the perimeter is settled, the rules bind the work in hand, and cutting one
+would hide a rule the agent is about to break -- §4 says so and that is not in
+question here. Orientation is the opposite situation: nothing binds yet,
+because nothing has been chosen.
+
+What orientation is for is choosing. That argues for the inverse allocation --
+constraints named and summarised, tasks listed in enough number to pick from --
+with the full text one `ank show` away, which is the same split §9 settled for
+`help` and its per-verb page.
+
+This is a specification question about §5 rather than a rendering preference,
+and it should be measured before it is answered: what a cold `context` costs
+today, on this corpus, against what the same call costs once a perimeter is
+given.

--- a/.ank/tasks/TASK-2c1ccba48426.md
+++ b/.ank/tasks/TASK-2c1ccba48426.md
@@ -5,7 +5,7 @@ slug: second-pass-coordination-findings
 title: Second-pass coordination findings
 created: 2026-08-06T23:24:57Z
 author: seanl@sean-laptop
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/**
 blocked_by: []
@@ -13,7 +13,7 @@ done_criteria: |
   The four findings appear in the body, each precise enough to act on, and ank check stays green on this repo.
 criteria_by: creator
 schema: 2
-version: 1
+version: 4
 ---
 
 Read-only second pass over the coordination plane - claims, renewal, completion
@@ -57,3 +57,7 @@ being unimplemented, and done not warning on constraint drift.
    execution mode exists to remove choice; but if so it is unrecorded, and
    ank status does not fill the gap either: it reports the agent's own claim, not
    anyone else's.
+
+## Log
+- 2026-08-11T03:41:26Z seanl@sean-laptop — Triage pass, each finding re-measured against the tree rather than trusted from the note. All four are still live. (1) log renewal recomputes DEFAULT_TTL.min(claim_ttl_max) at commands.rs:1316 and never reads the lease back off the record, so --ttl holds for one acquisition and collapses to thirty minutes at the first log; the record carries claimed and expires, so the granted lease is recoverable without a format change. (2) close calls claim::delete at human.rs:1910 where done converts the ref to a completion record, so a task closed on a branch reads open in every other clone until the merge -- the exact window ADR-bcf2 created the completion ref to close. (3) claim::prune at claim.rs:821 has no caller outside its own tests; the live predicate is human::maintain at human.rs:1153-1229. Two copies of the rule that decides when a coordination ref disappears, one unexercised in production. (4) execution mode renders the claimed task alone and drops the [claimed:holder] and [finished:sha] markers, so the agent best placed to notice a collision is the one that cannot see the plane; status reports the caller's own claim and not anyone else's. Filing one task per finding rather than fixing them under this claim: this task's criterion is about recording, and a fix needs a criterion of its own.
+- 2026-08-11T03:42:53Z seanl@sean-laptop — Four tasks filed, one per finding, each with a criterion that measures something the note did not: TASK-1b45f41e7b99 the TTL lease, TASK-78326e2e3e89 the close asymmetry, TASK-4981a1370c0b the duplicated pruning predicate, TASK-dacbcae6134c what a holder sees of the coordination plane. Three of the four are settled in the specification or an ADR before the code moves, because three of the four are questions about what the tool means rather than defects in what it does -- only the TTL one is unambiguously a bug. Noted while filing TASK-dacbcae6134c: the finding may be moot until level 1 ships, since within one clone the refs are shared and claim already refuses, and that is itself an answer worth writing down rather than a reason to drop it.

--- a/.ank/tasks/TASK-2c1ccba48426.md
+++ b/.ank/tasks/TASK-2c1ccba48426.md
@@ -5,15 +5,19 @@ slug: second-pass-coordination-findings
 title: Second-pass coordination findings
 created: 2026-08-06T23:24:57Z
 author: seanl@sean-laptop
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/**
 blocked_by: []
 done_criteria: |
   The four findings appear in the body, each precise enough to act on, and ank check stays green on this repo.
 criteria_by: creator
+proof:
+  - type: test
+    ref: "31456251424"
+    criteria: 4d0c2b12b6b4
 schema: 2
-version: 4
+version: 5
 ---
 
 Read-only second pass over the coordination plane - claims, renewal, completion
@@ -61,3 +65,4 @@ being unimplemented, and done not warning on constraint drift.
 ## Log
 - 2026-08-11T03:41:26Z seanl@sean-laptop — Triage pass, each finding re-measured against the tree rather than trusted from the note. All four are still live. (1) log renewal recomputes DEFAULT_TTL.min(claim_ttl_max) at commands.rs:1316 and never reads the lease back off the record, so --ttl holds for one acquisition and collapses to thirty minutes at the first log; the record carries claimed and expires, so the granted lease is recoverable without a format change. (2) close calls claim::delete at human.rs:1910 where done converts the ref to a completion record, so a task closed on a branch reads open in every other clone until the merge -- the exact window ADR-bcf2 created the completion ref to close. (3) claim::prune at claim.rs:821 has no caller outside its own tests; the live predicate is human::maintain at human.rs:1153-1229. Two copies of the rule that decides when a coordination ref disappears, one unexercised in production. (4) execution mode renders the claimed task alone and drops the [claimed:holder] and [finished:sha] markers, so the agent best placed to notice a collision is the one that cannot see the plane; status reports the caller's own claim and not anyone else's. Filing one task per finding rather than fixing them under this claim: this task's criterion is about recording, and a fix needs a criterion of its own.
 - 2026-08-11T03:42:53Z seanl@sean-laptop — Four tasks filed, one per finding, each with a criterion that measures something the note did not: TASK-1b45f41e7b99 the TTL lease, TASK-78326e2e3e89 the close asymmetry, TASK-4981a1370c0b the duplicated pruning predicate, TASK-dacbcae6134c what a holder sees of the coordination plane. Three of the four are settled in the specification or an ADR before the code moves, because three of the four are questions about what the tool means rather than defects in what it does -- only the TTL one is unambiguously a bug. Noted while filing TASK-dacbcae6134c: the finding may be moot until level 1 ships, since within one clone the refs are shared and claim already refuses, and that is itself an answer worth writing down rather than a reason to drop it.
+- 2026-08-11T03:46:43Z seanl@sean-laptop — done, proof test:31456251424

--- a/.ank/tasks/TASK-4981a1370c0b.md
+++ b/.ank/tasks/TASK-4981a1370c0b.md
@@ -1,0 +1,40 @@
+---
+id: TASK-4981a1370c0b
+type: task
+slug: two-copies-of-the-pruning-predicate-and-the-live
+title: Two copies of the pruning predicate, and the live one is not the documented one
+created: 2026-08-11T03:42:12Z
+author: seanl@sean-laptop
+status: open
+scope:
+  - crates/ank-cli/src/claim.rs
+  - crates/ank-cli/src/human.rs
+blocked_by: []
+done_criteria: |
+  One predicate decides when a coordination ref disappears, reachable from the path that actually runs. If claim::prune goes, every case its unit tests cover is covered against the surviving predicate before they are deleted, named one by one in the task log. cargo test --workspace is green and no test asserts against a function no production path reaches: a grep for the removed name matches nothing outside its own history.
+criteria_by: creator
+schema: 2
+version: 1
+---
+
+`claim::prune` is documented as "called by check" and is called by nothing
+outside its own unit tests. The live path is `human::maintain`, which
+reimplements the same predicate: a completion ref disappears once the task
+reads `done` or `closed` on the default branch.
+
+Two copies of the rule that decides when a coordination ref disappears, and the
+unexercised one is free to drift from the one that runs. It is already the
+weaker copy: `maintain` learned, from TASK-52fbffbfdf65, to ask the default
+branch whether a task exists at all before treating its ref as an orphan --
+because a checkout older than a task sees no such task and used to delete a
+claim another worktree was holding. Whether `prune` carries that lesson is
+exactly the question nobody has to answer today, since nothing calls it.
+
+TASK-52fbffbfdf65 measured what a wrong pruning decision costs: a lost claim is
+a task two agents can hold at once. That is the reason this is not a tidiness
+finding.
+
+The likely answer is deletion rather than reconciliation -- `maintain` is the
+one that runs, and it has the context `prune` lacks. Deleting it takes its unit
+tests with it, so whatever they assert that `maintain`'s tests do not has to be
+carried over rather than dropped.

--- a/.ank/tasks/TASK-78326e2e3e89.md
+++ b/.ank/tasks/TASK-78326e2e3e89.md
@@ -1,0 +1,36 @@
+---
+id: TASK-78326e2e3e89
+type: task
+slug: close-leaves-no-completion-ref-and-nothing-says
+title: close leaves no completion ref, and nothing says whether that is meant
+created: 2026-08-11T03:41:56Z
+author: seanl@sean-laptop
+status: open
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/src/claim.rs
+  - .ank/adr/**
+  - crates/ank-cli/tests/**
+blocked_by: []
+done_criteria: |
+  The completion-ref ADR states what close leaves on the coordination plane and why it differs from done, or says the two are the same and close leaves a completion record too. The code matches the statement. Verified through the binary: an integration test closes a task on a non-default branch and asserts, by reading refs/ank/claims/<id> with git from a second checkout, exactly what the decision says should be there.
+criteria_by: creator
+schema: 2
+version: 1
+---
+
+`done` turns the claim ref into a completion record precisely so that a task
+finished on an unmerged branch does not look free in every other clone
+(ADR-bcf222a31525). `close` deletes the ref outright, so a task closed on a
+branch reads `open` everywhere else until the merge -- the exact window the
+completion ref was introduced to close.
+
+The asymmetry may well be right: a close is a decision rather than a result, it
+carries no proof, and a decision taken on a branch that is never merged is a
+decision nobody took. But nothing says so. ADR-bcf222a31525 names the gap
+without settling it, and the code reads as an omission rather than as a choice
+-- `done` and `close` are the two terminal transitions, and only one of them
+leaves a trace on the coordination plane.
+
+Whichever way it goes, the ADR is where it is recorded, since it is the ADR
+that created the mechanism.

--- a/.ank/tasks/TASK-9ff86a0950bf.md
+++ b/.ank/tasks/TASK-9ff86a0950bf.md
@@ -1,0 +1,38 @@
+---
+id: TASK-9ff86a0950bf
+type: task
+slug: the-over-constrained-signal-reports-a-budget-it
+title: The over-constrained signal reports a budget it does not test against
+created: 2026-08-11T03:47:37Z
+author: seanl@sean-laptop
+status: open
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/tests/**
+blocked_by: []
+done_criteria: |
+  The over-constrained signal names the threshold it actually applies, so that the number a reader compares against is the number that fired. Verified through the binary: an integration test builds a corpus whose constraints exceed half the configured context_budget without reaching it, runs ank check, and asserts the reported figures are consistent -- the quantity shown and the limit shown stand in the relation the signal tested.
+criteria_by: creator
+schema: 2
+version: 1
+---
+
+`check` reports `over-constrained scope: 5527 characters of constraint against
+a budget of 8000`. 5527 is under 8000, so a reader either concludes the tool is
+wrong or goes looking for the real threshold in the source. Both were measured
+on this repository: the signal fires on every `check` run here, and one session
+read `human.rs` to find out why.
+
+The threshold is not the budget. The test is `weight * 2 > cfg.context_budget`
+-- constraints alone eating more than *half* the budget, which the code comment
+beside it states plainly and the message does not. The number the reader needs
+is 4000, and the message shows 8000.
+
+The wording is the whole defect. Nothing about the rule is wrong: half the
+budget spent on constraints before a single task body is read is worth a
+signal, and §5 is where that reasoning lives.
+
+Worth fixing beyond tidiness because this signal is noise today. It fires on
+seven tasks in this corpus, every reader who checks it concludes it is
+miscounting, and a signal nobody believes is a signal that hides the next real
+one.

--- a/.ank/tasks/TASK-abbaab9007a0.md
+++ b/.ank/tasks/TASK-abbaab9007a0.md
@@ -5,7 +5,7 @@ slug: first-pass-tool-review-findings
 title: First-pass tool review findings
 created: 2026-08-06T04:28:44Z
 author: seanl@sean-laptop
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/**
   - docs/**
@@ -14,7 +14,7 @@ done_criteria: |
   The five review findings appear in the body, each precise enough to act on, and ank check stays green on this repo.
 criteria_by: creator
 schema: 2
-version: 1
+version: 3
 ---
 
 Hands-on, read-only first pass over ank (context, help, find, graph, status, check, show, scope, review, plus deliberate error cases). Nothing claimed or done; these are notes for later triage.
@@ -28,3 +28,6 @@ Hands-on, read-only first pass over ank (context, help, find, graph, status, che
 4. Ambiguous short ids. graph/status show short prefixes (e.g. TASK-8ebd), real ids are long (TASK-8ebd6e02f125). Prefix resolution works but nothing flags ambiguity.
 
 5. Silent dead scope in review/check. A scope matching no file returns clean output; the dead-scope signal only surfaces later via check. An agent alone can miss that its perimeter is gone.
+
+## Log
+- 2026-08-11T03:48:25Z seanl@sean-laptop — Triage pass, each of the five re-measured against the tree. Three are live and are now tasks: TASK-9ff86a0950bf the over-constrained signal naming a budget it does not test against, the threshold being weight*2 > budget so the number a reader needs is half the one shown; TASK-c1f01f301d63 the four-character short id, fixed length against a corpus of 150 entities and growing, printed by four verbs and refused by resolution; TASK-1ead0e19fb73 orientation spending its budget on constraints and leaving nothing for the choice. Two are settled and are not being refiled. Finding 2, the skill/verb gap, was the tension ADR-c656cbcc33a9 and ADR-e17e1bbd93ff resolved: there is one surface, the skill teaches two modes, and the two tasks the note pointed at are done. Finding 5, a dead scope only surfacing later through check, is what the scope verb was added for (TASK-e717ee625c5c) -- its own doc comment names this case, and check already separates a dead scope from a scope ahead of the code. Recording that they were checked rather than dropping them silently: a finding that quietly disappears is indistinguishable from one nobody read.

--- a/.ank/tasks/TASK-abbaab9007a0.md
+++ b/.ank/tasks/TASK-abbaab9007a0.md
@@ -5,7 +5,7 @@ slug: first-pass-tool-review-findings
 title: First-pass tool review findings
 created: 2026-08-06T04:28:44Z
 author: seanl@sean-laptop
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/**
   - docs/**
@@ -13,8 +13,12 @@ blocked_by: []
 done_criteria: |
   The five review findings appear in the body, each precise enough to act on, and ank check stays green on this repo.
 criteria_by: creator
+proof:
+  - type: test
+    ref: "31456525512"
+    criteria: fd3455c4bfc0
 schema: 2
-version: 3
+version: 4
 ---
 
 Hands-on, read-only first pass over ank (context, help, find, graph, status, check, show, scope, review, plus deliberate error cases). Nothing claimed or done; these are notes for later triage.
@@ -31,3 +35,4 @@ Hands-on, read-only first pass over ank (context, help, find, graph, status, che
 
 ## Log
 - 2026-08-11T03:48:25Z seanl@sean-laptop — Triage pass, each of the five re-measured against the tree. Three are live and are now tasks: TASK-9ff86a0950bf the over-constrained signal naming a budget it does not test against, the threshold being weight*2 > budget so the number a reader needs is half the one shown; TASK-c1f01f301d63 the four-character short id, fixed length against a corpus of 150 entities and growing, printed by four verbs and refused by resolution; TASK-1ead0e19fb73 orientation spending its budget on constraints and leaving nothing for the choice. Two are settled and are not being refiled. Finding 2, the skill/verb gap, was the tension ADR-c656cbcc33a9 and ADR-e17e1bbd93ff resolved: there is one surface, the skill teaches two modes, and the two tasks the note pointed at are done. Finding 5, a dead scope only surfacing later through check, is what the scope verb was added for (TASK-e717ee625c5c) -- its own doc comment names this case, and check already separates a dead scope from a scope ahead of the code. Recording that they were checked rather than dropping them silently: a finding that quietly disappears is indistinguishable from one nobody read.
+- 2026-08-11T03:51:42Z seanl@sean-laptop — done, proof test:31456525512

--- a/.ank/tasks/TASK-c1f01f301d63.md
+++ b/.ank/tasks/TASK-c1f01f301d63.md
@@ -1,0 +1,40 @@
+---
+id: TASK-c1f01f301d63
+type: task
+slug: a-displayed-short-id-can-name-two-entities-and-n
+title: A displayed short id can name two entities, and nothing says so
+created: 2026-08-11T03:47:53Z
+author: seanl@sean-laptop
+status: open
+scope:
+  - crates/ank-core/src/id.rs
+  - crates/ank-cli/src/**
+  - crates/ank-cli/tests/**
+blocked_by: []
+done_criteria: |
+  A short id the binary prints resolves to exactly one entity in the corpus it was printed from. Verified through the binary: an integration test seeds two entities sharing the first four hex characters of their id, runs the verbs that display short ids, and asserts that every short id in their output is accepted by ank show without a code 2. The rule is written into section 3 or 4 of docs/ank-spec-v1.1.md before the code moves, since the displayed form of an identifier is part of the format's surface.
+criteria_by: creator
+schema: 2
+version: 1
+---
+
+`EntityId::short` is four hex characters, fixed, and `graph`, `status`,
+`context` and `find` all display it. Resolution refuses an ambiguous prefix
+cleanly -- code 2, "the prefix matches more than one" -- so nothing here
+produces a wrong answer. What it produces is an identifier the tool printed and
+the tool then refuses, which is a worse trade than it looks: the caller has no
+way to know the id they were handed is unusable until they use it.
+
+The arithmetic is not remote. Four hex characters is 65536 values, and this
+corpus already holds around 150 entities; the chance that some pair collides is
+already double digits and grows with the square of the corpus. A repository
+using ank for two years is not an edge case here, it is the target.
+
+Git solved this and the solution is known: abbreviate to the length that is
+unambiguous in the corpus at hand, not to a constant. The cost is that the
+displayed length is no longer fixed, which is a column-alignment question and
+nothing more.
+
+The alternative -- keep four and have `check` report collisions -- is cheaper
+and worse: it reports after the fact something the display could have avoided,
+and it leaves the printed id unusable in the meantime.

--- a/.ank/tasks/TASK-dacbcae6134c.md
+++ b/.ank/tasks/TASK-dacbcae6134c.md
@@ -1,0 +1,44 @@
+---
+id: TASK-dacbcae6134c
+type: task
+slug: execution-mode-hides-the-coordination-plane-and
+title: Execution mode hides the coordination plane, and nothing says whether that is meant
+created: 2026-08-11T03:42:29Z
+author: seanl@sean-laptop
+status: open
+scope:
+  - docs/ank-spec-v1.1.md
+  - crates/ank-cli/src/context.rs
+  - crates/ank-cli/src/status.rs
+blocked_by: []
+done_criteria: |
+  Section 5 of docs/ank-spec-v1.1.md says what a holder of a claim can see of the coordination plane and why, naming which verb answers it. If the answer is that execution mode shows nothing and status is where the question belongs, section 5 says so and status carries it; if execution mode is to show it, context does. Either way a test through the binary asserts what the specification now promises, with a second agent holding a claim on another task.
+criteria_by: creator
+schema: 2
+version: 1
+---
+
+With a claim held, `context` switches to execution mode and renders that task
+alone: criterion, constraints, log. The coordination markers `[claimed:holder]`
+and `[finished:sha on branch]` are orientation-mode only.
+
+So the agent best placed to notice a collision -- the one currently working --
+is the one that cannot see the coordination plane any more. `ank status` does
+not fill the gap: it reports the caller's own claim, not anyone else's.
+
+This may be correct by design. Execution mode exists to remove choice, and a
+list of what other agents hold is exactly the choice it removes; an agent that
+starts reading the plane mid-task is an agent that has stopped working on its
+own. If that is the reading, it is currently unrecorded, and the question will
+be asked again by the next person who notices.
+
+If it is not the reading, `status` is the natural place rather than `context`:
+it already answers "where am I", it is off the loop, and it costs execution
+mode nothing.
+
+What would settle it is a measurement rather than an opinion: whether a
+collision an agent could have acted on is actually reachable while a claim is
+held. Level 1 is not implemented (TASK-82c3341502c1), so within one clone the
+claim refs are shared and `claim` already refuses -- which may make this
+finding moot until claims are pushed, and that is itself an answer worth
+writing down.


### PR DESCRIPTION
Closes TASK-2c1ccba48426 (CI run 31456251424) and TASK-abbaab9007a0
(CI run 31456525512).

Both were notes-for-later-triage containers, and their criteria -- *the findings
appear in the body, and `ank check` stays green* -- were satisfiable by
inspection. Closing them on that alone would have been honest to the letter and
useless: the findings would stay notes and the tasks would leave the open list.
So every one of the nine was re-measured against the tree, and each survivor is
now a task with a criterion that measures something.

## Second pass, coordination (all four still live)

| | |
|---|---|
| TASK-1b45f41e7b99 | `log` renewal recomputes `DEFAULT_TTL.min(claim_ttl_max)` and never reads the lease off the record, so `--ttl` holds for one acquisition and collapses to thirty minutes at the first `log` -- which the loop tells agents to run often |
| TASK-78326e2e3e89 | `close` deletes the claim ref where `done` converts it to a completion record, so a task closed on a branch reads `open` in every other clone until the merge: the window ADR-bcf222a31525 created the completion ref to close |
| TASK-4981a1370c0b | `claim::prune` has no caller outside its own tests; the live predicate is `human::maintain`. Two copies of the rule that decides when a coordination ref disappears, and the unexercised one is free to drift |
| TASK-dacbcae6134c | execution mode drops the coordination markers, so the agent best placed to notice a collision is the one that cannot see the plane |

Three of the four are settled in the specification or in an ADR before the code
moves, because three of the four are questions about what the tool means rather
than defects in what it does. Only the TTL one is unambiguously a bug.

## First pass, tools (three live, two settled)

| | |
|---|---|
| TASK-9ff86a0950bf | `check` reports `5527 characters of constraint against a budget of 8000`, which reads as arithmetic nobody can believe. The test is `weight * 2 > context_budget`: the number a reader needs is 4000. It fires on seven tasks here, and a signal nobody believes hides the next real one |
| TASK-c1f01f301d63 | `EntityId::short` is four hex characters, fixed -- printed by four verbs, refused by resolution when two collide. 65536 values against a corpus near 150 and growing with the square |
| TASK-1ead0e19fb73 | a cold `ank context` answers with twelve constraints in full and one task line. Orientation is for choosing, and the budget does not distinguish it from execution, where a constraint is rightly never truncated |

Two are **settled and deliberately not refiled**: the skill/verb gap was the
tension ADR-c656cbcc33a9 and ADR-e17e1bbd93ff resolved, and a dead scope
surfacing only through `check` is what the `scope` verb was added for
(TASK-e717ee625c5c) -- its own doc comment names this case. That they were
checked is recorded in the task's log rather than left silent: a finding that
quietly disappears is indistinguishable from one nobody read.

No code changes. Nine `.ank/` entities, and CI is what proves `ank check` stays
green -- which is the half of both criteria that a local run cannot anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RYLJW2CXtQn1zCLRLcqZ7