### PR TITLE
find --json carries the coordination state its human listing shows

### DIFF
--- a/.ank/entities/TASK-e8e09606806f.md
+++ b/.ank/entities/TASK-e8e09606806f.md
@@ -5,7 +5,7 @@ slug: find-json-drops-the-coordination-state-its-human
 title: find --json drops the coordination state its human output shows
 created: 2026-08-15T06:08:39Z
 author: claude-code/opus-5
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/src/commands.rs
   - crates/ank-cli/tests/cli.rs
@@ -13,8 +13,13 @@ blocked_by: []
 done_criteria: |
   Every result of find --json carries the coordination state under the same key and the same value shape context --json already uses for it, and the stored status stays on its own key. A test in crates/ank-cli/tests/cli.rs drives the built binary: it seeds a completion ref and asserts that find --status open --json names the finished state that the human listing shows on the same row.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: ef0397656386715acb25afc030eb1e0850935e5b
+    criteria: 12b70edda06e
+    via: submitted
 schema: 3
-version: 3
+version: 4
 ---
 
 The human listing of `find` marks every row from the coordination plane, and its

--- a/.ank/entities/TASK-e8e09606806f.md
+++ b/.ank/entities/TASK-e8e09606806f.md
@@ -5,7 +5,7 @@ slug: find-json-drops-the-coordination-state-its-human
 title: find --json drops the coordination state its human output shows
 created: 2026-08-15T06:08:39Z
 author: claude-code/opus-5
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/src/commands.rs
   - crates/ank-cli/tests/cli.rs
@@ -14,7 +14,7 @@ done_criteria: |
   Every result of find --json carries the coordination state under the same key and the same value shape context --json already uses for it, and the stored status stays on its own key. A test in crates/ank-cli/tests/cli.rs drives the built binary: it seeds a completion ref and asserts that find --status open --json names the finished state that the human listing shows on the same row.
 criteria_by: creator
 schema: 3
-version: 2
+version: 3
 ---
 
 The human listing of `find` marks every row from the coordination plane, and its

--- a/.ank/log/TASK-e8e09606806f.md
+++ b/.ank/log/TASK-e8e09606806f.md
@@ -1,1 +1,2 @@
 - 2026-08-15T09:02:25Z claude-code/find-json-state — falsified: with the state field removed find --json emits open for a row the listing marks [finished:<sha> on feature]; with it spelled from the stored status instead of the plane, same. The test binds the value, not just the key.
+- 2026-08-15T09:09:44Z claude-code/find-json-state — done, proof commit:ef0397656386715acb25afc030eb1e0850935e5b

--- a/.ank/log/TASK-e8e09606806f.md
+++ b/.ank/log/TASK-e8e09606806f.md
@@ -1,0 +1,1 @@
+- 2026-08-15T09:02:25Z claude-code/find-json-state — falsified: with the state field removed find --json emits open for a row the listing marks [finished:<sha> on feature]; with it spelled from the stored status instead of the plane, same. The test binds the value, not just the key.

--- a/crates/ank-cli/src/commands.rs
+++ b/crates/ank-cli/src/commands.rs
@@ -934,14 +934,29 @@ pub fn find(
     let shown = total.min(cap);
 
     if inv.json() {
+        // `state` beside `status`, from the plane already read above and in the
+        // spelling `context --json` uses: the marker the human listing prints,
+        // brackets stripped. A marker is not colour — ADR-0c8ab846d262 keeps
+        // colour for the reader and structure for everyone — so the answer a
+        // terminal gets about a row finished on a branch is the answer a pipe
+        // gets, and a caller filtering on this JSON no longer schedules work the
+        // completion ref already closed. Additive: `status` stays the stored
+        // one, under the key it already has.
         let items: Vec<String> = hits[..shown]
             .iter()
             .map(|r| {
                 format!(
-                    "{{\"id\":\"{}\",\"kind\":\"{}\",\"status\":\"{}\",\"title\":{}}}",
+                    "{{\"id\":\"{}\",\"kind\":\"{}\",\"status\":\"{}\",\"state\":{},\"title\":{}}}",
                     r.id,
                     r.kind.as_str(),
                     r.status,
+                    json_string(
+                        crate::context::marker_for(
+                            &r.status,
+                            crate::context::coordination_of(&coord, &r.id)
+                        )
+                        .trim_matches(|c| c == '[' || c == ']')
+                    ),
                     json_string(&r.title)
                 )
             })

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -8509,6 +8509,96 @@ fn a_listing_counts_the_open_rows_a_claim_would_refuse_and_names_free() {
     );
 }
 
+/// `find --json` answers about the coordination plane, in the spelling
+/// `context --json` already uses (TASK-e8e09606806f).
+///
+/// The two surfaces of one verb used to disagree about the same row: a reader
+/// at a terminal saw `[finished:<sha> on <branch>]`, a script reading `--json`
+/// saw `open` and nothing else. A caller filtering on that JSON would schedule
+/// work already finished on a branch — exactly the window the completion ref
+/// exists to close, reopened for whoever automated the question.
+///
+/// ADR-0c8ab846d262 is the argument: colour depends on the reader, structure
+/// does not, and a marker is not colour. It is the answer, and it reads the
+/// same in a pipe.
+///
+/// The state is asserted against the very string the human listing prints, so
+/// a second spelling of one fact fails here rather than shipping.
+#[test]
+fn find_json_carries_the_coordination_state_the_human_listing_shows() {
+    let finished = "TASK-a00000000005";
+    let held = "TASK-b00000000005";
+    let candidate = "TASK-c00000000005";
+    let r = Repo::new().with_verifiers("verifiers:\n  ok:\n    run: echo fine\n");
+    r.seed_task_with(finished, Some("A criterion."), &["ok"]);
+    r.seed_task_scoped(held, "crates/**");
+    r.seed_task_scoped(candidate, "docs/**");
+    r.git(&["add", "-A"]);
+    r.git(&["commit", "-qm", "seed tasks"]);
+
+    // Both transitions happen on a branch, so `main` keeps reading `open` for
+    // both rows: the disagreement under test only exists while the file and the
+    // ref say different things.
+    r.git(&["checkout", "-q", "-b", "feature"]);
+    std::fs::write(r.0.join("work.txt"), "y").unwrap();
+    r.git(&["add", "-A"]);
+    r.git(&["commit", "-qm", "work"]);
+    let finished_at = r.head();
+    assert_eq!(code(&r.ank("claude-code@ank", &["claim", finished])), 0);
+    let out = r.ank("claude-code@ank", &["done"]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    r.git(&["add", "-A"]);
+    r.git(&["commit", "-qm", "done"]);
+    assert_eq!(code(&r.ank("claude-code@ank", &["claim", held])), 0);
+    r.git(&["add", "-A"]);
+    r.git(&["commit", "-qm", "claimed"]);
+
+    r.git(&["checkout", "-q", "main"]);
+    for id in [finished, held] {
+        assert!(
+            r.task_text(id).contains("status: open"),
+            "the fixture is wrong if main already carries the transition of {id}"
+        );
+    }
+
+    // What the reader at a terminal is told about the finished row.
+    let marker = format!("[finished:{} on feature]", &finished_at[..7]);
+    let listing = stdout(&r.ank("someone@ank", &["find", "--status", "open"]));
+    assert!(
+        listing.contains(&marker),
+        "the fixture is wrong if the human listing does not mark the row: \
+         {listing}"
+    );
+
+    let j = stdout(&r.ank("someone@ank", &["find", "--status", "open", "--json"]));
+
+    // The same fact, the same words, on the same row — and the stored status
+    // still on the key it always had, so nothing a caller reads today moves.
+    assert!(
+        j.contains(&format!(
+            "{{\"id\":\"{finished}\",\"kind\":\"task\",\"status\":\"open\",\
+             \"state\":\"{}\"",
+            marker.trim_matches(|c| c == '[' || c == ']')
+        )),
+        "the finished state the listing shows is missing from the JSON row: {j}"
+    );
+    assert!(
+        j.contains(&format!(
+            "{{\"id\":\"{held}\",\"kind\":\"task\",\"status\":\"open\",\
+             \"state\":\"claimed:claude-code@ank\""
+        )),
+        "a held row names its holder in the JSON too: {j}"
+    );
+    assert!(
+        j.contains(&format!(
+            "{{\"id\":\"{candidate}\",\"kind\":\"task\",\"status\":\"open\",\
+             \"state\":\"open\""
+        )),
+        "a row the plane says nothing about carries its stored status as its \
+         state, exactly as context --json spells it: {j}"
+    );
+}
+
 #[test]
 fn new_stores_the_normalised_glob_and_never_the_string_as_typed() {
     let r = scoped_repo();


### PR DESCRIPTION
Closes TASK-e8e09606806f.

## The defect

The two surfaces of one verb answered differently about the same row. The human listing of `find` marks every row from the coordination plane; its `--json` emitted the stored status alone. A reader at a terminal saw `[finished:<sha> on <branch>]` where a script saw `open`.

A caller filtering on that JSON would schedule work already finished on a branch — the window the completion ref exists to close, reopened for whoever automated the question.

## The change

`state` joins each result of `find --json`, beside `status`:

```json
{"id":"TASK-a00000000005","kind":"task","status":"open","state":"finished:9e5c1af on feature","title":"Example task"}
```

ADR-0c8ab846d262 is the argument: colour depends on the reader, structure does not. A marker is not colour — it is the answer, and it reads the same in a pipe.

The value is the spelling `context --json` already uses for the same fact: the marker `marker_for` prints, brackets stripped. Not a second spelling, since two spellings of one state would be the divergence this change removes, moved down a level. It comes from the plane the verb already read once for `--free` and for the listing's markers; a second read would be a second chance to disagree about which claims were live.

Additive: the stored status stays where it is, under the key it already has, so no existing consumer breaks.

## Verification

The test drives the built binary. It seeds a completion ref on a branch `main` does not carry, and asserts the JSON row names the very string the human listing prints on that row — so a second spelling fails there rather than shipping. A held row and an untouched row are asserted too.

Falsified twice before being kept:

- field dropped — the row reads `open`, and the failure output is the defect itself
- field present but spelled from the stored status instead of the plane — reads `open` too

So the assertion binds the value, not merely the key.

`cargo test --workspace` green (527 tests), `cargo fmt --check` clean, `ank check` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011mHCHGGRvy8Juc3UihnZWB
