### PR TITLE
The PROPOSED header counts the perimeter, not the survivors

### DIFF
--- a/.ank/tasks/TASK-058469991999.md
+++ b/.ank/tasks/TASK-058469991999.md
@@ -5,7 +5,7 @@ slug: the-proposed-section-of-context-counts-nothing-a
 title: The PROPOSED section of context counts nothing and then says one was cut
 created: 2026-08-11T22:40:54Z
 author: claude-code@sean-laptop
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/src/context.rs
   - crates/ank-cli/tests/cli.rs
@@ -21,7 +21,7 @@ done_criteria: |
   none.
 criteria_by: creator
 schema: 2
-version: 1
+version: 3
 ---
 
 Measured at the root of this repository, with exactly one proposed ADR in the
@@ -45,3 +45,6 @@ distrust the number they can see rather than go looking for the one they cannot.
 Same family as TASK-e3d00a6e62bb, and a different code path: that one is `review`
 printing no ratification queue at all, this one is `context` printing a queue that
 counts itself wrong. Worth reading together and fixing separately.
+
+## Log
+- 2026-08-12T22:03:15Z seanl@sean-laptop — Confirmed the cause before fixing: orientation_lines printed proposals.len(), the survivors of the cutting loop, and PROPOSED is the only section that loop can empty -- it stops at one task and at one constraint, never at zero proposals. So the header read (0) there and nowhere else. Header now carries proposals.len() + cut_proposals. The notice had to move with it: against a total, '+1 more' would name a second proposal that does not exist, so it reads '+N not shown' and names 'ank find --type adr --status proposed --scope <s>', which the test runs to prove it does not refuse. CONSTRAINTS and TASKS keep survivor headers on purpose -- section 5 mandates their counter shape and neither can reach zero. Falsified: reverting the header alone reproduces 'PROPOSED (0, non-binding)' above '+1 not shown'.

--- a/.ank/tasks/TASK-058469991999.md
+++ b/.ank/tasks/TASK-058469991999.md
@@ -5,7 +5,7 @@ slug: the-proposed-section-of-context-counts-nothing-a
 title: The PROPOSED section of context counts nothing and then says one was cut
 created: 2026-08-11T22:40:54Z
 author: claude-code@sean-laptop
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/src/context.rs
   - crates/ank-cli/tests/cli.rs
@@ -20,8 +20,12 @@ done_criteria: |
   one proposed ADR and a budget too small to print it, and on a perimeter with
   none.
 criteria_by: creator
+proof:
+  - type: test
+    ref: "31645590861"
+    criteria: 2ac64a2e7e68
 schema: 2
-version: 3
+version: 4
 ---
 
 Measured at the root of this repository, with exactly one proposed ADR in the
@@ -48,3 +52,4 @@ counts itself wrong. Worth reading together and fixing separately.
 
 ## Log
 - 2026-08-12T22:03:15Z seanl@sean-laptop — Confirmed the cause before fixing: orientation_lines printed proposals.len(), the survivors of the cutting loop, and PROPOSED is the only section that loop can empty -- it stops at one task and at one constraint, never at zero proposals. So the header read (0) there and nowhere else. Header now carries proposals.len() + cut_proposals. The notice had to move with it: against a total, '+1 more' would name a second proposal that does not exist, so it reads '+N not shown' and names 'ank find --type adr --status proposed --scope <s>', which the test runs to prove it does not refuse. CONSTRAINTS and TASKS keep survivor headers on purpose -- section 5 mandates their counter shape and neither can reach zero. Falsified: reverting the header alone reproduces 'PROPOSED (0, non-binding)' above '+1 not shown'.
+- 2026-08-12T22:12:20Z seanl@sean-laptop — done, proof test:31645590861

--- a/crates/ank-cli/src/context.rs
+++ b/crates/ank-cli/src/context.rs
@@ -954,14 +954,31 @@ fn orientation_lines(
             ));
         }
     }
+    // The header counts what the perimeter holds, not what survived the budget.
+    // This is the one section truncation can empty completely -- the cutting
+    // loop stops at one task and at one constraint, and never at zero proposals
+    // -- so a header counting survivors was free to read `(0, non-binding)`
+    // above a notice saying one had been cut, and a reader had no way to tell
+    // which of the two was lying (TASK-058469991999).
+    //
+    // The counter says `not shown` for the same reason: read against a total,
+    // `+1 more` would name a second proposal that does not exist. The two
+    // neighbouring sections keep `+N` as an addition to their header because
+    // neither of them can reach zero.
     if !proposals.is_empty() || cut_proposals > 0 {
         out.push(String::new());
-        out.push(style.header(&format!("PROPOSED ({}, non-binding)", proposals.len())));
+        out.push(style.header(&format!(
+            "PROPOSED ({}, non-binding)",
+            proposals.len() + cut_proposals
+        )));
         for p in proposals {
             out.push(format!("  {}  {}", style.id(&p.short), p.title));
         }
         if cut_proposals > 0 {
-            out.push(format!("  +{cut_proposals} more"));
+            out.push(format!(
+                "  +{cut_proposals} not shown, \
+                 ank find --type adr --status proposed --scope {scope_arg}"
+            ));
         }
     }
     if !tasks.is_empty() {

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -1913,6 +1913,121 @@ fn context_json_reaches_the_process_intact() {
     assert!(text.contains("\"ready\":1"), "{text}");
 }
 
+/// A perimeter holding one proposal, with a budget as the only variable.
+fn proposed_fixture(budget: &str, with_proposal: bool) -> Repo {
+    let r = Repo::new();
+    r.set_config(&format!(
+        "schema: 1\nclaim_ttl_max: 2h\ndefault_branch: main\ncontext_budget: {budget}\n"
+    ));
+    r.seed_task(ID, Some("A verifiable criterion."));
+    std::fs::create_dir_all(r.0.join("src")).unwrap();
+    std::fs::write(r.0.join("src/main.rs"), "fn main() {}\n").unwrap();
+    if with_proposal {
+        r.seed_adr(
+            "ADR-0000000000ab",
+            "Prefer idempotent migrations.",
+            "src/**",
+        );
+    }
+    r
+}
+
+/// The PROPOSED header counts the perimeter, never what survived the budget.
+///
+/// The defect this pins was visible at the root of this repository, on a corpus
+/// holding exactly one proposed ADR:
+///
+///     PROPOSED (0, non-binding)
+///       +1 more
+///
+/// The header asserting there were none, the next line asserting one had been
+/// cut, and nothing telling the reader which of the two to believe
+/// (TASK-058469991999). PROPOSED is the one section truncation can empty: the
+/// cutting order takes proposals down to zero while it stops at one task and at
+/// one constraint, so a header counting survivors read `(0)` there and nowhere
+/// else.
+///
+/// Through the binary, because the number is produced by the render and the
+/// render is only reached by the cutting loop, which is reached by the
+/// configured budget. A unit test on a hand-built view can assert the header
+/// without ever going through the loop that produces the contradiction.
+#[test]
+fn the_proposed_header_counts_the_perimeter_and_never_contradicts_its_notice() {
+    // Room for everything. The header reads 1 and no notice is printed, which
+    // is what makes the tight case below a statement about truncation rather
+    // than about a header that prints a constant.
+    let roomy = proposed_fixture("8000", true);
+    let text = stdout(&roomy.ank("claude-code@ank", &["context"]));
+    assert!(text.contains("PROPOSED (1, non-binding)"), "{text}");
+    assert!(text.contains("ADR-0000"), "{text}");
+    assert!(!text.contains("not shown"), "nothing was cut: {text}");
+
+    // Tight enough that the proposal itself is cut away.
+    let tight = proposed_fixture("100", true);
+    let text = stdout(&tight.ank("claude-code@ank", &["context"]));
+    assert!(
+        !text.contains("ADR-0000"),
+        "the budget was not tight enough to cut the proposal, so this test \
+         asserts nothing: {text}"
+    );
+    assert!(
+        text.contains("PROPOSED (1, non-binding)"),
+        "the header counted the survivors instead of the perimeter: {text}"
+    );
+
+    // The invariant read back out of the output rather than asserted as a
+    // wording: the header equals what was printed plus what was cut. A fix that
+    // changes either number in isolation fails here.
+    let header: usize = text
+        .lines()
+        .find_map(|l| l.trim().strip_prefix("PROPOSED ("))
+        .and_then(|rest| rest.split(',').next())
+        .expect("the section is present")
+        .parse()
+        .expect("the header leads with a count");
+    let notice = text
+        .lines()
+        .find(|l| l.contains("not shown"))
+        .unwrap_or_else(|| panic!("the section was emptied and said nothing: {text}"));
+    let cut: usize = notice
+        .trim()
+        .strip_prefix('+')
+        .and_then(|rest| rest.split_whitespace().next())
+        .expect("the notice leads with a count")
+        .parse()
+        .expect("the notice leads with a count");
+    let printed = text
+        .lines()
+        .filter(|l| l.trim_start().starts_with("ADR-"))
+        .count();
+    assert_eq!(
+        header,
+        printed + cut,
+        "the header disagrees with its own notice: {text}"
+    );
+
+    // The command the notice names answers rather than refuses. Naming a
+    // command that fails on the spot is what the error style forbids
+    // everywhere, and a truncation notice is not exempt from it.
+    let named: Vec<&str> = notice
+        .split_once("ank ")
+        .expect("the notice names the command that recovers what it cut")
+        .1
+        .split_whitespace()
+        .collect();
+    let out = tight.ank("claude-code@ank", &named);
+    assert_eq!(code(&out), 0, "ank {}: {}", named.join(" "), stderr(&out));
+    assert!(stdout(&out).contains("ADR-0000"), "{}", stdout(&out));
+
+    // A perimeter holding no proposal prints no section, at either budget, and
+    // in particular no notice counting what was never there.
+    for budget in ["8000", "100"] {
+        let none = proposed_fixture(budget, false);
+        let text = stdout(&none.ank("claude-code@ank", &["context"]));
+        assert!(!text.contains("PROPOSED"), "at budget {budget}: {text}");
+    }
+}
+
 #[test]
 fn a_done_through_the_binary_leaves_a_completion_ref_naming_commit_and_branch() {
     // Read back with git rather than through the module: what has to be true


### PR DESCRIPTION
At the root of this repository, on a corpus holding exactly one proposed ADR,
orientation answered:

```
PROPOSED (0, non-binding)
  +1 more
```

The header asserting there were none, the next line asserting one had been cut,
and nothing telling the reader which of the two to believe.

`orientation_lines` printed `proposals.len()` — the survivors of the cutting
loop — and PROPOSED is the only section that loop can empty: it stops at one
task and at one constraint, never at zero proposals. So the header read `(0)`
there and nowhere else.

The header now carries `proposals.len() + cut_proposals`. The notice moves with
it, and that half is not cosmetic: read against a total, `+1 more` would name a
second proposal that does not exist. It reads `+N not shown` and names the
command that recovers what it cut.

`CONSTRAINTS` and `TASKS` keep their survivor headers on purpose — §5 mandates
their counter shape (`+12 broad constraints, ank find …`) and neither section
can reach zero.

Now:

```
PROPOSED (1, non-binding)
  +1 not shown, ank find --type adr --status proposed --scope .
```

## Verification

Asserted through the binary in `crates/ank-cli/tests/cli.rs`, on a perimeter
with one proposed ADR and a budget too small to print it, and on one with none
at either budget. The test reads the arithmetic back out of the output — header
equals printed plus cut — rather than asserting a wording, and it runs the
command the notice names to prove it answers rather than refuses.

Falsified: reverting the header alone reproduces `PROPOSED (0, non-binding)`
above `+1 not shown`.

Closes TASK-058469991999, anchored on CI run 31645590861.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
