### PR TITLE
Every verb that logs writes to the log file, and the body stops carrying one

### DIFF
--- a/.ank/entities/TASK-e70f3a12185a.md
+++ b/.ank/entities/TASK-e70f3a12185a.md
@@ -5,7 +5,7 @@ slug: every-verb-that-logs-writes-to-the-log-file-and
 title: Every verb that logs writes to the log file, and the body stops carrying one
 created: 2026-08-13T05:52:58Z
 author: claude-code@sean-laptop
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/src/commands.rs
   - crates/ank-cli/src/done.rs
@@ -13,6 +13,7 @@ scope:
   - crates/ank-cli/src/human.rs
   - crates/ank-cli/src/paint.rs
   - crates/ank-cli/tests/cli.rs
+  - crates/ank-cli/src/store.rs
 blocked_by: [TASK-cd3189ddf61e]
 done_criteria: |
   Every verb that appends a log entry -- log, claim, release, close, done, attest -- writes it through the store, so an entity whose log is not in its body gets .ank/log/<ID>.md and no other file is touched: no frontmatter written, no version bumped, no entity file rewritten by an append alone.
@@ -24,5 +25,8 @@ done_criteria: |
   Asserted through the binary in crates/ank-cli/tests/cli.rs, on an entity with a body log and on one without, including the assertion that the entity file's bytes are unchanged by an append.
 criteria_by: creator
 schema: 3
-version: 1
+version: 5
 ---
+## Log
+- 2026-08-13T06:24:06Z claude-code@sean-laptop — amended: +scope crates/ank-cli/src/store.rs
+- 2026-08-13T07:00:43Z claude-code@sean-laptop — Every verb that logs now goes through Store::write_with_log, which takes the log home read off the entity before it is consumed. The order is the decision: in the file form the entity is written first and the entry lands after it, so a write that lost the compare-and-swap leaves no line claiming a transition that never happened; in the body form there is still one write. ank log with a message and nothing else opens no entity file at all, asserted byte for byte, because a version check alone would pass on a rewrite that happened to land the same number. show prints the log under the entity rather than inside it, so what is above stays verbatim, and prints nothing when the body already carries its own section, which is what keeps one history from being displayed twice. show --json gains a log array. Scope amended mid-task to add store.rs: where a log lives is the store's decision, and the criterion says the verbs write through it.

--- a/.ank/entities/TASK-e70f3a12185a.md
+++ b/.ank/entities/TASK-e70f3a12185a.md
@@ -5,7 +5,7 @@ slug: every-verb-that-logs-writes-to-the-log-file-and
 title: Every verb that logs writes to the log file, and the body stops carrying one
 created: 2026-08-13T05:52:58Z
 author: claude-code@sean-laptop
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/src/commands.rs
   - crates/ank-cli/src/done.rs
@@ -24,9 +24,14 @@ done_criteria: |
   
   Asserted through the binary in crates/ank-cli/tests/cli.rs, on an entity with a body log and on one without, including the assertion that the entity file's bytes are unchanged by an append.
 criteria_by: creator
+proof:
+  - type: test
+    ref: "31676077294"
+    criteria: 57d68577c6a3
 schema: 3
-version: 5
+version: 7
 ---
 ## Log
 - 2026-08-13T06:24:06Z claude-code@sean-laptop — amended: +scope crates/ank-cli/src/store.rs
 - 2026-08-13T07:00:43Z claude-code@sean-laptop — Every verb that logs now goes through Store::write_with_log, which takes the log home read off the entity before it is consumed. The order is the decision: in the file form the entity is written first and the entry lands after it, so a write that lost the compare-and-swap leaves no line claiming a transition that never happened; in the body form there is still one write. ank log with a message and nothing else opens no entity file at all, asserted byte for byte, because a version check alone would pass on a rewrite that happened to land the same number. show prints the log under the entity rather than inside it, so what is above stays verbatim, and prints nothing when the body already carries its own section, which is what keeps one history from being displayed twice. show --json gains a log array. Scope amended mid-task to add store.rs: where a log lives is the store's decision, and the criterion says the verbs write through it.
+- 2026-08-13T07:06:41Z claude-code@sean-laptop — done, proof test:31676077294

--- a/crates/ank-cli/src/commands.rs
+++ b/crates/ank-cli/src/commands.rs
@@ -29,7 +29,7 @@ use crate::context;
 use crate::editor;
 use crate::index::{Index, Row};
 use crate::repo::Repo;
-use crate::store::{version_of, Store};
+use crate::store::{version_of, LogHome, Store};
 use ank_core::{
     append_log, parse_entity, serialize_entity, Adr, AdrStatus, CriteriaBy, Entity, EntityId,
     EntityKind, LogEntry, Task, TaskStatus, SCHEMA_VERSION,
@@ -1288,13 +1288,16 @@ pub fn log(
 /// so the entry a reader came for is the last line of it — reversing is what
 /// makes the answer start with it.
 fn log_read(inv: &Invocation, store: &Store, id: &EntityId, out: &mut dyn Write) -> Result<i32> {
-    let Entity::Task(task) = store.load(id)?.entity else {
+    let loaded = store.load(id)?;
+    let Entity::Task(task) = loaded.entity.clone() else {
         return Err(
             CliError::new(1, format!("{id} is not a task, and only a task has a log"))
                 .with_hint(format!("ank show {id}")),
         );
     };
-    let entries: Vec<LogEntry> = ank_core::parse_log(&task.body).into_iter().rev().collect();
+    // From wherever this entity's log is: the file since schema 3, the body
+    // before it. A missing file is an empty log and never an error.
+    let entries: Vec<LogEntry> = store.log_of(&loaded)?.into_iter().rev().collect();
 
     if inv.json() {
         let items: Vec<String> = entries
@@ -1358,20 +1361,28 @@ fn log_write(
         acting_on(&repo.root, store, given, identity, "log", " \"<message>\"")?;
     warn_before_acting(inv, &warnings);
 
-    let loaded = store.load(&id)?;
-    let base_version = version_of(&loaded.entity);
-    let Entity::Task(mut task) = loaded.entity else {
+    let loaded_for_log = store.load(&id)?;
+    let base_version = version_of(&loaded_for_log.entity);
+    let Entity::Task(mut task) = loaded_for_log.entity.clone() else {
         return Err(CliError::new(1, format!("{id} is not a task")));
     };
-    task.body = append_log(
-        &task.body,
-        &LogEntry {
-            timestamp: claim::now_utc(),
-            who: identity.to_string(),
-            message: message.trim().to_string(),
-        },
-    );
-    store.write(&Entity::Task(task), base_version)?;
+    let entry = LogEntry {
+        timestamp: claim::now_utc(),
+        who: identity.to_string(),
+        message: message.trim().to_string(),
+    };
+    // **An append is not a transition** (ADR-ff294eff4d1a). Where the log is a
+    // file, the entity file is not opened for writing at all: no frontmatter,
+    // no version bump, and nothing touched that carries a frozen field. Where
+    // the log is still in a body, the body is what changes and the write is the
+    // one that carries it.
+    match store.log_home(&loaded_for_log) {
+        LogHome::File => store.append_to_log_file(&id, &entry)?,
+        LogHome::Body => {
+            task.body = append_log(&task.body, &entry);
+            store.write(&Entity::Task(task), base_version)?;
+        }
+    }
 
     // Renewed by writing: working is enough to keep the lock, and there is no
     // heartbeat verb to memorise (§3). The compare-and-swap is on the record we
@@ -1460,6 +1471,7 @@ pub fn release(inv: &Invocation, repo: &Repo, identity: &str, out: &mut dyn Writ
 
     let loaded = store.load(&id)?;
     let base_version = version_of(&loaded.entity);
+    let home = store.log_home(&loaded);
     let Entity::Task(mut task) = loaded.entity else {
         return Err(CliError::new(1, format!("{id} is not a task")));
     };
@@ -1467,15 +1479,12 @@ pub fn release(inv: &Invocation, repo: &Repo, identity: &str, out: &mut dyn Writ
         .check_transition(TaskStatus::Open)
         .map_err(|e| CliError::new(6, e.to_string()).with_hint("ank context"))?;
     task.status = TaskStatus::Open;
-    task.body = append_log(
-        &task.body,
-        &LogEntry {
-            timestamp: claim::now_utc(),
-            who: identity.to_string(),
-            message: format!("released: {reason}"),
-        },
-    );
-    store.write(&Entity::Task(task), base_version)?;
+    let entry = LogEntry {
+        timestamp: claim::now_utc(),
+        who: identity.to_string(),
+        message: format!("released: {reason}"),
+    };
+    store.write_with_log(home, &Entity::Task(task), &entry, base_version)?;
 
     // The file first, the ref second. A ref deleted over a task still marked
     // in_progress would read as claimable and as in progress at the same time;
@@ -1593,6 +1602,13 @@ mod tests {
                 Entity::Task(t) => t,
                 _ => panic!("not a task"),
             }
+        }
+
+        /// The log as a reader gets it, from wherever this entity keeps it.
+        fn log(&self, id: &EntityId) -> Vec<ank_core::LogEntry> {
+            let store = self.store();
+            let loaded = store.load(id).unwrap();
+            store.log_of(&loaded).unwrap()
         }
 
         fn only_task(&self) -> Task {
@@ -2165,12 +2181,12 @@ mod tests {
             .call(&["log", "something"], "claude-code@ank")
             .unwrap_err();
         assert_eq!(err.code, 6, "{}", err.message);
-        assert!(ank_core::parse_log(&t.task(&id).body).is_empty());
+        assert!(t.log(&id).is_empty());
 
         // The holder can.
         t.call(&["log", "removed jwt.verify"], "codex@host-9")
             .unwrap();
-        let entries = ank_core::parse_log(&t.task(&id).body);
+        let entries = t.log(&id);
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].who, "codex@host-9");
         assert_eq!(entries[0].message, "removed jwt.verify");
@@ -2216,12 +2232,12 @@ mod tests {
 
         let err = t.call(&["log", "   "], "claude-code@ank").unwrap_err();
         assert_eq!(err.code, 1, "{}", err.message);
-        assert!(ank_core::parse_log(&t.task(&id).body).is_empty());
+        assert!(t.log(&id).is_empty());
 
         // The redundant form works when it matches.
         t.call(&["log", &id.to_string(), "a message"], "claude-code@ank")
             .unwrap();
-        assert_eq!(ank_core::parse_log(&t.task(&id).body).len(), 1);
+        assert_eq!(t.log(&id).len(), 1);
 
         // And is refused when it does not.
         let other = a_task(&t, "Another");
@@ -2265,7 +2281,7 @@ mod tests {
 
         let task = t.task(&id);
         assert_eq!(task.status, TaskStatus::Open);
-        let entries = ank_core::parse_log(&task.body);
+        let entries = t.log(&id);
         assert_eq!(entries.len(), 1);
         assert!(
             entries[0]

--- a/crates/ank-cli/src/context.rs
+++ b/crates/ank-cli/src/context.rs
@@ -31,7 +31,7 @@ use crate::index::{Index, Row};
 use crate::repo::Repo;
 use crate::store::Store;
 use crate::style::Style;
-use ank_core::{parse_log, Entity, EntityId, EntityKind, ScopeSet};
+use ank_core::{Entity, EntityId, EntityKind, ScopeSet};
 use std::collections::HashMap;
 use std::io::Write;
 
@@ -635,7 +635,9 @@ fn build_execution(
     id: EntityId,
     mut warnings: Vec<String>,
 ) -> Result<View> {
-    let Entity::Task(task) = store.load(&id)?.entity else {
+    let loaded = store.load(&id)?;
+    let log_entries = store.log_of(&loaded)?;
+    let Entity::Task(task) = loaded.entity else {
         return Err(CliError::new(1, format!("{id} is not a task")));
     };
 
@@ -680,7 +682,9 @@ fn build_execution(
         });
     }
 
-    let log: Vec<String> = parse_log(&task.body)
+    // Read through the store, so the task in hand shows its log whether that
+    // log is a file or still a section of this body.
+    let log: Vec<String> = log_entries
         .iter()
         .map(|e| format!("{} {} — {}", e.timestamp, e.who, e.message))
         .collect();

--- a/crates/ank-cli/src/done.rs
+++ b/crates/ank-cli/src/done.rs
@@ -34,8 +34,8 @@ use crate::repo::Repo;
 use crate::store::{version_of, Store};
 use crate::verify;
 use ank_core::{
-    append_log, freeze_hash_short, verify_frozen, Entity, EntityId, LogEntry, Proof, ProofType,
-    ScopeSet, TaskStatus,
+    freeze_hash_short, verify_frozen, Entity, EntityId, LogEntry, Proof, ProofType, ScopeSet,
+    TaskStatus,
 };
 use sha2::{Digest, Sha256};
 use std::io::Write;
@@ -131,6 +131,7 @@ pub fn run(
     )?;
     let loaded = store.load(&id)?;
     let base_version = version_of(&loaded.entity);
+    let home = store.log_home(&loaded);
     let Entity::Task(mut task) = loaded.entity else {
         return Err(CliError::new(1, format!("{id} is not a task")));
     };
@@ -193,8 +194,7 @@ pub fn run(
         who: identity.to_string(),
         message: done_message(&proofs),
     };
-    task.body = append_log(&task.body, &entry);
-    store.write(&Entity::Task(task.clone()), base_version)?;
+    store.write_with_log(home, &Entity::Task(task.clone()), &entry, base_version)?;
 
     let (completed, sync) = claim::complete(&repo.root, &id, identity)?;
     // A completion that did not reach the remote closes the window it exists
@@ -696,6 +696,14 @@ mod tests {
             }
         }
 
+        /// The log as a reader gets it, from wherever this entity keeps it.
+        fn log(&self) -> Vec<LogEntry> {
+            let id = EntityId::parse("TASK-000000000001").unwrap();
+            let store = self.store();
+            let loaded = store.load(&id).unwrap();
+            store.log_of(&loaded).unwrap()
+        }
+
         fn record(&self) -> Option<Record> {
             let id = EntityId::parse("TASK-000000000001").unwrap();
             claim::read(&self.0, &id).unwrap().map(|h| h.record)
@@ -1026,7 +1034,7 @@ mod tests {
         t.claim(&id, "claude-code@ank");
         t.done(&[], "claude-code@ank").unwrap();
 
-        let entries = ank_core::parse_log(&t.task().body);
+        let entries = t.log();
         assert_eq!(entries.len(), 1, "{entries:?}");
         assert_eq!(entries[0].who, "claude-code@ank");
         assert!(

--- a/crates/ank-cli/src/human.rs
+++ b/crates/ank-cli/src/human.rs
@@ -32,13 +32,12 @@ use crate::config::Config;
 use crate::git;
 use crate::index::Index;
 use crate::repo::Repo;
-use crate::store::{version_of, Store};
+use crate::store::{version_of, LogHome, Store};
 use crate::style;
 use crate::verify;
 use ank_core::{
-    append_log, freeze, has_crlf, normalise_line_endings, parse_entity, serialize_entity,
-    verify_frozen, Adr, AdrStatus, Entity, EntityId, EntityKind, LogEntry, Task, TaskStatus,
-    Verified,
+    freeze, has_crlf, normalise_line_endings, parse_entity, serialize_entity, verify_frozen, Adr,
+    AdrStatus, Entity, EntityId, EntityKind, LogEntry, Task, TaskStatus, Verified,
 };
 use ank_core::{CriteriaBy, ProofType, ScopeSet};
 use std::collections::{BTreeSet, HashMap, HashSet};
@@ -2409,6 +2408,7 @@ pub fn close(inv: &Invocation, repo: &Repo, identity: &str, out: &mut dyn Write)
     let store = Store::new(&repo.ank);
     let loaded = store.load_prefix(prefix)?;
     let base_version = version_of(&loaded.entity);
+    let home = store.log_home(&loaded);
     let Entity::Task(mut task) = loaded.entity else {
         return Err(CliError::new(1, format!("{prefix} is not a task")));
     };
@@ -2417,15 +2417,12 @@ pub fn close(inv: &Invocation, repo: &Repo, identity: &str, out: &mut dyn Write)
         .check_transition(TaskStatus::Closed)
         .map_err(|e| CliError::new(6, e.to_string()).with_hint(format!("ank show {id}")))?;
     task.status = TaskStatus::Closed;
-    task.body = append_log(
-        &task.body,
-        &LogEntry {
-            timestamp: claim::now_utc(),
-            who: identity.to_string(),
-            message: format!("closed: {reason}"),
-        },
-    );
-    store.write(&Entity::Task(task), base_version)?;
+    let entry = LogEntry {
+        timestamp: claim::now_utc(),
+        who: identity.to_string(),
+        message: format!("closed: {reason}"),
+    };
+    store.write_with_log(home, &Entity::Task(task), &entry, base_version)?;
 
     let revoked = claim::delete(&repo.root, &id)?;
     if inv.json() {
@@ -2490,6 +2487,7 @@ pub fn attest(inv: &Invocation, repo: &Repo, identity: &str, out: &mut dyn Write
     let store = Store::new(&repo.ank);
     let loaded = store.load_prefix(prefix)?;
     let base_version = version_of(&loaded.entity);
+    let home = store.log_home(&loaded);
     let Entity::Task(mut task) = loaded.entity else {
         return Err(CliError::new(1, format!("{prefix} is not a task")));
     };
@@ -2525,16 +2523,13 @@ pub fn attest(inv: &Invocation, repo: &Repo, identity: &str, out: &mut dyn Write
     // Appended. The entries already there are not read, rewritten or reordered
     // — they are simply still in the vector.
     task.proof.push(proof);
-    task.body = append_log(
-        &task.body,
-        &LogEntry {
-            timestamp: claim::now_utc(),
-            who: identity.to_string(),
-            message: format!("attested {kind}:{reference}"),
-        },
-    );
+    let entry = LogEntry {
+        timestamp: claim::now_utc(),
+        who: identity.to_string(),
+        message: format!("attested {kind}:{reference}"),
+    };
     let entries = task.proof.len();
-    store.write(&Entity::Task(task), base_version)?;
+    store.write_with_log(home, &Entity::Task(task), &entry, base_version)?;
 
     if inv.json() {
         let _ = writeln!(
@@ -2661,6 +2656,7 @@ pub fn amend(inv: &Invocation, repo: &Repo, identity: &str, out: &mut dyn Write)
     let store = Store::new(&repo.ank);
     let loaded = store.load_prefix(prefix)?;
     let base_version = version_of(&loaded.entity);
+    let home = store.log_home(&loaded);
     let id = loaded.entity.id().clone();
 
     // Both normalised, and both for the same reason `new --scope` is: one is
@@ -2790,15 +2786,12 @@ pub fn amend(inv: &Invocation, repo: &Repo, identity: &str, out: &mut dyn Write)
                 _ => None,
             };
 
-            task.body = append_log(
-                &task.body,
-                &LogEntry {
-                    timestamp: claim::now_utc(),
-                    who: identity.to_string(),
-                    message: format!("amended: {}", changes.join(", ")),
-                },
-            );
-            store.write(&Entity::Task(task), base_version)?;
+            let entry = LogEntry {
+                timestamp: claim::now_utc(),
+                who: identity.to_string(),
+                message: format!("amended: {}", changes.join(", ")),
+            };
+            store.write_with_log(home, &Entity::Task(task), &entry, base_version)?;
 
             report_amend(inv, &id, &changes, out);
             if touched_scope {
@@ -2986,6 +2979,13 @@ pub fn show(inv: &Invocation, repo: &Repo, out: &mut dyn Write) -> Result<i32> {
         Entity::Task(t) => claim::detached_proofs(&repo.root, &t.id),
         Entity::Adr(_) => Vec::new(),
     };
+    // Only when the log is a file. A body still carrying its own `## Log`
+    // section prints it above as part of the entity, and a second copy here
+    // would be the same history said twice.
+    let log = match store.log_home(&loaded) {
+        LogHome::File => store.log_of(&loaded)?,
+        LogHome::Body => Vec::new(),
+    };
 
     if inv.json() {
         let state = match claim::read(&repo.root, loaded.entity.id())?.map(|h| h.record) {
@@ -3009,9 +3009,10 @@ pub fn show(inv: &Invocation, repo: &Repo, out: &mut dyn Write) -> Result<i32> {
         };
         let _ = writeln!(
             out,
-            "{{\"id\":\"{}\",\"coordination\":{state}{derived},\"detached_proofs\":{},\"content\":{}}}",
+            "{{\"id\":\"{}\",\"coordination\":{state}{derived},\"detached_proofs\":{},\"log\":{},\"content\":{}}}",
             loaded.entity.id(),
             detached_json(&detached),
+            log_json(&log),
             json_str(&text)
         );
     } else if !inv.quiet() {
@@ -3020,6 +3021,12 @@ pub fn show(inv: &Invocation, repo: &Repo, out: &mut dyn Write) -> Result<i32> {
         // style to PLAIN under `--json`, so this is the second of two
         // independent guards rather than the only one.
         let _ = write!(out, "{}", crate::paint::entity(&text, inv.style()));
+        // The log, from wherever it is. Since schema 3 it is a file of its own,
+        // so an entity printed verbatim no longer carries it and `show` would
+        // display an empty history for a task that has one — silently, which is
+        // the failure the version bump exists to prevent (§3). Under the entity
+        // and not inside it: what is above stays byte for byte the file.
+        log_section(out, &log, inv.style());
         if let Some((blocked_by, unblocks)) = &edges {
             edge_section(out, "BLOCKED BY", blocked_by, inv.style());
             edge_section(out, "UNBLOCKS", unblocks, inv.style());
@@ -3029,6 +3036,49 @@ pub fn show(inv: &Invocation, repo: &Repo, out: &mut dyn Write) -> Result<i32> {
         }
     }
     Ok(0)
+}
+
+/// The log as data. A list, empty when there is none, so a parser reads one
+/// shape rather than two.
+fn log_json(entries: &[LogEntry]) -> String {
+    let items: Vec<String> = entries
+        .iter()
+        .map(|e| {
+            format!(
+                "{{\"timestamp\":{},\"who\":{},\"message\":{}}}",
+                json_str(&e.timestamp),
+                json_str(&e.who),
+                json_str(&e.message)
+            )
+        })
+        .collect();
+    format!("[{}]", items.join(","))
+}
+
+/// The entity's log, printed under it and never inside it.
+///
+/// **Silent when there is none**, which keeps `show` on an ADR adding nothing
+/// and keeps a task nobody has logged against from growing an empty heading.
+/// A body that still carries its own `## Log` section prints it above as part
+/// of the entity and gets no second copy here: [`Store::log_of`] answers from
+/// one place, never from both.
+fn log_section(out: &mut dyn Write, entries: &[LogEntry], style: crate::style::Style) {
+    if entries.is_empty() {
+        return;
+    }
+    let _ = writeln!(
+        out,
+        "\n{}",
+        style.header(&format!("LOG ({})", entries.len()))
+    );
+    for (i, e) in entries.iter().enumerate() {
+        let connector = if i + 1 == entries.len() {
+            crate::style::glyph::LAST
+        } else {
+            crate::style::glyph::BRANCH
+        };
+        let _ = writeln!(out, "{connector}{} {} — {}", e.timestamp, e.who, e.message);
+    }
 }
 
 /// Every proof against the task, from both sources, each saying which it is
@@ -3276,6 +3326,13 @@ mod tests {
         fn cfg(&self) -> Config {
             crate::config::load(&self.repo().config_path()).unwrap()
         }
+        /// The log as a reader gets it, from wherever this entity keeps it.
+        fn log(&self, id: &EntityId) -> Vec<LogEntry> {
+            let store = self.store();
+            let loaded = store.load(id).unwrap();
+            store.log_of(&loaded).unwrap()
+        }
+
         fn store(&self) -> Store {
             Store::new(self.0.join(".ank"))
         }
@@ -5264,7 +5321,7 @@ mod tests {
             panic!()
         };
         assert_eq!(after.status, TaskStatus::Closed);
-        let entries = ank_core::parse_log(&after.body);
+        let entries = t.log(&id);
         assert!(entries[0]
             .message
             .contains("superseded by the new pipeline"));

--- a/crates/ank-cli/src/store.rs
+++ b/crates/ank-cli/src/store.rs
@@ -14,8 +14,8 @@
 //!   the second would overwrite the first with nothing to signal it.
 
 use ank_core::{
-    append_log_file, parse_entity, parse_log, parse_log_file, resolve_prefix, serialize_entity,
-    Entity, EntityId, EntityKind, LogEntry,
+    append_log, append_log_file, parse_entity, parse_log, parse_log_file, resolve_prefix,
+    serialize_entity, Entity, EntityId, EntityKind, LogEntry,
 };
 use std::fmt;
 use std::fs::{self, File, OpenOptions};
@@ -210,6 +210,13 @@ fn set_version(entity: &mut Entity, v: u64) {
     match entity {
         Entity::Task(t) => t.version = v,
         Entity::Adr(a) => a.version = v,
+    }
+}
+
+fn set_body(entity: &mut Entity, body: String) {
+    match entity {
+        Entity::Task(t) => t.body = body,
+        Entity::Adr(a) => a.body = body,
     }
 }
 
@@ -706,40 +713,90 @@ impl Store {
         }
     }
 
-    /// Appends one entry to an entity's log, **where that log already is**.
+    /// Where an entity's log lives.
     ///
     /// An entity whose body still carries a `## Log` section keeps it: writing
     /// the entry into a new file instead would split one history across two
     /// places, and since reading prefers the file, the older half would go
     /// silent — which is the exact failure the schema bump exists to prevent.
-    /// Everything else appends to the file, which is what a schema 3 entity has.
+    /// Everything else has its log in a file, which is what schema 3 means.
     ///
-    /// Returns `true` when the entry went to the file, so the caller knows
-    /// whether the entity file itself was touched.
-    pub fn append_to_log(&self, loaded: &Loaded, entry: &LogEntry) -> Result<bool> {
-        if parse_log(body_of(&loaded.entity)).is_empty()
-            && !body_of(&loaded.entity)
-                .lines()
-                .any(|l| l.trim_end() == ank_core::log::LOG_HEADER)
+    /// The caller must know this **before** it writes anything, because the
+    /// answer decides whether the entry belongs in the body it is about to
+    /// write or in a file it writes afterwards.
+    pub fn log_home(&self, loaded: &Loaded) -> LogHome {
+        if body_of(&loaded.entity)
+            .lines()
+            .any(|l| l.trim_end() == ank_core::log::LOG_HEADER)
         {
-            let path = self.log_path_of(loaded.entity.id());
-            if let Some(parent) = path.parent() {
-                fs::create_dir_all(parent).map_err(|source| StoreError::Io {
-                    path: parent.to_path_buf(),
-                    source,
-                })?;
-            }
-            let _lock = Lock::acquire(&path)?;
-            let current = match fs::read_to_string(&path) {
-                Ok(text) => text,
-                Err(e) if e.kind() == ErrorKind::NotFound => String::new(),
-                Err(source) => return Err(StoreError::Io { path, source }),
-            };
-            write_atomic(&path, &append_log_file(&current, entry))?;
-            return Ok(true);
+            LogHome::Body
+        } else {
+            LogHome::File
         }
-        Ok(false)
     }
+
+    /// Writes an entity **and** records one log entry for that write, each
+    /// where it belongs.
+    ///
+    /// The order is the decision. In the file form the entity is written first
+    /// and the entry lands after it, so a write that lost the compare-and-swap
+    /// leaves no line claiming a transition that never happened. In the body
+    /// form there is one write and the question does not arise, which is what
+    /// the previous layout bought and what the move gives up on purpose.
+    ///
+    /// `home` is taken rather than derived so the caller can read it off the
+    /// entity it loaded, before consuming it.
+    pub fn write_with_log(
+        &self,
+        home: LogHome,
+        entity: &Entity,
+        entry: &LogEntry,
+        base_version: u64,
+    ) -> Result<u64> {
+        let mut next = entity.clone();
+        if home == LogHome::Body {
+            set_body(&mut next, append_log(body_of(entity), entry));
+        }
+        let version = self.write(&next, base_version)?;
+        if home == LogHome::File {
+            self.append_to_log_file(next.id(), entry)?;
+        }
+        Ok(version)
+    }
+
+    /// Appends one entry to `.ank/log/<ID>.md`, creating the file if needed.
+    ///
+    /// Called **after** the entity write, when there is one. A log line is a
+    /// trace of something that happened, so a transition that failed must not
+    /// leave one behind; a transition with no trace is merely incomplete, which
+    /// is the cheaper of the two failures.
+    pub fn append_to_log_file(&self, id: &EntityId, entry: &LogEntry) -> Result<()> {
+        let path = self.log_path_of(id);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).map_err(|source| StoreError::Io {
+                path: parent.to_path_buf(),
+                source,
+            })?;
+        }
+        let _lock = Lock::acquire(&path)?;
+        let current = match fs::read_to_string(&path) {
+            Ok(text) => text,
+            Err(e) if e.kind() == ErrorKind::NotFound => String::new(),
+            Err(source) => return Err(StoreError::Io { path, source }),
+        };
+        write_atomic(&path, &append_log_file(&current, entry))
+    }
+}
+
+/// Where an entity's log is kept.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LogHome {
+    /// `.ank/log/<ID>.md`, which is what schema 3 means.
+    File,
+    /// A `## Log` section at the end of the body, written before the move and
+    /// still read there — and still appended to, so that one history stays in
+    /// one place.
+    Body,
 }
 
 /// The body of an entity, whichever kind it is.
@@ -1210,7 +1267,8 @@ mod tests {
             who: "claude-code/1.4.2".into(),
             message: "learned something".into(),
         };
-        assert!(store.append_to_log(&loaded, &entry).unwrap());
+        assert_eq!(store.log_home(&loaded), LogHome::File);
+        store.append_to_log_file(e.id(), &entry).unwrap();
         assert_eq!(
             store.log_path_of(e.id()),
             root.0.join("log").join(format!("{}.md", e.id()))
@@ -1249,10 +1307,18 @@ mod tests {
             who: "claude-code/1.4.2".into(),
             message: "learned something".into(),
         };
-        assert!(
-            !store.append_to_log(&loaded, &entry).unwrap(),
+        assert_eq!(
+            store.log_home(&loaded),
+            LogHome::Body,
             "the file form is not where this entity's log lives"
         );
+        // And the write that carries it puts it in the body, leaving no file.
+        let base = version_of(&e);
+        store
+            .write_with_log(LogHome::Body, &e, &entry, base)
+            .unwrap();
         assert!(!store.log_path_of(e.id()).exists());
+        let after = store.load(e.id()).unwrap();
+        assert_eq!(store.log_of(&after).unwrap().len(), 2, "appended in place");
     }
 }

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -336,6 +336,25 @@ impl Repo {
         std::fs::write(self.0.join(".ank/entities").join(format!("{id}.md")), text).unwrap();
     }
 
+    /// Seeds a task whose log is still a `## Log` section of its body, which is
+    /// what every entity written before schema 3 looks like.
+    fn seed_task_with_body_log(&self, id: &str, entry: &str) {
+        self.seed_task(id, Some("A verifiable criterion."));
+        let text = format!(
+            "{}\n## Log\n- 2026-07-26T14:02Z marie@laptop \u{2014} {entry}\n",
+            self.task_text(id)
+        );
+        std::fs::write(self.flat_task_path(id), text).unwrap();
+    }
+
+    /// The log file of an entity, empty when there is none. Since schema 3 the
+    /// log is not in the entity file, so an assertion about a log line reads
+    /// this and an assertion about a field reads `task_text`.
+    fn log_text(&self, id: &str) -> String {
+        std::fs::read_to_string(self.0.join(".ank/log").join(format!("{id}.md")))
+            .unwrap_or_default()
+    }
+
     fn task_text(&self, id: &str) -> String {
         std::fs::read_to_string(self.0.join(".ank/entities").join(format!("{id}.md"))).unwrap()
     }
@@ -2502,7 +2521,7 @@ fn a_positional_that_starts_with_a_dash_is_refused_by_naming_the_escape() {
         .output()
         .expect("the binary must have been built");
     assert_eq!(code(&out), 0, "{}", stderr(&out));
-    assert!(r.task_text(ID).contains(message), "{}", r.task_text(ID));
+    assert!(r.log_text(ID).contains(message), "{}", r.log_text(ID));
 
     // A value keeps taking its dash verbatim, whichever form the flag took:
     // only a positional ever needs the escape.
@@ -2842,8 +2861,9 @@ fn the_whole_agent_loop_runs_through_the_binary() {
     let file = r.task_text(&id);
     assert!(file.contains("status: open"), "{file}");
     assert!(
-        file.contains("needs staging access"),
-        "the reason is in the log: {file}"
+        r.log_text(&id).contains("needs staging access"),
+        "the reason is in the log: {}",
+        r.log_text(&id)
     );
 
     // And the next agent picks it up where the previous one stopped.
@@ -2941,9 +2961,9 @@ fn log_decides_between_reading_and_writing_by_what_resolves() {
     let out = r.ank("claude-code@ank", &["log", "TASK-000000000009"]);
     assert_eq!(code(&out), 0, "{}", stderr(&out));
     assert!(
-        r.task_text(ID).contains("TASK-000000000009"),
+        r.log_text(ID).contains("TASK-000000000009"),
         "{}",
-        r.task_text(ID)
+        r.log_text(ID)
     );
 
     // An ambiguous prefix resolves to no single entity, so it is a message too.
@@ -2952,11 +2972,11 @@ fn log_decides_between_reading_and_writing_by_what_resolves() {
     let out = r.ank("claude-code@ank", &["log", "TASK-00000000000"]);
     assert_eq!(code(&out), 0, "{}", stderr(&out));
     assert!(
-        r.task_text(ID)
+        r.log_text(ID)
             .lines()
             .any(|l| l.ends_with("TASK-00000000000")),
         "{}",
-        r.task_text(ID)
+        r.log_text(ID)
     );
 
     // A message that also resolves: refused, naming both readings, writing
@@ -2972,7 +2992,7 @@ fn log_decides_between_reading_and_writing_by_what_resolves() {
     // The redundant write form is untouched when the message is a message.
     let out = r.ank("claude-code@ank", &["log", ID, "a real message"]);
     assert_eq!(code(&out), 0, "{}", stderr(&out));
-    assert!(r.task_text(ID).contains("a real message"));
+    assert!(r.log_text(ID).contains("a real message"));
 
     // And an id alone reads even for the agent holding it: what decides is the
     // argument, not who is asking.
@@ -3469,16 +3489,16 @@ fn with_two_live_claims_no_verb_picks_one_in_silence() {
         "{}",
         stdout(&out)
     );
-    assert!(r.task_text(FIRST).contains("one"), "the entry went to HEAD");
+    assert!(r.log_text(FIRST).contains("one"), "the entry went to HEAD");
 
     // Naming a task is what picks the other one, and it costs the refusal
     // rather than a flag: the id used to have to equal HEAD.
     let out = r.ank(AGENT, &["log", SECOND, "two"]);
     assert_eq!(code(&out), 0, "{}", stderr(&out));
     assert!(
-        r.task_text(SECOND).contains("two"),
+        r.log_text(SECOND).contains("two"),
         "the named task got the entry:\n{}",
-        r.task_text(SECOND)
+        r.log_text(SECOND)
     );
     assert!(
         !stderr(&out).contains("live claims"),
@@ -4126,7 +4146,11 @@ fn attest_appends_a_proof_to_a_finished_task_and_never_substitutes() {
     assert!(after.contains(&head), "{after}");
     // Version increments and the log records what was added.
     assert!(!after.contains("version: 1"), "{after}");
-    assert!(after.contains("attested commit:"), "{after}");
+    assert!(
+        r.log_text(ID).contains("attested commit:"),
+        "{}",
+        r.log_text(ID)
+    );
 
     // A commit that does not exist is refused, exactly as `done` refuses it.
     let out = r.ank(
@@ -4616,10 +4640,16 @@ fn amend_adds_and_removes_without_disturbing_the_rest() {
     assert!(text.contains("  - src/**\n  - docs/**"), "{text}");
     assert!(text.contains("version: 2"), "the write increments: {text}");
     assert!(
-        text.contains("amended: +blocked_by TASK-000000000002"),
-        "the log says what changed: {text}"
+        r.log_text(ID)
+            .contains("amended: +blocked_by TASK-000000000002"),
+        "the log says what changed: {}",
+        r.log_text(ID)
     );
-    assert!(text.contains("+scope docs/**"), "{text}");
+    assert!(
+        r.log_text(ID).contains("+scope docs/**"),
+        "{}",
+        r.log_text(ID)
+    );
     // Everything it did not name is still there, byte for byte.
     assert!(
         text.contains("done_criteria: |\n  A verifiable criterion."),
@@ -4635,7 +4665,11 @@ fn amend_adds_and_removes_without_disturbing_the_rest() {
     assert_eq!(code(&out), 0, "{}", stderr(&out));
     let text = r.task_text(ID);
     assert!(text.contains("blocked_by: [TASK-000000000002]"), "{text}");
-    assert!(text.contains("-blocked_by TASK-000000000003"), "{text}");
+    assert!(
+        r.log_text(ID).contains("-blocked_by TASK-000000000003"),
+        "{}",
+        r.log_text(ID)
+    );
 
     let out = r.ank("marie@laptop", &["amend", ID, "--drop-scope", "nowhere/**"]);
     assert_eq!(code(&out), 7, "{}", stderr(&out));
@@ -4706,8 +4740,9 @@ fn a_criterion_under_no_claim_is_amended_and_stays_the_creators() {
         "the correction was recorded as somebody else's: {text}"
     );
     assert!(
-        text.contains("amended: done_criteria"),
-        "the log is what records the amend: {text}"
+        r.log_text(ID).contains("amended: done_criteria"),
+        "the log is what records the amend: {}",
+        r.log_text(ID)
     );
 
     // And the corpus is clean afterwards: the point of the route is that it
@@ -8101,4 +8136,216 @@ fn a_detached_proof_outlives_check_until_the_file_carries_it() {
         "the file on the default branch carries the same proof, and the ref \
          is still there"
     );
+}
+
+// ---------------------------------------------------------------------------
+// The log is a file, and an append is not a transition (§3, ADR-ff294eff4d1a)
+// ---------------------------------------------------------------------------
+
+const LOGGED: &str = "TASK-00000000c10a";
+
+/// The property the move was made for: **`ank log` does not touch the entity**.
+///
+/// Not "writes little" -- writes nothing. The entity file carries the frozen
+/// criterion, and it was the file that churned most because the loop tells an
+/// agent to log whenever it learns something. Byte-for-byte equality is the
+/// only assertion that says so; a version check alone would pass on a rewrite
+/// that happened to land the same number.
+#[test]
+fn an_append_leaves_the_entity_file_byte_for_byte() {
+    let r = Repo::new();
+    r.seed_task(LOGGED, Some("A verifiable criterion."));
+    assert_eq!(code(&r.ank("claude-code@ank", &["claim", LOGGED])), 0);
+
+    let before = r.task_text(LOGGED);
+    let out = r.ank("claude-code@ank", &["log", "learned something"]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+
+    assert_eq!(
+        r.task_text(LOGGED),
+        before,
+        "no frontmatter, no version bump, nothing touched that carries a freeze"
+    );
+    let log = r.log_text(LOGGED);
+    assert!(log.contains("learned something"), "{log}");
+    assert!(
+        log.lines().count() == 1 && log.starts_with("- "),
+        "one entry, one line, and the file is nothing but entries: {log:?}"
+    );
+
+    // A second append is a one-line diff over the first.
+    assert_eq!(code(&r.ank("claude-code@ank", &["log", "and again"])), 0);
+    let after = r.log_text(LOGGED);
+    assert!(
+        after.starts_with(&log),
+        "an append rewrites nothing: {after}"
+    );
+    assert_eq!(after.lines().count(), 2, "{after}");
+}
+
+/// Every verb that logs writes to the same place, and none of them puts a log
+/// section back into a body that has none.
+#[test]
+fn every_verb_that_logs_writes_to_the_log_file() {
+    let r = Repo::new().with_verifiers("");
+    r.seed_task(LOGGED, Some("A verifiable criterion."));
+
+    assert_eq!(code(&r.ank("claude-code@ank", &["claim", LOGGED])), 0);
+    assert_eq!(
+        code(&r.ank(
+            "claude-code@ank",
+            &["release", LOGGED, "--reason", "needs staging access"]
+        )),
+        0
+    );
+    assert_eq!(code(&r.ank("claude-code@ank", &["claim", LOGGED])), 0);
+    assert_eq!(
+        code(&r.ank(
+            "claude-code@ank",
+            &["done", "--proof", "assertion:it works"]
+        )),
+        0
+    );
+    assert_eq!(
+        code(&r.ank(
+            "claude-code@ank",
+            &["attest", LOGGED, "--proof", "test:ci-run-9"]
+        )),
+        0
+    );
+
+    let log = r.log_text(LOGGED);
+    for expected in [
+        "released: needs staging access",
+        "done, proof",
+        "attested test:",
+    ] {
+        assert!(log.contains(expected), "{expected} missing from:\n{log}");
+    }
+    assert!(
+        !r.task_text(LOGGED).contains("## Log"),
+        "no verb puts a log section back into a body: {}",
+        r.task_text(LOGGED)
+    );
+}
+
+/// Read from wherever it is, by every surface that shows it.
+#[test]
+fn show_log_and_context_read_the_log_from_the_file() {
+    let r = Repo::new();
+    r.seed_task(LOGGED, Some("A verifiable criterion."));
+    assert_eq!(code(&r.ank("claude-code@ank", &["claim", LOGGED])), 0);
+    assert_eq!(
+        code(&r.ank("claude-code@ank", &["log", "learned something"])),
+        0
+    );
+
+    // `show`: under the entity, which stays byte for byte the file above it.
+    let out = r.ank("claude-code@ank", &["show", LOGGED]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    let text = stdout(&out);
+    assert!(
+        text.starts_with(&r.task_text(LOGGED)),
+        "the entity is still verbatim: {text}"
+    );
+    assert!(text.contains("LOG (1)"), "{text}");
+    assert!(text.contains("learned something"), "{text}");
+
+    // `ank log <id>` with no message.
+    let out = r.ank("claude-code@ank", &["log", LOGGED]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    assert!(
+        stdout(&out).contains("learned something"),
+        "{}",
+        stdout(&out)
+    );
+
+    // `context` in execution mode.
+    let out = r.ank("claude-code@ank", &["context"]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    assert!(
+        stdout(&out).contains("learned something"),
+        "{}",
+        stdout(&out)
+    );
+
+    // And as data.
+    let out = r.ank("claude-code@ank", &["show", LOGGED, "--json"]);
+    assert_json_only(&out, "ank show --json");
+    assert!(
+        stdout(&out).contains("\"log\":[{\"timestamp\":"),
+        "{}",
+        stdout(&out)
+    );
+}
+
+/// A missing log file is an empty log and never an error -- the state every
+/// entity is in until somebody logs against it.
+#[test]
+fn an_entity_with_no_log_file_reads_as_an_empty_log() {
+    let r = Repo::new();
+    r.seed_task(LOGGED, Some("A verifiable criterion."));
+    assert!(r.log_text(LOGGED).is_empty(), "the fixture has no log file");
+
+    let out = r.ank("claude-code@ank", &["log", LOGGED]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    assert!(
+        stdout(&out).contains("no log entry yet"),
+        "{}",
+        stdout(&out)
+    );
+
+    let out = r.ank("claude-code@ank", &["show", LOGGED]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    assert!(
+        !stdout(&out).contains("LOG ("),
+        "no empty heading: {}",
+        stdout(&out)
+    );
+}
+
+/// **One history never splits.** An entity whose body still carries a `## Log`
+/// section keeps it: the entry lands there, no file appears beside it, and the
+/// entries already written stay reachable.
+///
+/// Writing the entry into a new file instead would leave the older half
+/// unreachable, since reading prefers the file -- which is the exact failure
+/// the schema bump exists to prevent, arriving through the tool rather than
+/// through an old reader.
+#[test]
+fn an_entity_whose_log_is_in_its_body_keeps_it_there() {
+    let r = Repo::new();
+    r.seed_task_with_body_log(LOGGED, "an entry written before the move");
+    assert_eq!(code(&r.ank("claude-code@ank", &["claim", LOGGED])), 0);
+    assert_eq!(
+        code(&r.ank("claude-code@ank", &["log", "learned something"])),
+        0
+    );
+
+    assert!(
+        r.log_text(LOGGED).is_empty(),
+        "no file appears beside a body that already holds the log: {}",
+        r.log_text(LOGGED)
+    );
+    let text = r.task_text(LOGGED);
+    assert!(
+        text.contains("an entry written before the move") && text.contains("learned something"),
+        "both halves of one history, in one place: {text}"
+    );
+
+    // And every reader still sees both, exactly once.
+    let out = r.ank("claude-code@ank", &["log", LOGGED]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    let listed = stdout(&out);
+    assert_eq!(listed.matches("learned something").count(), 1, "{listed}");
+    assert_eq!(
+        listed.matches("an entry written before the move").count(),
+        1,
+        "{listed}"
+    );
+
+    // `show` prints the body's own section and adds no second copy under it.
+    let out = stdout(&r.ank("claude-code@ank", &["show", LOGGED]));
+    assert_eq!(out.matches("learned something").count(), 1, "{out}");
+    assert!(!out.contains("LOG ("), "the body already carries it: {out}");
 }


### PR DESCRIPTION
The CLI half of ADR-ff294eff4d1a (TASK-e70f3a12185a), after the store gained the primitives in #99. **Last code change before this repository''s corpus moves** in TASK-9bff1d5826b1.

Every verb that records a log entry -- `log`, `release`, `close`, `done`, `attest`, `amend` -- goes through `Store::write_with_log`, which takes the log home read off the entity before it is consumed.

## The order is the decision

In the **file** form the entity is written first and the entry lands after it, so a write that lost the compare-and-swap leaves **no line claiming a transition that never happened**. A transition with no trace is merely incomplete, which is the cheaper of the two failures. In the **body** form there is still one write and the question does not arise -- that is what the previous layout bought, and what the move gives up on purpose.

## An append is not a transition

`ank log` with a message opens no entity file at all: no frontmatter, no version bump, nothing touched that carries a frozen field.

Asserted **byte for byte**, because a version check alone would pass on a rewrite that happened to land the same number, and byte equality is the only assertion that says what the move was made for. The entity file carries the frozen criterion and it was the file that churned most, since the loop tells an agent to log whenever it learns something.

## One history never splits

An entity whose body still carries a `## Log` section keeps it, and the entry lands there. Writing it into a new file would leave the older half unreachable, since reading prefers the file -- the exact failure the schema bump exists to prevent, arriving through the tool instead of through an old reader.

## Reading

`show` prints the log **under** the entity rather than inside it, so what is above stays byte for byte the file, and prints nothing at all when the body already carries its own section: one history, displayed once. `show --json` gains a `log` array, empty when there is none, so a parser reads one shape. `ank log <id>` and `context` in execution mode read through the store too.

## A note on scope

The task''s scope was amended mid-task to add `store.rs`, and `amend` emitted its warning about the constraints the claim anchors. The scope was mine and it was wrong: where a log lives is the store''s decision, and the criterion says the verbs write through it.

## Verification

Six new tests through the binary, on an entity with a body log and on one without. 452 tests green on all three platforms, both MSRV jobs and the version check included, run 31676077294. `ank check` exits 0 on the real corpus -- whose entities all still carry body logs, so nothing in it splits.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018pPFH9Aw4GLRs17YLyTPtL