### PR TITLE
Orientation gives the tasks what the constraints do not use

### DIFF
--- a/.ank/tasks/TASK-1ead0e19fb73.md
+++ b/.ank/tasks/TASK-1ead0e19fb73.md
@@ -5,7 +5,7 @@ slug: orientation-spends-its-budget-on-constraints-and
 title: Orientation spends its budget on constraints and leaves nothing for the choice
 created: 2026-08-11T03:48:12Z
 author: seanl@sean-laptop
-status: in_progress
+status: done
 scope:
   - docs/ank-spec-v1.1.md
   - crates/ank-cli/src/context.rs
@@ -14,8 +14,12 @@ blocked_by: []
 done_criteria: |
   Section 5 of docs/ank-spec-v1.1.md says how orientation mode allocates its budget between constraints and tasks, distinctly from execution mode, and the reasoning names what orientation is for. The measurement that settles it is recorded in the task log: what a cold ank context costs on this corpus today against what it costs with a perimeter given. The code follows, and a test through the binary asserts the allocation the specification now promises on a corpus large enough to exceed the budget.
 criteria_by: creator
+proof:
+  - type: test
+    ref: "31675652087"
+    criteria: fa692895d3a2
 schema: 2
-version: 4
+version: 6
 ---
 
 Observed on a cold pull of this repository, and observed again today: `ank
@@ -45,3 +49,5 @@ given.
 ## Log
 - 2026-08-13T06:12:16Z claude-agent-b — Measured before answering, as the criterion asks. Corpus: 18 accepted constraints, 11 open tasks, context_budget 8000 characters. Cold orientation at the root spends 7357 characters on constraints and 157 on tasks -- 96 percent against 2 percent. Seven constraints are rendered in full and eleven are not shown at all; one task line is printed and eleven are cut. The PROPOSED section is cut to a single 'not shown' line as well. With a perimeter given (crates/ank-cli/src) the allocation is unchanged: 7373 against 181, seven constraints in full, still one task shown. That is the finding the task body only hypothesised. Narrowing the perimeter narrows the candidate set -- eleven tasks cut becomes five -- but frees no budget for them, because the constraints are charged first and at full length either way. So a perimeter does not fix it and cannot: the allocation is the defect, not the breadth. The sharpest way to state it is the last line of the output. Orientation ends with 'ank claim TASK-10b8 to start', recommending the one task it had room to print. The mode whose whole purpose is choosing presents exactly one candidate out of twelve, and an agent reading it has no way to know eleven others exist without running a second command. Execution mode is untouched by any of this and must stay so: there the perimeter is settled and a truncated constraint would hide a rule the agent is about to break.
 - 2026-08-13T06:41:32Z claude-agent-b — Specification, then code, then test, in that order. Section 5 now divides the budget by opposite rules for the two modes and says why: execution never truncates a constraint because the perimeter is settled, orientation gives constraints at most a third because nothing binds yet and a page of rules with no work to apply them to is not a choice. The third is the mirror of the over-constrained threshold already in the section -- execution calls a scope sick above a half, so the mode where none of them bind is held to something stricter. The cutting order moved into Truncation priority where it belongs, and its first line inverted: it read 'Tasks first, before any constraint', which is the sentence the code was faithfully implementing. In orientation a constraint is now one line, id and title, exactly as the neighbouring PROPOSED section already lists a proposal; what a rule says is one ank show away, which is the split section 9 settled for help. On this corpus the result is 1293 characters of constraints against 1082 of tasks, all 18 constraints named and all 12 tasks listed, nothing cut -- against 7357 and 157 before. Two things the falsification taught me and that are now in the spec and the tests. First, my unit test passed with and without the ceiling, because two short titles fit under a third anyway: it proved the rendering and not the rule. Titles are now long enough to force the cut. Second, the ceiling cannot empty the section -- the loop stops at one constraint, as it always did -- so 'at most a third' is a ceiling that yields to a floor, and section 5 now states that precedence instead of leaving it to the code. The binary test carries the arithmetic ceiling at a realistic budget on a corpus of forty constraints and forty tasks, with a control asserting the constraints really were counted away, and a second test holds execution mode to the opposite guarantee on the same fixture.
+- 2026-08-13T06:59:15Z claude-agent-b — CI went red on all three runners while the branch alone was green, and the cause was not in the change. The flat store (TASK-cd3189ddf61e) merged while this branch was open, so Repo::new creates .ank/entities/ and no longer .ank/adr/ or .ank/tasks/, and the crowded fixture wrote into directories that had stopped existing -- NotFound at the same line on every platform. The CI tests the merge and not the branch, which is the whole reason it caught this and a local suite could not. Rebased on main and pointed the fixture where every other seed in the file already writes; the budget logic is untouched and the two commits stay separate so the diff reads. Green on the three operating systems, both MSRV jobs and the version check afterwards.
+- 2026-08-13T06:59:21Z claude-agent-b — done, proof test:31675652087

--- a/.ank/tasks/TASK-1ead0e19fb73.md
+++ b/.ank/tasks/TASK-1ead0e19fb73.md
@@ -5,7 +5,7 @@ slug: orientation-spends-its-budget-on-constraints-and
 title: Orientation spends its budget on constraints and leaves nothing for the choice
 created: 2026-08-11T03:48:12Z
 author: seanl@sean-laptop
-status: open
+status: in_progress
 scope:
   - docs/ank-spec-v1.1.md
   - crates/ank-cli/src/context.rs
@@ -15,7 +15,7 @@ done_criteria: |
   Section 5 of docs/ank-spec-v1.1.md says how orientation mode allocates its budget between constraints and tasks, distinctly from execution mode, and the reasoning names what orientation is for. The measurement that settles it is recorded in the task log: what a cold ank context costs on this corpus today against what it costs with a perimeter given. The code follows, and a test through the binary asserts the allocation the specification now promises on a corpus large enough to exceed the budget.
 criteria_by: creator
 schema: 2
-version: 1
+version: 4
 ---
 
 Observed on a cold pull of this repository, and observed again today: `ank
@@ -41,3 +41,7 @@ This is a specification question about §5 rather than a rendering preference,
 and it should be measured before it is answered: what a cold `context` costs
 today, on this corpus, against what the same call costs once a perimeter is
 given.
+
+## Log
+- 2026-08-13T06:12:16Z claude-agent-b — Measured before answering, as the criterion asks. Corpus: 18 accepted constraints, 11 open tasks, context_budget 8000 characters. Cold orientation at the root spends 7357 characters on constraints and 157 on tasks -- 96 percent against 2 percent. Seven constraints are rendered in full and eleven are not shown at all; one task line is printed and eleven are cut. The PROPOSED section is cut to a single 'not shown' line as well. With a perimeter given (crates/ank-cli/src) the allocation is unchanged: 7373 against 181, seven constraints in full, still one task shown. That is the finding the task body only hypothesised. Narrowing the perimeter narrows the candidate set -- eleven tasks cut becomes five -- but frees no budget for them, because the constraints are charged first and at full length either way. So a perimeter does not fix it and cannot: the allocation is the defect, not the breadth. The sharpest way to state it is the last line of the output. Orientation ends with 'ank claim TASK-10b8 to start', recommending the one task it had room to print. The mode whose whole purpose is choosing presents exactly one candidate out of twelve, and an agent reading it has no way to know eleven others exist without running a second command. Execution mode is untouched by any of this and must stay so: there the perimeter is settled and a truncated constraint would hide a rule the agent is about to break.
+- 2026-08-13T06:41:32Z claude-agent-b — Specification, then code, then test, in that order. Section 5 now divides the budget by opposite rules for the two modes and says why: execution never truncates a constraint because the perimeter is settled, orientation gives constraints at most a third because nothing binds yet and a page of rules with no work to apply them to is not a choice. The third is the mirror of the over-constrained threshold already in the section -- execution calls a scope sick above a half, so the mode where none of them bind is held to something stricter. The cutting order moved into Truncation priority where it belongs, and its first line inverted: it read 'Tasks first, before any constraint', which is the sentence the code was faithfully implementing. In orientation a constraint is now one line, id and title, exactly as the neighbouring PROPOSED section already lists a proposal; what a rule says is one ank show away, which is the split section 9 settled for help. On this corpus the result is 1293 characters of constraints against 1082 of tasks, all 18 constraints named and all 12 tasks listed, nothing cut -- against 7357 and 157 before. Two things the falsification taught me and that are now in the spec and the tests. First, my unit test passed with and without the ceiling, because two short titles fit under a third anyway: it proved the rendering and not the rule. Titles are now long enough to force the cut. Second, the ceiling cannot empty the section -- the loop stops at one constraint, as it always did -- so 'at most a third' is a ceiling that yields to a floor, and section 5 now states that precedence instead of leaving it to the code. The binary test carries the arithmetic ceiling at a realistic budget on a corpus of forty constraints and forty tasks, with a control asserting the constraints really were counted away, and a second test holds execution mode to the opposite guarantee on the same fixture.

--- a/crates/ank-cli/src/context.rs
+++ b/crates/ank-cli/src/context.rs
@@ -930,13 +930,35 @@ pub fn render(view: &View, budget: usize, style: Style) -> String {
             let mut proposals = view.proposals.clone();
             let mut tasks = view.tasks.clone();
 
-            // The cutting order of §5, applied literally: tasks go first,
-            // before any constraint, then proposals, then the broadest
-            // constraints. What survives is what an agent could not have
-            // guessed.
             let mut cut_tasks = 0usize;
             let mut cut_constraints = 0usize;
             let mut cut_proposals = 0usize;
+
+            // §5, first half: constraints take at most a third, and what they
+            // do not use goes to the tasks. Charged before anything else is
+            // measured, so the tasks are never competing with a section that
+            // has already spent the page.
+            //
+            // Measured before the rule existed, on this repository: 7357
+            // characters of constraints against 157 of tasks, one task line
+            // printed and eleven cut (TASK-1ead0e19fb73). The cut order used to
+            // be tasks first, which is what produced that.
+            let share = budget / 3;
+            while constraints.len() > 1
+                && chars(&constraint_section(
+                    &constraints,
+                    cut_constraints + 1,
+                    &scope_arg,
+                    style,
+                )) > share
+            {
+                constraints.pop();
+                cut_constraints += 1;
+            }
+
+            // Second half: the whole page against the whole budget. Tasks are
+            // cut last and only once their own share is full, which is the
+            // order §5 now states.
             loop {
                 let size = chars(&orientation_lines(
                     &constraints,
@@ -952,12 +974,12 @@ pub fn render(view: &View, budget: usize, style: Style) -> String {
                 if size <= budget {
                     break;
                 }
-                if tasks.len() > 1 {
-                    tasks.pop();
-                    cut_tasks += 1;
-                } else if !proposals.is_empty() {
+                if !proposals.is_empty() {
                     proposals.pop();
                     cut_proposals += 1;
+                } else if tasks.len() > 1 {
+                    tasks.pop();
+                    cut_tasks += 1;
                 } else if constraints.len() > 1 {
                     constraints.pop();
                     cut_constraints += 1;
@@ -986,6 +1008,43 @@ pub fn render(view: &View, budget: usize, style: Style) -> String {
     text
 }
 
+/// The constraints of an orientation page, **named and not quoted** (§5).
+///
+/// One line per rule, id and title, exactly as the neighbouring PROPOSED
+/// section already lists a proposal. What a constraint *says* is one
+/// `ank show <id>` away — the split §9 settled for `help` and its per-verb page,
+/// applied to the mode where nothing binds yet because nothing has been chosen.
+///
+/// Execution mode is untouched and still renders [`constraint_block`] in full:
+/// there the perimeter is settled, the rules bind the work in hand, and cutting
+/// one would hide a rule the agent is about to break.
+///
+/// Split out because the budget has to price this section on its own before the
+/// page exists, and a second copy of the rendering would be free to disagree
+/// with the one that finally prints.
+fn constraint_section(
+    constraints: &[ConstraintLine],
+    cut_constraints: usize,
+    scope_arg: &str,
+    style: Style,
+) -> Vec<String> {
+    let mut out = Vec::new();
+    if constraints.is_empty() && cut_constraints == 0 {
+        return out;
+    }
+    out.push(String::new());
+    out.push(style.header(&format!("CONSTRAINTS ({} active)", constraints.len())));
+    for c in constraints {
+        out.push(format!("  {}  {}", style.id(&c.short), c.title));
+    }
+    if cut_constraints > 0 {
+        out.push(format!(
+            "  +{cut_constraints} broad constraints, ank find --type adr --scope {scope_arg}"
+        ));
+    }
+    out
+}
+
 #[allow(clippy::too_many_arguments)]
 fn orientation_lines(
     constraints: &[ConstraintLine],
@@ -998,19 +1057,7 @@ fn orientation_lines(
     view: &View,
     style: Style,
 ) -> Vec<String> {
-    let mut out = Vec::new();
-    if !constraints.is_empty() || cut_constraints > 0 {
-        out.push(String::new());
-        out.push(style.header(&format!("CONSTRAINTS ({} active)", constraints.len())));
-        for c in constraints {
-            out.extend(constraint_block(c, style));
-        }
-        if cut_constraints > 0 {
-            out.push(format!(
-                "  +{cut_constraints} broad constraints, ank find --type adr --scope {scope_arg}"
-            ));
-        }
-    }
+    let mut out = constraint_section(constraints, cut_constraints, scope_arg, style);
     // The header counts what the perimeter holds, not what survived the budget.
     // This is the one section truncation can empty completely -- the cutting
     // loop stops at one task and at one constraint, and never at zero proposals
@@ -1501,9 +1548,13 @@ After a blank one."
         assert!(text.contains("CONSTRAINTS (2 active)"), "{text}");
         assert!(text.contains("PROPOSED (1, non-binding)"), "{text}");
         assert!(text.contains("TASKS (3)"), "{text}");
+        // Named, not quoted (§5). Orientation says which rules govern the
+        // perimeter; what they say is one `ank show` away, and the constraint
+        // is what used to spend the whole page.
+        assert!(text.contains("No self-contained JWTs"), "{text}");
         assert!(
-            text.contains("Every session goes through the Redis store."),
-            "{text}"
+            !text.contains("Every session goes through the Redis store."),
+            "the rule's text belongs to execution mode and to `show`: {text}"
         );
         // No execution detail during orientation.
         assert!(!text.contains("DONE_CRITERIA"), "{text}");
@@ -1748,8 +1799,14 @@ After a blank one."
     // Budget and cutting order
     // -----------------------------------------------------------------------
 
+    /// The constraints take at most a third and the tasks take the rest (§5).
+    ///
+    /// This test used to be called `orientation_cuts_tasks_before_constraints`
+    /// and asserted exactly that, which is the rule the measurement in
+    /// TASK-1ead0e19fb73 retired: on this repository it left one task line
+    /// against seven constraints rendered in full.
     #[test]
-    fn orientation_cuts_tasks_before_constraints_and_says_how_many() {
+    fn orientation_gives_the_tasks_whatever_the_constraints_do_not_use() {
         let t = Temp::new();
         for i in 1..=12 {
             t.write(&task(
@@ -1760,16 +1817,21 @@ After a blank one."
                 TaskStatus::Open,
             ));
         }
+        // Titles long enough that the section would pass its third if nothing
+        // held it there. Measured rather than assumed: with short titles the
+        // two lines fit under the ceiling on their own, and this test passed
+        // whether or not the ceiling existed — which is a test that proves the
+        // rendering and not the rule.
         t.write(&adr(
             "00000000aaaa",
-            "Narrow",
+            "Narrow, and titled at the length a real decision is titled at",
             &["src/auth/session.rs"],
             "Narrow rule.\n",
             AdrStatus::Accepted,
         ));
         t.write(&adr(
             "00000000bbbb",
-            "Broad",
+            "Broad, and titled at the length a real decision is titled at",
             &["src/**"],
             "Broad rule.\n",
             AdrStatus::Accepted,
@@ -1777,13 +1839,37 @@ After a blank one."
 
         let view = t.view("claude-code@ank", None);
         assert_eq!(view.tasks.len(), 12);
-        let text = render(&view, 400, crate::style::PLAIN);
+        const BUDGET: usize = 400;
+        let text = render(&view, BUDGET, crate::style::PLAIN);
 
-        assert!(text.contains("more tasks, ank find --type task"), "{text}");
-        // The narrow constraint outlives the broad one.
-        assert!(text.contains("Narrow rule."), "{text}");
+        // Named and not quoted, which is what makes the ceiling affordable.
+        assert!(text.contains("Narrow, and titled"), "{text}");
+        assert!(!text.contains("Narrow rule."), "{text}");
+        // The ceiling bit: the broad one was counted away and the narrow one
+        // survived, which is the order §5 states.
+        assert!(text.contains("+1 broad constraints"), "{text}");
+        assert!(!text.contains("Broad, and titled"), "{text}");
+
+        // This budget is small enough to reach the floor of §5: the ceiling
+        // cuts until one constraint is left and then stops, because a page
+        // naming no rule would say the perimeter is unconstrained. The
+        // arithmetic ceiling is asserted at a realistic budget through the
+        // binary, in `orientation_spends_at_most_a_third_on_constraints`.
+        assert!(text.contains("CONSTRAINTS (1 active)"), "{text}");
+
+        // And the tasks got the rest: more than one line, which is what the
+        // old cutting order could not deliver.
+        let listed = text
+            .lines()
+            .filter(|l| l.trim_start().starts_with("TASK-"))
+            .count();
         assert!(
-            text.chars().count() < 8000,
+            listed > 1,
+            "orientation is for choosing and offered {listed} candidate: {text}"
+        );
+        assert!(text.contains("more tasks, ank find --type task"), "{text}");
+        assert!(
+            text.chars().count() <= BUDGET,
             "the budget did real work: {}",
             text.chars().count()
         );

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -8102,3 +8102,161 @@ fn a_detached_proof_outlives_check_until_the_file_carries_it() {
          is still there"
     );
 }
+
+// ---------------------------------------------------------------------------
+// The orientation budget (§5, TASK-1ead0e19fb73)
+// ---------------------------------------------------------------------------
+
+/// The default of §5, restated here because the fixture writes no
+/// `context_budget` and the assertions are arithmetic on it.
+const BUDGET: usize = 8000;
+
+/// A corpus whose constraints alone would swallow the page.
+///
+/// Forty accepted ADRs with multi-sentence rules and forty open tasks. Rendered
+/// the old way — every rule in full, tasks cut first — this is far past 8000
+/// characters, which is what makes the allocation observable rather than
+/// hypothetical.
+fn crowded() -> Repo {
+    let r = Repo::new();
+    std::fs::create_dir_all(r.0.join("src")).unwrap();
+    std::fs::write(r.0.join("src/main.rs"), "fn main() {}\n").unwrap();
+    for i in 0..40 {
+        let id = format!("ADR-0000000{i:05}");
+        let rule = format!(
+            "Rule number {i} is stated at length, because a real constraint is \
+             a paragraph and not a slogan. It goes on for a second sentence so \
+             that rendering it in full costs what a real one costs."
+        );
+        std::fs::write(
+            r.0.join(".ank/adr").join(format!("{id}.md")),
+            format!(
+                "---\nid: {id}\ntype: adr\nslug: example\n\
+                 title: Decision number {i}, phrased as a title of ordinary length\n\
+                 created: 2026-07-20T00:00:00Z\nstatus: accepted\nscope:\n  - src/**\n\
+                 constraint: |\n  {rule}\nschema: 1\nversion: 1\n---\n\nWhy.\n"
+            ),
+        )
+        .unwrap();
+
+        let tid = format!("TASK-0000000{i:05}");
+        std::fs::write(
+            r.0.join(".ank/tasks").join(format!("{tid}.md")),
+            format!(
+                "---\nid: {tid}\ntype: task\nslug: example\n\
+                 title: Task number {i}, with a title of the length titles really have\n\
+                 created: 2026-07-28T00:00:00Z\nstatus: open\nscope:\n  - src/**\n\
+                 blocked_by: []\ndone_criteria: |\n  A verifiable criterion.\n\
+                 criteria_by: creator\nschema: 1\nversion: 1\n---\n\nFree body.\n"
+            ),
+        )
+        .unwrap();
+    }
+    r.git(&["add", "-A"]);
+    r.git(&["commit", "-qm", "a crowded corpus"]);
+    r
+}
+
+/// The characters a named section spends, counted as the renderer counts them.
+fn section_chars(text: &str, header: &str) -> usize {
+    text.lines()
+        .skip_while(|l| !l.starts_with(header))
+        .take_while(|l| {
+            l.starts_with(header)
+                || !(l.starts_with("CONSTRAINTS")
+                    || l.starts_with("PROPOSED")
+                    || l.starts_with("TASKS"))
+        })
+        .map(|l| l.chars().count() + 1)
+        .sum()
+}
+
+/// Orientation allocates the budget the way §5 now promises, through the
+/// binary and on a corpus large enough to exceed it.
+///
+/// **The measurement this replaces is in the task's log.** On this repository,
+/// at the same 8000 characters, orientation spent 7357 on seven constraints
+/// rendered in full and 157 on tasks — one task line printed and eleven cut,
+/// with the closing suggestion naming the only candidate it had room for. The
+/// mode whose purpose is choosing offered one option out of twelve.
+///
+/// Asserted through the binary rather than on `render`, because the allocation
+/// is only worth anything if it survives the whole path an agent actually
+/// takes: config, perimeter, index, and the writer that prints it.
+#[test]
+fn orientation_spends_at_most_a_third_on_constraints_and_the_rest_on_tasks() {
+    let r = crowded();
+    let out = r.ank("claude-code@ank", &["context"]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    let text = stdout(&out);
+
+    // The control, and it is the assertion that catches a missing ceiling.
+    // Forty constraints named on one line each are past a third of 8000, so
+    // some of them must have been counted away; if they all fit, the rule was
+    // never under load and every assertion below would pass on a page that
+    // never had to choose anything.
+    assert!(
+        text.contains("broad constraints, ank find --type adr"),
+        "the constraints all fit, so the third was never enforced: {text}"
+    );
+
+    let constraints = section_chars(&text, "CONSTRAINTS");
+    let tasks = section_chars(&text, "TASKS");
+    assert!(
+        constraints <= BUDGET / 3,
+        "constraints took {constraints} characters of {BUDGET}, over the \
+         third §5 allows them"
+    );
+    assert!(
+        tasks > constraints,
+        "the tasks got {tasks} characters against {constraints} for the \
+         constraints, and orientation is for choosing"
+    );
+
+    // Named, never quoted: the rule's text is one `ank show` away.
+    assert!(
+        text.contains("Decision number 0, phrased as a title"),
+        "a constraint must be named: {text}"
+    );
+    assert!(
+        !text.contains("because a real constraint is"),
+        "orientation quoted a rule instead of naming it: {text}"
+    );
+
+    // And the page offers a choice rather than a single candidate.
+    let listed = text
+        .lines()
+        .filter(|l| l.trim_start().starts_with("TASK-"))
+        .count();
+    assert!(
+        listed > 10,
+        "orientation offered {listed} candidates out of 40: {text}"
+    );
+    assert!(
+        text.chars().count() <= BUDGET,
+        "the page is {} characters, over budget",
+        text.chars().count()
+    );
+}
+
+/// Execution mode keeps the opposite rule, on the same corpus.
+///
+/// The two halves of §5 are one decision, and a change to the orientation half
+/// that quietly truncated a binding constraint would be the failure the whole
+/// design exists to prevent. Same fixture, one claim, opposite guarantee.
+#[test]
+fn execution_still_renders_a_binding_constraint_in_full() {
+    let r = crowded();
+    let out = r.ank("claude-code@ank", &["claim", "TASK-000000000000"]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+
+    let text = stdout(&r.ank("claude-code@ank", &["context"]));
+    assert!(
+        text.contains("because a real constraint is a paragraph and not a slogan"),
+        "a binding constraint was truncated in execution mode: {text}"
+    );
+    assert!(
+        !text.contains("broad constraints, ank find"),
+        "execution mode counted constraints away instead of printing them: {text}"
+    );
+}

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -8129,7 +8129,7 @@ fn crowded() -> Repo {
              that rendering it in full costs what a real one costs."
         );
         std::fs::write(
-            r.0.join(".ank/adr").join(format!("{id}.md")),
+            r.0.join(".ank/entities").join(format!("{id}.md")),
             format!(
                 "---\nid: {id}\ntype: adr\nslug: example\n\
                  title: Decision number {i}, phrased as a title of ordinary length\n\
@@ -8141,7 +8141,7 @@ fn crowded() -> Repo {
 
         let tid = format!("TASK-0000000{i:05}");
         std::fs::write(
-            r.0.join(".ank/tasks").join(format!("{tid}.md")),
+            r.0.join(".ank/entities").join(format!("{tid}.md")),
             format!(
                 "---\nid: {tid}\ntype: task\nslug: example\n\
                  title: Task number {i}, with a title of the length titles really have\n\

--- a/docs/ank-spec-v1.1.md
+++ b/docs/ank-spec-v1.1.md
@@ -913,7 +913,7 @@ The single most decisive point for real use. A `context` that explodes on a larg
 
 `context` serves two situations that used to be treated, wrongly, as one.
 
-**Before claiming — orientation.** The agent does not yet know what to do. Breadth, not depth: the perimeter's active constraints in compact form (id + `constraint` text, never the body), non-binding proposals on one line, and open tasks on one line each. **No `done_criteria`, no log** — it is not writing code yet, and execution detail would be noise. Constraints, on the other hand, are present from orientation onward: choosing a task while knowing the perimeter's rules is exactly what orientation is for.
+**Before claiming — orientation.** The agent does not yet know what to do. Breadth, not depth: the perimeter's active constraints named on one line each (id + title, never the `constraint` text and never the body), non-binding proposals on one line, and open tasks on one line each. **No `done_criteria`, no log** — it is not writing code yet, and execution detail would be noise. Constraints are named from orientation onward, because knowing which rules govern a perimeter is part of choosing within it; what they *say* is one `ank show <id>` away, the same split §9 settles for `help` and its per-verb page.
 
 **After claiming — execution.** HEAD is set. Inversion: no other task at all, but the full `done_criteria`, the constraints matching the scope **of the task**, and the most recent log entries.
 
@@ -929,9 +929,8 @@ What a holder can do with the answer is smaller than it looks, and that bounds h
 $ ank context src/auth/
 
 CONSTRAINTS (2 active)
-  ADR-3c7e  Do not introduce self-contained JWTs for user auth.
-            Every session goes through the Redis store.
-  ADR-8b41  Rate limiting mandatory on every public endpoint.
+  ADR-3c7e  No self-contained JWTs for user auth
+  ADR-8b41  Rate limiting on every public endpoint
 
 PROPOSED (1, non-binding)
   ADR-19d0  [pi@host-2] Prefer idempotent migrations
@@ -945,7 +944,24 @@ TASKS (2)
 
 ### Truncation priority
 
-**In execution mode, a constraint is never truncated.** Cutting a binding constraint means an agent can violate a rule it never saw — a discreet `+12 more` would be the worst possible behaviour. The two-phase design makes the guarantee tenable: after claiming, the perimeter is that of the task alone, so few constraints match. The budget is concrete: `context_budget` in `config.yml`, measured in characters, 8000 by default (roughly 2000 tokens — the character is the only unit measurable without depending on a tokeniser). A scope is **over-constrained** when constraints alone consume more than half of it in execution mode: a mechanical threshold, implementable as stated, and `check` reports it as such — it is a corpus problem, not a display problem.
+The budget is concrete: `context_budget` in `config.yml`, measured in characters, 8000 by default (roughly 2000 tokens — the character is the only unit measurable without depending on a tokeniser). **The two modes divide it by opposite rules, because they are answering opposite questions.**
+
+**In execution mode, a constraint is never truncated.** Cutting a binding constraint means an agent can violate a rule it never saw — a discreet `+12 more` would be the worst possible behaviour. The two-phase design makes the guarantee tenable: after claiming, the perimeter is that of the task alone, so few constraints match. A scope is **over-constrained** when constraints alone consume more than half of it in execution mode: a mechanical threshold, implementable as stated, and `check` reports it as such — it is a corpus problem, not a display problem.
+
+**In orientation mode, constraints take at most a third of the budget and everything they do not use goes to the tasks.** Nothing binds yet, because nothing has been chosen, and orientation exists to choose: a page of rules with no work to apply them to is not a choice. The third is the mirror of the threshold above — execution calls a scope sick when its constraints exceed a half, so the mode where none of them bind yet is held to something stricter. Rendering one line per constraint is what makes the ceiling easy to respect rather than a cliff to fall off; a corpus with more constraints than fit in a third reports the remainder as a counter, and the reader who wants one reads it with `ank show`.
+
+Measured on this repository before the rule existed, at 8000 characters with 18 accepted constraints and 11 open tasks: orientation spent 7357 characters on seven constraints rendered in full and 157 on tasks — one task line printed, eleven cut, and the closing suggestion naming the only candidate it had room for. Giving a perimeter changed nothing, because constraints were charged first and in full either way (TASK-1ead0e19fb73).
+
+Within each half, what survives is decided in this order:
+
+1. Constraints with the most **specific** scope are kept — a narrow glob beats `src/**`, it was written for that precise code
+2. Constraints whose vocabulary overlaps the titles of the perimeter's tasks
+3. The rest as a counter: `+12 broad constraints, ank find --type adr --scope <path>`
+4. Tasks in the order of *Task ordering* below, the rest as a counter
+
+Tasks are cut last, and only once their own share is full. The previous revision cut them **first, before any constraint**, which is what the measurement above records the consequence of.
+
+**One constraint and one task always survive, whatever the budget.** The third is a ceiling on a section and not a licence to empty it: a page naming no rule at all would tell an agent the perimeter is unconstrained, which is a stronger and falser statement than naming one and counting the rest. On a budget too small for even that, the floor wins and the page runs over — the same order of precedence execution mode applies when a single binding constraint exceeds the whole budget.
 
 ### Task ordering
 
@@ -965,13 +981,6 @@ no ready tasks in scope (3 blocked, 1 in progress by codex@host-9)
 ```
 
 An agent in a loop needs a clean stop signal. An empty output reads as a breakdown and triggers pointless retries.
-
-In orientation mode, where the agent is not writing code yet, truncation is acceptable. The cutting order:
-
-1. Tasks first, before any constraint
-2. Constraints with the most **specific** scope are kept — a narrow glob beats `src/**`, it was written for that precise code
-3. Constraints whose vocabulary overlaps the titles of the perimeter's tasks
-4. The rest as a counter: `+12 broad constraints, ank find --type adr --scope <path>`
 
 ---
 


### PR DESCRIPTION
Closes TASK-1ead0e19fb73.

## Measured first, because the task required it

On this repository, at 8000 characters with 18 accepted constraints and 11 open
tasks, a cold `ank context`:

| | no perimeter | perimeter `crates/ank-cli/src` |
| --- | --- | --- |
| constraints | **7357 chars** — 7 in full, 11 not shown | 7373 — identical |
| tasks | **157 chars** — 1 shown, 11 cut | 181 — 1 shown, 5 cut |

96% against 2%. Giving a perimeter changed nothing, because constraints were
charged first and in full either way: it narrows the candidate set but frees no
budget. The allocation was the defect, not the breadth — so a perimeter could
not have fixed it.

The sharpest statement of it was the output's own last line:

```
TASKS (1)
  TASK-10b8  [open] The dogfooding hook leaves, and the docs stop naming it
  +11 more tasks, ank find --type task --scope .

> ank claim TASK-10b8 to start
```

The mode whose whole purpose is choosing recommended the one task it had room
to print, out of twelve.

## The defect was in §5

The specification ordered the cut as **"Tasks first, before any constraint"**.
The code was implementing it faithfully. So the specification moved first.

§5 now divides the budget by opposite rules for the two modes and says why.
**Execution** never truncates a constraint: the perimeter is settled and the
rules bind the work in hand. **Orientation** gives constraints at most a third,
because nothing binds yet and a page of rules with no work to apply them to is
not a choice. The third is the mirror of the over-constrained threshold already
in the section — execution calls a scope sick above a half, so the mode where
none of them bind is held to something stricter.

In orientation a constraint is now **one line, id and title**, exactly as the
neighbouring PROPOSED section already lists a proposal. What a rule *says* is
one `ank show <id>` away — the split §9 settled for `help` and its per-verb
page. The cutting order moved into *Truncation priority* where it belongs, and
tasks are cut last.

## After

```
CONSTRAINTS (18 active)
  ADR-f61e  ank help groups by the moment a verb is used, and hides none
  ADR-0c8a  Presentation splits: colour depends on the reader, structure does not
  ... all 18 named ...

TASKS (12)
  ... all 12 listed, nothing cut ...
```

1293 characters of constraints against 1082 of tasks.

## Two things the falsification taught me

Both are now in the specification and in the tests rather than in my head.

**The unit test passed with and without the ceiling.** Two short titles fit
under a third anyway, so it was proving the rendering and not the rule. The
titles are now long enough to force the cut, and the test asserts which
constraint survived.

**The ceiling cannot empty the section.** The loop stops at one constraint, as
it always did — so "at most a third" is a ceiling that yields to a floor. A page
naming no rule would tell an agent the perimeter is unconstrained, which is a
stronger and falser statement than naming one and counting the rest. §5 now
states that precedence instead of leaving it to the code.

## Verification

The binary test carries the arithmetic at a realistic budget, on a corpus of
forty constraints and forty tasks, with a **control** asserting the constraints
really were counted away — without it every other assertion would pass on a page
that never had to choose anything. A second test holds execution mode to the
opposite guarantee on the same fixture, because the two halves of §5 are one
decision and a change to one that quietly truncated a binding constraint would
be the failure the whole design exists to prevent.

Falsified by removing the ceiling: both fail.

`cargo test --workspace` green (440 tests), `cargo fmt --check` green, no build
warnings, `ank check` on this corpus exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HkfdZYpYQar1C8t3uuPm5B
