### PR TITLE
review prints the ratification queue it exists for

### DIFF
--- a/.ank/tasks/TASK-e3d00a6e62bb.md
+++ b/.ank/tasks/TASK-e3d00a6e62bb.md
@@ -5,7 +5,7 @@ slug: review-does-not-print-the-ratification-queue-it
 title: review does not print the ratification queue it exists for
 created: 2026-08-11T22:21:41Z
 author: claude-code@sean-laptop
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/src/human.rs
   - crates/ank-cli/tests/cli.rs
@@ -19,7 +19,7 @@ done_criteria: |
   at least one proposed ADR and on one holding none.
 criteria_by: creator
 schema: 2
-version: 1
+version: 3
 ---
 
 `ank help review` says the verb serves "the ratification queue and the health of
@@ -55,3 +55,6 @@ alone. Confirm rather than assume.
 The one-line-when-empty rule is not decoration: it is the same reasoning `status`
 already applies to `elsewhere no claim by another agent`. Silence and "this verb
 does not answer that" read identically, and this task exists because they did.
+
+## Log
+- 2026-08-13T04:49:58Z claude-agent-b — Confirmed rather than assumed, as the body asked. review iterated index rows filtering kind == Adr and status == accepted, so proposed never entered the function at all; the dead half is sound and untouched -- it reads the check findings whose message opens with 'dead scope', and that message is unchanged. Reproduced on this corpus: ank status says queue 1 proposal(s), ank review prints nothing and --json carries no such key. Two judgement calls worth recording. The queue is not filtered by dead, unlike the constraints: a proposal whose scope has died is still waiting for a human, and dropping it would hide the entry most in need of the answer -- its dead scope is reported in its own section either way. And it is filtered by the perimeter, like the constraints, because review deciding for itself what a path contains is the disagreement TASK-df4c removed from three other places. Falsified by clearing the collected list before rendering: both the unit test and the binary test fail, and the empty-queue line is what the unit test catches.

--- a/.ank/tasks/TASK-e3d00a6e62bb.md
+++ b/.ank/tasks/TASK-e3d00a6e62bb.md
@@ -5,7 +5,7 @@ slug: review-does-not-print-the-ratification-queue-it
 title: review does not print the ratification queue it exists for
 created: 2026-08-11T22:21:41Z
 author: claude-code@sean-laptop
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/src/human.rs
   - crates/ank-cli/tests/cli.rs
@@ -18,8 +18,12 @@ done_criteria: |
   Asserted through the binary in crates/ank-cli/tests/cli.rs, on a corpus holding
   at least one proposed ADR and on one holding none.
 criteria_by: creator
+proof:
+  - type: test
+    ref: "31668318542"
+    criteria: d993fea13f95
 schema: 2
-version: 3
+version: 4
 ---
 
 `ank help review` says the verb serves "the ratification queue and the health of
@@ -58,3 +62,4 @@ does not answer that" read identically, and this task exists because they did.
 
 ## Log
 - 2026-08-13T04:49:58Z claude-agent-b — Confirmed rather than assumed, as the body asked. review iterated index rows filtering kind == Adr and status == accepted, so proposed never entered the function at all; the dead half is sound and untouched -- it reads the check findings whose message opens with 'dead scope', and that message is unchanged. Reproduced on this corpus: ank status says queue 1 proposal(s), ank review prints nothing and --json carries no such key. Two judgement calls worth recording. The queue is not filtered by dead, unlike the constraints: a proposal whose scope has died is still waiting for a human, and dropping it would hide the entry most in need of the answer -- its dead scope is reported in its own section either way. And it is filtered by the perimeter, like the constraints, because review deciding for itself what a path contains is the disagreement TASK-df4c removed from three other places. Falsified by clearing the collected list before rendering: both the unit test and the binary test fail, and the empty-queue line is what the unit test catches.
+- 2026-08-13T04:54:26Z claude-agent-b — done, proof test:31668318542

--- a/crates/ank-cli/src/human.rs
+++ b/crates/ank-cli/src/human.rs
@@ -1511,8 +1511,9 @@ pub fn review(inv: &Invocation, repo: &Repo, cfg: &Config, out: &mut dyn Write) 
         .collect();
 
     let mut live = Vec::new();
+    let mut proposed = Vec::new();
     for row in index.all()? {
-        if row.kind != EntityKind::Adr || row.status != "accepted" {
+        if row.kind != EntityKind::Adr {
             continue;
         }
         // The third copy of this matching, now gone the way of the other two:
@@ -1521,15 +1522,29 @@ pub fn review(inv: &Invocation, repo: &Repo, cfg: &Config, out: &mut dyn Write) 
         if !crate::context::in_perimeter(&row.scope, path.as_deref()) {
             continue;
         }
-        if dead.contains(&row.id.to_string()) {
-            continue;
+        match row.status.as_str() {
+            // The queue `accept` draws from, and the question this verb opens
+            // with. Not filtered by `dead`, unlike the constraints below: a
+            // proposal whose scope has died is still waiting for a human, and
+            // dropping it from the queue would hide the one entry most in need
+            // of the answer. Its dead scope is reported in its own section.
+            "proposed" => proposed.push(row),
+            "accepted" => {
+                if dead.contains(&row.id.to_string()) {
+                    continue;
+                }
+                let matched = ScopeSet::new(&row.scope)
+                    .map(|s| files.iter().filter(|f| s.matches(f)).count())
+                    .unwrap_or(0);
+                live.push((row, matched));
+            }
+            // `superseded` binds nobody and is not waiting for anybody: it is
+            // history, and history is not a review of the present.
+            _ => {}
         }
-        let matched = ScopeSet::new(&row.scope)
-            .map(|s| files.iter().filter(|f| s.matches(f)).count())
-            .unwrap_or(0);
-        live.push((row, matched));
     }
     live.sort_by_key(|(r, _)| r.id.to_string());
+    proposed.sort_by_key(|r| r.id.to_string());
 
     let mut dead: Vec<String> = dead.into_iter().collect();
     dead.sort();
@@ -1545,9 +1560,17 @@ pub fn review(inv: &Invocation, repo: &Repo, cfg: &Config, out: &mut dyn Write) 
                 )
             })
             .collect();
+        // `files` is not carried here, and its absence is the point: it counts
+        // what a constraint binds today, and a proposal binds nothing until it
+        // is ratified. The queue's question is which decisions are waiting.
+        let waiting: Vec<String> = proposed
+            .iter()
+            .map(|r| format!("{{\"id\":\"{}\",\"title\":{}}}", r.id, json_str(&r.title)))
+            .collect();
         let _ = writeln!(
             out,
-            "{{\"live\":[{}],\"dead\":{},\"faults\":{},\"signals\":{}}}",
+            "{{\"proposed\":[{}],\"live\":[{}],\"dead\":{},\"faults\":{},\"signals\":{}}}",
+            waiting.join(","),
             items.join(","),
             dead.len(),
             report.faults(),
@@ -1557,6 +1580,27 @@ pub fn review(inv: &Invocation, repo: &Repo, cfg: &Config, out: &mut dyn Write) 
     }
     if !inv.quiet() {
         let style = inv.style();
+        // First, because it is the question `review` exists to answer: §4 opens
+        // its description with "ratification queue", and a maintainer runs this
+        // before ratifying. It used to print nowhere at all, and an empty queue
+        // and an unprinted queue read identically (TASK-e3d00a6e62bb).
+        if proposed.is_empty() {
+            // Said even when there is nothing to say, on the reasoning `status`
+            // already applies to `elsewhere no claim by another agent`: silence
+            // and "this verb does not answer that" are the same bytes, and this
+            // verb is where the question has an answer.
+            let _ = writeln!(out, "{}", style.key("nothing proposed for ratification"));
+        } else {
+            let _ = writeln!(
+                out,
+                "{}",
+                style.header(&format!("PROPOSED ({})", proposed.len()))
+            );
+            for r in &proposed {
+                let _ = writeln!(out, "  {}  {}", style.id(&r.id.to_string()), r.title);
+            }
+        }
+        let _ = writeln!(out);
         let _ = writeln!(
             out,
             "{}",
@@ -4881,5 +4925,47 @@ mod tests {
         assert!(out.contains("ADR-00000000aaaa"), "{out}");
         assert!(out.contains("DEAD SCOPES (1)"), "{out}");
         assert!(out.contains("ADR-00000000bbbb"), "{out}");
+        // The queue is answered even when it is empty, because an empty queue
+        // and an unprinted queue used to be the same bytes.
+        assert!(out.contains("nothing proposed for ratification"), "{out}");
+        assert!(!out.contains("PROPOSED"), "{out}");
+    }
+
+    /// The ratification queue `review` is described by and did not print.
+    ///
+    /// Three properties, and the third is the one the defect turned on: a
+    /// proposal must not be counted as a live constraint, it must come before
+    /// them, and a proposal whose scope has died stays in the queue — it is
+    /// waiting for a human either way, and the reader most in need of the
+    /// answer is the one whose entry would have been dropped.
+    #[test]
+    fn review_opens_with_what_is_waiting_for_ratification() {
+        let t = Temp::new();
+        t.write(&adr("00000000aaaa", AdrStatus::Accepted, &["src/**"]));
+        t.write(&adr("00000000cccc", AdrStatus::Proposed, &["src/**"]));
+        t.write(&adr("00000000dddd", AdrStatus::Proposed, &["nowhere/**"]));
+        // History, and history is not a review of the present.
+        t.write(&adr("00000000eeee", AdrStatus::Superseded, &["src/**"]));
+
+        let (_, out) = t.call(&["review"], "marie@laptop").unwrap();
+        assert!(out.contains("PROPOSED (2)"), "{out}");
+        assert!(out.contains("LIVE CONSTRAINTS (1)"), "{out}");
+        assert!(
+            out.find("PROPOSED (2)") < out.find("LIVE CONSTRAINTS (1)"),
+            "the queue is what a maintainer runs this for, and it comes first: {out}"
+        );
+        assert!(out.contains("ADR-00000000dddd"), "{out}");
+        assert!(
+            !out.contains("ADR-00000000eeee"),
+            "a superseded decision is waiting for nobody: {out}"
+        );
+
+        let (_, json) = t.call(&["review", "--json"], "marie@laptop").unwrap();
+        assert!(
+            json.contains("\"proposed\":[{\"id\":\"ADR-00000000cccc\""),
+            "{json}"
+        );
+        assert!(json.contains("\"live\":["), "{json}");
+        assert!(json.contains("\"dead\":1"), "{json}");
     }
 }

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -7429,3 +7429,110 @@ fn the_note_reaches_json_as_a_list_and_not_as_drawn_text() {
     // parser reads one shape rather than two.
     assert!(text.contains("\"note\":[]"), "{text}");
 }
+
+// ---------------------------------------------------------------------------
+// review, and the ratification queue it exists for (TASK-e3d00a6e62bb)
+// ---------------------------------------------------------------------------
+
+/// `review` is described by `ank help`, by `SKILL.md` and by §4 as the
+/// ratification queue, and it printed no queue at all.
+///
+/// The consequence was not cosmetic. `accept` is the one human authority act in
+/// the system, `review` is the only surface meant to say what is waiting for
+/// it, and a maintainer running `review` before ratifying was told there was
+/// nothing to ratify. The failure was silent in the direction that matters: an
+/// empty queue and an unprinted queue were the same bytes.
+///
+/// Both halves of the criterion are here in one fixture, because the second is
+/// reached by ratifying the first — which is also the transition a reader would
+/// perform, and the one that must move an entry from the queue into the
+/// constraints rather than duplicating it into both.
+#[test]
+fn review_prints_the_ratification_queue_it_is_described_by() {
+    const BOUND: &str = "ADR-00000000b0b0";
+    const WAITING: &str = "ADR-00000000c0c0";
+    const ELSEWHERE: &str = "ADR-00000000d0d0";
+
+    let r = Repo::new();
+    r.enable_signing();
+    std::fs::create_dir_all(r.0.join("src")).unwrap();
+    std::fs::write(r.0.join("src/main.rs"), "fn main() {}\n").unwrap();
+    std::fs::create_dir_all(r.0.join("docs")).unwrap();
+    std::fs::write(r.0.join("docs/guide.md"), "# guide\n").unwrap();
+    r.seed_adr(BOUND, "Do not do X.", "src/**");
+    r.seed_adr(WAITING, "Do not do Y.", "src/**");
+    r.seed_adr(ELSEWHERE, "Do not do Z.", "docs/**");
+    r.git(&["add", "-A"]);
+    r.git(&["commit", "-qm", "seed"]);
+    let out = r.ank("marie@laptop", &["accept", BOUND]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+
+    let text = stdout(&r.ank("claude-code@ank", &["review"]));
+    assert!(text.contains("PROPOSED (2)"), "{text}");
+    assert!(text.contains(WAITING) && text.contains(ELSEWHERE), "{text}");
+    assert!(
+        text.find("PROPOSED (2)") < text.find("LIVE CONSTRAINTS"),
+        "the queue is what a maintainer opens this for, and §4 opens the \
+         description with it: {text}"
+    );
+    assert!(
+        text.contains("LIVE CONSTRAINTS (1)"),
+        "a proposal binds nobody and must not be counted as a constraint: {text}"
+    );
+
+    // The two surfaces answer one corpus. `status` counted the queue correctly
+    // on the same tree while `review` printed none, and that disagreement is
+    // exactly the shape of the defect.
+    let status = stdout(&r.ank("claude-code@ank", &["status"]));
+    assert!(
+        status.contains("queue 2 proposal(s)"),
+        "status and review must agree on the queue: {status}"
+    );
+
+    // The perimeter binds the queue as it binds the constraints, or `review`
+    // would be deciding for itself what a path contains — the disagreement
+    // TASK-df4c39031583 removed from three other places.
+    let narrowed = stdout(&r.ank("claude-code@ank", &["review", "src"]));
+    assert!(narrowed.contains("PROPOSED (1)"), "{narrowed}");
+    assert!(narrowed.contains(WAITING), "{narrowed}");
+    assert!(!narrowed.contains(ELSEWHERE), "{narrowed}");
+
+    let out = r.ank("claude-code@ank", &["review", "--json"]);
+    assert_json_only(&out, "ank review --json");
+    let json = stdout(&out);
+    assert!(
+        json.contains(&format!("\"proposed\":[{{\"id\":\"{WAITING}\"")),
+        "a caller parsing review gets the queue as data: {json}"
+    );
+    assert!(
+        json.contains("\"live\":[") && json.contains("\"dead\":"),
+        "alongside the two keys that were already there: {json}"
+    );
+
+    // The other half of the criterion: a corpus holding no proposal at all.
+    for id in [WAITING, ELSEWHERE] {
+        let out = r.ank("marie@laptop", &["accept", id]);
+        assert_eq!(code(&out), 0, "{}", stderr(&out));
+    }
+
+    let text = stdout(&r.ank("claude-code@ank", &["review"]));
+    assert!(
+        text.contains("nothing proposed for ratification"),
+        "an empty queue is said in one line rather than vanishing, on the \
+         reasoning status already applies to `elsewhere`: {text}"
+    );
+    assert!(
+        !text.contains("PROPOSED"),
+        "a header over nothing is not the one line asked for: {text}"
+    );
+    assert!(
+        text.contains("LIVE CONSTRAINTS (3)"),
+        "ratifying moves an entry from the queue into the constraints: {text}"
+    );
+
+    let json = stdout(&r.ank("claude-code@ank", &["review", "--json"]));
+    assert!(
+        json.contains("\"proposed\":[]"),
+        "the key stays, so a parser reads one shape rather than two: {json}"
+    );
+}


### PR DESCRIPTION
Closes TASK-e3d00a6e62bb.

`ank help review` calls it "the ratification queue and the health of the
corpus: what is proposed, and which scopes have gone dead". `SKILL.md` teaches
it the same way. §4 opens the description with "ratification queue, pending
proposals, corpus health". It printed neither: the loop over the index filtered
on `accepted`, so a proposed ADR never entered the function.

The consequence is not cosmetic. `accept` is the one human authority act in the
system, `review` is the only surface meant to say what is waiting for it, and a
maintainer running `review` before ratifying was told there was nothing to
ratify. The failure was silent in the direction that matters: an empty queue
and an unprinted queue were the same bytes.

Before, on this repository's own corpus — `ank status` counting `queue 1
proposal(s)` on the same tree:

```
LIVE CONSTRAINTS (18)
  ...
0 fault(s), 33 signal(s)
```

After:

```
PROPOSED (1)
  ADR-1713af205186  An MCP server is a decision, not a task

LIVE CONSTRAINTS (18)
  ...
```

The queue prints first, because that is the question the verb opens its own
description with. An empty one is said in one line rather than vanishing —
`nothing proposed for ratification`, the reasoning `status` already applies to
`elsewhere no claim by another agent`. `--json` carries `proposed` alongside
`live` and `dead`, and keeps the key as `[]` when empty so a parser reads one
shape rather than two. No `files` count on it: that counts what a constraint
binds today, and a proposal binds nothing until it is ratified.

## Two judgement calls

**Not filtered by dead scopes**, unlike the constraints. A proposal whose scope
has died is still waiting for a human, and dropping it from the queue would
hide the entry most in need of the answer; its dead scope is reported in its
own section either way.

**Filtered by the perimeter**, like the constraints — `review` deciding for
itself what a path contains is the disagreement TASK-df4c39031583 removed from
three other places.

## Verification

The dead half was confirmed sound rather than assumed, as the task asked: it
reads the `check` findings whose message opens with `dead scope`, and that
message is untouched.

Asserted through the binary in `crates/ank-cli/tests/cli.rs` on both corpora
the criterion names — one holding proposals, one holding none, reached by
ratifying the first, which is the transition a reader would actually perform.
The test also asserts `status` and `review` agree on the count, since that
disagreement is the exact shape of the defect. A unit test covers the ordering,
the superseded exclusion and the empty line.

Falsified by clearing the collected list before rendering: both tests fail.

`cargo test --workspace` green (422 tests), `cargo fmt --check` green, no build
warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HkfdZYpYQar1C8t3uuPm5B
