### PR TITLE
Section 6 describes the repository resolution it is cited for

### DIFF
--- a/.ank/tasks/TASK-62136e8c2b69.md
+++ b/.ank/tasks/TASK-62136e8c2b69.md
@@ -5,15 +5,19 @@ slug: section-6-never-describes-the-discovery-walk-it
 title: Section 6 never describes the discovery walk it is cited for
 created: 2026-08-09T16:23:15Z
 author: claude-code@ank
-status: in_progress
+status: done
 scope:
   - docs/ank-spec-v1.1.md
 blocked_by: []
 done_criteria: |
   Section 6 of docs/ank-spec-v1.1.md describes how a repository is resolved: the walk up from the working directory to the nearest .ank/, what stops it, how --repo short-circuits it, and the warning emitted when the resolved root lies outside the working directory's git repository. crates/ank-cli/src/repo.rs cites a section that answers what it claims. cargo test and ank check stay green.
 criteria_by: creator
+proof:
+  - type: test
+    ref: "31670097356"
+    criteria: 03de1e80cbbf
 schema: 2
-version: 3
+version: 4
 ---
 
 Found while executing TASK-2f01baf94632 and left out of it, whose scope is crates/ank-cli/** .
@@ -26,3 +30,4 @@ The warning is now part of the behaviour and belongs in the same text: it fires 
 
 ## Log
 - 2026-08-13T05:21:23Z claude-agent-c — The section was written against repo.rs and cli.rs rather than from the task body, and every claim in it is one the code makes: code 1 with the hint 'ank init' comes from repo::missing, which serves both the exhausted walk and a --repo path holding no corpus; --repo accepting the .ank/ directory in place of its parent comes from repo::at; the four properties of the warning come from cli::warn_if_outside_repository, including --quiet silencing it, which the task body does not mention. No code change was needed: repo.rs cites section 6 and section 6 now answers.
+- 2026-08-13T05:26:34Z claude-agent-c — done, proof test:31670097356

--- a/.ank/tasks/TASK-62136e8c2b69.md
+++ b/.ank/tasks/TASK-62136e8c2b69.md
@@ -5,7 +5,7 @@ slug: section-6-never-describes-the-discovery-walk-it
 title: Section 6 never describes the discovery walk it is cited for
 created: 2026-08-09T16:23:15Z
 author: claude-code@ank
-status: open
+status: in_progress
 scope:
   - docs/ank-spec-v1.1.md
 blocked_by: []
@@ -13,7 +13,7 @@ done_criteria: |
   Section 6 of docs/ank-spec-v1.1.md describes how a repository is resolved: the walk up from the working directory to the nearest .ank/, what stops it, how --repo short-circuits it, and the warning emitted when the resolved root lies outside the working directory's git repository. crates/ank-cli/src/repo.rs cites a section that answers what it claims. cargo test and ank check stay green.
 criteria_by: creator
 schema: 2
-version: 1
+version: 3
 ---
 
 Found while executing TASK-2f01baf94632 and left out of it, whose scope is crates/ank-cli/** .
@@ -23,3 +23,6 @@ repo.rs opens with 'Repository discovery (section 6)'. Section 6 covers the stor
 So the behaviour every invocation depends on -- which corpus am I even in -- is specified nowhere, and a reader following the pointer in repo.rs arrives at a section that does not answer. That is also why TASK-2f01baf94632 could add a warning to that walk without contradicting a line of the specification: there was no line.
 
 The warning is now part of the behaviour and belongs in the same text: it fires only on the walk and never on an explicit --repo, it is emitted on standard error so --json stays byte-for-byte what a parser reads, and it degrades rather than failing. The comparison behind it is on the git common directory rather than the toplevel, so two worktrees of one repository do not read as two repositories.
+
+## Log
+- 2026-08-13T05:21:23Z claude-agent-c — The section was written against repo.rs and cli.rs rather than from the task body, and every claim in it is one the code makes: code 1 with the hint 'ank init' comes from repo::missing, which serves both the exhausted walk and a --repo path holding no corpus; --repo accepting the .ank/ directory in place of its parent comes from repo::at; the four properties of the warning come from cli::warn_if_outside_repository, including --quiet silencing it, which the task body does not mention. No code change was needed: repo.rs cites section 6 and section 6 now answers.

--- a/docs/ank-spec-v1.1.md
+++ b/docs/ank-spec-v1.1.md
@@ -1007,6 +1007,23 @@ The dual read is a **window, not a feature**: it exists for the one release acro
 
 **Index lifecycle, fixed** (formerly open point 1): the index stores a content hash per `.ank/` file. Every command compares the files in the perimeter it touches against those hashes and incrementally reindexes what diverged — the index is therefore always up to date *at read time*, with no daemon and no watcher. `check` reindexes fully. An index that is absent or of an unknown schema is rebuilt silently: deleting it is always a safe operation.
 
+### Resolving the repository
+
+Every invocation begins by answering which corpus it is in, and the answer is derived from the working directory rather than configured.
+
+**The walk.** With no `--repo`, resolution starts at the working directory and walks up, parent by parent, to the **first** directory containing a `.ank/`. That directory is the root and the corpus is `<root>/.ank/`. It is git's rule for `.git`, for git's reason: an agent is launched in whatever subdirectory the work happens to be in, and a corpus that had to be named would be a flag on every command.
+
+**What stops it** is the first `.ank/` and nothing else — not a `.git/`, not a workspace manifest, not a mount point. The walk ends at the filesystem root, and ending there is a generic error (code 1) naming `ank init`. Nothing is created implicitly: a corpus that appears because a command ran in the wrong directory is worse than a refusal.
+
+**`--repo <path>` short-circuits the walk** without ever contradicting it. The path given must itself contain a `.ank/`, and resolution stops there with no walk at all. The `.ank/` directory is accepted in place of its parent, since being off by one level is the likely mistake and refusing it would gain nothing. A path holding no corpus is the same code 1 naming the same command.
+
+**A corpus outside the working directory's repository is warned about, not refused.** Because the walk stops at the first `.ank/` and at nothing else, a checkout nested inside another repository silently resolves the outer corpus. That is not merely reading the wrong files: claims are refs (§7), so they land in the resolved root's repository and never in the one holding the code being changed, and the inner repository ends with no ank ref at all. So the walk compares the two and, when they differ, prints a warning naming the resolved root and the two ways out — `ank init` here, or `--repo` to confirm the corpus was meant. Four properties, each load-bearing:
+
+- **Only on the walk.** `--repo` is the caller saying which corpus they mean, and warning about an answer asked for by name would fire forever in the one layout this behaviour makes usable: a single `.ank/` above several checkouts, with scopes written `repoA/src/**`. That layout was never designed for and is not forbidden either; naming `--repo` once is what separates it from the accident.
+- **Compared on the git common directory, not the toplevel.** A linked worktree has a toplevel of its own and shares `refs/` with the checkout that made it, so comparing toplevels would report two worktrees of one repository as two repositories. The question being asked is where a claim ref lands (§7), and that is the common directory. A working directory in no repository at all is a legible answer too, and says so in its own words.
+- **On standard error.** It is no part of any verb's answer, and §4 requires `--json` to stay byte-for-byte what a caller's parser already reads; a line on stdout would break every one of them to say something no parser asked for. `--quiet` silences it.
+- **It degrades and never fails** (§2). The walk succeeded, and the caller may well have meant it.
+
 ### Three levels of search
 
 1. **Scope resolution** — glob matching, deterministic, zero ambiguity. Covers the bulk of cases; this is what `context` does.


### PR DESCRIPTION
Closes TASK-62136e8c2b69.

## The gap

`repo.rs` opens with `Repository discovery (§6)`. Section 6 covered the storage
layout, the flat tree, atomic writes, the derived index and the three levels of
search. It said nothing about resolution: not the walk up to the nearest
`.ank/`, not its stopping condition, not what `--repo` does beyond appearing in
§4's list of three global flags.

So the behaviour every invocation depends on -- which corpus am I even in --
was specified nowhere, and a reader following the pointer in `repo.rs` arrived
at a section that does not answer.

That absence is also why TASK-2f01baf94632 could add a warning to that walk
without contradicting a line of the specification: there was no line.

## What this adds

A `Resolving the repository` subsection in §6, between the storage layout and
the three levels of search -- what a corpus looks like, how you find it, how you
search it:

- the walk up from the working directory to the first `.ank/`, and git's reason
  for the same rule
- what stops it, and that a walk reaching the filesystem root is a generic error
  (code 1) naming `ank init` rather than an implicit `init`
- `--repo <path>` short-circuiting it, accepting the `.ank/` directory in place
  of its parent, and refusing a path holding no corpus with the same code
- the warning when the resolved root lies outside the working directory's git
  repository, with the four properties that are load-bearing: only on the walk,
  compared on the git common directory rather than the toplevel so two worktrees
  of one repository are one repository, on standard error so `--json` stays
  byte-for-byte what a parser reads, and degrading rather than failing

## Verification

Written from `repo.rs` and `cli.rs` rather than from the task body, so every
claim is one the code makes -- including two the body does not mention: `code 1`
with the `ank init` hint serves both the exhausted walk and a `--repo` path
holding no corpus (`repo::missing`, reached from both), and `--quiet` silences
the warning (`cli::warn_if_outside_repository`).

No code moves: `repo.rs` cites §6 and §6 now answers.

CI run [31670097356](https://github.com/haksolot/ank/actions/runs/31670097356):
green, 434 tests, `ank check` clean. `tests/skill.rs` reads §4's `Commands`
block for the verb order and is untouched by a subsection added to §6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011FhetohH64Sy7cCE78gwQC
