### PR TITLE
check names where a dead scope went, and the command that repairs it

### DIFF
--- a/.ank/tasks/TASK-1e79ff3738df.md
+++ b/.ank/tasks/TASK-1e79ff3738df.md
@@ -5,7 +5,7 @@ slug: check-names-where-a-dead-scope-went-and-the-comm
 title: check names where a dead scope went, and the command that repairs it
 created: 2026-08-11T22:28:53Z
 author: claude-code@sean-laptop
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/src/human.rs
   - crates/ank-cli/src/git.rs
@@ -29,8 +29,12 @@ done_criteria: |
   where a file named literally in an ADR scope is renamed, and one where it is
   deleted.
 criteria_by: creator
+proof:
+  - type: test
+    ref: "31666937353"
+    criteria: 3de877ee5e0b
 schema: 2
-version: 4
+version: 5
 ---
 
 Implements ADR-97beaf55e73a. Blocked on the lazy-git task because the skip-in-
@@ -67,3 +71,4 @@ tidier.
 ## Log
 - 2026-08-13T04:08:50Z claude-agent-b — Read the four branches the proposal has to serve and found one the criterion does not resolve. check_scope_alive reports structural death (a scope matching no file) two ways: a signal for an open or in_progress task, a fault for an ADR or a finished task. The criterion says the repair is 'ank amend for a task', but amend refuses a done or closed task outright (code 7, 'its plan is settled') -- and those are exactly the tasks the fault branch covers. Naming ank amend there would name a command that refuses on the spot, which ADR-97be forbids in the same breath as the accepted-ADR case. Resolution: the walk runs on both branches, since both are the same structural condition (spec section 11, and check_scope_alive's own doc comment says so), which is what makes 'ank amend for a task' real -- an open task is the one task amend accepts. A done or closed task gets the rename named and no repair command, because there is none. Accepted or superseded ADR gets the supersession, worded as amend's own refusal already words it.
 - 2026-08-13T04:22:28Z claude-agent-b — Implemented and falsified. git::rename_of is rev-list -1 HEAD -- <path> then diff-tree -M -r -z --name-status --no-commit-id on that commit; diff-tree was missing from the PLUMBING list and is added with the criterion ADR-9307 asks for. Deliberately no --full-history here, unlike ratification_at: there the target is one commit identified by subject and simplification would lose the anchor, here the target is the change itself, and --full-history would keep the merges that merely carried it -- a merge is a commit diff-tree prints nothing for, so asking for more history would answer less often. The walk is skipped for a glob carrying a wildcard: git has no answer for where src/** went, and the single-file entry is the common case. Finding gained a note field rather than folding the proposal into message, because review filters findings on the opening of message and a note carries no severity of its own. Rendered with the LAST and CLEAR glyphs already declared in section 4, so no character is added to the structure alphabet. Falsified by making the walk return nothing: the five tests that assert it fail, and outside_a_repository_the_rename_walk_is_skipped_without_a_word stays green, which is what it should do. The renamed-ADR test spends the proposed command instead of matching it -- split back into argv, handed to the binary, must exit 0 and leave the scope alive.
+- 2026-08-13T04:28:44Z claude-agent-b — done, proof test:31666937353

--- a/.ank/tasks/TASK-1e79ff3738df.md
+++ b/.ank/tasks/TASK-1e79ff3738df.md
@@ -5,7 +5,7 @@ slug: check-names-where-a-dead-scope-went-and-the-comm
 title: check names where a dead scope went, and the command that repairs it
 created: 2026-08-11T22:28:53Z
 author: claude-code@sean-laptop
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/src/human.rs
   - crates/ank-cli/src/git.rs
@@ -30,7 +30,7 @@ done_criteria: |
   deleted.
 criteria_by: creator
 schema: 2
-version: 1
+version: 4
 ---
 
 Implements ADR-97beaf55e73a. Blocked on the lazy-git task because the skip-in-
@@ -63,3 +63,7 @@ confident.
 Cost: the walk runs per dead scope, and a healthy corpus has none, so the common
 path pays nothing. Do not hoist it above the dead-scope test to make the code
 tidier.
+
+## Log
+- 2026-08-13T04:08:50Z claude-agent-b — Read the four branches the proposal has to serve and found one the criterion does not resolve. check_scope_alive reports structural death (a scope matching no file) two ways: a signal for an open or in_progress task, a fault for an ADR or a finished task. The criterion says the repair is 'ank amend for a task', but amend refuses a done or closed task outright (code 7, 'its plan is settled') -- and those are exactly the tasks the fault branch covers. Naming ank amend there would name a command that refuses on the spot, which ADR-97be forbids in the same breath as the accepted-ADR case. Resolution: the walk runs on both branches, since both are the same structural condition (spec section 11, and check_scope_alive's own doc comment says so), which is what makes 'ank amend for a task' real -- an open task is the one task amend accepts. A done or closed task gets the rename named and no repair command, because there is none. Accepted or superseded ADR gets the supersession, worded as amend's own refusal already words it.
+- 2026-08-13T04:22:28Z claude-agent-b — Implemented and falsified. git::rename_of is rev-list -1 HEAD -- <path> then diff-tree -M -r -z --name-status --no-commit-id on that commit; diff-tree was missing from the PLUMBING list and is added with the criterion ADR-9307 asks for. Deliberately no --full-history here, unlike ratification_at: there the target is one commit identified by subject and simplification would lose the anchor, here the target is the change itself, and --full-history would keep the merges that merely carried it -- a merge is a commit diff-tree prints nothing for, so asking for more history would answer less often. The walk is skipped for a glob carrying a wildcard: git has no answer for where src/** went, and the single-file entry is the common case. Finding gained a note field rather than folding the proposal into message, because review filters findings on the opening of message and a note carries no severity of its own. Rendered with the LAST and CLEAR glyphs already declared in section 4, so no character is added to the structure alphabet. Falsified by making the walk return nothing: the five tests that assert it fail, and outside_a_repository_the_rename_walk_is_skipped_without_a_word stays green, which is what it should do. The renamed-ADR test spends the proposed command instead of matching it -- split back into argv, handed to the binary, must exit 0 and leave the scope alive.

--- a/crates/ank-cli/src/git.rs
+++ b/crates/ank-cli/src/git.rs
@@ -42,6 +42,12 @@ const PLUMBING: &[&str] = &[
     "for-each-ref",
     "config",
     "--version",
+    // `diff-tree` and not `show` or `log --name-status`: the porcelain pair
+    // format their output for a reader, `diff-tree` for a program. Its
+    // `--name-status` records have carried the same shape since rename
+    // detection existed, and `-z` removes the one part that was ever
+    // version-dependent — the C-quoting of an unusual path.
+    "diff-tree",
     // The three level 1 needs (§7), each admitted on the criterion rather than
     // on convenience. `push` signals a refused compare-and-swap by its exit
     // code, which is the same contract `update-ref` is trusted for, and
@@ -526,6 +532,97 @@ pub fn file_at(cwd: &Path, rev: &str, path: &str) -> Result<Option<String>> {
         return Ok(None);
     }
     Ok(Some(String::from_utf8_lossy(&out.stdout).to_string()))
+}
+
+/// Where a path went, when the commit that removed it recorded a rename.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Rename {
+    /// The path the file carries now, repository-relative, `/`-separated.
+    pub to: String,
+    /// The commit that moved it, abbreviated for a reader to paste back.
+    pub sha: String,
+}
+
+/// The rename that killed `path`, or `None` when git cannot name one
+/// (ADR-97beaf55e73a).
+///
+/// Two plumbing calls and no porcelain. `rev-list -1 HEAD -- <path>` is the
+/// last commit that touched the path, and `diff-tree` on that commit is what
+/// says whether the touch was a rename.
+///
+/// **No `--full-history` here, and the difference from [`ratification_at`] is
+/// deliberate.** There the target is one specific commit, identified by its
+/// subject, and simplification dropping it would lose the anchor. Here the
+/// target is the change itself: default simplification walks to the commit that
+/// actually made it, where `--full-history` would keep the merges that merely
+/// carried it — and a merge is a commit `diff-tree` prints nothing for, so
+/// asking for more history would answer less often.
+///
+/// `None` is the honest answer for everything this cannot explain: a deletion,
+/// a move under git's similarity threshold, a path renamed by a merge, a
+/// shallow clone, a repository with no `HEAD`. The caller must never render any
+/// of them as a claim about what happened to the file.
+pub fn rename_of(cwd: &Path, path: &str) -> Result<Option<Rename>> {
+    let args = ["rev-list", "-1", "HEAD", "--", path];
+    let out = output(cwd, &args)?;
+    if !out.status.success() {
+        return Ok(None);
+    }
+    let sha = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if sha.is_empty() {
+        return Ok(None);
+    }
+
+    // `-r` to reach into subtrees, `-M` to detect the rename at all,
+    // `--no-commit-id` so the first record is a change and not the commit name.
+    // No pathspec: it would restrict rename detection to the paths named, and
+    // the destination is precisely the path we do not know yet.
+    let args = [
+        "diff-tree",
+        "-M",
+        "-r",
+        "-z",
+        "--name-status",
+        "--no-commit-id",
+        sha.as_str(),
+    ];
+    let out = output(cwd, &args)?;
+    if !out.status.success() {
+        return Ok(None);
+    }
+    let to = rename_target(&String::from_utf8_lossy(&out.stdout), path);
+    Ok(to.map(|to| Rename {
+        to,
+        sha: sha.chars().take(12).collect(),
+    }))
+}
+
+/// The destination `text` records for `from`, if any.
+///
+/// Split out and pure because every branch of it is a shape of git's output,
+/// and a shape is cheaper to assert on directly than to stage in a repository.
+///
+/// `--name-status -z` emits NUL-terminated fields: a status, then one path, or
+/// two when the status is a rename or a copy. The letter carries a similarity
+/// score (`R100`), which is why the test is on the first byte.
+fn rename_target(text: &str, from: &str) -> Option<String> {
+    let mut fields = text.split('\0').filter(|f| !f.is_empty());
+    while let Some(status) = fields.next() {
+        let renamed = status.starts_with('R');
+        let Some(src) = fields.next() else {
+            return None;
+        };
+        if !renamed && !status.starts_with('C') {
+            continue;
+        }
+        let Some(dst) = fields.next() else {
+            return None;
+        };
+        if renamed && src == from {
+            return Some(dst.to_string());
+        }
+    }
+    None
 }
 
 /// The `constraint`+`scope` hash a ratification commit recorded for `id`, or
@@ -1077,5 +1174,98 @@ mod tests {
         ));
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // -----------------------------------------------------------------------
+    // Rename detection (ADR-97beaf55e73a)
+    // -----------------------------------------------------------------------
+
+    /// The shapes of `--name-status -z`, asserted on the bytes rather than
+    /// staged in a repository.
+    ///
+    /// Every branch here is a way for the parser to lose its place: a rename it
+    /// must skip past to reach the one asked about, a status with one field
+    /// where the record before it had two, and a truncated tail that a
+    /// `next().unwrap()` would have panicked on.
+    #[test]
+    fn a_rename_record_is_read_by_its_source_and_the_others_are_stepped_over() {
+        let two_field = "M\0a.rs\0R100\0old.rs\0new.rs\0A\0z.rs\0";
+        assert_eq!(
+            rename_target(two_field, "old.rs"),
+            Some("new.rs".to_string()),
+            "the rename is found past a status carrying one path"
+        );
+        assert_eq!(
+            rename_target(two_field, "a.rs"),
+            None,
+            "a path that was modified was not renamed, and saying otherwise \
+             would put a file where it never went"
+        );
+        assert_eq!(
+            rename_target("R100\0first.rs\0moved.rs\0R80\0old.rs\0new.rs\0", "old.rs"),
+            Some("new.rs".to_string()),
+            "a rename record must be stepped over as two fields, not one"
+        );
+        // A copy is `C` and carries two paths like a rename does. The source
+        // survives a copy, so it can never be what killed a scope — but a
+        // parser that read it as one field would misalign every record after
+        // it, which is how the answer becomes wrong for a different path.
+        assert_eq!(
+            rename_target("C100\0kept.rs\0copy.rs\0R100\0old.rs\0new.rs\0", "old.rs"),
+            Some("new.rs".to_string())
+        );
+        assert_eq!(rename_target("C100\0kept.rs\0copy.rs\0", "kept.rs"), None);
+        assert_eq!(rename_target("", "old.rs"), None);
+        assert_eq!(
+            rename_target("R100\0old.rs\0", "old.rs"),
+            None,
+            "output cut mid-record answers nothing, and must not panic"
+        );
+    }
+
+    #[test]
+    fn a_renamed_path_names_where_it_went_and_a_deleted_one_names_nothing() {
+        let t = Temp::new_repo();
+        t.commit("src/old.rs", "fn main() {}\n// enough body to be similar\n");
+
+        // Through git's own rename detection and not a hand-written record:
+        // what is under test is whether `-M` fires on a real commit, which is
+        // the one thing a parser test cannot say.
+        std::fs::rename(t.0.join("src/old.rs"), t.0.join("src/new.rs")).unwrap();
+        t.porcelain(&["add", "-A"]);
+        t.porcelain(&["commit", "-qm", "move it"]);
+        let sha = run(&t.0, &["rev-parse", "HEAD"]).unwrap();
+
+        let moved = rename_of(&t.0, "src/old.rs").unwrap().expect("git saw it");
+        assert_eq!(moved.to, "src/new.rs");
+        assert!(
+            sha.starts_with(&moved.sha),
+            "the commit named must be the one that moved it: {} is not a \
+             prefix of {sha}",
+            moved.sha
+        );
+
+        // A deletion is the case the caller must render as nothing at all.
+        t.commit("src/gone.rs", "fn gone() {}\n");
+        std::fs::remove_file(t.0.join("src/gone.rs")).unwrap();
+        t.porcelain(&["add", "-A"]);
+        t.porcelain(&["commit", "-qm", "delete it"]);
+        assert_eq!(
+            rename_of(&t.0, "src/gone.rs").unwrap(),
+            None,
+            "a deleted file went nowhere, and no rename may be invented for it"
+        );
+
+        // A path that never existed is the third silence, and it must not be an
+        // error: a scope can be a typo, and `check` reports that as it is.
+        assert_eq!(rename_of(&t.0, "src/never.rs").unwrap(), None);
+    }
+
+    /// A repository with no commit at all: `rev-list HEAD` fails, and the
+    /// answer is silence rather than the environment error `run` would raise.
+    #[test]
+    fn a_repository_with_no_head_answers_nothing_rather_than_failing() {
+        let t = Temp::new_repo();
+        assert_eq!(rename_of(&t.0, "src/old.rs").unwrap(), None);
     }
 }

--- a/crates/ank-cli/src/human.rs
+++ b/crates/ank-cli/src/human.rs
@@ -33,6 +33,7 @@ use crate::git;
 use crate::index::Index;
 use crate::repo::Repo;
 use crate::store::{version_of, Store};
+use crate::style;
 use crate::verify;
 use ank_core::{
     append_log, freeze, has_crlf, normalise_line_endings, parse_entity, serialize_entity,
@@ -61,6 +62,15 @@ pub struct Finding {
     pub level: Level,
     pub subject: String,
     pub message: String,
+    /// What the finding does not say and the reader needs anyway, printed
+    /// under it rather than folded into `message`.
+    ///
+    /// Separate from the message for three reasons that all point the same way:
+    /// a note carries no severity of its own and must not count as a second
+    /// finding; `review` filters findings by the opening of `message`, which a
+    /// longer sentence would break; and a caller reading `--json` gets the
+    /// explanation as data instead of as prose it would have to split.
+    pub note: Vec<String>,
 }
 
 impl Finding {
@@ -69,6 +79,7 @@ impl Finding {
             level: Level::Fault,
             subject: subject.to_string(),
             message: message.into(),
+            note: Vec::new(),
         }
     }
     fn signal(subject: impl std::fmt::Display, message: impl Into<String>) -> Finding {
@@ -76,7 +87,12 @@ impl Finding {
             level: Level::Signal,
             subject: subject.to_string(),
             message: message.into(),
+            note: Vec::new(),
         }
+    }
+    fn with_note(mut self, lines: Vec<String>) -> Finding {
+        self.note = lines;
+        self
     }
 }
 
@@ -263,7 +279,8 @@ pub fn inspect(repo: &Repo, cfg: &Config, path: Option<&str>, prune: bool) -> Re
     // `None` is the half never asked for, and it is distinct from `Some(Err)` —
     // a repository whose default branch cannot be resolved. The two produce one
     // line each and must not produce two between them.
-    let (coord, default_branch) = if git::usable_here(&repo.root) {
+    let has_git = git::usable_here(&repo.root);
+    let (coord, default_branch) = if has_git {
         let coord = coordination(&repo.root, &mut report)?;
         let branch = git::resolve_default_branch(
             cfg.default_branch.as_deref(),
@@ -285,7 +302,12 @@ pub fn inspect(repo: &Repo, cfg: &Config, path: Option<&str>, prune: bool) -> Re
         if !in_scope(entity) {
             continue;
         }
-        check_scope_alive(entity, &files, &mut report);
+        check_scope_alive(
+            entity,
+            &files,
+            has_git.then_some(repo.root.as_path()),
+            &mut report,
+        );
         match entity {
             Entity::Task(t) => check_task(
                 t,
@@ -579,7 +601,19 @@ fn tracked_files(root: &Path) -> Vec<String> {
 /// Structural death (§11): a scope matching no file. Verifiable, unlike
 /// temporal decay — a three-year-old constraint can be vital. Never acted on
 /// automatically: the code may simply have moved.
-fn check_scope_alive(entity: &Entity, files: &[String], report: &mut Report) {
+///
+/// `git_root` is `Some` only where there is a repository to ask, and it is what
+/// turns "the scope matches nothing" into "the file moved here, and this is the
+/// command that follows it" (ADR-97beaf55e73a). Where it is `None` the walk is
+/// skipped in silence: a corpus outside a repository already says so once, in
+/// the coordination line, and a second sentence about a question nobody could
+/// ask would be noise.
+fn check_scope_alive(
+    entity: &Entity,
+    files: &[String],
+    git_root: Option<&Path>,
+    report: &mut Report,
+) {
     let globs = entity.scope();
     if globs.is_empty() {
         report
@@ -610,7 +644,7 @@ fn check_scope_alive(entity: &Entity, files: &[String], report: &mut Report) {
         if files.iter().any(|f| one.matches(f)) {
             continue;
         }
-        report.findings.push(if ahead_of_the_code {
+        let finding = if ahead_of_the_code {
             Finding::signal(
                 entity.id(),
                 format!("scope '{glob}' matches no file yet: work not started, or a typo"),
@@ -620,7 +654,80 @@ fn check_scope_alive(entity: &Entity, files: &[String], report: &mut Report) {
                 entity.id(),
                 format!("dead scope '{glob}': no file matches it"),
             )
+        };
+        // The cost clause of ADR-97beaf55e73a, and the reason this sits here
+        // rather than above the loop: two git processes per glob, paid only by a
+        // glob that already matches nothing. A healthy corpus reaches this line
+        // no times.
+        report.findings.push(match git_root {
+            Some(root) => finding.with_note(scope_moved(entity, glob, root)),
+            None => finding,
         });
+    }
+}
+
+/// The note under a dead scope: where git says the path went, and what repairs
+/// the entity (ADR-97beaf55e73a).
+///
+/// Empty for everything git cannot explain, which is most of what can go wrong
+/// with a scope. **Silence here is not evidence.** A deletion, a move under the
+/// similarity threshold and a typo that never named a real file all produce the
+/// same nothing, so no wording below may suggest which — the reader is left
+/// exactly where they stand today, and the finding above says all that is known.
+fn scope_moved(entity: &Entity, glob: &str, root: &Path) -> Vec<String> {
+    // A glob is not a path, and git has no answer for "where did `src/**` go".
+    // The single-file entry is what this serves, and it is the common one: 343
+    // of the 462 scope entries in this repository's own corpus name one file
+    // with no wildcard.
+    if glob.contains(['*', '?', '[', ']', '{', '}']) {
+        return Vec::new();
+    }
+    // A git failure is not a corpus fault and must never become one: the scope
+    // is dead either way, and that is already reported. What is lost is the
+    // explanation, which is exactly what `None` means everywhere else here.
+    let Ok(Some(moved)) = git::rename_of(root, glob) else {
+        return Vec::new();
+    };
+    let mut note = vec![format!(
+        "git records {glob} renamed to {} in {}",
+        moved.to, moved.sha
+    )];
+    note.extend(repair(entity, glob, &moved.to));
+    note
+}
+
+/// The one command that changes the scope of this entity without refusing on
+/// the spot.
+///
+/// Four states and three answers, because `amend` accepts a scope change on
+/// exactly two of them. The refusals it would otherwise raise are what decides
+/// each branch, and each is a refusal this file writes itself.
+fn repair(entity: &Entity, from: &str, to: &str) -> Option<String> {
+    let id = entity.id();
+    let amend = format!("ank amend {id} --drop-scope \"{from}\" --scope \"{to}\"");
+    match entity {
+        // A plan still in flight: `amend` is the verb, and it is what this
+        // reader wants — the rename is what tells a typo from a file that moved
+        // under the work.
+        Entity::Task(t) if matches!(t.status, TaskStatus::Open | TaskStatus::InProgress) => {
+            Some(amend)
+        }
+        // Done or closed, and `amend` refuses it: §3 allows one write to a
+        // finished task and it is a proof. The scope records where the work
+        // happened, which is a fact about the past that a later rename does not
+        // falsify — so the rename is named and nothing is proposed. Naming a
+        // command that exits 7 would be worse than naming none.
+        Entity::Task(_) => None,
+        Entity::Adr(a) if a.status == AdrStatus::Proposed => Some(amend),
+        // Accepted or superseded: `constraint` and `scope` are hashed into the
+        // ratification commit, so `amend` refuses with code 6 and the change is
+        // a succession. Worded as that refusal words it, and deliberately not
+        // shortened — a supersession is a decision, and a one-flag command
+        // would read as a formality.
+        Entity::Adr(_) => Some(format!(
+            "ank new adr --supersedes {id} --title \"<t>\" --scope \"{to}\" \
+             --constraint \"<rule>\""
+        )),
     }
 }
 
@@ -1299,15 +1406,17 @@ fn render(report: &Report, inv: &Invocation, out: &mut dyn Write) {
             .findings
             .iter()
             .map(|f| {
+                let note: Vec<String> = f.note.iter().map(|l| json_str(l)).collect();
                 format!(
-                    "{{\"level\":\"{}\",\"subject\":\"{}\",\"message\":{}}}",
+                    "{{\"level\":\"{}\",\"subject\":\"{}\",\"message\":{},\"note\":[{}]}}",
                     if f.level == Level::Fault {
                         "fault"
                     } else {
                         "signal"
                     },
                     f.subject,
-                    json_str(&f.message)
+                    json_str(&f.message),
+                    note.join(",")
                 )
             })
             .collect();
@@ -1335,6 +1444,18 @@ fn render(report: &Report, inv: &Invocation, out: &mut dyn Write) {
             style.yellow("signal:")
         };
         let _ = writeln!(out, "{tag} {}: {}", f.subject, f.message);
+        // The structure alphabet of §4 and nothing outside it: a note is the
+        // last child of its finding, so `LAST` opens it and `CLEAR` continues
+        // it. Text and never colour — it carries the command to run next, and a
+        // reader who piped this to a file must read the same bytes (ADR-0c8a).
+        for (i, line) in f.note.iter().enumerate() {
+            let lead = if i == 0 {
+                style::glyph::LAST
+            } else {
+                style::glyph::CLEAR
+            };
+            let _ = writeln!(out, "{lead}{line}");
+        }
     }
     for p in &report.pruned {
         let _ = writeln!(out, "{} {}", style.retracted("pruned"), style.id(p));

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -7112,3 +7112,320 @@ fn the_takeover_warnings_of_log_and_amend_are_on_standard_error() {
     assert_json_only(&out, "ank amend --json");
     assert!(stderr(&out).contains("codex@host-9"), "{}", stderr(&out));
 }
+
+// ---------------------------------------------------------------------------
+// A dead scope, and where git says the file went (ADR-97beaf55e73a)
+// ---------------------------------------------------------------------------
+
+const DEAD_ADR: &str = "ADR-00000000aaaa";
+
+/// A body long enough for git's rename detection to fire on it.
+///
+/// `-M` is a similarity heuristic: a one-line file renamed and a one-line file
+/// deleted beside a new one-line file are the same event to it. A fixture
+/// sitting under the threshold would exercise the fallback while claiming to
+/// exercise the detection, and would pass for the wrong reason.
+const SIMILAR: &str = "fn main() {\n    let a = 1;\n    let b = 2;\n    println!(\"{a}{b}\");\n}\n";
+
+/// A repository whose history holds one commit that moved `from` — or deleted
+/// it, when `to` is `None` — with `from` named literally in a proposed ADR.
+fn moved_fixture(from: &str, to: Option<&str>) -> Repo {
+    let r = Repo::new();
+    std::fs::create_dir_all(r.0.join("src")).unwrap();
+    std::fs::write(r.0.join(from), SIMILAR).unwrap();
+    r.seed_adr(DEAD_ADR, "Do not do X.", from);
+    r.git(&["add", "-A"]);
+    r.git(&["commit", "-qm", "seed"]);
+    match to {
+        Some(to) => std::fs::rename(r.0.join(from), r.0.join(to)).unwrap(),
+        None => std::fs::remove_file(r.0.join(from)).unwrap(),
+    }
+    r.git(&["add", "-A"]);
+    r.git(&["commit", "-qm", "move it"]);
+    r
+}
+
+/// The note lines of the one finding that has any, connector stripped.
+///
+/// Reads the drawn output rather than `--json`, because what these tests are
+/// about is what a reader is shown, and the structure layer is part of that.
+/// §4's alphabet is closed, so the two leads below are the two that exist and a
+/// third would fail here rather than pass unnoticed.
+fn proposal(text: &str) -> Option<Vec<String>> {
+    let mut lines: Vec<String> = Vec::new();
+    for line in text.lines() {
+        if let Some(rest) = line.strip_prefix("└── ") {
+            assert!(lines.is_empty(), "two notes in one output: {text}");
+            lines.push(rest.to_string());
+        } else if !lines.is_empty() {
+            match line.strip_prefix("    ") {
+                Some(rest) => lines.push(rest.to_string()),
+                None => break,
+            }
+        }
+    }
+    (!lines.is_empty()).then_some(lines)
+}
+
+/// The finding keeps its wording, and the note under it answers the question
+/// the reader has at that moment.
+///
+/// Through the binary because the walk is two `git` processes and a parser
+/// agreeing with each other, and neither half proves the answer reached
+/// standard output carrying the other.
+///
+/// **The proposed command is run, not merely matched.** ADR-97beaf55e73a
+/// requires a command that will not refuse on the spot, and the only way to
+/// assert that is to spend it: the text is split back into arguments and handed
+/// to the binary, which must exit 0 and leave the scope alive.
+#[test]
+fn a_renamed_file_names_where_it_went_and_the_command_that_repairs_it() {
+    let r = moved_fixture("src/old.rs", Some("src/new.rs"));
+    let head = r.git(&["rev-parse", "HEAD"]);
+
+    let out = r.ank("claude-code@ank", &["check"]);
+    assert_eq!(code(&out), 8, "a dead scope is a fault: {}", stderr(&out));
+    let text = stdout(&out);
+
+    // Untouched: the task that ordered this says not to move when the finding
+    // fires or what severity it carries.
+    assert!(
+        text.contains("dead scope 'src/old.rs': no file matches it"),
+        "{text}"
+    );
+
+    let note = proposal(&text).unwrap_or_else(|| panic!("the rename is named: {text}"));
+    let named = note[0].rsplit(' ').next().unwrap();
+    assert!(
+        note[0].contains("src/new.rs") && head.starts_with(named),
+        "the note must name the new path and the commit that moved it, and \
+         the commit is {head}: {note:?}"
+    );
+
+    let command = note[1].clone();
+    assert!(
+        command.starts_with("ank amend ") && command.contains(DEAD_ADR),
+        "a proposed ADR is repaired by amend: {command}"
+    );
+
+    // Spent rather than read. A command that refuses here is the exact defect
+    // ADR-97beaf55e73a names, and no amount of matching on the string sees it.
+    let args: Vec<String> = command
+        .split_whitespace()
+        .skip(1)
+        .map(|a| a.trim_matches('"').to_string())
+        .collect();
+    let argv: Vec<&str> = args.iter().map(String::as_str).collect();
+    let repaired = r.ank("claude-code@ank", &argv);
+    assert_eq!(
+        code(&repaired),
+        0,
+        "the proposal must not refuse on the spot: `{command}` exited {} — {}",
+        code(&repaired),
+        stderr(&repaired)
+    );
+
+    // And it repaired what it was proposed for.
+    let after = stdout(&r.ank("claude-code@ank", &["check"]));
+    assert!(
+        !after.contains("dead scope"),
+        "the proposed command must leave the scope alive: {after}"
+    );
+}
+
+/// The other half of the criterion, and the one that must add nothing.
+///
+/// A deletion, a move under the similarity threshold and a scope that never
+/// named a real file are one silence to git. The reader is left exactly where
+/// they stand today — no proposal, and above all no sentence asserting the file
+/// was deleted, because this code cannot know that.
+#[test]
+fn a_deleted_file_leaves_the_finding_exactly_as_it_was() {
+    let deleted = moved_fixture("src/old.rs", None);
+    let out = deleted.ank("claude-code@ank", &["check"]);
+    assert_eq!(code(&out), 8, "{}", stderr(&out));
+    let text = stdout(&out);
+    assert!(
+        text.contains("dead scope 'src/old.rs': no file matches it"),
+        "{text}"
+    );
+    assert_eq!(
+        proposal(&text),
+        None,
+        "git cannot explain a deletion, and nothing may be proposed: {text}"
+    );
+    for word in ["renamed", "delet", "removed"] {
+        assert!(
+            !text.contains(word),
+            "'{word}' claims to know what became of the file: {text}"
+        );
+    }
+
+    // What makes the silence mean something: the same corpus and the same
+    // finding, differing by the rename and by nothing else.
+    let renamed = moved_fixture("src/old.rs", Some("src/new.rs"));
+    assert!(
+        proposal(&stdout(&renamed.ank("claude-code@ank", &["check"]))).is_some(),
+        "the renamed fixture must be explained, or the deleted one proves \
+         nothing about the walk"
+    );
+}
+
+/// `amend` refuses the scope of an accepted ADR with code 6, so proposing it
+/// there would name a command that fails on the spot. The proposal is a
+/// supersession, and the refusal it avoids is asserted rather than assumed.
+#[test]
+fn an_accepted_adr_is_offered_a_supersession_and_never_an_amend() {
+    let r = Repo::new();
+    r.enable_signing();
+    std::fs::create_dir_all(r.0.join("src")).unwrap();
+    std::fs::write(r.0.join("src/old.rs"), SIMILAR).unwrap();
+    r.seed_adr(DEAD_ADR, "Do not do X.", "src/old.rs");
+    r.git(&["add", "-A"]);
+    r.git(&["commit", "-qm", "seed"]);
+    let out = r.ank("marie@laptop", &["accept", DEAD_ADR]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+
+    std::fs::rename(r.0.join("src/old.rs"), r.0.join("src/new.rs")).unwrap();
+    r.git(&["add", "-A"]);
+    r.git(&["commit", "-qm", "move it"]);
+
+    let text = stdout(&r.ank("claude-code@ank", &["check"]));
+    let note = proposal(&text).unwrap_or_else(|| panic!("the rename is named: {text}"));
+    assert!(
+        note[1].starts_with("ank new adr --supersedes ") && note[1].contains("src/new.rs"),
+        "an accepted ADR is changed by a succession: {note:?}"
+    );
+    assert!(
+        !note[1].contains("ank amend"),
+        "amend refuses this with code 6, and naming it would be the defect: {note:?}"
+    );
+
+    let refused = r.ank(
+        "claude-code@ank",
+        &[
+            "amend",
+            DEAD_ADR,
+            "--drop-scope",
+            "src/old.rs",
+            "--scope",
+            "src/new.rs",
+        ],
+    );
+    assert_eq!(
+        code(&refused),
+        6,
+        "the branch exists because amend refuses here: {}",
+        stderr(&refused)
+    );
+}
+
+/// The two task states, which `amend` treats as opposites.
+///
+/// An open task is amended, and the rename is what tells a typo from a file
+/// that moved under the work. A finished one is not: §3 allows a single write
+/// to it and that write is a proof, so `amend` exits 7 — and a proposal naming
+/// it would be the refusal this feature exists to avoid. The rename is named
+/// either way, because where the file went is the answer in both states.
+#[test]
+fn a_finished_task_is_told_where_the_file_went_and_offered_no_command() {
+    for (status, expected) in [("open", Some("ank amend ")), ("done", None)] {
+        let r = Repo::new();
+        std::fs::create_dir_all(r.0.join("src")).unwrap();
+        std::fs::write(r.0.join("src/old.rs"), SIMILAR).unwrap();
+        r.seed_task_scoped(ID, "src/old.rs");
+        let seeded = r
+            .task_text(ID)
+            .replace("status: open", &format!("status: {status}"));
+        std::fs::write(r.0.join(".ank/tasks").join(format!("{ID}.md")), seeded).unwrap();
+        r.git(&["add", "-A"]);
+        r.git(&["commit", "-qm", "seed"]);
+        std::fs::rename(r.0.join("src/old.rs"), r.0.join("src/new.rs")).unwrap();
+        r.git(&["add", "-A"]);
+        r.git(&["commit", "-qm", "move it"]);
+
+        let text = stdout(&r.ank("claude-code@ank", &["check"]));
+        let note = proposal(&text).unwrap_or_else(|| panic!("{status}: no note in {text}"));
+        assert!(
+            note[0].contains("src/new.rs"),
+            "{status}: the rename is named whatever the state: {note:?}"
+        );
+        match expected {
+            Some(verb) => assert!(
+                note.get(1).is_some_and(|c| c.starts_with(verb)),
+                "{status}: {note:?}"
+            ),
+            None => assert_eq!(
+                note.len(),
+                1,
+                "{status}: amend refuses a settled plan, so nothing is proposed: {note:?}"
+            ),
+        }
+    }
+}
+
+/// No repository, no walk, and no line saying so.
+///
+/// The cost clause of ADR-97beaf55e73a has a silence clause beside it, and the
+/// silence is the part a test has to hold: `check` already says once that the
+/// coordination half was skipped, and a second sentence about a question that
+/// could not be asked is noise in the one output an agent reads whole.
+#[test]
+fn outside_a_repository_the_rename_walk_is_skipped_without_a_word() {
+    let b = Bare::new();
+    std::fs::write(
+        b.0.join(".ank/adr").join(format!("{DEAD_ADR}.md")),
+        format!(
+            "---\nid: {DEAD_ADR}\ntype: adr\nslug: example\ntitle: A decision\n\
+             created: 2026-07-20T00:00:00Z\nstatus: proposed\nscope:\n  - src/old.rs\n\
+             constraint: |\n  Do not do X.\nschema: 1\nversion: 1\n---\n\nWhy.\n"
+        ),
+    )
+    .unwrap();
+
+    let out = b.ank(&["check"]);
+    assert_eq!(
+        code(&out),
+        8,
+        "the dead scope is still a fault: {}",
+        stderr(&out)
+    );
+    let text = stdout(&out);
+    assert!(
+        text.contains("dead scope 'src/old.rs': no file matches it"),
+        "{text}"
+    );
+    assert_eq!(proposal(&text), None, "{text}");
+    for word in ["rename", "git records"] {
+        assert!(
+            !text.contains(word),
+            "'{word}' is a word about a walk that never ran: {text}"
+        );
+    }
+}
+
+/// `--json` carries the note as data, and no structure character with it.
+#[test]
+fn the_note_reaches_json_as_a_list_and_not_as_drawn_text() {
+    let r = moved_fixture("src/old.rs", Some("src/new.rs"));
+    let out = r.ank("claude-code@ank", &["check", "--json"]);
+    assert_json_only(&out, "ank check --json");
+    let text = stdout(&out);
+    assert!(
+        text.contains("\"note\":[\"git records src/old.rs renamed to src/new.rs in "),
+        "{text}"
+    );
+    assert!(
+        text.contains("ank amend "),
+        "the command a caller would run is data too: {text}"
+    );
+    for glyph in ["└", "├", "│"] {
+        assert!(
+            !text.contains(glyph),
+            "--json carries no structure layer (ADR-0c8ab846d262): {text}"
+        );
+    }
+    // A finding with nothing to add carries the key and an empty list, so a
+    // parser reads one shape rather than two.
+    assert!(text.contains("\"note\":[]"), "{text}");
+}


### PR DESCRIPTION
Implements ADR-97beaf55e73a, closing TASK-1e79ff3738df.

A scope matching no file was reported and left there. When git recorded a
rename of that path, `check` now prints under the finding where the file went,
in which commit, and the one command that changes the scope without refusing on
the spot.

```
error: ADR-00000000aaaa: dead scope 'src/old.rs': no file matches it
└── git records src/old.rs renamed to src/new.rs in 4f2a91c0d3e8
    ank amend ADR-00000000aaaa --drop-scope "src/old.rs" --scope "src/new.rs"
```

## The walk

Two plumbing calls, both admitted on the criterion of ADR-9307e5d214a7:
`rev-list` for the last commit touching the dead path, `diff-tree -M` for the
rename entry. `diff-tree` was missing from the allowed list and is added with
its reason.

No `--full-history`, unlike `ratification_at`, and the difference is
deliberate: there the target is one commit identified by its subject and
simplification dropping it would lose the anchor; here the target is the change
itself, and keeping the merges that merely carried it would answer less often —
a merge is a commit `diff-tree` prints nothing for.

## The proposal

It branches on what `amend` actually accepts, because naming a command that
exits on the spot is the defect the ADR forbids:

| entity | proposal | why |
| --- | --- | --- |
| task `open` / `in_progress` | `ank amend` | the rename is what tells a typo from a file that moved under the work |
| ADR `proposed` | `ank amend` | nothing anchors its scope yet |
| ADR `accepted` / `superseded` | a supersession | `amend` refuses with code 6: the scope is hashed into the ratification commit |
| task `done` / `closed` | none | `amend` refuses with code 7; §3 allows one write to a finished task and it is a proof |

The rename itself is named in all four cases, because where the file went is
the answer either way.

## What it stays silent about

A deletion, a move under git's similarity threshold, a wildcard glob, a corpus
outside a repository — one silence each, and no wording suggests the file was
deleted. The walk runs only on a glob that already matched nothing, so a
healthy corpus pays for none of it.

## Notes on the shape

`Finding` carries the note as a list rather than a longer `message`: `review`
filters findings on the opening of `message`, a note has no severity of its own
and must not count as a second finding, and `--json` hands a caller data
instead of prose to split. Drawn with the `LAST` and `CLEAR` glyphs §4 already
declares, so the structure alphabet gains no character.

## Verification

Asserted through the binary in `crates/ank-cli/tests/cli.rs`, six tests. The
renamed-ADR case **spends** the proposed command rather than matching it: the
text is split back into argv, handed to the binary, and must exit 0 and leave
the scope alive — which is the only way to assert "will not refuse on the spot".

Falsified by making the walk return nothing: the five tests that assert it
fail, and the one asserting the silence outside a repository stays green.

`cargo test --workspace` green (420 tests), `cargo fmt --check` green, no build
warnings, `ank check` on this corpus still exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HkfdZYpYQar1C8t3uuPm5B
