### PR TITLE
Reopen three deferred rows, and file the work they imply

### DIFF
--- a/.ank/entities/ADR-25f977377fa0.md
+++ b/.ank/entities/ADR-25f977377fa0.md
@@ -1,0 +1,80 @@
+---
+id: ADR-25f977377fa0
+type: adr
+slug: a-log-entry-is-an-entity-written-once
+title: A log entry is an entity, written once
+created: 2026-08-15T06:53:45Z
+author: claude-code/opus-5
+status: proposed
+scope:
+  - crates/ank-core/**
+  - crates/ank-cli/**
+  - docs/**
+constraint: |
+  A log entry is an entity of kind log. It is allocated an id at creation, written once, and never modified: a correction is a new entry naming the one it corrects. The entity an entry is about is a field on the entry, not the file it lives in, and any kind may carry entries. Nothing is ever appended to an existing file, so two concurrent entries are two new files and the merge that an appended file required does not arise.
+schema: 3
+version: 2
+---
+
+ADR-ff294eff4d1a decided between a section of the entity body and a file of its
+own. It never considered an entity, so there is no argument here to overturn —
+only one to write. That is worth stating plainly, because the reflex when a
+record exists is to assume the question was asked.
+
+**One of the reasons that record still rests on is false, and it is checkable.**
+Three places assert that git resolves two appends by itself: section 7 of the
+specification, the invariant comment in `crates/ank-core/src/log.rs`, and this
+ADR's predecessor. **There is no `merge=union` anywhere in the repository** —
+`.gitattributes` sets `text eol=lf` and one binary exception, and nothing else.
+Git's three-way merge conflicts on two lines appended to the end of one file;
+that is the textbook adjacent-change case, not an edge. The property that
+actually protects the corpus today is *one file per entity*, which comes from the
+addressing and would hold whatever the merge behaviour was.
+
+The consequence lands exactly where the predecessor claimed its strongest gain.
+Its third argument was that a second party had nowhere to append — a pipeline
+recording that it ran, a reviewer noting why a task came back, a second agent in
+the same tree. Those are two appends to the *same* file on two branches, so they
+are the case that conflicts. And the first second-party verb that shipped
+declines the affordance: `attest --detached` writes no log entry, and the
+specification says that is not an omission.
+
+It degrades quietly, too. A conflict marker in a log file is a signal and exits
+0, where the same marker in an entity is a fault and exits 8. An unresolved merge
+in a log passes CI green.
+
+**What an entry cannot do today**, measured rather than supposed. The log is not
+indexed at all: the word does not appear in the index module, and the scan opens
+three directories, never `.ank/log/`. So no question about the log has an answer
+inside the tool — which tasks mention a term, what an agent did this week, when a
+task last moved. Of six message conventions in use, five are written by `format!`
+and read back by nothing, so nothing checks that a `closed:` line agrees with the
+status or that an `amended:` line names fields that changed. The sixth,
+`discrepancy:`, is the only one parsed, and it has zero instances. `log` and
+`show` print without cap or flag while `find` and `context` are both budgeted.
+Nothing deletes a log, so an orphan log is unreachable by every verb and unseen by
+`check`. The log is 487 entries, 224 KB, 27 percent of the corpus.
+
+**Why an entity per entry, and not an entity per log.** An entity carries
+`version`, incremented on every write under compare-and-swap, so making the log
+file an entity turns every append back into a transition — which is what
+ADR-ff294eff4d1a removed, and which it already refused in its half-measure form:
+keeping the section and merely not bumping `version` would make `version` mean
+changed, except sometimes.
+
+An entry, by contrast, is written once and never modified. Append-only stops
+being a convention the format asks for and becomes a property of the storage:
+there is no file to append to. Two concurrent entries are two new files, so the
+conflict does not arise instead of being asserted away. And an entry that is an
+entity has an id, an author, a timestamp and a scope, which is what makes it
+indexable, findable, and able to cross a repository boundary like anything else.
+
+**The cost, written here rather than discovered later.** ADR-c9f9d0d6f05d
+guarantees that an address is computed and never looked up, and the log's address
+is arithmetic on the entity's id. That goes: the entries of an entity become a
+query. The flat directory grows from roughly 210 files to roughly 700. Both are
+accepted deliberately; neither is a surprise to be reported afterwards.
+
+A correction is a new entry naming the one it corrects, never an edit. The
+predecessor's point that a rewritten past entry is a visible git diff still
+holds, and is now the only way one could happen.

--- a/.ank/entities/ADR-a1de673043b4.md
+++ b/.ank/entities/ADR-a1de673043b4.md
@@ -1,0 +1,79 @@
+---
+id: ADR-a1de673043b4
+type: adr
+slug: corpora-federate-by-reading-never-by-writing
+title: Corpora federate by reading, never by writing
+created: 2026-08-15T06:53:45Z
+author: claude-code/opus-5
+status: proposed
+scope:
+  - crates/ank-cli/**
+  - docs/**
+constraint: |
+  One .ank per repository stays authoritative: a corpus belongs to the code it constrains. A repository declares its peers in config.yml, and a verb may read a peer's corpus and never write to it. A constraint may declare that it binds a peer, and that is what crosses. Claims stay per repository, so nothing is arbitrated across a boundary the refs cannot reach. Aggregation happens above the repositories and never instead of them.
+schema: 3
+version: 2
+---
+
+Section 10 records multi-repository federation as deferred, and does it well: the
+absence is described as locked shut in seven places rather than as an oversight.
+This decision does not dispute the record. It sorts it, and it names the one case
+the record did not anticipate.
+
+**The seven locks are not equal, and three of them are help rather than
+obstacle.** Entities live in one flat directory where the file name *is* the id
+and no directory means anything, so two corpora concatenate with nothing to
+reconcile. Ids are generated without coordination, hashing the act of creation, so
+two corpora that never met do not collide — around 3.6e-9 for two corpora of a
+thousand. The index is a cache from which nothing is believed over the files, so
+a reader that builds its own over several corpora contradicts no invariant. Three
+more are surface, and a revision moves them: `Repo` carries one root, `--repo` is
+single-valued, `config.yml` rejects unknown fields. **One is semantic**:
+`refs/ank/*` is per repository, so a claim has no home across a boundary.
+
+That sorting is what makes the retained shape affordable, and the shape is the
+record's own: one `.ank/` per repository stays authoritative, because a corpus
+belongs to the code it constrains, and aggregation happens above the repositories
+and never instead of them. Reading across corpora is the useful part; writing
+across them is not.
+
+**The case the record did not anticipate is the shared constraint.** Its trigger
+is written for dependencies — repeated real work where a task in one repository
+is blocked by a task in another and the pair is tracked by hand. A decision that
+binds a backend and a frontend at once is not that. It is a constraint problem,
+and today it has **no legal expression at all**:
+
+- The scope cannot reach. `normalize_path` refuses an absolute path and refuses a
+  climb that pops above the root, and section 3 states why scope is the only
+  attachment — it is verifiable, a glob is confronted with the filesystem, where a
+  label drifts. A glob naming a sibling checkout would be confronted with a path
+  that exists on one laptop and in no CI, which turns it back into the label the
+  design refused. Written anyway, it matches nothing and degrades into a dead
+  scope, which is a corpus fault.
+- The copy is already forbidden. ADR-e3cb36646d77 refused five satellite
+  repositories each carrying their own copy of the skill, and the sentence is
+  general: the copy is what makes it wrong, a second copy has no anchor, it
+  drifts, nothing turns red, and one day an agent is taught the opposite of a
+  ratified ADR.
+
+Neither scope nor copy. That is a hole rather than an inconvenience, and it is
+the argument that reopens the row.
+
+**What crosses, and what does not.** A peer is declared in `config.yml`, by name,
+in the repository that wants to read it — never discovered, and never inferred
+from the filesystem, because inference is how a corpus starts depending on where
+somebody checked something out. A constraint may declare that it binds a peer,
+and that declaration is read by the peer, so the ADR keeps exactly one home and
+is never copied. Claims do not cross: the one semantic lock stays locked, and
+pretending otherwise would promise an arbitration the refs cannot deliver.
+
+**Two things to decide deliberately rather than inherit**, both found by
+measuring rather than reading. The one-claim-per-identity rule is silently per
+repository, since `already_holding` reads the refs of the resolved root, so one
+`ANK_AGENT` holds a claim in every repository at once and nothing notices; by the
+rule's own reasoning — code 7 means the caller is not available — that is
+doubtful. And a cross-repository `blocked_by` is blocked by eager resolution at
+creation, chosen so an unknown reference does not surface later as a corpus error
+nobody can attribute; the display layer already prints an edge it could not
+resolve, so the attribution property survives a reference that resolves through a
+declared peer, or reports as unresolvable here rather than as nonexistent.

--- a/.ank/entities/ADR-ce550b0dfa39.md
+++ b/.ank/entities/ADR-ce550b0dfa39.md
@@ -1,0 +1,80 @@
+---
+id: ADR-ce550b0dfa39
+type: adr
+slug: a-specification-is-an-entity-and-its-authority-i
+title: A specification is an entity, and its authority is the whole document
+created: 2026-08-15T06:53:45Z
+author: claude-code/opus-5
+status: proposed
+scope:
+  - docs/**
+  - crates/ank-core/**
+  - crates/ank-cli/**
+constraint: |
+  A specification is an entity of kind spec: one entity per document, never one per section. It declares no constraint field, because what it carries is description and not a rule, and it moves through the lifecycle every entity has: proposed, accepted, superseded, ratified by signature, anchored by hash, versioned. context names it the way it names an ADR, id and title, and never quotes its body; show is what reads it. A section is reached by reading the document, never by a second entity.
+schema: 3
+version: 2
+---
+
+Section 10 refused a `spec` kind once already, and this decision is not that
+proposal returning. What was refused was **spec sections as routable entities**:
+cutting one document into scoped fragments served by `context` the way
+constraints are. The reason given holds and is not disputed here — a
+specification's authority comes from being one coherent document, its sections
+are not independent the way ADRs are, and fragmenting it creates drift between
+the fragments, which is the exact failure one document prevents.
+
+This decision keeps that whole. One entity per document. A section is reached by
+reading the document, never by an entity of its own, and `context` never quotes
+a body it would have to cut.
+
+What is being answered is a different complaint, and the record did not
+anticipate it: **the specification does not move the way every other decision in
+this repository moves.** It has no status, no supersession, no ratification, no
+hash anchor, no version. It is a file edited by hand, in a tool whose premise is
+that a decision should be readable, anchored and verifiable. The premise is not
+applied to the document that states it.
+
+The remedy section 10 offered instead has died on contact with use, and that is
+measured rather than argued. Thirty-five ADRs in this corpus, and **not one is a
+distilled specification section**. The ten that name `docs/ank-spec-v1.1.md` name
+it in `scope:` — decisions that *change* the document, which is the opposite
+direction. `see:`, the one field meant to point outward, is used three times,
+never at the specification, and `context` never renders it.
+
+Nobody tried because the vehicle cannot carry it. `constraint` is capped in
+practice — the longest ever written is 1251 characters, median around 420 — it is
+frozen at ratification, since `amend` exits 6 on an accepted ADR whose scope is
+anchored in the ratification commit, it is invisible during orientation, which
+serves id and title and no rule text at all, and the over-constrained ceiling of
+half the budget is **already exceeded by eight tasks**, between 5839 and 12284
+characters. The channel was full before anything was put in it.
+
+Section 11 does not cover the remainder and cannot. Every mechanism it describes
+is subtractive and presupposes a rule that could in principle be checked: a
+constraint is born in prose because we do not yet know how to check it, and
+`enforced_by` takes it out of injected context once we do. Nothing in section 11
+ever puts a description *in*. "Ank already has the sink for what grows" is true
+of rules and of nothing else.
+
+And the missing feature is already implemented by hand. `CLAUDE.md` in this
+repository carries a heading that admits it — implementation constraints,
+summary of the ADRs, the ADRs are authoritative — across 120 lines that are
+unscoped, unhashed, loaded on every session whatever the perimeter, and
+confronted with the ADRs they summarise by nothing at all. It drifts by
+construction. A shadow implementation of a refused feature is the strongest
+evidence the refusal was wrong.
+
+**What this decision does not do.** It does not route sections. It does not put a
+specification into `context` in full: the attention budget is 8000 characters and
+this document is 218601 bytes, twenty-seven times the whole budget, so serving it
+was never on the table and naming it is the entire point. It does not make the
+specification binding the way an ADR is — a `spec` describes, an `adr` binds, and
+an entity that did both would be an ADR with an unbounded constraint, which is
+the ceiling problem restated rather than solved. It does not add a `constraint`
+field to the kind, and the absence is the difference that justifies a kind at all.
+
+The cost is worth writing down. A specification entity is large, and every verb
+that walks the corpus will walk it. `check` verifies the byte-for-byte round trip
+on every entity, so the document is parsed and re-serialised on every run. That
+is acceptable and it is not free.

--- a/.ank/entities/TASK-13e802e46050.md
+++ b/.ank/entities/TASK-13e802e46050.md
@@ -1,0 +1,65 @@
+---
+id: TASK-13e802e46050
+type: task
+slug: a-corpus-declares-its-peers-and-reads-them-witho
+title: A corpus declares its peers, and reads them without ever writing
+created: 2026-08-15T06:56:37Z
+author: claude-code/opus-5
+status: open
+scope:
+  - crates/ank-cli/src/config.rs
+  - crates/ank-cli/src/repo.rs
+  - crates/ank-cli/src/context.rs
+  - crates/ank-cli/tests/cli.rs
+blocked_by: [TASK-1d47cc52c42d]
+done_criteria: |
+  config.yml accepts a declaration naming sibling corpora and still rejects an unknown key. A declared peer is read and never written: a constraint declaring that it binds a peer is served by ank context inside that peer, while the ADR exists in exactly one corpus. A peer that cannot be read warns once and answers locally rather than failing. A test in crates/ank-cli/tests/cli.rs builds two corpora, declares one the peer of the other, asserts the constraint is served in the peer, and asserts no file under the peer corpus was modified.
+criteria_by: creator
+schema: 3
+version: 2
+---
+
+The read half of ADR-a1de673043b4, and only the read half. Writing across corpora
+is not deferred here for lack of time — it is refused, and the refusal is the
+decision.
+
+**What this is for.** A decision that binds a backend and a frontend at once has
+no legal expression today. A scope cannot reach a sibling: an absolute path and a
+climb above the root are both refused, and a glob that named one would be
+confronted with a path that exists on one laptop and in no CI, which turns it
+back into the label that scope was chosen to avoid. And the copy is already
+forbidden — ADR-e3cb36646d77 refused satellite repositories each carrying their
+own copy, because the copy has no anchor, it drifts, nothing turns red, and one
+day an agent is taught the opposite of a ratified decision. Neither scope nor
+copy: that is the hole this closes.
+
+**A peer is declared, never discovered.** Do not walk the filesystem looking for
+sibling `.ank` directories, and do not infer a peer from a git remote. Inference
+is how a corpus starts depending on where somebody happened to check something
+out, which is the same failure as an absolute scope wearing a different hat. The
+declaration is a key in `config.yml`, which today rejects unknown keys in three
+places — that rejection is deliberate and stays, so the key is added rather than
+the strictness removed.
+
+**One home, read from the other end.** The ADR lives in exactly one corpus. What
+crosses is the reading, so the peer's `context` serves a constraint whose home is
+elsewhere. The test has to assert both halves: that the constraint is served, and
+that **no file under the peer's corpus was modified**. The second assertion is
+what makes this task's title true, and it is the one that will still be right in
+a year.
+
+**Degrade, never fail.** A peer that is not on disk, or is a corpus this build
+cannot read, warns once and answers locally. That is the same rule `status
+--remote` already follows for an unreachable remote, and the same reason: a
+reader does not fail because something it was told about is absent.
+
+**Claims do not cross, and this task does not pretend otherwise.** `refs/ank/*`
+is per repository and that is the one lock the sorting in ADR-a1de673043b4 left
+standing. Anything that looked like cross-repository arbitration here would
+promise something the refs cannot deliver.
+
+Two things noticed while measuring, deliberately **not** in this task's scope, so
+that nobody fixes them by accident and reports it afterwards: the
+one-claim-per-identity rule is silently per repository, and cross-repository
+`blocked_by` is blocked by eager resolution at creation rather than by principle.
+Both need their own task and their own criterion.

--- a/.ank/entities/TASK-1d47cc52c42d.md
+++ b/.ank/entities/TASK-1d47cc52c42d.md
@@ -1,0 +1,62 @@
+---
+id: TASK-1d47cc52c42d
+type: task
+slug: the-specification-records-that-three-deferred-ro
+title: The specification records that three deferred rows have fired
+created: 2026-08-15T06:56:12Z
+author: claude-code/opus-5
+status: open
+scope:
+  - docs/**
+blocked_by: []
+done_criteria: |
+  A new revision of docs/ank-spec-v1.1.md records the trigger as fired for the rows 'Spec sections as routable entities' and 'Multi-repository federation', and records that ADR-ff294eff4d1a decided between a body section and a file and never considered an entity per entry. Section 3 declares the kinds spec and log in the registry, each with its field table. Section 7 states the federation shape ADR-a1de673043b4 fixes. The three passages that still describe the log as an append-only section of the entity file are corrected, as is the sentence claiming git unions two appends with no driver. No source file path and no line number enters the document. ank check stays green.
+criteria_by: creator
+schema: 3
+version: 2
+---
+
+The specification is the source of truth and it moves first: format changes go
+through this document, then the goldens, then the code. Every other task in this
+group is blocked on this one for that reason, and not because the prose is
+prettier written early.
+
+Three rows change, and each for a different reason. Do not flatten them into one
+sentence about pressure.
+
+**Spec sections as routable entities.** The refusal stands as written for what it
+refused — fragmenting one document into scoped entities that drift apart. What
+fires is not that. It is that the remedy the row offers instead, distilling a
+section into a scoped ADR, has **zero instances** across thirty-five ADRs in the
+corpus that wrote the refusal, and that the vehicle it names cannot carry the
+load: the longest constraint ever written is 1251 characters, the field is frozen
+at ratification, it is invisible during orientation, and the over-constrained
+ceiling is already exceeded by eight tasks. Record that the trigger as worded was
+unfalsifiable by construction, and that what is admitted is a whole-document kind,
+never a section.
+
+**Multi-repository federation.** The trigger there is written for dependencies. It
+does not anticipate the shared constraint, which today has no legal expression at
+all: a scope cannot reach a sibling, because an absolute path and a climb above
+the root are both refused and a glob that named one would become the label scope
+exists to avoid; and the copy is already forbidden by ADR-e3cb36646d77. Neither
+scope nor copy is the hole. Record it as such, and keep the shape the row already
+retained: one corpus per repository stays authoritative, aggregation above and
+never instead.
+
+**The log.** ADR-ff294eff4d1a is not superseded and nothing here says it was
+wrong. It decided between a body section and a file of its own, and never
+considered an entity per entry, so the record gains a sentence saying that rather
+than a reversal.
+
+**Four corrections that are pure defect.** Three passages still describe the log
+as an append-only section of the entity file: the settled list in the revision
+summary, and two in section 12, one of which still lists `log = timestamped
+union` among the merge driver rules that section 7 removed. And section 7 claims
+git's own union resolves an appended file with no driver, which is false —
+nothing in the repository configures `merge=union`, and git's three-way merge
+conflicts on two appends. The property that actually protects is one file per
+entity, which comes from the addressing.
+
+**No source file path and no line number goes into this document.** They are what
+rots; TASK-35df68dd0eb3 learned it the hard way and its log says so.

--- a/.ank/entities/TASK-3a0347e72bf3.md
+++ b/.ank/entities/TASK-3a0347e72bf3.md
@@ -5,7 +5,7 @@ slug: ank-log-refuses-every-kind-but-task-and-the-spec
 title: ank log refuses every kind but task, and the spec says any kind may carry one
 created: 2026-08-15T06:08:39Z
 author: claude-code/opus-5
-status: open
+status: closed
 scope:
   - crates/ank-cli/src/commands.rs
   - crates/ank-cli/tests/cli.rs
@@ -15,7 +15,7 @@ done_criteria: |
   ank log reads and writes the log of any entity kind. The two refusals in crates/ank-cli/src/commands.rs that name a task are gone, ank log on an ADR appends to the log file computed from its id, ank show on that ADR prints the entries, and no claim renewal is attempted for a kind that cannot be claimed. A test in crates/ank-cli/tests/cli.rs drives the built binary against an ADR, writing an entry and reading it back.
 criteria_by: creator
 schema: 3
-version: 2
+version: 3
 ---
 
 Section 3 says it in one sentence: any kind may carry a log, and a missing log

--- a/.ank/entities/TASK-3e68786fa443.md
+++ b/.ank/entities/TASK-3e68786fa443.md
@@ -1,0 +1,51 @@
+---
+id: TASK-3e68786fa443
+type: task
+slug: the-spec-kind-reaches-the-cli-named-and-never-qu
+title: The spec kind reaches the CLI, named and never quoted
+created: 2026-08-15T06:56:37Z
+author: claude-code/opus-5
+status: open
+scope:
+  - crates/ank-cli/**
+blocked_by: [TASK-e8df857e87d7]
+done_criteria: |
+  The binary creates, reads and lists a spec entity through its own surface: ank new spec with a title and a scope creates one, ank show prints it whole byte for byte, ank find --type spec lists it, and ank context names it beside the constraints with its id and its title and never quotes its body in either mode. ank help lists the kind wherever it lists task and adr. A test in crates/ank-cli/tests/cli.rs drives the built binary through create, show, find and context, and asserts that context prints no line of the body.
+criteria_by: creator
+schema: 3
+version: 2
+---
+
+The kind exists after TASK-e8df857e87d7; this is what makes it reachable.
+
+**Named, never quoted — and the assertion is the point of the test.** The
+specification this repository stores is 218601 bytes against an attention budget
+of 8000 characters, twenty-seven times the whole budget. So `context` treats a
+spec exactly as it treats an ADR in orientation: id and title, one line, nothing
+else. Unlike an ADR, there is no execution mode where the body is served either,
+because there is no `constraint` field to serve and the body is the document. If
+a single line of a spec body ever reaches `context`, the budget is gone and the
+mode is broken. Assert the negative, not just the positive.
+
+**`ank show` is the reader**, byte for byte, as it already is for every entity.
+That is not a new rule, it is the existing split section 5 settles for `help` and
+its per-verb page: what a thing *says* is one `show` away.
+
+**Places the kind list is written out by hand**, and every one of them is a place
+this task has to reach or the surface disagrees with itself: the `new`
+subcommands and the runtime match behind them, `find --type` and its refusal
+message, the two-bucket partition `find` uses to split results, `help`'s usage
+line, and the short-id computation, which walks a fixed array of kinds. The
+registry does not reach these; they are CLI surface. TASK-e2603a487256 was filed
+to make `ank new spec` explain the refusal and is closed by this task instead —
+the command now works, which is the better answer.
+
+**Watch the `Entity` match arms in `show`.** The frontmatter and body go through
+the registry-driven serialiser and will render with no help, but the derived
+sections underneath — blocked-by and unblocks edges, detached proofs — are
+matched per kind. A spec has neither, and the arm has to say so rather than fall
+through to a task's.
+
+A `scope` is mandatory on every entity, so a spec has one, and it should name
+what the document governs rather than where the document lives. A specification
+of the ank format scopes the format's implementation, not `docs/`.

--- a/.ank/entities/TASK-6c0463fb4319.md
+++ b/.ank/entities/TASK-6c0463fb4319.md
@@ -1,0 +1,60 @@
+---
+id: TASK-6c0463fb4319
+type: task
+slug: three-texts-claim-git-unions-two-appends-and-not
+title: Three texts claim git unions two appends, and nothing configures it
+created: 2026-08-15T06:56:12Z
+author: claude-code/opus-5
+status: open
+scope:
+  - .gitattributes
+  - crates/ank-core/src/log.rs
+  - crates/ank-cli/src/commands.rs
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/tests/cli.rs
+blocked_by: []
+done_criteria: |
+  The invariant comment in crates/ank-core/src/log.rs no longer claims that git unions two appends with no merge driver, and .gitattributes declares merge=union for the log path so the property holds where it is still relied on. A conflict marker in a log file is reported by check with the same severity as one in an entity file. ank log and ank show cap what they print the way find does and announce what they cut. ADR-ff294eff4d1a is not edited: ratified content is anchored by hash. A test in crates/ank-cli/tests/cli.rs merges two branches that each appended a different entry to one log and asserts both entries survive with no conflict marker.
+criteria_by: creator
+schema: 3
+version: 2
+---
+
+A claim stated in three places and configured in none. Section 7 of the
+specification, the invariant comment in `crates/ank-core/src/log.rs`, and
+ADR-ff294eff4d1a all say git's own union resolves two appends with no merge
+driver. `.gitattributes` sets `text eol=lf` and one binary exception, and that is
+the whole file; there is no `merge=union` anywhere in the repository. Git's
+three-way merge conflicts on two lines appended to the end of one file. That is
+the textbook adjacent-change case.
+
+The property that has actually been protecting the corpus is **one file per
+entity**, which comes from the addressing and would hold whatever git did. Two
+agents on two tasks touch two files. The case the ADR celebrated most — a second
+party appending to a task's log, a pipeline, a reviewer, a second agent in the
+same tree — is exactly the one that conflicts, because those are two appends to
+the same file on two branches.
+
+**And it fails silently, which is the half that matters.** A conflict marker in a
+log file is refused by the strict log parser, which `check` turns into a signal
+and exits 0. The same marker in an entity is a fault and exits 8, on the stated
+grounds that a merge left half done is a corpus fault long before it is a parse
+error. So an unresolved merge in a log passes CI green today. Fix that asymmetry;
+it is the part with teeth.
+
+**Do not edit ADR-ff294eff4d1a.** Ratified content is anchored by hash, and
+historical context is not falsified by a later correction. The specification is
+corrected by TASK-1d47cc52c42d, this task corrects the code comment, and the ADR
+stays as written.
+
+**Yes, TASK-df9c6d46e8ef will make the appended file disappear entirely.** This
+task is still worth doing and worth doing first: the migration may not land, and
+until it does the exposure is real, on a corpus where the log is 27 percent of the
+bytes. The caps are permanent value regardless — `log` and `show` are the only
+two readers in the tool with no budget and no flags, while `find` and `context`
+are both bounded, and the module header of `find` states the reason: a reader
+without a cap is a context-explosion vector.
+
+The test has to be a real merge of two real branches, not an assertion about the
+contents of `.gitattributes`. A criterion that talks about git's behaviour is
+tested by making git behave.

--- a/.ank/entities/TASK-df9c6d46e8ef.md
+++ b/.ank/entities/TASK-df9c6d46e8ef.md
@@ -1,0 +1,67 @@
+---
+id: TASK-df9c6d46e8ef
+type: task
+slug: log-entries-become-entities-and-the-corpus-migra
+title: Log entries become entities, and the corpus migrates without losing one
+created: 2026-08-15T06:56:47Z
+author: claude-code/opus-5
+status: open
+scope:
+  - crates/ank-cli/**
+  - crates/ank-core/**
+blocked_by: [TASK-e8df857e87d7, TASK-3e68786fa443]
+done_criteria: |
+  A log entry is written as an entity naming the entity it is about, and nothing is appended to an existing file. ank log with an id and ank show read the entries back, newest first and oldest first respectively, capped and announcing what they cut. Entries are indexed and reachable through ank find. Any kind carries entries, an ADR included. The entries the corpus already holds are migrated, with their count asserted equal before and after and no message altered, and the previous log directory is no longer written. A test in crates/ank-cli/tests/cli.rs drives the built binary for write, read, show, find, the ADR case, and two concurrent entries merging with no conflict.
+criteria_by: creator
+schema: 3
+version: 2
+---
+
+The deepest change of the group, and the last, because it moves 27 percent of the
+corpus by volume.
+
+**Why an entry and not a log.** An entity carries `version`, incremented on every
+write under compare-and-swap. Making the per-entity log file an entity would turn
+every append back into a transition, which is exactly what ADR-ff294eff4d1a
+removed — and that ADR already refused the half-measure of keeping the section
+and merely not bumping `version`, on the grounds that it would make `version`
+mean changed, except sometimes. An entry, written once and never modified, has no
+such problem: there is no file to append to, so append-only stops being a
+convention the format requests and becomes a property of the storage.
+
+**What it buys, and each of these is a gap measured today.** The log is not
+indexed at all — the scan opens three directories and never the log directory —
+so no question about it has an answer inside the tool. Entries gain an id, an
+author, a timestamp and a scope, which is what makes them reachable by `find` and
+what lets them cross a repository boundary like anything else. Two concurrent
+entries become two new files, so the conflict genuinely disappears instead of
+being asserted away. And a second party finally has somewhere to write: the ADR's
+own example, a pipeline recording that it ran, is today served by a ref because
+`attest --detached` writes no entry at all.
+
+**The migration is the risk, and the criterion is written around it.** 487
+entries across 168 files. Assert the count equal before and after and assert no
+message altered — a migration that silently drops one entry is worse than no
+migration, because the loss is invisible and permanent. The strict parser refuses
+a whole file on its first malformed line, so a file that fails to parse must stop
+the migration and name the file, never be skipped.
+
+**Do not lose the ordering.** Entries carry an ISO timestamp kept as written and
+never reformatted. `log` reads newest first and `show` oldest first, and both
+orders come from the timestamp, not from a directory listing. Two entries in the
+same second are possible and the order between them must be stable rather than
+whatever the filesystem returns.
+
+**Caps.** These two readers are the only ones in the tool with no budget, and
+after this change they read through an index that will happily return everything.
+TASK-6c0463fb4319 caps them first; do not undo that, and make sure the cap
+survives the new read path.
+
+**Any kind carries entries**, an ADR included. The refusal that named a task by
+name was filed as TASK-3a0347e72bf3 and is closed by this one: the guard does not
+get lifted, the storage it guarded stops existing.
+
+The previous log directory stops being written. Whether it stops being *read* is
+a judgement call this task should make explicitly and record: a corpus written by
+an older build still has one, and the same courtesy the store already extends to
+the previous entity layout is the precedent to follow.

--- a/.ank/entities/TASK-e2603a487256.md
+++ b/.ank/entities/TASK-e2603a487256.md
@@ -5,7 +5,7 @@ slug: ank-new-spec-answers-unknown-subcommand-instead
 title: ank new spec answers unknown subcommand instead of naming the recorded deferral
 created: 2026-08-15T06:08:39Z
 author: claude-code/opus-5
-status: open
+status: closed
 scope:
   - crates/ank-cli/src/commands.rs
   - crates/ank-cli/tests/cli.rs
@@ -14,7 +14,7 @@ done_criteria: |
   ank new spec exits 1 with a message naming the deferral recorded in TASK-00660963bcce and section 10 of the specification, and a hint whose command is ank new adr. Any other unknown subcommand keeps the message it has today. A test in crates/ank-cli/tests/cli.rs drives the built binary and asserts both cases.
 criteria_by: creator
 schema: 3
-version: 2
+version: 3
 ---
 
 `ank new spec` is the one wrong subcommand somebody actually types, because a

--- a/.ank/entities/TASK-e8df857e87d7.md
+++ b/.ank/entities/TASK-e8df857e87d7.md
@@ -1,0 +1,52 @@
+---
+id: TASK-e8df857e87d7
+type: task
+slug: the-core-admits-the-spec-and-log-kinds
+title: The core admits the spec and log kinds
+created: 2026-08-15T06:56:22Z
+author: claude-code/opus-5
+status: open
+scope:
+  - crates/ank-core/**
+blocked_by: [TASK-1d47cc52c42d]
+done_criteria: |
+  crates/ank-core declares the kinds spec and log in its registry, each with an entity struct, a field table and canonical serialisation, and EntityKind, Entity and the parser admit them. A spec declares no constraint field; a log entry names the entity it is about. A golden fixture per new kind round-trips byte for byte under crates/ank-core/tests/golden.rs, and an invalid fixture per new kind is refused naming what is wrong. cargo test --workspace passes and cargo fmt --check is clean.
+criteria_by: creator
+schema: 3
+version: 2
+---
+
+The registry exists so that adding a kind is a table entry rather than a second
+parser, and this is the first time anybody uses it for that. ADR-c9f9d0d6f05d is
+explicit that the cost of a kind is a row, a golden fixture and a section of the
+specification — never a second serializer, a second parser branch, and never a
+second directory. Hold it to that: if this task grows a `match` arm per kind
+somewhere the registry should have answered, the registry is what is wrong.
+
+Two kinds, and they differ from `adr` in one field each.
+
+**`spec` declares no `constraint`.** That absence is the whole justification for
+the kind. A specification describes; an ADR binds. An entity that did both would
+be an ADR with an unbounded constraint, which is the ceiling problem restated
+rather than solved, and the ceiling is already exceeded by eight tasks.
+
+**A `log` entry names the entity it is about.** Today that association is
+arithmetic on the id, and it becomes a field. This is what ADR-c9f9's "the
+address is computed, never looked up" costs, and it is accepted deliberately in
+ADR-25f977377fa0 rather than discovered here.
+
+**The enum indexes the registry by declaration order.** `EntityKind` is a closed
+enum whose variants index `KINDS` positionally, and a test asserts the two agree.
+Adding rows in one place and variants in another, in a different order, is the
+failure this arrangement is built to catch — let it catch you rather than
+reasoning about it.
+
+**Goldens are the specification made executable.** The round trip is byte for
+byte on canonical form, so a valid fixture per kind proves the serialiser and the
+parser agree, and an invalid fixture per kind proves the refusal names what is
+wrong rather than failing vaguely. A kind with no invalid fixture is a kind whose
+strictness is untested, and the existing `bad-status.md` is the shape to copy.
+
+Nothing in the CLI moves under this task. `ank new spec` and the log verb come
+after, in TASK-3e68786fa443 and TASK-df9c6d46e8ef, and keeping the core change
+alone is what lets those two proceed in parallel with anything else.

--- a/.ank/log/TASK-3a0347e72bf3.md
+++ b/.ank/log/TASK-3a0347e72bf3.md
@@ -1,0 +1,1 @@
+- 2026-08-15T06:58:48Z claude-code/opus-5 — closed: Absorbed by ADR-25f977377fa0 and TASK-df9c6d46e8ef: the two-line guard naming a task is not lifted, the per-entity log file it guarded stops being the storage. Any kind carrying entries is a criterion of that task.

--- a/.ank/log/TASK-e2603a487256.md
+++ b/.ank/log/TASK-e2603a487256.md
@@ -1,0 +1,1 @@
+- 2026-08-15T06:58:47Z claude-code/opus-5 — closed: Superseded by ADR-ce550b0dfa39: with a spec kind in the registry, ank new spec creates an entity instead of needing an error that explains why it cannot. TASK-3e68786fa443 carries the surface work, and the deferral this task would have named is recorded as fired by TASK-1d47cc52c42d.


### PR DESCRIPTION
No code. Three ADRs, **proposed and unratified** — they are yours to accept or refuse — six tasks, and two closures.

## Why each row is reopened

Each on a different ground, and none on the ground of wanting the feature.

**`spec`.** What §10 refused was *sections as routable entities*: fragmenting one document into scoped fragments that drift apart. That refusal holds and is not disputed. What is proposed is a whole-document kind, which keeps the coherence the refusal protected. What fires is the *remedy* — distil a section into a scoped ADR — which has **zero instances across thirty-five ADRs in the corpus that wrote it**, on a vehicle that cannot carry the load: longest constraint ever written 1251 characters, frozen at ratification (`amend` exits 6), invisible during orientation, and the over-constrained ceiling already exceeded by eight tasks between 5839 and 12284 characters. §11 cannot absorb the remainder either — every mechanism in it is subtractive and presupposes a checkable rule. Meanwhile `CLAUDE.md` performs the refused feature by hand, under a heading that admits it is a summary of an authoritative source nothing confronts it with.

**Federation.** The row stands as recorded, including its retained shape: one corpus per repository stays authoritative, aggregation above and never instead. But its trigger is written for *dependencies*, and does not anticipate the **shared constraint**, which today has no legal expression at all — a scope cannot reach a sibling (an absolute path and a climb above the root are both refused, and a glob naming one becomes the label scope exists to avoid), and ADR-e3cb36646d77 already forbids the copy. Neither scope nor copy is a hole, not an inconvenience.

**The log.** There is no refusal to overturn: ADR-ff294eff4d1a decided between a body section and a file of its own, and never considered an entity per entry. And one argument it still rests on is **false** — §7, `log.rs` and the ADR all claim git unions two appends with no driver, and nothing in the repository configures `merge=union`. Git's three-way merge conflicts on two appends. The property actually protecting the corpus is one file per entity, which comes from the addressing. Worse, a conflict marker in a log is a signal (exit 0) where the same marker in an entity is a fault (exit 8).

## The six tasks, and why the scopes are cut this way

```
TASK-1d47  the specification records the three rows have fired      docs/**
TASK-6c04  merge=union, and the two uncapped readers                .gitattributes + cli
  TASK-e8df  the core admits the spec and log kinds                 crates/ank-core/**
    TASK-3e68  the spec kind reaches the CLI                        crates/ank-cli/**
      TASK-df9c  log entries become entities, corpus migrated
  TASK-13e8  a corpus declares its peers, and only reads them       config/repo/context
```

The specification moves first — format changes go spec, then goldens, then code. `1d47` and `6c04` are disjoint by construction (one is docs-only, the other code-only) and can be taken together.

## Closed

- **TASK-e2603a487256** — `ank new spec` no longer needs an error explaining the refusal; the command works.
- **TASK-3a0347e72bf3** — the guard naming a task is not lifted, the storage it guarded stops existing.

## What is deliberately not here

Two defects found while measuring, left for their own task and their own criterion rather than fixed by accident: the one-claim-per-identity rule is silently per repository, and cross-repository `blocked_by` is blocked by eager resolution at creation rather than by principle.

`ank check` green — 181 tasks, 38 adr, 0 faults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EvZMJnyhvKiAogLC5Se2Ev