### PR TITLE
The skill states the execution model the loop it teaches assumes

### DIFF
--- a/.ank/tasks/TASK-e3f4b6295b23.md
+++ b/.ank/tasks/TASK-e3f4b6295b23.md
@@ -5,7 +5,7 @@ slug: the-skill-is-silent-on-the-nominal-execution-mod
 title: The skill is silent on the nominal execution model
 created: 2026-08-06T23:24:21Z
 author: seanl@sean-laptop
-status: in_progress
+status: done
 scope:
   - skill/**
   - docs/**
@@ -13,8 +13,12 @@ blocked_by: []
 done_criteria: |
   An agent that has loaded only skill/SKILL.md can state the nominal execution model - one working tree per agent, its own branch, its own ANK_AGENT - or the corpus records why the skill deliberately omits it.
 criteria_by: creator
+proof:
+  - type: test
+    ref: "31516796042"
+    criteria: e60d97ea86fc
 schema: 2
-version: 3
+version: 4
 ---
 
 Section 7 of the spec states the nominal case: one working tree per agent -
@@ -56,3 +60,4 @@ current state, where nothing in the corpus says which one was chosen.
 - 2026-08-11T17:17:07Z claude-code@nested-pebble — The skill now states the execution model, and it cost no superseding ADR. The task listed that as exit 1 and priced it highest, and the price was measured rather than assumed: what ADR-e17e freezes is which verbs the file teaches -- enforced by the_skill_teaches_nothing_beyond_what_is_frozen, a denylist of accept, close, attest, edit, status and scope -- plus the ceiling. This adds neither a verb nor a flag. TASK-21031b516bb2 had already added the styling guarantee on exactly those terms, ceiling held, revision regenerated, a test to keep it, with no succession, so the recipe existed and this follows it. 119 lines and 956 words against 140 and 1200.
 Two things changed in this task's premises since it was written, both from TASK-a548c95261a5 this morning. Its central argument was that two sessions sharing the fallback identity get a silent renewal where the skill implies a refusal; they now get a refusal too, code 7, naming ANK_AGENT. And the skill's own list of why claim refuses became incomplete by omission, so the list is corrected in the same edit -- a file loaded permanently that is wrong about a refusal costs more than one that is silent about it.
 The test asserts worktree, ANK_AGENT and degraded, and deliberately not branch: the file already says "finished on another branch", so a test resting on that token would have stayed green over a deleted paragraph. Falsified before being trusted -- removing the paragraph turns it red on the first token it cannot find.
+- 2026-08-11T17:20:58Z claude-code@nested-pebble — done, proof test:31516796042

--- a/.ank/tasks/TASK-e3f4b6295b23.md
+++ b/.ank/tasks/TASK-e3f4b6295b23.md
@@ -5,7 +5,7 @@ slug: the-skill-is-silent-on-the-nominal-execution-mod
 title: The skill is silent on the nominal execution model
 created: 2026-08-06T23:24:21Z
 author: seanl@sean-laptop
-status: open
+status: in_progress
 scope:
   - skill/**
   - docs/**
@@ -14,7 +14,7 @@ done_criteria: |
   An agent that has loaded only skill/SKILL.md can state the nominal execution model - one working tree per agent, its own branch, its own ANK_AGENT - or the corpus records why the skill deliberately omits it.
 criteria_by: creator
 schema: 2
-version: 1
+version: 3
 ---
 
 Section 7 of the spec states the nominal case: one working tree per agent -
@@ -51,3 +51,8 @@ superseding ADR and a human signature. Three candidate exits:
 
 The criterion is written to accept any of the three: what it forbids is the
 current state, where nothing in the corpus says which one was chosen.
+
+## Log
+- 2026-08-11T17:17:07Z claude-code@nested-pebble — The skill now states the execution model, and it cost no superseding ADR. The task listed that as exit 1 and priced it highest, and the price was measured rather than assumed: what ADR-e17e freezes is which verbs the file teaches -- enforced by the_skill_teaches_nothing_beyond_what_is_frozen, a denylist of accept, close, attest, edit, status and scope -- plus the ceiling. This adds neither a verb nor a flag. TASK-21031b516bb2 had already added the styling guarantee on exactly those terms, ceiling held, revision regenerated, a test to keep it, with no succession, so the recipe existed and this follows it. 119 lines and 956 words against 140 and 1200.
+Two things changed in this task's premises since it was written, both from TASK-a548c95261a5 this morning. Its central argument was that two sessions sharing the fallback identity get a silent renewal where the skill implies a refusal; they now get a refusal too, code 7, naming ANK_AGENT. And the skill's own list of why claim refuses became incomplete by omission, so the list is corrected in the same edit -- a file loaded permanently that is wrong about a refusal costs more than one that is silent about it.
+The test asserts worktree, ANK_AGENT and degraded, and deliberately not branch: the file already says "finished on another branch", so a test resting on that token would have stayed green over a deleted paragraph. Falsified before being trusted -- removing the paragraph turns it red on the first token it cannot find.

--- a/crates/ank-cli/tests/skill.rs
+++ b/crates/ank-cli/tests/skill.rs
@@ -330,6 +330,46 @@ fn the_skill_states_that_what_an_agent_reads_is_never_styled() {
     }
 }
 
+/// **The skill states the execution model the loop it teaches assumes**
+/// (TASK-e3f4b6295b23).
+///
+/// §7 states it, `docs/getting-started.md` repeats it, and the one file every
+/// agent actually loads said none of it: never a working tree of its own, never
+/// a branch of its own, never `ANK_AGENT`. That gap costs more than a
+/// documentation gap normally would, because the coordination the skill *does*
+/// teach is only correct under the model. "It refuses when the task is held" is
+/// true between agents with distinct identities; two sessions sharing the
+/// fallback identity are one agent to the refs, and what they get instead is a
+/// shared claim and a refusal handed to whichever of them asks second
+/// (TASK-a548c95261a5).
+///
+/// Not a superseding ADR, and the reason is measured rather than assumed. What
+/// ADR-e17e1bbd93ff freezes is which *verbs* the file teaches, which
+/// `the_skill_teaches_nothing_beyond_what_is_frozen` enforces, plus the ceiling
+/// below. This adds neither a verb nor a flag: it is a fact about the
+/// arrangement an agent is already working inside, the same register as "the
+/// criterion is frozen at claim". TASK-21031b516bb2 added the styling guarantee
+/// on exactly those terms — ceiling held, revision regenerated, a test to keep
+/// it — and that is the recipe followed here.
+///
+/// Asserted by the three things the sentence has to establish, and by tokens no
+/// other line of the file supplies, so that a correct rewrite passes and a
+/// removal fails. `branch` would have been the natural fourth and is deliberately
+/// not used: the file already says "finished on another branch", so a test
+/// resting on it would stay green over a deleted paragraph.
+#[test]
+fn the_skill_states_the_execution_model_it_assumes() {
+    let text = skill();
+    for token in ["worktree", "ANK_AGENT", "degraded"] {
+        assert!(
+            text.contains(token),
+            "SKILL.md does not say {token:?}: an agent that has loaded only this \
+             file knows the loop and not the arrangement the loop assumes, and \
+             the coordination it teaches is only correct under that arrangement"
+        );
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Which revision is installed (TASK-b495234f192c)
 // ---------------------------------------------------------------------------

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -2,7 +2,7 @@
 name: ank
 description: Read a repository's tasks and binding constraints, claim work, and finish it with proof. Use when working in a repo that has a .ank/ directory.
 metadata:
-  revision: "8295e2081364"
+  revision: "3f350ad26459"
 ---
 
 # ank
@@ -24,7 +24,8 @@ are never truncated; if something is cut, it says so.
 
 **`ank claim <id>`** — takes the task and freezes its `done_criteria` by hash.
 It refuses, with the reason and the next command, when the task is held, blocked,
-finished on another branch, or has no criterion to be measured against.
+finished on another branch, has no criterion to be measured against, or when you
+already hold a live claim on another task.
 
 **`ank show <id>`** — the entity whole, frontmatter and body, byte for byte.
 `context` gives you the criterion and the constraints; the body is where the
@@ -92,6 +93,14 @@ ends is part of planning well.
   directly. `ank show <id>` gives you an entity whole, `ank find` lists,
   `ank context` binds — the CLI knows the budget, the freeze and who holds what;
   the files do not.
+
+- **One agent, one working tree, one identity.** The nominal case is a tree per
+  agent — a clone or a `git worktree` — each on its own branch. `ANK_AGENT`
+  names the session and falls back to `<user>@<hostname>`, so two sessions in
+  one tree are one agent to the refs: they share a claim instead of arbitrating
+  over it, and the second one is refused work it should have been given. Set it
+  per session. Several agents in one tree runs, and is a degraded mode rather
+  than the design.
 
 - **What you read is never styled.** Colour is emitted only when a human is at
   a terminal, never into a pipe, a file or `--json`, so the bytes reaching you


### PR DESCRIPTION
Section 7 states the nominal execution model, `docs/getting-started.md` repeats it, and `skill/SKILL.md` -- the one file every agent actually loads -- said none of it: never a working tree of its own, never a branch of its own, never `ANK_AGENT`.

That gap costs more than a documentation gap normally would, because the coordination the skill *does* teach is only correct under the model. "It refuses when the task is held" is true between agents with distinct identities; two sessions sharing the fallback identity are one agent to the refs.

## No superseding ADR, and the price was measured

TASK-e3f4b6295b23 listed this as its exit 1 and priced it highest. What ADR-e17e1bbd93ff freezes is which *verbs* the file teaches -- enforced by `the_skill_teaches_nothing_beyond_what_is_frozen`, a denylist of `accept`, `close`, `attest`, `edit`, `status`, `scope` -- plus the ceiling. This adds neither a verb nor a flag: it is a fact about the arrangement an agent is already working inside, the same register as "the criterion is frozen at claim".

TASK-21031b516bb2 added the styling guarantee on exactly those terms -- ceiling held, revision regenerated, a test to keep it, no succession. That is the recipe followed here. **119 lines and 956 words against 140 and 1200.**

## Two premises moved this morning

Both from TASK-a548c95261a5, merged in #82:

- The task's central argument was that two sessions sharing an identity get a *silent renewal* where the skill implies a refusal. They now get a refusal too, code 7, naming `ANK_AGENT`.
- The skill's own list of why `claim` refuses became incomplete by omission, so it is corrected in the same edit. A permanently loaded file that is wrong about a refusal costs more than one that is silent about it.

## The test

Asserts `worktree`, `ANK_AGENT` and `degraded`, and deliberately **not** `branch`: the file already says "finished on another branch", so a test resting on that token would stay green over a deleted paragraph. Falsified before being trusted -- removing the paragraph turns it red on the first token it cannot find.

TASK-e3f4b6295b23

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KxhFCZTsaGLwqCwMKH1wZF