### PR TITLE
One live claim per identity, and no verb picks HEAD in silence

### DIFF
--- a/.ank/tasks/TASK-97d8747416ea.md
+++ b/.ank/tasks/TASK-97d8747416ea.md
@@ -5,7 +5,7 @@ slug: two-live-claims-on-one-identity-make-head-a-sile
 title: Two live claims on one identity make HEAD a silent choice
 created: 2026-08-11T06:43:21Z
 author: seanl@sean-laptop
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/src/claim.rs
   - crates/ank-cli/src/commands.rs
@@ -17,7 +17,7 @@ done_criteria: |
   With two live claims held by one identity, no verb acts on one of them without the caller being able to tell which: section 3 of docs/ank-spec-v1.1.md says what log, release and done do in that state before the code moves, and the code follows. Verified through the binary: an integration test takes two claims under one identity and asserts, for each of the three verbs, the behaviour the specification now promises -- and if that behaviour is to act on a derived HEAD, the output names the task acted on.
 criteria_by: creator
 schema: 2
-version: 2
+version: 4
 ---
 
 Found while making the second claim visible in `status` (TASK-38b384543551),
@@ -53,3 +53,4 @@ so making it the way to disambiguate costs the refusal, not the flag.
 
 ## Log
 - 2026-08-11T16:19:15Z claude-code@nested-pebble — amended: +blocked_by TASK-a548c95261a5
+- 2026-08-11T16:48:14Z claude-code@nested-pebble — Section 3 first, then the code. HEAD stays derived and the resolution stays the lowest id -- for-each-ref orders by refname and nothing else would be reproducible -- and what changes is that the choice is never silent. log and release name the task they resolved to, every other live claim with its expiry, the command that names one explicitly, and the way out; on stderr, before the write, so stdout stays what a parser reads, with the same sentences in a warnings array under --json as claim already carries. done refuses instead, code 6, before the retake and before a single verifier: it is the verb whose effect running it again cannot undo, and code 6 is already what the three answer when HEAD resolves to no task -- resolving to several is that fact from the other side. The explicit id stops meaning "must equal HEAD" and means "a task this agent holds a live claim on", which cost the refusal and no flag; standing_on is on_task asked at a task instead of at the refs, so naming and deriving cannot drift. head_of and check_matches_head are gone, replaced by one acting_on that answers both questions at once and warns only on the derived path -- a caller that named its task has already said which one it meant. The test builds the state by claim, expire, claim, revive, and asserts done's refusal with a witness file the verifier writes: "before a single verifier ran" is otherwise assumed rather than tested.

--- a/.ank/tasks/TASK-97d8747416ea.md
+++ b/.ank/tasks/TASK-97d8747416ea.md
@@ -5,7 +5,7 @@ slug: two-live-claims-on-one-identity-make-head-a-sile
 title: Two live claims on one identity make HEAD a silent choice
 created: 2026-08-11T06:43:21Z
 author: seanl@sean-laptop
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/src/claim.rs
   - crates/ank-cli/src/commands.rs
@@ -16,8 +16,12 @@ blocked_by: [TASK-a548c95261a5]
 done_criteria: |
   With two live claims held by one identity, no verb acts on one of them without the caller being able to tell which: section 3 of docs/ank-spec-v1.1.md says what log, release and done do in that state before the code moves, and the code follows. Verified through the binary: an integration test takes two claims under one identity and asserts, for each of the three verbs, the behaviour the specification now promises -- and if that behaviour is to act on a derived HEAD, the output names the task acted on.
 criteria_by: creator
+proof:
+  - type: test
+    ref: "31514339777"
+    criteria: 077e517262e1
 schema: 2
-version: 4
+version: 5
 ---
 
 Found while making the second claim visible in `status` (TASK-38b384543551),
@@ -54,3 +58,4 @@ so making it the way to disambiguate costs the refusal, not the flag.
 ## Log
 - 2026-08-11T16:19:15Z claude-code@nested-pebble — amended: +blocked_by TASK-a548c95261a5
 - 2026-08-11T16:48:14Z claude-code@nested-pebble — Section 3 first, then the code. HEAD stays derived and the resolution stays the lowest id -- for-each-ref orders by refname and nothing else would be reproducible -- and what changes is that the choice is never silent. log and release name the task they resolved to, every other live claim with its expiry, the command that names one explicitly, and the way out; on stderr, before the write, so stdout stays what a parser reads, with the same sentences in a warnings array under --json as claim already carries. done refuses instead, code 6, before the retake and before a single verifier: it is the verb whose effect running it again cannot undo, and code 6 is already what the three answer when HEAD resolves to no task -- resolving to several is that fact from the other side. The explicit id stops meaning "must equal HEAD" and means "a task this agent holds a live claim on", which cost the refusal and no flag; standing_on is on_task asked at a task instead of at the refs, so naming and deriving cannot drift. head_of and check_matches_head are gone, replaced by one acting_on that answers both questions at once and warns only on the derived path -- a caller that named its task has already said which one it meant. The test builds the state by claim, expire, claim, revive, and asserts done's refusal with a witness file the verifier writes: "before a single verifier ran" is otherwise assumed rather than tested.
+- 2026-08-11T16:52:14Z claude-code@nested-pebble — done, proof test:31514339777

--- a/.ank/tasks/TASK-97d8747416ea.md
+++ b/.ank/tasks/TASK-97d8747416ea.md
@@ -12,12 +12,12 @@ scope:
   - crates/ank-cli/src/done.rs
   - docs/ank-spec-v1.1.md
   - crates/ank-cli/tests/**
-blocked_by: []
+blocked_by: [TASK-a548c95261a5]
 done_criteria: |
   With two live claims held by one identity, no verb acts on one of them without the caller being able to tell which: section 3 of docs/ank-spec-v1.1.md says what log, release and done do in that state before the code moves, and the code follows. Verified through the binary: an integration test takes two claims under one identity and asserts, for each of the three verbs, the behaviour the specification now promises -- and if that behaviour is to act on a derived HEAD, the output names the task acted on.
 criteria_by: creator
 schema: 2
-version: 1
+version: 2
 ---
 
 Found while making the second claim visible in `status` (TASK-38b384543551),
@@ -50,3 +50,6 @@ half and may be the whole of it: an agent told which of its two claims a verb
 acted on can correct course, where one told nothing cannot. The explicit id
 form already exists on all three verbs and currently refuses anything but HEAD,
 so making it the way to disambiguate costs the refusal, not the flag.
+
+## Log
+- 2026-08-11T16:19:15Z claude-code@nested-pebble — amended: +blocked_by TASK-a548c95261a5

--- a/.ank/tasks/TASK-a548c95261a5.md
+++ b/.ank/tasks/TASK-a548c95261a5.md
@@ -5,7 +5,7 @@ slug: claim-refuses-a-second-live-claim-under-one-iden
 title: claim refuses a second live claim under one identity
 created: 2026-08-11T16:19:10Z
 author: claude-code@nested-pebble
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/src/claim.rs
   - docs/ank-spec-v1.1.md
@@ -15,8 +15,12 @@ blocked_by: []
 done_criteria: |
   ank claim refuses a task while the calling identity already holds a live claim on another one: exit code 7, the held task and its expiry named, and both ways out named -- release it, or a second session on this machine sets its own ANK_AGENT. The refusal lands before anything is written: the refused task carries no claim ref afterwards and its file still reads open. A lapsed claim is not a live one, so pickup after expiry is untouched. Section 4 of docs/ank-spec-v1.1.md says this before the code moves, including a row in the table of refusals on state, since it promised enforcement the binary never performed. Tested through the binary: two ank claim calls under one identity, asserting the code, the output and the absence of the second ref, because a refusal that only exists in a function is not a refusal. cargo test and ank check stay green.
 criteria_by: creator
+proof:
+  - type: test
+    ref: "31513121056"
+    criteria: 697614d58dc8
 schema: 2
-version: 4
+version: 5
 ---
 
 Section 4 says, of HEAD, that it "assumes and enforces one active claim at a
@@ -64,3 +68,4 @@ is closed.
 ## Log
 - 2026-08-11T16:31:36Z claude-code@nested-pebble — amended: +scope docs/getting-started.md
 - 2026-08-11T16:33:51Z claude-code@nested-pebble — claim now refuses a second live claim under one identity, code 7 and last of the preconditions: everything above refuses on the task asked for, and an agent told to hand back its work for a task that would have refused it anyway has paid for nothing. The check excludes the task being claimed, so re-claiming what one already holds stays the transition check's question. Two measured consequences. The guide showed the old warning as sample output, so docs/getting-started.md was added to the scope rather than left lying -- a fix that makes documentation false is not finished. And the fixture of TASK-38b384543551 could no longer be built by claiming twice: it is now claim, expire, claim, revive, which takes both claims through the binary and forges only the clock, exactly as expire_claim already did. That is the harness TASK-97d8747416ea needs too, since the state stays reachable without the CLI (ADR-6b3fa9ba3a05) and the verbs must still stop choosing HEAD in silence. Hint carries both ways out in one line because CliError holds a single hint and cli.rs is out of this perimeter; the parenthetical form is the one other_task_hint already uses.
+- 2026-08-11T16:38:22Z claude-code@nested-pebble — done, proof test:31513121056

--- a/.ank/tasks/TASK-a548c95261a5.md
+++ b/.ank/tasks/TASK-a548c95261a5.md
@@ -1,0 +1,66 @@
+---
+id: TASK-a548c95261a5
+type: task
+slug: claim-refuses-a-second-live-claim-under-one-iden
+title: claim refuses a second live claim under one identity
+created: 2026-08-11T16:19:10Z
+author: claude-code@nested-pebble
+status: in_progress
+scope:
+  - crates/ank-cli/src/claim.rs
+  - docs/ank-spec-v1.1.md
+  - crates/ank-cli/tests/**
+  - docs/getting-started.md
+blocked_by: []
+done_criteria: |
+  ank claim refuses a task while the calling identity already holds a live claim on another one: exit code 7, the held task and its expiry named, and both ways out named -- release it, or a second session on this machine sets its own ANK_AGENT. The refusal lands before anything is written: the refused task carries no claim ref afterwards and its file still reads open. A lapsed claim is not a live one, so pickup after expiry is untouched. Section 4 of docs/ank-spec-v1.1.md says this before the code moves, including a row in the table of refusals on state, since it promised enforcement the binary never performed. Tested through the binary: two ank claim calls under one identity, asserting the code, the output and the absence of the second ref, because a refusal that only exists in a function is not a refusal. cargo test and ank check stay green.
+criteria_by: creator
+schema: 2
+version: 4
+---
+
+Section 4 says, of HEAD, that it "assumes and enforces one active claim at a
+time per agent". The binary has never enforced it. claim warns at acquisition
+and takes the ref anyway, and the reasoning for that sits in claim.rs, at the
+call to live_claims_of: one claim at a time is a convention and not a lock,
+parallel agents with distinct identities are the design, so this warns and
+never refuses.
+
+That reasoning holds for identities. It does not hold for one identity, which
+is the case it was written under. Two sessions in one tree with ANK_AGENT unset
+are both <user>@<hostname>, git sees one agent, and nothing refuses -- so the
+claims do not collide, they accumulate. What follows is the whole cost:
+on_task returns the first live record and for-each-ref sorts by refname, so
+HEAD becomes the lowest task id of the two, chosen silently by log, release and
+done (TASK-97d8747416ea).
+
+This corrects TASK-d79dc424c63d, which is done and stays done with its proof
+intact (section 3): it named the second claim rather than refusing it, and
+naming it was measured to be not enough -- the warning is printed once, at
+acquisition, and a convention that announces itself only when it is taken fades
+exactly as a session lengthens. TASK-38b384543551 gave status a second occasion
+to say it. This removes the occasion for it to arise.
+
+Code 7 and not 4. The table in section 4 gives 4 the meaning "take something
+else", and here the task asked for is available -- it is the caller that is
+not. 7 is the missing prerequisite, and the prerequisite is exact: finish or
+hand back what is already held. The message says which of the two, and names
+ANK_AGENT for the session that never claimed anything and is being answered
+about somebody else's claim.
+
+A refusal on state, never on identity (ADR-e17e1bbd93ff). What is read is the
+coordination plane -- which refs exist and who holds them -- and the rule
+applies to every caller alike. ANK_AGENT is not consulted to decide who is
+allowed, only to read what is held, which is what it already does everywhere
+else.
+
+The state does not become unreachable, and this task does not claim it does.
+Ank is not a gatekeeper (ADR-6b3fa9ba3a05): a ref written by hand, a claim
+taken by an earlier binary, or a claim that lapsed and was revived all produce
+it. That residue is TASK-97d8747416ea, which this one blocks: it is about the
+verbs that act once the state exists, and it stays worth doing after the door
+is closed.
+
+## Log
+- 2026-08-11T16:31:36Z claude-code@nested-pebble — amended: +scope docs/getting-started.md
+- 2026-08-11T16:33:51Z claude-code@nested-pebble — claim now refuses a second live claim under one identity, code 7 and last of the preconditions: everything above refuses on the task asked for, and an agent told to hand back its work for a task that would have refused it anyway has paid for nothing. The check excludes the task being claimed, so re-claiming what one already holds stays the transition check's question. Two measured consequences. The guide showed the old warning as sample output, so docs/getting-started.md was added to the scope rather than left lying -- a fix that makes documentation false is not finished. And the fixture of TASK-38b384543551 could no longer be built by claiming twice: it is now claim, expire, claim, revive, which takes both claims through the binary and forges only the clock, exactly as expire_claim already did. That is the harness TASK-97d8747416ea needs too, since the state stays reachable without the CLI (ADR-6b3fa9ba3a05) and the verbs must still stop choosing HEAD in silence. Hint carries both ways out in one line because CliError holds a single hint and cli.rs is out of this perimeter; the parenthetical form is the one other_task_hint already uses.

--- a/crates/ank-cli/src/claim.rs
+++ b/crates/ank-cli/src/claim.rs
@@ -603,6 +603,79 @@ pub fn on_task(cwd: &Path, identity: &str) -> Result<Option<Standing>> {
     Ok(lapsed_one)
 }
 
+/// The standing of one named task, if this identity is the one on it.
+///
+/// [`on_task`] asked at a task instead of at the refs. It is what the explicit
+/// id on `log`, `release` and `done` resolves through: §4 makes that id "a task
+/// this agent holds a live claim on" rather than "HEAD spelled out", so naming
+/// a task and deriving HEAD have to produce the same kind of answer or the two
+/// paths drift (TASK-97d8747416ea).
+///
+/// A lapsed claim answers here exactly as it does in `on_task`, and for the
+/// same reason: it is still this agent's task, and `log` and `done` retake it
+/// (§3).
+pub fn standing_on(cwd: &Path, identity: &str, id: &EntityId) -> Result<Option<Standing>> {
+    let Some(held) = read(cwd, id)? else {
+        return Ok(None);
+    };
+    let Record::Claim(c) = held.record else {
+        return Ok(None);
+    };
+    if c.holder != identity {
+        return Ok(None);
+    }
+    let lapsed = is_expired(&c, now_secs(), id)?;
+    Ok(Some(Standing {
+        id: id.clone(),
+        object: held.object,
+        record: c,
+        lapsed,
+    }))
+}
+
+/// What a verb says when it derived HEAD out of more than one live claim.
+///
+/// The choice itself stays deterministic — the lowest id, because the refs are
+/// enumerated in refname order — and §3 asks that it never be silent. That is
+/// the whole defect this answers: `log` wrote its entry, `release` handed a
+/// task back and `done` verified one, none of them saying which of the two it
+/// had picked or that there had been a choice (TASK-97d8747416ea).
+///
+/// Written once and said by every caller, like [`way_out`] which it ends with:
+/// the sentences name a task id and a variable, and two copies are two chances
+/// to name the wrong one.
+///
+/// Empty when there is nothing to report, so a caller can print it
+/// unconditionally and the nominal case stays silent.
+/// `tail` is what the verb needs after the id to stay a command somebody can
+/// run: a message for `log`, a reason for `release`. §4 makes a hint the exact
+/// command to run next, and `ank log TASK-8f3a` on its own is a different verb
+/// — it reads.
+pub fn sharing_warnings(
+    verb: &str,
+    tail: &str,
+    acting_on: &EntityId,
+    also: &[(EntityId, ClaimRecord)],
+) -> Vec<String> {
+    if also.is_empty() {
+        return Vec::new();
+    }
+    let mut said = vec![format!(
+        "{} live claims on this identity, acting on {acting_on}",
+        also.len() + 1
+    )];
+    said.extend(
+        also.iter()
+            .map(|(id, c)| format!("also holding {id} until {}", c.expires)),
+    );
+    // The command, not the advice: naming another task is what the explicit id
+    // is for, and the agent that meant the other one needs to be able to copy
+    // the line rather than derive it (§4).
+    said.push(format!("ank {verb} {}{tail} acts on that one", also[0].0));
+    said.push(way_out());
+    said
+}
+
 /// Takes a lapsed claim back, in the same agent's name (§3).
 ///
 /// **The anchors are carried over, never recomputed.** Re-freezing the

--- a/crates/ank-cli/src/claim.rs
+++ b/crates/ank-cli/src/claim.rs
@@ -347,6 +347,59 @@ pub fn live_claims_of(
     Ok(held)
 }
 
+/// One live claim at a time per identity, refused rather than warned about
+/// (§4).
+///
+/// §4 said "assumes and **enforces** one active claim at a time per agent" for
+/// as long as this code only warned. The gap is not academic: the default
+/// identity is `<user>@<hostname>` (§8), so two sessions in one working tree
+/// are one agent as far as the refs can tell, and their claims do not
+/// collide — they accumulate. `on_task` then returns the first live record and
+/// `ank_refs` sorts by refname, so HEAD becomes the lowest of the two, picked
+/// in silence by `log`, `release` and `done` (TASK-97d8747416ea). This closes
+/// the door that state comes through, and TASK-a548c95261a5 records why the
+/// previous answer — name it, never refuse (TASK-d79dc424c63d) — was measured
+/// to be not enough: the warning is printed once, at acquisition, and a
+/// convention that announces itself only when it is taken fades exactly as a
+/// session lengthens.
+///
+/// **Code 7, not 4.** 4 means "take something else" (§4), and the task asked
+/// for is available — it is the caller that is not. What is missing is a
+/// prerequisite, and it is exact: finish or hand back what is already held.
+///
+/// **The message names the identity, never the caller.** Under a shared
+/// identity the session being refused may have claimed nothing at all; it is
+/// being answered about somebody else's claim, and "you already hold" would
+/// simply be false. The hint carries both ways through, the second in a
+/// parenthetical, exactly as the "another ready task" hints do — and the
+/// sentence comes from [`way_out`] rather than a second copy of it.
+///
+/// **The task being claimed is excluded.** Re-claiming what one already holds
+/// is a different question, answered by the transition check and by `acquire`,
+/// and this refusal has no business intercepting it.
+///
+/// Refusing on state and never on identity (ADR-c656cbcc33a9): what is read is
+/// the coordination plane — which refs exist and who holds them — and the
+/// answer is the same for every caller. A lapsed claim is not a live one, so
+/// pickup after expiry (§3) passes through untouched.
+fn already_holding(cwd: &Path, identity: &str, target: &EntityId, now: i64) -> Result<()> {
+    let held = live_claims_of(cwd, identity, target, now)?;
+    // The lowest id, which is the one HEAD resolves to and therefore the one
+    // `release` in the hint would hand back. Naming all of them would be a
+    // longer message about a state this refusal exists to prevent.
+    let Some((id, record)) = held.first() else {
+        return Ok(());
+    };
+    Err(CliError::new(
+        7,
+        format!(
+            "{identity} holds a live claim on {id} ({})",
+            remaining_text(record, now)
+        ),
+    )
+    .with_hint(format!("ank release --reason \"<why>\"   ({})", way_out())))
+}
+
 /// The record a task's ref carries, if it carries one. An absent ref is
 /// `None`, never an error: that is the nominal state of a free task.
 pub fn read(cwd: &Path, id: &EntityId) -> Result<Option<Held>> {
@@ -1024,6 +1077,12 @@ pub fn run(
         .check_transition(TaskStatus::InProgress)
         .map_err(|e| CliError::new(6, e.to_string()).with_hint(format!("ank show {}", task.id)))?;
 
+    // Last of the preconditions, and last on purpose. Everything above refuses
+    // on the task asked for; this one refuses on what the caller already holds,
+    // and an agent told to hand back its work for a task that would have
+    // refused it anyway has paid for nothing.
+    already_holding(&repo.root, identity, &task.id, now_secs())?;
+
     let constraints = constraints_hash(&applicable_constraints(&store, repo, &task)?);
     let acquired = acquire(
         &repo.root,
@@ -1040,10 +1099,16 @@ pub fn run(
     task.status = TaskStatus::InProgress;
     store.write(&Entity::Task(task.clone()), base_version)?;
 
-    // Held after the ref is taken, so nothing is said about a claim that was
-    // refused. One claim at a time is a convention and not a lock, so this
-    // warns and never refuses: parallel agents, each with its own identity, are
-    // the design (§7), and the case worth naming is the one where they are not.
+    // Read a second time, after the ref is taken, and what it can still find is
+    // the race `already_holding` cannot close: two sessions of one identity
+    // that both passed the check before either took its ref. The window is
+    // narrow and it is real, so it is named rather than assumed away — the
+    // refusal above is what makes this the exception it now reads as.
+    //
+    // It still warns and never refuses, and here that is the only option left:
+    // the ref is taken and the transition is written, so a refusal at this
+    // point would refuse a claim the agent holds. `status` says the same thing
+    // for as long as the state lasts (TASK-38b384543551).
     let also_held = live_claims_of(&repo.root, identity, &acquired.id, now_secs())?;
     let warnings: Vec<String> = also_held
         .iter()

--- a/crates/ank-cli/src/commands.rs
+++ b/crates/ank-cli/src/commands.rs
@@ -1112,17 +1112,7 @@ pub(crate) fn json_string(s: &str) -> String {
 // log and release: both act on the task this agent holds
 // ---------------------------------------------------------------------------
 
-/// The task this agent holds a live claim on, with the record and the object to
-/// compare against. Both verbs need it, and neither may act without it: the log
-/// is the task's anchoring register, and if anyone could write to it, it would
-/// stop being a reliable trace of what the holder did (§4).
-fn head_of(cwd: &Path, identity: &str) -> Result<(EntityId, String, ClaimRecord)> {
-    held_by(cwd, identity)?.ok_or_else(|| {
-        CliError::new(6, "no task in progress for this agent").with_hint("ank context")
-    })
-}
-
-/// The same lookup without the refusal, for the caller that reports rather than
+/// The lookup without the refusal, for the caller that reports rather than
 /// acts. `status` describes a repository that may well have no claim in it, and
 /// a reader must never fail because there is nothing to say.
 /// The two columns a listing spends on its left margin, spent on saying whether
@@ -1154,19 +1144,90 @@ pub(crate) fn held_by(
     Ok(claim::on_task(cwd, identity)?.map(|s| (s.id, s.object, s.record)))
 }
 
-/// The optional id is redundant by construction and must match HEAD (§4). It
-/// exists for explicitness in scripts, never as a way to act on somebody else's
-/// task.
-fn check_matches_head(store: &Store, given: Option<&String>, head: &EntityId) -> Result<()> {
-    let Some(given) = given else { return Ok(()) };
-    let asked = store.resolve(given)?;
-    if &asked != head {
-        return Err(
-            CliError::new(6, format!("{asked} is not the task in progress ({head})"))
-                .with_hint(format!("ank log {head} \"<message>\"")),
-        );
+/// The task a verb acts on, and what it owes the caller before it acts.
+///
+/// Both `log` and `release` need it and neither may act without it: the log is
+/// the task's anchoring register, and if anyone could write to it, it would
+/// stop being a reliable trace of what the holder did (§4).
+///
+/// The optional id is redundant in the nominal case and exists for explicitness
+/// in scripts (§4). What it means changed with TASK-97d8747416ea: not "must
+/// equal HEAD" but "must name a task this agent holds a live claim on". Holding
+/// one claim the two readings are the same sentence; holding several — the
+/// state `claim` refuses to create and the corpus can still be in — it is what
+/// says which of them the verb acts on, and that costs the refusal rather than
+/// a new flag.
+///
+/// HEAD is still resolved first, so an agent holding nothing is answered
+/// `no task in progress for this agent` whether or not it named a task: the
+/// question "do you hold anything" comes before "is this the one".
+///
+/// The warnings are for the derived case alone. A caller that named its task
+/// has already said which one it meant, and telling it back would be noise on
+/// the one path that cannot be ambiguous.
+fn acting_on(
+    cwd: &Path,
+    store: &Store,
+    given: Option<&String>,
+    identity: &str,
+    verb: &str,
+    tail: &str,
+) -> Result<(EntityId, String, ClaimRecord, Vec<String>)> {
+    let head = claim::on_task(cwd, identity)?.ok_or_else(|| {
+        CliError::new(6, "no task in progress for this agent").with_hint("ank context")
+    })?;
+
+    let standing = match given {
+        Some(given) => {
+            let asked = store.resolve(given)?;
+            if asked == head.id {
+                head
+            } else {
+                claim::standing_on(cwd, identity, &asked)?.ok_or_else(|| {
+                    CliError::new(
+                        6,
+                        format!("{asked} is not the task in progress ({})", head.id),
+                    )
+                    .with_hint(format!("ank {verb} {}{tail}", head.id))
+                })?
+            }
+        }
+        None => head,
+    };
+
+    let warnings = match given {
+        Some(_) => Vec::new(),
+        None => claim::sharing_warnings(
+            verb,
+            tail,
+            &standing.id,
+            &claim::live_claims_of(cwd, identity, &standing.id, claim::now_secs())?,
+        ),
+    };
+    Ok((standing.id, standing.object, standing.record, warnings))
+}
+
+/// The sentences of [`claim::sharing_warnings`] on their way out, before the
+/// verb writes anything.
+///
+/// **Standard error, and before the write.** §3 asks that the choice be
+/// visible, and a line printed after the entry landed reports rather than
+/// warns. Standard error for the reason `log`'s takeover warning already uses
+/// it: stdout under `--json` is a parser's input (§4).
+fn warn_before_acting(inv: &Invocation, warnings: &[String]) {
+    if inv.json() {
+        return;
     }
-    Ok(())
+    let style = inv.style().on_stderr();
+    for w in warnings {
+        eprintln!("{} {w}", style.yellow("warning:"));
+    }
+}
+
+/// The same sentences for a parser, as `claim --json` already carries them.
+fn warnings_json(warnings: &[String]) -> String {
+    let items: Vec<String> = warnings.iter().map(|w| json_string(w)).collect();
+    format!(",\"warnings\":[{}]", items.join(","))
 }
 
 /// `log [<id>] [<message>]` (§4). `git log` reads, and so does this one when it
@@ -1285,8 +1346,9 @@ fn log_write(
             .with_hint("ank log \"<what you just did>\""));
     }
 
-    let (id, witness, record) = head_of(&repo.root, identity)?;
-    check_matches_head(store, given, &id)?;
+    let (id, witness, record, warnings) =
+        acting_on(&repo.root, store, given, identity, "log", " \"<message>\"")?;
+    warn_before_acting(inv, &warnings);
 
     let loaded = store.load(&id)?;
     let base_version = version_of(&loaded.entity);
@@ -1342,7 +1404,11 @@ fn log_write(
     }
 
     if inv.json() {
-        let _ = writeln!(out, "{{\"task\":\"{id}\",\"logged\":true}}");
+        let _ = writeln!(
+            out,
+            "{{\"task\":\"{id}\",\"logged\":true{}}}",
+            warnings_json(&warnings)
+        );
     } else if !inv.quiet() {
         let _ = writeln!(
             out,
@@ -1369,8 +1435,15 @@ pub fn release(inv: &Invocation, repo: &Repo, identity: &str, out: &mut dyn Writ
     };
 
     let store = Store::new(&repo.ank);
-    let (id, _, _) = head_of(&repo.root, identity)?;
-    check_matches_head(&store, inv.positionals.first(), &id)?;
+    let (id, _, _, warnings) = acting_on(
+        &repo.root,
+        &store,
+        inv.positionals.first(),
+        identity,
+        "release",
+        " --reason \"<why>\"",
+    )?;
+    warn_before_acting(inv, &warnings);
 
     let loaded = store.load(&id)?;
     let base_version = version_of(&loaded.entity);
@@ -1399,8 +1472,9 @@ pub fn release(inv: &Invocation, repo: &Repo, identity: &str, out: &mut dyn Writ
     if inv.json() {
         let _ = writeln!(
             out,
-            "{{\"task\":\"{id}\",\"status\":\"open\",\"reason\":{}}}",
-            json_string(&reason)
+            "{{\"task\":\"{id}\",\"status\":\"open\",\"reason\":{}{}}}",
+            json_string(&reason),
+            warnings_json(&warnings)
         );
     } else if !inv.quiet() {
         let _ = writeln!(

--- a/crates/ank-cli/src/done.rs
+++ b/crates/ank-cli/src/done.rs
@@ -261,19 +261,60 @@ fn resolve_head(
     identity: &str,
     cap: std::time::Duration,
 ) -> Result<(EntityId, Held)> {
-    let Some(standing) = claim::on_task(cwd, identity)? else {
+    let Some(head) = claim::on_task(cwd, identity)? else {
         return Err(CliError::new(6, "no task in progress for this agent").with_hint("ank context"));
     };
-    if let Some(given) = given {
-        let asked = store.resolve(given)?;
-        if asked != standing.id {
-            return Err(CliError::new(
-                6,
-                format!("{asked} is not the task in progress ({})", standing.id),
-            )
-            .with_hint(format!("ank done {}", standing.id)));
+    let standing = match given {
+        Some(given) => {
+            let asked = store.resolve(given)?;
+            if asked == head.id {
+                head
+            } else {
+                // Not "must equal HEAD" any more, but "a task this agent holds
+                // a live claim on" (§4). The refusal is what it costs, not a
+                // flag, and it is unchanged for an id this agent does not hold.
+                claim::standing_on(cwd, identity, &asked)?.ok_or_else(|| {
+                    CliError::new(
+                        6,
+                        format!("{asked} is not the task in progress ({})", head.id),
+                    )
+                    .with_hint(format!("ank done {}", head.id))
+                })?
+            }
         }
-    }
+        None => {
+            // **The sharp one.** `log` writes an entry another entry corrects
+            // and `release` hands back a task that can be claimed again;
+            // `done` cannot be undone by running it again. An agent that meant
+            // the task it claimed a minute ago and got the one it claimed an
+            // hour ago finds a task marked done, carrying a proof, whose work
+            // was never verified — so where the other two name the choice and
+            // act, this refuses and lets the caller name it (§3).
+            //
+            // Before the retake and before a single verifier: the answer must
+            // not cost ten minutes of test suite, and nothing may move on a
+            // task the caller has not named.
+            let also = claim::live_claims_of(cwd, identity, &head.id, claim::now_secs())?;
+            if !also.is_empty() {
+                let mut all: Vec<String> = vec![head.id.to_string()];
+                all.extend(also.iter().map(|(id, _)| id.to_string()));
+                return Err(CliError::new(
+                    6,
+                    format!(
+                        "{} live claims on this identity, and done takes one: {}",
+                        all.len(),
+                        all.join(", ")
+                    ),
+                )
+                .with_hint(format!(
+                    "ank done {}   ({})",
+                    head.id,
+                    claim::way_out()
+                )));
+            }
+            head
+        }
+    };
     if standing.lapsed && claim::retake(cwd, &standing, cap)? == claim::Cas::Lost {
         // Somebody claimed it between the read and the retake. Naming them is
         // the answer §3 asks for, and it is what tells the agent its work has

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -2734,6 +2734,150 @@ fn status_names_every_live_claim_of_this_identity() {
     assert!(!said.contains("also"), "{said}");
 }
 
+/// With two live claims under one identity, no verb acts on one of them without
+/// the caller being able to tell which (TASK-97d8747416ea).
+///
+/// `on_task` returns the first live record and `ank_refs` goes through
+/// `for-each-ref`, which sorts by refname, so HEAD is the lowest task id among
+/// the agent's live claims -- chosen, and until now chosen in silence. `log`
+/// wrote its entry there, `release` handed that one back, and `done` ran the
+/// verifiers of that one and moved it to `done`, none of them saying which of
+/// the two they had picked.
+///
+/// The state is built the way it stays reachable: `claim` refuses to create it
+/// (TASK-a548c95261a5), and a lapse revived produces it. Both claims are taken
+/// by the binary and only the clock between them is forged.
+///
+/// Through the binary because the assertion is on what reaches the caller, and
+/// on a real verifier because the point about `done` is *when* it refuses: a
+/// witness file the verifier writes is how "before a single verifier ran" is
+/// asserted rather than assumed.
+#[test]
+fn with_two_live_claims_no_verb_picks_one_in_silence() {
+    const FIRST: &str = "TASK-000000000e01";
+    const SECOND: &str = "TASK-000000000e02";
+    const THIRD: &str = "TASK-000000000e03";
+    const AGENT: &str = "claude-code@ank";
+
+    let r =
+        Repo::new().with_verifiers("verifiers:\n  witness:\n    run: echo ran > verifier-ran\n");
+    let witness = r.0.join("verifier-ran");
+    for id in [FIRST, SECOND, THIRD] {
+        r.seed_task_with(id, Some("A verifiable criterion."), &["witness"]);
+    }
+
+    // Two live claims, one identity. HEAD is FIRST, being the lower id.
+    assert_eq!(code(&r.ank(AGENT, &["claim", FIRST])), 0);
+    r.expire_claim(FIRST);
+    assert_eq!(code(&r.ank(AGENT, &["claim", SECOND])), 0);
+    r.revive_claim(FIRST);
+
+    // `log` acts, and says so before it writes.
+    let out = r.ank(AGENT, &["log", "one"]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    let said = stderr(&out);
+    assert!(said.contains(FIRST), "the task acted on is named: {said}");
+    assert!(said.contains(SECOND), "and the other live claim: {said}");
+    assert!(
+        said.contains("ank log"),
+        "and the command that names one explicitly: {said}"
+    );
+    assert!(said.contains("ANK_AGENT"), "and the way out: {said}");
+    assert!(
+        stdout(&out).contains(&format!("logged on {FIRST}")),
+        "{}",
+        stdout(&out)
+    );
+    assert!(r.task_text(FIRST).contains("one"), "the entry went to HEAD");
+
+    // Naming a task is what picks the other one, and it costs the refusal
+    // rather than a flag: the id used to have to equal HEAD.
+    let out = r.ank(AGENT, &["log", SECOND, "two"]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    assert!(
+        r.task_text(SECOND).contains("two"),
+        "the named task got the entry:\n{}",
+        r.task_text(SECOND)
+    );
+    assert!(
+        !stderr(&out).contains("live claims"),
+        "a caller that named its task is told nothing back: {}",
+        stderr(&out)
+    );
+
+    // The same sentences for a parser -- the caller that scripts around these
+    // verbs is exactly the caller running several sessions.
+    let json = stdout(&r.ank(AGENT, &["log", "--json", "three"]));
+    assert!(json.contains("\"warnings\""), "{json}");
+    assert!(json.contains(SECOND), "{json}");
+
+    // `done` refuses instead, being the verb whose effect running it again
+    // cannot undo -- and refuses before a verifier has run.
+    let out = r.ank(AGENT, &["done"]);
+    assert_eq!(code(&out), 6, "{}{}", stdout(&out), stderr(&out));
+    let said = stderr(&out);
+    assert!(said.contains(FIRST) && said.contains(SECOND), "{said}");
+    assert!(
+        said.contains(&format!("ank done {FIRST}")),
+        "the refusal names a command to run: {said}"
+    );
+    assert!(
+        !witness.exists(),
+        "a verifier ran before the caller had answered which task"
+    );
+    assert!(
+        r.task_text(FIRST).contains("status: in_progress")
+            && r.task_text(SECOND).contains("status: in_progress"),
+        "the refusal moved a task anyway"
+    );
+
+    // Named, it goes through, and it is the named one that moves.
+    let out = r.ank(AGENT, &["done", SECOND]);
+    assert_eq!(code(&out), 0, "{}{}", stdout(&out), stderr(&out));
+    assert!(witness.exists(), "the verifier of the named task never ran");
+    assert!(
+        r.task_text(SECOND).contains("status: done"),
+        "\n{}",
+        r.task_text(SECOND)
+    );
+    assert!(
+        r.task_text(FIRST).contains("status: in_progress"),
+        "done moved a task nobody named:\n{}",
+        r.task_text(FIRST)
+    );
+
+    // And `release`, which needs the state rebuilt: SECOND carries a completion
+    // ref now, so the second live claim is a fresh one.
+    r.expire_claim(FIRST);
+    assert_eq!(code(&r.ank(AGENT, &["claim", THIRD])), 0);
+    r.revive_claim(FIRST);
+
+    let out = r.ank(AGENT, &["release", "--reason", "the criterion is wrong"]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    let said = stderr(&out);
+    assert!(said.contains(FIRST) && said.contains(THIRD), "{said}");
+    assert!(said.contains("ank release"), "{said}");
+    assert!(
+        stdout(&out).contains(&format!("released {FIRST}")),
+        "{}",
+        stdout(&out)
+    );
+    assert!(
+        r.task_text(THIRD).contains("status: in_progress"),
+        "release handed back a task nobody named:\n{}",
+        r.task_text(THIRD)
+    );
+
+    // One claim, which is the nominal case, says none of it.
+    let out = r.ank(AGENT, &["log", "alone now"]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    assert!(
+        !stderr(&out).contains("live claims"),
+        "the nominal case pays for the exceptional one: {}",
+        stderr(&out)
+    );
+}
+
 /// A holder returning to a lapsed claim carries on; one whose task was taken
 /// over is told by whom.
 ///

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -166,8 +166,31 @@ impl Repo {
             .then(|| String::from_utf8_lossy(&out.stdout).to_string())
     }
 
-    /// Pushes a claim's expiry an hour into the past, leaving everything else
-    /// in the record untouched.
+    /// Pushes a claim's expiry into the past, leaving everything else in the
+    /// record untouched.
+    fn expire_claim(&self, id: &str) {
+        // Long past any TTL plus its tolerance, and stable whatever the
+        // machine's clock reads.
+        self.set_expiry(id, "2020-01-01T00:00:00Z");
+    }
+
+    /// The same surgery the other way: an expiry far enough ahead that the
+    /// claim reads live again.
+    ///
+    /// It exists because `claim` now refuses a second live claim under one
+    /// identity (TASK-a548c95261a5), and one identity holding two live claims
+    /// is still a state the corpus can be in — a ref written by hand, a claim
+    /// taken by an earlier binary, a lapse revived. Ank is not a gatekeeper
+    /// (ADR-6b3fa9ba3a05), so the fixtures that assert what the tool says about
+    /// that state cannot be built by claiming twice any more. Claim, expire,
+    /// claim, revive: both claims are taken by the binary and only the clock is
+    /// forged, which is what `expire_claim` was already doing.
+    fn revive_claim(&self, id: &str) {
+        self.set_expiry(id, "2099-01-01T00:00:00Z");
+    }
+
+    /// Rewrites a claim record's expiry and leaves every other byte of it
+    /// alone.
     ///
     /// Forged rather than waited for: expiry is judged with a two-minute
     /// clock-drift tolerance on top of the TTL, so the shortest honest wait for
@@ -175,16 +198,13 @@ impl Repo {
     /// one. The resulting ref is byte-identical to one that lapsed on its own —
     /// the record carries the expiry, and nothing else records the passage of
     /// time.
-    fn expire_claim(&self, id: &str) {
-        let record = self.claim_ref(id).expect("there is a claim to expire");
-        // Long past any TTL plus its tolerance, and stable whatever the
-        // machine's clock reads.
-        let past = "2020-01-01T00:00:00Z";
+    fn set_expiry(&self, id: &str, when: &str) {
+        let record = self.claim_ref(id).expect("there is a claim to date");
         let rewritten: String = record
             .lines()
             .map(|l| {
                 if l.starts_with("expires: ") {
-                    format!("expires: {past}")
+                    format!("expires: {when}")
                 } else {
                     l.to_string()
                 }
@@ -2075,19 +2095,25 @@ fn a_verb_is_never_abbreviated() {
     assert!(said.contains("unknown command 'cl'"), "{said}");
 }
 
-/// A second claim under one identity is named, never refused (TASK-d79dc424c63d).
+/// A second claim under one identity is refused (TASK-a548c95261a5).
 ///
 /// Observed while dogfooding: a task claimed in one terminal follows you into a
 /// second one, because `ANK_AGENT` unset makes both `<user>@<hostname>`. The
 /// identity is not bound to the session on purpose — a PID or a TTY in it would
-/// break resuming a claim after a restart — so what the fix owes the user is the
-/// warning and the way out.
+/// break resuming a claim after a restart.
 ///
-/// Through the binary, because a warning that never reaches stdout is not a
-/// warning, and because the environment variable under test is read by the
-/// process and not by the function.
+/// TASK-d79dc424c63d answered that with a warning naming the way out, and stays
+/// `done` with its proof intact (§3). The warning was measured to be not
+/// enough: it is printed once, at acquisition, and the claims do not
+/// collide — they accumulate, until `log`, `release` and `done` pick the lowest
+/// task id of the two in silence (TASK-97d8747416ea). §4 had said `claim`
+/// *enforces* one live claim per agent for as long as this only warned.
+///
+/// Through the binary, because the environment variable under test is read by
+/// the process and not by the function, and because a refusal that only exists
+/// in a function is not a refusal.
 #[test]
-fn a_second_claim_under_one_identity_warns_and_names_what_is_already_held() {
+fn a_second_claim_under_one_identity_is_refused_and_names_both_ways_out() {
     let first = "TASK-000000000d01";
     let second = "TASK-000000000d02";
     let r = Repo::new().with_verifiers("verifiers:\n  ok:\n    run: echo fine\n");
@@ -2097,47 +2123,74 @@ fn a_second_claim_under_one_identity_warns_and_names_what_is_already_held() {
     assert_eq!(code(&r.ank("claude-code@ank", &["claim", first])), 0);
 
     let out = r.ank("claude-code@ank", &["claim", second]);
-    let said = stdout(&out);
+    let said = format!("{}{}", stdout(&out), stderr(&out));
     assert_eq!(
         code(&out),
-        0,
-        "a convention warns, it does not refuse: {said}"
+        7,
+        "the prerequisite is missing, not the task: {said}"
     );
     assert!(
-        said.contains(&format!("already holds {first}")),
+        said.contains(first),
         "the claim already held is named: {said}"
     );
-    assert!(said.contains("ANK_AGENT"), "and the way out of it: {said}");
     assert!(
-        said.contains(&format!("claimed {second}")),
-        "the claim itself still went through: {said}"
+        said.contains("ank release"),
+        "the first way out is a command: {said}"
+    );
+    assert!(
+        said.contains("ANK_AGENT"),
+        "and the second is the one that fits a session that claimed nothing: {said}"
     );
 
-    // The other identity is the supported case and must stay silent: parallel
-    // agents, one ref per task, is the design and not the anomaly.
+    // Refused before anything was written. A refusal that leaves a ref behind
+    // is a claim with a bad conscience.
+    assert!(
+        r.claim_ref(second).is_none(),
+        "the refused task carries a claim ref"
+    );
+    assert!(
+        r.task_text(second).contains("status: open"),
+        "the refused task was moved anyway:\n{}",
+        r.task_text(second)
+    );
+
+    // The other identity is the supported case and must pass: parallel agents,
+    // one ref per task, is the design and not the anomaly.
     let third = "TASK-000000000d03";
     r.seed_task(third, Some("A criterion."));
     let out = r.ank("codex@ank", &["claim", third]);
-    let said = stdout(&out);
-    assert_eq!(code(&out), 0, "{}", stderr(&out));
-    assert!(
-        !said.contains("warning:"),
-        "a distinct identity holding its own task is not an anomaly: {said}"
+    assert_eq!(
+        code(&out),
+        0,
+        "a distinct identity holding its own task is not an anomaly: {}",
+        stderr(&out)
     );
 
-    // The lapsed case is a module test: the drift tolerance is two minutes, so
-    // waiting for an expiry here would cost two minutes of wall time.
+    // A lapsed claim is not a live one, so pickup after expiry (§3) passes
+    // through untouched — the same task, refused a moment ago, now claimable.
+    r.expire_claim(first);
+    let out = r.ank("claude-code@ank", &["claim", second]);
+    assert_eq!(
+        code(&out),
+        0,
+        "an expired claim refuses the next one: {}",
+        stderr(&out)
+    );
 }
 
-/// The warning sends the reader to `getting-started`, so `getting-started` has
-/// to be where the answer is (TASK-d79dc424c63d).
+/// The way out sends the reader to `getting-started`, so `getting-started` has
+/// to be where the answer is (TASK-d79dc424c63d, TASK-a548c95261a5).
 ///
 /// Driven by the binary rather than by a hand-copied string: the point is not
 /// that the guide mentions a variable, it is that the exact line the binary
-/// prints has somewhere to land. A warning naming a fix nobody wrote down is
-/// the defect this task is about, one level up.
+/// prints has somewhere to land. Naming a fix nobody wrote down is the defect
+/// this task is about, one level up.
+///
+/// Read off the refusal now that the second claim is one, and off standard
+/// error with it. What is under test is the sentence, not which stream carried
+/// it — `way_out` is written once and both callers read it.
 #[test]
-fn the_guide_documents_the_identity_the_warning_tells_you_to_set() {
+fn the_guide_documents_the_identity_the_way_out_tells_you_to_set() {
     let first = "TASK-000000000d11";
     let second = "TASK-000000000d12";
     let r = Repo::new().with_verifiers("verifiers:\n  ok:\n    run: echo fine\n");
@@ -2145,8 +2198,9 @@ fn the_guide_documents_the_identity_the_warning_tells_you_to_set() {
     r.seed_task(second, Some("A criterion."));
     assert_eq!(code(&r.ank("claude-code@ank", &["claim", first])), 0);
 
-    let said = stdout(&r.ank("claude-code@ank", &["claim", second]));
-    let warned: Vec<&str> = said.lines().filter(|l| l.starts_with("warning:")).collect();
+    let out = r.ank("claude-code@ank", &["claim", second]);
+    let said = format!("{}{}", stdout(&out), stderr(&out));
+    let warned: Vec<&str> = said.lines().filter(|l| l.contains("ANK_AGENT")).collect();
     assert!(!warned.is_empty(), "nothing to document: {said}");
 
     let guide = std::fs::read_to_string(
@@ -2156,10 +2210,14 @@ fn the_guide_documents_the_identity_the_warning_tells_you_to_set() {
 
     // The variable the warning names, and the shape of an invocation that sets
     // it: naming it without showing how to use it is half an answer.
+    // Trimmed of what punctuates the sentence rather than names the variable:
+    // the way out reaches the reader inside a hint's parenthetical, and
+    // `ANK_AGENT)` is the same variable as `ANK_AGENT`.
     let named: Vec<&str> = warned
         .iter()
         .flat_map(|l| l.split_whitespace())
         .filter(|w| w.contains("ANK_AGENT"))
+        .map(|w| w.trim_matches(|c: char| !c.is_ascii_alphanumeric() && c != '_'))
         .collect();
     assert!(!named.is_empty(), "the warning names no way out: {said}");
     for w in named {
@@ -2632,17 +2690,15 @@ fn status_names_every_live_claim_of_this_identity() {
     r.seed_task(ID, Some("A verifiable criterion."));
     r.seed_task(SECOND, Some("Another verifiable criterion."));
 
-    // One identity, two claims. Not refused, and deliberately so: one claim at
-    // a time is a convention, and parallel agents with distinct identities are
-    // the design.
+    // One identity, two live claims. `claim` refuses to produce that state now
+    // (TASK-a548c95261a5), and the state still exists — ank is not a gatekeeper
+    // (ADR-6b3fa9ba3a05), and a lapse revived is one of the ways in. Both
+    // claims are taken by the binary; only the clock between them is forged.
     assert_eq!(code(&r.ank("claude-code@ank", &["claim", ID])), 0);
+    r.expire_claim(ID);
     let out = r.ank("claude-code@ank", &["claim", SECOND]);
     assert_eq!(code(&out), 0, "{}", stderr(&out));
-    let said = format!("{}{}", stdout(&out), stderr(&out));
-    assert!(
-        said.contains("already holds"),
-        "the acquisition still says it: {said}"
-    );
+    r.revive_claim(ID);
 
     // The moment passes; the state does not.
     let said = stdout(&r.ank("claude-code@ank", &["status"]));

--- a/docs/ank-spec-v1.1.md
+++ b/docs/ank-spec-v1.1.md
@@ -236,6 +236,15 @@ Two hours granted and then honoured is not hoarding: `claim_ttl_max` is what bou
 
 **Return after expiry.** A 40-minute build with no `log` expires the claim; that is normal, not a fault. On expiry the task stays `in_progress` and becomes claimable again. When the original holder returns: if nobody took the task over, `log` and `done` **re-acquire silently** and carry on; if another agent took it over in the meantime, they fail with code 4 and the name of the new holder. Mechanically, "silently" means checking that no active claim exists for the task — the ref `refs/ank/claims/<id>` — then recreating it in the current agent's name, both steps resting on the atomic primitive of a ref update. No data is lost either way — the log says where each holder stopped.
 
+**Two live claims under one identity.** `claim` refuses to create that state (§4) and the CLI is not a gatekeeper, so it remains reachable: a ref written by hand, a claim taken by an earlier binary, a lapse revived. HEAD is then derived from more than one candidate, and what the verbs owe their caller is that **the choice is never silent** — the whole cost of the state is not that it exists but that `log`, `release` and `done` used to resolve it without a word.
+
+HEAD stays derived and the resolution stays deterministic: the lowest task id among the identity's live claims, because the refs are enumerated in refname order and nothing else would be reproducible. On top of that:
+
+- **`log` and `release` act, and say so first.** Before writing anything they name the task they resolved to, every other live claim of the identity with its expiry, the command that names another one explicitly, and the way out of a shared identity. On standard error, so that stdout stays what a parser already reads (§4); under `--json` the same sentences arrive in a `warnings` array, as `claim` already does — the caller that scripts around these verbs is exactly the caller running several sessions.
+- **`done` refuses**, code 6, and refuses **before running a single verifier**. It is the verb whose effect cannot be undone by running it again: an agent that meant the task it claimed a minute ago and got the one it claimed an hour ago finds a task marked `done`, carrying a proof, whose work was never verified. The refusal names every candidate and gives the command for one of them. Code 6 is what `log`, `release` and `done` already answer when HEAD resolves to no task at all; resolving to several is the same fact from the other side.
+
+**The explicit ID is what disambiguates**, which costs the refusal rather than a new flag. It stops meaning "must equal HEAD" and means "must name a task this agent holds a live claim on" — still never a way to act on somebody else's task, and still code 6 when it names one this agent does not hold. With one claim, which is the nominal case, the two readings are the same sentence.
+
 ### ADR
 
 `.ank/adr/ADR-3c7e0b9142af.md`
@@ -426,7 +435,7 @@ The refusal is on state and not on identity, in the sense of the table above: wh
 
 **It does not make the state unreachable, and nothing here assumes it does.** The CLI is not a gatekeeper (§7, §12): a ref written by hand, a claim taken by an earlier binary, or a claim that lapsed and was revived all produce one identity holding two live claims. What `log`, `release` and `done` do when they meet it is settled in §3, not here.
 
-The optional ID on `log`, `done` and `release` is therefore always redundant: it exists only for explicitness in scripts, and **must match HEAD**, otherwise error 6. It is never a way to act on somebody else's task.
+The optional ID on `log`, `done` and `release` is therefore redundant in the nominal case: it exists for explicitness in scripts, and it **must name a task this agent holds a live claim on**, otherwise error 6. It is never a way to act on somebody else's task. Holding one claim, that is the same rule as "must match HEAD"; holding several — the state §3 describes and this section refuses to create — it is what names which of them a verb acts on.
 
 ### Pickup and abandonment
 

--- a/docs/ank-spec-v1.1.md
+++ b/docs/ank-spec-v1.1.md
@@ -365,7 +365,7 @@ The binary refuses, and what it refuses on is always a fact about the corpus or 
 |---|---|
 | frozen field diverged from its anchoring hash, or illegal transition | 6 |
 | claim held by another agent, or task already finished on another branch | 4 |
-| task blocked, no `done_criteria`, or `accept` off the default branch | 7 |
+| task blocked, no `done_criteria`, `accept` off the default branch, or a live claim already held by the calling identity | 7 |
 | proof missing or invalid | 5 |
 
 That list is the guarantee. A state refusal applies to every caller equally and means the same thing to all of them, which is what makes it worth writing an exit code for; a refusal conditioned on identity would mean whatever the caller declared itself to be. `$ANK_AGENT` names who acted — it goes into the log, into the claim ref and into `check`'s signals — and it is never consulted to decide whether a verb runs.
@@ -407,6 +407,24 @@ The agent cannot get the identifier wrong, and every iteration saves a context r
 **HEAD is not stored, it is derived**: it is the task on which the current agent holds an active claim. Nothing to synchronise, nothing to clean up, no state that can become inconsistent with the real claim.
 
 This assumes and enforces **one active claim at a time per agent**. That is a useful constraint in itself: an agent must finish or release before moving on, which prevents task hoarding and keeps work in progress readable by others.
+
+**Enforcing it is what `claim` does**, and for a long time this paragraph said so while the binary only warned. A `claim` made while the calling identity already holds a live claim on another task refuses with **code 7**, naming the task held, its expiry, and both ways through:
+
+```
+$ ank claim 8f3a
+error[7]: claude-code@host-3 holds a live claim on TASK-51c2 (expires in 24m)
+  -> ank release --reason "<why>"   (a second session on this machine sets its own ANK_AGENT)
+```
+
+**Code 7 and not 4.** The task asked for is available; it is the caller that is not. 4 means "take something else" and the reaction called for here is the opposite — finish or hand back what is already held — so the code that carries "missing prerequisite" is the one that says it.
+
+**The second way out is not decoration**, and it is why this hint carries a parenthetical the way the "another ready task" hints do. The default identity is `<user>@<hostname>` (§8), so two sessions in one working tree read as one agent, and the session being refused may never have claimed anything: it is being answered about somebody else's claim, and `ANK_AGENT` is the only thing that separates the two. That is also why the message names the identity rather than addressing the caller as the holder — under a shared identity, telling it "you already hold" would be false.
+
+The refusal comes **after** the refusals about the task itself — no criterion, blocked, already claimed elsewhere, illegal transition. An agent told to release the work it holds, for a task that would have refused it anyway, has been made to pay for nothing.
+
+The refusal is on state and not on identity, in the sense of the table above: what is read is the coordination plane — which refs exist and who holds them — and the answer is the same for every caller. A **lapsed** claim is not a live one, so pickup after expiry (§3) is untouched, and an agent returning to a task whose lease ran out claims it exactly as before.
+
+**It does not make the state unreachable, and nothing here assumes it does.** The CLI is not a gatekeeper (§7, §12): a ref written by hand, a claim taken by an earlier binary, or a claim that lapsed and was revived all produce one identity holding two live claims. What `log`, `release` and `done` do when they meet it is settled in §3, not here.
 
 The optional ID on `log`, `done` and `release` is therefore always redundant: it exists only for explicitness in scripts, and **must match HEAD**, otherwise error 6. It is never a way to act on somebody else's task.
 
@@ -687,7 +705,7 @@ The semantics are carried by the code so that the shell can route without parsin
 | 4 | task unavailable — claim held by another agent, or task already finished on another branch (§7) |
 | 5 | proof missing or invalid |
 | 6 | illegal transition, or frozen field modified (hash diverged) |
-| 7 | missing prerequisite — no criterion, task blocked, or `accept` off the default branch |
+| 7 | missing prerequisite — no criterion, task blocked, `accept` off the default branch, or a live claim already held by the calling identity |
 | 8 | `check`: invariants violated (reserved for `check`, for CI) |
 | 9 | environment unavailable — not a task failure |
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -234,26 +234,30 @@ time, per person and per agent.
 
 ### One identity per session
 
-Claiming a second task while you already hold one is allowed, and it says so:
+Claiming a second task while you already hold one is refused:
 
     $ ank claim 51c2
-    warning: marie@laptop already holds TASK-820d259af6a7 until 2026-07-28T12:30:00Z
-    warning: a second session on this machine sets its own ANK_AGENT
-    claimed TASK-51c2a7f0b3d9 add-secret-rotation -> HEAD
+    error[7]: marie@laptop holds a live claim on TASK-820d259af6a7 (expires in 24m)
+      -> ank release --reason "<why>"   (a second session on this machine sets its own ANK_AGENT)
 
-If that is what you meant, ignore it. If it surprises you, it is almost
-certainly two terminals: `$ANK_AGENT` unset resolves to `<user>@<hostname>`, so
-two sessions on one machine are the same agent as far as the refs can tell —
-they see each other's claims, and each renews the other's. Give every
-concurrent session an identity of its own:
+If you meant it, the first way out is the one to take: finish the task you hold
+or hand it back. If the refusal surprises you, it is almost certainly two
+terminals: `$ANK_AGENT` unset resolves to `<user>@<hostname>`, so two sessions
+on one machine are the same agent as far as the refs can tell — they would see
+each other's claims and renew them. Give every concurrent session an identity
+of its own:
 
     $ ANK_AGENT=marie-2@laptop ank claim 51c2
 
-Nothing is broken in the refs when you do not: identity is declared, never
-proved, and it is deliberately not bound to the session — a PID or a TTY in it
-would mean losing your claim to a restarted terminal. Parallel agents, each
-with its own `ANK_AGENT`, are the supported case; one ref per task is what
-arbitrates them.
+That is why the refusal names the identity rather than calling you its holder:
+under a shared identity, the session being refused may have claimed nothing at
+all. Identity is declared, never proved, and it is deliberately not bound to the
+session — a PID or a TTY in it would mean losing your claim to a restarted
+terminal. Parallel agents, each with its own `ANK_AGENT`, are the supported
+case; one ref per task is what arbitrates them.
+
+An expired claim is not a live one, so this never stands between you and a task
+whose lease ran out — yours or anybody's.
 
 Run `ank context` again and the output inverts: no other task, the full
 criterion, and the constraints matching this task's scope.


### PR DESCRIPTION
Two tasks, in order. The first closes the door; the second answers the state that stays reachable anyway.

## TASK-a548c95261a5 — `claim` refuses a second live claim under one identity

Section 4 said `claim` "assumes and enforces one active claim at a time per agent" for as long as the binary only warned. Two sessions in one working tree with `ANK_AGENT` unset are one agent as far as the refs can tell, so their claims do not collide -- they accumulate.

- **Code 7, not 4.** The task asked for is available; it is the caller that is not, and what is missing is a prerequisite: finish or hand back what is already held.
- **Last of the preconditions**, so nobody is told to release their work for a task that would have refused them anyway.
- **The message names the identity, never the caller.** Under a shared identity the refused session may have claimed nothing at all, and the hint carries both ways through, taken from `way_out()` rather than copied.
- **A lapsed claim is not a live one**, so pickup after expiry is untouched.

Corrects TASK-d79dc424c63d, which stays `done` with its proof intact (spec section 3).

## TASK-97d8747416ea — log, release and done stop choosing HEAD in silence

`on_task` returns the first live record and `for-each-ref` sorts by refname, so HEAD was the lowest task id of the two, picked without a word. The CLI is not a gatekeeper (ADR-6b3fa9ba3a05), so the state survives the refusal above: a ref written by hand, a claim taken by an earlier binary, a lapse revived.

- **`log` and `release` act and say so first** -- the task resolved to, every other live claim with its expiry, the command that names one explicitly, and the way out. Standard error, before the write; the same sentences in a `warnings` array under `--json`, as `claim` already carries.
- **`done` refuses**, code 6, before the retake and before a single verifier runs. It is the verb whose effect running it again cannot undo. Code 6 is already what these verbs answer when HEAD resolves to no task; resolving to several is that fact from the other side.
- **The explicit id disambiguates**: it stops meaning "must equal HEAD" and means "a task this agent holds a live claim on". That cost the refusal, not a flag.

`head_of` and `check_matches_head` are replaced by one `acting_on`, which answers both questions in one lookup and warns only on the derived path.

## Tests

The two-live-claims fixture can no longer be built by claiming twice, so it is claim, expire, claim, revive: both claims taken through the binary, only the clock forged. `done`'s refusal is asserted with a witness file its verifier writes -- "before a single verifier ran" is otherwise assumed rather than tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KxhFCZTsaGLwqCwMKH1wZF