### PR TITLE
Level 1: claims are pushed, so two clones arbitrate

### DIFF
--- a/.ank/tasks/TASK-82c3341502c1.md
+++ b/.ank/tasks/TASK-82c3341502c1.md
@@ -5,7 +5,7 @@ slug: level-1-claims-pushed-so-two-clones-arbitrate
 title: "Level 1: claims pushed, so two clones arbitrate"
 created: 2026-08-10T05:57:50Z
 author: claude-code@ank
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/**
   - docs/**
@@ -14,7 +14,7 @@ done_criteria: |
   claim, log and done push refs/ank/claims/<id> to the remote, and a test drives two clones of one repository through the binary: the second claim on a task already held in the first is refused with code 4. Offline, the claim is taken locally, marked unsynchronised, and warned about rather than refused -- degrade, do not fail. Section 7 stops saying level 1 is unimplemented in the same change, and the negative test in git.rs that guards that sentence goes with it. cargo test, cargo fmt --check and ank check stay green.
 criteria_by: creator
 schema: 2
-version: 1
+version: 3
 ---
 
 Split out of TASK-83d6eefdb36e, which found the gap and deliberately did not pick between implementing it and writing it down. The specification now says what is true -- only level 0 ships, worktrees of one clone are arbitrated and separate clones are not -- so this task is the other exit, taken on its own terms rather than under a criterion written for both.
@@ -30,3 +30,10 @@ The cost lands on the hot path. log renews the TTL and an agent logs often; ever
 Offline is the hard half. A claim taken with no remote reachable has to be marked unsynchronised and said out loud, and the wording matters more than the mechanism: the risk of a concurrent claim is displayed, not hidden.
 
 The test is named in the criterion because the criterion is about the binary: two clones of one repository, the second claim refused with code 4. A unit test over the push helper would prove the helper works and leave the property untested.
+
+## Log
+- 2026-08-11T18:12:58Z claude-code@nested-pebble — Level 1 ships. The primitive was probed before any design: git push --force-with-lease=<ref>:<expect> with an empty expectation means "this ref must not exist", it works on a ref pointing at a blob, and two clones racing produce one winner with the loser getting a non-zero exit and the remote unchanged. So the lease is the same witness the local update-ref already swaps on, and the two checks are one rule rather than two that agree today.
+That made the placement obvious: every write of the plane already goes through claim::put, so the push lives there and covers acquisition, the renewal log performs, the retake of a lapsed claim and the completion record done writes, without any of the four remembering to. Local swap first, then the remote: a push landing over a local write that lost would leave this clone believing something its own refs deny. A refused push corrects the local ref to the winner's record by fetching it, rather than rolling back to nothing, because the caller's next question is who holds it and lost_the_race reads exactly there.
+Two things beyond the criterion, both because the change creates the state that needs them. release and close push the deletion: a claim handed back but left standing on the remote would make the task unclaimable in every other clone until its TTL ran out, which is a defect this change would otherwise introduce. And level 0 stays silent -- no remote is not a degradation, it is the default mode, so the discriminant is remote.origin.url and absence warns about nothing. That discriminant turned out to matter more than expected: ank init writes remote.origin.fetch with no URL, so keying on the remote's existence rather than its URL would have put every freshly initialised solo repository into level 1 and made it warn on every claim.
+Refused and unreachable are told apart by asking rather than by reading stderr: one ls-remote of the same ref after a failed push. An answer means the remote is there and the swap genuinely lost; no answer means the remote is what failed. Push says "rejected" in prose written for people, and parsing it is the fragility ADR-b8884edcebe3 exists to prevent.
+The hot path, measured rather than inherited as section 7 asked. Twenty ank log runs on Windows: 668 ms each against a local bare origin, 639 ms with no remote -- about 30 ms of local overhead, lost in the process spawning that dominates a run there. The network is the real cost: ten ls-remote calls against the GitHub origin averaged 515 ms. So a log costs about half a second more in the field, which is the "on the order of a second" the section always claimed and now has a number for.

--- a/.ank/tasks/TASK-82c3341502c1.md
+++ b/.ank/tasks/TASK-82c3341502c1.md
@@ -5,7 +5,7 @@ slug: level-1-claims-pushed-so-two-clones-arbitrate
 title: "Level 1: claims pushed, so two clones arbitrate"
 created: 2026-08-10T05:57:50Z
 author: claude-code@ank
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/**
   - docs/**
@@ -13,8 +13,12 @@ blocked_by: []
 done_criteria: |
   claim, log and done push refs/ank/claims/<id> to the remote, and a test drives two clones of one repository through the binary: the second claim on a task already held in the first is refused with code 4. Offline, the claim is taken locally, marked unsynchronised, and warned about rather than refused -- degrade, do not fail. Section 7 stops saying level 1 is unimplemented in the same change, and the negative test in git.rs that guards that sentence goes with it. cargo test, cargo fmt --check and ank check stay green.
 criteria_by: creator
+proof:
+  - type: test
+    ref: "31521596785"
+    criteria: 25f435711515
 schema: 2
-version: 3
+version: 4
 ---
 
 Split out of TASK-83d6eefdb36e, which found the gap and deliberately did not pick between implementing it and writing it down. The specification now says what is true -- only level 0 ships, worktrees of one clone are arbitrated and separate clones are not -- so this task is the other exit, taken on its own terms rather than under a criterion written for both.
@@ -37,3 +41,4 @@ That made the placement obvious: every write of the plane already goes through c
 Two things beyond the criterion, both because the change creates the state that needs them. release and close push the deletion: a claim handed back but left standing on the remote would make the task unclaimable in every other clone until its TTL ran out, which is a defect this change would otherwise introduce. And level 0 stays silent -- no remote is not a degradation, it is the default mode, so the discriminant is remote.origin.url and absence warns about nothing. That discriminant turned out to matter more than expected: ank init writes remote.origin.fetch with no URL, so keying on the remote's existence rather than its URL would have put every freshly initialised solo repository into level 1 and made it warn on every claim.
 Refused and unreachable are told apart by asking rather than by reading stderr: one ls-remote of the same ref after a failed push. An answer means the remote is there and the swap genuinely lost; no answer means the remote is what failed. Push says "rejected" in prose written for people, and parsing it is the fragility ADR-b8884edcebe3 exists to prevent.
 The hot path, measured rather than inherited as section 7 asked. Twenty ank log runs on Windows: 668 ms each against a local bare origin, 639 ms with no remote -- about 30 ms of local overhead, lost in the process spawning that dominates a run there. The network is the real cost: ten ls-remote calls against the GitHub origin averaged 515 ms. So a log costs about half a second more in the field, which is the "on the order of a second" the section always claimed and now has a number for.
+- 2026-08-11T18:17:29Z claude-code@nested-pebble — done, proof test:31521596785

--- a/crates/ank-cli/src/claim.rs
+++ b/crates/ank-cli/src/claim.rs
@@ -501,11 +501,132 @@ fn current_object(cwd: &Path, id: &EntityId) -> Result<Option<String>> {
     Ok(if o.is_empty() { None } else { Some(o) })
 }
 
+/// How far a write of the coordination plane got (§7).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Sync {
+    /// No remote: level 0, the default mode and the only one that shipped
+    /// before level 1. Silent by construction — a warning here would fire on
+    /// every claim of every solo repository.
+    Local,
+    /// The remote took it, so the claim holds repository-wide and not merely
+    /// in this clone.
+    Pushed,
+    /// A remote exists and could not be reached. The claim stands locally and
+    /// the caller says so: degrade, do not fail (§2), and the risk of a
+    /// concurrent claim is displayed rather than hidden.
+    Unsynchronised(String),
+}
+
+impl Sync {
+    /// The sentence a verb prints when the plane did not reach the remote, or
+    /// `None` when there is nothing to report.
+    ///
+    /// Written once because three verbs say it and a warning restated three
+    /// times is three chances to describe a different state.
+    pub fn warning(&self) -> Option<String> {
+        match self {
+            Sync::Local | Sync::Pushed => None,
+            Sync::Unsynchronised(_) => Some(
+                "claim not pushed: it holds in this clone only, and another clone \
+                 can take the same task"
+                    .to_string(),
+            ),
+        }
+    }
+}
+
+/// The outcome of a write: whether it took, and how far it reached.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Written {
+    pub cas: Cas,
+    pub sync: Sync,
+}
+
 /// Puts `record` on the ref. `witness` is the object the caller read: `None`
 /// requires the ref to be absent, `Some` requires it to be exactly there.
-pub fn put(cwd: &Path, id: &EntityId, record: &Record, witness: Option<&str>) -> Result<Cas> {
+///
+/// **The one place the two planes meet** (§7). Every write of a claim goes
+/// through here — acquisition, the renewal `log` performs, the retake of a
+/// lapsed claim, the completion record `done` writes — so pushing here covers
+/// all four without any of them remembering to. The lease handed to the remote
+/// is the same `witness` the local swap used, which is what makes the two
+/// checks one rule rather than two that agree today.
+///
+/// **Local first, then the remote.** The local swap is what this clone's own
+/// verbs read next; a push landing over a local write that lost would leave
+/// this clone believing something the refs deny.
+///
+/// A remote that refuses the swap means another clone holds the task, and the
+/// local ref is then corrected to the winner's record rather than rolled back
+/// to nothing: the caller's next question is *who holds it*, and the answer has
+/// to be readable where it looks.
+pub fn put(cwd: &Path, id: &EntityId, record: &Record, witness: Option<&str>) -> Result<Written> {
     let blob = write_blob(cwd, record)?;
-    update(cwd, id, &blob, witness)
+    if update(cwd, id, &blob, witness)? == Cas::Lost {
+        return Ok(Written {
+            cas: Cas::Lost,
+            sync: Sync::Local,
+        });
+    }
+    push(cwd, id, Some(&blob), witness)
+}
+
+/// The remote half of a write, shared by [`put`] and [`delete`].
+fn push(cwd: &Path, id: &EntityId, new: Option<&str>, witness: Option<&str>) -> Result<Written> {
+    if git::remote(cwd)?.is_none() {
+        return Ok(Written {
+            cas: Cas::Won,
+            sync: Sync::Local,
+        });
+    }
+    let name = ref_name(id);
+    match git::push_claim(cwd, &name, new, witness)? {
+        git::Pushed::Ok => Ok(Written {
+            cas: Cas::Won,
+            sync: Sync::Pushed,
+        }),
+        git::Pushed::Refused { .. } => {
+            // The winner's record, brought here so that whoever asks next reads
+            // the truth rather than this clone's rejected guess. If even that
+            // fails, the local ref keeps what we wrote and the caller still
+            // learns it lost — a wrong holder named is worse than none.
+            let _ = git::fetch_claim(cwd, &name);
+            Ok(Written {
+                cas: Cas::Lost,
+                sync: Sync::Pushed,
+            })
+        }
+        git::Pushed::Unreachable { reason } => Ok(Written {
+            cas: Cas::Won,
+            sync: Sync::Unsynchronised(reason),
+        }),
+    }
+}
+
+/// The remote's view of one claim, brought into this clone before a decision
+/// rests on it (§7).
+///
+/// `claim` runs this first so that a task held in another clone is refused with
+/// its holder named, rather than taken locally and then unwound by a rejected
+/// push. The push remains what arbitrates; this only makes the common case
+/// answer politely.
+///
+/// Silent on every failure. An unreachable remote means the local view is the
+/// only one available, and saying so belongs to the write that follows, which
+/// is where the risk actually lands.
+pub fn sync_from_remote(cwd: &Path, id: &EntityId) -> Result<()> {
+    if git::remote(cwd)?.is_none() {
+        return Ok(());
+    }
+    let name = ref_name(id);
+    let Ok(Some(theirs)) = git::ls_remote(cwd, &name) else {
+        return Ok(());
+    };
+    if current_object(cwd, id)?.as_deref() == Some(theirs.as_str()) {
+        return Ok(());
+    }
+    let _ = git::fetch_claim(cwd, &name);
+    Ok(())
 }
 
 /// Deletes the ref. This is what `release` and `close` do — and only they:
@@ -517,16 +638,23 @@ pub fn put(cwd: &Path, id: &EntityId, record: &Record, witness: Option<&str>) ->
 /// next `log` (§3). `release` therefore has to establish that it holds the
 /// claim before calling this — [`read`] answers that — and the check belongs to
 /// the verb, not here, where it would make `close` impossible to express.
+/// **The deletion travels too** (§7). Level 1 makes a claim visible to every
+/// clone, so a release that stayed local would leave the task looking held
+/// everywhere else until its TTL ran out — a state this change creates and
+/// therefore owes an answer to. The remote failing to take it is not worth
+/// failing the release over: the handback is durable state and already written,
+/// and the stale ref expires on its own.
 pub fn delete(cwd: &Path, id: &EntityId) -> Result<bool> {
     let name = ref_name(id);
-    if current_object(cwd, id)?.is_none() {
+    let Some(witness) = current_object(cwd, id)? else {
         return Ok(false);
-    }
+    };
     let args = ["update-ref", "-d", name.as_str()];
     let out = git::output(cwd, &args)?;
     if !out.status.success() {
         return Err(git::failed(&args, &out));
     }
+    let _ = push(cwd, id, None, Some(&witness));
     Ok(true)
 }
 
@@ -686,7 +814,7 @@ pub fn sharing_warnings(
 ///
 /// The compare-and-swap is on the object the record was read from, so an agent
 /// that took the task over between the read and this write keeps it.
-pub fn retake(cwd: &Path, standing: &Standing, cap: Duration) -> Result<Cas> {
+pub fn retake(cwd: &Path, standing: &Standing, cap: Duration) -> Result<Written> {
     let ttl = renewal_ttl(&standing.record, cap);
     let record = Record::Claim(ClaimRecord {
         expires: format_utc(now_secs() + ttl.as_secs() as i64),
@@ -842,6 +970,8 @@ pub struct Acquired {
     /// True when the ref already carried a claim we replaced — the original
     /// holder returning after expiry, or a takeover from a lapsed one.
     pub taken_over: bool,
+    /// How far the claim reached: this clone, or the whole repository (§7).
+    pub sync: Sync,
 }
 
 /// Takes the ref for `identity`, or says precisely why it cannot be taken.
@@ -893,28 +1023,37 @@ pub fn acquire(
         constraints: constraints_hash.to_string(),
     });
 
-    match put(cwd, id, &record, witness)? {
+    let written = put(cwd, id, &record, witness)?;
+    match written.cas {
         Cas::Won => {}
-        // Somebody landed between our read and our write. Re-read to name
-        // them: the winner is the one whose message the agent needs.
+        // Somebody landed between our read and our write — in this clone, or in
+        // another one whose push got there first (§7). Re-read to name them:
+        // the winner is the one whose message the agent needs, and `put` has
+        // already brought a remote winner's record here for that.
         Cas::Lost => return Err(lost_the_race(cwd, id, now, other_ready)?),
     }
 
-    let Record::Claim(written) = record else {
+    let Record::Claim(taken) = record else {
         unreachable!("just built as a claim")
     };
     Ok(Acquired {
         id: id.clone(),
-        holder: written.holder,
-        expires: written.expires,
+        holder: taken.holder,
+        expires: taken.expires,
         taken_over: witness.is_some(),
+        sync: written.sync,
     })
 }
 
 /// Replaces whatever the ref carries with a completion record, keeping the
 /// address. Called by `done` (TASK-e5f6a7b8c9d0); no TTL is written, because
 /// what ends the completion ref is durable state catching up, not time.
-pub fn complete(cwd: &Path, id: &EntityId, identity: &str) -> Result<CompletedRecord> {
+///
+/// The completion is pushed like every other write of the plane, and that is
+/// what makes it useful across clones (§7): a completion ref that stayed local
+/// would tell the other clones nothing, which is exactly the window it exists
+/// to close.
+pub fn complete(cwd: &Path, id: &EntityId, identity: &str) -> Result<(CompletedRecord, Sync)> {
     let commit = git::run(cwd, &["rev-parse", "HEAD"])?;
     let branch = git::current_branch(cwd)?;
     let witness = current_object(cwd, id)?;
@@ -931,11 +1070,15 @@ pub fn complete(cwd: &Path, id: &EntityId, identity: &str) -> Result<CompletedRe
         &Record::Completed(record.clone()),
         witness.as_deref(),
     )? {
-        Cas::Won => Ok(record),
-        Cas::Lost => Err(
-            CliError::new(4, format!("{id} moved while it was being completed"))
-                .with_hint(format!("ank claim {id}")),
-        ),
+        Written {
+            cas: Cas::Won,
+            sync,
+        } => Ok((record, sync)),
+        Written { cas: Cas::Lost, .. } => Err(CliError::new(
+            4,
+            format!("{id} moved while it was being completed"),
+        )
+        .with_hint(format!("ank claim {id}"))),
     }
 }
 
@@ -1145,6 +1288,12 @@ pub fn run(
             )
         }
     };
+    // The remote's view first, so a task held in another clone is refused with
+    // its holder named rather than taken here and unwound by a rejected push
+    // (§7). Silent when there is no remote, and silent when there is one and it
+    // cannot be reached — that is the write's news to break, not the read's.
+    sync_from_remote(&repo.root, &task.id)?;
+
     check_blockers(&repo.root, &store, &task, ready.as_deref())?;
     task.status
         .check_transition(TaskStatus::InProgress)
@@ -1187,6 +1336,9 @@ pub fn run(
         .iter()
         .map(|(id, c)| format!("{identity} already holds {id} until {}", c.expires))
         .chain((!also_held.is_empty()).then(way_out))
+        // A claim that did not reach the remote holds in this clone alone, and
+        // §7 is explicit that the risk is displayed rather than hidden.
+        .chain(acquired.sync.warning())
         .collect();
 
     if inv.json() {
@@ -1540,7 +1692,7 @@ mod tests {
             criteria: "aaaabbbbcccc".into(),
             constraints: "ddddeeeeffff".into(),
         });
-        assert_eq!(put(&t.0, &id, &record, None).unwrap(), Cas::Won);
+        assert_eq!(put(&t.0, &id, &record, None).unwrap().cas, Cas::Won);
 
         let refs = git::ank_refs(&t.0).unwrap();
         assert_eq!(refs.len(), 1, "{refs:?}");
@@ -1862,7 +2014,7 @@ mod tests {
         let commit = t.commit_all("seed");
         take(&t, &task, "claude-code@ank", DEFAULT_TTL).unwrap();
 
-        let done = complete(&t.0, &task.id, "claude-code@ank").unwrap();
+        let (done, _) = complete(&t.0, &task.id, "claude-code@ank").unwrap();
         assert_eq!(done.commit, commit);
         assert_eq!(done.branch.as_deref(), Some("main"));
 

--- a/crates/ank-cli/src/commands.rs
+++ b/crates/ank-cli/src/commands.rs
@@ -1387,21 +1387,26 @@ fn log_write(
         ttl: ttl.as_secs(),
         ..record
     });
-    match claim::put(&repo.root, &id, &refreshed, Some(&witness))? {
-        claim::Cas::Won => {}
-        claim::Cas::Lost => {
-            // The entry is written; only the renewal lost. Saying so is better
-            // than letting the agent believe it holds the lock for another half
-            // hour.
-            // Standard error, for the reason `done`'s progress line is: it is
-            // not the answer, and stdout under `--json` is a parser's input
-            // (§4, TASK-2eefcdd80124).
-            eprintln!(
-                "{} {id} was taken over while logging, the claim was not renewed",
-                inv.style().on_stderr().yellow("warning:")
-            );
-        }
+    let renewed = claim::put(&repo.root, &id, &refreshed, Some(&witness))?;
+    // What the write turned up, as opposed to what was known before it. Said
+    // after, because none of it could have been said before.
+    //
+    // Standard error, for the reason `done`'s progress line is: it is not the
+    // answer, and stdout under `--json` is a parser's input (§4,
+    // TASK-2eefcdd80124).
+    let mut after: Vec<String> = Vec::new();
+    if renewed.cas == claim::Cas::Lost {
+        // The entry is written; only the renewal lost. Saying so is better than
+        // letting the agent believe it holds the lock for another half hour.
+        after.push(format!(
+            "{id} was taken over while logging, the claim was not renewed"
+        ));
     }
+    // The renewal is a push too (§7), so a remote that went away between the
+    // claim and this log is reported here rather than discovered at `done`.
+    after.extend(renewed.sync.warning());
+    warn_before_acting(inv, &after);
+    let warnings = [warnings, after].concat();
 
     if inv.json() {
         let _ = writeln!(

--- a/crates/ank-cli/src/context.rs
+++ b/crates/ank-cli/src/context.rs
@@ -1543,7 +1543,7 @@ After a blank one."
         let id = EntityId::parse("TASK-000000000003").unwrap();
         t.commit();
         t.claim_as(&id, "codex@host-9");
-        let done = claim::complete(&t.0, &id, "codex@host-9").unwrap();
+        let (done, _) = claim::complete(&t.0, &id, "codex@host-9").unwrap();
 
         let view = t.view("claude-code@ank", None);
         let line = view.tasks.iter().find(|t| t.id == id).unwrap();

--- a/crates/ank-cli/src/done.rs
+++ b/crates/ank-cli/src/done.rs
@@ -196,7 +196,14 @@ pub fn run(
     task.body = append_log(&task.body, &entry);
     store.write(&Entity::Task(task.clone()), base_version)?;
 
-    let completed = claim::complete(&repo.root, &id, identity)?;
+    let (completed, sync) = claim::complete(&repo.root, &id, identity)?;
+    // A completion that did not reach the remote closes the window it exists
+    // for in this clone only (§7). On standard error, beside the constraint
+    // drift warning and for the same reason: it is not the answer, and `done
+    // --json` is a parser's input.
+    if let Some(w) = sync.warning() {
+        eprintln!("{} {w}", inv.style().on_stderr().yellow("warning:"));
+    }
 
     if inv.json() {
         let _ = writeln!(
@@ -315,7 +322,7 @@ fn resolve_head(
             head
         }
     };
-    if standing.lapsed && claim::retake(cwd, &standing, cap)? == claim::Cas::Lost {
+    if standing.lapsed && claim::retake(cwd, &standing, cap)?.cas == claim::Cas::Lost {
         // Somebody claimed it between the read and the retake. Naming them is
         // the answer §3 asks for, and it is what tells the agent its work has
         // an owner rather than a problem.

--- a/crates/ank-cli/src/git.rs
+++ b/crates/ank-cli/src/git.rs
@@ -42,6 +42,15 @@ const PLUMBING: &[&str] = &[
     "for-each-ref",
     "config",
     "--version",
+    // The three level 1 needs (§7), each admitted on the criterion rather than
+    // on convenience. `push` signals a refused compare-and-swap by its exit
+    // code, which is the same contract `update-ref` is trusted for, and
+    // `--force-with-lease` is what makes the swap explicit rather than
+    // inferred. `ls-remote` prints `<oid>\t<refname>` per line and has since it
+    // existed. `fetch` is read for its exit code alone, never parsed.
+    "push",
+    "fetch",
+    "ls-remote",
 ];
 
 /// The verb an invocation actually runs, skipping the leading `-c <key>=<value>`
@@ -113,6 +122,122 @@ pub fn run(cwd: &Path, args: &[&str]) -> Result<String> {
         return Err(failed(args, &out));
     }
     Ok(String::from_utf8_lossy(&out.stdout).trim_end().to_string())
+}
+
+// ---------------------------------------------------------------------------
+// The remote, and the compare-and-swap that crosses clones (§7, level 1)
+// ---------------------------------------------------------------------------
+
+/// The remote claims are arbitrated through, or `None` for a repository that
+/// has none.
+///
+/// **Absence is level 0 and not a failure.** A repository with no remote is the
+/// default mode and the only one that ever shipped before this: it must stay
+/// silent, or every solo `claim` would carry a warning about a network nobody
+/// asked for. What warns is a remote that exists and cannot be reached.
+///
+/// `origin` by name rather than by discovery. §7 says "any existing remote",
+/// and picking one out of several would be a rule nobody declared; `origin` is
+/// what `init` writes the `refs/ank/*` refspec for, and it is the name every
+/// clone already has.
+pub fn remote(cwd: &Path) -> Result<Option<String>> {
+    let out = output(cwd, &["config", "--get", "remote.origin.url"])?;
+    if !out.status.success() {
+        return Ok(None);
+    }
+    let url = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    Ok((!url.is_empty()).then_some(url))
+}
+
+/// What a push of a claim ref did.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Pushed {
+    /// The remote took it: this clone holds the claim repository-wide.
+    Ok,
+    /// The remote refused the swap — another clone got there first. The object
+    /// it holds instead, when `ls-remote` could name it.
+    Refused { holds: Option<String> },
+    /// The remote exists and could not be reached. Degrade, do not fail (§2):
+    /// the claim stands locally and the caller says so out loud.
+    Unreachable { reason: String },
+}
+
+/// Pushes a claim ref under a lease, which is the compare-and-swap of §7
+/// crossing clones.
+///
+/// `expect` is the object the caller read before writing, exactly as it is for
+/// the local `update-ref`: `None` means the ref must not exist on the remote.
+/// Git spells that as `--force-with-lease=<ref>:<expect>` with an empty
+/// expectation, and the check runs server-side and atomically, so two clones
+/// racing produce one winner without either trusting the other.
+///
+/// `new` of `None` is a deletion, which `release` and `close` need: a ref left
+/// behind on the remote makes a handed-back task unclaimable everywhere else
+/// until its TTL runs out — a state this change would otherwise create.
+///
+/// **A refused push is distinguished from an unreachable remote by asking, not
+/// by reading stderr.** Push says "rejected" in prose written for people, and
+/// parsing it would be the fragility ADR-b8884edcebe3 exists to prevent. So a
+/// failure is followed by one `ls-remote` of the same ref: an answer means the
+/// remote is there and the swap genuinely lost, and no answer at all means the
+/// remote is what failed. It costs a round trip on the failing path only.
+pub fn push_claim(
+    cwd: &Path,
+    refname: &str,
+    new: Option<&str>,
+    expect: Option<&str>,
+) -> Result<Pushed> {
+    let lease = format!("--force-with-lease={refname}:{}", expect.unwrap_or(""));
+    let spec = match new {
+        Some(object) => format!("{object}:{refname}"),
+        None => format!(":{refname}"),
+    };
+    let args = ["push", lease.as_str(), "origin", spec.as_str()];
+    let out = output(cwd, &args)?;
+    if out.status.success() {
+        return Ok(Pushed::Ok);
+    }
+    match ls_remote(cwd, refname) {
+        Ok(holds) => Ok(Pushed::Refused { holds }),
+        // The remote could not be interrogated either, so the push failure was
+        // never about contention.
+        Err(_) => Ok(Pushed::Unreachable {
+            reason: String::from_utf8_lossy(&out.stderr).trim().to_string(),
+        }),
+    }
+}
+
+/// The object the remote holds at `refname`, or `None` when the ref is absent
+/// there. An unreachable remote is an error, which is what tells `push_claim`
+/// which kind of failure it just had.
+///
+/// One line per ref, `<oid>\t<refname>`, which is what makes `ls-remote`
+/// admissible under ADR-b8884edcebe3.
+pub fn ls_remote(cwd: &Path, refname: &str) -> Result<Option<String>> {
+    let args = ["ls-remote", "origin", refname];
+    let out = output(cwd, &args)?;
+    if !out.status.success() {
+        return Err(failed(&args, &out));
+    }
+    let text = String::from_utf8_lossy(&out.stdout);
+    Ok(text
+        .lines()
+        .find_map(|l| l.split_whitespace().next().map(str::to_string)))
+}
+
+/// Brings the remote's view of one claim ref into this clone.
+///
+/// `claim` runs it before deciding, so a task held in another clone is refused
+/// with the holder named rather than taken and then rolled back. The push is
+/// still what arbitrates — this only closes the common case politely.
+///
+/// Failure is not an error to the caller: an unreachable remote means the
+/// answer is the local one, and the push that follows is where that gets said.
+/// Read for its exit code alone, never parsed.
+pub fn fetch_claim(cwd: &Path, refname: &str) -> Result<bool> {
+    let spec = format!("+{refname}:{refname}");
+    let out = output(cwd, &["fetch", "--quiet", "origin", spec.as_str()])?;
+    Ok(out.status.success())
 }
 
 /// The installed version, as `(major, minor)`.
@@ -570,27 +695,12 @@ mod tests {
     use super::*;
     use std::sync::atomic::{AtomicU64, Ordering};
 
-    /// §7 says level 1 is unimplemented, and this is what keeps that sentence
-    /// from going stale in silence (TASK-83d6eefdb36e).
-    ///
-    /// Every git verb the tool may run passes [`PLUMBING`], so a claim that
-    /// crosses clones needs one of these three to appear here first. A negative
-    /// test: it fails the day the feature lands, not while it is absent, and it
-    /// names what the same change owes the specification. The specification is
-    /// the source of truth, and a source of truth that quietly stops describing
-    /// the binary is worse than one that never described it.
-    #[test]
-    fn no_remote_verb_is_allowed_while_the_spec_says_level_1_is_unimplemented() {
-        for verb in ["push", "fetch", "ls-remote"] {
-            assert!(
-                !PLUMBING.contains(&verb),
-                "`{verb}` is allowed now, so claims can reach another clone: \
-                 section 7 of docs/ank-spec-v1.1.md still says level 1 is \
-                 unimplemented and names what a second clone can do, and it has \
-                 to be rewritten in this change"
-            );
-        }
-    }
+    // `no_remote_verb_is_allowed_while_the_spec_says_level_1_is_unimplemented`
+    // stood here and did its job: it failed the day level 1 landed, naming what
+    // the same change owed the specification (TASK-83d6eefdb36e). §7 no longer
+    // says level 1 is unimplemented, so the sentence it guarded is gone and the
+    // guard goes with it (TASK-82c3341502c1). A negative test kept past the
+    // absence it describes asserts the opposite of what is true.
 
     struct Temp(PathBuf);
 

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -342,6 +342,51 @@ impl Repo {
             .expect("the binary must have been built")
     }
 
+    /// A bare origin and a second clone of this repository, both carrying the
+    /// corpus this one seeded.
+    ///
+    /// Two clones and not two worktrees, because that is the whole distinction
+    /// level 1 exists for: worktrees share `refs/ank/` and were always
+    /// arbitrated, clones do not and are arbitrated only by the push (§7).
+    /// Returned as a plain path rather than a `Repo`, so nothing about it can
+    /// accidentally be seeded twice.
+    fn cloned(&self) -> (PathBuf, PathBuf) {
+        let origin = self.0.with_extension("origin.git");
+        let other = self.0.with_extension("other");
+        for p in [&origin, &other] {
+            let _ = std::fs::remove_dir_all(p);
+        }
+        let out = git_command(&self.0)
+            .args(["init", "-q", "--bare", "-b", "main"])
+            .arg(&origin)
+            .output()
+            .unwrap();
+        assert!(out.status.success(), "init --bare: {}", stderr(&out));
+
+        self.git(&["add", "-A"]);
+        self.git(&["commit", "-qm", "corpus"]);
+        self.git(&["remote", "add", "origin", origin.to_str().unwrap()]);
+        self.git(&["push", "-q", "origin", "main"]);
+
+        let out = git_command(&self.0)
+            .arg("clone")
+            .arg("-q")
+            .arg(&origin)
+            .arg(&other)
+            .output()
+            .unwrap();
+        assert!(out.status.success(), "clone: {}", stderr(&out));
+        for args in [
+            ["config", "user.email", "test@ank.local"],
+            ["config", "user.name", "Test"],
+            ["config", "commit.gpgsign", "false"],
+        ] {
+            let out = git_command(&other).args(args).output().unwrap();
+            assert!(out.status.success(), "{args:?}: {}", stderr(&out));
+        }
+        (origin, other)
+    }
+
     /// The same invocation, with `text` on stdin.
     ///
     /// Piped rather than redirected from a file, because a pipe is what the
@@ -2732,6 +2777,111 @@ fn status_names_every_live_claim_of_this_identity() {
     let said = stdout(&quiet.ank("claude-code@ank", &["status"]));
     assert!(!said.contains("ANK_AGENT"), "{said}");
     assert!(!said.contains("also"), "{said}");
+}
+
+/// Two clones of one repository arbitrate, which is the whole of level 1
+/// (TASK-82c3341502c1).
+///
+/// Worktrees of one clone share `refs/ank/` and were always settled by the
+/// local compare-and-swap. Clones do not share it: each held its own
+/// `refs/ank/claims/<id>` and neither ever learned of the other, so both agents
+/// claimed the same task, both succeeded, and nothing detected it — not then
+/// and not later, since `check` prunes on the default branch, where two agents
+/// having done the same work looks like two agents having done their work.
+///
+/// What settles it is the push, under `--force-with-lease` with the object the
+/// caller read as the expectation: server-side, atomic, and on every host. The
+/// test drives both clones through the binary because that is what the property
+/// is about — a unit test over the push helper would prove the helper works and
+/// leave two clones untested.
+#[test]
+fn two_clones_of_one_repository_arbitrate_over_a_claim() {
+    let r = Repo::new().with_verifiers("verifiers:\n  ok:\n    run: git --version\n");
+    r.seed_task(ID, Some("A verifiable criterion."));
+    let (_origin, other) = r.cloned();
+
+    // The first clone takes it, and the claim reaches the remote.
+    let out = r.ank("claude-code@ank", &["claim", ID]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    assert!(
+        !format!("{}{}", stdout(&out), stderr(&out)).contains("not pushed"),
+        "a reachable remote must not report an unsynchronised claim: {}",
+        stderr(&out)
+    );
+
+    // The second clone, which has never seen that ref, is refused -- and told
+    // by whom, which it can only know by having been given the winner's record.
+    let out = r.ank_at("codex@host-9", &["claim", ID], &other);
+    assert_eq!(
+        code(&out),
+        4,
+        "the second clone took a task already held:\n{}{}",
+        stdout(&out),
+        stderr(&out)
+    );
+    assert!(
+        stderr(&out).contains("claude-code@ank"),
+        "the refusal names no holder: {}",
+        stderr(&out)
+    );
+
+    // And the loser leaves the durable state alone: a refused claim is not a
+    // task moved to in_progress in a clone that does not hold it.
+    let text = std::fs::read_to_string(other.join(".ank/tasks").join(format!("{ID}.md"))).unwrap();
+    assert!(
+        text.contains("status: open"),
+        "the refused clone moved the task anyway:\n{text}"
+    );
+}
+
+/// A remote that exists and cannot be reached degrades, it does not fail
+/// (TASK-82c3341502c1, §2).
+///
+/// The claim is taken locally and the risk is displayed rather than hidden --
+/// what is at stake is that another clone can take the same task, so that is
+/// what the warning says. Measured against a remote that is configured and
+/// gone, which is the shape a laptop off the network actually has: a URL that
+/// resolves to nothing.
+#[test]
+fn an_unreachable_remote_warns_and_the_claim_still_holds_locally() {
+    let r = Repo::new();
+    r.seed_task(ID, Some("A verifiable criterion."));
+    r.git(&[
+        "remote",
+        "add",
+        "origin",
+        // A path that will never exist: git fails to connect rather than
+        // refusing a swap, which is exactly the distinction under test.
+        &r.0.with_extension("gone.git").to_string_lossy(),
+    ]);
+
+    let out = r.ank("claude-code@ank", &["claim", ID]);
+    assert_eq!(
+        code(&out),
+        0,
+        "an unreachable remote must not fail the claim:\n{}",
+        stderr(&out)
+    );
+    let said = format!("{}{}", stdout(&out), stderr(&out));
+    assert!(
+        said.contains("not pushed") && said.contains("another clone"),
+        "the risk is displayed, not hidden: {said}"
+    );
+    assert!(
+        r.claim_ref(ID).is_some(),
+        "the claim did not hold locally, which is the half that must not degrade"
+    );
+
+    // And a repository with no remote at all says none of it: that is level 0,
+    // the default mode, and a warning there would fire on every solo claim.
+    let solo = Repo::new();
+    solo.seed_task(ID, Some("A verifiable criterion."));
+    let out = solo.ank("claude-code@ank", &["claim", ID]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    assert!(
+        !format!("{}{}", stdout(&out), stderr(&out)).contains("not pushed"),
+        "level 0 is not a degradation and must stay silent"
+    );
 }
 
 /// What a holder of a claim sees of the coordination plane (TASK-dacbcae6134c).

--- a/docs/ank-spec-v1.1.md
+++ b/docs/ank-spec-v1.1.md
@@ -929,7 +929,7 @@ A git-like model: fully functional locally, deployable progressively, never depe
 
 The nominal case is **one working tree per agent**, each on its own branch. That is what local proofs already assume (a `verify` run in a tree other agents are modifying in parallel would prove nothing clean) and it is the effective practice of agent harnesses. Several agents sharing one tree works but is a degraded mode, not a design mode.
 
-**Use `git worktree`, not clones, while level 1 is unimplemented.** The two are not interchangeable here: worktrees of one repository share `refs/ank/`, so claims arbitrate between them; separate clones do not share it, and two agents will hold the same task without either being told. The reasons are below, under what ships.
+**Without a remote, use `git worktree` and not clones.** The two are not interchangeable there: worktrees of one repository share `refs/ank/`, so claims arbitrate between them; separate clones do not share it, and two agents will hold the same task without either being told. With a remote, level 1 arbitrates the clones too and the choice becomes one of convenience. The reasons are below, under what ships.
 
 ### Separation of the two planes
 
@@ -993,30 +993,38 @@ Two uses depend on it, and not in the same way. `accept` **fails** with code 9: 
 
 ### Why `version` coexists with git's CAS
 
-The two cover disjoint ranges. Git's CAS protects **between working trees sharing a `refs/ank/`** — and, once level 1 ships, between clones at push time. The `version` field protects **inside a single working tree**. With one tree per agent that case becomes rare — but not nil: a human and an agent often share the same tree, and the field costs one integer. We keep it for the residual case, without presenting it as the main defence any more.
+The two cover disjoint ranges. Git's CAS protects **between working trees sharing a `refs/ank/`**, and between clones at push time wherever there is a remote. The `version` field protects **inside a single working tree**. With one tree per agent that case becomes rare — but not nil: a human and an agent often share the same tree, and the field costs one integer. We keep it for the residual case, without presenting it as the main defence any more.
 
 ### What ships, and what a second clone can therefore do
 
-**Only level 0 is implemented.** Levels 1 and 2 below describe where this goes; neither exists in the binary today. There is no push, no fetch and no `ls-remote` anywhere in the code: `ank init` adds the `refs/ank/*` **fetch** refspec and nothing more.
+**Levels 0 and 1 are implemented; level 2 is not.** Which one a repository is in is not configured and cannot be chosen: it is whether the repository has a remote named `origin`. Without one, claims are local refs and nothing is pushed — that is level 0, and it stays silent, because a warning about a network nobody asked for would fire on every claim of every solo repository. With one, every write of the coordination plane is pushed, and the arbitration is repository-wide.
 
 The consequence is exact, and it is stated here rather than left to be discovered:
 
-- **Two working trees of one clone are arbitrated.** Every `git worktree` of a repository shares `refs/ank/`, so the compare-and-swap settles them. One agent wins, the other gets code 4.
-- **Two separate clones are not.** Each holds its own `refs/ank/claims/<id>` and neither ever learns of the other. Both agents claim the same task, both succeed, both work. Nothing detects it, and nothing detects it later either: `check` prunes on the default branch, where two agents having done the same work looks like two agents having done their work.
+- **Two working trees of one clone are arbitrated**, remote or no remote. Every `git worktree` of a repository shares `refs/ank/`, so the local compare-and-swap settles them. One agent wins, the other gets code 4.
+- **Two separate clones are arbitrated when there is a remote, and only then.** Each holds its own `refs/ank/claims/<id>`; what makes them agree is the push, which the second clone loses. Without a remote, neither clone ever learns of the other: both agents claim the same task, both succeed, both work, and nothing detects it later either — `check` prunes on the default branch, where two agents having done the same work looks like two agents having done their work.
 
-So "one piece of work, one holder" holds **per clone, not per repository**. Until level 1 ships, an operator running several agents on one repository gets that property from `git worktree` and does not get it from clones.
+So "one piece of work, one holder" holds **per repository with a remote, and per clone without one.** An operator running several agents against a bare repository gets the property from the push; one running them on a single machine with no remote gets it from `git worktree` and does not get it from clones.
 
 ### Level 0 — local
 
-No remote. Claims use the **same `refs/ank/claims/<id>` refs, locally**: a local git ref update is already atomic, and level 1 becomes literally "the same ref, pushed" — no migration, no state to convert. There is **no fallback without git**: git is a hard dependency, and an uninitialised repository exits with code 9 and the exact command. Functional without configuration, like a `git init` without a push. Default mode, and the only mode.
+No remote. Claims use the **same `refs/ank/claims/<id>` refs, locally**: a local git ref update is already atomic, and level 1 is literally "the same ref, pushed" — no migration, no state to convert, and a repository that gains a remote is at level 1 from its next claim. There is **no fallback without git**: git is a hard dependency, and an uninitialised repository exits with code 9 and the exact command. Functional without configuration, like a `git init` without a push. Default mode, and the only mode.
 
-### Level 1 — git remote only (not implemented)
+### Level 1 — git remote only
 
-Any existing remote, GitHub included. Zero infrastructure.
+Any existing remote, GitHub included. Zero infrastructure, and no configuration: a repository with an `origin` is at level 1.
 
-The central insight: **a git ref update is already an atomic compare-and-swap**. A non-fast-forward push fails server-side, atomically, on every host. That is exactly the primitive claims need — the CAS is guaranteed by git, not by home-made code.
+The central insight: **a git ref update is already an atomic compare-and-swap**. The push carries the swap explicitly, as `--force-with-lease=<ref>:<expected>`, where the expected value is the object the caller read before writing — the very same witness the local `update-ref` swaps on, so the two checks are one rule rather than two that agree today. An empty expectation means "this ref must not exist", which is what taking a free task is. The check runs server-side and atomically, on every host, so two clones racing produce one winner without either trusting the other.
 
-TTL renewal through `log` updates the local ref then pushes; at one log every few minutes and a push on the order of a second, the cost is marginal. The transition to a completion ref at `done` is pushed the same way, and that is what makes it useful: a completion ref that stayed local would tell other clones nothing, which is exactly the window it exists to close. **Offline at level 1**, the claim is taken locally and marked unsynchronised, with a warning: degrade, do not fail — the risk of a concurrent claim is displayed, not hidden.
+Every write of the plane goes through it, and that is what makes it one mechanism rather than four: acquisition, the TTL renewal `log` performs, the retake of a lapsed claim, and the completion record `done` writes. The completion matters most: one that stayed local would tell the other clones nothing, which is exactly the window it exists to close. **`release` and `close` push the deletion** on the same terms — a claim handed back but left standing on the remote would make the task unclaimable everywhere else until its TTL ran out.
+
+`claim` reads the remote before deciding, so a task held in another clone is refused with its holder named rather than taken locally and unwound by a rejected push. The push is still what arbitrates; the read only makes the ordinary case answer politely. **No other verb pays for the network.** `context`, `status`, `find` and `check` describe the plane they have.
+
+A refused push and an unreachable remote are told apart **by asking, not by reading stderr**: push says "rejected" in prose written for people, and parsing it would be exactly the fragility the plumbing rule exists to prevent (§12). A failed push is followed by one `ls-remote` of the same ref — an answer means the remote is there and the swap genuinely lost; no answer at all means the remote is what failed. That costs a round trip on the failing path only.
+
+**Offline at level 1**, the claim is taken locally and marked unsynchronised, with a warning naming what is at risk: degrade, do not fail (§2). The claim holds in this clone and another clone can take the same task, and that is displayed rather than hidden.
+
+**The cost on the hot path, measured rather than inherited.** `log` renews the TTL and an agent logs often, so every renewal is a round trip. On Windows, twenty `ank log` runs against a local bare origin averaged 668 ms each against 639 ms with no remote at all — about **30 ms** of local overhead, lost in the process spawning that dominates a run there. What is not local is the network: ten `ls-remote` calls against a GitHub origin averaged **515 ms**. So a `log` in the field costs roughly half a second more than it did, which is the "on the order of a second" this section always claimed and now has a number for. At one log every few minutes it is under a percent of the time an agent spends working, and it buys the property the whole level exists for.
 
 The trade-off: latency on the order of a second, no notifications. Comfortable up to two or three agents, saturates beyond.
 
@@ -1170,8 +1178,7 @@ File format · one command surface, refusing on state and never on identity, wit
 | `.ank/` merge driver | The resolution rules are fixed (§7); automating them can wait for the first real conflicts. |
 | `touched` inferred from commits | Scope-drift detection. A git dependency, not blocking to get started. |
 | `enforced_by` (mechanisation) | The underlying mechanism against context inflation (see §11). Useless while the ADR corpus is small. |
-| Level 1 (claims pushed to a remote) | Described in §7 and not implemented. Worktrees of one clone are arbitrated today; separate clones are not. |
-| `ank serve` (level 2) | Level 1 is enough up to three concurrent agents, once level 1 exists. |
+| `ank serve` (level 2) | Level 1 ships and is enough up to three concurrent agents. |
 | `ank review --coherence` (ADR corpus analysis) | Detecting contradictions and duplicates. No value on a small corpus. The ratification queue itself is in v1. |
 | Read-only web view | To reopen only if non-developers must read the board. |
 | Linear/Jira export | Management visibility. Never writing back into Ank. |


### PR DESCRIPTION
Worktrees of one clone share `refs/ank/` and were always settled by the local compare-and-swap. Clones do not share it: each held its own `refs/ank/claims/<id>` and neither ever learned of the other, so both agents claimed the same task, both succeeded, and nothing detected it -- not then, and not later either, since `check` prunes on the default branch where two agents having done the same work looks like two agents having done their work.

## The primitive, probed before anything was designed

`git push --force-with-lease=<ref>:<expect>` with an **empty** expectation means "this ref must not exist". It works on a ref pointing at a blob, the check runs server-side and atomically, and two clones racing produce one winner -- the loser gets a non-zero exit and the remote is unchanged. The lease is the same witness `update-ref` already swaps on locally, so **the two checks are one rule** rather than two that agree today.

## Where it lives

Every write of the plane already went through `claim::put`, so the push lives there and covers all four callers without any of them remembering to: acquisition, `log`'s TTL renewal, the retake of a lapsed claim, and the completion record `done` writes.

- **Local swap first, then the remote.** A push landing over a local write that lost would leave this clone believing something its own refs deny.
- **A refused push fetches the winner's record** rather than rolling back to nothing: the caller's next question is *who holds it*, and `lost_the_race` reads exactly there.
- **`claim` reads the remote before deciding**, so a task held elsewhere is refused with its holder named rather than taken and unwound. No other verb pays for the network.

## Two additions the change owes itself

- **`release` and `close` push the deletion.** A claim handed back but left standing on the remote would make the task unclaimable in every other clone until its TTL ran out -- a state this change would otherwise introduce.
- **Level 0 stays silent.** No remote is the default mode, not a degradation. The discriminant is `remote.origin.url`, and that detail matters: `ank init` writes `remote.origin.fetch` with no URL, so keying on the remote's *existence* would have put every freshly initialised solo repository into level 1 and made it warn on every claim.

## Refused vs unreachable

Told apart **by asking, not by reading stderr**: one `ls-remote` of the same ref after a failed push. An answer means the remote is there and the swap genuinely lost; no answer means the remote is what failed. Push says "rejected" in prose written for people, and parsing it is the fragility ADR-b8884edcebe3 exists to prevent. `push`, `fetch` and `ls-remote` join the PLUMBING list on that criterion, and the negative test that guarded the "level 1 is unimplemented" sentence goes with the sentence.

## The hot path, measured rather than inherited

| | per `ank log` |
|---|---|
| no remote (level 0) | 639 ms |
| local bare origin | 668 ms |
| **local overhead** | **~30 ms** |
| real round trip to GitHub (`ls-remote` x10) | **515 ms** |

So a `log` costs about half a second more in the field -- the "on the order of a second" section 7 always claimed, now with a number. At one log every few minutes that is under a percent of an agent's working time.

## Tests

Two clones of one repository driven through the binary: the second claim on a task already held in the first is refused with **code 4** and names the holder, and the losing clone leaves its durable state alone. Plus the offline half: a configured, unreachable remote warns and the claim still holds locally, while a repository with no remote says nothing at all. Both falsified by disabling the remote lookup.

TASK-82c3341502c1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KxhFCZTsaGLwqCwMKH1wZF