### PR TITLE
The three agent experience reports become five ADRs and eleven tasks

### DIFF
--- a/.ank/entities/ADR-052accd6e3b2.md
+++ b/.ank/entities/ADR-052accd6e3b2.md
@@ -1,0 +1,59 @@
+---
+id: ADR-052accd6e3b2
+type: adr
+slug: two-live-claims-whose-scopes-intersect-are-named
+title: Two live claims whose scopes intersect are named at claim time, and never refused
+created: 2026-08-13T16:21:38Z
+author: claude-code/2.1.229
+status: proposed
+scope:
+  - crates/ank-cli/src/claim.rs
+  - crates/ank-cli/src/context.rs
+  - docs/ank-spec-v1.1.md
+constraint: |
+  claim names every live claim whose scope intersects the one being taken, with the paths in common, and takes the task regardless. The same computation is what find --free filters on. Scope overlap is a signal and never a refusal: refusing on it would turn a coarse glob into a lock.
+schema: 3
+version: 1
+---
+
+Claims coordinate tasks, and at that job they are correct and cheap. Three agents
+worked this corpus for a full session with zero contended tasks. What the claim
+plane says nothing about is **files**, and that is where the session's real cost
+landed.
+
+The default branch moved six times under one agent, across pull requests 91, 97,
+98, 101, 102, 104 and 105, and produced two merge conflicts. Both were in
+`crates/ank-cli/tests/cli.rs`, and both had the same cause: two agents holding
+two disjoint tasks each appended a block of tests to the end of the same file.
+Nothing warned either of them. The claims were on disjoint tasks, correctly; the
+edits were on one file, and the plane has nothing to say about files.
+
+**The information needed to warn is already in the corpus.** Both tasks declared
+`crates/ank-cli/**`. A scope intersection between two live claims is computable
+from the entities and the refs, with no network call and no new field. The agent
+that filed this finding ranked it as the one change that would have prevented
+both of its conflicts.
+
+The second-order damage is why a warning is worth more than it looks: resolving
+one textually trivial conflict mechanically dropped a closing brace and the file
+stopped compiling. A conflict that is trivial to read is not trivial when a
+script resolves it at speed.
+
+**A signal, never a wall, and the reason is measured.** Scope overlap is coarse:
+`crates/ank-cli/tests/**` in one claim locks every task that touches any test,
+and one held task made five of seven remaining candidates unworkable in a
+session. Refusing on that would make the glob a mutex and would push agents to
+declare narrower scopes than the truth to get past it -- which is the failure
+mode a guard should never have. Naming it costs one line and leaves the decision
+where it belongs.
+
+`find --free` is the same computation read from the other side: an agent choosing
+work wants the candidates that do not collide, and today it reads seven task
+files by hand to find out. One agent did exactly that.
+
+**This is not the tail of the problem, and the ADR says so rather than implying
+it is.** The expensive collisions in that session were semantic, not textual: the
+same defect written into two files by two agents, in different functions, with no
+git conflict at all -- caught by a test and by nothing else. Scope overlap does
+not detect that, and ADR-f8a6cf65160e is what names it. What this buys is the
+cheap half, for the price of a line.

--- a/.ank/entities/ADR-0bb7ea8991bc.md
+++ b/.ank/entities/ADR-0bb7ea8991bc.md
@@ -1,0 +1,59 @@
+---
+id: ADR-0bb7ea8991bc
+type: adr
+slug: a-claim-is-renewed-by-working-not-by-reporting
+title: A claim is renewed by working, not by reporting
+created: 2026-08-13T16:20:09Z
+author: claude-code/2.1.229
+status: proposed
+scope:
+  - crates/ank-cli/src/claim.rs
+  - crates/ank-cli/src/commands.rs
+  - docs/ank-spec-v1.1.md
+constraint: |
+  A verb the holder runs against the task it holds renews that claim's lease, and the repository states its own rhythm through claim_ttl_default in config.yml. Renewal with no change to the scope files stays a check signal, which is what keeps reading from becoming a way to hold.
+schema: 3
+version: 1
+---
+
+Section 3 renews a claim implicitly on `log`, on the reasoning that working is
+enough to keep the lock and there is no `heartbeat` verb to memorise. The
+reasoning is right and the mechanism does not implement it: `log` is *reporting*,
+not working, and the two come apart exactly where it costs.
+
+All three parallel sessions hit it independently, which is why this is a decision
+and not a bug.
+
+- One lost its claim three times. Its tasks ran one to three hours against a
+  1800-second lease. It found `--ttl 2h` only after losing two.
+- One called it the single biggest coordination hazard it met: a task of its own
+  involved a push, a three-platform CI run and a merge, well over thirty minutes
+  of holding nothing worth logging.
+- One watched another agent's claim lapse while that agent was still working, and
+  from outside it was indistinguishable from an abandoned task. Only the human
+  knew otherwise.
+
+**The shape of the failure is the argument.** After the design is settled there
+is often an hour of mechanical fixing -- thirty-four failing fixtures, in one
+measured case -- during which there is genuinely nothing to log. `ank log` is
+documented as being for discovery, not for completion, and that advice is right.
+So the lease lapses precisely during the stretch where nothing interesting is
+happening, which is also the stretch where a second agent would most safely take
+over. The lock is weakest where the work is least interruptible.
+
+**Why renewal on any of the holder's verbs is safe, and where the guard is.**
+The obvious objection is that an agent could then hold a task forever by reading
+it. That objection is already answered and the answer is not new machinery:
+section 4 has `check` report **repeated claim renewals with no modification to
+the scope files** as a possible-hoarding signal. Visibility rather than
+restriction is this project's standing choice -- it is how task flooding is
+handled, how self-created blockers are handled, and how a criterion set by the
+claimer is handled. Reading to hold is a lie somebody wrote down, in a corpus
+that already reports it.
+
+**`claim_ttl_default` beside `claim_ttl_max`, and not instead of it.** The cap
+stops an agent granting itself a day; the default states what this repository's
+work actually looks like. Thirty minutes is shorter than this project's own CI
+run, so the shipped default is wrong for the repository that wrote it, and every
+agent rediscovers `--ttl` by losing a claim first. A repository that can say so
+once says it once.

--- a/.ank/entities/ADR-47e2ac102f58.md
+++ b/.ank/entities/ADR-47e2ac102f58.md
@@ -1,0 +1,60 @@
+---
+id: ADR-47e2ac102f58
+type: adr
+slug: the-corpus-a-verb-answers-about-is-the-checkout
+title: The corpus a verb answers about is the checkout's, and drift from the default branch is named
+created: 2026-08-13T16:19:43Z
+author: claude-code/2.1.229
+status: proposed
+scope:
+  - crates/ank-cli/src/status.rs
+  - crates/ank-cli/src/human.rs
+  - docs/ank-spec-v1.1.md
+constraint: |
+  Every verb answers about the corpus in the working tree. Where that corpus differs from the corpus on the default branch, status and check say so and name the git command that closes the gap. No verb fetches, merges, or rewrites an entity file to close it itself.
+schema: 3
+version: 1
+---
+
+Ank treats coordination as the hard problem and solves it well, while treating
+durable state as ordinary git and leaving it there. Under several agents that is
+backwards, and three parallel sessions measured it.
+
+Claims never failed. Three agents, one corpus, a full session, not one contended
+task and not one piece of lost work: the per-task ref plus `status` naming
+holders coordinated without any agent talking to another. The corpus being a
+moving target failed repeatedly, and it is the only thing in those three reports
+that caused a failure rather than friction.
+
+The failure, in full, because it is the argument. A worktree sat on a branch
+opened before the flat-layout move landed. Its `.ank/` was therefore the previous
+one, and nothing said so. A new test fixture written on that branch wrote into
+`.ank/adr/` and `.ank/tasks/`, which had stopped existing on the default branch.
+The local suite was green, because CI tests the *merge* and a local run
+structurally cannot. Red on all three runners. Twice before that, the same
+staleness produced an open-task list reported to the user that was simply wrong:
+tasks reading `open` in the checkout were already `done` on the default branch.
+
+`status` reports the branch and the default branch. `check` reports tasks
+finished on other branches. Neither answers the question that matters with
+several agents merging continuously: **is my copy of the corpus behind the
+default branch?**
+
+**Named, and never repaired.** A verb that fetched to answer would sanitise the
+plane underneath everybody else, which is the same argument that made
+`status --remote` read with `ls-remote` rather than fetch (TASK-028bcee93801),
+and the same argument by which `check` prunes refs and touches no file. A reader
+that rewrites what it reads has stopped being a reader. The gap is git's to
+close, on the operator's word, and what Ank owes is that nobody is surprised by
+it.
+
+The machinery is already here: `git::file_at(cwd, rev, path)` reads a file at a
+revision and is what the pruning predicate uses, so the question costs no network
+call and no new dependency.
+
+**Not `--since`.** Section 10 defers differential context as the first candidate
+for v1.1, and two of the three reports asked for it under the name "what moved
+since I last looked". This is not that: `--since` needs per-agent seen-state,
+where drift from the default branch is a fact about two revisions and needs
+nothing remembered. The cheap half of the question is the half that caused the
+failure, and it is the half this settles.

--- a/.ank/entities/ADR-af533e7a3e03.md
+++ b/.ank/entities/ADR-af533e7a3e03.md
@@ -1,0 +1,55 @@
+---
+id: ADR-af533e7a3e03
+type: adr
+slug: a-write-whose-only-product-is-a-ref-fails-when-t
+title: A write whose only product is a ref fails when the ref does not reach the remote
+created: 2026-08-13T16:20:32Z
+author: claude-code/2.1.229
+status: proposed
+scope:
+  - crates/ank-cli/src/claim.rs
+  - .github/workflows/ci.yml
+  - docs/ank-spec-v1.1.md
+constraint: |
+  A verb whose whole product is a ref exits non-zero when the push of that ref is refused. A verb that also wrote to disk degrades, warns and exits zero. Which of the two a verb is, its help says; a caller never has to infer it from what the verb happens to touch.
+schema: 3
+version: 1
+---
+
+Section 2 says degrade rather than fail, and that principle is right for a claim:
+the claim holds in this clone, the work goes on, and the risk of a concurrent
+claim is displayed rather than hidden. `attest --detached` inherited the same
+treatment and it is the wrong treatment, because the two are not the same object.
+
+Measured on a scratch corpus against a real `file://` remote:
+
+    remote reachable    "pushed":true    --            exit 0
+    remote unreachable  "pushed":false   warning: ...  exit 0
+
+**A proof ref exists to be readable by somebody else.** That is the whole of what
+`--detached` is for (ADR-493471d64ba0): a pipeline anchors a run without
+producing a commit. When the push fails, the ref is readable by nobody, the
+attestation did not happen, and the verb reports success. There is no degraded
+mode here to fall back to -- unlike a claim, nothing was written to disk that
+still means something.
+
+**The proof this is not theoretical is in the tree.** `.github/workflows/ci.yml`
+carries a comment that reads, in full: *read the flag, not the exit code. A proof
+is a ref, so it is worth something only once it reaches the remote -- and when
+the push is refused, `attest` still exits 0 and warns on standard error. Trusting
+the code would go green having lost the attestation, which is the exact silence
+this job was written to remove.* The repository that ships the verb already works
+around the verb, in a comment, in its own pipeline. That is the strongest
+argument available that the default contract is wrong: the first integration
+written against it had to be written against the flag instead.
+
+The information is in `--json` and an integration written carefully reads it. The
+default is what an integration written in a hurry uses, and an automated caller
+reads the exit code -- that is what an exit code is.
+
+**Stated per verb, never inferred.** The line between the two kinds is not
+"writes a ref" versus "writes a file": `claim` writes a ref too and belongs on
+the degrade side, because the claim it recorded still governs this clone. The
+distinguishing question is whether anything survives the failed push that is
+worth having. A caller cannot derive that from the outside, so each verb's help
+says which it is, and the rule stops being something to reason about.

--- a/.ank/entities/ADR-b6b69053a47b.md
+++ b/.ank/entities/ADR-b6b69053a47b.md
@@ -1,0 +1,53 @@
+---
+id: ADR-b6b69053a47b
+type: adr
+slug: a-test-reference-a-caller-typed-is-not-the-proof
+title: A test reference a caller typed is not the proof a pipeline attested
+created: 2026-08-13T16:21:07Z
+author: claude-code/2.1.229
+status: proposed
+scope:
+  - crates/ank-core/src/model.rs
+  - crates/ank-cli/src/human.rs
+  - docs/ank-spec-v1.1.md
+constraint: |
+  A proof records the route by which it arrived. A test reference that nothing validated does not silence the done with no test proof signal; only a proof carried on refs/ank/proof or produced by a declared verifier does. The trust hierarchy of section 4 states what each type guarantees and what validated it.
+schema: 3
+version: 1
+---
+
+The strongest claim this project makes is that an agent cannot declare itself
+done without proof. On this corpus it degraded to an agent typing a number, and
+the session that lived inside it could not see that from where it stood.
+
+The mechanism, exactly. `submitted_proof` validates a `commit:` against git --
+Ank validates what it can -- and records everything else as given.
+`ProofType::is_weak` covers `Assertion` and `HumanReview` and not `Test`
+(model.rs). So `--proof test:<anything>` is recorded as a strong proof, unchecked,
+and silences the `done with no test proof` signal, which is the one finding
+designed to catch a completion nothing external anchors. No task in this corpus
+declares a `verify:` list, so `ank done` never runs a verifier either: for five
+consecutive tasks the entire proof burden was a human-typed run id. That agent
+checked every run was green on the right sha before typing it. Nothing in the
+tool did.
+
+**The fix is not to mark `test:` weak.** A `test:` reference is the strongest
+thing in the hierarchy when a pipeline put it there -- section 4 ranks
+`test:ci://<ref>` above `commit:` precisely because the environment is out of the
+agent's reach. Flattening that to weak would punish the anchor the project spent
+ADR-493471d64ba0 and `attest --detached` building. What differs is not the type,
+it is who wrote it.
+
+**So the route is what gets recorded.** A proof that arrived on
+`refs/ank/proof/<id>`, written by a pipeline, is a third-party statement. A proof
+produced by a declared verifier is Ank's own statement. A `test:` string typed at
+a keyboard is neither, and the signal that says nothing external anchors this
+completion should keep saying so until one of the first two exists.
+
+**What this deliberately does not do.** It does not refuse the typed reference.
+Section 4 already argues that CI proves the tree passes its tests and not that
+*this* criterion was met, and that the link between the two exists only because
+somebody wrote a test encoding the criterion -- so the human assertion stays, and
+forgetting to make it is what gets reported. This changes what gets reported and
+never what gets refused. The CLI is not a gatekeeper, and a proof somebody typed
+in good faith is worth having in the record; it is worth having as what it is.

--- a/.ank/entities/TASK-072c2ccc524d.md
+++ b/.ank/entities/TASK-072c2ccc524d.md
@@ -1,0 +1,61 @@
+---
+id: TASK-072c2ccc524d
+type: task
+slug: check-names-a-corpus-behind-the-default-branch-a
+title: check names a corpus behind the default branch, and status says how far
+created: 2026-08-13T16:22:26Z
+author: claude-code/2.1.229
+status: open
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/src/status.rs
+  - crates/ank-cli/tests/cli.rs
+  - docs/ank-spec-v1.1.md
+blocked_by: []
+done_criteria: |
+  check emits a signal, once for the corpus, when an entity file in the working tree differs from the same file on the default branch or is absent from one of the two, naming the count and the git command that closes the gap. status carries the same fact on one line. Neither fetches: the assertion that no network call is made is made by the test, not assumed.
+  
+  Where the default branch cannot be resolved, or there is no repository, the question is skipped in silence rather than warned about, on the same rule the rename walk already follows.
+  
+  Section 4 of docs/ank-spec-v1.1.md lists the signal among what check reports, and section 10's deferred --since row records that its trigger was observed twice and that it stays deferred, with this signal named as what answers the cheap half.
+  
+  Asserted through the binary in crates/ank-cli/tests/cli.rs: a clone whose corpus is behind its default branch, one that is ahead, one that is level, and one with no resolvable default branch.
+criteria_by: creator
+schema: 3
+version: 1
+---
+
+Implements ADR-47e2ac102f58. This is the finding that caused a failure rather
+than friction, and the only one of its kind in three reports.
+
+Reuse `git::file_at(cwd, rev, path)` (git.rs). It reads a file at a revision
+through `cat-file`, it is already what the pruning predicate uses, and it already
+distinguishes an absent path from an unresolvable revision -- so a mistyped
+`default_branch` cannot read as "nothing has moved". That distinction is the one
+worth keeping: this signal is about a difference, and an error about the
+revision must never render as one.
+
+**Once for the corpus, never per entity.** Section 4 fixed this rule twice
+already, for entities predating `author` and for pre-convention actor values, and
+for the same reason each time: one line per file is the volume that teaches a
+reader to stop reading `check`. A corpus six entities behind the default branch
+would otherwise print six lines saying one thing.
+
+The count is what makes it actionable, and the count is a comparison and not a
+history walk. Do not reach for `rev-list` to say how many commits behind: the
+question is about the corpus, a branch can move ten times without touching
+`.ank/`, and an answer in commits would fire constantly and mean nothing.
+
+Do not fetch, and assert that. A verb that fetched to answer would rewrite the
+plane underneath every other agent in the clone -- the same argument that made
+`status --remote` read with `ls-remote` and that keeps `check` from touching
+files while it prunes refs. The test must fail if a fetch is introduced, which
+means asserting on the absence of the network call rather than on the output
+alone.
+
+The `--since` row of section 10 is edited in the same pass, and only to record
+what happened: two of three parallel sessions asked for "what moved since I last
+looked", the trigger was therefore observed, and the row stays deferred because
+`--since` needs per-agent seen-state where this needs none. A deferral whose
+trigger has fired and is not written down is how a document starts disagreeing
+with the people using it.

--- a/.ank/entities/TASK-12db5686c024.md
+++ b/.ank/entities/TASK-12db5686c024.md
@@ -1,0 +1,59 @@
+---
+id: TASK-12db5686c024
+type: task
+slug: the-lease-is-renewed-by-the-holder-s-work-and-cl
+title: The lease is renewed by the holder's work, and claim_ttl_default states the rhythm
+created: 2026-08-13T16:23:06Z
+author: claude-code/2.1.229
+status: open
+scope:
+  - crates/ank-cli/src/claim.rs
+  - crates/ank-cli/src/config.rs
+  - crates/ank-cli/tests/cli.rs
+  - docs/ank-spec-v1.1.md
+blocked_by: []
+done_criteria: |
+  A verb run by the holder against the task it holds renews that claim's lease, recomputed from the duration the claim record carries and re-capped by claim_ttl_max, exactly as log already does. Verbs that do not act on the held task renew nothing.
+  
+  claim_ttl_default joins the closed key set of config.yml, defaults to 30 minutes, and is capped by claim_ttl_max at claim time. ank config reads and writes it like every other key, and an unset key still reads as the tool's value marked as a default.
+  
+  Section 3 of docs/ank-spec-v1.1.md says renewal follows the holder's work rather than log alone, and the key table in section 4 carries claim_ttl_default, both before the code moves.
+  
+  Asserted through the binary in crates/ank-cli/tests/cli.rs: the lease moves after a holder's verb on the held task, does not move for a verb about another task, is re-capped when claim_ttl_max is lowered mid-claim, and claim without --ttl takes claim_ttl_default.
+criteria_by: creator
+schema: 3
+version: 1
+---
+
+Implements ADR-0bb7ea8991bc. Three independent sessions raised this and one
+called it the biggest coordination hazard it met.
+
+**The key set is closed** (section 4), so `ank config` refuses a key the parser
+does not know, by name. The specification therefore moves first or the feature
+cannot be configured at all -- and the table is the specification here, not
+documentation of it.
+
+The renewal arithmetic is already settled and must not be re-derived.
+TASK-1b45f41e7b99 measured the failure that produced it: renewal recomputed the
+default instead of the granted duration, so an agent that asked for two hours
+held them once and fell back to thirty minutes at its first `log` -- the flag
+failing at exactly the case it exists for. The duration lives in the claim record
+and every renewal recomputes the expiry from it, re-capped at renewal time so a
+lowered cap takes effect on the next renewal rather than at the next claim. This
+task widens which verbs renew and changes none of that.
+
+**Which verbs renew is the part to get wrong carefully.** The rule is the
+holder's verbs against the held task, and it is a rule rather than a list because
+a list is what goes stale when a verb is added. `show <other task>` renews
+nothing. `context` in execution mode is about the held task and renews.
+`status` is off the loop and about the repository, so it does not.
+
+The guard against holding by reading already exists and is not new machinery:
+section 4 has `check` report repeated renewals with no modification to the scope
+files as a possible-hoarding signal. Do not add a second guard, and do not turn
+that signal into a refusal -- visibility rather than restriction is the standing
+choice, and it is what makes this widening safe.
+
+Thirty minutes stays the shipped default. What changes is that a repository can
+say its own number once, instead of every agent rediscovering `--ttl` by losing
+a claim first.

--- a/.ank/entities/TASK-19d82da76c78.md
+++ b/.ank/entities/TASK-19d82da76c78.md
@@ -1,0 +1,57 @@
+---
+id: TASK-19d82da76c78
+type: task
+slug: the-over-constrained-scope-signal-names-the-cons
+title: The over-constrained-scope signal names the constraints it charges and a way out
+created: 2026-08-13T16:25:08Z
+author: claude-code/2.1.229
+status: open
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/src/context.rs
+  - docs/ank-spec-v1.1.md
+blocked_by: []
+done_criteria: |
+  The over-constrained-scope finding names the constraints charged against the perimeter and what each costs, largest first, in addition to the total it already prints. Under --json the per-constraint charge is structured data rather than a sentence to parse.
+  
+  The finding names an act available to the reader, and where the entity is one no verb can amend it says so rather than naming a command that would refuse.
+  
+  Section 5 of docs/ank-spec-v1.1.md states what the finding reports, and section 11 records that per-constraint charge is what makes the mechanisation pressure of enforced_by measurable rather than asserted.
+  
+  Asserted through the binary in crates/ank-cli/tests/cli.rs: a perimeter over the limit reports its constraints in descending order of charge, and a perimeter under it reports nothing.
+criteria_by: creator
+schema: 3
+version: 1
+---
+
+`check` reports `over-constrained scope` on eight tasks in this corpus, at 5839,
+7669, 8339, 8629, 9774, 10918, 11267 and 12284 characters against a limit of
+4000. The largest is a task filed today. One agent executed one of the eight and
+recorded the consequence: on the largest tasks -- the ones where knowing every
+binding constraint matters most -- `context` cannot serve them in full. It is
+honest about truncating, which is right, and **the signal names a problem with no
+path out of it**: there is no verb to split a scope, and no guidance on which
+constraints to drop. A finding that names a number and no act trains readers to
+skip it.
+
+The number that is missing is the breakdown. A total says the perimeter is
+expensive; the charge per constraint says *which* constraint is expensive, and
+that is the only form of the fact anybody can act on. Measured at orientation on
+this repository: 7357 characters of constraint against 157 of tasks, from
+eighteen constraints -- so a handful of them dominate and nothing says which.
+
+**This is the counterweight to filing five ADRs in one sitting.** Every constraint
+added is charged against every perimeter it matches, and the corpus that just
+grew is the corpus already over budget. Section 11 turns that pressure the right
+way round: growing context should push toward mechanising constraints via
+`enforced_by`, not toward deleting decisions. That argument is currently made
+without numbers. Per-constraint charge is the number, and it is what makes
+"mechanise this one first" a measurement rather than a preference.
+
+**Do not add a verb to split a scope.** The absence is real and inventing a verb
+for it is a surface added to a problem that a narrower scope, or a mechanised
+constraint, already answers. What is missing is the information to choose, not a
+new way to act.
+
+Say nothing when nothing is over the limit. A per-constraint breakdown printed on
+a healthy perimeter is the volume problem this project keeps refusing.

--- a/.ank/entities/TASK-27cf26cbc414.md
+++ b/.ank/entities/TASK-27cf26cbc414.md
@@ -1,0 +1,83 @@
+---
+id: TASK-27cf26cbc414
+type: task
+slug: a-dead-scope-git-can-explain-is-a-signal-and-the
+title: A dead scope git can explain is a signal, and the explanation reaches a glob
+created: 2026-08-13T16:18:58Z
+author: claude-code/2.1.229
+status: open
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/src/git.rs
+  - crates/ank-cli/tests/cli.rs
+  - docs/ank-spec-v1.1.md
+blocked_by: []
+done_criteria: |
+  A dead scope whose death git can explain is reported as a signal; one it cannot explain keeps the severity it has today. The rule only ever lowers a severity and never raises one, so a dead scope that is a signal today is a signal after this.
+  
+  scope_moved answers for a glob as well as for a literal path. The literal prefix before the first wildcard is what is asked about, and a prefix whose files git records as renamed into one directory is explained by that directory; sources landing in more than one destination produce no explanation, on the rule that silence is never evidence.
+  
+  Section 4 of docs/ank-spec-v1.1.md carries both before the code moves: the dead-scope entry states the two severities and what separates them, and states that the walk serves a glob through its literal prefix.
+  
+  Asserted through the binary in crates/ank-cli/tests/cli.rs, four fixtures: a file named literally in a finished task's scope is renamed and committed, and check exits 0 with a signal naming the new path; the same file is deleted instead, and check exits 8; a directory named by a glob is moved wholesale, and check exits 0 naming the new directory; the files under such a prefix are scattered across two directories, and check exits 8 with no explanation.
+criteria_by: creator
+schema: 3
+version: 1
+---
+
+Unblocks TASK-9bff1d5826b1. The flat-layout move kills six scopes and `check`
+goes from 0 faults to 6, which the move's own criterion forbids. Measured on the
+move as it stands on branch chore/flat-layout-9bff: four of the six are
+`.ank/adr/**`, one is `.ank/tasks/TASK-aca0cb103980.md`, one is
+`.ank/tasks/TASK-a1b2c3d4e5f6.md`.
+
+**The wildcard half is what makes this real, and it is the half easy to leave
+out.** `scope_moved` (human.rs) returns nothing the moment a glob carries a
+wildcard, so the severity change alone resolves two of the six and leaves four
+red. A task that lowers the severity and stops there does not unblock the move,
+and would look finished while doing it.
+
+The severity rule, stated as a floor rather than as a table, is the part to get
+right. `check_scope_alive` decides severity today by kind and status: signal for
+an open or in_progress task, fault for an ADR or a finished task, because a
+task's scope says where work will happen and an ADR's says what it binds. That
+reasoning stays. What is added is a second question asked only of the entities
+that would fault -- did git record where the path went -- and a yes lowers it to
+a signal. Rewriting it as a fresh two-axis table is how an open task with an
+unexplained dead scope quietly becomes a fault, which is a widening nobody asked
+for.
+
+Why this is the right shape and not a concession. `check` faulting on a dead
+scope treats "this scope matches nothing" as a corpus defect. When git can name
+the commit that moved the path, the corpus is not broken -- it is outdated in a
+way the reader can see and follow, which is precisely what ADR-97beaf55e73a
+built the walk to show. The fault is worth keeping for the case the walk cannot
+explain, where the reader has nothing to go on. Without this split, any directory
+rename reddens the corpus permanently: `amend` refuses a done task with code 7,
+measured on TASK-3109a736c255, and TASK-1e79ff3738df settled deliberately that
+such a task gets the rename named and no repair command. So today the fault fires
+with no act available to anybody that would clear it, which is the shape of a
+finding readers learn to skip.
+
+The prefix walk, concretely. `.ank/adr/**` has the literal prefix `.ank/adr`.
+`rev-list -1 HEAD -- .ank/adr` gives the last commit that touched it, and
+`diff-tree -M -r -z --name-status --no-commit-id` on that commit gives the
+renames; the sources under the prefix and their destinations are what answer.
+Both verbs are already in the PLUMBING allow-list of ADR-b8884edcebe3 -- check
+that rather than trusting this line, because the debug_assert is what catches a
+miss and only in debug builds.
+
+Do not take `--full-history`. `rename_of`'s doc comment explains why it is absent
+there and the same reasoning holds here: default simplification walks to the
+commit that made the change, and a merge is a commit `diff-tree` prints nothing
+for, so asking for more history answers less often.
+
+The silence rule is not decoration, and it is where this most easily goes wrong.
+A deletion, a move under the similarity threshold, a scattered directory and a
+typo that never named a real file all produce the same nothing. No wording added
+here may let a reader infer which -- `scope_moved`'s doc comment already says so,
+and the glob branch has one more way to be tempted, because "the prefix moved
+mostly there" is a sentence that will suggest itself and must not be written.
+
+Cost stays where it is: the walk runs only on a scope already dead, and a healthy
+corpus has none. Do not hoist it above the dead-scope test to tidy the code.

--- a/.ank/entities/TASK-29461c1f508d.md
+++ b/.ank/entities/TASK-29461c1f508d.md
@@ -1,0 +1,55 @@
+---
+id: TASK-29461c1f508d
+type: task
+slug: a-typed-test-reference-stops-silencing-the-ancho
+title: A typed test reference stops silencing the anchor signal
+created: 2026-08-13T16:23:46Z
+author: claude-code/2.1.229
+status: open
+scope:
+  - crates/ank-core/src/model.rs
+  - crates/ank-cli/src/human.rs
+  - docs/ank-spec-v1.1.md
+blocked_by: []
+done_criteria: |
+  A proof records how it arrived, and check derives the anchor signal from that rather than from the type alone: a test proof carried on refs/ank/proof or produced by a declared verifier silences done with no test proof, and a test reference a caller passed to done or attest does not.
+  
+  The record survives a round trip byte for byte and the goldens carry the new form, since this touches what a proof entry says. A corpus written before the distinction existed keeps whatever it says and is never reinterpreted: the signal must not start firing retroactively on the ten completions already anchored.
+  
+  The trust hierarchy table of section 4 of docs/ank-spec-v1.1.md states what each type guarantees and what validated it, before the code moves.
+  
+  Asserted through the binary in crates/ank-cli/tests/cli.rs: a typed test proof leaves the signal firing, an attested one clears it, and a corpus at the previous schema is unchanged.
+criteria_by: creator
+schema: 3
+version: 1
+---
+
+Implements ADR-b6b69053a47b. `ProofType::is_weak` covers `Assertion` and
+`HumanReview` and not `Test` (model.rs), and `submitted_proof` validates a
+`commit:` against git while recording everything else as given. So
+`--proof test:<anything>` is unchecked, not weak, and silences the one finding
+designed to catch a completion nothing external anchors.
+
+**The format question comes before the code question, and it is the whole risk
+here.** A proof entry is part of the format, the round-trip is guaranteed byte
+for byte on canonical form, and the field order is data in the emitter table
+rather than control flow. Adding provenance means the specification moves, then
+the goldens, then the code -- in that order, and the goldens are written to fail
+first.
+
+Two shapes are available and the task chooses, rather than the ADR: a field on
+`Proof` recording the route, or deriving it at read time from the presence of
+`refs/ank/proof/<id>`. The second stores nothing and answers only while the ref
+survives, and a proof ref is pruned once the proof reaches the default branch --
+so the answer would change under a corpus that did nothing. Weigh that before
+preferring it for costing no format change.
+
+**Retroactive firing is the failure mode to test for.** This corpus carries ten
+`done` tasks anchored by references typed by hand and eleven anchored by the
+pipeline. A distinction that cannot tell them apart in the existing files must
+default to leaving them alone: a rule that reddens twenty-one historical
+completions on the day it lands is a rule everybody turns off. The entities that
+predate the distinction mean what they meant -- the same reading section 3
+applies to pre-convention actors and to entities predating `author`.
+
+This changes what is reported and never what is refused.

--- a/.ank/entities/TASK-58475a5570ba.md
+++ b/.ank/entities/TASK-58475a5570ba.md
@@ -1,0 +1,59 @@
+---
+id: TASK-58475a5570ba
+type: task
+slug: claim-names-the-live-claims-whose-scope-intersec
+title: claim names the live claims whose scope intersects, and find --free filters on it
+created: 2026-08-13T16:22:26Z
+author: claude-code/2.1.229
+status: open
+scope:
+  - crates/ank-cli/src/claim.rs
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/tests/cli.rs
+  - docs/ank-spec-v1.1.md
+blocked_by: []
+done_criteria: |
+  claim prints one line per live claim held by another identity whose scope intersects the scope of the task being taken, naming the holder, the task and the paths in common, then takes the task. It never refuses on that basis, and the test asserts the exit code is 0 with the lines present.
+  
+  find --free lists open tasks whose scope intersects no live claim, computed the same way, and says how many it hid. Without the flag find is unchanged.
+  
+  Section 4 of docs/ank-spec-v1.1.md carries --free in the commands block and states that scope overlap is reported and never refused.
+  
+  Asserted through the binary in crates/ank-cli/tests/cli.rs: two claims whose globs overlap on a file, two whose globs do not, and an overlap against a lapsed claim which must produce nothing because a lapsed claim is not a live one.
+criteria_by: creator
+schema: 3
+version: 1
+---
+
+Implements ADR-052accd6e3b2. The agent that filed it called this the one change
+that would have prevented both of its merge conflicts, and both were the same
+shape: two agents on disjoint tasks appending tests to the end of
+`crates/ank-cli/tests/cli.rs`.
+
+The computation exists in pieces. Scope globs are matched by `ank_core::scope`,
+and live claims are enumerated from `refs/ank/claims/*` -- `status` already reads
+exactly that set and prints holder and expiry. What is missing is the
+intersection, and an intersection of globs is not a set intersection: two globs
+overlap when some path could match both, which for the corpus's shapes means
+comparing literal prefixes and wildcard tails rather than expanding anything.
+
+**Report the paths in common, not the fact of overlap.** `crates/ank-cli/**`
+against `crates/ank-cli/tests/**` overlaps on everything under the second, and a
+line saying only "these overlap" leaves the reader exactly where they started.
+Where both globs are literal the answer is a path; where one is a wildcard the
+honest answer is the narrower glob, and it is written as a glob rather than
+expanded into a file list that would be wrong the moment a file is added.
+
+**A lapsed claim is not a live one**, and getting that wrong makes the signal
+fire on abandoned work forever. Section 4 already fixes the reading for `claim`'s
+own refusal and the same predicate applies here.
+
+`--free` is the same computation for the agent choosing rather than taking. One
+session read seven task files by hand to discover that a single held task, whose
+scope was `crates/ank-cli/tests/**`, made five of the seven unworkable. Say how
+many were hidden: a filter that silently returns two candidates out of seven is a
+filter that will be trusted for the wrong reason.
+
+Scope overlap is coarse and that is the argument for a signal rather than a wall,
+not an argument for making it precise first. Do not narrow anybody's scope to
+make the output quieter.

--- a/.ank/entities/TASK-5c7ebad62d93.md
+++ b/.ank/entities/TASK-5c7ebad62d93.md
@@ -1,0 +1,51 @@
+---
+id: TASK-5c7ebad62d93
+type: task
+slug: a-detached-proof-that-misses-the-remote-exits-no
+title: A detached proof that misses the remote exits non-zero, and ci.yml stops reading the flag
+created: 2026-08-13T16:23:46Z
+author: claude-code/2.1.229
+status: open
+scope:
+  - crates/ank-cli/src/claim.rs
+  - crates/ank-cli/src/human.rs
+  - .github/workflows/ci.yml
+  - docs/ank-spec-v1.1.md
+blocked_by: []
+done_criteria: |
+  ank attest --detached exits non-zero when the push of refs/ank/proof is refused, with the warning it already prints and a hint naming the next command. Its help says the verb fails on an unreachable remote. Verbs whose write also landed on disk are untouched and still exit 0 with a warning, which the test asserts for claim so the change cannot silently generalise.
+  
+  The attestation step of .github/workflows/ci.yml reads the exit code, and the comment explaining why it read the flag instead is removed rather than left contradicting the code.
+  
+  Section 7 of docs/ank-spec-v1.1.md states the rule and which side of it each verb is on, before the code moves.
+  
+  Asserted through the binary in crates/ank-cli/tests/cli.rs against a file:// remote made unreachable: attest --detached exits non-zero, claim on the same remote exits 0 and warns.
+criteria_by: creator
+schema: 3
+version: 1
+---
+
+Implements ADR-af533e7a3e03. The measurement, on a scratch corpus with a real
+`file://` remote: reachable gives `"pushed":true` and exit 0; unreachable gives
+`"pushed":false`, a warning on standard error, and **exit 0**.
+
+The strongest evidence that the contract is wrong is already committed. The
+attestation step of `ci.yml` carries a comment saying to read the flag and not
+the exit code, because trusting the code would go green having lost the
+attestation. The first integration ever written against this verb was written
+around it. Removing that comment is part of the work, and not a tidy-up: a
+comment explaining a workaround that no longer exists is how the next reader
+learns to distrust the verb again.
+
+**Do not generalise the change.** `claim` writes a ref too and stays on the
+degrade side, because the claim it recorded still governs this clone and the risk
+of a concurrent claim is displayed rather than hidden -- section 2, and
+`Sync::warning` says exactly that in `claim.rs`. `Sync::proof_warning` is already
+a separate sentence beside it, on the reasoning that a claim not pushed can be
+taken twice while a proof not pushed is invisible to everyone. That split is the
+seam this change follows. The test asserting `claim` still exits 0 is what keeps
+the change from spreading.
+
+The hint matters as much as the code. A pipeline that fails here has a remote it
+could not reach, and the self-correcting-error rule means naming what to run --
+not generic help, and not a suggestion to retry blindly.

--- a/.ank/entities/TASK-6f4ff66894d2.md
+++ b/.ank/entities/TASK-6f4ff66894d2.md
@@ -1,0 +1,51 @@
+---
+id: TASK-6f4ff66894d2
+type: task
+slug: status-prints-the-identity-it-resolved-and-where
+title: status prints the identity it resolved and where it came from
+created: 2026-08-13T16:23:06Z
+author: claude-code/2.1.229
+status: open
+scope:
+  - crates/ank-cli/src/status.rs
+  - crates/ank-cli/src/identity.rs
+  - crates/ank-cli/tests/cli.rs
+  - docs/ank-spec-v1.1.md
+blocked_by: []
+done_criteria: |
+  ank status prints one line naming the identity in effect and its source, distinguishing a value that came from ANK_AGENT from the user-at-host fallback. Under --json the identity and its source are separate fields, as ank config already separates value and source.
+  
+  Section 4 of docs/ank-spec-v1.1.md lists the line among what status answers.
+  
+  Asserted through the binary in crates/ank-cli/tests/cli.rs: with ANK_AGENT set, and with it unset.
+criteria_by: creator
+schema: 3
+version: 1
+---
+
+Cheapest finding in the three reports and the one with the best ratio. An agent
+whose shell state does not persist between tool calls has to prefix the identity
+on every single invocation -- dozens of them in a session. Forget it once and the
+identity falls back silently to `<user>@<hostname>`, which in this repository is
+`seanl@sean-laptop`, an identity the corpus shows authoring twelve entities.
+
+What follows is not a warning, it is a refusal on state: a `log` or a `done` from
+the wrong identity fails because the claim is held by somebody else, and the
+message talks about claims rather than about identity. That behaviour is correct
+-- refusals are on state, never on identity -- and it is a genuinely confusing
+first encounter, because the true fact is one nothing on that path names.
+
+The source is the whole point and the line is worth nothing without it. `ank
+config` already made this distinction and made it for the same reason: a resolved
+default reads `8000 (default)` and not `8000`, because "the tool's value" and
+"this repository's value" are different answers to the question being asked. An
+identity that came from the environment and one that came from the hostname are
+different facts, and only the second is a trap.
+
+**One tension to record while here, not to solve here.** ADR-3877fef1d662 types
+an identity written into an entity as `<producer>/<version>` for an agent, with
+no host component -- while the point of `ANK_AGENT` is to separate two sessions
+in one tree, which the host component is what does. Two Claude Code sessions of
+the same version in one working tree are one identity under the typed form. This
+task prints what was resolved and does not adjudicate that; a note in the log is
+where it belongs until somebody has met it.

--- a/.ank/entities/TASK-9bff1d5826b1.md
+++ b/.ank/entities/TASK-9bff1d5826b1.md
@@ -8,7 +8,7 @@ author: claude-code@sean-laptop
 status: open
 scope:
   - .ank/**
-blocked_by: [TASK-cd3189ddf61e, TASK-e70f3a12185a]
+blocked_by: [TASK-cd3189ddf61e, TASK-e70f3a12185a, TASK-27cf26cbc414]
 done_criteria: |
   Every entity of this corpus sits at .ank/entities/<ID>.md, .ank/tasks/ and
   .ank/adr/ no longer exist, and every ## Log section that was in a task body sits
@@ -26,7 +26,7 @@ done_criteria: |
   extraction requires.
 criteria_by: creator
 schema: 2
-version: 2
+version: 5
 ---
 
 Last step of the format change, and the one that is irreversible in practice even
@@ -56,3 +56,6 @@ appear, and knowing which moved is what makes the diff reviewable.
 
 ## Log
 - 2026-08-13T05:53:07Z claude-code@sean-laptop — amended: +blocked_by TASK-e70f3a12185a
+- 2026-08-13T16:14:56Z claude-code@sean-laptop — amended: +blocked_by TASK-208878dc8db1
+- 2026-08-13T16:18:25Z claude-code@sean-laptop — amended: -blocked_by TASK-208878dc8db1
+- 2026-08-13T16:19:12Z claude-code/2.1.229 — amended: +blocked_by TASK-27cf26cbc414

--- a/.ank/entities/TASK-ca784c5feda4.md
+++ b/.ank/entities/TASK-ca784c5feda4.md
@@ -1,0 +1,50 @@
+---
+id: TASK-ca784c5feda4
+type: task
+slug: the-help-surface-says-what-the-verb-does-done-s
+title: "The help surface says what the verb does: done's hint, its verifier wording, and check's writes"
+created: 2026-08-13T16:24:22Z
+author: claude-code/2.1.229
+status: open
+scope:
+  - crates/ank-cli/src/done.rs
+  - crates/ank-cli/src/cli.rs
+  - crates/ank-cli/tests/cli.rs
+blocked_by: []
+done_criteria: |
+  The refusal of done when no proof is given names commit:<sha>, a proof the caller already holds, rather than a run id it must wait for. ank help done says a verifier comes from the task's verify list, not from config.yml alone, so a reader cannot conclude the declared verifiers will run. ank help check says the verb prunes refs, since a verb named check reads as read-only and this one writes.
+  
+  Asserted through the binary in crates/ank-cli/tests/cli.rs: the text of the refusal, and the two help pages.
+criteria_by: creator
+schema: 3
+version: 1
+---
+
+Three small wrongs on the surface agents read first, and each one measurably
+misled a session.
+
+**The hint steers toward the practice a task in this corpus was written to end.**
+`done.rs` refuses with `--proof test:<ci-run-ref>`, hard-coded. TASK-2dff950e5d51
+replaced that workflow: the pipeline attests the run itself and the agent closes
+on `commit:<sha>`, a proof it already holds and one Ank actually validates
+against git. The old rhythm cost one session two full CI waits per task, and it
+is exactly what an agent reconstructs from habit when the tool suggests it.
+
+**The verifier wording made an agent write the wrong thing into CLAUDE.md.**
+`ank help done` says it refuses when there is no proof and no verifier declared
+to produce one, which reads as though `config.yml`'s verifiers would run.
+`check-repo` and `cargo-test` are declared there and no task in this corpus names
+them in a `verify:` list, so `done` always demands `--proof`. An agent believed
+the help text, wrote it into the project guide, and found out only by running the
+command. Verifiers come from the task, and the sentence has to say so.
+
+**`check` writes.** It printed `pruned refs/ank/claims/...` while an agent was
+reading its output, having run it freely in loops on the assumption that a verb
+called `check` reads. The behaviour is specified and correct -- `check` is the
+only command that prunes -- and the help page is where a caller finds out before
+scripting around it.
+
+None of this changes behaviour. It is the self-correcting-error rule applied to
+the places where the tool describes itself, and that rule is load-bearing here:
+one session reused a refusal's own wording verbatim as the specification of a
+feature, which only works because the wording is trusted to be exact.

--- a/.ank/entities/TASK-ca7b61b00896.md
+++ b/.ank/entities/TASK-ca7b61b00896.md
@@ -1,0 +1,55 @@
+---
+id: TASK-ca7b61b00896
+type: task
+slug: the-binary-says-when-it-is-older-than-the-corpus
+title: The binary says when it is older than the corpus it reads
+created: 2026-08-13T16:24:22Z
+author: claude-code/2.1.229
+status: open
+scope:
+  - crates/ank-cli/src/main.rs
+  - crates/ank-cli/src/repo.rs
+  - crates/ank-cli/tests/cli.rs
+  - docs/getting-started.md
+blocked_by: []
+done_criteria: |
+  A binary reading a corpus that declares a schema it does not know says so on every verb, naming the schema found, the newest it supports, and what to do, rather than failing on the first field it does not recognise or answering as if the file were understood.
+  
+  docs/getting-started.md says where the binary a contributor runs comes from, and that a globally installed ank tracks the published version rather than the tree.
+  
+  Asserted through the binary in crates/ank-cli/tests/cli.rs: a corpus one schema ahead, read by verbs that list and by verbs that show.
+criteria_by: creator
+schema: 3
+version: 1
+---
+
+Two sessions lost time to the same trap and one nearly reported a regression that
+did not exist.
+
+The project rule is to run `ank` from outside `target/`, because Windows locks a
+running executable during a relink. In practice that means the globally installed
+build, which tracks the *published* version and not the tree. So the tool
+managing the work is a different version from the one being changed. After
+merging an orientation fix, one agent ran `ank context`, saw the old output, and
+nearly filed a regression. After a CI job attested eleven tasks, another saw the
+global binary report all eleven as still unanchored while the binary built from
+the tree reported zero -- the published 0.2.0 predates detached proofs. Both print
+`ank 0.2.0`; only the commit in `--version` separates them, and you have to know
+to look.
+
+**`--version` already carries the commit, so this is not about adding it.** It is
+about the one case the tool can detect on its own without being asked: a corpus
+declaring a schema newer than `SCHEMA_VERSION`. `parse.rs` refuses that on the
+version rather than on the first unknown field, which is the only diagnosis that
+names the cause -- and `Error::UnknownSchema` already carries both numbers. What
+is missing is that the message reaches a reader running an ordinary verb, rather
+than surfacing as a parse failure on one file.
+
+A version mismatch that is *older tool, older corpus* is not detectable and this
+task does not pretend otherwise. That half belongs in the documentation, which is
+why `getting-started.md` is in scope: the split between the dogfooded binary and
+the binary under test is a standing property of this repository, and a project
+note is where a contributor will look, not a memory belonging to one session.
+
+Keep it out of the hot path. The schema is already read at parse time, so the
+answer is available where the file is loaded and needs no second read.

--- a/.ank/entities/TASK-f6b8eb330be5.md
+++ b/.ank/entities/TASK-f6b8eb330be5.md
@@ -1,0 +1,58 @@
+---
+id: TASK-f6b8eb330be5
+type: task
+slug: a-criterion-proved-partly-wrong-is-recorded-on-t
+title: A criterion proved partly wrong is recorded on the task without releasing it
+created: 2026-08-13T16:25:08Z
+author: claude-code/2.1.229
+status: open
+scope:
+  - docs/ank-spec-v1.1.md
+  - crates/ank-core/src/model.rs
+  - crates/ank-cli/src/human.rs
+blocked_by: []
+done_criteria: |
+  Section 3 of docs/ank-spec-v1.1.md states how a holder records that a frozen criterion rests on a false premise, what that record does and does not change, and why it is neither an edit to the criterion nor a release. The frozen hash is untouched by it, and the specification says so.
+  
+  The record is readable by check, which reports it as a signal on the task, and it is visible to a reader of the entity. It is never a condition of done and never weakens what done verifies.
+  
+  The format moves first: the specification, then the goldens, then the code, and the round-trip stays byte-identical on canonical form.
+  
+  Asserted through the binary: a task carrying the record still freezes and verifies its criterion by the same hash, and check names it.
+criteria_by: creator
+schema: 3
+version: 1
+---
+
+Two of the three parallel sessions met this and neither had a tool for it.
+
+One found a criterion requiring that CLAUDE.md stop instructing an agent to carry
+a CI run id by hand. CLAUDE.md never carried that instruction: the clause was
+unsatisfiable as written, one of four, and the other three were met. `release
+--reason` is the documented exit and would have thrown away work that was
+otherwise correct. The agent recorded the discrepancy with `ank log` and said so
+in the pull request, and wrote that this was a convention it invented rather than
+something the tool offers. Another found a criterion demanding an invalid fixture
+that a binding ADR forbade, and resolved the contradiction in prose.
+
+**The frozen criterion is the thing to keep, and this must not weaken it.** Both
+sessions said independently that the freeze was the system working: once it
+forced a documented judgement call instead of a quiet edit, once it forced a
+measurement that overturned the assumption the task was written on. A field that
+let a holder mark a clause "wrong" and proceed would be the criterion made
+editable through a side door, which is the whole failure the hash exists to
+prevent. So the record changes nothing mechanically: the hash still anchors,
+`done` still verifies against it, and what the record buys is that the
+disagreement is in the corpus rather than in a pull request comment nobody
+reopens.
+
+**Settle the shape in the specification before adding any field.** `ank log`
+already carries this today, and the honest question is whether a first-class
+field earns its cost over the convention -- what `check` could say about a
+logged discrepancy that it cannot say about a field, and the reverse. Section 3
+is where that is decided, and the criterion above requires the answer to be
+written before code moves. It is legitimate for the answer to be that the log
+entry is the record and what is missing is only that `check` reads it.
+
+This is a format change either way, so the order is not negotiable: the
+specification, then the goldens written to fail, then the code.


### PR DESCRIPTION
Three agents worked this corpus in parallel on 2026-08-12/13 and each wrote a report. Nothing had been drawn from them into the corpus, so they were three documents nobody was obliged to read. This is the triage.

## What was dropped, because it is already answered

Verified against the tree's own binary before filing:

- the lapsed claim reporting `no task in progress` — TASK-5bd23835d5a0
- the orientation budget — TASK-1ead0e19fb73
- the CI round trip to copy a run id — TASK-2dff950e5d51
- the `PreToolUse` hook matching pattern text rather than path — dissolved by TASK-10b8a29fd853, which removes `.claude/` entirely

## Five ADRs, proposed

| id | decision |
|---|---|
| ADR-47e2 | the corpus a verb answers about is the checkout's, and drift from the default branch is named, never repaired |
| ADR-0bb7 | a claim is renewed by working, not by reporting |
| ADR-af53 | a write whose only product is a ref fails when the ref does not reach the remote |
| ADR-b6b6 | a test reference a caller typed is not the proof a pipeline attested |
| ADR-052a | two live claims whose scopes intersect are named at claim time, and never refused |

## Eleven tasks

TASK-072c, TASK-5847, TASK-6f4f, TASK-12db, TASK-5c7e, TASK-2946, TASK-ca78, TASK-ca7b, TASK-19d8, TASK-f6b8 implement them or stand alone.

TASK-27cf was found by doing rather than by reading. The flat-layout move takes `check` from 0 faults to 6: six done tasks declare a scope naming the previous layout, four of them the glob `.ank/adr/**`, and `amend` refuses a done task with code 7. TASK-9bff1d5826b1 is amended to be blocked by it and was released with the reason in its log.

## Two consequences visible in check, both meant

ADR-3877fef1d662 types an identity written into an entity, and no entity in this corpus had ever followed it — the convention was written down and not practised. These sixteen are the first, authored `claude-code/2.1.229`. That turns on the signal reporting an entity written by an agent with no human reading, once per entity. A reading recorded by a human clears each one.

The over-constrained-scope signal now fires on most of them at 12284 characters, the corpus maximum, because a task that must revise the specification scopes `docs/ank-spec-v1.1.md` and inherits every constraint bound to it. TASK-19d8 is what makes that number actionable, and it is in this batch deliberately: five more constraints are charged against a budget already at 7357 of 8000.

`ank check` exits 0 on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DnH8FSBduWoapK8oyun9mP