### PR TITLE
One predicate decides when a coordination ref disappears

### DIFF
--- a/.ank/tasks/TASK-4981a1370c0b.md
+++ b/.ank/tasks/TASK-4981a1370c0b.md
@@ -5,7 +5,7 @@ slug: two-copies-of-the-pruning-predicate-and-the-live
 title: Two copies of the pruning predicate, and the live one is not the documented one
 created: 2026-08-11T03:42:12Z
 author: seanl@sean-laptop
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/src/claim.rs
   - crates/ank-cli/src/human.rs
@@ -13,8 +13,12 @@ blocked_by: []
 done_criteria: |
   One predicate decides when a coordination ref disappears, reachable from the path that actually runs. If claim::prune goes, every case its unit tests cover is covered against the surviving predicate before they are deleted, named one by one in the task log. cargo test --workspace is green and no test asserts against a function no production path reaches: a grep for the removed name matches nothing outside its own history.
 criteria_by: creator
+proof:
+  - type: test
+    ref: "31464502863"
+    criteria: 01eb68a84a3a
 schema: 2
-version: 4
+version: 5
 ---
 
 `claim::prune` is documented as "called by check" and is called by nothing
@@ -42,3 +46,4 @@ carried over rather than dropped.
 ## Log
 - 2026-08-11T06:10:36Z seanl@sean-laptop — Case-by-case comparison done before touching anything. maintain is strictly the richer predicate: it iterates the records inspect already read rather than re-reading the refs, it knows the orphan case and carries the TASK-52fbffbfdf65 lesson of asking the default branch rather than the working tree, it separates a branch it cannot read from a file that is absent -- reporting once and pruning nothing rather than propagating the error -- it emits the finished-on-another-branch signal, and it takes prune as a parameter so review inspects without touching the plane. claim::prune has none of that and propagates file_at errors with ?. So the answer is deletion, as the task body expected. Four cases its tests cover are not covered against maintain and are being carried over first: the working tree saying done while the branch does not, which is the sharp half and the whole point of the predicate; closed pruning like done, which the code handles and no test exercises; a live claim on an open task present on the branch being left alone; and a task present in the tree but absent from the default branch being left alone. claiming_never_prunes does not call prune and survives untouched.
 - 2026-08-11T06:16:41Z seanl@sean-laptop — Carried over first, deleted second, and the four are named here as the criterion asks. the_tree_saying_done_is_not_the_branch_saying_done covers the working tree saying done while the branch does not, then pruning once the commit lands -- the sharp half, and the whole reason the predicate reads the branch. closed_prunes_like_done_and_the_rest_is_left_alone covers the other three in one fixture: closed settling a ref as done does, a live claim on an open task left alone, and a task present in the tree but never carried by the default branch left alone. Both assert through inspect, which is the path check runs, rather than against a function nothing calls. Then claim::prune and its two tests went. claiming_never_prunes stayed: it never called prune, it asserts that claim leaves refs where they are. The removed name now matches only two doc comments that explain where the cases went, which is its own history and nothing else. Note for whoever reads this later: maintain takes prune as a bool and Report carries pruned, so a grep for the bare word still hits -- the thing that is gone is claim::prune, the second implementation.
+- 2026-08-11T06:20:22Z seanl@sean-laptop — done, proof test:31464502863

--- a/.ank/tasks/TASK-4981a1370c0b.md
+++ b/.ank/tasks/TASK-4981a1370c0b.md
@@ -5,7 +5,7 @@ slug: two-copies-of-the-pruning-predicate-and-the-live
 title: Two copies of the pruning predicate, and the live one is not the documented one
 created: 2026-08-11T03:42:12Z
 author: seanl@sean-laptop
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/src/claim.rs
   - crates/ank-cli/src/human.rs
@@ -14,7 +14,7 @@ done_criteria: |
   One predicate decides when a coordination ref disappears, reachable from the path that actually runs. If claim::prune goes, every case its unit tests cover is covered against the surviving predicate before they are deleted, named one by one in the task log. cargo test --workspace is green and no test asserts against a function no production path reaches: a grep for the removed name matches nothing outside its own history.
 criteria_by: creator
 schema: 2
-version: 1
+version: 4
 ---
 
 `claim::prune` is documented as "called by check" and is called by nothing
@@ -38,3 +38,7 @@ The likely answer is deletion rather than reconciliation -- `maintain` is the
 one that runs, and it has the context `prune` lacks. Deleting it takes its unit
 tests with it, so whatever they assert that `maintain`'s tests do not has to be
 carried over rather than dropped.
+
+## Log
+- 2026-08-11T06:10:36Z seanl@sean-laptop — Case-by-case comparison done before touching anything. maintain is strictly the richer predicate: it iterates the records inspect already read rather than re-reading the refs, it knows the orphan case and carries the TASK-52fbffbfdf65 lesson of asking the default branch rather than the working tree, it separates a branch it cannot read from a file that is absent -- reporting once and pruning nothing rather than propagating the error -- it emits the finished-on-another-branch signal, and it takes prune as a parameter so review inspects without touching the plane. claim::prune has none of that and propagates file_at errors with ?. So the answer is deletion, as the task body expected. Four cases its tests cover are not covered against maintain and are being carried over first: the working tree saying done while the branch does not, which is the sharp half and the whole point of the predicate; closed pruning like done, which the code handles and no test exercises; a live claim on an open task present on the branch being left alone; and a task present in the tree but absent from the default branch being left alone. claiming_never_prunes does not call prune and survives untouched.
+- 2026-08-11T06:16:41Z seanl@sean-laptop — Carried over first, deleted second, and the four are named here as the criterion asks. the_tree_saying_done_is_not_the_branch_saying_done covers the working tree saying done while the branch does not, then pruning once the commit lands -- the sharp half, and the whole reason the predicate reads the branch. closed_prunes_like_done_and_the_rest_is_left_alone covers the other three in one fixture: closed settling a ref as done does, a live claim on an open task left alone, and a task present in the tree but never carried by the default branch left alone. Both assert through inspect, which is the path check runs, rather than against a function nothing calls. Then claim::prune and its two tests went. claiming_never_prunes stayed: it never called prune, it asserts that claim leaves refs where they are. The removed name now matches only two doc comments that explain where the cases went, which is its own history and nothing else. Note for whoever reads this later: maintain takes prune as a bool and Report carries pruned, so a grep for the bare word still hits -- the thing that is gone is claim::prune, the second implementation.

--- a/crates/ank-cli/src/claim.rs
+++ b/crates/ank-cli/src/claim.rs
@@ -920,35 +920,19 @@ fn lost_the_race(
 /// reader does not sanitise the coordination plane underneath everyone else,
 /// and concentrating maintenance in one command is what makes its timing
 /// predictable.
-pub fn prune(cwd: &Path, tasks_prefix: &str, default_branch: &str) -> Result<Vec<EntityId>> {
-    let mut pruned = Vec::new();
-    for r in git::ank_refs(cwd)? {
-        let Some(rest) = r.name.strip_prefix(CLAIMS_PREFIX) else {
-            // Another ank namespace, or an orphan ref whose name is not an
-            // identifier. Not ours to judge here.
-            continue;
-        };
-        let Ok(id) = EntityId::parse(rest) else {
-            continue;
-        };
-        let path = format!("{}/{id}.md", tasks_prefix.trim_end_matches('/'));
-        let Some(text) = git::file_at(cwd, default_branch, &path)? else {
-            // Absent from the default branch: this is precisely the unmerged
-            // case the ref exists for.
-            continue;
-        };
-        // A file that does not parse settles nothing, so it prunes nothing;
-        // reporting it is `check`'s job, not maintenance's.
-        let Ok(Entity::Task(t)) = ank_core::parse_entity(&text) else {
-            continue;
-        };
-        if matches!(t.status, TaskStatus::Done | TaskStatus::Closed) {
-            delete(cwd, &id)?;
-            pruned.push(id);
-        }
-    }
-    Ok(pruned)
-}
+// The predicate itself lives in `human::maintain`, which is what `check` runs.
+// A second implementation stood here for a long time, documented as "called by
+// check" and called by nothing outside its own tests (TASK-4981a1370c0b): two
+// copies of the rule that decides when a coordination ref disappears, and the
+// unexercised one free to drift from the one that runs. It was already the
+// weaker copy — it had never learned, as `maintain` did from
+// TASK-52fbffbfdf65, to ask the default branch whether a task exists before
+// treating its ref as an orphan, because a checkout older than a task sees no
+// such task and used to delete a claim another worktree was holding.
+//
+// What a wrong pruning decision costs is a lost claim, which is a task two
+// agents can hold at once. That is why the duplication was worth removing
+// rather than tidying.
 
 // ---------------------------------------------------------------------------
 // The verb
@@ -1232,7 +1216,7 @@ fn other_ready_task(cwd: &Path, store: &Store, task: &Task) -> Option<EntityId> 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ank_core::{serialize_entity, Adr, Proof};
+    use ank_core::{serialize_entity, Adr};
     use std::path::PathBuf;
     use std::process::Command;
     use std::sync::atomic::{AtomicU64, Ordering};
@@ -1787,71 +1771,14 @@ mod tests {
     // Pruning
     // -----------------------------------------------------------------------
 
-    #[test]
-    fn pruning_follows_the_default_branch_and_never_the_working_tree() {
-        let t = Temp::new_repo();
-        let mut task = open_task("000000000001");
-        t.seed(&task);
-        t.commit_all("seed");
-        take(&t, &task, "claude-code@ank", DEFAULT_TTL).unwrap();
-        complete(&t.0, &task.id, "claude-code@ank").unwrap();
-
-        // The working tree says done; the branch does not yet. This is the
-        // unmerged case, and pruning here would reopen the window.
-        task.status = TaskStatus::Done;
-        task.proof = vec![Proof {
-            proof_type: ank_core::ProofType::Commit,
-            reference: "0123456".into(),
-            tree: None,
-            criteria: None,
-            verifier: None,
-        }];
-        t.seed(&task);
-        assert_eq!(
-            prune(&t.0, ".ank/tasks", "main").unwrap(),
-            vec![],
-            "the tree is not the branch"
-        );
-        assert!(read(&t.0, &task.id).unwrap().is_some());
-
-        // Once the branch carries it, the ref has no further use.
-        t.commit_all("done");
-        assert_eq!(
-            prune(&t.0, ".ank/tasks", "main").unwrap(),
-            vec![task.id.clone()]
-        );
-        assert!(read(&t.0, &task.id).unwrap().is_none());
-    }
-
-    #[test]
-    fn pruning_covers_closed_and_leaves_everything_else_alone() {
-        let t = Temp::new_repo();
-        let mut closed = open_task("000000000001");
-        let live = open_task("00000000ffff");
-        t.seed(&closed);
-        t.seed(&live);
-        t.commit_all("seed");
-
-        take(&t, &closed, "claude-code@ank", DEFAULT_TTL).unwrap();
-        take(&t, &live, "codex@host-9", DEFAULT_TTL).unwrap();
-
-        closed.status = TaskStatus::Closed;
-        t.seed(&closed);
-        t.commit_all("closed");
-
-        assert_eq!(prune(&t.0, ".ank/tasks", "main").unwrap(), vec![closed.id]);
-        assert!(
-            read(&t.0, &live.id).unwrap().is_some(),
-            "an open task's claim is not maintenance's business"
-        );
-
-        // A task absent from the default branch is exactly the unmerged case.
-        let unmerged = open_task("00000000aaaa");
-        t.seed(&unmerged);
-        take(&t, &unmerged, "claude-code@ank", DEFAULT_TTL).unwrap();
-        assert_eq!(prune(&t.0, ".ank/tasks", "main").unwrap(), vec![]);
-        assert!(read(&t.0, &unmerged.id).unwrap().is_some());
-    }
+    // The two tests that stood here exercised the second copy of the pruning
+    // predicate, and went with it (TASK-4981a1370c0b). Every case they covered
+    // is asserted against the predicate that actually runs, in `human`'s tests:
+    // `the_tree_saying_done_is_not_the_branch_saying_done` for the branch
+    // against the working tree, and
+    // `closed_prunes_like_done_and_the_rest_is_left_alone` for `closed`, for an
+    // open task's live claim, and for a task the default branch has never
+    // carried. The one below stays: it is about `claim`, not about pruning.
 
     #[test]
     fn claiming_never_prunes() {

--- a/crates/ank-cli/src/human.rs
+++ b/crates/ank-cli/src/human.rs
@@ -3451,6 +3451,83 @@ mod tests {
         assert!(claim::read(&t.0, &id).unwrap().is_none());
     }
 
+    /// The predicate is the file **as the default branch carries it**, and the
+    /// working tree is not the branch (ADR-bcf222a31525).
+    ///
+    /// The sharp half, and the one that decides whether the mechanism works at
+    /// all: `done` writes to the working tree, so between the work and the
+    /// merge the tree says `done` while the branch does not. Pruning there
+    /// would reopen the exact window the completion ref exists to close, in the
+    /// exact situation it exists for.
+    ///
+    /// Carried over from `claim::prune`'s own tests when that second copy of
+    /// the predicate was deleted (TASK-4981a1370c0b). The rule had two
+    /// implementations and this half was only ever asserted against the one
+    /// nothing called.
+    #[test]
+    fn the_tree_saying_done_is_not_the_branch_saying_done() {
+        let t = Temp::new();
+        let id = EntityId::parse("TASK-000000000001").unwrap();
+        t.write(&task("000000000001", TaskStatus::InProgress, &[]));
+        t.commit("seed");
+        t.claim_as(&id, "codex@host-9", "A verifiable criterion.\n");
+        claim::complete(&t.0, &id, "codex@host-9").unwrap();
+
+        // The tree says done. The branch has not been told.
+        t.write(&task("000000000001", TaskStatus::Done, &[]));
+        let r = inspect(&t.repo(), &t.cfg(), None, true).unwrap();
+        assert!(
+            r.pruned.is_empty(),
+            "the tree is not the branch: {:?}",
+            r.pruned
+        );
+        assert!(claim::read(&t.0, &id).unwrap().is_some());
+
+        // Committing is what makes it true for everybody else.
+        t.commit("done");
+        let r = inspect(&t.repo(), &t.cfg(), None, true).unwrap();
+        assert_eq!(r.pruned.len(), 1, "{:?}", r.pruned);
+        assert!(claim::read(&t.0, &id).unwrap().is_none());
+    }
+
+    /// `closed` settles a ref exactly as `done` does, and everything else is
+    /// left alone.
+    ///
+    /// Three cases in one fixture, all carried over from `claim::prune`'s tests
+    /// (TASK-4981a1370c0b): a closed task prunes, a live claim on an open task
+    /// is not maintenance's business, and a task the default branch has never
+    /// carried is the unmerged case the ref exists for.
+    #[test]
+    fn closed_prunes_like_done_and_the_rest_is_left_alone() {
+        let t = Temp::new();
+        let closed = EntityId::parse("TASK-000000000001").unwrap();
+        let live = EntityId::parse("TASK-00000000ffff").unwrap();
+        t.write(&task("000000000001", TaskStatus::InProgress, &[]));
+        t.write(&task("00000000ffff", TaskStatus::InProgress, &[]));
+        t.commit("seed");
+        t.claim_as(&closed, "codex@host-9", "A verifiable criterion.\n");
+        t.claim_as(&live, "claude-code@ank", "A verifiable criterion.\n");
+
+        t.write(&task("000000000001", TaskStatus::Closed, &[]));
+        t.commit("closed");
+
+        // A task the branch has never seen: present in the tree, absent there.
+        let unmerged = EntityId::parse("TASK-00000000aaaa").unwrap();
+        t.write(&task("00000000aaaa", TaskStatus::InProgress, &[]));
+        t.claim_as(&unmerged, "claude-code@ank", "A verifiable criterion.\n");
+
+        let r = inspect(&t.repo(), &t.cfg(), None, true).unwrap();
+        assert_eq!(r.pruned, vec![claim::ref_name(&closed)], "{:?}", r.pruned);
+        assert!(
+            claim::read(&t.0, &live).unwrap().is_some(),
+            "an open task's claim is not maintenance's business"
+        );
+        assert!(
+            claim::read(&t.0, &unmerged).unwrap().is_some(),
+            "a task the default branch has never carried is the unmerged case"
+        );
+    }
+
     #[test]
     fn an_orphan_ref_is_pruned_and_review_never_prunes_anything() {
         let t = Temp::new();


### PR DESCRIPTION
Closes TASK-4981a1370c0b, anchored on CI run 31464502863.

`claim::prune` was documented as *called by check* and called by nothing
outside its own tests. The live path is `human::maintain`, which reimplemented
the same rule -- two copies of the predicate that decides when a coordination
ref disappears, and the unexercised one free to drift from the one that runs.

**It was already the weaker copy.** It had never learned, as `maintain` did
from TASK-52fbffbfdf65, to ask the default branch whether a task exists before
treating its ref as an orphan -- a checkout older than a task sees no such task
and used to delete a claim another worktree was holding at that moment. It also
propagated a git error where `maintain` reports it once and prunes nothing, and
it knew nothing of the finished-on-another-branch signal or of `review`
inspecting without touching the plane.

What a wrong pruning decision costs is a lost claim, which is a task two agents
can hold at once. That is why this was worth removing rather than tidying.

## Carried over first, deleted second

Every case the removed tests covered is now asserted against the predicate that
actually runs, through `inspect`:

| case | now asserted by |
|---|---|
| the working tree says `done`, the branch does not -- and pruning once the commit lands | `the_tree_saying_done_is_not_the_branch_saying_done` |
| `closed` settles a ref exactly as `done` does | `closed_prunes_like_done_and_the_rest_is_left_alone` |
| a live claim on an open task is left alone | same |
| a task present in the tree but never carried by the default branch is left alone | same |

The first is the sharp one and the whole reason the predicate reads the branch
(ADR-bcf222a31525): `done` writes to the working tree, so between the work and
the merge the tree says `done` while the branch does not, and pruning there
would reopen the exact window the completion ref exists to close.

`claiming_never_prunes` stays -- it never called `prune`, and it asserts that
`claim` leaves refs where it found them.

The removed name now matches only the two doc comments recording where its
cases went. `maintain` still takes a `prune` bool and `Report` still carries
`pruned`; what is gone is the second implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RYLJW2CXtQn1zCLRLcqZ7