### PR TITLE
git is required by the verbs that coordinate, not by startup

### DIFF
--- a/.ank/tasks/TASK-65017ea098f2.md
+++ b/.ank/tasks/TASK-65017ea098f2.md
@@ -5,13 +5,16 @@ slug: git-is-required-by-the-verbs-that-coordinate-not
 title: git is required by the verbs that coordinate, not by startup
 created: 2026-08-11T22:22:09Z
 author: claude-code@sean-laptop
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/src/cli.rs
   - crates/ank-cli/src/repo.rs
   - crates/ank-cli/src/git.rs
   - crates/ank-cli/src/human.rs
   - crates/ank-cli/tests/cli.rs
+  - crates/ank-cli/src/context.rs
+  - crates/ank-cli/src/status.rs
+  - docs/ank-spec-v1.1.md
 blocked_by: []
 done_criteria: |
   In a directory holding a .ank/ corpus and no .git/ anywhere above it, the
@@ -30,7 +33,7 @@ done_criteria: |
   All of it asserted through the binary in crates/ank-cli/tests/cli.rs.
 criteria_by: creator
 schema: 2
-version: 1
+version: 8
 ---
 
 Implements ADR-9307e5d214a7. Read it first: the distinction the work turns on is
@@ -64,3 +67,11 @@ things, not just the toplevel.
 The byte-identical clause in the criterion is the regression guard. This task is
 supposed to change what happens outside a repository and nothing whatsoever
 inside one, and the only way to know is to diff the output.
+
+## Log
+- 2026-08-12T22:17:41Z seanl@sean-laptop — The task body's hard half does not exist. It says 'Repository resolution currently IS the git toplevel, so with the gate gone there is no root to resolve. Walk up for .ank/ instead' -- but repo::discover already walks up for .ank/ and never calls git; repo.rs has no git dependency at all. The whole gate is one line, cli.rs:1269 git::ensure_usable(&repo.root) inside startup(), plus init.rs:62. warn_if_outside_repository already handles the degradation the ADR asks for, including the 'is in no git repository' branch, and is simply never reached today because ensure_usable refuses first. So the work is: make the requirement per-verb, split check into two halves, and update the stale comment in crosses_repository which asserts '(_, None) => ensure_usable has already refused with code 9'. The (None, None) case stays silent on purpose -- no repository anywhere is not a boundary crossing, and check's skip line is what reports it.
+- 2026-08-12T22:19:38Z seanl@sean-laptop — amended: +scope crates/ank-cli/src/context.rs, +scope crates/ank-cli/src/status.rs
+- 2026-08-12T22:19:47Z seanl@sean-laptop — Extended the scope with context.rs and status.rs. The declared scope was narrower than the frozen criterion needs: it named cli.rs, repo.rs, git.rs, human.rs and tests/cli.rs, but removing the startup gate exposes every verb at once, and context.rs and status.rs are the two readers that call git with '?' -- context::coordination through ank_refs, status through current_branch and origin_head. Left alone they would go from a clean 'not inside a git repository -> git init' to a raw git failure, still code 9. The criterion's first list does not name them, so this is not required by it; ADR-9307's constraint is what requires it -- 'a verb that only reads or writes the corpus requires none of it and answers on the files alone' -- and context is the verb the loop opens with. The criterion is untouched. The other verbs it does name -- show, find, graph, scope, new, amend -- call no git at all, so removing the gate is the whole change for them.
+- 2026-08-12T22:25:59Z seanl@sean-laptop — Measured the byte-identical clause rather than assuming it. The installed npm binary is main@c86eeeb, which is exactly the pre-change tree, so it serves as the before. On this corpus, with a live claim ref and completion refs present: check 4247 bytes before and after, byte for byte identical, coordination findings included. status (352), review (1699) and graph (13659) likewise identical. Outside a repository, walked through the binary: show, find, graph, scope, check, context, status all exit 0; claim, log, done, release, close, accept, attest all exit 9; new task and amend exit 0; init exits 9 naming git init. check prints exactly one coordination line and the maintenance arm stays silent -- the None case is distinct from Some(Err) precisely so the two do not print a line each.
+- 2026-08-12T22:31:53Z seanl@sean-laptop — amended: +scope docs/ank-spec-v1.1.md
+- 2026-08-12T22:32:17Z seanl@sean-laptop — Amended the scope once more with docs/ank-spec-v1.1.md. Section 13 said 'The version is checked at startup' and section 7 said 'an uninitialised repository exits with code 9' without qualification -- both direct contradictions of ADR-9307, and my own change is what turns them from true into false. Fixed the two, stating the per-verb rule and the enumeration in section 13 and qualifying section 7 with 'a coordinating verb'. Left the broader section 6 prose alone: TASK-62136e8c2b69 owns the discovery walk, which section 6 has never described, and folding it in here would take that task's subject without its criterion.

--- a/.ank/tasks/TASK-65017ea098f2.md
+++ b/.ank/tasks/TASK-65017ea098f2.md
@@ -5,7 +5,7 @@ slug: git-is-required-by-the-verbs-that-coordinate-not
 title: git is required by the verbs that coordinate, not by startup
 created: 2026-08-11T22:22:09Z
 author: claude-code@sean-laptop
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/src/cli.rs
   - crates/ank-cli/src/repo.rs
@@ -32,8 +32,12 @@ done_criteria: |
   
   All of it asserted through the binary in crates/ank-cli/tests/cli.rs.
 criteria_by: creator
+proof:
+  - type: test
+    ref: "31647946347"
+    criteria: 6ed1069e03fb
 schema: 2
-version: 8
+version: 9
 ---
 
 Implements ADR-9307e5d214a7. Read it first: the distinction the work turns on is
@@ -75,3 +79,4 @@ inside one, and the only way to know is to diff the output.
 - 2026-08-12T22:25:59Z seanl@sean-laptop — Measured the byte-identical clause rather than assuming it. The installed npm binary is main@c86eeeb, which is exactly the pre-change tree, so it serves as the before. On this corpus, with a live claim ref and completion refs present: check 4247 bytes before and after, byte for byte identical, coordination findings included. status (352), review (1699) and graph (13659) likewise identical. Outside a repository, walked through the binary: show, find, graph, scope, check, context, status all exit 0; claim, log, done, release, close, accept, attest all exit 9; new task and amend exit 0; init exits 9 naming git init. check prints exactly one coordination line and the maintenance arm stays silent -- the None case is distinct from Some(Err) precisely so the two do not print a line each.
 - 2026-08-12T22:31:53Z seanl@sean-laptop — amended: +scope docs/ank-spec-v1.1.md
 - 2026-08-12T22:32:17Z seanl@sean-laptop — Amended the scope once more with docs/ank-spec-v1.1.md. Section 13 said 'The version is checked at startup' and section 7 said 'an uninitialised repository exits with code 9' without qualification -- both direct contradictions of ADR-9307, and my own change is what turns them from true into false. Fixed the two, stating the per-verb rule and the enumeration in section 13 and qualifying section 7 with 'a coordinating verb'. Left the broader section 6 prose alone: TASK-62136e8c2b69 owns the discovery walk, which section 6 has never described, and folding it in here would take that task's subject without its criterion.
+- 2026-08-12T22:44:27Z seanl@sean-laptop — done, proof test:31647946347

--- a/crates/ank-cli/src/cli.rs
+++ b/crates/ank-cli/src/cli.rs
@@ -246,6 +246,22 @@ pub struct CommandSpec {
     /// What the usage line cannot carry and the caller needs before calling: a
     /// value's grammar, or what interprets it. One line each.
     pub notes: &'static [&'static str],
+    /// Whether the verb **coordinates**, and so requires git 2.34 or newer
+    /// inside a repository (ADR-9307e5d214a7).
+    ///
+    /// The distinction is not between git and something else, it is between
+    /// coordinating — which needs an arbiter — and reading a corpus, which
+    /// needs a parser. A verb that only reads or writes entities answers on the
+    /// files alone, and `check` runs the half of its invariants that needs no
+    /// arbiter rather than refusing.
+    ///
+    /// Declared here rather than as a list beside the dispatch, for the reason
+    /// that matters more than tidiness: the field makes the compiler ask the
+    /// question of every verb that is ever added. A separate enumeration would
+    /// let a new coordinating verb default to silence, which is the shape of
+    /// the defect this ADR corrects — a property of the verb decided somewhere
+    /// the verb is not.
+    pub coordinates: bool,
     /// The task that carries the implementation, **while it does not exist**.
     /// It is therefore also the marker of an unrouted verb: a command that
     /// [`dispatch`] reaches clears the field, so the two never drift apart the
@@ -263,6 +279,7 @@ pub struct CommandSpec {
 pub const COMMANDS: &[CommandSpec] = &[
     CommandSpec {
         name: "context",
+        coordinates: false,
         summary: "what binds this perimeter and what is claimable; with a claim held, the criterion and the constraints in full",
         subcommands: &[],
         max_positionals: 1,
@@ -275,6 +292,7 @@ pub const COMMANDS: &[CommandSpec] = &[
     },
     CommandSpec {
         name: "claim",
+        coordinates: true,
         summary: "takes the task and freezes its done_criteria by hash; refuses one held, blocked, or finished on another branch",
         subcommands: &[],
         max_positionals: 1,
@@ -290,6 +308,7 @@ pub const COMMANDS: &[CommandSpec] = &[
     },
     CommandSpec {
         name: "show",
+        coordinates: false,
         summary: "the entity whole, frontmatter and body, byte for byte",
         subcommands: &[],
         max_positionals: 1,
@@ -302,6 +321,7 @@ pub const COMMANDS: &[CommandSpec] = &[
     },
     CommandSpec {
         name: "log",
+        coordinates: true,
         summary: "an id alone reads the log; an id and a message appends one and renews the claim, which needs holding it",
         subcommands: &[],
         max_positionals: 2,
@@ -316,6 +336,7 @@ pub const COMMANDS: &[CommandSpec] = &[
     },
     CommandSpec {
         name: "done",
+        coordinates: true,
         summary: "runs the declared verifiers, records what ran, and moves the task to done; needs the claim, and a proof if nothing is declared",
         subcommands: &[],
         max_positionals: 1,
@@ -331,6 +352,7 @@ pub const COMMANDS: &[CommandSpec] = &[
     },
     CommandSpec {
         name: "release",
+        coordinates: true,
         summary: "hands the task back, with the reason recorded in its log",
         subcommands: &[],
         max_positionals: 1,
@@ -343,6 +365,7 @@ pub const COMMANDS: &[CommandSpec] = &[
     },
     CommandSpec {
         name: "new",
+        coordinates: false,
         summary: "writes a task or an ADR that needs no hand finishing",
         subcommands: &["task", "adr"],
         max_positionals: 0,
@@ -367,6 +390,7 @@ pub const COMMANDS: &[CommandSpec] = &[
     },
     CommandSpec {
         name: "find",
+        coordinates: false,
         summary: "searches titles, scopes and criteria; --status open lists what remains, with no query",
         subcommands: &[],
         max_positionals: 1,
@@ -382,6 +406,7 @@ pub const COMMANDS: &[CommandSpec] = &[
     // refused the commit until it moved (TASK-15336a0012d5).
     CommandSpec {
         name: "status",
+        coordinates: false,
         summary: "where am I: branch, claim, perimeter, queue, findings",
         subcommands: &[],
         max_positionals: 0,
@@ -394,6 +419,7 @@ pub const COMMANDS: &[CommandSpec] = &[
     },
     CommandSpec {
         name: "review",
+        coordinates: false,
         summary: "the ratification queue and the health of the corpus: what is proposed, and which scopes have gone dead",
         subcommands: &[],
         max_positionals: 1,
@@ -406,6 +432,7 @@ pub const COMMANDS: &[CommandSpec] = &[
     },
     CommandSpec {
         name: "accept",
+        coordinates: true,
         summary: "promotes a proposed ADR to accepted, through a signed ratification commit; on the default branch only",
         subcommands: &[],
         max_positionals: 1,
@@ -425,6 +452,7 @@ pub const COMMANDS: &[CommandSpec] = &[
     },
     CommandSpec {
         name: "close",
+        coordinates: true,
         summary: "closes a task that will never be done; --reason is mandatory",
         subcommands: &[],
         max_positionals: 1,
@@ -443,6 +471,7 @@ pub const COMMANDS: &[CommandSpec] = &[
     },
     CommandSpec {
         name: "amend",
+        coordinates: false,
         summary: "changes blocked_by, scope, and a done_criteria no live claim freezes",
         subcommands: &[],
         max_positionals: 1,
@@ -471,6 +500,7 @@ pub const COMMANDS: &[CommandSpec] = &[
     },
     CommandSpec {
         name: "attest",
+        coordinates: true,
         summary: "appends a proof to a finished task: the one write allowed after done",
         subcommands: &[],
         max_positionals: 1,
@@ -485,6 +515,7 @@ pub const COMMANDS: &[CommandSpec] = &[
     // `tests/skill.rs` is what holds this to §4 rather than to memory.
     CommandSpec {
         name: "edit",
+        coordinates: false,
         summary: "opens an entity in $EDITOR and validates what comes back",
         subcommands: &[],
         max_positionals: 1,
@@ -500,6 +531,7 @@ pub const COMMANDS: &[CommandSpec] = &[
     },
     CommandSpec {
         name: "graph",
+        coordinates: false,
         summary: "the blocked_by DAG in readable text, indented under what blocks it",
         subcommands: &[],
         max_positionals: 1,
@@ -512,6 +544,7 @@ pub const COMMANDS: &[CommandSpec] = &[
     },
     CommandSpec {
         name: "scope",
+        coordinates: false,
         summary: "what covers a path: the constraints that bind it and the tasks that touch it",
         subcommands: &[],
         max_positionals: 1,
@@ -524,6 +557,7 @@ pub const COMMANDS: &[CommandSpec] = &[
     },
     CommandSpec {
         name: "check",
+        coordinates: false,
         summary: "the mechanical invariants: parse, round-trip, references, frozen fields, orphaned claims",
         subcommands: &[],
         max_positionals: 1,
@@ -539,6 +573,7 @@ pub const COMMANDS: &[CommandSpec] = &[
     // states -- what `init` writes, `config` maintains.
     CommandSpec {
         name: "config",
+        coordinates: false,
         summary: "reads and writes .ank/config.yml: the key alone reads, a value writes, --unset removes",
         subcommands: &[],
         max_positionals: 2,
@@ -561,6 +596,7 @@ pub const COMMANDS: &[CommandSpec] = &[
     },
     CommandSpec {
         name: "init",
+        coordinates: true,
         summary: "creates .ank/ here or at <path>, writes config.yml, adds the refs/ank/* refspec; refuses --repo",
         subcommands: &[],
         max_positionals: 1,
@@ -576,6 +612,7 @@ pub const COMMANDS: &[CommandSpec] = &[
     },
     CommandSpec {
         name: "help",
+        coordinates: false,
         summary: "every verb in one flat listing, or one verb in full",
         subcommands: &[],
         max_positionals: 1,
@@ -1264,9 +1301,18 @@ fn warn_if_outside_repository(inv: &Invocation, repo: &crate::repo::Repo, cwd: &
 
 fn startup(inv: &Invocation, cwd: &std::path::Path) -> Result<Startup> {
     let repo = crate::repo::resolve(inv.repo(), cwd)?;
-    // git is a hard dependency, and its version is checked at startup
-    // (ADR-b8884edcebe3).
-    crate::git::ensure_usable(&repo.root)?;
+    // git is required by the verbs that coordinate, and never at startup
+    // (ADR-9307e5d214a7, superseding ADR-b8884edcebe3). The gate used to stand
+    // in front of the dispatch rather than in front of the operation, so `show`,
+    // `find`, `graph`, `scope`, `new`, `amend` and the whole formal half of
+    // `check` refused outside a repository although none of them touches a ref,
+    // a commit or a branch.
+    //
+    // Repository resolution never needed git and does not gain it here:
+    // `repo::discover` walks up for `.ank/` exactly as it always has.
+    if spec_of(inv.command).is_some_and(|s| s.coordinates) {
+        crate::git::ensure_usable(&repo.root)?;
+    }
     warn_if_outside_repository(inv, &repo, cwd);
     let config = crate::config::load(&repo.config_path())?;
     let identity = crate::identity::resolve();

--- a/crates/ank-cli/src/context.rs
+++ b/crates/ank-cli/src/context.rs
@@ -95,6 +95,18 @@ pub(crate) fn coordination(
     warnings: &mut Vec<String>,
 ) -> Result<HashMap<EntityId, Coordination>> {
     let mut map = HashMap::new();
+    // No repository, no coordination plane — and that is an answer rather than
+    // a failure (ADR-9307e5d214a7). It is the same reasoning the damaged-ref
+    // case below already applies, one step further out: a reader describes the
+    // corpus it can see, and `check` is what reports the reach it did not have.
+    //
+    // Written here rather than at each caller on purpose. `context`, `find`,
+    // `graph`, `scope`, `show` and `status` all enumerate the plane through
+    // this function, and a degradation repeated six times is six chances to
+    // degrade differently.
+    if !git::usable_here(cwd) {
+        return Ok(map);
+    }
     for r in git::ank_refs(cwd)? {
         let Some(rest) = r.name.strip_prefix(claim::CLAIMS_PREFIX) else {
             continue;

--- a/crates/ank-cli/src/git.rs
+++ b/crates/ank-cli/src/git.rs
@@ -310,9 +310,28 @@ pub fn toplevel(cwd: &Path) -> Result<PathBuf> {
 }
 
 /// Checks the whole git environment: presence, version, and repository.
+///
+/// This is the gate a **coordinating** verb passes through — `claim`, `log`,
+/// `done`, `release`, `close`, `accept`, `attest`, `init` — and it is called per
+/// verb, never at startup (ADR-9307e5d214a7). It does two things, and both are
+/// load-bearing: a repository alone is not enough, because the 2.34 floor is
+/// what SSH signing needs, so a gate that only resolved the toplevel would let
+/// an old git through to `accept`.
 pub fn ensure_usable(cwd: &Path) -> Result<PathBuf> {
     check_version(version()?)?;
     toplevel(cwd)
+}
+
+/// Whether a coordinating operation could run here: git present, recent enough,
+/// and a repository around `cwd`.
+///
+/// Never an error, and that is the whole difference with [`ensure_usable`]. The
+/// verbs that coordinate call `ensure_usable` and exit 9 naming the command to
+/// run; the readers call this to choose which half of their answer they can
+/// produce. A probe that could refuse would put the startup gate back one level
+/// down, which is the defect ADR-9307e5d214a7 exists to remove.
+pub fn usable_here(cwd: &Path) -> bool {
+    ensure_usable(cwd).is_ok()
 }
 
 /// The **common** git directory of the repository containing `cwd`, absolute,
@@ -369,8 +388,13 @@ pub fn crosses_repository(here: Option<&Path>, root: Option<&Path>) -> bool {
         // No repository here, and one where the corpus was found. Worth saying
         // for the same reason: the refs are somewhere the caller is not.
         (None, Some(_)) => true,
-        // The corpus is not in a repository. `ensure_usable` has already
-        // refused with code 9, and there is no second thing to say about it.
+        // The corpus is in no repository at all. This used to be unreachable —
+        // `ensure_usable` refused at startup before any caller got here — and
+        // git being required per verb makes it ordinary (ADR-9307e5d214a7). It
+        // is still not a crossing: there is no second plane for the refs to
+        // land in, so there is nothing to warn about being on the wrong side
+        // of. `check` is what reports the state, in the one line saying the
+        // coordination half was skipped.
         (_, None) => false,
     }
 }

--- a/crates/ank-cli/src/human.rs
+++ b/crates/ank-cli/src/human.rs
@@ -247,13 +247,39 @@ pub fn inspect(repo: &Repo, cfg: &Config, path: Option<&str>, prune: bool) -> Re
     // repository once and matching many globs against it beats walking it per
     // entity, and the corpus is small where the tree is not.
     let files = tracked_files(&repo.root);
-    let coord = coordination(&repo.root, &mut report)?;
-    let default_branch = git::resolve_default_branch(
-        cfg.default_branch.as_deref(),
-        git::origin_head(&repo.root)?.as_deref(),
-    );
 
-    check_signers(repo, &mut report);
+    // From here the inspection has two halves, and one of them can be absent
+    // (ADR-9307e5d214a7). Everything above is the corpus — parse, canonical
+    // form, filename against id, `blocked_by` references, glob validity — and a
+    // parser answers all of it. Everything below needs an arbiter: claim refs,
+    // the default branch, ratification signatures, completion-ref pruning.
+    //
+    // Where there is no repository to ask, the second half is skipped and said
+    // so, in exactly one line. That line is not optional: a check that silently
+    // examines less than it did is how a corpus passes a gate that stopped
+    // looking. It is a signal rather than a fault, because a corpus outside a
+    // repository is not a sick corpus — it is an inspection with a smaller
+    // reach, and the exit code has to keep meaning what §4 says it means.
+    // `None` is the half never asked for, and it is distinct from `Some(Err)` —
+    // a repository whose default branch cannot be resolved. The two produce one
+    // line each and must not produce two between them.
+    let (coord, default_branch) = if git::usable_here(&repo.root) {
+        let coord = coordination(&repo.root, &mut report)?;
+        let branch = git::resolve_default_branch(
+            cfg.default_branch.as_deref(),
+            git::origin_head(&repo.root)?.as_deref(),
+        );
+        check_signers(repo, &mut report);
+        (coord, Some(branch))
+    } else {
+        report.findings.push(Finding::signal(
+            "coordination",
+            "half skipped: no git repository here, so claim refs, ratification \
+             signatures and completion refs were neither read nor judged \
+             (git init to coordinate)",
+        ));
+        (HashMap::new(), None)
+    };
 
     for (_, entity) in &entities {
         if !in_scope(entity) {
@@ -268,7 +294,7 @@ pub fn inspect(repo: &Repo, cfg: &Config, path: Option<&str>, prune: bool) -> Re
                 &coord,
                 cfg,
                 &store,
-                default_branch.as_deref().ok(),
+                default_branch.as_ref().and_then(|b| b.as_deref().ok()),
                 &mut report,
             ),
             Entity::Adr(a) => check_adr(a, repo, &adr_ids, &entities, &mut report),
@@ -312,12 +338,16 @@ pub fn inspect(repo: &Repo, cfg: &Config, path: Option<&str>, prune: bool) -> Re
     // Maintenance last, so a corpus fault is still reported when pruning cannot
     // run for want of a default branch.
     match &default_branch {
-        Ok(branch) => maintain(repo, branch, &coord, &statuses, prune, &mut report)?,
-        Err(_) => report.findings.push(Finding::signal(
+        Some(Ok(branch)) => maintain(repo, branch, &coord, &statuses, prune, &mut report)?,
+        Some(Err(_)) => report.findings.push(Finding::signal(
             "coordination",
             "default branch indeterminable, completion refs neither pruned nor judged \
              (ank config default_branch <name>)",
         )),
+        // The coordination half was skipped, and it has already said so once.
+        // A second line here would report the consequence as if it were a
+        // separate finding.
+        None => {}
     }
 
     report.findings.sort_by(|a, b| {

--- a/crates/ank-cli/src/status.rs
+++ b/crates/ank-cli/src/status.rs
@@ -30,11 +30,27 @@ pub fn run(
     identity: &str,
     out: &mut dyn Write,
 ) -> Result<i32> {
-    let branch = git::current_branch(&repo.root)?;
-    let default = git::resolve_default_branch(
-        cfg.default_branch.as_deref(),
-        git::origin_head(&repo.root)?.as_deref(),
-    );
+    // git per verb, never at startup (ADR-9307e5d214a7). Outside a repository
+    // `status` still answers on the corpus, and the coordination plane becomes
+    // the one thing it says it cannot see. Both are three-state on purpose:
+    // `None` is the question never asked, and it is not the same answer as a
+    // repository with no commit yet, or one whose default branch is
+    // indeterminable. Collapsing them would print "unborn, no commit yet" at a
+    // caller who has no repository at all.
+    let coordinated = git::usable_here(&repo.root);
+    let branch = if coordinated {
+        Some(git::current_branch(&repo.root)?)
+    } else {
+        None
+    };
+    let default = if coordinated {
+        Some(git::resolve_default_branch(
+            cfg.default_branch.as_deref(),
+            git::origin_head(&repo.root)?.as_deref(),
+        ))
+    } else {
+        None
+    };
 
     let index = Index::open(&repo.ank)?;
     let rows = index.all()?;
@@ -49,7 +65,11 @@ pub fn run(
     // "no claim" would be false; and the expiry alone is a past timestamp a
     // reader scans over, so the state is spelled out in words. Nothing here is
     // carried by a date the reader has to compare against the clock.
-    let standing = crate::claim::on_task(&repo.root, identity)?;
+    let standing = if coordinated {
+        crate::claim::on_task(&repo.root, identity)?
+    } else {
+        None
+    };
     let held = standing
         .as_ref()
         .map(|s| (s.id.clone(), s.object.clone(), s.record.clone()));
@@ -185,8 +205,16 @@ pub fn run(
              \"also_held\":[{}],\"elsewhere\":[{}],\
              \"constraints\":{constraints},\"queue\":{queue},\"unmerged\":{unmerged},\
              \"faults\":{},\"signals\":{}}}",
-            opt_json(branch.as_deref()),
-            opt_json(default.as_ref().ok().map(|s| s.as_str())),
+            // Both collapse to null, and legitimately: a parser asking for the
+            // branch gets "there is none to report", and the three ways of
+            // having none are a distinction the human surface draws in words.
+            opt_json(branch.as_ref().and_then(|b| b.as_deref())),
+            opt_json(
+                default
+                    .as_ref()
+                    .and_then(|d| d.as_ref().ok())
+                    .map(|s| s.as_str())
+            ),
             also_json.join(","),
             elsewhere_json.join(","),
             report.faults(),
@@ -203,10 +231,10 @@ pub fn run(
     // what a reader skips once they know the shape.
     let style = inv.style();
     match (&branch, &default) {
-        (Some(b), Ok(d)) => {
+        (Some(Some(b)), Some(Ok(d))) => {
             let _ = writeln!(out, "{} {b} (default {d})", style.key("branch"));
         }
-        (Some(b), Err(_)) => {
+        (Some(Some(b)), _) => {
             let _ = writeln!(out, "{} {b}", style.key("branch"));
             // Degraded, and named. Without a default branch nothing can say
             // whether a completion ref has landed, and a silent zero above
@@ -220,8 +248,19 @@ pub fn run(
         }
         // A repository with no commit is the nominal state of one freshly
         // `ank init`-ed, not an error.
-        (None, _) => {
+        (Some(None), _) => {
             let _ = writeln!(out, "{} unborn, no commit yet", style.key("branch"));
+        }
+        // No repository at all, which is a corpus being read rather than
+        // coordinated (ADR-9307e5d214a7). Said as a state and not as a warning:
+        // nothing here is wrong, and the lines below that describe claims are
+        // about a plane that does not exist rather than one that is empty.
+        (None, _) => {
+            let _ = writeln!(
+                out,
+                "{} none, no git repository here (git init to coordinate)",
+                style.key("branch")
+            );
         }
     }
 

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -1913,6 +1913,213 @@ fn context_json_reaches_the_process_intact() {
     assert!(text.contains("\"ready\":1"), "{text}");
 }
 
+/// A `.ank/` corpus with no repository anywhere above it.
+///
+/// `GIT_CEILING_DIRECTORIES` rather than trusting the machine. Git's walk for
+/// `.git` would otherwise leave the temporary directory and could well reach the
+/// developer's own repository — `TMPDIR` inside a checkout is unusual and not
+/// forbidden — and a test whose entire subject is "there is no repository here"
+/// must not depend on where temp happens to live. The ceiling stops the walk at
+/// the fixture's parent, on every machine, so the state under test is
+/// constructed rather than hoped for.
+///
+/// The `.ank/` walk needs no such treatment: `discover` stops at the first
+/// `.ank/` going up, and the fixture puts one at its own root.
+struct Bare(PathBuf);
+
+impl Bare {
+    fn new() -> Bare {
+        static SEQ: AtomicU64 = AtomicU64::new(0);
+        let p = std::env::temp_dir().join(format!(
+            "ank-cli-bare-{}-{}",
+            std::process::id(),
+            SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::create_dir_all(p.join(".ank/tasks")).unwrap();
+        std::fs::create_dir_all(p.join(".ank/adr")).unwrap();
+        std::fs::create_dir_all(p.join("src")).unwrap();
+        std::fs::write(p.join("src/main.rs"), "fn main() {}\n").unwrap();
+        std::fs::write(
+            p.join(".ank/config.yml"),
+            "schema: 1\nclaim_ttl_max: 2h\ndefault_branch: main\n",
+        )
+        .unwrap();
+        std::fs::write(
+            p.join(".ank/tasks").join(format!("{ID}.md")),
+            format!(
+                "---\nid: {ID}\ntype: task\nslug: example\ntitle: Example task\n\
+                 created: 2026-07-28T00:00:00Z\nstatus: open\nscope:\n  - src/**\n\
+                 blocked_by: []\ndone_criteria: |\n  A verifiable criterion.\n\
+                 criteria_by: creator\nschema: 1\nversion: 1\n---\n\nFree body.\n"
+            ),
+        )
+        .unwrap();
+        Bare(p)
+    }
+
+    /// Run from inside the corpus and without `--repo`, because the criterion is
+    /// about a caller standing in a directory, and `--repo` short-circuits the
+    /// very walk being tested.
+    fn ank(&self, args: &[&str]) -> Output {
+        ank_command()
+            .args(args)
+            .env("ANK_AGENT", "claude-code@ank")
+            .env("GIT_CEILING_DIRECTORIES", self.0.parent().unwrap())
+            .current_dir(&self.0)
+            .output()
+            .expect("the binary must have been built")
+    }
+}
+
+impl Drop for Bare {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+/// Reading a corpus needs a parser; coordinating needs an arbiter.
+///
+/// The gate used to stand in front of the dispatch rather than in front of the
+/// operation: `startup` called `git::ensure_usable` for every verb but `help`,
+/// `config` and `--version`, so `show`, `find`, `graph`, `scope`, `new`, `amend`
+/// and the whole formal half of `check` refused outside a repository although
+/// none of them touches a ref, a commit or a branch (ADR-9307e5d214a7).
+///
+/// Both halves are asserted here, and the second is the one that keeps this
+/// honest: degrading the coordinating verbs too would make the first half pass
+/// while removing the property the coordination plane exists for. A `claim` with
+/// no arbiter would succeed and guarantee nothing.
+#[test]
+fn outside_a_repository_the_readers_answer_and_the_coordinators_refuse() {
+    let b = Bare::new();
+
+    // Code 9 is the environment, and the criterion is that it never appears for
+    // want of a repository. 8 stays legitimate: it means findings.
+    for args in [
+        vec!["show", ID],
+        vec!["find", "--status", "open"],
+        vec!["graph"],
+        vec!["scope", "src/main.rs"],
+        vec!["check"],
+        vec!["context"],
+        vec!["status"],
+        vec![
+            "new", "task", "--title", "T", "--scope", "src/**", "-c", "C.",
+        ],
+        vec!["amend", ID, "--scope", "docs/**"],
+    ] {
+        let out = b.ank(&args);
+        assert!(
+            code(&out) == 0 || code(&out) == 8,
+            "ank {} exited {} outside a repository: {}",
+            args.join(" "),
+            code(&out),
+            stderr(&out)
+        );
+    }
+
+    // And the arbiter is still required where an arbiter is the point. Each one
+    // names the command to run, which is what separates a refusal from a wall.
+    for args in [
+        vec!["claim", ID],
+        vec!["log", "a message"],
+        vec!["done", "--proof", "test:1"],
+        vec!["release", "--reason", "why"],
+        vec!["close", ID, "--reason", "why"],
+        vec!["accept", "ADR-000000000001"],
+        vec!["attest", ID, "--proof", "test:1"],
+        vec!["init"],
+    ] {
+        let out = b.ank(&args);
+        let said = format!("{}{}", stdout(&out), stderr(&out));
+        assert_eq!(
+            code(&out),
+            9,
+            "ank {} did not refuse outside a repository: {said}",
+            args.join(" ")
+        );
+        assert!(
+            said.contains("git init"),
+            "ank {} refused without naming the command: {said}",
+            args.join(" ")
+        );
+    }
+}
+
+/// `check` grows two halves, and the absent one says so exactly once.
+///
+/// A check that silently examines less than it did is how a corpus passes a gate
+/// that stopped looking, so the line is not optional. Exactly one, because the
+/// consequences of the missing half are many — no claim refs, no default branch,
+/// no signatures, no pruning — and reporting each would turn one state into a
+/// wall of findings. The maintenance arm distinguishes "never asked" from
+/// "asked and indeterminable" for precisely that reason.
+#[test]
+fn check_outside_a_repository_skips_the_coordination_half_and_says_so_once() {
+    let b = Bare::new();
+    let out = b.ank(&["check"]);
+    let said = stdout(&out);
+
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    let lines: Vec<&str> = said
+        .lines()
+        .filter(|l| l.contains("coordination"))
+        .collect();
+    assert_eq!(
+        lines.len(),
+        1,
+        "the coordination half must report its absence once and once only: {said}"
+    );
+    assert!(lines[0].contains("skipped"), "{said}");
+    assert!(
+        lines[0].starts_with("signal:"),
+        "a corpus outside a repository is not a sick corpus, so the exit code \
+         must keep meaning what it means: {said}"
+    );
+    // The formal half really ran, rather than the verb having answered nothing
+    // and reported the skip.
+    assert!(said.contains("1 tasks"), "{said}");
+
+    // `--json` carries it too. A pipeline is the caller most likely to be
+    // outside a repository, and the one least able to notice a line it never
+    // sees.
+    let json = stdout(&b.ank(&["check", "--json"]));
+    assert!(json.trim_start().starts_with('{'), "{json}");
+    assert!(json.contains("coordination"), "{json}");
+    assert!(json.contains("skipped"), "{json}");
+}
+
+/// Inside a repository, nothing observable moves.
+///
+/// This is the regression guard, and the task it belongs to is meant to change
+/// what happens outside a repository and nothing whatsoever inside one. The
+/// byte-for-byte comparison against the previous build was made on this
+/// repository's own corpus — `check`, `status`, `review` and `graph`, all
+/// identical, coordination findings included — and what a test can hold from
+/// here is the property that comparison proved: the coordination half runs, and
+/// never announces itself as skipped.
+#[test]
+fn inside_a_repository_the_coordination_half_still_runs() {
+    let r = Repo::new();
+    r.seed_task(ID, Some("A verifiable criterion."));
+    assert_eq!(code(&r.ank("codex@host-9", &["claim", ID])), 0);
+
+    let said = stdout(&r.ank("claude-code@ank", &["check"]));
+    assert!(
+        !said.contains("skipped"),
+        "the coordination half announced itself absent inside a repository: {said}"
+    );
+
+    // The plane was read rather than merely not refused: the claim another agent
+    // holds reaches a reader that had to enumerate the refs to know about it.
+    let ctx = stdout(&r.ank("claude-code@ank", &["context"]));
+    assert!(ctx.contains("[claimed:codex@host-9]"), "{ctx}");
+
+    let status = stdout(&r.ank("claude-code@ank", &["status"]));
+    assert!(status.contains("branch main"), "{status}");
+    assert!(!status.contains("no git repository"), "{status}");
+}
+
 /// A perimeter holding one proposal, with a budget as the only variable.
 fn proposed_fixture(budget: &str, with_proposal: bool) -> Repo {
     let r = Repo::new();

--- a/docs/ank-spec-v1.1.md
+++ b/docs/ank-spec-v1.1.md
@@ -1008,7 +1008,7 @@ So "one piece of work, one holder" holds **per repository with a remote, and per
 
 ### Level 0 — local
 
-No remote. Claims use the **same `refs/ank/claims/<id>` refs, locally**: a local git ref update is already atomic, and level 1 is literally "the same ref, pushed" — no migration, no state to convert, and a repository that gains a remote is at level 1 from its next claim. There is **no fallback without git**: git is a hard dependency, and an uninitialised repository exits with code 9 and the exact command. Functional without configuration, like a `git init` without a push. Default mode, and the only mode.
+No remote. Claims use the **same `refs/ank/claims/<id>` refs, locally**: a local git ref update is already atomic, and level 1 is literally "the same ref, pushed" — no migration, no state to convert, and a repository that gains a remote is at level 1 from its next claim. There is **no fallback without git**: git is the only claim mechanism, and a coordinating verb run in an uninitialised repository exits with code 9 and the exact command (§13). Reading the corpus is not coordinating and needs none of it. Functional without configuration, like a `git init` without a push. Default mode, and the only mode.
 
 ### Level 1 — git remote only
 
@@ -1226,7 +1226,11 @@ Three entries are new and serve the ref lifecycle and the default branch (§7). 
 
 The rule that matters is not the enumeration but its criterion: a command enters this list only if its output is stable by contract across git versions. That criterion is what excludes porcelain, and it excludes it by its reason rather than by its name — a closed list goes stale at every new need, as this one just did.
 
-**Minimum version: git 2.34.** That is the version introducing SSH signing and `gpg.ssh.allowedSignersFile`; below it, `accept` and `check` cannot fulfil their contract. The version is checked at startup, and too old a version exits with **code 9** — an environment to repair, not a task failure — with the upgrade link.
+**Minimum version: git 2.34.** That is the version introducing SSH signing and `gpg.ssh.allowedSignersFile`; below it, `accept` and `check` cannot fulfil their contract. Too old a version exits with **code 9** — an environment to repair, not a task failure — with the upgrade link.
+
+**The check is per verb, and never at startup** (ADR-9307e5d214a7). A verb that coordinates — `claim`, `log`, `done`, `release`, `close`, `accept`, `attest`, `init` — requires git 2.34 or newer inside a repository, and exits 9 naming the command when git is missing, too old, or the working directory is outside a repository. A verb that only reads or writes the corpus requires none of it and answers on the files alone: `show`, `find`, `graph`, `scope`, `new`, `amend` and `context` need a parser, not an arbiter. `check` runs the invariants that need no git — parse, round-trip, `blocked_by` references, glob validity, filename against id — and skips the coordination half, saying so in exactly one line rather than refusing.
+
+The distinction is not between git and something else, it is between coordinating and reading. A gate standing in front of the dispatch rather than in front of the operation made a binary that could not validate a corpus unless that corpus sat in a git repository — which is smaller than what §14 claims for the format, and smaller than the golden suite is published as. Repository resolution never depended on git and does not gain it: the walk up for `.ank/` is what §6 describes.
 
 ### Ank and git: who commits
 


### PR DESCRIPTION
Implements ADR-9307e5d214a7.

`startup()` called `git::ensure_usable` for every verb but `help`, `config` and
`--version`, so the gate stood in front of the dispatch rather than in front of
the operation. `show`, `find`, `graph`, `scope`, `new`, `amend` and the whole
formal half of `check` refused outside a repository although none of them
touches a ref, a commit or a branch.

```
$ ank find --status open        # a .ank/ corpus, no .git/ anywhere above it
error[9]: ... is not inside a git repository
  -> git init
```

## What changed

The requirement becomes a property of the verb. `CommandSpec` gains
`coordinates`, set on exactly the eight the ADR enumerates — `claim`, `log`,
`done`, `release`, `close`, `accept`, `attest`, `init`. A field rather than a
list beside the dispatch, because the compiler then asks the question of every
verb ever added; a list would let a new coordinating verb default to silence,
which is the shape of the defect this ADR corrects.

The task body describes a second, harder half that does not exist:
`repo::discover` has always walked up for `.ank/` and never called git, so
repository resolution needed no change at all.

`check` grows two halves, one of which can be absent. The line announcing the
skip is not optional — a check that silently examines less than it did is how a
corpus passes a gate that stopped looking — and there is exactly one, because
the consequences of the missing half are many. The default branch is now
three-state: *never asked* is not the same answer as *asked and indeterminable*,
and collapsing them printed a line each.

`context::coordination` returns an empty plane instead of failing, the same
degradation it already applies to a damaged ref one step further out. Written
there rather than at each caller: `context`, `find`, `graph`, `scope`, `show`
and `status` all enumerate the plane through it. `status` grows a state for a
corpus in no repository, distinct from a repository with no commit yet.

§13 said "the version is checked at startup" and §7 said an uninitialised
repository exits 9 without qualification. Both were true before this commit and
false after it, so both move with the code. §6 is left alone —
TASK-62136e8c2b69 owns the discovery walk.

## Now

```
READ  exit=0  show · find · graph · scope · check · context · status · new task · amend
COORD exit=9  claim · log · done · release · close · accept · attest · init

signal: coordination: half skipped: no git repository here, so claim refs,
        ratification signatures and completion refs were neither read nor
        judged (git init to coordinate)
```

## Verification

Outside a repository, through the binary: the readers exit 0 or 8, the eight
coordinators exit 9 each naming the command, and `check` reports the skip once,
in the human output and in `--json`. The fixture pins
`GIT_CEILING_DIRECTORIES` rather than trusting where `TMPDIR` lives, so "there
is no repository here" is constructed rather than hoped for.

Inside one, nothing observable moves. Measured against the previous build on
this repository's own corpus, with a live claim ref and completion refs present:
`check` 4247 bytes byte-for-byte identical, coordination findings included, and
`status`, `review` and `graph` likewise.

Restoring the startup gate fails both new tests.

Closes TASK-65017ea098f2, anchored on CI run 31647946347.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
