### PR TITLE
A specification is several documents, and the monolith was already drifting

### DIFF
--- a/.ank/entities/ADR-5a690829388d.md
+++ b/.ank/entities/ADR-5a690829388d.md
@@ -1,0 +1,89 @@
+---
+id: ADR-5a690829388d
+type: adr
+slug: a-specification-is-several-documents-and-their-c
+title: A specification is several documents, and their coherence is verified rather than assumed
+created: 2026-08-15T15:46:54Z
+author: claude-code/opus-5
+status: proposed
+scope:
+  - docs/**
+  - crates/ank-cli/**
+constraint: |
+  A specification is several documents, one entity each, and each is ratified and anchored on its own. Coherence between them is verified rather than assumed: a reference from one document to another is a declared field, check reports one naming an entity that is absent, unaccepted or superseded, and changing a ratified document is a supersession that leaves a chain. A document that cannot be read alone is not a document, and the decomposition is argued in the corpus rather than derived from section numbers.
+supersedes: ADR-ce550b0dfa39
+schema: 3
+version: 2
+---
+
+ADR-ce550b0dfa39 was ratified today and is superseded today, which deserves an
+explanation rather than an apology. It admitted the `spec` kind on the narrowest
+ground that would carry it — one entity per document, never one per section —
+because that was the only shape section 10's standing refusal did not forbid.
+Taking the narrow ground was right; keeping it is not, and what changed is not
+an opinion but a measurement this session produced.
+
+**The refusal rested on a premise nobody had checked.** Its wording is that a
+specification's authority comes from being one coherent document, and that
+fragmenting it creates drift between the fragments — section 4 refuses on state
+because section 8 makes roles advisory, section 7 means nothing without section
+3. Every word of that describes a real dependency. What it assumes is that
+keeping them in one file is what keeps them true.
+
+It is not, and the evidence is the document itself. While three agents worked on
+unrelated tasks in this repository, the specification was found to carry **four
+stale passages at once**: three describing the log as an append-only section of
+the entity file, a shape ADR-ff294eff4d1a had retired, and one asserting that
+git's own union resolves two appends with no merge driver, which is false and
+which nothing in the repository configured. A fourth copy of the same false
+claim sat in `docs/format.md`. Those passages survived every revision of a
+document whose coherence was the reason not to split it, and they were found by
+accident, by readers looking for something else.
+
+**A monolith's coherence is enforced by nobody.** That is the whole of it. The
+file has no anchor, no ratification, no hash, and no verb that confronts it with
+anything. A section can be edited in place with no signal, contradicted by the
+section below it with no signal, and left describing a retired shape for months
+with no signal. The one mechanism watching it is a human reading fifteen hundred
+lines, which is exactly the mechanism that failed four times.
+
+What replaces it is mechanical, and each part of it already exists:
+
+- **Each document is anchored.** `ratified` holds the hash of the body and the
+  scope (ADR-ce550b0dfa39, kept), so a document that moves after ratification is
+  reported as altered. The monolith could never be anchored, because it was
+  never an entity.
+- **Each reference is declared and checked.** A dependency between documents
+  stops being a sentence a reader must notice and becomes a field `check`
+  verifies, the way `blocked_by` is verified today — absent, unaccepted or
+  superseded targets are reported. Section 4 depending on section 8 is then a
+  fact the corpus holds, not a fact a reader must reconstruct.
+- **Each change leaves a chain.** Revising a ratified document is a
+  supersession, so the history of a rule is a chain of entities rather than a
+  git diff nobody reopens.
+
+So the disagreement with the superseded decision is narrow and total: it is not
+that drift does not matter, it is that **the monolith was already drifting and
+nothing said so**. Splitting does not introduce the risk; it introduces the
+detector.
+
+**What is kept from ADR-ce550b0dfa39**, unchanged: one entity per document, a
+`spec` declares no `constraint`, `context` names it and never quotes it, and its
+authority moves through the lifecycle every entity has.
+
+**What this costs, stated rather than discovered.** A reader who needs the whole
+must open several entities, and the narrative thread that a single document
+carries — the long argument running from intent to implementation — is weaker
+across a boundary than inside one. That is the real price of this decision. It is
+paid deliberately, and the mitigation is the rule in the constraint: a document
+that cannot be read alone is not a document, so the decomposition is argued and
+defended in the corpus rather than derived from the section numbers that happen
+to exist today. A split into thirteen entities because the file has thirteen
+sections would be the fragmentation section 10 refused, wearing this decision as
+a disguise.
+
+**Section numbers are not the seam.** They are an artifact of one document's
+table of contents. The seam is a body of rules that a reader can act on without
+holding another one open, and finding it is work — which is why the split is a
+task with a criterion and not a mechanical operation performed under this
+decision.

--- a/.ank/entities/TASK-1162c24b7c75.md
+++ b/.ank/entities/TASK-1162c24b7c75.md
@@ -1,0 +1,64 @@
+---
+id: TASK-1162c24b7c75
+type: task
+slug: the-specification-becomes-several-spec-entities
+title: The specification becomes several spec entities, and the seam is argued
+created: 2026-08-15T15:47:43Z
+author: claude-code/opus-5
+status: open
+scope:
+  - docs/**
+  - .ank/**
+blocked_by: [TASK-50dd8f9b565c]
+done_criteria: |
+  docs/ank-spec-v1.1.md is replaced by spec entities, each created through ank new spec, each carrying a scope naming what it governs and the references it makes to the others. The decomposition is argued in the body of each: a document that cannot be read without holding another one open is not a document, and no boundary is taken from a section number without a reason given. No sentence of the specification is lost: the concatenation of the entities covers every rule the file carried, and the four passages already corrected stay corrected. ank check is green with no unresolved reference, and the file is gone from docs/ rather than left beside the entities to drift against them.
+criteria_by: creator
+schema: 3
+version: 2
+---
+
+The last step of a chain that started with a complaint: a specification that does
+not move the way every other decision in this repository moves. It now can —
+`new spec` creates, `accept` ratifies and anchors, `amend` refuses an accepted
+one, `check` reports a body that moved. What is left is to actually put the
+document through it.
+
+**The seam is the hard part, and it is the whole task.** Section numbers are an
+artifact of one file's table of contents, not a decomposition. A split into
+thirteen entities because there are thirteen sections would be the fragmentation
+section 10 refused, wearing ADR-5a690829388d as a disguise, and it would earn
+every consequence that refusal predicted. The test to apply to each candidate
+boundary is the one in the constraint: **a document that cannot be read without
+holding another one open is not a document.** Where that test fails, the two
+belong together, whatever their numbers say.
+
+Expect that test to merge sections rather than split them. The specification's
+own examples of entanglement — the CLI refusing on state because roles are
+advisory, synchronisation meaning nothing without the data model — are arguments
+for fewer documents than there are sections, not more.
+
+**Argue each boundary in the body of the document it creates.** A reader arriving
+in a year must be able to see why this document ends where it ends, and that
+reasoning is worth more than the split itself: it is what stops the next agent
+from moving a rule across a boundary because it seemed tidy.
+
+**Nothing may be lost, and that is checkable.** Every rule the file carried has
+to be somewhere afterwards. Verify it by construction rather than by reading:
+account for every section of the source, and say where each went. The four
+passages this session corrected — three describing the log as a section of the
+entity body, one claiming git unions two appends — stay corrected; a split that
+resurrects them from an older reading of the file would be the worst possible
+outcome, since it would restore exactly the defects that justified the decision.
+
+**The file goes.** Leaving `docs/ank-spec-v1.1.md` beside the entities would
+create two sources of truth that drift against each other within a week, which
+is the failure this whole chain exists to prevent, reintroduced at the last
+step. Anything that must survive as a file — an index, a reading order — is a
+pointer to entities and never a copy of them.
+
+**Watch what cites the old path.** `CLAUDE.md`, `AGENTS.md`, `docs/agents.md`,
+`docs/getting-started.md` and several ADR scopes name `docs/ank-spec-v1.1.md`.
+An ADR's scope is anchored at ratification and **must not be edited** — that is
+a frozen field, and a dead scope on an accepted ADR is a `check` signal with a
+recorded repair, not something to fix by hand here. Report what falls into that
+case rather than silently touching it.

--- a/.ank/entities/TASK-50dd8f9b565c.md
+++ b/.ank/entities/TASK-50dd8f9b565c.md
@@ -1,0 +1,61 @@
+---
+id: TASK-50dd8f9b565c
+type: task
+slug: check-verifies-the-references-a-spec-declares-to
+title: check verifies the references a spec declares to another
+created: 2026-08-15T15:47:33Z
+author: claude-code/opus-5
+status: open
+scope:
+  - crates/ank-cli/**
+  - crates/ank-core/**
+  - docs/**
+blocked_by: []
+done_criteria: |
+  A spec declares its references to other specs in a field of its own, and ank check reports a reference naming an entity that is absent from the corpus, that is not accepted, or that has been superseded without the citing document following the chain. The finding is a fault where the target is absent and a signal where it is unaccepted or superseded, and each names the command that repairs it. A test in crates/ank-cli/tests/cli.rs drives the built binary through the three cases.
+criteria_by: creator
+schema: 3
+version: 2
+---
+
+This is the mechanism ADR-5a690829388d rests on, and it comes first for that
+reason. That decision argues that splitting a specification is safe because the
+drift it risks is **detected** rather than merely deprecated. Until this task
+lands, that sentence is a promise with nothing behind it, and a corpus split
+before it would carry exactly the fragmentation section 10 refused, with the
+detector still unwritten.
+
+**The precedent is `blocked_by`, and it should be followed rather than
+reinvented.** A task naming a blocker the corpus does not hold is already a
+fault, reported with the id it could not resolve, and the display layer still
+prints the edge it could not follow rather than silently shortening the list. A
+reference between specifications is the same shape of thing: a declared
+dependency, resolved locally, and worth naming when it dangles.
+
+**Three cases, and they do not deserve the same severity.**
+
+- **Absent** is a fault. The citing document names something this corpus does
+  not have, so a reader following the reference finds nothing — the same
+  condition `blocked_by` treats as a fault today.
+- **Unaccepted** is a signal. A document may legitimately cite a draft while
+  both are being written, and refusing that would make it impossible to write
+  two specifications at once. What it must not do is pass unmentioned.
+- **Superseded** is a signal, and it is the interesting one. A superseded target
+  is not missing, it moved, and the chain says where. The finding names the
+  successor, so the repair is a citation update rather than an investigation.
+  This is the case the split will produce most often, since revising a document
+  is a supersession under ADR-5a690829388d.
+
+**Each finding names the command that repairs it.** That is not decoration here
+but the whole difference between a check that helps and a check that scolds: a
+superseded reference has an exact successor, so the message can carry it.
+
+**Do not verify prose.** A reference is a declared field, and a section number
+written in a sentence is not one. Scanning bodies for citations would make the
+check depend on how somebody phrased a paragraph, which is the drift this exists
+to catch, moved into the detector.
+
+One thing to settle explicitly rather than in passing: whether a reference is
+allowed to name a kind other than `spec`. A specification citing a binding ADR is
+plausible and probably right; a specification citing a task is not. Decide it,
+record it, and let `check` enforce whichever way it goes.


### PR DESCRIPTION
No code. One ADR that **supersedes ADR-ce550b0dfa39, ratified an hour ago**, and the two tasks it implies.

## Why supersede something this new

ADR-ce550b0dfa39 admitted the `spec` kind on the narrowest ground §10's standing refusal left open: *one entity per document, never one per section*. Taking the narrow ground was right. Keeping it is not, and what changed is a measurement this session produced rather than an opinion.

The refusal says a specification's authority comes from being **one coherent document**, and that fragmenting it creates drift between the fragments — §4 refuses on state because §8 makes roles advisory, §7 means nothing without §3. Every dependency it names is real. What it assumes is that keeping them in one file is what keeps them true.

**It is not.** While three agents worked on unrelated tasks in this repository, the specification was found carrying **four stale passages at once**: three describing the log as an append-only section of the entity file — a shape ADR-ff294eff4d1a had retired — and one asserting that git's own union resolves two appends with no merge driver, which is false and which nothing in the repository configured. A fourth copy of that claim sat in `docs/format.md`. They survived every revision of the document whose coherence was the reason not to split it, and they were found by accident, by readers looking for something else.

**A monolith's coherence is enforced by nobody.** No anchor, no ratification, no hash, no verb that confronts it with anything. The one mechanism watching it is a human reading 1490 lines — which is exactly the mechanism that failed four times.

Splitting does not introduce the risk. **It introduces the detector**, and each part already exists: each document anchored by hash at ratification, each reference declared and verified the way `blocked_by` is, each change a supersession leaving a chain.

## What is kept from the superseded decision

Unchanged: one entity per document, a `spec` declares no `constraint`, `context` names it and never quotes it, and its authority moves through the lifecycle every entity has.

## What it costs, stated rather than discovered

A reader who needs the whole must open several entities, and the long argument running from intent to implementation is weaker across a boundary than inside one. That is the real price. The mitigation is in the constraint: **a document that cannot be read alone is not a document**, so the decomposition is argued in the corpus rather than derived from the section numbers that happen to exist today. A split into thirteen entities because the file has thirteen sections would be the fragmentation §10 refused, wearing this decision as a disguise.

## The two tasks

```
TASK-50dd  check verifies the references a spec declares to another
└── TASK-1162  the specification becomes several spec entities, and the seam is argued
```

**The detector comes first, deliberately.** Until `TASK-50dd8f9b565c` lands, this decision's central sentence is a promise with nothing behind it, and a corpus split before it would carry exactly the fragmentation the old refusal predicted with the detector still unwritten.

`ank check` green. It already reports the succession as open — *supersedes ADR-ce550b0dfa39, which is not marked superseded (proposed: not yet a succession)* — which closes when this ADR is accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EvZMJnyhvKiAogLC5Se2Ev