### PR TITLE
status names every live claim, and execution mode stays silent by design

### DIFF
--- a/.ank/tasks/TASK-dacbcae6134c.md
+++ b/.ank/tasks/TASK-dacbcae6134c.md
@@ -5,17 +5,18 @@ slug: execution-mode-hides-the-coordination-plane-and
 title: Execution mode hides the coordination plane, and nothing says whether that is meant
 created: 2026-08-11T03:42:29Z
 author: seanl@sean-laptop
-status: open
+status: in_progress
 scope:
   - docs/ank-spec-v1.1.md
   - crates/ank-cli/src/context.rs
   - crates/ank-cli/src/status.rs
+  - crates/ank-cli/tests/**
 blocked_by: []
 done_criteria: |
   Section 5 of docs/ank-spec-v1.1.md says what a holder of a claim can see of the coordination plane and why, naming which verb answers it. If the answer is that execution mode shows nothing and status is where the question belongs, section 5 says so and status carries it; if execution mode is to show it, context does. Either way a test through the binary asserts what the specification now promises, with a second agent holding a claim on another task.
 criteria_by: creator
 schema: 2
-version: 1
+version: 4
 ---
 
 With a claim held, `context` switches to execution mode and renders that task
@@ -42,3 +43,10 @@ held. Level 1 is not implemented (TASK-82c3341502c1), so within one clone the
 claim refs are shared and `claim` already refuses -- which may make this
 finding moot until claims are pushed, and that is itself an answer worth
 writing down.
+
+## Log
+- 2026-08-11T17:30:54Z claude-code@nested-pebble — amended: +scope crates/ank-cli/tests/**
+- 2026-08-11T17:39:29Z claude-code@nested-pebble — Measured before deciding, which is what the task asked for. build_execution already fills View.in_progress with every live holder, and render never reads it on that path -- execution mode prints the task, the criterion, the constraints and the log, and nothing else. So the plane was not merely hidden from a holder, it was computed for it and thrown away. That settles the shape: execution mode shows nothing and is right not to, because it exists to remove choice and a list of what other agents hold is choice-shaped, and the field it filled for nobody is the evidence rather than the argument.
+What a holder could act on is smaller than it looks, and that is what makes status the right home rather than context. At level 0 the refs are shared inside the clone, so two agents cannot hold one task -- claim refuses with code 4 and names the holder -- and a holder reading that somebody else is on another task learns something true and acts on none of it. Worth reporting, not worth paying for on every turn. When claims are pushed (level 1, TASK-82c3341502c1) the answer becomes worth more and nothing here has to move, because it is already a question status answers.
+status therefore names every live claim in the repository, read through the same context::coordination map every listing verb uses rather than a second enumeration, sorted by id so two runs that changed nothing print the same bytes. It says "elsewhere no claim by another agent" when there is none: silence and "this verb does not answer that" read identically, and relocating a question is worthless if the new home is mute. --json carries elsewhere on the same terms as also_held.
+One process lesson, paid for here. My first falsification of the new test was a regex that matched nothing, so the file was unchanged and the test passed -- and a falsification that does not change the file is a green that means nothing, indistinguishable from a test that guards the behaviour. Removing the block by line range turned it red on the right assertion. Check that the file moved before trusting what the suite says about it.

--- a/.ank/tasks/TASK-dacbcae6134c.md
+++ b/.ank/tasks/TASK-dacbcae6134c.md
@@ -5,7 +5,7 @@ slug: execution-mode-hides-the-coordination-plane-and
 title: Execution mode hides the coordination plane, and nothing says whether that is meant
 created: 2026-08-11T03:42:29Z
 author: seanl@sean-laptop
-status: in_progress
+status: done
 scope:
   - docs/ank-spec-v1.1.md
   - crates/ank-cli/src/context.rs
@@ -15,8 +15,12 @@ blocked_by: []
 done_criteria: |
   Section 5 of docs/ank-spec-v1.1.md says what a holder of a claim can see of the coordination plane and why, naming which verb answers it. If the answer is that execution mode shows nothing and status is where the question belongs, section 5 says so and status carries it; if execution mode is to show it, context does. Either way a test through the binary asserts what the specification now promises, with a second agent holding a claim on another task.
 criteria_by: creator
+proof:
+  - type: test
+    ref: "31518704754"
+    criteria: be34a1c3e2e7
 schema: 2
-version: 4
+version: 5
 ---
 
 With a claim held, `context` switches to execution mode and renders that task
@@ -50,3 +54,4 @@ writing down.
 What a holder could act on is smaller than it looks, and that is what makes status the right home rather than context. At level 0 the refs are shared inside the clone, so two agents cannot hold one task -- claim refuses with code 4 and names the holder -- and a holder reading that somebody else is on another task learns something true and acts on none of it. Worth reporting, not worth paying for on every turn. When claims are pushed (level 1, TASK-82c3341502c1) the answer becomes worth more and nothing here has to move, because it is already a question status answers.
 status therefore names every live claim in the repository, read through the same context::coordination map every listing verb uses rather than a second enumeration, sorted by id so two runs that changed nothing print the same bytes. It says "elsewhere no claim by another agent" when there is none: silence and "this verb does not answer that" read identically, and relocating a question is worthless if the new home is mute. --json carries elsewhere on the same terms as also_held.
 One process lesson, paid for here. My first falsification of the new test was a regex that matched nothing, so the file was unchanged and the test passed -- and a falsification that does not change the file is a green that means nothing, indistinguishable from a test that guards the behaviour. Removing the block by line range turned it red on the right assertion. Check that the file moved before trusting what the suite says about it.
+- 2026-08-11T17:43:46Z claude-code@nested-pebble — done, proof test:31518704754

--- a/crates/ank-cli/src/status.rs
+++ b/crates/ank-cli/src/status.rs
@@ -86,6 +86,32 @@ pub fn run(
         None => Vec::new(),
     };
 
+    // **Every live claim in the repository, the caller's and everybody
+    // else's** (§5, TASK-dacbcae6134c). `context` in execution mode shows none
+    // of it and is right not to: it exists to remove choice, and a list of what
+    // other agents hold is choice-shaped. The information is not withheld, it
+    // is relocated here — `status` is off the loop, costs nothing to skip, and
+    // is the verb an agent runs to learn where things stand rather than what to
+    // do next.
+    //
+    // Read through the same `coordination` map every listing verb uses, not a
+    // second enumeration of the refs: one plane, one reading, and a second one
+    // would be free to disagree with the first.
+    let plane = context::coordination(&repo.root, &mut Vec::new())?;
+    let mut elsewhere: Vec<(ank_core::EntityId, String, String)> = plane
+        .iter()
+        .filter_map(|(id, state)| match state {
+            context::Coordination::Claimed { holder, expires } if holder != identity => {
+                Some((id.clone(), holder.clone(), expires.clone()))
+            }
+            _ => None,
+        })
+        .collect();
+    // By id, as `live_claims_of` orders its own answer: the plane is a map, and
+    // a status whose lines move between two runs that changed nothing is a
+    // status nobody diffs.
+    elsewhere.sort_by(|a, b| a.0.to_string().cmp(&b.0.to_string()));
+
     // `prune: false`. A reader does not sanitise the coordination plane
     // underneath everyone else, which is the rule `context` already follows.
     let report = human::inspect(repo, cfg, None, false)?;
@@ -140,15 +166,29 @@ pub fn run(
             .iter()
             .map(|(id, c)| format!("{{\"id\":\"{id}\",\"expires\":\"{}\"}}", c.expires))
             .collect();
+        // The other agents' claims, on the same terms as `also_held`: a caller
+        // that scripts around `status` is the one most likely to be running
+        // several agents at once, and a field the human surface has and this
+        // one lacks hides the case from the reader most likely to meet it.
+        let elsewhere_json: Vec<String> = elsewhere
+            .iter()
+            .map(|(id, holder, expires)| {
+                format!(
+                    "{{\"id\":\"{id}\",\"holder\":{},\"expires\":\"{expires}\"}}",
+                    commands::json_string(holder)
+                )
+            })
+            .collect();
         let _ = writeln!(
             out,
             "{{\"branch\":{},\"default_branch\":{},\"claim\":{claim_json},\
-             \"also_held\":[{}],\
+             \"also_held\":[{}],\"elsewhere\":[{}],\
              \"constraints\":{constraints},\"queue\":{queue},\"unmerged\":{unmerged},\
              \"faults\":{},\"signals\":{}}}",
             opt_json(branch.as_deref()),
             opt_json(default.as_ref().ok().map(|s| s.as_str())),
             also_json.join(","),
+            elsewhere_json.join(","),
             report.faults(),
             report.signals()
         );
@@ -219,6 +259,29 @@ pub fn run(
                 let _ = writeln!(out, "{}", style.key("no claim"));
             }
         },
+    }
+
+    // Said even when there is nothing to say. Silence and "this verb does not
+    // answer that" read identically, and the whole point of relocating the
+    // question here is that it has an answer (§5).
+    match elsewhere.len() {
+        0 => {
+            let _ = writeln!(out, "{}", style.key("elsewhere no claim by another agent"));
+        }
+        n => {
+            let _ = writeln!(
+                out,
+                "{} {n} claim(s) by other agents",
+                style.key("elsewhere")
+            );
+            for (id, holder, expires) in &elsewhere {
+                let _ = writeln!(
+                    out,
+                    "  {} {holder} until {expires}",
+                    style.id(&id.to_string())
+                );
+            }
+        }
     }
 
     let perimeter = match &claimed {

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -2734,6 +2734,72 @@ fn status_names_every_live_claim_of_this_identity() {
     assert!(!said.contains("also"), "{said}");
 }
 
+/// What a holder of a claim sees of the coordination plane (TASK-dacbcae6134c).
+///
+/// The agent best placed to notice a collision is the one currently working,
+/// and it is the one `context` stops showing the plane to: execution mode drops
+/// every other task, so `[claimed:holder]` has no listing left to sit on. §5
+/// now says that is deliberate -- execution mode exists to remove choice, and a
+/// list of what other agents hold is choice-shaped -- and that the information
+/// is relocated rather than withheld, to `status`, which is off the loop and
+/// costs nothing to skip.
+///
+/// The four assertions are the specification's four halves: orientation shows
+/// it, execution does not, `status` does, and `status` says so even when there
+/// is nothing to say -- silence and "this verb does not answer that" read
+/// identically otherwise.
+#[test]
+fn a_holder_reads_the_plane_through_status_and_execution_context_stays_silent() {
+    const MINE: &str = "TASK-000000000f01";
+    const THEIRS: &str = "TASK-000000000f02";
+    let r = Repo::new();
+    r.seed_task(MINE, Some("A verifiable criterion."));
+    r.seed_task(THEIRS, Some("A verifiable criterion."));
+    assert_eq!(code(&r.ank("codex@host-9", &["claim", THEIRS])), 0);
+
+    // Orientation, before claiming anything: the marker is here, and this is
+    // the moment it is worth reading -- the agent is choosing.
+    let said = stdout(&r.ank("claude-code@ank", &["context"]));
+    assert!(
+        said.contains("codex@host-9"),
+        "orientation hides who holds what, which is when it matters:\n{said}"
+    );
+
+    assert_eq!(code(&r.ank("claude-code@ank", &["claim", MINE])), 0);
+
+    // Execution mode: nothing of the plane, deliberately.
+    let said = stdout(&r.ank("claude-code@ank", &["context"]));
+    assert!(
+        said.contains(MINE),
+        "execution mode lost its own task:\n{said}"
+    );
+    assert!(
+        !said.contains(THEIRS) && !said.contains("codex@host-9"),
+        "execution mode offers a task it exists to keep out of view:\n{said}"
+    );
+
+    // `status` is where the question was relocated to.
+    let said = stdout(&r.ank("claude-code@ank", &["status"]));
+    assert!(
+        said.contains(THEIRS) && said.contains("codex@host-9"),
+        "status names no claim but the caller's own:\n{said}"
+    );
+
+    let json = stdout(&r.ank("claude-code@ank", &["status", "--json"]));
+    assert!(json.contains("\"elsewhere\""), "{json}");
+    assert!(json.contains("codex@host-9"), "{json}");
+
+    // And with nobody else on anything, it answers rather than going quiet.
+    let solo = Repo::new();
+    solo.seed_task(MINE, Some("A verifiable criterion."));
+    assert_eq!(code(&solo.ank("claude-code@ank", &["claim", MINE])), 0);
+    let said = stdout(&solo.ank("claude-code@ank", &["status"]));
+    assert!(
+        said.contains("no claim by another agent"),
+        "an empty plane and an unanswered question read alike:\n{said}"
+    );
+}
+
 /// With two live claims under one identity, no verb acts on one of them without
 /// the caller being able to tell which (TASK-97d8747416ea).
 ///

--- a/docs/ank-spec-v1.1.md
+++ b/docs/ank-spec-v1.1.md
@@ -838,6 +838,12 @@ The single most decisive point for real use. A `context` that explodes on a larg
 
 Same command, output driven by HEAD. Nothing more for the agent to memorise, and most of the useless context disappears.
 
+**What a holder sees of the coordination plane: nothing, and `status` is where the question belongs.** The markers `[claimed:holder]` and `[finished:<sha> on <branch>]` are orientation's, and execution mode carries no listing for them to sit on. That is deliberate rather than incidental. Execution mode exists to remove choice — it is why it drops every other task — and a list of what other agents hold is choice-shaped: it invites the one thing the mode is built to prevent, an agent shopping for work it has not finished. The end-of-loop line does name holders (`1 in progress by codex@host-9`), and it belongs to orientation for the same reason: it is what an agent reads when it has nothing to do.
+
+The information is not withheld, it is relocated. **`ank status` names every live claim in the repository, the caller's own and the other agents'**, with the holder and the expiry. `status` is off the loop, costs nothing to skip, and is what an agent runs when it wants to know where things stand rather than what to do next — the same argument that put a second claim of one identity there rather than in `context` (§7, TASK-38b384543551). It says so even when there is nothing to say, because silence and "this verb does not answer that" read identically.
+
+What a holder can do with the answer is smaller than it looks, and that bounds how much either verb owes it. At level 0 the claim refs are shared within the clone, so two agents cannot hold one task: `claim` refuses with code 4 and names the holder. A holder reading that another agent is on another task therefore learns something true and acts on none of it — which is exactly why the reporting verb is the right home and the working verb is not. When claims are pushed (level 1, §7), two clones arbitrate and the answer becomes worth more; nothing here has to change for that, because it is already a question `status` answers.
+
 ```
 $ ank context src/auth/
 


### PR DESCRIPTION
The agent best placed to notice a collision is the one currently working, and it is the one `context` stops showing the plane to. Section 5 now says what a holder of a claim sees of the coordination plane, why, and which verb answers it.

## Measured before decided

`build_execution` already fills `View.in_progress` with every live holder, and `render` never reads it on that path -- execution mode prints the task, the criterion, the constraints and the log, and nothing else. The plane was not merely hidden from a holder: it was computed for it and discarded.

That settles the shape. Execution mode shows nothing and is right not to -- it exists to remove choice, and a list of what other agents hold is choice-shaped. The end-of-loop line does name holders, and it belongs to orientation for the same reason: it is what an agent reads when it has nothing to do.

## Relocated, not withheld

`ank status` now names **every live claim in the repository**, the caller's own and the other agents', with the holder and the expiry:

```
claim TASK-dacb Execution mode hides the coordination plane
  expires 2026-08-11T17:58:53Z
elsewhere 1 claim(s) by other agents
  TASK-f02  codex@host-9 until 2026-08-11T18:12:00Z
```

Read through the same `context::coordination` map every listing verb uses -- one plane, one reading -- and sorted by id, so two runs that changed nothing print the same bytes. It says `elsewhere no claim by another agent` when there is none: silence and "this verb does not answer that" read identically, and relocating a question is worthless if its new home is mute. `--json` carries `elsewhere` on the same terms as `also_held`.

## What bounds it

At level 0 the refs are shared inside the clone, so two agents cannot hold one task -- `claim` refuses with code 4 and names the holder. A holder reading that another agent is on another task learns something true and acts on none of it, which is exactly why the reporting verb is the right home and the working verb is not. When claims are pushed (level 1, TASK-82c3341502c1) the answer is worth more, and nothing here has to change.

## Test

Through the binary, with a second agent holding a claim on another task, asserting the specification's four halves: orientation shows it, execution does not, `status` does, and `status` answers when the plane is empty. Falsified by removing the block -- it turns red on the right assertion.

TASK-dacbcae6134c

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KxhFCZTsaGLwqCwMKH1wZF