### PR TITLE
close leaves no completion ref, and the asymmetry is the decision

### DIFF
--- a/.ank/adr/ADR-6d8736c04cfa.md
+++ b/.ank/adr/ADR-6d8736c04cfa.md
@@ -1,0 +1,115 @@
+---
+id: ADR-6d8736c04cfa
+type: adr
+slug: close-leaves-no-completion-ref-and-the-asymmetry
+title: close leaves no completion ref, and the asymmetry with done is the decision
+created: 2026-08-11T18:45:19Z
+author: claude-code@nested-pebble
+status: proposed
+scope:
+  - crates/ank-cli/src/claim.rs
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/src/config.rs
+  - crates/ank-cli/src/git.rs
+  - docs/**
+constraint: |
+  The claim ref is not deleted at done: it becomes a completion ref pointing
+  at the HEAD commit of the done, with no TTL, and is pruned only once the
+  task appears done or closed on the default branch. claim refuses a task
+  carrying a completion ref (code 4), naming the commit and the branch.
+  accept refuses to run outside the default branch, with no way around it.
+  
+  close leaves no completion ref. It deletes the claim ref, revoking any live
+  claim in the same operation, and a task closed on an unmerged branch is
+  claimable everywhere else until the closure lands on the default branch. The
+  asymmetry with done is the decision and not an omission: done earns a
+  repository-wide refusal with a frozen criterion, declared verifiers and a
+  proof, and close is gated by a reason alone.
+supersedes: ADR-bcf222a31525
+schema: 2
+version: 2
+---
+
+## Context
+
+ADR-bcf222a31525 created the completion ref, and named this gap without settling
+it. Its own words, under "What this ADR does not do":
+
+> It does not give `close` a completion ref. A task closed on an unmerged branch
+> carries the same invisibility window as a finished one, but `close` is a human
+> act and a rare one, and the pruning predicate already accepts `closed` — the
+> gap, if it shows up, can be fixed without touching the format.
+
+That deferral has outlived its premise. ADR-e17e1bbd93ff dissolved the human
+side: every verb is available to every caller, and section 3 says `close` is
+outside the loop SKILL.md teaches "rather than closed to agents". `close` is not
+a human act, because there is no such category left. The sentence has to be
+replaced rather than left standing, since it is the only reason the corpus
+records for an asymmetry between the two terminal transitions.
+
+Level 1 also shipped since (TASK-82c3341502c1): claim refs are pushed, so the
+deletion `close` performs now travels to every clone rather than staying in one.
+What was a local asymmetry is now a repository-wide one, which is the scale the
+decision has to be right at.
+
+## Decision
+
+The asymmetry is the decision. `close` deletes the claim ref and leaves nothing
+behind; `done` leaves a completion record. Four reasons, in the order they
+matter.
+
+**`done` earns the repository-wide refusal and `close` does not.** A completion
+record makes every other `claim` fail with code 4, and since level 1 that
+refusal holds across the whole repository. `done` reaches it through a criterion
+frozen at claim, the verifiers the task declares, and a proof recorded in the
+file. `close` reaches its transition through a string. Granting the same power
+to the cheaper act would make an unproven decision, taken on a branch nobody has
+reviewed, binding on everyone.
+
+**`close` revokes somebody else's live claim** (section 3): the ref is deleted
+whoever holds it, and the holder learns of it at its next `log`. If `close` also
+wrote a record that refused every subsequent `claim`, one agent could take a task
+away from another *and* prevent anyone from picking it up, unilaterally and
+without merging anything. The revocation is defensible precisely because what
+follows it is a free task.
+
+**The two errors are not the same size.** A `done` invisible elsewhere costs
+work that was already performed — the expensive, unrecoverable waste the
+completion ref was built for. A `close` invisible elsewhere costs work on a task
+somebody proposed to abandon, and if that work completes it produces a proof,
+which is evidence against the closure rather than a loss. The failure modes are
+asymmetric in the same direction as the acts.
+
+**Symmetry would cost the format, which ADR-bcf222a31525 hoped to avoid.**
+`claim`'s refusal reads the record and says "finished on another branch". Saying
+"closed on another branch" needs a discriminator the completion record does not
+carry, and adding one is a format change: the specification first, then the
+goldens, then the code (ADR-63b59c5c26f7). A record that lied about which
+transition produced it would be worse than the gap.
+
+## Consequences
+
+None on the code, which already behaves this way: `close` calls `claim::delete`,
+and the pruning predicate already accepts `closed` alongside `done`. What
+changes is that the behaviour is now a rule with its reasons attached, and an
+integration test asserts it through the binary from a second checkout, where
+before it was an untested consequence of an unstated choice.
+
+The window itself is not closed and is not claimed to be. A task closed on an
+unmerged branch reads `open` everywhere else until the closure lands on the
+default branch. That is accepted, at the price named above.
+
+## Alternatives rejected
+
+**A completion record for `close`.** The symmetry is superficially attractive and
+is answered in full above: it hands the cheaper act the more binding power, and
+it costs the format.
+
+**A third record state, neither claim nor completion.** It would let `claim`
+refuse accurately and separately, and it is a format change with a migration for
+one rare case — the same price as the alternative above, paid for a narrower
+benefit.
+
+**Leaving the question open.** That is the state this supersedes. The code read
+as an omission rather than as a choice, and the only reason on record had been
+retired by a later decision without anyone noticing (TASK-78326e2e3e89).

--- a/.ank/tasks/TASK-78326e2e3e89.md
+++ b/.ank/tasks/TASK-78326e2e3e89.md
@@ -5,7 +5,7 @@ slug: close-leaves-no-completion-ref-and-nothing-says
 title: close leaves no completion ref, and nothing says whether that is meant
 created: 2026-08-11T03:41:56Z
 author: seanl@sean-laptop
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/src/human.rs
   - crates/ank-cli/src/claim.rs
@@ -16,7 +16,7 @@ done_criteria: |
   The completion-ref ADR states what close leaves on the coordination plane and why it differs from done, or says the two are the same and close leaves a completion record too. The code matches the statement. Verified through the binary: an integration test closes a task on a non-default branch and asserts, by reading refs/ank/claims/<id> with git from a second checkout, exactly what the decision says should be there.
 criteria_by: creator
 schema: 2
-version: 1
+version: 3
 ---
 
 `done` turns the claim ref into a completion record precisely so that a task
@@ -34,3 +34,9 @@ leaves a trace on the coordination plane.
 
 Whichever way it goes, the ADR is where it is recorded, since it is the ADR
 that created the mechanism.
+
+## Log
+- 2026-08-11T18:51:30Z claude-code@nested-pebble — The asymmetry is settled as deliberate, in ADR-6d8736c04cfa superseding ADR-bcf222a31525. Two premises had moved under the original deferral and both point the same way. Its stated reason -- close is a human act and a rare one -- was retired by ADR-e17e1bbd93ff, which dissolved the human side entirely; section 3 now says close is outside the loop SKILL.md teaches rather than closed to agents, so the category the sentence rests on no longer exists. And level 1 shipped this morning, so the deletion close performs travels to every clone: what was a local asymmetry is a repository-wide one, which is the scale the decision had to be right at.
+The decisive argument is not symmetry but what each act has earned. A completion record refuses every other claim with code 4, repository-wide once pushed. done reaches that through a criterion frozen at claim, the verifiers the task declares and a proof in the file; close reaches its transition through a string. And close revokes somebody else's live claim, so the symmetric version would let one agent take a task away and stop anyone picking it up, unilaterally, on a branch nobody reviewed. The revocation is defensible precisely because what follows it is a free task.
+No code changed, because the code already behaved this way: close calls claim::delete and the pruning predicate already accepts Done | Closed. What was missing was the decision and the test. The test reads refs/ank/claims/<id> with git from a worktree checkout and asserts both halves in one go -- close leaves nothing, done leaves a record naming the commit and the branch -- because an absence proves nothing without the presence beside it, and it ends by claiming the closed task from that checkout, which states the price the decision accepts instead of leaving it implied. Falsified before being trusted: making close stop deleting turns it red on the right assertion.
+The ADR stays proposed. The succession happens at accept, not at new adr --supersedes (check_adr in human.rs), so ADR-bcf2 keeps binding and check emits a signal rather than a fault -- which is why the nine citations of it in the crate are still correct today and are left alone. Re-pointing them is TASK-d9d364bad929, filed rather than folded in: three of the files are outside this scope, and citing a proposed ADR from live code would be the same defect one step to the left.

--- a/.ank/tasks/TASK-78326e2e3e89.md
+++ b/.ank/tasks/TASK-78326e2e3e89.md
@@ -5,7 +5,7 @@ slug: close-leaves-no-completion-ref-and-nothing-says
 title: close leaves no completion ref, and nothing says whether that is meant
 created: 2026-08-11T03:41:56Z
 author: seanl@sean-laptop
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/src/human.rs
   - crates/ank-cli/src/claim.rs
@@ -15,8 +15,12 @@ blocked_by: []
 done_criteria: |
   The completion-ref ADR states what close leaves on the coordination plane and why it differs from done, or says the two are the same and close leaves a completion record too. The code matches the statement. Verified through the binary: an integration test closes a task on a non-default branch and asserts, by reading refs/ank/claims/<id> with git from a second checkout, exactly what the decision says should be there.
 criteria_by: creator
+proof:
+  - type: test
+    ref: "31524923743"
+    criteria: a8c4e33fe968
 schema: 2
-version: 3
+version: 4
 ---
 
 `done` turns the claim ref into a completion record precisely so that a task
@@ -40,3 +44,4 @@ that created the mechanism.
 The decisive argument is not symmetry but what each act has earned. A completion record refuses every other claim with code 4, repository-wide once pushed. done reaches that through a criterion frozen at claim, the verifiers the task declares and a proof in the file; close reaches its transition through a string. And close revokes somebody else's live claim, so the symmetric version would let one agent take a task away and stop anyone picking it up, unilaterally, on a branch nobody reviewed. The revocation is defensible precisely because what follows it is a free task.
 No code changed, because the code already behaved this way: close calls claim::delete and the pruning predicate already accepts Done | Closed. What was missing was the decision and the test. The test reads refs/ank/claims/<id> with git from a worktree checkout and asserts both halves in one go -- close leaves nothing, done leaves a record naming the commit and the branch -- because an absence proves nothing without the presence beside it, and it ends by claiming the closed task from that checkout, which states the price the decision accepts instead of leaving it implied. Falsified before being trusted: making close stop deleting turns it red on the right assertion.
 The ADR stays proposed. The succession happens at accept, not at new adr --supersedes (check_adr in human.rs), so ADR-bcf2 keeps binding and check emits a signal rather than a fault -- which is why the nine citations of it in the crate are still correct today and are left alone. Re-pointing them is TASK-d9d364bad929, filed rather than folded in: three of the files are outside this scope, and citing a proposed ADR from live code would be the same defect one step to the left.
+- 2026-08-11T18:56:29Z claude-code@nested-pebble — done, proof test:31524923743

--- a/.ank/tasks/TASK-d9d364bad929.md
+++ b/.ank/tasks/TASK-d9d364bad929.md
@@ -1,0 +1,38 @@
+---
+id: TASK-d9d364bad929
+type: task
+slug: re-point-the-citations-of-the-superseded-complet
+title: Re-point the citations of the superseded completion-ref ADR
+created: 2026-08-11T18:51:09Z
+author: claude-code@nested-pebble
+status: open
+scope:
+  - crates/ank-cli/src/**
+  - crates/ank-cli/tests/**
+blocked_by: []
+done_criteria: |
+  Once ADR-6d8736c04cfa is accepted and ADR-bcf222a31525 is marked superseded, no source file of the crate cites the superseded id as the reason for a design: the nine citations in claim.rs, context.rs, done.rs, git.rs and human.rs name the ADR that binds, or drop the citation where history is what they were recording. The id joins the DEAD list of no_superseded_adr_is_cited_in_the_crate, which is what makes the property hold afterwards rather than being restored by hand. cargo test and ank check stay green.
+criteria_by: creator
+schema: 2
+version: 1
+---
+
+Deliberately not folded into TASK-78326e2e3e89, which created the succession.
+Three of the nine files are outside that task's scope -- context.rs, done.rs and
+git.rs -- and, more to the point, the citations are still correct while the
+successor is `proposed`: the succession happens at `accept` (human.rs, check_adr),
+so ADR-bcf222a31525 stays accepted and keeps binding until a human ratifies the
+replacement on the default branch. Re-pointing them earlier would have made live
+code cite an ADR that binds nobody, which is the same defect one step to the left.
+
+The test that will hold it already exists and already carries the reasoning:
+no_superseded_adr_is_cited_in_the_crate, whose DEAD list is hand-maintained and
+whose doc comment says why a comment citing a superseded ADR is worse than no
+comment at all -- it hands the next reader a constraint that binds nobody, with
+the authority of a decision record. Two ADRs are in that list for exactly this,
+and they went on asserting a frozen agent surface long after the split they
+protected had been dissolved.
+
+Blocked by nothing in the corpus, and blocked in fact by an act only a human
+performs. If the succession is never accepted, this task is closed rather than
+done: there is then no superseded ADR and nothing to re-point.

--- a/crates/ank-cli/src/claim.rs
+++ b/crates/ank-cli/src/claim.rs
@@ -638,6 +638,13 @@ pub fn sync_from_remote(cwd: &Path, id: &EntityId) -> Result<()> {
 /// next `log` (§3). `release` therefore has to establish that it holds the
 /// claim before calling this — [`read`] answers that — and the check belongs to
 /// the verb, not here, where it would make `close` impossible to express.
+///
+/// **A deletion and not a completion record, for `close` as much as for
+/// `release`** (TASK-78326e2e3e89). The asymmetry with `done` is decided rather
+/// than inherited: a completion record refuses every other `claim` with code 4,
+/// and `done` earns that with a frozen criterion, its verifiers and a proof
+/// where the other two are gated by a reason. The reasoning is at `close` in
+/// `human.rs`, where the act is.
 /// **The deletion travels too** (§7). Level 1 makes a claim visible to every
 /// clone, so a release that stayed local would leave the task looking held
 /// everywhere else until its TTL ran out — a state this change creates and

--- a/crates/ank-cli/src/human.rs
+++ b/crates/ank-cli/src/human.rs
@@ -1880,6 +1880,23 @@ fn commit_signed(cwd: &Path, paths: &[String], message: &str) -> Result<String> 
 ///
 /// Never by deleting the file: that would break other tasks' `blocked_by`
 /// references, where `closed` preserves them.
+///
+/// **It leaves nothing on the coordination plane, and that is the decision**
+/// (TASK-78326e2e3e89). `done` turns the claim ref into a completion record so
+/// that a task finished on an unmerged branch does not look free everywhere
+/// else (ADR-bcf222a31525); `close` deletes the ref, so a task closed on a
+/// branch is claimable elsewhere until the closure lands on the default branch.
+/// The asymmetry is not an omission. A completion record refuses every other
+/// `claim` with code 4, repository-wide once the ref is pushed, and `done`
+/// earns that with a frozen criterion, declared verifiers and a proof where
+/// this verb is gated by a reason alone. `close` also revokes somebody else's
+/// live claim, so the symmetric version would let one agent take a task away
+/// *and* stop anyone picking it up, on a branch nobody has reviewed.
+///
+/// The two errors differ in size the same way: a `done` invisible elsewhere
+/// wastes work already performed, a `close` invisible elsewhere costs work on a
+/// task somebody proposed to abandon — and that work, if it finishes, produces
+/// a proof, which argues against the closure rather than being lost.
 pub fn close(inv: &Invocation, repo: &Repo, identity: &str, out: &mut dyn Write) -> Result<i32> {
     let prefix = inv.positionals.first().ok_or_else(|| {
         CliError::new(1, "close expects an id").with_hint("ank close <id> --reason \"<r>\"")

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -166,6 +166,22 @@ impl Repo {
             .then(|| String::from_utf8_lossy(&out.stdout).to_string())
     }
 
+    /// The same read, performed from another checkout of this repository.
+    ///
+    /// `refs/ank/` is shared by every worktree, so this is not a different
+    /// answer — it is the same one, asked from where the question actually
+    /// arises: another agent, on another branch, wanting to know what the plane
+    /// says about a task.
+    fn claim_ref_at(&self, at: &Path, id: &str) -> Option<String> {
+        let out = git_command(at)
+            .args(["cat-file", "-p", &format!("refs/ank/claims/{id}")])
+            .output()
+            .unwrap();
+        out.status
+            .success()
+            .then(|| String::from_utf8_lossy(&out.stdout).to_string())
+    }
+
     /// Pushes a claim's expiry into the past, leaving everything else in the
     /// record untouched.
     fn expire_claim(&self, id: &str) {
@@ -2777,6 +2793,90 @@ fn status_names_every_live_claim_of_this_identity() {
     let said = stdout(&quiet.ank("claude-code@ank", &["status"]));
     assert!(!said.contains("ANK_AGENT"), "{said}");
     assert!(!said.contains("also"), "{said}");
+}
+
+/// `close` leaves nothing on the coordination plane where `done` leaves a
+/// completion record, and that asymmetry is the decision (TASK-78326e2e3e89).
+///
+/// ADR-bcf222a31525 created the completion ref so that a task finished on an
+/// unmerged branch would not look free everywhere else, and named this gap
+/// without settling it -- on the ground that `close` is "a human act and a rare
+/// one", which ADR-e17e1bbd93ff retired by dissolving the human side entirely.
+/// The code has behaved this way throughout; what it lacked was a decision
+/// saying so and a test holding it.
+///
+/// Read **from a second checkout**, because that is where the question arises:
+/// `refs/ank/` is shared by every worktree, and an agent on another branch is
+/// exactly the reader the completion ref exists for. Both halves are asserted
+/// in one test, since either alone would pass for the wrong reason -- an
+/// absence proves nothing without the presence beside it.
+#[test]
+fn close_leaves_no_completion_ref_where_done_leaves_one() {
+    const CLOSED: &str = "TASK-000000000b01";
+    const FINISHED: &str = "TASK-000000000b02";
+    const AGENT: &str = "claude-code@ank";
+
+    let r = Repo::new().with_verifiers("verifiers:\n  ok:\n    run: git --version\n");
+    r.seed_task_with(CLOSED, Some("A verifiable criterion."), &["ok"]);
+    r.seed_task_with(FINISHED, Some("A verifiable criterion."), &["ok"]);
+    r.git(&["add", "-A"]);
+    r.git(&["commit", "-qm", "the two tasks"]);
+
+    // Not the default branch. The whole question is what another checkout can
+    // see before the merge, so a test run on `main` would answer nothing.
+    r.git(&["checkout", "-q", "-b", "feature"]);
+    let other = r.0.with_extension("second-checkout");
+    r.git(&[
+        "worktree",
+        "add",
+        "--detach",
+        other.to_str().unwrap(),
+        "HEAD",
+    ]);
+
+    // close: the ref exists, and then it does not.
+    assert_eq!(code(&r.ank(AGENT, &["claim", CLOSED])), 0);
+    assert!(
+        r.claim_ref_at(&other, CLOSED).is_some(),
+        "the claim has to be visible from the other checkout to be worth losing"
+    );
+    let out = r.ank(
+        AGENT,
+        &["close", CLOSED, "--reason", "superseded by the pipeline"],
+    );
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    assert!(
+        r.claim_ref_at(&other, CLOSED).is_none(),
+        "close left a record on the plane:\n{:?}",
+        r.claim_ref_at(&other, CLOSED)
+    );
+
+    // done, on the same branch and read from the same checkout: a completion
+    // record, naming the commit and the branch it was finished on.
+    assert_eq!(code(&r.ank(AGENT, &["claim", FINISHED])), 0);
+    let out = r.ank(AGENT, &["done"]);
+    assert_eq!(code(&out), 0, "{}{}", stdout(&out), stderr(&out));
+    let record = r
+        .claim_ref_at(&other, FINISHED)
+        .expect("done leaves a completion record where close leaves nothing");
+    assert!(
+        record.contains("commit:") && record.contains("feature"),
+        "the completion record names neither the commit nor the branch:\n{record}"
+    );
+
+    // And the price the decision accepts, stated rather than implied: the task
+    // closed on this branch is claimable from a checkout the closure has not
+    // reached. It is not a defect here, it is the thing being agreed to.
+    let out = r.ank_at("codex@host-9", &["claim", CLOSED], &other);
+    assert_eq!(
+        code(&out),
+        0,
+        "a task closed on an unmerged branch is claimable elsewhere, which is \
+         what the decision accepts:\n{}",
+        stderr(&out)
+    );
+
+    r.git(&["worktree", "remove", "--force", other.to_str().unwrap()]);
 }
 
 /// Two clones of one repository arbitrate, which is the whole of level 1


### PR DESCRIPTION
`done` turns the claim ref into a completion record so that a task finished on an unmerged branch does not look free everywhere else (ADR-bcf222a31525). `close` deletes the ref, so a task closed on a branch reads `open` elsewhere until the merge -- the exact window the completion ref exists to close. The ADR **named that gap and deferred it**, on the ground that `close` is "a human act and a rare one".

## Both premises have moved

- **`close` is not a human act.** ADR-e17e1bbd93ff dissolved the human side entirely -- every verb is available to every caller -- and section 3 says `close` is outside the loop SKILL.md teaches "rather than closed to agents". The category the sentence rested on no longer exists.
- **The plane is shared.** Level 1 shipped this morning (#85), so the deletion `close` performs now travels to every clone. What was a local asymmetry is a repository-wide one, which is the scale the decision has to be right at.

## The decision: the asymmetry is right

ADR-6d8736c04cfa supersedes ADR-bcf222a31525, restating its constraint and adding the close clause.

- **`done` earns the repository-wide refusal and `close` does not.** A completion record makes every other `claim` fail with code 4. `done` reaches it through a criterion frozen at claim, the verifiers the task declares and a proof in the file; `close` reaches its transition through a string.
- **`close` revokes somebody else's live claim.** The symmetric version would let one agent take a task away *and* prevent anyone from picking it up, unilaterally, on a branch nobody has reviewed. The revocation is defensible precisely because what follows it is a free task.
- **The two errors differ in size.** A `done` invisible elsewhere wastes work already performed. A `close` invisible elsewhere costs work on a task somebody proposed to abandon -- and if that work finishes it produces a proof, which argues against the closure rather than being lost.
- **Symmetry would cost the format.** `claim`'s refusal reads the record and says "finished on another branch"; saying "closed" needs a discriminator the record does not carry, so specification, then goldens, then code (ADR-63b59c5c26f7). The old ADR hoped the gap could be fixed "without touching the format".

## No behaviour changed

`close` already called `claim::delete`, and the pruning predicate already accepted `Closed` beside `Done`. What was missing was the decision and a test.

## The test

Through the binary, from a **second checkout** (`git worktree add --detach`), which is where the question arises. Both halves in one test, since an absence proves nothing without the presence beside it: nothing on the plane after `close`, a completion record naming the commit and the branch after `done`. It ends by claiming the closed task from that checkout -- stating the price the decision accepts instead of leaving it implied. Falsified by making `close` stop deleting.

## The ADR stays `proposed`

The succession happens at `accept`, not at `new adr --supersedes`, so ADR-bcf222a31525 keeps binding, `check` emits a signal rather than a fault, and its nine citations in the crate stay correct. **Accepting it is a human act** -- signed, on the default branch. Re-pointing the citations afterwards is TASK-d9d364bad929, filed rather than folded in.

TASK-78326e2e3e89

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KxhFCZTsaGLwqCwMKH1wZF