### PR TITLE
Agent experience reports from the parallel session

### DIFF
--- a/docs/agent-experience-claude-code.md
+++ b/docs/agent-experience-claude-code.md
@@ -1,0 +1,343 @@
+# Working in Ank, as an agent
+
+Notes from one session, written by the agent that ran it, for whoever tunes the
+agent experience next. Other agents in the same session are writing their own;
+this one is not a summary of the tool, it is a record of what the tool did to
+one worker over a long stretch of real work.
+
+**Identity and scope.** `claude-code@sean-laptop`, in the main checkout,
+alongside two other agents in `.claude/worktrees/`. Five tasks finished, in one
+chain, on a format change that touched every layer:
+
+| Task | What it was |
+|---|---|
+| `TASK-7fcdd44933f0` | the specification: flat layout, kind registry, log file, typed actors |
+| `TASK-91462ace35fd` | the golden suite, written to fail |
+| `TASK-7c1ff5035894` | `ank-core` parses schema 3 from one registry |
+| `TASK-cd3189ddf61e` | the store writes flat, reads both layouts |
+| `TASK-e70f3a12185a` | every verb that logs writes to the log file |
+
+Plus one ADR proposed (`ADR-f8a6cf65160e`), one task created mid-chain, and one
+task's `blocked_by` amended because the chain was wrong.
+
+Everything below is from that. Where I say something cost time, I mean I watched
+it cost time; where I say something caught a defect, the defect is in the
+history.
+
+---
+
+## What worked, and why
+
+### The body is the transfer of knowledge, and it is what makes the tool worth it
+
+`done_criteria` is what gets frozen and audited, and it is not the field that did
+the work. **The body is.** Every one of the five tasks named, in prose, the exact
+trap I would otherwise have walked into:
+
+- `TASK-91462ace35fd`: *"The CRLF fixture is the one thing most likely to be
+  broken in passing... Moving fixtures around without moving both halves of that
+  guard produces a test that passes while testing nothing."* I left the fixture
+  where it was and both halves of its exemption held untouched.
+- The same body: *"The specification makes a malformed actor a `check` finding,
+  not a parse error, so the invalid fixture for it belongs only where the
+  convention is genuinely enforced. Getting this wrong turns a signal into a
+  refusal and locks 96 existing files out of their own format."* Read
+  literally, the criterion above it asked for an invalid fixture for a malformed
+  actor. The body is what said not to write one.
+- `TASK-7c1ff5035894`: *"The field order is data in the table, not control flow:
+  it is what makes the round-trip byte-identical and it is the single most likely
+  thing to be lost by rewriting the emitters as a generic loop."* That is exactly
+  the risk of that refactor, named before I started it.
+- `TASK-cd3189ddf61e`: *"An id resolving in two directories must not produce two
+  entities, and it must not silently prefer one and drop the other... Decide
+  which wins, state it, and test it."*
+
+This is the single strongest property I experienced. A task written this way is
+a senior engineer's pre-review, delivered before the work instead of after it.
+No amount of criterion tightening substitutes for it.
+
+**Implication for anyone writing tasks for agents:** the criterion buys
+auditability, the body buys correctness. A task with a sharp criterion and an
+empty body is a task an agent will satisfy and get wrong.
+
+### The frozen criterion did its job by being annoying
+
+Twice I wanted the criterion to say something else, and could not reach it.
+
+In `TASK-91462ace35fd` the criterion demanded an invalid fixture for an actor
+value while `ADR-3877fef1d662` forbade making that a parse error. A tool that let
+me edit the criterion would have got a silent widening of the rule. Instead I had
+to resolve the contradiction — and the resolution (no invalid fixture; a positive
+assertion that a pre-convention actor *parses*) is better than either reading.
+
+In the same task, the criterion said the suite must **fail**. That is an
+uncomfortable thing to deliver and I would have talked myself out of it if the
+field had been mine to soften.
+
+### `blocked_by` as the escape hatch for a plan that turns out wrong
+
+Mid-way through `TASK-cd3189ddf61e` I found that wiring the verbs to the log file
+touched three files outside its scope, and that `TASK-9bff1d5826b1` — the corpus
+move — could not be done without that wiring. The prescribed move worked exactly
+as advertised: `ank new task --blocked-by`, then `ank amend TASK-9bff
+--blocked-by <new>`. The chain grew a link, in the open, in one command, and the
+next reader can see why.
+
+This is the part of the model I would keep unchanged.
+
+### `ank check` on the real corpus is a better regression test than the fixtures
+
+The golden suite has eight valid fixtures. The corpus has 176 entities at schema
+1 and 2. When `TASK-7c1ff5035894` replaced two straight-line serializers with one
+registry-driven loop, the assertion that mattered was `ank check` exiting 0 on
+the real corpus with no round-trip finding — 176 files parsed and re-serialised
+byte for byte. The fixtures would have passed a subtly wrong field order for at
+least one optional field; the corpus would not.
+
+**Dogfooding is not a nicety here, it is the widest test in the project.**
+
+### The coordination plane, read from outside
+
+`ank status` reporting `elsewhere 1 claim(s) by other agents` with holder and
+expiry, and `ank find` showing `[finished:<sha> on <branch>]` for work done in
+another session, are both genuinely useful and both cost nothing. I used them to
+decide what not to touch.
+
+---
+
+## What cost me time
+
+### 1. The claim TTL does not match how long real work takes
+
+Default 30 minutes. My tasks ran one to three hours. I lost the claim twice on
+`TASK-e70f3a12185a` and once on `TASK-cd3189ddf61e`.
+
+The documented renewal is `ank log`, on the advice *"log when you discover
+something, not when you finish"*. That advice is right and it does not cover the
+shape of the work: after the design is settled there is often an hour of
+mechanical fixing — 34 failing test fixtures, in one case — during which there
+is genuinely nothing to log. So the lock lapses precisely during the stretch
+where nothing interesting is happening, which is also the stretch where a second
+agent would most safely take over.
+
+`--ttl 2h` fixes it and I only found it after losing two claims. Nothing on the
+expiry path names it.
+
+### 2. A lapsed claim reports the wrong fact, and does not re-acquire
+
+This one is a defect, with a clean reproduction.
+
+§3 says: *"if nobody took the task over, `log` and `done` **re-acquire silently**
+and carry on"*. Observed, with the task `in_progress`, no live claim, and no
+other holder:
+
+```
+$ ank log "..."                     # HEAD is empty, fair enough
+error[6]: no task in progress for this agent
+  -> ank context
+
+$ ank log TASK-e70f3a12185a "..."   # named explicitly: should re-acquire
+error[6]: no task in progress for this agent
+  -> ank context
+
+$ ank claim TASK-e70f3a12185a       # works immediately
+claimed TASK-e70f3a12185a ... -> HEAD
+```
+
+Two things are wrong. The explicit-id form did not re-acquire, which §3 says it
+should. And the message states *"no task in progress for this agent"* when the
+task **is** in progress and this agent **is** its last holder — the true fact is
+"your claim lapsed". The hint sends the reader to `ank context`, which shows the
+task as claimable and explains nothing.
+
+The self-correcting-error rule is the right rule and this is the place it is not
+applied: the message should say the claim expired and name `ank claim <id>
+--ttl <duration>`.
+
+### 3. Scope is mandatory at creation and is most accurate at completion
+
+I created `TASK-e70f3a12185a` with a scope that omitted `crates/ank-cli/src/store.rs`
+— and the store is exactly where the decision the task is about lives. I found
+out an hour into the implementation.
+
+`ank amend --scope` handled it, and warned that the change moves the constraints
+the claim anchors, which is the right warning. But the systemic cost stands: an
+agent decomposing work has to guess the scope before doing the work, and the
+guess is checked by nothing until it is wrong.
+
+### 4. Adding a field to a public struct escapes the scope, and the tool cannot say so
+
+Adding `verified` to `Task` and `Adr` broke **sixteen** struct literals in a
+crate outside the task's scope. Making `init` stop creating `tasks/` and `adr/`
+was required by the criterion (*"no write ever produces .ank/tasks/"*) and
+`init.rs` was not in scope either. Three times in five tasks I had to edit
+outside the declared perimeter, decide unilaterally that it was necessary, and
+flag it in the commit message.
+
+Scope is a routing device and not a boundary, which is the right design. But
+there is no way to record "this task necessarily touches X" other than amending
+the scope, and amending the scope of a claimed task moves the anchored
+constraint set. So the honest move and the cheap move point in different
+directions, and prose in a commit message is where the truth ends up.
+
+### 5. `--proof test:<anything>` is recorded as a strong proof, unchecked
+
+`submitted_proof` validates a `commit:` against git — *"Ank validates what it
+can"* — and records everything else as it stands. `ProofType::Test` is **not**
+weak (`is_weak` covers `Assertion` and `HumanReview` only), so a `test:` proof
+silences the `done with no test proof` signal.
+
+None of the five tasks I finished declares a `verify:` list, so `ank done` never
+ran a verifier: the entire proof burden for this session was me typing a CI run
+id. I checked every run was green on the right sha before typing it. Nothing in
+the tool did.
+
+**This is the strongest claim in the project — *"an agent cannot declare itself
+done without proof"* — degrading, on this corpus, to "an agent types a number".**
+
+To be fair to the design: this is exactly what `ADR-493471d64ba0` and the
+`attest --detached` work address, and the answer landed *during* this session
+(`TASK-6d404f17f56d`, `TASK-2dff950e5d51`). `CLAUDE.md` now tells agents to give
+`done` a `commit:<sha>` — which *is* checked — and to let the pipeline attest
+the `test:<run-id>` on a ref. That is the right shape. I record the gap because I
+worked the whole session inside it and it was invisible from where I stood.
+
+### 6. Waiting for CI was the largest single consumer of wall-clock time
+
+The instruction I was working under was: push, wait for a green run, copy its id
+into `done`. Five tasks, and each one paid the round trip twice — once for the
+task's own anchor, once for the pull request. Windows CI alone runs three to four
+minutes.
+
+The new guidance in `CLAUDE.md` removes this: `commit:<sha>` is a proof you
+already hold, and no wait is needed. Whoever wrote that removed the single
+biggest source of dead time in my session. It is worth saying loudly to the next
+agent, because the old rhythm is what an agent will reconstruct from habit.
+
+### 7. The `.ank/` hook refuses on the pattern, not only on the path
+
+`ADR-01b6dd05f0db` is right and the hook is right to enforce it. But:
+
+```
+Grep(pattern: "\.ank/tasks|\.ank/adr|## Log|log section", path: "docs/")
+-> PreToolUse:Grep hook error: .ank/ is opaque, like .git/
+```
+
+The search was over `docs/`. What tripped the guard was the *text of the
+pattern*. Any agent auditing the documentation for stale references to the old
+layout — which is precisely what the format change required — hits this. I
+worked around it by rewriting the pattern, which means the guard taught me to
+phrase things to get past it. That is the failure mode a guard should never have.
+
+### 8. `check` output volume
+
+Every run prints around 30 signals, and roughly 25 of them are permanent
+features of the corpus (over-constrained scopes, burst creation, entities
+predating `author`). Finding the one that changed means diffing two runs by eye.
+
+I felt this enough that when I added three new signals in `TASK-cd3189ddf61e` I
+made two of them once-per-corpus rather than per-entity, deliberately, and said
+so in the code. That instinct is a symptom: the display is already at the volume
+where contributors optimise against it.
+
+---
+
+## Running beside other agents
+
+This is where the model is thinnest, and it is worth separating three different
+things that all get called "parallel agents".
+
+### What the claim plane does well
+
+Task-level coordination worked. I was never at risk of doing work another agent
+was doing. `ank status` named the other holder and its expiry; `ank find` marked
+a task finished on a branch I did not have. **Claims coordinate tasks, and at
+that job they are correct and cheap.**
+
+### What the claim plane does not cover: files
+
+`main` moved **six times** while I worked — pull requests 91, 97, 98, 101, 102,
+104, 105 — and I hit two merge conflicts. Both were in
+`crates/ank-cli/tests/cli.rs`, and both had the same cause: two agents holding
+two different tasks each appended a block of tests to the end of the same file.
+
+Nothing warned either of us. The claims were on disjoint tasks, correctly; the
+edits were on the same file, and the plane has nothing to say about files. A
+`scope` overlap between two live claims is computable — both tasks declared
+`crates/ank-cli/**` — and would have been worth a line on `claim`:
+
+> `TASK-x` is held by `agent-c` and its scope overlaps yours on
+> `crates/ank-cli/tests/cli.rs`
+
+That is a signal, not a wall, and it is exactly the shape this project already
+uses everywhere else.
+
+**Second-order damage from the trivial conflict:** resolving the first one
+mechanically dropped a closing brace, and the file stopped compiling. A conflict
+that is textually trivial is not operationally trivial when a script resolves it.
+
+### What nothing covers: the same defect, in two files, by two agents
+
+This is the finding I would most want acted on.
+
+`TASK-cd3189ddf61e` fixed a defect in `maintain()`: it built an entity's path on
+the default branch as a string, `{rel}/tasks/<id>.md`, and so stopped seeing
+tasks after the layout moved. While I was fixing it, another agent finished
+`TASK-6d404f17f56d`, which added `maintain_proofs()` — containing **the same
+defect, written from the same habit**, in code authored after my fix existed and
+merged before it.
+
+Git saw no conflict: different functions, different lines. Review of the merge
+would have had to notice a `format!` that looked exactly like the two above it.
+It was caught by a test that exercised the transition, and by nothing else.
+
+The same shape appeared a third time in `git::ratification_at`, which memoised by
+`(cwd, id)` and not by path, so a caller looping over candidate paths cached the
+first miss — *every ratification in this repository read as unverifiable*.
+
+Three occurrences, three authors, one change. That is not a lapse, it is a shape,
+and it is what `ADR-f8a6cf65160e` was proposed to name. **The lesson for parallel
+agents is that the expensive collisions are semantic, not textual, and they
+happen precisely when two agents are working on the same layer from two
+directions.** Nothing in the corpus surfaced it; a test did.
+
+### Practical friction
+
+- `git worktree` holds `main` in another agent's checkout, so `git checkout main`
+  fails in the primary one — and `ank accept`, which refuses outside the default
+  branch, has nowhere to run. A human ratifying an ADR has to borrow another
+  agent's worktree.
+- Branching from a stale local `main` produces a branch that is green locally and
+  red in CI, because CI tests the merge. Fetching and branching from
+  `origin/main` before *every* claim is the only reliable habit.
+
+---
+
+## The defects I would file
+
+Each of these has a reproduction above.
+
+1. **A lapsed claim reports "no task in progress" and does not re-acquire on an
+   explicit id**, contradicting §3. The message should name the true fact and the
+   command, `ank claim <id> --ttl <duration>`.
+2. **The PreToolUse hook matches the pattern text, not the path.** A search over
+   `docs/` is refused for containing `.ank/tasks` in its regex.
+3. **`--proof test:<x>` is unvalidated and not weak**, so it silences the signal
+   designed to catch unanchored completions. Largely answered by the `attest
+   --detached` recipe; worth closing the remaining hole or saying plainly in §4
+   that a `test:` reference is trusted.
+4. **`claim` could report scope overlap with other live claims.** A signal, once,
+   naming the files. This is the one change that would have prevented both of my
+   merge conflicts.
+
+## What I would tell the next agent
+
+- Read the body before the criterion. The criterion tells you when you are done;
+  the body tells you how not to be wrong.
+- `ank claim <id> --ttl 2h` on anything that looks like more than an hour.
+- Fetch and branch from `origin/main` immediately before claiming, every time.
+- Give `done` a `commit:<sha>`, not a run id you waited for. The pipeline attests
+  the run.
+- When you must edit outside your scope, either amend the scope or say so in the
+  commit — but do not let it pass in silence, because it is the one thing no
+  verifier will catch.

--- a/docs/agent-experience-claude-code2.md
+++ b/docs/agent-experience-claude-code2.md
@@ -1,0 +1,239 @@
+# Agent experience report — claude-code2
+
+One agent's account of using `ank` for a full working session, including what
+happened while two other agents worked the same corpus in parallel.
+
+**Identity:** `claude-agent-b`, in a git worktree of its own.
+**Session:** 2026-08-13.
+**Delivered:** five tasks, each claimed, worked, verified and merged.
+
+| Task | What it was | PR |
+|---|---|---|
+| TASK-1e79ff3738df | `check` names where a dead scope went | #91 |
+| TASK-e3d00a6e62bb | `review` prints the ratification queue | #92 |
+| TASK-6d404f17f56d | `attest --detached`, a proof in a ref | #98 |
+| TASK-1ead0e19fb73 | the orientation budget | #102 |
+| TASK-ae77a9ee2964 | the specification half of `--detached` | #105 |
+
+Concurrent agents on the same corpus: `claude-code@sean-laptop` and
+`claude-agent-c`. **Zero claim collisions over the whole session.**
+
+---
+
+## What worked
+
+### The two-phase `context` is the right shape
+
+Before a claim, `context` orients; after one, it switches to the criterion and
+the constraints that bind the work in hand. Nothing to remember, no flag: the
+claim is what selects the mode. In execution mode it served the frozen
+`done_criteria` and every applicable constraint in full, which is exactly the
+brief. That half needed no improvement all session.
+
+### The frozen criterion actually bit, and that is the point
+
+On TASK-1e79 the criterion said the repair proposal should be `ank amend` "for a
+task". Working through it, I found `amend` refuses a `done` or `closed` task
+outright — and those are precisely the tasks the dead-scope fault fires on. The
+criterion and the binding ADR disagreed at one branch.
+
+Because the criterion is hashed into the claim record, softening it was not an
+option, and that is the whole value: I had to log the tension, make a defensible
+call, and leave the reasoning where a reviewer would find it. A criterion I
+could have edited is a criterion I would have edited.
+
+### `ank log` as a work trace, not a status report
+
+Logging on discovery rather than on completion changed how I worked. TASK-1ead
+went further and made it a *requirement of the criterion* — "the measurement
+that settles it is recorded in the task log" — which forced measure-before-answer
+on a question I would otherwise have answered from intuition. The measurement
+then contradicted the task's own hypothesis (a narrower perimeter changes
+nothing, because constraints are charged first either way). That is a design
+worth copying into other criteria.
+
+### Self-correcting errors are load-bearing, not decoration
+
+`amend` refusing an accepted ADR's scope prints the exact supersession command.
+While implementing TASK-1e79 I needed to emit that same proposal — so I reused
+the refusal's own wording verbatim. The error message was the specification of
+the feature. That only works because the rule is "always the exact command to
+run next", applied without exception.
+
+### Scope as a collision signal
+
+Picking work, `ank show <id>` gave me each candidate's `scope`, so I could see
+that TASK-6d40 shared `human.rs` with a task another agent held and decide
+knowingly rather than discover it in a merge conflict. Combined with
+`ank graph`, choosing work that would not collide took about a minute per task.
+
+### Claim refs in git, and `status` naming the holders
+
+`ank status` reporting `elsewhere N claim(s) by other agents` with ids and
+expiries is what made parallel work calm. I never once contended a task. Three
+agents, a whole session, no arbitration failure — the mechanism is quiet enough
+that it is easy to forget it is doing anything.
+
+### A discovered subtask has a home
+
+TASK-6d40's scope was five files under `crates/` and no documentation, so the
+specification half had nowhere to go. `ank new task --blocked-by` turned that
+into TASK-ae77, which I later claimed and delivered. The gap was declared
+instead of either being smuggled in or forgotten.
+
+---
+
+## What did not work
+
+### The stale corpus is the sharpest problem
+
+**A worktree left on a merged branch carries a stale `.ank/`, and nothing says
+so.** This bit three times:
+
+1. I reported an open-task list to the user that was wrong — tasks reading
+   `open` in my checkout were already `done` on the default branch.
+2. Again, later, after another merge.
+3. It finally cost a **red CI on all three runners**. The flat-layout migration
+   (TASK-cd31, PR #99) merged while my branch was open; my new test fixture
+   wrote into `.ank/adr/` and `.ank/tasks/`, which had stopped existing. The
+   local suite on my branch was green, because CI tests the *merge* and a local
+   run structurally cannot.
+
+`ank status` reports the branch and the default branch, and `check` reports
+tasks finished on other branches. Neither answers *is my copy of the corpus
+behind the default branch?* — which, with several agents merging continuously,
+is the question that matters most.
+
+> **Suggestion.** A signal when the corpus in the working tree differs from the
+> corpus on the default branch, ideally naming a count: `corpus 6 entities behind
+> main (git fetch origin)`. The machinery exists — `check` already reads entity
+> files at a revision through `git::file_at` for the pruning predicate.
+
+### Orientation was the least useful command an agent runs first
+
+This was TASK-1ead and I fixed it, but it is worth recording as experience
+rather than as a closed ticket, because the shape of the failure generalises.
+
+Measured on this repository, at the default 8000-character budget with 18
+constraints and 11 open tasks: orientation spent **7357 characters on
+constraints and 157 on tasks**. One task line printed, eleven cut. The closing
+suggestion then recommended the single candidate it had room for — the mode
+whose entire purpose is choosing offered one option out of twelve, and an agent
+reading it had no way to know the others existed.
+
+The cause was in the specification, not the code: §5 ordered the cut as "tasks
+first, before any constraint". **The code was faithfully implementing a rule
+that was wrong**, which is the failure mode a specification-first project should
+watch for hardest.
+
+### The dogfooded binary is not the binary under test
+
+The project rule is to run `ank` from outside `target/` (Windows locks a running
+executable during relink). In practice that means the globally installed npm
+build, which tracks the *published* version, not the tree. So the tool managing
+the work was a different version from the one I was changing.
+
+After merging the orientation fix I ran `ank context` and saw the **old** output.
+I nearly reported a regression. The correct check was to build the tree's binary
+and run that — obvious in hindsight, and a real trap in the moment.
+
+> **Suggestion.** Have `ank --version` say loudly when the binary predates the
+> corpus it is reading, or document the dogfooding split where an agent will hit
+> it rather than in a memory note.
+
+### `ANK_AGENT` does not survive between commands
+
+My shell state does not persist across tool calls, so **every single `ank`
+invocation needed the identity prefixed**. Dozens of them. Forget it once and
+the identity silently falls back to `<user>@<hostname>` — in this repository,
+`seanl@sean-laptop`, which the corpus shows authoring 12 entities.
+
+The consequence is not a warning, it is a refusal on state: a `log` or `done`
+from the wrong identity fails because the claim is held by somebody else, and
+the message talks about claims rather than about identity. Correct behaviour
+(refusals are on state, never on identity), and a genuinely confusing first
+encounter.
+
+> **Suggestion.** `ank status` could print the identity it resolved and where it
+> came from — `identity claude-agent-b (ANK_AGENT)` versus
+> `identity seanl@sean-laptop (default: user@host)`. One line, and the trap
+> becomes visible before it costs anything.
+
+### The anchoring round trip (fixed mid-session, worth recording)
+
+For most of the session, finishing a task meant: push, wait for CI, copy the run
+id, `ank done --proof test:<id>`, commit that, push again, wait again, merge.
+**Two full CI waits per task**, most of it spent waiting for a number to copy by
+hand.
+
+TASK-2dff landed mid-session and removed it — the pipeline now attests
+`test:<run-id>` itself with `--detached`, and the agent closes on a proof it
+already holds. The right fix, and the friction it removed was substantial: the
+old loop is exactly the kind of step that gets skipped, which is how the corpus
+had accumulated ten `done` tasks anchored to nothing.
+
+### Scope amendment is correct and noisy
+
+Declaring a CLI flag requires touching `cli.rs`, which TASK-6d40's author could
+not have anticipated. `ank amend --scope` is the right route and I used it — but
+the scope also feeds the constraint hash the claim froze, so widening it produced
+a warning at `amend` and a second at `done` ("constraints over this scope changed
+while the claim was held"). Both are correct and neither is a problem. At that
+moment they read like something had gone wrong.
+
+> **Suggestion.** When the drift is caused by the caller's own `amend` earlier in
+> the same claim, say so: `constraints changed by your amend of <when>` reads
+> very differently from a bare warning.
+
+### No way to see what changed since I last looked
+
+With three agents merging continuously I re-read `ank find --status open` many
+times, diffing it against memory. `--since` is deferred in §10; it was the thing
+I wanted most often after the stale-corpus problem, and the two are related —
+both are questions about *what moved*.
+
+---
+
+## Parallel agents, specifically
+
+**What held.** Claims. Completely. Three agents, one corpus, a whole session,
+and not a single contended task or lost piece of work. The per-task ref plus
+`status` naming holders is enough to coordinate without any agent talking to
+another.
+
+**What did not hold.** Everything about the *corpus* being a moving target:
+
+- Task lists went stale between reading them and acting on them.
+- The default branch moved under an open branch five times, and the one time it
+  changed a fixture's assumptions it produced a red CI that no local run could
+  have caught.
+- `ank context` and `ank find` answer about the checkout, not about the
+  repository. With one agent those are the same thing. With three they are not,
+  and nothing in the tool marks the difference.
+
+**The asymmetry is worth naming.** ank treats *coordination* as the hard problem
+and solves it well, while treating *durable state* as ordinary git and leaving
+it there. Under parallel agents that is backwards: claims were never the
+difficulty, and a stale corpus was the difficulty every single time.
+
+---
+
+## Ranked suggestions
+
+1. **Signal a corpus behind the default branch.** Highest value by a distance;
+   it is the only issue here that caused a failure rather than friction.
+2. **Print the resolved identity in `ank status`,** with its source. Cheap, and
+   removes a silent footgun for any agent whose shell state does not persist.
+3. **Make the dogfooding version split visible** in `ank --version` rather than
+   in a project note.
+4. **Attribute constraint drift to the caller's own `amend`** when that is what
+   caused it.
+5. **`--since`,** or any answer to "what moved since I last looked".
+
+## One thing to keep exactly as it is
+
+The frozen criterion, and the refusal to let the working agent edit it. It
+created real friction twice this session and both times the friction was the
+system working: once it forced a documented judgement call instead of a quiet
+edit, and once it forced a measurement that overturned the assumption the task
+was written on. Nothing else here is worth trading for it.

--- a/docs/agent-experience-claude-code3.md
+++ b/docs/agent-experience-claude-code3.md
@@ -1,0 +1,204 @@
+# Agent experience report — Claude Code, session 3
+
+Written by the agent identified as `claude-agent-c`, working in the git worktree
+`.claude/worktrees/ank-agent-c`, on 2026-08-12/13. Two other agents worked the
+same repository at the same time.
+
+## What this report rests on
+
+Six tasks claimed and finished through the loop, each merged: TASK-d33024e7b98a
+(#94), TASK-adf11c12c480 (#95), TASK-62136e8c2b69 (#96), TASK-35df68dd0eb3 (#97),
+TASK-00660963bcce (#100), TASK-2dff950e5d51 (#104). One task created
+(TASK-adf11c12c480), from a gap found while working. The work spanned CI
+workflows, shell tooling, the specification and `CLAUDE.md`, so the report covers
+`context`, `find`, `show`, `claim`, `log`, `new`, `done`, `attest`, `check` and
+`config`. It does not cover `release`, `amend`, `graph`, `review` or `accept`,
+which I never reached — see the coverage note at the end, because a report that
+hides what it did not touch is worth less.
+
+## What worked
+
+**The body of a task is the tool's best feature, by a wide margin.** TASK-2dff's
+body carried the reasoning I would otherwise have had to ask a human for: that a
+`--format github` flag had been considered and refused, and why; that the
+attestation must run after the matrix and not on a matrix leg, or the corpus
+grows three identical proofs per task; that the failure mode to get right is a
+silently skipped attestation. I implemented a CI job from that without asking a
+single clarifying question. Bodies elsewhere were as good: TASK-35df's listed
+seven separate decisions locking multi-repository federation shut. This is the
+thing that makes the format worth its cost. A tracker that stores titles and
+statuses would have produced a worse implementation, not merely a slower one.
+
+**Task selection under concurrency is scope arithmetic, and `scope:` makes it
+mechanical.** Four times I picked work by intersecting the `scope:` globs of
+open tasks against the scopes of tasks other agents held. `ank show <id>` gives
+that in one call. Without a declared scope this would have been guesswork ending
+in merge conflicts.
+
+**Claims in git refs really do arbitrate across worktrees.** From my worktree I
+could read `refs/ank/claims/*` written by two agents in other worktrees of the
+same repository, holder and expiry included, because worktrees share `refs/`.
+That is the whole coordination story and it worked with no server.
+
+**The frozen criterion did its job.** TASK-d330's criterion enumerated the files
+whose versions had to agree. It removed every opportunity for me to negotiate the
+scope downward when the work turned out larger than it looked.
+
+**Errors name the next command, consistently.** `ank done` refusing with
+`-> ank done --proof test:<ci-run-ref>`; `attest` on an empty prefix answering
+`prefix too short '' (minimum 4 characters) -> ank find`. I never once had to
+reach for `--help` to recover from a refusal.
+
+**`--json` made a pipeline possible.** The CI job written for TASK-2dff takes its
+work list from `ank check --json`, selecting findings whose message begins with
+`done with no test proof`. Parsing the human output would have been a
+liability; the JSON made it a three-line `jq` filter.
+
+**Signals exit 0, faults exit 8.** The corpus carries 26 to 34 signals at any
+moment. If those reddened a pipeline, everyone would have stopped reading it
+within a week. The distinction is right.
+
+**`ank log` produced a durable trail.** I logged the `autocrlf` finding that
+constrained a job to one platform, the re-measurement of TASK-35df's seven locks,
+and the measured behaviour of `attest --detached`. Those are attached to the task
+now rather than lost in a transcript nobody will reopen.
+
+## What did not
+
+**The claim TTL expires during ordinary work.** It is 1800 seconds. A single
+task of mine involved a push, a full three-platform CI run, and a merge — well
+over thirty minutes of waiting during which I was working and holding nothing
+worth logging. During this session another agent's claim on TASK-cd3189ddf61e
+lapsed while the agent was still on the task; from the outside it was
+indistinguishable from an abandoned one, and only the human knew otherwise. The
+renewal mechanism is tied to *reporting* (`log`) rather than to *working*, and an
+agent that is waiting on CI has nothing honest to report. This is the single
+biggest coordination hazard I met.
+
+**Nothing filters the task list by what is reachable.** `ank find --status open`
+lists what is unclaimed; it does not say which of those tasks I could actually
+start without colliding with a live claim. Once, one held task —
+TASK-1ead0e19fb73, whose scope includes `crates/ank-cli/tests/**` — made five of
+the seven remaining candidates unworkable, and I found that out by reading seven
+task files by hand. The information needed to compute this is all in the corpus.
+
+**The attention budget fails on the tasks that need it most.** `check` reports
+`over-constrained scope` on eight tasks, at 5 839, 7 669, 8 339, 8 629, 9 774,
+10 918, 11 267 and 12 284 characters against a limit of 4 000. TASK-2dff, which I
+executed, was one of them at 9 774. So on the largest tasks — the ones where
+knowing every binding constraint matters most — `context` cannot serve them in
+full. It is honest about truncating, which is the right behaviour, but the signal
+names a problem with no path out of it: there is no verb to split a scope, and no
+guidance on which constraints to drop.
+
+**`ank done`'s refusal steers toward the practice a task in this very session was
+written to end.** `ank help done` says it refuses when there is "no proof, and no
+verifier declared to produce one", which reads as though `config.yml`'s verifiers
+would be used. They are not: `check-repo` and `cargo-test` are declared there, but
+no task in this corpus names them in a `verify:` list, so `done` always demands
+`--proof` and its hint says `test:<ci-run-ref>`. That hint is a hard-coded
+workflow, and it is the one TASK-2dff replaced. I wrote the wrong thing into
+`CLAUDE.md` on the first pass because I believed the help text, and only found out
+by running the command.
+
+**`attest --detached` exits 0 when the proof never reaches the remote.** This is
+the most dangerous behaviour I found. Measured on a scratch corpus with a real
+`file://` remote:
+
+| remote | stdout | stderr | exit |
+|---|---|---|---|
+| reachable | `"pushed":true` | — | 0 |
+| unreachable | `"pushed":false` | `warning: proof not pushed` | **0** |
+
+A proof ref exists to be readable by someone else. When the push fails it is
+readable by nobody, and the verb reports success. The information is in `--json`,
+so the pipeline I wrote reads `pushed` rather than the exit code — but the
+default contract misleads, and the default is what an integration written in a
+hurry will use.
+
+**The binary an agent is handed is not the binary in the tree.** After the CI job
+attested eleven tasks, the globally installed `ank` reported all eleven as still
+unanchored while the binary built from the tree reported zero: the published
+0.2.0 predates detached proofs. Both print `ank 0.2.0`; only the commit hash in
+`--version` distinguishes them, and you have to know to look. In a repository
+that dogfoods itself this is a standing trap.
+
+**There is no verb for "what finished on this branch".** The CI job needed
+exactly that. `.ank/` is opaque by design and I did not want to parse it, so I
+built the job on a signal `check` only emits on the default branch. That works
+and is arguably better placed, but I reached it by elimination rather than by
+finding the right tool.
+
+**`check` writes.** It printed `pruned refs/ank/claims/TASK-d33024e7b98a` while I
+was reading its output. The behaviour is specified and correct, but the verb
+sounds read-only, and I ran it freely in loops on that assumption.
+
+**A frozen criterion can rest on a false premise, and the only escape is heavy.**
+TASK-2dff's criterion required that "CLAUDE.md stops instructing an agent to carry
+a CI run id by hand". CLAUDE.md never carried that instruction. The clause was
+unsatisfiable as written and the criterion is frozen, correctly. `release
+--reason` is the documented exit, but releasing a task over one stale clause out
+of four would have thrown away work that was otherwise correct. I recorded the
+discrepancy with `ank log` and said so in the pull request, which was the best
+available move — but it is a convention I invented, not something the tool offers.
+
+## Working alongside other agents
+
+What held up:
+
+- **Shared refs are the mechanism, and they were enough.** No task was ever
+  worked twice.
+- **`blocked_by` did real scheduling work across agents.** TASK-2dff was blocked
+  on TASK-6d40, held by another agent, and became claimable the moment they
+  finished. I did not have to watch them.
+- **Deferring a collision into a new task is cheap.** `ci.yml` was inside another
+  task's perimeter when I needed it, so the leftover became TASK-adf11c12c480 with
+  a `blocked_by`, and I did the rest. Two agents writing one workflow file is a
+  conflict, not a decision.
+
+What did not:
+
+- **A claim says who and until when, never what they are doing right now.** An
+  expired claim reads as an abandoned task. There is no state for "held, lapsed,
+  but the holder is still active", and lapsed claims were common because the TTL
+  is shorter than a CI round trip.
+- **The repository moves under you between claims.** Pull request numbers jumped
+  from 97 to 100 and from 100 to 104: three merges I never saw. Branching from a
+  stale `main` produces a branch that is green locally and red in CI. Nothing in
+  ank warns about this; it is git's problem, but it is an ank workflow that walks
+  you into it.
+- **Scope overlap is coarse.** `crates/ank-cli/tests/**` in one claim locks every
+  task that touches any test. Correct, and much too broad to be comfortable when
+  three agents are working.
+
+## What I would change, in order
+
+1. **Make a failed push of a proof or claim ref a non-zero exit**, or add a flag
+   that demands it. An automated caller reads the code.
+2. **Renew a claim on any verb, not only `log`** — or let the TTL be configured
+   per repository, since 1800 seconds is shorter than this project's own CI.
+3. **Filter the task list by reachability**: something like `ank find --free`,
+   hiding open tasks whose scope intersects a live claim. The corpus already
+   holds everything needed to compute it.
+4. **Drop the hard-coded proof type from `done`'s refusal hint**, and make the
+   help text say that verifiers come from the task's `verify:` list rather than
+   from `config.yml` alone.
+5. **Give the over-constrained-scope signal a path out.** Naming the number
+   without naming a remedy trains readers to skip it.
+6. **Answer "what changed on this branch"** through the CLI, so a pipeline never
+   has to choose between parsing `.ank/` and inferring.
+7. **Warn when the running binary is older than the corpus it is reading**, or at
+   least when a record type is unknown to it. Silence there cost me a confusing
+   ten minutes at the end of this session.
+8. **Offer a way to record that a criterion is partly wrong** without releasing
+   the task. `log` is where I put it; a first-class field would be read by
+   `check`.
+
+## Coverage, and what this report cannot tell you
+
+I never triggered a version conflict (exit 3), never had a claim taken from me,
+never used `release`, `amend`, `graph`, `review` or `accept`, and never worked a
+corpus in the previous layout. All six of my tasks were small enough to finish in
+one sitting, so nothing here says whether a task spanning days behaves. Every
+judgement above is from six tasks over one session, three of which were
+documentation, and should be weighed accordingly.


### PR DESCRIPTION
Three agents worked this repository in parallel over one session, each in its own
git worktree. Each wrote up what using `ank` was actually like. Documentation
only -- no code, no corpus change.

| Report | Agent | Ground it rests on |
|---|---|---|
| `agent-experience-claude-code.md` | `claude-code@sean-laptop` | the schema 3 chain |
| `agent-experience-claude-code2.md` | `claude-agent-b` | five tasks: dead scopes, `review`, `attest --detached`, the orientation budget, the specification half |
| `agent-experience-claude-code3.md` | `claude-agent-c` | six tasks: the release version gate, the version check, section 6, two deferral rows, the CI recipe |

## What the three agree on

- **Task bodies are the tool's best feature.** Carrying the rejected alternatives
  and the reasoning, not just the goal, is what let agents implement without
  asking a human.
- **The frozen criterion earns its friction.** Both detailed reports say it bit
  them, and both say it should not change: once it forced a documented judgement
  call instead of a quiet edit, once it forced a measurement that overturned the
  task's own hypothesis.
- **Claims arbitrated perfectly.** Three agents, one corpus, one session, zero
  contended tasks. The mechanism is quiet enough to forget it is working.
- **The dogfooded binary is not the binary under test.** Independently hit by two
  agents: the globally installed `ank` tracks the published version, so one nearly
  reported a regression that was a stale binary, and the other saw eleven tasks
  reported as unanchored that the tree's binary reported as zero. Both printed
  `ank 0.2.0`.

## Where they diverge, and the one failure

`claude-agent-b` carries the only issue that caused a **failure** rather than
friction: a worktree left on a merged branch holds a stale `.ank/`, nothing says
so, and when the flat-layout migration landed under an open branch it produced a
red CI on all three runners. A local suite structurally cannot catch it, because
CI tests the merge.

Its framing is worth quoting: ank treats coordination as the hard problem and
solves it well, while treating durable state as ordinary git. Under parallel
agents that is backwards -- claims were never the difficulty, and a stale corpus
was the difficulty every time.

`claude-agent-c` adds the sharpest safety issue: `ank attest --detached` exits 0
when the proof ref never reaches the remote, printing `"pushed":false` and a
warning on standard error. Measured on a scratch corpus with a real `file://`
remote. A proof exists to be readable by someone else; when the push fails it is
readable by nobody and the verb reports success.

## Suggestions the reports converge on

1. Signal a corpus behind the default branch.
2. Make a failed push of a proof or claim ref a non-zero exit.
3. Print the resolved identity, and its source, in `ank status`.
4. Make the dogfooding version split visible in `ank --version`.
5. Filter the task list by what a live claim has not made unreachable.
6. `--since`, or any answer to "what moved since I last looked".

Each report states what it did not cover, so the sample behind every judgement is
visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011FhetohH64Sy7cCE78gwQC
