### PR TITLE
The version check is exercised on every push, not only on a tag

### DIFF
--- a/.ank/tasks/TASK-adf11c12c480.md
+++ b/.ank/tasks/TASK-adf11c12c480.md
@@ -5,15 +5,19 @@ slug: the-version-check-is-exercised-on-every-push-not
 title: The version check is exercised on every push, not only on a tag
 created: 2026-08-13T04:32:59Z
 author: claude-agent-c
-status: in_progress
+status: done
 scope:
   - .github/workflows/ci.yml
 blocked_by: [TASK-91462ace35fd]
 done_criteria: |
   ci.yml runs .github/scripts/check-version-fixtures.sh on every push and pull request, so a change that breaks check-version.sh is red on the branch that made it rather than on the next tag. It runs the fixtures alone and never compares the tree against a version: there is no tag on a push, and a check that invented one would fail every branch between releases.
 criteria_by: creator
+proof:
+  - type: test
+    ref: "31668935610"
+    criteria: 4279599f37c9
 schema: 2
-version: 3
+version: 4
 ---
 
 Discovered while implementing TASK-d33024e7b98a.
@@ -37,3 +41,4 @@ already asserted by the first fixture -- which reads the version out of
 
 ## Log
 - 2026-08-13T05:01:34Z claude-agent-c — The fixtures run on ubuntu alone, not on the test matrix. Two reasons, and the second is the one that decided it: ubuntu is the platform of use, since the version job in release.yml runs there; and on windows-latest git checks out with autocrlf, so a .sh under .github/scripts/ arrives in CRLF and bash refuses it. Keeping these scripts in LF is a .gitattributes decision about the tree, outside this task's scope. Falsified in both directions before committing: a check-version.sh that always exits 0 turns four fixtures red, and a JSON parser anchored on the wrong indentation turns all five red with 'the file's shape moved' rather than passing on an empty read.
+- 2026-08-13T05:06:16Z claude-agent-c — done, proof test:31668935610

--- a/.ank/tasks/TASK-adf11c12c480.md
+++ b/.ank/tasks/TASK-adf11c12c480.md
@@ -5,7 +5,7 @@ slug: the-version-check-is-exercised-on-every-push-not
 title: The version check is exercised on every push, not only on a tag
 created: 2026-08-13T04:32:59Z
 author: claude-agent-c
-status: open
+status: in_progress
 scope:
   - .github/workflows/ci.yml
 blocked_by: [TASK-91462ace35fd]
@@ -13,7 +13,7 @@ done_criteria: |
   ci.yml runs .github/scripts/check-version-fixtures.sh on every push and pull request, so a change that breaks check-version.sh is red on the branch that made it rather than on the next tag. It runs the fixtures alone and never compares the tree against a version: there is no tag on a push, and a check that invented one would fail every branch between releases.
 criteria_by: creator
 schema: 2
-version: 1
+version: 3
 ---
 
 Discovered while implementing TASK-d33024e7b98a.
@@ -34,3 +34,6 @@ What ci.yml must not do is compare the tree against a version. A push carries
 no tag, so there is nothing to compare with, and the tree's own agreement is
 already asserted by the first fixture -- which reads the version out of
 `crates/ank-cli/Cargo.toml` and holds every other literal to it.
+
+## Log
+- 2026-08-13T05:01:34Z claude-agent-c — The fixtures run on ubuntu alone, not on the test matrix. Two reasons, and the second is the one that decided it: ubuntu is the platform of use, since the version job in release.yml runs there; and on windows-latest git checks out with autocrlf, so a .sh under .github/scripts/ arrives in CRLF and bash refuses it. Keeping these scripts in LF is a .gitattributes decision about the tree, outside this task's scope. Falsified in both directions before committing: a check-version.sh that always exits 0 turns four fixtures red, and a JSON parser anchored on the wrong indentation turns all five red with 'the file's shape moved' rather than passing on an empty read.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,35 @@ jobs:
       # Exit 8 means findings, and that is a failure here. Signals exit 0.
       - run: cargo run -q --bin ank -- check
 
+  # release.yml refuses to build when the tag and the manifests disagree on the
+  # version, and it exercises that check against fixtures before trusting it.
+  # Both run on a tag or a dispatch and nowhere else, which left the check itself
+  # untested between releases: an edit to check-version.sh, or to the shape of
+  # any of the seven manifests it parses, was only discovered by the run it was
+  # supposed to gate — and by then the tag is spent (TASK-adf11c12c480).
+  #
+  # The fixtures alone, never the comparison. A push carries no tag, so there is
+  # no version to hold the manifests to, and a check that invented one would be
+  # red on every branch between releases.
+  #
+  # That is not a gap: the first fixture reads the version out of
+  # crates/ank-cli/Cargo.toml and holds every other literal to it, so a bump that
+  # touched six files out of seven is red here, on the branch that made it.
+  #
+  # One platform, and ubuntu because it is the platform of use: the version job
+  # in release.yml runs there, and a rehearsal on an OS the check never runs on
+  # rehearses nothing. Windows would also need .gitattributes to keep these
+  # scripts in LF, which is a decision about the tree rather than about this job.
+  version-check:
+    name: version check / ubuntu-latest
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: the version check refuses what it should refuse
+        run: bash .github/scripts/check-version-fixtures.sh
+
   # The MSRV declared in the manifests, built on the toolchain it names. The
   # job above runs on whatever the runner image ships, which is what lets an
   # MSRV claim rot in silence: it was wrong by seventeen minor versions before


### PR DESCRIPTION
Closes TASK-adf11c12c480, the follow-up opened by #94.

## The gap

#94 made `release.yml` refuse to build when the tag and the manifests disagree,
and made it play `check-version-fixtures.sh` first so its verdict is worth
something. Both run on a tag or a dispatch and nowhere else, which left the
check itself untested between releases: an edit to `check-version.sh`, or to the
shape of any of the seven manifests it parses, was only discovered by the run it
was supposed to gate -- and by then the tag is spent.

The fixtures were left out of `ci.yml` in #94 for one reason: that file was
inside another task's perimeter while the work was done, and two agents writing
one workflow is a conflict rather than a decision. That task has since landed.

## What this adds

A `version check / ubuntu-latest` job running the fixtures on every push and
pull request.

The fixtures alone, never the comparison: a push carries no tag, so there is no
version to hold the manifests to, and a check that invented one would be red on
every branch between releases. The tree's own agreement is still asserted all
the same -- the first fixture reads the version out of `crates/ank-cli/Cargo.toml`
and holds every other literal to it, so a bump that touched six files out of
seven is red on the branch that made it.

ubuntu alone, for two reasons. It is the platform of use: the `version` job in
`release.yml` runs there, and a rehearsal on an OS the check never runs on
rehearses nothing. And `windows-latest` checks out with `autocrlf`, so a `.sh`
under `.github/scripts/` arrives in CRLF and bash refuses it -- holding those
scripts to LF is a `.gitattributes` decision about the tree rather than about
this job.

## Verification

CI run [31668935610](https://github.com/haksolot/ank/actions/runs/31668935610),
the push that added the job: green, and the job reported all five fixtures.

Falsified in both directions before committing, since a job that cannot go red
is a job that proves nothing:

- a `check-version.sh` that always exits 0 turns four fixtures red, each saying
  it expected a refusal and got a pass
- a JSON parser anchored on the wrong indentation turns all five red with
  "the file's shape moved", rather than passing on an empty read

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011FhetohH64Sy7cCE78gwQC
