### PR TITLE
Assemble the parallel multi-agent workflow in the docs

### DIFF
--- a/.ank/entities/TASK-ff6ce27c29ad.md
+++ b/.ank/entities/TASK-ff6ce27c29ad.md
@@ -5,7 +5,7 @@ slug: document-the-parallel-multi-agent-workflow-end-t
 title: Document the parallel multi-agent workflow end to end
 created: 2026-08-13T16:41:06Z
 author: claude-code/2.1.229
-status: in_progress
+status: done
 scope:
   - docs/**
   - README.md
@@ -13,6 +13,10 @@ scope:
 blocked_by: []
 done_criteria: |
   docs/agents.md carries a 'Parallel work and integration' section assembling the end-to-end multi-agent workflow (parallelism from blocked_by, one branch per task, integration as an ordinary task, integration branch pattern and when not to use it, what ank leaves to git); getting-started.md points to it; README.md names multi-agent coordination; CLAUDE.md cites the live skill-freeze ADR instead of ADR-c656cbcc33a9; ank check and cargo test are green.
+proof:
+  - type: commit
+    ref: e609493b5afdaf7c1d632812e4ef2f04692daccb
+    criteria: 6b657cb00ae0
 schema: 3
-version: 3
+version: 4
 ---

--- a/.ank/entities/TASK-ff6ce27c29ad.md
+++ b/.ank/entities/TASK-ff6ce27c29ad.md
@@ -1,0 +1,18 @@
+---
+id: TASK-ff6ce27c29ad
+type: task
+slug: document-the-parallel-multi-agent-workflow-end-t
+title: Document the parallel multi-agent workflow end to end
+created: 2026-08-13T16:41:06Z
+author: claude-code/2.1.229
+status: in_progress
+scope:
+  - docs/**
+  - README.md
+  - CLAUDE.md
+blocked_by: []
+done_criteria: |
+  docs/agents.md carries a 'Parallel work and integration' section assembling the end-to-end multi-agent workflow (parallelism from blocked_by, one branch per task, integration as an ordinary task, integration branch pattern and when not to use it, what ank leaves to git); getting-started.md points to it; README.md names multi-agent coordination; CLAUDE.md cites the live skill-freeze ADR instead of ADR-c656cbcc33a9; ank check and cargo test are green.
+schema: 3
+version: 3
+---

--- a/.ank/log/TASK-ff6ce27c29ad.md
+++ b/.ank/log/TASK-ff6ce27c29ad.md
@@ -1,0 +1,2 @@
+- 2026-08-13T16:41:30Z claude-code/2.1.229 — amended: done_criteria
+- 2026-08-13T16:43:24Z claude-code/2.1.229 — ADR-f61e2d2c75e8 is the live skill-freeze ADR (supersedes e17e, which superseded c656). CLAUDE.md was stale twice over: it cited c656 and still described ank help as one flat listing, which f61e replaced with grouping by moment of use. Fixed both while adding the parallel-workflow docs.

--- a/.ank/log/TASK-ff6ce27c29ad.md
+++ b/.ank/log/TASK-ff6ce27c29ad.md
@@ -1,2 +1,3 @@
 - 2026-08-13T16:41:30Z claude-code/2.1.229 — amended: done_criteria
 - 2026-08-13T16:43:24Z claude-code/2.1.229 — ADR-f61e2d2c75e8 is the live skill-freeze ADR (supersedes e17e, which superseded c656). CLAUDE.md was stale twice over: it cited c656 and still described ank help as one flat listing, which f61e replaced with grouping by moment of use. Fixed both while adding the parallel-workflow docs.
+- 2026-08-13T16:48:32Z claude-code/2.1.229 — done, proof commit:e609493b5afdaf7c1d632812e4ef2f04692daccb

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,12 +70,15 @@ run on all three.
 - The format is the specification: `ank-core` is the reference implementation,
   and the round-trip stays byte-identical on canonical form. Any format change
   goes through the specification first, then the goldens, then the code.
-- The CLI exposes one surface (ADR-c656cbcc33a9): every verb is available to
-  every caller, and it refuses on state, never on identity. What is frozen at 8
-  verbs is not the dispatch table but the content of `skill/SKILL.md` (`context
-  claim show log done new find release`) — it is loaded permanently, so growing
-  what it teaches costs a superseding ADR and a human signature. `ank help` is
-  one flat listing, in the order of §4, with no headings and no grouping.
+- The CLI exposes one surface (ADR-f61e2d2c75e8, carrying ADR-c656cbcc33a9
+  forward): every verb is available to every caller, and it refuses on state,
+  never on identity. What is frozen is not the dispatch table but the content of
+  `skill/SKILL.md` — the loop (`context claim show log done`, with `new find
+  release` off-loop) and the planning verbs (`new adr`, `amend`, `review`,
+  `graph`, `check`) — it is loaded permanently, so growing what it teaches costs
+  a superseding ADR and a human signature. `ank help` lists every verb, grouped
+  by the moment a verb is used, within a group in the order of §4; a group never
+  says who may use a verb.
 - `.ank/` is reached only through the CLI, never by opening the files
   (ADR-01b6dd05f0db). A `PreToolUse` hook in `.claude/` refuses it.
 - Immutability is verifiable, not defended: freezes are anchored by hash, and

--- a/README.md
+++ b/README.md
@@ -69,8 +69,11 @@ does not control, and `ank check` compares. Editing a criterion to unblock
 yourself unblocks nothing; it makes the divergence visible.
 
 **Git does the hard parts.** Claims are git refs, so the compare-and-swap that
-arbitrates two agents is the one git already guarantees. Undo, history and
-recovery are git's. There is nothing to run.
+arbitrates two agents is the one git already guarantees. Parallel agents are the
+nominal case, not an extension — a worktree per agent, a branch per task,
+`blocked_by` for what actually waits; the assembled workflow is in
+[handing ank to an agent][agents]. Undo, history and recovery are git's. There
+is nothing to run.
 
 ## Where this sits
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -163,6 +163,55 @@ records who was working rather than restricting who may. Nothing in ank refuses
 on identity; the refusals are on state, and the one hard authority line is the
 signed ratification commit `ank accept` produces.
 
+## Parallel work and integration
+
+The section above says who works where. This one assembles the whole run:
+several tasks, several agents, one change landing on the default branch.
+
+**Parallelism is derived, not declared.** `blocked_by` is the only relation
+between tasks, and it is the only thing that serializes work. Tasks whose
+blockers are finished are ready together, and `ank context` computes that
+mechanically: every open task in the perimeter, the ready ones first, ordered by
+how many other tasks each would unblock. Do not serialize independent tasks
+because they belong to the same change. If the order matters, that is a
+`blocked_by`; if there is no `blocked_by`, the order is a fiction. `ank graph`
+prints the DAG when you want the shape rather than the next move.
+
+**One branch per task.** Each agent claims its task, works in its own tree on
+its own branch, and finishes there. `ank done` proves the task in the working
+tree it ran in — the verifiers ran against those files and the proof records
+their hash. It does not prove the change merges, or that the combined system
+works. That gap is held by the refs, not by convention: `done` turns the claim
+ref into a completion record naming the commit and the branch, every other tree
+answers `finished on another branch (commit …, branch …), not merged here yet`
+until the merge lands, and `check` prunes the record only once the default
+branch says the task is done.
+
+**Integration is a task.** When several tasks form one change, the whole is
+verified the way the parts were: an ordinary task, `blocked_by` each part, with
+its own criterion and its own verifiers. This is the spec's model rather than a
+workaround — `blocked_by` is a DAG with no rollup precisely because a parent
+that completes when its children do is completion without proof, and the seam
+between the parts is exactly where integration regressions live. The
+integration task becomes ready when the last part finishes; whoever claims it
+merges the branches, runs the combined verification, and records `done` like
+any other task.
+
+Where the branches meet is git's business, and both shapes are legitimate:
+
+- **Independent tasks merge to the default branch directly.** Two tasks that
+  share nothing need no ceremony between them, and no integration task either.
+- **A multi-task change goes through an integration branch.** Branch it off the
+  default branch, merge each task's branch into it, resolve conflicts there,
+  and point the integration task's verification at the combined result. The
+  default branch receives one verified change instead of three partial ones.
+
+**What ank will not do.** No verb creates a worktree, names a branch, or merges
+one. Tasks, claims, criteria, dependencies and proofs are ank's plane; branches,
+worktrees, merges and history are git's, and git is already good at them. The
+one place the planes touch is `accept`, which runs on the default branch and
+nowhere else.
+
 ## Where to go next
 
 - [getting-started.md](getting-started.md) — install to a first finished task,

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -240,6 +240,10 @@ case; one ref per task is what arbitrates them.
 An expired claim is not a live one, so this never stands between you and a task
 whose lease ran out — yours or anybody's.
 
+How parallel sessions assemble into one change — a branch per task, `done` as a
+local proof, integration as a task of its own — is in [agents.md](agents.md),
+under "Parallel work and integration".
+
 Run `ank context` again and the output inverts: no other task, the full
 criterion, and the constraints matching this task's scope.
 


### PR DESCRIPTION
## Why

An external AI review proposed that ank should formalise parallel multi-agent work: one agent / one worktree / one branch, integration as a step distinct from a local `done`, integration modelled as an ordinary task behind `blocked_by`, and no new git-shaped verbs. Reviewing it against the tree showed that ~80% of the proposal is already shipped and normative — spec sections 3 and 7, `skill/SKILL.md`, `docs/agents.md` — but scattered: the pieces were documented separately and assembled nowhere. That an informed reader could rediscover the design as a proposal is the measure of the gap.

## What

- **`docs/agents.md`** — new section "Parallel work and integration": parallelism derived from `blocked_by` (never declared), one branch per task, `done` as a local proof carried by the completion refs, integration as an ordinary task with its own criterion, the integration-branch pattern and when it is unnecessary, and what ank deliberately leaves to git.
- **`docs/getting-started.md`** — a pointer to that section from "One identity per session".
- **`README.md`** — one sentence in "Git does the hard parts" naming parallel agents as the nominal case.
- **`CLAUDE.md`** — the CLI-surface bullet was stale twice over: it cited ADR-c656cbcc33a9 where ADR-f61e2d2c75e8 now binds, and still described `ank help` as one flat listing, which f61e replaced with grouping by the moment a verb is used.

No code, no spec change, `skill/SKILL.md` untouched (frozen by ADR-f61e2d2c75e8; the proposal's suggested skill addition is redundant with the existing non-negotiable rule and was rejected).

Tracked as TASK-ff6ce27c29ad, done with proof `commit:e609493`.

## Verification

- `ank check` exit 0 (signals only)
- `cargo test --workspace` green
- `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XVHVcMbuYWfZ3ABLF4UMTU