### PR TITLE
The over-constrained signal reports the limit it tested

### DIFF
--- a/.ank/tasks/TASK-5bd23835d5a0.md
+++ b/.ank/tasks/TASK-5bd23835d5a0.md
@@ -1,0 +1,57 @@
+---
+id: TASK-5bd23835d5a0
+type: task
+slug: done-and-log-refuse-a-lapsed-claim-the-specifica
+title: done and log refuse a lapsed claim the specification says they re-acquire
+created: 2026-08-11T05:38:10Z
+author: seanl@sean-laptop
+status: open
+scope:
+  - crates/ank-cli/src/done.rs
+  - crates/ank-cli/src/commands.rs
+  - crates/ank-cli/src/claim.rs
+  - crates/ank-cli/tests/**
+blocked_by: []
+done_criteria: |
+  With a lapsed claim on a task nobody else has taken, done and log carry on rather than refusing: they re-acquire the ref in the caller's name, as section 3 of docs/ank-spec-v1.1.md describes. A task taken over by another agent in the meantime still fails with code 4 and names the new holder. Verified through the binary: an integration test claims with a short --ttl, waits for the claim to lapse without logging, and asserts that log then done both succeed and that refs/ank/claims/<id> names the caller; a second test has another agent claim the lapsed task first and asserts code 4 with the new holder named.
+criteria_by: creator
+schema: 2
+version: 1
+---
+
+Measured in the nominal flow, not constructed. A claim on TASK-9ff86a0950bf
+lapsed while its CI run finished; nobody had taken it over, and the ref was
+still sitting there naming this agent as holder. Both `ank done` and
+`ank done <id>` answered:
+
+    error[6]: no task in progress for this agent
+      -> ank context
+
+Section 3 promises the opposite, in as many words:
+
+> Return after expiry. A 40-minute build with no `log` expires the claim; that
+> is normal, not a fault. On expiry the task stays `in_progress` and becomes
+> claimable again. When the original holder returns: if nobody took the task
+> over, `log` and `done` re-acquire silently and carry on; if another agent
+> took it over in the meantime, they fail with code 4 and the name of the new
+> holder.
+
+So the specified behaviour is three-way -- re-acquire, code 4 with the new
+holder, or nothing to do -- and the binary collapses it to one refusal that
+names none of the three. The mechanics are already written down there too:
+check that no active claim exists for the task, then recreate the ref in the
+current agent's name, both resting on the atomic ref update.
+
+The case is not exotic; it is the one the paragraph was written for. A CI wait
+is longer than a thirty-minute TTL more often than not, and `done` is precisely
+the command an agent runs after one. The workaround is `ank claim <id>` again,
+which works because `acquire` handles a lapsed ref correctly -- so what is
+missing is the route from `done` to that code path, not the code path.
+
+Worth checking whether `log` has the same gap: the same helper resolves the
+held task for both, and the sentence in section 3 names them together.
+
+Whether re-acquisition should be silent or announced is a real question the
+implementer should settle rather than assume. Silent is what section 3 says;
+a line on standard error saying the claim had lapsed and was retaken costs
+nothing and tells the agent something true about the world.

--- a/.ank/tasks/TASK-9ff86a0950bf.md
+++ b/.ank/tasks/TASK-9ff86a0950bf.md
@@ -5,7 +5,7 @@ slug: the-over-constrained-signal-reports-a-budget-it
 title: The over-constrained signal reports a budget it does not test against
 created: 2026-08-11T03:47:37Z
 author: seanl@sean-laptop
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/src/human.rs
   - crates/ank-cli/tests/**
@@ -14,7 +14,7 @@ done_criteria: |
   The over-constrained signal names the threshold it actually applies, so that the number a reader compares against is the number that fired. Verified through the binary: an integration test builds a corpus whose constraints exceed half the configured context_budget without reaching it, runs ank check, and asserts the reported figures are consistent -- the quantity shown and the limit shown stand in the relation the signal tested.
 criteria_by: creator
 schema: 2
-version: 1
+version: 3
 ---
 
 `check` reports `over-constrained scope: 5527 characters of constraint against
@@ -36,3 +36,6 @@ Worth fixing beyond tidiness because this signal is noise today. It fires on
 seven tasks in this corpus, every reader who checks it concludes it is
 miscounting, and a signal nobody believes is a signal that hides the next real
 one.
+
+## Log
+- 2026-08-11T05:04:22Z seanl@sean-laptop — No specification change: section 5 already states the rule correctly, over-constrained being constraints alone consuming more than half the budget in execution mode. Only the message lied. The fix is one variable for the threshold tested and the threshold reported, not a rewording -- the test was weight*2 > context_budget and the message printed the budget, so the two numbers came from different places and were free to disagree. Now both come from the same binding and cannot. Integer division is exact here in both directions: weight > b/2 floored and weight*2 > b select the same set, so the threshold moved presentation only. The test parses the two numbers back out of the message and asserts the relation rather than the wording -- a test on a fixed string would have passed on the old message, which was well-formed and wrong. Proven to bite: restoring the old format fails with '301 characters of constraint against a budget of 400'. No existing test asserted the old wording, which is why it survived from revision c.

--- a/.ank/tasks/TASK-9ff86a0950bf.md
+++ b/.ank/tasks/TASK-9ff86a0950bf.md
@@ -5,7 +5,7 @@ slug: the-over-constrained-signal-reports-a-budget-it
 title: The over-constrained signal reports a budget it does not test against
 created: 2026-08-11T03:47:37Z
 author: seanl@sean-laptop
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/src/human.rs
   - crates/ank-cli/tests/**
@@ -13,8 +13,12 @@ blocked_by: []
 done_criteria: |
   The over-constrained signal names the threshold it actually applies, so that the number a reader compares against is the number that fired. Verified through the binary: an integration test builds a corpus whose constraints exceed half the configured context_budget without reaching it, runs ank check, and asserts the reported figures are consistent -- the quantity shown and the limit shown stand in the relation the signal tested.
 criteria_by: creator
+proof:
+  - type: test
+    ref: "31462037023"
+    criteria: c77967b89e0c
 schema: 2
-version: 3
+version: 5
 ---
 
 `check` reports `over-constrained scope: 5527 characters of constraint against
@@ -39,3 +43,4 @@ one.
 
 ## Log
 - 2026-08-11T05:04:22Z seanl@sean-laptop — No specification change: section 5 already states the rule correctly, over-constrained being constraints alone consuming more than half the budget in execution mode. Only the message lied. The fix is one variable for the threshold tested and the threshold reported, not a rewording -- the test was weight*2 > context_budget and the message printed the budget, so the two numbers came from different places and were free to disagree. Now both come from the same binding and cannot. Integer division is exact here in both directions: weight > b/2 floored and weight*2 > b select the same set, so the threshold moved presentation only. The test parses the two numbers back out of the message and asserts the relation rather than the wording -- a test on a fixed string would have passed on the old message, which was well-formed and wrong. Proven to bite: restoring the old format fails with '301 characters of constraint against a budget of 400'. No existing test asserted the old wording, which is why it survived from revision c.
+- 2026-08-11T05:37:47Z seanl@sean-laptop — done, proof test:31462037023

--- a/crates/ank-cli/src/human.rs
+++ b/crates/ank-cli/src/human.rs
@@ -780,16 +780,25 @@ fn check_task(
 
     // Over-constrained (§5): constraints alone eating more than half the budget
     // in execution mode. A corpus problem, not a display problem.
+    //
+    // **One variable for the threshold tested and the threshold reported.** It
+    // used to test `weight * 2 > context_budget` and report the budget, so the
+    // message read `5527 characters of constraint against a budget of 8000` --
+    // arithmetic no reader can believe. Every reader who checked it concluded
+    // the tool was miscounting, and one went to the source to find out that the
+    // limit is half of that (TASK-9ff86a0950bf). The two numbers cannot
+    // disagree again while they come from the same binding, which is the fix;
+    // rewording alone would have left the next edit free to separate them.
     if matches!(t.status, TaskStatus::Open | TaskStatus::InProgress) {
         if let Ok(applicable) = claim::applicable_constraints(store, repo, t) {
             let weight: usize = applicable.iter().map(|(_, c)| c.chars().count()).sum();
-            if weight * 2 > cfg.context_budget {
+            let limit = cfg.context_budget / 2;
+            if weight > limit {
                 report.findings.push(Finding::signal(
                     &t.id,
                     format!(
                         "over-constrained scope: {weight} characters of constraint against a \
-                         budget of {}",
-                        cfg.context_budget
+                         limit of {limit}, half of context_budget"
                     ),
                 ));
             }

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -2569,6 +2569,87 @@ fn init_refuses_repo_and_writes_into_neither_repository() {
     let _ = std::fs::remove_dir_all(&named);
 }
 
+/// The over-constrained signal reports the threshold it actually applied.
+///
+/// The two numbers are parsed back out of the message and compared, which is
+/// the only assertion that catches the defect: the signal used to report the
+/// budget while testing half of it, so `check` said `5527 characters of
+/// constraint against a budget of 8000` and every reader who checked the
+/// arithmetic concluded the tool was miscounting (TASK-9ff86a0950bf). A test
+/// asserting a fixed wording would have passed on that message.
+///
+/// The corpus is built to land in the gap the defect lived in: over half the
+/// budget, under the budget. Anywhere else the two readings agree.
+#[test]
+fn the_over_constrained_signal_reports_the_limit_it_tested() {
+    let r = Repo::new();
+    r.set_config("schema: 1\nclaim_ttl_max: 2h\ndefault_branch: main\ncontext_budget: 400\n");
+    r.seed_task(ID, Some("A verifiable criterion."));
+    std::fs::create_dir_all(r.0.join("src")).unwrap();
+    std::fs::write(r.0.join("src/main.rs"), "fn main() {}\n").unwrap();
+
+    // 300 characters: over the 200 that half of 400 allows, and well under 400.
+    let rule = "x".repeat(300);
+    r.seed_adr("ADR-0000000000ab", &rule, "src/**");
+    let accepted = r
+        .adr_text("ADR-0000000000ab")
+        .replace("status: proposed", "status: accepted");
+    std::fs::write(r.0.join(".ank/adr/ADR-0000000000ab.md"), accepted).unwrap();
+
+    let out = r.ank("claude-code@ank", &["check"]);
+    let said = format!("{}{}", stdout(&out), stderr(&out));
+    let line = said
+        .lines()
+        .find(|l| l.contains("over-constrained"))
+        .unwrap_or_else(|| panic!("the signal did not fire on a corpus built to trip it:\n{said}"));
+
+    // From the message alone: the subject is an id, and an id is full of digits.
+    let message = line
+        .split_once("over-constrained scope:")
+        .expect("the line was found by that needle")
+        .1;
+    let numbers: Vec<usize> = message
+        .split(|c: char| !c.is_ascii_digit())
+        .filter(|w| !w.is_empty())
+        .map(|w| w.parse().unwrap())
+        .collect();
+    assert_eq!(
+        numbers.len(),
+        2,
+        "the signal must name the quantity and the limit, and nothing else \
+         numeric: {line}"
+    );
+    let (quantity, limit) = (numbers[0], numbers[1]);
+    assert!(
+        quantity > limit,
+        "the signal fired while reporting a limit the quantity does not exceed, \
+         which is arithmetic no reader can believe: {line}"
+    );
+    // The constraint as stored carries its trailing newline, so the count is
+    // the 300 written plus it.
+    assert_eq!(quantity, 301, "{line}");
+    assert_eq!(limit, 200, "half of the configured budget: {line}");
+
+    // And it stays silent just under the threshold, so the assertion above is
+    // about the reported figures and not about a signal that always fires.
+    let quiet = Repo::new();
+    quiet.set_config("schema: 1\nclaim_ttl_max: 2h\ndefault_branch: main\ncontext_budget: 400\n");
+    quiet.seed_task(ID, Some("A verifiable criterion."));
+    std::fs::create_dir_all(quiet.0.join("src")).unwrap();
+    std::fs::write(quiet.0.join("src/main.rs"), "fn main() {}\n").unwrap();
+    quiet.seed_adr("ADR-0000000000ab", &"x".repeat(150), "src/**");
+    let accepted = quiet
+        .adr_text("ADR-0000000000ab")
+        .replace("status: proposed", "status: accepted");
+    std::fs::write(quiet.0.join(".ank/adr/ADR-0000000000ab.md"), accepted).unwrap();
+    let out = quiet.ank("claude-code@ank", &["check"]);
+    assert!(
+        !stdout(&out).contains("over-constrained"),
+        "{}",
+        stdout(&out)
+    );
+}
+
 /// A renewal reuses the lease the claim was granted, and re-caps it.
 ///
 /// Through the binary and against the ref itself, because the lease is a fact


### PR DESCRIPTION
Closes TASK-9ff86a0950bf, anchored on CI run 31462037023.

`check` said `5527 characters of constraint against a budget of 8000`, which is
arithmetic no reader can believe: 5527 is under 8000. The threshold is not the
budget -- the test is `weight * 2 > context_budget`, constraints alone eating
more than **half** of it. Section 5 states that correctly; the message did not.
The number a reader needs was 4000 and the message showed 8000.

```
-over-constrained scope: 5527 characters of constraint against a budget of 8000
+over-constrained scope: 5527 characters of constraint against a limit of 4000, half of context_budget
```

**The fix is one variable for the threshold tested and the threshold reported**,
not a rewording. The two numbers came from different places and were therefore
free to disagree; now they come from the same binding and cannot. Integer
division is exact in both directions here -- `weight > b/2` floored and
`weight * 2 > b` select the same set -- so the threshold itself did not move,
only its presentation.

Worth more than tidiness: the signal fires on seven tasks in this corpus, every
reader who checked it concluded the tool was miscounting, and one went to the
source to find out otherwise. A signal nobody believes hides the next real one.

## The test asserts the relation, not the wording

It parses the two numbers back out of the message and asserts that the quantity
exceeds the limit. A test on a fixed string would have passed on the old
message, which was well-formed and wrong -- and no test asserted it at all,
which is how it survived since revision `c`. Proven to bite: restoring the old
format fails with

```
the signal fired while reporting a limit the quantity does not exceed, which is
arithmetic no reader can believe: ... 301 characters of constraint against a
budget of 400
```

No specification change: section 5 already had the rule right.

## Found while closing this

The claim lapsed during the CI wait, and `ank done` refused with
`error[6]: no task in progress for this agent` instead of re-acquiring. Section
3 calls that case normal and specifies the opposite. Filed as
TASK-5bd23835d5a0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RYLJW2CXtQn1zCLRLcqZ7