### PR TITLE
status names every live claim of this identity

### DIFF
--- a/.ank/tasks/TASK-38b384543551.md
+++ b/.ank/tasks/TASK-38b384543551.md
@@ -5,7 +5,7 @@ slug: the-shared-identity-warning-is-emitted-once-and
 title: The shared-identity warning is emitted once and never again
 created: 2026-08-08T22:45:06Z
 author: seanl@sean-laptop
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/**
 blocked_by: []
@@ -20,8 +20,12 @@ done_criteria: |
   --json carries the same information, and piped output stays byte-for-byte what it
   was (ADR-962c25797569). cargo test and ank check stay green.
 criteria_by: creator
+proof:
+  - type: test
+    ref: "31466188804"
+    criteria: a5268cda80a5
 schema: 2
-version: 3
+version: 4
 ---
 
 Found by two sessions colliding in one working tree on 2026-08-08, and the logs
@@ -82,3 +86,4 @@ happened during this same episode; neither is ank's to fix.
 
 ## Log
 - 2026-08-11T06:43:42Z seanl@sean-laptop — status now lists every live claim of this identity, with claim's own way-out sentence rather than a second copy of it -- way_out() lives in claim.rs and both callers read it, because two copies of an instruction are two chances to name a different variable and the variable is the whole content. --json carries also_held with the same information: the caller that scripts around status is exactly the caller running several sessions. The context question is decided against, and the reasoning is recorded at held_in in context.rs, which is where someone would go to add it. Relevance says yes -- context is what an agent reads every turn -- and two things outweigh it. Budget: ADR-e17e treats every word in context as paid for, and this would be paid on every turn of every session that never hits the state, to report something already announced at acquisition and now reported by a verb that costs nothing. Placement: the collision does not bite while reading, it bites in the verbs that resolve HEAD, so warning where the agent reads is a worse fit than answering where it acts. That second half is now TASK-97d8747416ea, filed rather than folded in: on_task returns the first live record and for-each-ref sorts by refname, so HEAD is the lowest task id of the two, chosen silently, and done is the verb whose effect cannot be undone by running it again.
+- 2026-08-11T06:47:40Z seanl@sean-laptop — done, proof test:31466188804

--- a/.ank/tasks/TASK-38b384543551.md
+++ b/.ank/tasks/TASK-38b384543551.md
@@ -5,7 +5,7 @@ slug: the-shared-identity-warning-is-emitted-once-and
 title: The shared-identity warning is emitted once and never again
 created: 2026-08-08T22:45:06Z
 author: seanl@sean-laptop
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/**
 blocked_by: []
@@ -21,7 +21,7 @@ done_criteria: |
   was (ADR-962c25797569). cargo test and ank check stay green.
 criteria_by: creator
 schema: 2
-version: 1
+version: 3
 ---
 
 Found by two sessions colliding in one working tree on 2026-08-08, and the logs
@@ -79,3 +79,6 @@ git add .ank sweeping another session's claim file into an unrelated commit.
 Section 7 already answers it by calling a shared tree a degraded mode rather than
 a design mode, and ADR-9ede1ffd04e2 puts that policy above the tool. Both
 happened during this same episode; neither is ank's to fix.
+
+## Log
+- 2026-08-11T06:43:42Z seanl@sean-laptop — status now lists every live claim of this identity, with claim's own way-out sentence rather than a second copy of it -- way_out() lives in claim.rs and both callers read it, because two copies of an instruction are two chances to name a different variable and the variable is the whole content. --json carries also_held with the same information: the caller that scripts around status is exactly the caller running several sessions. The context question is decided against, and the reasoning is recorded at held_in in context.rs, which is where someone would go to add it. Relevance says yes -- context is what an agent reads every turn -- and two things outweigh it. Budget: ADR-e17e treats every word in context as paid for, and this would be paid on every turn of every session that never hits the state, to report something already announced at acquisition and now reported by a verb that costs nothing. Placement: the collision does not bite while reading, it bites in the verbs that resolve HEAD, so warning where the agent reads is a worse fit than answering where it acts. That second half is now TASK-97d8747416ea, filed rather than folded in: on_task returns the first live record and for-each-ref sorts by refname, so HEAD is the lowest task id of the two, chosen silently, and done is the verb whose effect cannot be undone by running it again.

--- a/.ank/tasks/TASK-97d8747416ea.md
+++ b/.ank/tasks/TASK-97d8747416ea.md
@@ -1,0 +1,52 @@
+---
+id: TASK-97d8747416ea
+type: task
+slug: two-live-claims-on-one-identity-make-head-a-sile
+title: Two live claims on one identity make HEAD a silent choice
+created: 2026-08-11T06:43:21Z
+author: seanl@sean-laptop
+status: open
+scope:
+  - crates/ank-cli/src/claim.rs
+  - crates/ank-cli/src/commands.rs
+  - crates/ank-cli/src/done.rs
+  - docs/ank-spec-v1.1.md
+  - crates/ank-cli/tests/**
+blocked_by: []
+done_criteria: |
+  With two live claims held by one identity, no verb acts on one of them without the caller being able to tell which: section 3 of docs/ank-spec-v1.1.md says what log, release and done do in that state before the code moves, and the code follows. Verified through the binary: an integration test takes two claims under one identity and asserts, for each of the three verbs, the behaviour the specification now promises -- and if that behaviour is to act on a derived HEAD, the output names the task acted on.
+criteria_by: creator
+schema: 2
+version: 1
+---
+
+Found while making the second claim visible in `status` (TASK-38b384543551),
+and deliberately left out of it: that task is about reporting, this one is
+about acting.
+
+With two live claims under one identity, `claim::on_task` returns on the first
+live record it meets and `git::ank_refs` goes through `for-each-ref`, which
+sorts by refname. So HEAD is the lowest task id among the agent's live claims,
+chosen silently. `log` writes its entry there, `release` hands that one back,
+and `done` runs the verifiers of that one and moves it to done -- none of them
+saying which of the two they picked, or that there was a choice.
+
+The 2026-08-08 episode that produced TASK-38b384543551 was a session releasing
+a task because it believed HEAD was ambiguous between verbs. It turned out not
+to have been ambiguous that time. This is the case where it genuinely is, and
+the tool answers it by picking.
+
+`done` is the sharp one: it is the verb whose effect cannot be undone by
+running it again. An agent that meant the task it had just claimed and got the
+one it claimed an hour earlier finds a task marked done, with a proof, whose
+work was never verified.
+
+The shape of the answer is a real question and not a foregone one. Refusing
+would contradict what claim.rs states in as many words -- one claim at a time
+is a convention, not a lock, and parallel agents are the design -- so a refusal
+on state here would have to be argued rather than assumed, and section 3 says
+`done` derives HEAD rather than taking an id. Naming the choice is the cheaper
+half and may be the whole of it: an agent told which of its two claims a verb
+acted on can correct course, where one told nothing cannot. The explicit id
+form already exists on all three verbs and currently refuses anything but HEAD,
+so making it the way to disambiguate costs the refusal, not the flag.

--- a/crates/ank-cli/src/claim.rs
+++ b/crates/ank-cli/src/claim.rs
@@ -303,6 +303,16 @@ pub fn parse_record(text: &str, id: &EntityId) -> Result<Record> {
 /// warning, and a reader of other people's refs does not get to fail the write
 /// it accompanies. `acquire` is the one that reads the ref it is about to
 /// touch, and it is right to call the same damage a hard error.
+/// The one sentence that says how to stop sharing an identity.
+///
+/// **Written once and said by both places that raise the case.** `claim` says it
+/// at acquisition and `status` says it whenever the state persists
+/// (TASK-38b384543551); two copies of a way out are two chances to name a
+/// different variable, and the variable is the whole content of the advice.
+pub fn way_out() -> String {
+    format!("a second session on this machine sets its own {ENV_AGENT}")
+}
+
 pub fn live_claims_of(
     cwd: &Path,
     identity: &str,
@@ -1038,10 +1048,7 @@ pub fn run(
     let warnings: Vec<String> = also_held
         .iter()
         .map(|(id, c)| format!("{identity} already holds {id} until {}", c.expires))
-        .chain(
-            (!also_held.is_empty())
-                .then(|| format!("a second session on this machine sets its own {ENV_AGENT}")),
-        )
+        .chain((!also_held.is_empty()).then(way_out))
         .collect();
 
     if inv.json() {

--- a/crates/ank-cli/src/context.rs
+++ b/crates/ank-cli/src/context.rs
@@ -708,6 +708,19 @@ pub(crate) fn coordination_of<'a>(
 /// HEAD is derived, never stored. Shared so that a listing marking the caller's
 /// own row and `context` switching to execution mode cannot disagree about
 /// whose task it is.
+///
+/// **A second live claim under this identity is deliberately not reported
+/// here** (TASK-38b384543551, decided there rather than left open). `status`
+/// carries it. The relevance argument for putting it in `context` is real —
+/// this is what an agent reads every turn — and it loses to two others.
+///
+/// `context` is loaded on every call and ADR-e17e1bbd93ff treats every word in
+/// it as paid for, so a line covering a state that is rare, already announced
+/// at acquisition, and reported by a verb costing nothing would be paid on
+/// every turn of every session that never hits it. And the place the collision
+/// actually bites is not reading: it is the verbs that resolve HEAD, where two
+/// live claims mean one is picked and the other ignored. Warning where the
+/// agent reads is a worse fit than answering where the agent acts.
 pub(crate) fn held_in(map: &HashMap<EntityId, Coordination>, identity: &str) -> Option<EntityId> {
     map.iter().find_map(|(id, state)| match state {
         Coordination::Claimed { holder, .. } if holder == identity => Some(id.clone()),

--- a/crates/ank-cli/src/status.rs
+++ b/crates/ank-cli/src/status.rs
@@ -67,6 +67,25 @@ pub fn run(
             .map(|r| (r, record.expires.clone()))
     });
 
+    // **Every live claim of this identity, not only the one binding the
+    // perimeter** (TASK-38b384543551). `claim` names a second one at the moment
+    // it is taken and never again, and a convention that announces itself only
+    // when it is taken fades exactly as a session lengthens. `status` is the
+    // verb a session runs when it has lost track, so it is the second occasion
+    // the tool never had — two sessions in one tree, both with ANK_AGENT unset,
+    // read as one agent, and the misread that followed cost a release taken for
+    // no reason on 2026-08-08.
+    //
+    // Still a warning and never a refusal: one claim at a time is a convention,
+    // parallel agents with distinct identities are the design (§7), and the
+    // case worth naming is the one where they are not.
+    let also_held = match &standing {
+        Some(s) => {
+            crate::claim::live_claims_of(&repo.root, identity, &s.id, crate::claim::now_secs())?
+        }
+        None => Vec::new(),
+    };
+
     // `prune: false`. A reader does not sanitise the coordination plane
     // underneath everyone else, which is the rule `context` already follows.
     let report = human::inspect(repo, cfg, None, false)?;
@@ -113,13 +132,23 @@ pub fn run(
             ),
             None => "null".into(),
         };
+        // The same information, not a shorter version of it: a caller that
+        // scripts around `status` is exactly the caller running several
+        // sessions, and a field the human surface has and this one lacks would
+        // hide the case from the reader most likely to cause it.
+        let also_json: Vec<String> = also_held
+            .iter()
+            .map(|(id, c)| format!("{{\"id\":\"{id}\",\"expires\":\"{}\"}}", c.expires))
+            .collect();
         let _ = writeln!(
             out,
             "{{\"branch\":{},\"default_branch\":{},\"claim\":{claim_json},\
+             \"also_held\":[{}],\
              \"constraints\":{constraints},\"queue\":{queue},\"unmerged\":{unmerged},\
              \"faults\":{},\"signals\":{}}}",
             opt_json(branch.as_deref()),
             opt_json(default.as_ref().ok().map(|s| s.as_str())),
+            also_json.join(","),
             report.faults(),
             report.signals()
         );
@@ -166,6 +195,7 @@ pub fn run(
                 task.title
             );
             let _ = writeln!(out, "  {} {}", style.key("expires"), expiry(expires));
+            also_claimed(out, &also_held, &style);
         }
         // A held claim whose task the index has lost would print nothing at
         // all, so the ref is reported on its own rather than dropped.
@@ -183,6 +213,7 @@ pub fn run(
                     style.key("expires"),
                     expiry(&record.expires)
                 );
+                also_claimed(out, &also_held, &style);
             }
             None => {
                 let _ = writeln!(out, "{}", style.key("no claim"));
@@ -227,6 +258,37 @@ pub fn run(
     };
     let _ = writeln!(out, "\n{}", style.next(&format!("> {next}")));
     Ok(0)
+}
+
+/// The other live claims this identity holds, under the one binding the
+/// perimeter.
+///
+/// Indented with the expiry it sits beside, because it qualifies the claim line
+/// above rather than opening a section: `status` has no headings, and a second
+/// column of keys would be one. The way out is `claim`'s own sentence, taken
+/// from `claim::way_out` rather than restated (TASK-38b384543551).
+///
+/// Plain text either way. What is said here is a state a reader must be able to
+/// act on, so none of it is carried by colour (ADR-0c8ab846d262) — the same
+/// bytes reach a terminal and a pipe.
+fn also_claimed(
+    out: &mut dyn Write,
+    also: &[(ank_core::EntityId, crate::claim::ClaimRecord)],
+    style: &crate::style::Style,
+) {
+    if also.is_empty() {
+        return;
+    }
+    for (id, record) in also {
+        let _ = writeln!(
+            out,
+            "  {} {} until {}",
+            style.key("also"),
+            style.id(&id.to_string()),
+            record.expires
+        );
+    }
+    let _ = writeln!(out, "  {}", crate::claim::way_out());
 }
 
 /// The directory a glob is anchored at — `crates/ank-cli/**` gives

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -2614,6 +2614,70 @@ fn init_refuses_repo_and_writes_into_neither_repository() {
     let _ = std::fs::remove_dir_all(&named);
 }
 
+/// A second live claim on one identity stays visible after the moment it was
+/// taken.
+///
+/// `claim` names it once, at acquisition, and never again. A convention that
+/// announces itself only when it is taken fades exactly as a session lengthens,
+/// and `status` is the verb a session runs when it has lost track — which is
+/// how two sessions in one tree, both with `ANK_AGENT` unset, read as one agent
+/// and produced a release taken on a misread (TASK-38b384543551).
+///
+/// Asserted on what reaches stdout, because a warning that never reaches stdout
+/// is not a warning.
+#[test]
+fn status_names_every_live_claim_of_this_identity() {
+    let r = Repo::new();
+    const SECOND: &str = "TASK-000000000002";
+    r.seed_task(ID, Some("A verifiable criterion."));
+    r.seed_task(SECOND, Some("Another verifiable criterion."));
+
+    // One identity, two claims. Not refused, and deliberately so: one claim at
+    // a time is a convention, and parallel agents with distinct identities are
+    // the design.
+    assert_eq!(code(&r.ank("claude-code@ank", &["claim", ID])), 0);
+    let out = r.ank("claude-code@ank", &["claim", SECOND]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    let said = format!("{}{}", stdout(&out), stderr(&out));
+    assert!(
+        said.contains("already holds"),
+        "the acquisition still says it: {said}"
+    );
+
+    // The moment passes; the state does not.
+    let said = stdout(&r.ank("claude-code@ank", &["status"]));
+    let other = said
+        .lines()
+        .filter(|l| l.contains(ID) || l.contains(SECOND))
+        .count();
+    assert!(
+        other >= 2,
+        "status names one claim and hides the other:\n{said}"
+    );
+    assert!(
+        said.contains("ANK_AGENT"),
+        "status must repeat the way out claim already names:\n{said}"
+    );
+
+    // The same information for a caller that scripts around it -- which is
+    // exactly the caller running several sessions.
+    let json = stdout(&r.ank("claude-code@ank", &["status", "--json"]));
+    assert!(json.contains("\"also_held\""), "{json}");
+    assert!(
+        json.contains(SECOND) || json.contains(ID),
+        "the second claim is absent from --json:\n{json}"
+    );
+
+    // And one identity holding one claim says none of it: the line exists to
+    // report a state, not to decorate every status.
+    let quiet = Repo::new();
+    quiet.seed_task(ID, Some("A verifiable criterion."));
+    assert_eq!(code(&quiet.ank("claude-code@ank", &["claim", ID])), 0);
+    let said = stdout(&quiet.ank("claude-code@ank", &["status"]));
+    assert!(!said.contains("ANK_AGENT"), "{said}");
+    assert!(!said.contains("also"), "{said}");
+}
+
 /// A holder returning to a lapsed claim carries on; one whose task was taken
 /// over is told by whom.
 ///


### PR DESCRIPTION
Closes TASK-38b384543551, anchored on CI run 31466188804.

`claim` names a second claim under the same identity at the moment it is taken
and never again -- `live_claims_of` had exactly one production call site, inside
the `claim` verb. A convention that announces itself only when it is taken fades
exactly as a session lengthens, and `status` is the verb a session runs when it
has lost track. So the tool had no second occasion to say so, at the one place
built for asking where things stand.

That is what produced the 2026-08-08 episode: two sessions in one tree, both
with `ANK_AGENT` unset, reading as one agent, and a release taken on a misread
of which task was HEAD.

```
claim   TASK-000000000001 Example task
  expires 2026-08-11T09:12:00Z
  also  TASK-000000000002 until 2026-08-11T09:14:00Z
  a second session on this machine sets its own ANK_AGENT
```

Still a warning and never a refusal: one claim at a time is a convention rather
than a lock, and parallel agents with distinct identities are the design (§7).
The case worth naming is the one where they are not.

The way out is `claim`'s own sentence, moved to `claim::way_out` and read by
both callers rather than restated -- two copies of an instruction are two
chances to name a different variable, and the variable is the whole content of
the advice. `--json` gains `also_held` with the same information: the caller
that scripts around `status` is exactly the caller running several sessions.

## context is decided against, and the reasoning is recorded

The task asked for the question to be settled here rather than left open. It is
recorded at `held_in` in context.rs, which is where someone would go to add it.

Relevance argues for it -- `context` is what an agent reads every turn -- and it
loses to two things. ADR-e17e1bbd93ff treats every word in `context` as paid
for, and this would be paid on every turn of every session that never hits the
state, to report something already announced at acquisition and now reported by
a verb that costs nothing. And the collision does not bite while reading: it
bites in the verbs that resolve HEAD, so warning where the agent reads is a
worse fit than answering where the agent acts.

## Found on the way, filed rather than folded in

TASK-97d8747416ea: `on_task` returns the first live record and `for-each-ref`
sorts by refname, so with two live claims HEAD is the lowest task id, chosen
silently. `log` writes there, `release` hands that one back, `done` verifies and
finishes it -- and `done` is the verb whose effect cannot be undone by running
it again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RYLJW2CXtQn1zCLRLcqZ7