### PR TITLE
A CI recipe that names no vendor, and this repository adopts it

### DIFF
--- a/.ank/tasks/TASK-2dff950e5d51.md
+++ b/.ank/tasks/TASK-2dff950e5d51.md
@@ -5,7 +5,7 @@ slug: a-ci-recipe-that-names-no-vendor-and-this-reposi
 title: A CI recipe that names no vendor, and this repository adopts it
 created: 2026-08-11T22:26:13Z
 author: claude-code@sean-laptop
-status: open
+status: in_progress
 scope:
   - docs/getting-started.md
   - .github/workflows/ci.yml
@@ -26,7 +26,7 @@ done_criteria: |
   what the pipeline now does.
 criteria_by: creator
 schema: 2
-version: 1
+version: 3
 ---
 
 Blocked on `attest --detached`, because the recipe is the reason that verb exists
@@ -52,3 +52,6 @@ green and was never written down.
 Note the ordering constraint in the workflow: the attestation is only meaningful
 after the tests pass, and it must not run on a matrix leg. One attestation per
 run, after the matrix, or the corpus grows three identical proofs per task.
+
+## Log
+- 2026-08-13T06:54:21Z claude-agent-c — Measured, not assumed: ank attest --detached exits 0 whether or not the ref reached the remote. On a scratch corpus with a real file:// remote it prints pushed:true and the ref is there; with the remote pointed at a path that does not exist it prints pushed:false, warns on stderr, and still exits 0. A pipeline reading the exit code would go green having lost the attestation, which is exactly the silence this task says to remove, so the job reads the flag and the docs say why. Two other findings: check gates the 'done with no test proof' signal on the task appearing done on the default branch, so no diff of .ank/ is needed and the job belongs on that branch rather than on every push; and CLAUDE.md never contained an instruction to carry a run id by hand, so half the criterion was already satisfied and only the pointer was added.

--- a/.ank/tasks/TASK-2dff950e5d51.md
+++ b/.ank/tasks/TASK-2dff950e5d51.md
@@ -26,7 +26,7 @@ done_criteria: |
   what the pipeline now does.
 criteria_by: creator
 schema: 2
-version: 3
+version: 4
 ---
 
 Blocked on `attest --detached`, because the recipe is the reason that verb exists
@@ -55,3 +55,4 @@ run, after the matrix, or the corpus grows three identical proofs per task.
 
 ## Log
 - 2026-08-13T06:54:21Z claude-agent-c — Measured, not assumed: ank attest --detached exits 0 whether or not the ref reached the remote. On a scratch corpus with a real file:// remote it prints pushed:true and the ref is there; with the remote pointed at a path that does not exist it prints pushed:false, warns on stderr, and still exits 0. A pipeline reading the exit code would go green having lost the attestation, which is exactly the silence this task says to remove, so the job reads the flag and the docs say why. Two other findings: check gates the 'done with no test proof' signal on the task appearing done on the default branch, so no diff of .ank/ is needed and the job belongs on that branch rather than on every push; and CLAUDE.md never contained an instruction to carry a run id by hand, so half the criterion was already satisfied and only the pointer was added.
+- 2026-08-13T07:05:12Z claude-agent-c — The CLAUDE.md paragraph was written wrong the first time and is corrected: ank done does not fall back on the config's verifiers here, because no task in this corpus declares a verify: list, so done refuses without --proof and names the flag. What the pipeline removes is not the proof but the round trip -- push, wait for green, copy the run id -- so the guidance is to close on commit:<sha>, which is a strong proof already in hand, and let the attest job add the test anchor once the task lands on the default branch. assertion and human-review are the weak types; commit and test are not.

--- a/.ank/tasks/TASK-2dff950e5d51.md
+++ b/.ank/tasks/TASK-2dff950e5d51.md
@@ -5,7 +5,7 @@ slug: a-ci-recipe-that-names-no-vendor-and-this-reposi
 title: A CI recipe that names no vendor, and this repository adopts it
 created: 2026-08-11T22:26:13Z
 author: claude-code@sean-laptop
-status: in_progress
+status: done
 scope:
   - docs/getting-started.md
   - .github/workflows/ci.yml
@@ -25,8 +25,12 @@ done_criteria: |
   CLAUDE.md stops instructing an agent to carry a CI run id by hand and points at
   what the pipeline now does.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 8debfc8e063934e2c2d92472ff76caf0b9f2d42b
+    criteria: f6678d30ca4a
 schema: 2
-version: 4
+version: 5
 ---
 
 Blocked on `attest --detached`, because the recipe is the reason that verb exists
@@ -56,3 +60,4 @@ run, after the matrix, or the corpus grows three identical proofs per task.
 ## Log
 - 2026-08-13T06:54:21Z claude-agent-c — Measured, not assumed: ank attest --detached exits 0 whether or not the ref reached the remote. On a scratch corpus with a real file:// remote it prints pushed:true and the ref is there; with the remote pointed at a path that does not exist it prints pushed:false, warns on stderr, and still exits 0. A pipeline reading the exit code would go green having lost the attestation, which is exactly the silence this task says to remove, so the job reads the flag and the docs say why. Two other findings: check gates the 'done with no test proof' signal on the task appearing done on the default branch, so no diff of .ank/ is needed and the job belongs on that branch rather than on every push; and CLAUDE.md never contained an instruction to carry a run id by hand, so half the criterion was already satisfied and only the pointer was added.
 - 2026-08-13T07:05:12Z claude-agent-c — The CLAUDE.md paragraph was written wrong the first time and is corrected: ank done does not fall back on the config's verifiers here, because no task in this corpus declares a verify: list, so done refuses without --proof and names the flag. What the pipeline removes is not the proof but the round trip -- push, wait for green, copy the run id -- so the guidance is to close on commit:<sha>, which is a strong proof already in hand, and let the attest job add the test anchor once the task lands on the default branch. assertion and human-review are the weak types; commit and test are not.
+- 2026-08-13T07:05:27Z claude-agent-c — done, proof commit:8debfc8e063934e2c2d92472ff76caf0b9f2d42b

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,114 @@ jobs:
       # Exit 8 means findings, and that is a failure here. Signals exit 0.
       - run: cargo run -q --bin ank -- check
 
+  # `done` records what ran on the machine that ran it. That is a local claim,
+  # and `check` says so on the default branch: "done with no test proof: nothing
+  # external anchors it". Ten tasks in this corpus carried that signal, each one
+  # a run that went green and was never written down, and the answer is not for
+  # an agent to copy a run id by hand into `done` -- it is for the run itself to
+  # say what it proved (TASK-2dff950e5d51).
+  #
+  # `check` is the work list, and no diff of `.ank/` is computed here. The signal
+  # is gated on the task appearing done on the default branch, deliberately: on a
+  # feature branch straight after `done` no run has happened yet, so there is
+  # nothing to anchor and this job finds nothing to do. On the push that merges
+  # it, the same signal names exactly what landed.
+  #
+  # After the matrix and never inside it: an attestation is only meaningful once
+  # the tests pass, and one per leg would grow three identical proofs per task.
+  #
+  # `push`, and on the default branch. A pull_request event runs on a merge
+  # commit that no branch carries, and a fork's token cannot push a ref -- which
+  # would fail this job for a reason about the event rather than about the
+  # corpus.
+  #
+  # The branch condition restates a gate that already lives in `check`, and that
+  # is worth naming rather than hiding: on a feature branch the signal does not
+  # fire, so this job would build the binary for two minutes to be told there is
+  # nothing to do, on every push. If ank ever reports unanchored tasks off the
+  # default branch, this line is what stops the pipeline from noticing.
+  attest:
+    name: attest / ubuntu-latest
+    needs: [test, version-check, msrv, msrv-tight]
+    if: >-
+      github.event_name == 'push' &&
+      github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+    runs-on: ubuntu-latest
+    # The one job here that writes, and it writes refs/ank/proof/* and nothing
+    # else: `--detached` produces no commit, so the branch is never touched.
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: the tasks this run anchors
+        id: unanchored
+        run: |
+          code=0
+          out=$(cargo run -q --bin ank -- check --json) || code=$?
+          # The contract, and the whole of it: 8 is findings, 9 is the
+          # environment. Both are red here, and 9 says which so nobody goes
+          # looking for a broken corpus.
+          case $code in
+            0) ;;
+            8) echo "ank check: findings, see the test job"; exit 1 ;;
+            9) echo "ank check: environment unavailable, not a corpus failure"; exit 2 ;;
+            *) echo "ank check: unexpected exit $code"; exit 1 ;;
+          esac
+          ids=$(printf '%s' "$out" | jq -r '
+            .findings[]
+            | select(.message | startswith("done with no test proof"))
+            | .subject')
+          echo "$ids"
+          {
+            echo "ids<<EOF"
+            echo "$ids"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      # Read the flag, not the exit code. A proof is a ref, so it is worth
+      # something only once it reaches the remote -- and when the push is
+      # refused, `attest` still exits 0 and warns on standard error. Trusting
+      # the code would go green having lost the attestation, which is the exact
+      # silence this job was written to remove.
+      - name: anchor them on this run
+        env:
+          IDS: ${{ steps.unanchored.outputs.ids }}
+          ANK_AGENT: process:github-actions
+        run: |
+          if [ -z "$(printf '%s' "$IDS" | tr -d '[:space:]')" ]; then
+            echo "nothing to anchor: every finished task already carries a test proof"
+            exit 0
+          fi
+          failed=0
+          for id in $IDS; do
+            out=$(cargo run -q --bin ank -- attest "$id" \
+              --proof "test:$GITHUB_RUN_ID" --detached --json) || {
+              echo "attest failed for $id"
+              failed=1
+              continue
+            }
+            echo "$out"
+            if ! printf '%s' "$out" | jq -e '.pushed' > /dev/null; then
+              echo "attested $id but the proof never reached the remote"
+              failed=1
+            fi
+          done
+          [ "$failed" -eq 0 ]
+
+      # `--detached` writes a ref and no file. A working tree that moved would
+      # mean the proof landed in the corpus instead, which is a commit this job
+      # must never need.
+      - name: the working tree did not move
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "attest wrote to the working tree; --detached must not:"
+            git status --porcelain
+            exit 1
+          fi
+          echo "clean: the attestation is a ref, not a commit"
+
   # release.yml refuses to build when the tag and the manifests disagree on the
   # version, and it exercises that check against fixtures before trusting it.
   # Both run on a tag or a dispatch and nowhere else, which left the check itself

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,14 +43,16 @@ project dogfooding ank on itself.
    writes the proof. Never edit `status:` by hand, and never report your own
    result: an agent that grades itself can simply be wrong.
 
-**Do not carry a CI run id by hand.** `done` records what ran on your machine;
-the external anchor is the pipeline's job. Once the task lands on the default
-branch, `check` reports it as `done with no test proof` and the `attest` job in
-`ci.yml` anchors it with `ank attest <id> --proof test:<run-id> --detached` — a
-ref, no commit, and the run fails rather than skipping in silence when the proof
-does not reach the remote. Passing `--proof test:<run-id>` to `done` yourself
-duplicates that anchor with a number you copied. The recipe, and the contract it
-rests on, are in `docs/getting-started.md`.
+**Do not push, wait for a green run, and copy its id into `done`.** No task in
+this corpus declares a `verify:` list, so `done` does still require a `--proof` —
+but the one to give it is a proof you already hold, `commit:<sha>`, not a number
+you had to wait for. The external anchor is the pipeline's work: once the task
+lands on the default branch, `check` reports `done with no test proof` and the
+`attest` job in `ci.yml` records `test:<run-id>` on `refs/ank/proof/<id>` with
+`ank attest --detached` — a ref, no commit, and a red run rather than a silent
+skip when the proof does not reach the remote. `assertion` and `human-review` are
+weak proofs and `check` says so; `commit` and `test` are not. The recipe, and the
+contract it rests on, are in `docs/getting-started.md`.
 
 **A criterion that talks about the binary is tested through the binary.** When
 a `done_criteria` says "the binary does X", the test must invoke the binary —

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,15 @@ project dogfooding ank on itself.
    writes the proof. Never edit `status:` by hand, and never report your own
    result: an agent that grades itself can simply be wrong.
 
+**Do not carry a CI run id by hand.** `done` records what ran on your machine;
+the external anchor is the pipeline's job. Once the task lands on the default
+branch, `check` reports it as `done with no test proof` and the `attest` job in
+`ci.yml` anchors it with `ank attest <id> --proof test:<run-id> --detached` — a
+ref, no commit, and the run fails rather than skipping in silence when the proof
+does not reach the remote. Passing `--proof test:<run-id>` to `done` yourself
+duplicates that anchor with a number you copied. The recipe, and the contract it
+rests on, are in `docs/getting-started.md`.
+
 **A criterion that talks about the binary is tested through the binary.** When
 a `done_criteria` says "the binary does X", the test must invoke the binary —
 not only the function meant to produce X. Two real defects slipped through

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -352,6 +352,102 @@ anything, and the message always ends with the exact command to run next.
 Code 9 is the one to read carefully: it says the environment is broken, not
 that your work is wrong. Fix the machine, not the code.
 
+## Running ank in a pipeline
+
+Read this part before the recipes, because the recipes are the easy half. The
+whole integration surface is two things: **an exit code, and `--json`**. Learn
+those and you can write the pipeline for a CI system nobody here has heard of.
+
+`ank check` is the verb a pipeline runs. It exits:
+
+- **0** — the corpus is healthy. Signals exit 0 too: they are observations, not
+  faults, and reddening a build over one teaches a team to stop reading `check`.
+- **8** — findings. This is the failure a pipeline exists to catch.
+- **9** — the environment, not the corpus: git too old, `sh` missing, the default
+  branch indeterminable. Nothing is wrong with the files, and a pipeline that
+  collapses 9 into "the check failed" sends somebody to fix sound work.
+
+`--json` is opt-in on every verb and is what you parse. It carries no colour and
+no layout, and it stays byte-for-byte what your parser already reads.
+
+That is the contract. Everything below is the CI system's own syntax around it.
+
+**A bare shell**, which is the recipe the other two wrap:
+
+    #!/bin/sh
+    code=0
+    ank check || code=$?
+    case $code in
+      0) ;;
+      8) echo "ank check: findings, see above" >&2; exit 1 ;;
+      9) echo "ank check: environment unavailable, not a corpus failure" >&2; exit 2 ;;
+      *) echo "ank check: unexpected exit $code" >&2; exit 1 ;;
+    esac
+
+**GitHub Actions:**
+
+    - name: ank check
+      run: |
+        code=0
+        ank check || code=$?
+        case $code in
+          0) ;;
+          8) exit 1 ;;
+          9) echo "::notice::ank could not run: environment"; exit 2 ;;
+          *) exit 1 ;;
+        esac
+
+**GitLab CI:**
+
+    ank:check:
+      script:
+        - |
+          code=0
+          ank check || code=$?
+          case $code in
+            0) ;;
+            8) exit 1 ;;
+            9) echo "ank could not run: environment"; exit 2 ;;
+            *) exit 1 ;;
+          esac
+
+Three vendors, one contract, and the third one is a shell script in a YAML file
+like the other two.
+
+`ank check || code=$?` and never a bare `ank check` followed by `case $?`: a
+GitHub Actions `run:` block is `bash -e`, so the bare form aborts the step on
+exit 8 and the routing you wrote is never reached. The `|| code=$?` form is what
+survives `set -e`, which is why it is in all three rather than in the one that
+needs it.
+
+**There is no `--format github`, and there never will be.** Annotations,
+folding markers and job summaries are one vendor's protocol, and putting them in
+the binary would couple the tool to a company. A pipeline that wants annotations
+pipes `--json` into whatever produces them — which is exactly the arrangement
+that lets the fourth vendor work without anybody shipping a release for it.
+
+### Anchoring a run
+
+`done` records what ran on the machine that ran it. That is a local claim, and a
+pipeline can anchor the same task to a run anybody can re-read:
+
+    ank attest <id> --proof test:<run-id> --detached
+
+`--detached` writes the proof to `refs/ank/proof/<id>` and touches no file, so
+the pipeline produces **no commit** — it needs no write access to the branch and
+cannot race the merge.
+
+One thing to get right, and it is the reason `--json` matters here. The proof is
+a ref, so it has to reach the remote to be worth anything; if the push is
+refused, `attest` still exits 0 and warns on standard error. A pipeline reading
+only the exit code would go green having lost the attestation. Read the flag
+instead:
+
+    ank attest "$id" --proof "test:$RUN_ID" --detached --json | grep -q '"pushed":true'
+
+This repository's own `ci.yml` does exactly that, and fails the run when it is
+false rather than skipping in silence.
+
 ## Handing the loop to an agent
 
 Four routes install the same file — the `skills` CLI, the Claude Code plugin,


### PR DESCRIPTION
Closes TASK-2dff950e5d51, which was blocked on `attest --detached` (#98) because
the recipe is the reason that verb exists.

## The contract, before any vendor

`docs/getting-started.md` gains a pipeline section that states the contract first,
so a reader on a fourth CI system is not left translating from GitHub: `ank check`
exits **0** on a healthy corpus and on signals, **8** on findings, **9** on a broken
environment, and `--json` is what a pipeline parses. Then the same recipe three
times -- a bare shell, GitHub Actions, GitLab CI -- and the third is a shell script
in a YAML file like the other two.

No `--format github`, no `::error::` annotations, and the section says why:
annotations are one vendor's protocol, and a repository that wants them pipes
`--json` into whatever produces them.

The recipes use `ank check || code=$?` rather than a bare call followed by
`case $?`. A GitHub Actions `run:` block is `bash -e`, so the bare form aborts the
step on exit 8 and never reaches the routing the reader just wrote.

## This repository adopts it

An `attest` job, after the matrix and once per run -- an attestation is only
meaningful once the tests pass, and one per matrix leg would grow three identical
proofs per task. It anchors what `check` reports as unanchored with
`ank attest --detached`: a ref under `refs/ank/proof/<id>`, no commit, no write to
the branch.

**It reads `"pushed"` out of `--json`, not the exit code, and that is the whole
point of the job.** Measured on a scratch corpus with a real `file://` remote:

| remote | stdout | stderr | exit |
|---|---|---|---|
| reachable | `"pushed":true` | — | 0 |
| unreachable | `"pushed":false` | `warning: proof not pushed` | **0** |

A pipeline trusting the exit code would go green having lost the attestation --
the same silence that left ten `done` tasks in this corpus anchored to nothing.

No diff of `.ank/` is computed anywhere: `check` gates that signal on the task
appearing done on the default branch, so the signal *is* the work list. The job
condition restating that gate is named in the comment, since it is what would hide
a future change to it.

## CLAUDE.md

Half the criterion was already satisfied -- CLAUDE.md never told an agent to carry
a run id by hand. What it gains is the pointer, and a correction I got wrong on the
first pass: `done` does **not** fall back on the verifiers in `config.yml` here,
because no task in this corpus declares a `verify:` list, so it refuses with code 5
and names `--proof`. Verified by running it. What the pipeline removes is the round
trip -- push, wait for green, copy the id -- so the guidance is to close on
`commit:<sha>`, a strong proof already in hand.

## Verification

CI run [31676375727](https://github.com/haksolot/ank/actions/runs/31676375727):
green, 447 tests, `ank check` clean. The `attest` job correctly **skipped** on this
branch, which is its designed behaviour off the default branch.

This task is itself closed on `commit:` rather than `test:<run-id>`, dogfooding the
practice it introduces.

**Residual gap, stated plainly:** the `attest` job's own steps first execute on the
push that merges this. What is verified before then is the half that decides
correctness -- the `pushed` flag semantics above, measured through the binary -- and
the job's skip condition. The `jq` extraction filter was exercised against this
corpus's real `check --json` output, which currently names ten unanchored tasks;
those are what the first main run will anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011FhetohH64Sy7cCE78gwQC
