### PR TITLE
The release refuses to build when the tag and the manifests disagree

### DIFF
--- a/.ank/tasks/TASK-adf11c12c480.md
+++ b/.ank/tasks/TASK-adf11c12c480.md
@@ -1,0 +1,36 @@
+---
+id: TASK-adf11c12c480
+type: task
+slug: the-version-check-is-exercised-on-every-push-not
+title: The version check is exercised on every push, not only on a tag
+created: 2026-08-13T04:32:59Z
+author: claude-agent-c
+status: open
+scope:
+  - .github/workflows/ci.yml
+blocked_by: [TASK-91462ace35fd]
+done_criteria: |
+  ci.yml runs .github/scripts/check-version-fixtures.sh on every push and pull request, so a change that breaks check-version.sh is red on the branch that made it rather than on the next tag. It runs the fixtures alone and never compares the tree against a version: there is no tag on a push, and a check that invented one would fail every branch between releases.
+criteria_by: creator
+schema: 2
+version: 1
+---
+
+Discovered while implementing TASK-d33024e7b98a.
+
+The release workflow now refuses to build when the tag and the manifests
+disagree, and it exercises the check against fixtures before trusting its
+verdict. Both run on a tag or a dispatch and nowhere else, which leaves the
+check itself untested between releases: an edit to `check-version.sh`, or to
+the shape of any of the seven manifests it parses, is only discovered by the
+run that was supposed to be gated by it.
+
+`ci.yml` is where the fixtures belong. They were left out of TASK-d33024e7b98a
+for one reason only: that file was inside the perimeter another task held while
+the work was done, and two agents writing one workflow is a conflict rather
+than a decision.
+
+What ci.yml must not do is compare the tree against a version. A push carries
+no tag, so there is nothing to compare with, and the tree's own agreement is
+already asserted by the first fixture -- which reads the version out of
+`crates/ank-cli/Cargo.toml` and holds every other literal to it.

--- a/.ank/tasks/TASK-d33024e7b98a.md
+++ b/.ank/tasks/TASK-d33024e7b98a.md
@@ -5,7 +5,7 @@ slug: the-release-takes-its-version-from-the-tag-and-n
 title: The release takes its version from the tag and never asks the manifests
 created: 2026-08-11T23:31:56Z
 author: claude-code@sean-laptop
-status: open
+status: in_progress
 scope:
   - .github/workflows/release.yml
 blocked_by: []
@@ -24,7 +24,7 @@ done_criteria: |
   of step and one where all agree.
 criteria_by: creator
 schema: 2
-version: 1
+version: 4
 ---
 
 `release.yml` derives the published version from `$GITHUB_REF_NAME` and from
@@ -58,3 +58,7 @@ npm manifests at release time with `npm pkg set version=`, so those files are
 overwritten by the run rather than read by it. They are still worth comparing:
 the tree is what a reader sees between releases, and a tree that says `0.1.3`
 while `latest` is `0.2.0` is the same lie told to a different audience.
+
+## Log
+- 2026-08-13T04:32:16Z claude-agent-c — check-version.sh reads the ten version literals with sed and awk, not jq: jq is on every GitHub runner but on no maintainer's machine by default, and the seven files it parses are ones this repository writes itself. The parser refuses on absence -- a literal it cannot find is reported as 'the file's shape moved' and fails, so a manifest that changes shape turns the check red instead of quietly dropping out of it. Verified on five fixture trees built by copying the real manifests, so what is under test is the shapes actually in the tree.
+- 2026-08-13T04:32:31Z claude-agent-c — The criterion asks for the check to be asserted against fixtures, and the assertion lives in the release workflow alone: ci.yml is inside the perimeter TASK-91462ace35fd holds right now, so adding the fixture run there would be two agents writing one file. The consequence is real and worth a follow-up -- between releases nothing exercises check-version.sh, so a change that breaks it is only discovered by a dispatch or a tag. The scope of this task names .github/workflows/release.yml only; the two scripts under .github/scripts/ are what the criterion calls 'the check script' and have nowhere else to live.

--- a/.ank/tasks/TASK-d33024e7b98a.md
+++ b/.ank/tasks/TASK-d33024e7b98a.md
@@ -5,7 +5,7 @@ slug: the-release-takes-its-version-from-the-tag-and-n
 title: The release takes its version from the tag and never asks the manifests
 created: 2026-08-11T23:31:56Z
 author: claude-code@sean-laptop
-status: in_progress
+status: done
 scope:
   - .github/workflows/release.yml
 blocked_by: []
@@ -23,8 +23,12 @@ done_criteria: |
   Asserted by running the check script against a fixture where one manifest is out
   of step and one where all agree.
 criteria_by: creator
+proof:
+  - type: test
+    ref: "31667801620"
+    criteria: ca48d46fa093
 schema: 2
-version: 4
+version: 6
 ---
 
 `release.yml` derives the published version from `$GITHUB_REF_NAME` and from
@@ -62,3 +66,5 @@ while `latest` is `0.2.0` is the same lie told to a different audience.
 ## Log
 - 2026-08-13T04:32:16Z claude-agent-c — check-version.sh reads the ten version literals with sed and awk, not jq: jq is on every GitHub runner but on no maintainer's machine by default, and the seven files it parses are ones this repository writes itself. The parser refuses on absence -- a literal it cannot find is reported as 'the file's shape moved' and fails, so a manifest that changes shape turns the check red instead of quietly dropping out of it. Verified on five fixture trees built by copying the real manifests, so what is under test is the shapes actually in the tree.
 - 2026-08-13T04:32:31Z claude-agent-c — The criterion asks for the check to be asserted against fixtures, and the assertion lives in the release workflow alone: ci.yml is inside the perimeter TASK-91462ace35fd holds right now, so adding the fixture run there would be two agents writing one file. The consequence is real and worth a follow-up -- between releases nothing exercises check-version.sh, so a change that breaks it is only discovered by a dispatch or a tag. The scope of this task names .github/workflows/release.yml only; the two scripts under .github/scripts/ are what the criterion calls 'the check script' and have nowhere else to live.
+- 2026-08-13T04:45:20Z claude-agent-c — CI is green on this branch: ci run 31667756352, and the release workflow dispatched on the branch as run 31667801620 to exercise the new version job on a real runner. The dispatch is the only path that reaches it -- ci.yml does not run release.yml -- and it publishes nothing, since publish and publish-npm are gated on refs/tags/v. The version job passed both of its steps: the fixtures, and the no-tag branch that skips the comparison and says so.
+- 2026-08-13T04:48:21Z claude-agent-c — done, proof test:31667801620

--- a/.github/scripts/check-version-fixtures.sh
+++ b/.github/scripts/check-version-fixtures.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+#
+# check-version.sh, run against fixture trees: one where every manifest agrees,
+# and three where something is out of step.
+#
+#   check-version-fixtures.sh
+#
+# A check that gates a release is a check nobody watches until the day it is
+# wrong, and the one failure mode that costs a tag is a check that passes when
+# it should not. So the fixtures are built from the manifests actually in the
+# tree, copied and then broken: what is under test is the parsing of the shapes
+# this repository really writes, not of a simplified copy that would drift away
+# from them without either one turning red.
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$root"
+
+check="$root/.github/scripts/check-version.sh"
+
+manifests=(
+  crates/ank-cli/Cargo.toml
+  crates/ank-core/Cargo.toml
+  npm/ank/package.json
+  npm/ank-linux-x64-musl/package.json
+  npm/ank-darwin-arm64/package.json
+  npm/ank-win32-x64/package.json
+  .claude-plugin/plugin.json
+)
+
+# Read independently of the script under test, so the fixture's expectation is
+# not derived from the code that has to meet it.
+version="$(sed -n '/^\[package\]/,/^\[[^p]/ s/^version[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' \
+  crates/ank-cli/Cargo.toml | head -n 1)"
+if [ -z "$version" ]; then
+  echo "cannot read the version out of crates/ank-cli/Cargo.toml" >&2
+  exit 9
+fi
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+# plant <dir> -- the seven manifests, at their real paths, byte for byte.
+plant() {
+  local dir="$1" m
+  for m in "${manifests[@]}"; do
+    mkdir -p "$dir/$(dirname "$m")"
+    cp "$m" "$dir/$m"
+  done
+}
+
+# rewrite <file> <sed script> -- sed -i is not portable to the macOS runner.
+rewrite() {
+  local f="$1" script="$2"
+  sed "$script" "$f" > "$f.new"
+  mv "$f.new" "$f"
+}
+
+failures=0
+
+# expect_pass <name> <tree>
+expect_pass() {
+  local name="$1" tree="$2" out
+  if out="$(bash "$check" "$version" "$tree" 2>&1)"; then
+    echo "ok    $name"
+    return
+  fi
+  echo "FAIL  $name: expected agreement, got"
+  echo "$out" | sed 's/^/      /'
+  failures=$((failures + 1))
+}
+
+# expect_fail <name> <tree> <expected count> <substring ...>
+expect_fail() {
+  local name="$1" tree="$2" want="$3" out s
+  shift 3
+  if out="$(bash "$check" "$version" "$tree" 2>&1)"; then
+    echo "FAIL  $name: expected a refusal, the check passed"
+    echo "$out" | sed 's/^/      /'
+    failures=$((failures + 1))
+    return
+  fi
+  if ! printf '%s\n' "$out" | grep -q "disagrees with $want of "; then
+    echo "FAIL  $name: expected $want disagreements, got"
+    echo "$out" | sed 's/^/      /'
+    failures=$((failures + 1))
+    return
+  fi
+  for s in "$@"; do
+    if ! printf '%s\n' "$out" | grep -qF "$s"; then
+      echo "FAIL  $name: the report never names $s"
+      echo "$out" | sed 's/^/      /'
+      failures=$((failures + 1))
+      return
+    fi
+  done
+  echo "ok    $name"
+}
+
+# Every manifest as the tree carries it. This one also asserts the tree agrees
+# with itself between releases, which is the state a reader sees.
+plant "$tmp/agree"
+expect_pass "the tree agrees with itself at $version" "$tmp/agree"
+
+# One manifest left behind, and only that one reported.
+plant "$tmp/one"
+rewrite "$tmp/one/npm/ank-win32-x64/package.json" \
+  's/^  "version": ".*"/  "version": "0.0.0-stale"/'
+expect_fail "one stale manifest is named" "$tmp/one" 1 \
+  "npm/ank-win32-x64/package.json" \
+  "0.0.0-stale" \
+  "npm pkg set version=$version --prefix npm/ank-win32-x64"
+
+# Two, in two files and of two shapes -- a Cargo table and a pinned dependency.
+# Both are named: a report that stops at the first sends the maintainer round
+# the loop once per stale file.
+plant "$tmp/two"
+rewrite "$tmp/two/crates/ank-core/Cargo.toml" \
+  '0,/^version = ".*"/s/^version = ".*"/version = "0.0.0-stale"/'
+rewrite "$tmp/two/npm/ank/package.json" \
+  's|^    "@haksolot/ank-darwin-arm64": ".*"|    "@haksolot/ank-darwin-arm64": "0.0.0-stale"|'
+expect_fail "every disagreement is named, not the first" "$tmp/two" 2 \
+  "crates/ank-core/Cargo.toml" \
+  "npm/ank/package.json @haksolot/ank-darwin-arm64"
+
+# A literal the parser can no longer find. This is the failure that matters:
+# a shape that moves must turn the check red rather than quietly stop checking
+# that file.
+plant "$tmp/shape"
+rewrite "$tmp/shape/.claude-plugin/plugin.json" '/^  "version":/d'
+expect_fail "a version literal that moved is a failure, not a pass" "$tmp/shape" 1 \
+  ".claude-plugin/plugin.json" \
+  "the file's shape moved"
+
+# A file that is not there at all.
+plant "$tmp/missing"
+rm "$tmp/missing/npm/ank-linux-x64-musl/package.json"
+expect_fail "a manifest that is gone is a failure" "$tmp/missing" 1 \
+  "npm/ank-linux-x64-musl/package.json" \
+  "file missing"
+
+if [ "$failures" -ne 0 ]; then
+  echo
+  echo "$failures fixture(s) failed"
+  exit 1
+fi
+
+echo
+echo "check-version.sh behaves on every fixture"

--- a/.github/scripts/check-version.sh
+++ b/.github/scripts/check-version.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+#
+# Every version literal in the tree, compared with the version the release is
+# about to publish.
+#
+#   check-version.sh <version> [root]
+#
+# The release derives what it publishes from the tag and from nothing else, so
+# a tag pushed without bumping the manifests produces an archive, an npm package
+# and a release page that all agree with each other and all disagree with the
+# binary they contain. The smoke job cannot catch it: it compares the artefact
+# with itself, which is a correct test of the wrapper and no test at all of the
+# version.
+#
+# Ten literals across seven files carry the version today, which is nine more
+# chances to be careful than anyone gets right forever. This makes the
+# disagreement fail instead.
+#
+# Every disagreement is named, not the first one: a check that stops at the
+# first sends the maintainer round the loop once per stale file, and the loop
+# here costs a tag.
+#
+# The parsing is sed and awk. jq is on the runner but not on every machine a
+# maintainer would run this from, and the shapes read here are seven files this
+# repository writes itself. A literal the parser cannot find is a failure and
+# never a pass -- a shape that moved must turn this red, or the check quietly
+# stops checking.
+set -uo pipefail
+
+version="${1:?usage: check-version.sh <version> [root]}"
+root="${2:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+
+cd "$root" || exit 9
+
+# Parallel arrays rather than one associative array: this also runs on the
+# macOS runner's bash 3.2, where associative arrays do not exist.
+bad_what=()
+bad_found=()
+bad_fix=()
+total=0
+
+# The version in the [package] table, which is rust-version's neighbour. Scoped
+# to that table on purpose: a `version = "..."` under [dependencies] is a
+# dependency requirement and has nothing to do with what this release ships.
+cargo_version() {
+  awk '
+    /^\[/ { in_package = ($0 == "[package]") }
+    in_package && /^version[[:space:]]*=/ {
+      if (match($0, /"[^"]*"/)) {
+        print substr($0, RSTART + 1, RLENGTH - 2)
+        exit
+      }
+    }
+  ' "$1"
+}
+
+# The top-level "version" key, anchored on its two-space indentation. A nested
+# "version" lives deeper and is not what a release publishes.
+json_version() {
+  sed -n 's/^  "version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$1" | head -n 1
+}
+
+# One pinned entry of optionalDependencies, four-space indented.
+json_pinned_dep() {
+  sed -n "s|^    \"$2\"[[:space:]]*:[[:space:]]*\"\([^\"]*\)\".*|\1|p" "$1" | head -n 1
+}
+
+# compare <label> <file> <found> <fix>
+#
+# An absent file and an unreadable literal are both failures, and both say which
+# it was: "no version found" means the file's shape moved and this script is the
+# thing to repair, not the manifest.
+compare() {
+  local what="$1" file="$2" found="$3" fix="$4"
+  total=$((total + 1))
+  if [ ! -f "$file" ]; then
+    bad_what+=("$what")
+    bad_found+=("file missing")
+    bad_fix+=("$fix")
+    return
+  fi
+  if [ -z "$found" ]; then
+    bad_what+=("$what")
+    bad_found+=("no version found -- the file's shape moved")
+    bad_fix+=("teach .github/scripts/check-version.sh the new shape of $file")
+    return
+  fi
+  [ "$found" = "$version" ] && return
+  bad_what+=("$what")
+  bad_found+=("$found")
+  bad_fix+=("$fix")
+}
+
+for crate in ank-cli ank-core; do
+  f="crates/$crate/Cargo.toml"
+  compare "$f" "$f" "$(cargo_version "$f" 2>/dev/null)" \
+    "$f: version = \"$version\""
+done
+
+# npm-assemble.sh stamps the npm manifests at release time with `npm pkg set`,
+# so the run overwrites these rather than reading them. They are compared all
+# the same: the tree is what a reader sees between releases, and a tree that
+# says 0.1.3 while `latest` is 0.2.0 is the same lie told to a different
+# audience.
+compare "npm/ank/package.json" "npm/ank/package.json" \
+  "$(json_version npm/ank/package.json 2>/dev/null)" \
+  "npm pkg set version=$version --prefix npm/ank"
+
+for p in ank-linux-x64-musl ank-darwin-arm64 ank-win32-x64; do
+  # The wrapper pins its platform packages exactly, so a pin left behind
+  # resolves an install to a binary from a different build.
+  compare "npm/ank/package.json @haksolot/$p" "npm/ank/package.json" \
+    "$(json_pinned_dep npm/ank/package.json "@haksolot/$p" 2>/dev/null)" \
+    "npm pkg set \"optionalDependencies.@haksolot/$p=$version\" --prefix npm/ank"
+
+  compare "npm/$p/package.json" "npm/$p/package.json" \
+    "$(json_version "npm/$p/package.json" 2>/dev/null)" \
+    "npm pkg set version=$version --prefix npm/$p"
+done
+
+compare ".claude-plugin/plugin.json" ".claude-plugin/plugin.json" \
+  "$(json_version .claude-plugin/plugin.json 2>/dev/null)" \
+  ".claude-plugin/plugin.json: \"version\": \"$version\""
+
+count=${#bad_what[@]}
+
+if [ "$count" -eq 0 ]; then
+  echo "version $version agrees with all $total version literals"
+  exit 0
+fi
+
+echo "version $version disagrees with $count of $total version literals"
+echo
+i=0
+while [ "$i" -lt "$count" ]; do
+  printf '  %-50s %s\n' "${bad_what[$i]}" "${bad_found[$i]}"
+  i=$((i + 1))
+done
+echo
+echo "repair every line above, then move the tag:"
+i=0
+while [ "$i" -lt "$count" ]; do
+  echo "  ${bad_fix[$i]}"
+  i=$((i + 1))
+done
+exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,49 @@ permissions:
   contents: read
 
 jobs:
+  # The tag is the only source of the published version: the archive names, the
+  # npm packages and the release title all derive from `$GITHUB_REF_NAME`, and
+  # nothing compares it with the version compiled into the binary. So a tag
+  # pushed without bumping the manifests ships artefacts that agree with each
+  # other and disagree with what they contain, and the npm smoke job cannot see
+  # it -- it compares the artefact with itself, deliberately, which tests the
+  # wrapper and not the version.
+  #
+  # It runs before the build and gates it, because the point is to refuse to
+  # publish: a check at the end has already spent the matrix, and the tag is
+  # the one thing here that is awkward to take back.
+  version:
+    name: version
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      # The positive control, first. This job exists to be red on a day nobody
+      # is watching it, and the failure that costs a tag is a check that passes
+      # when it should not -- so the check is exercised against fixtures where
+      # it must refuse before its verdict on the tree is worth anything.
+      - name: the check refuses what it should refuse
+        shell: bash
+        run: bash .github/scripts/check-version-fixtures.sh
+
+      # `GITHUB_REF_TYPE` and not the `v*` pattern the packaging step matches
+      # on: a dispatch runs from a branch, and what makes the comparison
+      # impossible is the absence of a tag rather than the shape of a name.
+      - name: the tag and the manifests agree
+        shell: bash
+        run: |
+          set -e
+          if [ "${GITHUB_REF_TYPE:-branch}" != "tag" ]; then
+            echo "no tag on this run: there is no version to compare the manifests with."
+            echo "skipped, and a dispatch publishes nothing."
+            exit 0
+          fi
+          bash .github/scripts/check-version.sh "${GITHUB_REF_NAME#v}"
+
   build:
     name: ${{ matrix.os }}
+    needs: version
     runs-on: ${{ matrix.os }}
     strategy:
       # A missing platform is the information we came for. Without fail-fast,


### PR DESCRIPTION
Closes TASK-d33024e7b98a.

## The defect

`release.yml` derives the published version from `$GITHUB_REF_NAME` and from
nothing else. Nothing compares it with the version compiled into the binary, so
a tag pushed without bumping the manifests produces an archive named
`ank-0.2.0-...`, an npm package published as `0.2.0`, a release titled `v0.2.0`
-- and a binary inside all three answering `ank 0.1.3`. Every artefact agrees
with every other artefact and all of them disagree with the thing they contain.

The npm smoke job cannot catch it, and it is worth being precise about why: it
compares `"$direct" --version` with `npx ank --version`, deliberately against
the artefact rather than a literal. Both sides read the same binary, so both are
equally wrong when the manifest is stale.

## What this adds

`.github/scripts/check-version.sh` holds the ten version literals across seven
files to the version being published:

- `crates/ank-cli/Cargo.toml` and `crates/ank-core/Cargo.toml`, the `[package]`
  version scoped to that table so a dependency requirement is never mistaken
  for it
- `npm/ank/package.json` and its three pinned `optionalDependencies`
- the three platform manifests
- `.claude-plugin/plugin.json`

It names every disagreement rather than the first, with the exact repair for
each -- a report that stops at the first sends the maintainer round a loop that
costs a tag each time. Parsing is sed and awk: jq is on every runner and on no
maintainer's machine by default, and the shapes read here are files this
repository writes itself. A literal the parser cannot find is a failure and
never a pass, so a shape that moves turns the check red instead of quietly
dropping out of it.

The new `version` job gates `build`, so nothing compiles before the refusal:
the point is to refuse to publish, and a check at the end has already spent the
matrix. A dispatch carries no tag and says it is skipping rather than passing in
silence.

`.github/scripts/check-version-fixtures.sh` runs first, as a positive control --
the same reasoning as `msrv-tight` in `ci.yml`. This check exists to be red on a
day nobody is watching, and the failure that costs a tag is the one where it
passes when it should not. The fixtures are built by copying the real manifests
and then breaking them, so what is under test is the parsing of the shapes
actually in the tree: one stale manifest, two stale in two different shapes, a
literal removed, a file removed.

## Verification

Release workflow dispatched on this branch, run
[31667801620](https://github.com/haksolot/ank/actions/runs/31667801620): green.
The `version` job passed both steps on a real runner -- the five fixtures, and
the no-tag branch printing that it skips -- and `publish` and `publish-npm`
skipped, as a dispatch must. The dispatch is the only path that reaches the new
job, since `ci.yml` does not run `release.yml`.

`ci` run [31667756352](https://github.com/haksolot/ank/actions/runs/31667756352):
green, 411 tests. `cargo fmt --check` and `ank check` clean.

One honest gap: the branch where a tag genuinely disagrees was exercised
locally, by extracting the step's `run:` body out of the YAML and running it
verbatim in all three states (no tag, agreeing tag, disagreeing tag). Running
that half on a runner would mean pushing a tag.

## Follow-up

TASK-adf11c12c480 carries the leftover: the fixtures belong in `ci.yml` so a
break is red on the branch that made it rather than on the next tag. They were
left out here because `ci.yml` was inside another task's perimeter while this
was written, and two agents writing one workflow is a conflict rather than a
decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011FhetohH64Sy7cCE78gwQC
