### PR TITLE
check verifies the references a spec declares to another

### DIFF
--- a/.ank/entities/LOG-2e999b4600a5.md
+++ b/.ank/entities/LOG-2e999b4600a5.md
@@ -1,0 +1,17 @@
+---
+id: LOG-2e999b4600a5
+type: log
+title: "settled the open question: a spec reference may name a spec or an adr, and nothing else. A"
+created: 2026-08-15T16:46:21Z
+author: claude-code/opus-5
+scope:
+  - crates/ank-cli/**
+  - crates/ank-core/**
+  - docs/**
+about: TASK-50dd8f9b565c
+seq: 0
+schema: 3
+version: 1
+---
+
+ specification citing a binding decision is right - the corpus already keeps the rule elsewhere - while a task is work that finishes and a log entry is a trace, so a document citing one would cite something the corpus is designed to retire. The kind rule is enforced where it can be attributed (new spec --reference, amend --reference) and reported by check as a fault; it is deliberately not a parse error, on the precedent of about on a log entry, because refusing to read a whole corpus over a citation is a worse failure than naming it.

--- a/.ank/entities/LOG-e29c68762d4b.md
+++ b/.ank/entities/LOG-e29c68762d4b.md
@@ -1,0 +1,15 @@
+---
+id: LOG-e29c68762d4b
+type: log
+title: done, proof commit:3a84c6e831324cf0aa8f5f3e8416bce59922a02a
+created: 2026-08-15T17:08:33Z
+author: claude-code/opus-5
+scope:
+  - crates/ank-cli/**
+  - crates/ank-core/**
+  - docs/**
+about: TASK-50dd8f9b565c
+seq: 1
+schema: 3
+version: 1
+---

--- a/.ank/entities/TASK-50dd8f9b565c.md
+++ b/.ank/entities/TASK-50dd8f9b565c.md
@@ -5,7 +5,7 @@ slug: check-verifies-the-references-a-spec-declares-to
 title: check verifies the references a spec declares to another
 created: 2026-08-15T15:47:33Z
 author: claude-code/opus-5
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/**
   - crates/ank-core/**
@@ -14,8 +14,13 @@ blocked_by: []
 done_criteria: |
   A spec declares its references to other specs in a field of its own, and ank check reports a reference naming an entity that is absent from the corpus, that is not accepted, or that has been superseded without the citing document following the chain. The finding is a fault where the target is absent and a signal where it is unaccepted or superseded, and each names the command that repairs it. A test in crates/ank-cli/tests/cli.rs drives the built binary through the three cases.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 3a84c6e831324cf0aa8f5f3e8416bce59922a02a
+    criteria: 54302b7f30c6
+    via: submitted
 schema: 3
-version: 3
+version: 4
 ---
 
 This is the mechanism ADR-5a690829388d rests on, and it comes first for that

--- a/.ank/entities/TASK-50dd8f9b565c.md
+++ b/.ank/entities/TASK-50dd8f9b565c.md
@@ -5,7 +5,7 @@ slug: check-verifies-the-references-a-spec-declares-to
 title: check verifies the references a spec declares to another
 created: 2026-08-15T15:47:33Z
 author: claude-code/opus-5
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/**
   - crates/ank-core/**
@@ -15,7 +15,7 @@ done_criteria: |
   A spec declares its references to other specs in a field of its own, and ank check reports a reference naming an entity that is absent from the corpus, that is not accepted, or that has been superseded without the citing document following the chain. The finding is a fault where the target is absent and a signal where it is unaccepted or superseded, and each names the command that repairs it. A test in crates/ank-cli/tests/cli.rs drives the built binary through the three cases.
 criteria_by: creator
 schema: 3
-version: 2
+version: 3
 ---
 
 This is the mechanism ADR-5a690829388d rests on, and it comes first for that

--- a/crates/ank-cli/src/cli.rs
+++ b/crates/ank-cli/src/cli.rs
@@ -448,6 +448,7 @@ pub const COMMANDS: &[CommandSpec] = &[
             multi("--blocked-by"),
             flag("--constraint"),
             flag("--supersedes"),
+            multi("--reference"),
             multi("--verify"),
             flag("--body"),
         ],
@@ -455,6 +456,7 @@ pub const COMMANDS: &[CommandSpec] = &[
         notes: &[
             "a scope is mandatory: an entity attached to nothing is invisible",
             "--body - reads the body from stdin, so a long one needs no shell quoting",
+            "--reference declares what a spec rests on; it takes a spec or an adr, and check resolves it",
         ],
         refuses_globals: &[],
         owner_task: None,
@@ -570,13 +572,15 @@ pub const COMMANDS: &[CommandSpec] = &[
         group: "shape the work",
         renews: Renews::Named,
         coordinates: false,
-        summary: "changes blocked_by, scope, and a done_criteria no live claim freezes",
+        summary: "changes blocked_by, references, scope, and a done_criteria no live claim freezes",
         subcommands: &[],
         max_positionals: 1,
         positional_help: "<id>",
         flags: &[
             multi("--blocked-by"),
             multi("--drop-blocked-by"),
+            multi("--reference"),
+            multi("--drop-reference"),
             multi("--scope"),
             multi("--drop-scope"),
             // Offered now, and it was `refused` here for as long as the verb
@@ -592,6 +596,7 @@ pub const COMMANDS: &[CommandSpec] = &[
         notes: &[
             "adds and removes explicitly, never a replacement list, so nothing is dropped by being forgotten",
             "--criteria replaces the criterion outright, and leaves criteria_by where it stands",
+            "--reference and --drop-reference reach a spec's citations, on an accepted one too: the anchor covers its body and scope, not what it cites",
         ],
         refuses_globals: &[],
         owner_task: None,

--- a/crates/ank-cli/src/commands.rs
+++ b/crates/ank-cli/src/commands.rs
@@ -115,6 +115,15 @@ pub fn new(
                     "ank new task --title \"<t>\" --scope \"<glob>\" --blocked-by \"<id>\"",
                 ));
             }
+            if !inv.values("--reference").is_empty() {
+                return Err(CliError::new(
+                    1,
+                    "--reference applies to a spec: what a task depends on is blocked_by",
+                )
+                .with_hint(
+                    "ank new task --title \"<t>\" --scope \"<glob>\" --blocked-by \"<id>\"",
+                ));
+            }
             let criteria = inv.value("--criteria").map(ensure_newline);
             let mut blocked_by = Vec::new();
             for raw in inv.values("--blocked-by") {
@@ -159,6 +168,18 @@ pub fn new(
                     "ank new adr --title \"<t>\" --scope \"<glob>\" --constraint \"<rule>\"",
                 ));
             }
+            // A spec declares what it rests on; an ADR states a rule, and what
+            // it points at is `see`. Refused rather than dropped, on the same
+            // reasoning as the line above.
+            if !inv.values("--reference").is_empty() {
+                return Err(CliError::new(
+                    1,
+                    "--reference applies to a spec: an ADR binds rather than cites",
+                )
+                .with_hint(
+                    "ank new adr --title \"<t>\" --scope \"<glob>\" --constraint \"<rule>\"",
+                ));
+            }
             let constraint = required(inv, "--constraint", "the binding rule, in one sentence")?;
             Entity::Adr(Adr {
                 supersedes: supersedes_of(inv, &store, kind)?,
@@ -186,6 +207,7 @@ pub fn new(
             reject_foreign_flags(inv, kind)?;
             Entity::Spec(Spec {
                 supersedes: supersedes_of(inv, &store, kind)?,
+                references: references_of(inv, &store)?,
                 id: id.clone(),
                 slug: Some(slugify(&title)),
                 title: title.clone(),
@@ -429,6 +451,10 @@ fn skeleton(
             author: Some(identity.to_string()),
             status: SpecStatus::Proposed,
             scope,
+            // Empty, as `supersedes` is: the skeleton carries what the flags
+            // said and nothing invented. A caller who cites a document types
+            // the field into the template, and it round-trips like any other.
+            references: Vec::new(),
             supersedes: None,
             ratified: None,
             // A reading is recorded by whoever reads, never by `new` (§3).
@@ -878,6 +904,52 @@ fn supersedes_of(inv: &Invocation, store: &Store, kind: EntityKind) -> Result<Op
         .with_hint(format!("ank find --type {what}")));
     }
     Ok(Some(id))
+}
+
+/// Whether a specification may cite this kind (§3, ADR-5a690829388d).
+///
+/// A spec and an ADR, and nothing else. A document resting on a binding decision
+/// is ordinary and worth declaring; a task is work that finishes and a log entry
+/// is a trace of a moment, so a document citing one would cite something the
+/// corpus is designed to retire.
+///
+/// Stated once and read by all three callers — `new spec`, `amend` and `check` —
+/// because a rule enforced at a write and reported at a read is exactly the
+/// shape that comes to disagree with itself.
+pub(crate) fn citable(kind: EntityKind) -> bool {
+    matches!(kind, EntityKind::Spec | EntityKind::Adr)
+}
+
+/// Why that kind is not citable, in one sentence, for whoever has to say it.
+pub(crate) fn not_citable(id: &EntityId) -> String {
+    format!(
+        "{id} is a {}: a specification cites a spec or an adr, and nothing that is \
+         meant to be retired",
+        id.kind().as_str()
+    )
+}
+
+/// `--reference`, resolved at the point of the write.
+///
+/// Resolved rather than recorded raw, for the reason `--blocked-by` and
+/// `--supersedes` are: a reference matching nothing would otherwise surface in
+/// `check`, as a corpus fault nobody can attribute to the act that caused it.
+/// What `check` is left to report is the corpus moving underneath a citation
+/// that was good when it was written — a target deleted, promoted or superseded
+/// since — which is the drift ADR-5a690829388d exists to catch.
+fn references_of(inv: &Invocation, store: &Store) -> Result<Vec<EntityId>> {
+    let mut out: Vec<EntityId> = Vec::new();
+    for raw in inv.values("--reference") {
+        let target = store.resolve(raw.trim())?;
+        if !citable(target.kind()) {
+            return Err(CliError::new(1, not_citable(&target))
+                .with_hint("ank find --type spec".to_string()));
+        }
+        if !out.contains(&target) {
+            out.push(target);
+        }
+    }
+    Ok(out)
 }
 
 /// The prose that justifies the entity, in canonical shape.

--- a/crates/ank-cli/src/human.rs
+++ b/crates/ank-cli/src/human.rs
@@ -1622,12 +1622,145 @@ fn check_spec(
 ) {
     let view = Anchored::from(s);
     check_succession(&view, spec_ids, entities, report);
+    check_references(s, entities, report);
     check_anchor(
         &view,
         repo,
         "the document no longer says what was ratified",
         report,
     );
+}
+
+/// What a spec's `references` owe (§4, ADR-5a690829388d).
+///
+/// This is the mechanism that decision rests on: splitting a specification is
+/// safe because the drift it risks is **detected** rather than deprecated, and
+/// until a reference is resolved against the corpus that sentence is a promise
+/// with nothing behind it.
+///
+/// **The precedent is `blocked_by`, followed rather than reinvented.** A
+/// declared dependency, resolved locally, named when it dangles. What differs is
+/// that a specification has two states between "there" and "not there", and they
+/// do not deserve the same severity:
+///
+/// - **absent** is a fault, the same condition a `blocked_by` naming nothing is:
+///   a reader following the reference finds nothing;
+/// - **not accepted** is a signal, because a document may legitimately cite a
+///   draft while both are being written — refusing that would make it impossible
+///   to write two specifications at once — and what it must not do is pass
+///   unmentioned;
+/// - **superseded** is a signal, and it is the interesting one: the target is
+///   not missing, it moved, and the chain says where. The finding names the
+///   successor, so the repair is a citation update and not an investigation.
+///
+/// **A reference that followed the chain is not reported at all.** Where the
+/// citing document also names the end of the chain it has already done what the
+/// finding would ask of it, and a rule that fired anyway would fire on every
+/// correct citation the day after any document is revised.
+///
+/// Only the declared field is read. A section number written in a sentence is
+/// not a reference, and scanning bodies for citations would make the check
+/// depend on how somebody phrased a paragraph — which is the drift this exists
+/// to catch, moved into the detector.
+fn check_references(s: &Spec, entities: &[(PathBuf, Entity)], report: &mut Report) {
+    let find = |id: &EntityId| entities.iter().find(|(_, e)| e.id() == id).map(|(_, e)| e);
+    for target in &s.references {
+        // The kind rule, read from the id and before any lookup: an id states
+        // its own kind, and a task that does not exist is refused for the same
+        // reason the one that does is.
+        if !crate::commands::citable(target.kind()) {
+            report.findings.push(Finding::fault(
+                &s.id,
+                format!(
+                    "{} (ank amend {} --drop-reference {target})",
+                    crate::commands::not_citable(target),
+                    s.id
+                ),
+            ));
+            continue;
+        }
+        let Some(entity) = find(target) else {
+            report.findings.push(Finding::fault(
+                &s.id,
+                format!(
+                    "references {target}, which does not exist \
+                     (ank amend {} --drop-reference {target})",
+                    s.id
+                ),
+            ));
+            continue;
+        };
+        // Both citable kinds carry the same lifecycle, and the view is what
+        // says so once instead of matching on the kind here.
+        let Some(view) = Anchored::of(entity) else {
+            continue;
+        };
+        match view.status {
+            AdrStatus::Accepted => {}
+            AdrStatus::Proposed => report.findings.push(Finding::signal(
+                &s.id,
+                format!("references {target}, which is not accepted (ank accept {target})"),
+            )),
+            AdrStatus::Superseded => {
+                let head = chain_head(target, entities);
+                // The chain followed: nothing to say. The document already
+                // cites where the target went.
+                if head.as_ref().is_some_and(|h| s.references.contains(h)) {
+                    continue;
+                }
+                report.findings.push(Finding::signal(
+                    &s.id,
+                    match head {
+                        Some(head) => format!(
+                            "references {target}, which is superseded by {head} \
+                             (ank amend {} --reference {head} --drop-reference {target})",
+                            s.id
+                        ),
+                        // A superseded entity nothing supersedes is already a
+                        // fault against that entity, reported by
+                        // `check_succession`. Here it means the citation has
+                        // nowhere to follow to, and saying so is more use than
+                        // naming a successor that does not exist.
+                        None => format!(
+                            "references {target}, which is superseded and names no successor \
+                             (ank show {target})"
+                        ),
+                    },
+                ));
+            }
+        }
+    }
+}
+
+/// The end of a supersession chain: the entity that replaced this one, then the
+/// one that replaced that, until nothing does.
+///
+/// `None` where nothing supersedes the target at all — a corpus fault of its
+/// own, reported against the target and not against whoever cites it.
+///
+/// The walk is bounded by the number of entities and remembers where it has
+/// been, because a corpus can hold a cycle: `check_cycles` reports one for
+/// `blocked_by`, and nothing forbids a hand-written pair of documents naming
+/// each other. A walk that trusted the chain to terminate would hang the whole
+/// verb on a file somebody typed wrong.
+fn chain_head(target: &EntityId, entities: &[(PathBuf, Entity)]) -> Option<EntityId> {
+    let successor = |id: &EntityId| {
+        entities.iter().find_map(|(_, e)| {
+            Anchored::of(e)
+                .filter(|v| v.supersedes == Some(id))
+                .map(|v| v.id.clone())
+        })
+    };
+    let mut seen: Vec<EntityId> = vec![target.clone()];
+    let mut head = successor(target)?;
+    while let Some(next) = successor(&head) {
+        if seen.contains(&next) {
+            break;
+        }
+        seen.push(head);
+        head = next;
+    }
+    Some(head)
 }
 
 /// The succession half, for either kind that has one.
@@ -3911,22 +4044,46 @@ pub fn amend(inv: &Invocation, repo: &Repo, identity: &str, out: &mut dyn Write)
     )?;
     let add_blocked = resolve_all(&store, inv.values("--blocked-by"))?;
     let drop_blocked = resolve_all(&store, inv.values("--drop-blocked-by"))?;
+    // A dropped reference is **not** resolved against the corpus, and that is
+    // the whole point of the flag: the case it exists for is a citation naming
+    // an entity this corpus no longer holds, which `check` reports as a fault
+    // and `resolve` would refuse to look up. It is matched against what the
+    // entity stores, exactly as `--drop-scope` is.
+    let add_refs = resolve_all(&store, inv.values("--reference"))?;
+    let drop_refs = parse_all(inv.values("--drop-reference"), &id)?;
 
     if add_scope.is_empty()
         && drop_scope.is_empty()
         && add_blocked.is_empty()
         && drop_blocked.is_empty()
+        && add_refs.is_empty()
+        && drop_refs.is_empty()
         && criteria.is_none()
     {
         return Err(
             CliError::new(7, format!("nothing to amend on {id}")).with_hint(format!(
                 "ank amend {id} --blocked-by <id> | --drop-blocked-by <id> | \
-                 --scope <glob> | --drop-scope <glob> | --criteria \"<c>\""
+                 --scope <glob> | --drop-scope <glob> | --criteria \"<c>\" | \
+                 --reference <id> | --drop-reference <id>"
             )),
         );
     }
 
     let mut changes: Vec<String> = Vec::new();
+
+    // Refused rather than dropped, on the reasoning every other foreign flag on
+    // this verb follows: a flag silently ignored teaches the caller it worked.
+    // Stated once for the two kinds that do not carry the field, because the
+    // sentence is the same one twice — what a task depends on is `blocked_by`,
+    // and an ADR binds rather than cites.
+    if !matches!(loaded.entity, Entity::Spec(_)) && !(add_refs.is_empty() && drop_refs.is_empty()) {
+        let kind = ank_core::Fields::kind_spec(&loaded.entity).name;
+        return Err(CliError::new(
+            1,
+            format!("references applies to a spec: a {kind} cites nothing"),
+        )
+        .with_hint(format!("ank show {id}")));
+    }
 
     match loaded.entity {
         Entity::Task(mut task) => {
@@ -4117,7 +4274,17 @@ pub fn amend(inv: &Invocation, repo: &Repo, identity: &str, out: &mut dyn Write)
             // because no narrower field carries the authority. So an accepted
             // spec's scope is refused here on the same terms an accepted ADR's
             // is, and revising an accepted specification is a supersession.
-            if spec.status != SpecStatus::Proposed {
+            //
+            // **The refusal is on the scope and not on the entity**, which is
+            // what makes the repair `check` names reachable. A citation is not
+            // covered by the anchor — the commit hashes the body and the scope,
+            // and a reference is neither — and the finding that matters most
+            // fires on accepted documents, since revising one is a supersession
+            // and a supersession is what leaves the citations behind. Refusing
+            // the whole verb here would name a repair the verb turns down
+            // (ADR-5a690829388d).
+            let touches_anchor = !add_scope.is_empty() || !drop_scope.is_empty();
+            if touches_anchor && spec.status != SpecStatus::Proposed {
                 return Err(CliError::new(
                     6,
                     format!(
@@ -4128,6 +4295,13 @@ pub fn amend(inv: &Invocation, repo: &Repo, identity: &str, out: &mut dyn Write)
                 .with_hint("ank new spec --supersedes <id> --title \"<t>\" --scope \"<glob>\""));
             }
 
+            amend_references(
+                &mut spec.references,
+                &add_refs,
+                &drop_refs,
+                &id,
+                &mut changes,
+            )?;
             amend_scope(&mut spec.scope, &add_scope, &drop_scope, &id, &mut changes)?;
             if changes.is_empty() {
                 return Err(CliError::new(7, format!("{id} already reads that way"))
@@ -4151,6 +4325,57 @@ pub fn amend(inv: &Invocation, repo: &Repo, identity: &str, out: &mut dyn Write)
     }
 
     Ok(0)
+}
+
+/// The `references` half, for the one kind that carries the field.
+///
+/// Add and remove and never replace, exactly as the scope half does: a verb
+/// taking the whole list silently drops whatever the caller forgot to repeat.
+/// A citation the document does not carry is refused rather than ignored,
+/// because "dropped" and "was never there" are the same output otherwise and
+/// only one of them is what the caller meant.
+///
+/// Emptying the list out is allowed, and it is the one place this differs from
+/// the scope: a document that cites nothing is an ordinary document, where an
+/// entity with no scope attaches to nothing and is invisible.
+fn amend_references(
+    references: &mut Vec<EntityId>,
+    add: &[EntityId],
+    drop: &[EntityId],
+    id: &EntityId,
+    changes: &mut Vec<String>,
+) -> Result<()> {
+    for r in drop {
+        if !references.contains(r) {
+            return Err(CliError::new(7, format!("{id} does not reference {r}"))
+                .with_hint(format!("ank show {id}")));
+        }
+    }
+    references.retain(|r| !drop.contains(r));
+    for r in add {
+        if r == id {
+            return Err(CliError::new(
+                7,
+                format!("{id} cannot reference itself: a document is read whole"),
+            )
+            .with_hint(format!("ank amend {id} --reference <other-id>")));
+        }
+        // The kind rule, at the point of the write and in the words `check`
+        // uses for the same state. Both readings come from one function
+        // (ADR-5a690829388d).
+        if !crate::commands::citable(r.kind()) {
+            return Err(CliError::new(1, crate::commands::not_citable(r))
+                .with_hint(format!("ank amend {id} --reference <SPEC-id|ADR-id>")));
+        }
+        if !references.contains(r) {
+            changes.push(format!("+references {r}"));
+            references.push(r.clone());
+        }
+    }
+    for r in drop {
+        changes.push(format!("-references {r}"));
+    }
+    Ok(())
 }
 
 /// The scope half, shared by both kinds.
@@ -4203,6 +4428,28 @@ fn trimmed(values: &[String]) -> Vec<String> {
         .map(|s| s.trim().to_string())
         .filter(|s| !s.is_empty())
         .collect()
+}
+
+/// The same list, read as identifiers and never looked up.
+///
+/// For `--drop-reference` alone, and the asymmetry with [`resolve_all`] is the
+/// decision rather than an omission: the citation worth dropping is usually one
+/// whose target the corpus has lost, and resolving it would refuse the very
+/// repair `check` names. A prefix is therefore not accepted here — there is
+/// nothing to disambiguate it against — so the id is typed whole, which is what
+/// the finding prints.
+fn parse_all(raw: &[String], id: &EntityId) -> Result<Vec<EntityId>> {
+    let mut out = Vec::new();
+    for r in raw {
+        let target = EntityId::parse(r.trim()).map_err(|e| {
+            CliError::new(7, format!("{e}"))
+                .with_hint(format!("ank amend {id} --drop-reference <full-id>"))
+        })?;
+        if !out.contains(&target) {
+            out.push(target);
+        }
+    }
+    Ok(out)
 }
 
 /// Every reference resolved at the point of the edit. An unknown one refused

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -484,6 +484,42 @@ impl Repo {
         .unwrap();
     }
 
+    /// A spec, in canonical form, with the two fields a citation test varies.
+    ///
+    /// Written by hand rather than through `ank new spec`, and necessarily so:
+    /// the states under test are a reference to an entity this corpus does not
+    /// hold and a citation left behind by a supersession, and `new` resolves
+    /// every reference it is given — so no writer will produce either of them.
+    /// That is the division of labour the field rests on: the write refuses what
+    /// it can attribute, and `check` reports the corpus moving underneath a
+    /// citation that was good when it was written.
+    fn seed_spec(&self, id: &str, status: &str, references: &[&str], supersedes: Option<&str>) {
+        let references = match references {
+            [] => String::new(),
+            r => format!("references: [{}]\n", r.join(", ")),
+        };
+        let supersedes = supersedes
+            .map(|s| format!("supersedes: {s}\n"))
+            .unwrap_or_default();
+        std::fs::write(
+            self.0.join(".ank/entities").join(format!("{id}.md")),
+            format!(
+                "---\nid: {id}\ntype: spec\nslug: a-document\ntitle: A document\n\
+                 created: 2026-08-01T00:00:00Z\nauthor: human:marie\nstatus: {status}\n\
+                 scope:\n  - docs/**\n{references}{supersedes}schema: 3\nversion: 1\n---\n\
+                 \nThe document itself.\n"
+            ),
+        )
+        .unwrap();
+    }
+
+    /// A file under `docs/`, so that a seeded spec's scope names something and
+    /// the dead-scope machinery stays out of the fixture under test.
+    fn seed_docs(&self) {
+        std::fs::create_dir_all(self.0.join("docs")).unwrap();
+        std::fs::write(self.0.join("docs/doc.md"), "The document.\n").unwrap();
+    }
+
     /// `accept` signs for real, and a signature configured from the developer's
     /// own global git config would make this test pass here and nowhere else.
     /// SSH because `ssh-keygen` ships beside git on all three platforms and
@@ -2452,6 +2488,221 @@ fn inside_a_repository_the_coordination_half_still_runs() {
     let status = stdout(&r.ank("claude-code@ank", &["status"]));
     assert!(status.contains("branch main"), "{status}");
     assert!(!status.contains("no git repository"), "{status}");
+}
+
+// ---------------------------------------------------------------------------
+// References between documents (TASK-50dd8f9b565c, ADR-5a690829388d)
+// ---------------------------------------------------------------------------
+
+const CITING: &str = "SPEC-00000000a001";
+const GONE: &str = "SPEC-00000000ffff";
+const DRAFT: &str = "SPEC-00000000b002";
+const REPLACED: &str = "SPEC-00000000c003";
+const SUCCESSOR: &str = "SPEC-00000000d004";
+const FOLLOWER: &str = "SPEC-00000000e005";
+
+/// A corpus holding all three states a reference can be in, and one document
+/// that has already followed its chain.
+fn cited_fixture() -> Repo {
+    let r = Repo::new();
+    r.seed_docs();
+    r.seed_spec(CITING, "proposed", &[GONE, DRAFT, REPLACED], None);
+    r.seed_spec(DRAFT, "proposed", &[], None);
+    r.seed_spec(REPLACED, "superseded", &[], None);
+    r.seed_spec(SUCCESSOR, "accepted", &[], Some(REPLACED));
+    r.seed_spec(FOLLOWER, "proposed", &[REPLACED, SUCCESSOR], None);
+    r
+}
+
+/// Every finding `check` prints about one entity.
+fn findings_about(said: &str, id: &str) -> Vec<String> {
+    said.lines()
+        .filter(|l| l.contains(id))
+        .map(str::to_string)
+        .collect()
+}
+
+/// **`check` resolves what a specification declares it rests on**
+/// (ADR-5a690829388d, TASK-50dd8f9b565c).
+///
+/// This is the mechanism that decision rests on. It argues that cutting a
+/// specification into documents is safe because the drift it risks is
+/// *detected*, and until this runs through the binary that is a promise with
+/// nothing behind it.
+///
+/// Through the binary, because the claim is about what `check` reports and what
+/// its exit code then means to a pipeline: a fault has to reach exit 8 and a
+/// signal has to leave it at 0, and no unit test on the report can say whether
+/// the process agreed.
+#[test]
+fn check_resolves_the_references_a_spec_declares_to_another() {
+    let r = cited_fixture();
+    let out = r.ank("claude-code@ank", &["check"]);
+    let said = stdout(&out);
+
+    // Absent: a fault, the same condition `blocked_by` naming nothing is.
+    let about = findings_about(&said, GONE);
+    assert_eq!(about.len(), 1, "one line for the missing target: {said}");
+    assert!(about[0].starts_with("error:"), "{said}");
+    assert!(about[0].contains("does not exist"), "{said}");
+    assert!(
+        about[0].contains(&format!("ank amend {CITING} --drop-reference {GONE}")),
+        "a finding names the command that repairs it: {said}"
+    );
+
+    // Unaccepted: a signal. Two specifications are legitimately written at
+    // once, and refusing that would make it impossible to write the second.
+    let about = findings_about(&said, DRAFT);
+    assert_eq!(about.len(), 1, "{said}");
+    assert!(about[0].starts_with("signal:"), "{said}");
+    assert!(about[0].contains("not accepted"), "{said}");
+    assert!(about[0].contains(&format!("ank accept {DRAFT}")), "{said}");
+
+    // Superseded: a signal naming the successor, so the repair is a citation
+    // update and not an investigation.
+    let about: Vec<String> = findings_about(&said, REPLACED)
+        .into_iter()
+        .filter(|l| l.contains(CITING))
+        .collect();
+    assert_eq!(about.len(), 1, "{said}");
+    assert!(about[0].starts_with("signal:"), "{said}");
+    assert!(
+        about[0].contains(&format!("superseded by {SUCCESSOR}")),
+        "{said}"
+    );
+    assert!(
+        about[0].contains(&format!(
+            "ank amend {CITING} --reference {SUCCESSOR} --drop-reference {REPLACED}"
+        )),
+        "the successor is known, so the message carries it: {said}"
+    );
+
+    // The chain followed is not reported at all. A document citing both the
+    // replaced one and its successor has already done what the finding would
+    // ask of it, and a rule firing anyway would fire on every correct citation
+    // the day after any document is revised.
+    assert!(
+        findings_about(&said, FOLLOWER).is_empty(),
+        "a reference that followed its chain was reported: {said}"
+    );
+
+    // The severities reach the process: one fault, so exit 8.
+    assert_eq!(code(&out), 8, "{said}");
+}
+
+/// The commands those findings name are commands the verb accepts.
+///
+/// A finding naming a repair that refuses on the spot is worse than a finding
+/// with no repair at all, and two of the three here land on documents `amend`
+/// used to turn down outright: a citation is not covered by the ratification
+/// anchor, so following a chain on an accepted document is an amend and never a
+/// supersession.
+#[test]
+fn the_repair_a_reference_finding_names_is_one_amend_accepts() {
+    let r = cited_fixture();
+
+    // The absent target, dropped. It cannot be resolved — that is what the
+    // fault says — so the flag matches what the entity stores.
+    let out = r.ank(
+        "claude-code@ank",
+        &["amend", CITING, "--drop-reference", GONE],
+    );
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+
+    // The chain, followed in one call.
+    let out = r.ank(
+        "claude-code@ank",
+        &[
+            "amend",
+            CITING,
+            "--reference",
+            SUCCESSOR,
+            "--drop-reference",
+            REPLACED,
+        ],
+    );
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+
+    // And an accepted document's citations are reachable, where its scope is
+    // not: the anchor covers the body and the scope, and a reference is
+    // neither.
+    let out = r.ank(
+        "claude-code@ank",
+        &["amend", SUCCESSOR, "--reference", DRAFT],
+    );
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    let out = r.ank(
+        "claude-code@ank",
+        &["amend", SUCCESSOR, "--scope", "src/**"],
+    );
+    assert_eq!(code(&out), 6, "{}", stdout(&out));
+
+    // What is left is the draft, which was a signal before and still is.
+    let said = stdout(&r.ank("claude-code@ank", &["check"]));
+    assert!(findings_about(&said, GONE).is_empty(), "{said}");
+    assert!(
+        findings_about(&said, REPLACED)
+            .iter()
+            .all(|l| !l.contains(CITING)),
+        "{said}"
+    );
+    assert_eq!(
+        code(&r.ank("claude-code@ank", &["check"])),
+        0,
+        "the faults are gone, so the exit code is: {said}"
+    );
+}
+
+/// A specification cites a spec or an adr, and nothing that is meant to be
+/// retired. The rule is one function, read by the two writers and by `check`.
+#[test]
+fn a_reference_names_a_document_or_a_decision_and_no_other_kind() {
+    let r = cited_fixture();
+    r.seed_task(ID, Some("A verifiable criterion."));
+
+    // An ADR is citable, and it is the case the rule exists to allow: a
+    // document resting on a binding decision.
+    r.seed_adr("ADR-00000000a0a0", "A rule.", "docs/**");
+    let out = r.ank(
+        "claude-code@ank",
+        &["amend", CITING, "--reference", "ADR-00000000a0a0"],
+    );
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+
+    // A task is not. It is work that finishes, so a document citing one would
+    // cite something the corpus is designed to retire.
+    let out = r.ank("claude-code@ank", &["amend", CITING, "--reference", ID]);
+    assert_eq!(code(&out), 1, "{}", stdout(&out));
+    assert!(stderr(&out).contains("spec or an adr"), "{}", stderr(&out));
+
+    // The same refusal at creation, where the citation is first written.
+    let out = r.ank(
+        "claude-code@ank",
+        &[
+            "new",
+            "spec",
+            "--title",
+            "A document",
+            "--scope",
+            "docs/**",
+            "--reference",
+            ID,
+        ],
+    );
+    assert_eq!(code(&out), 1, "{}", stdout(&out));
+    assert!(stderr(&out).contains("spec or an adr"), "{}", stderr(&out));
+
+    // And the field belongs to the one kind that carries it.
+    let out = r.ank(
+        "claude-code@ank",
+        &["amend", ID, "--reference", "ADR-00000000a0a0"],
+    );
+    assert_eq!(code(&out), 1, "{}", stdout(&out));
+    assert!(
+        stderr(&out).contains("references applies to a spec"),
+        "{}",
+        stderr(&out)
+    );
 }
 
 /// A perimeter holding one proposal, with a budget as the only variable.
@@ -7605,6 +7856,10 @@ fn valid_value(flag: &str) -> &'static str {
         "--scope" | "--drop-scope" => "src/**",
         "--blocked-by" | "--drop-blocked-by" => "TASK-000000000001",
         "--supersedes" => "ADR-000000000001",
+        // A whole id and not a prefix: `--drop-reference` matches what the
+        // entity stores rather than resolving against the corpus, which is what
+        // makes dropping a citation to a deleted document possible at all.
+        "--reference" | "--drop-reference" => "SPEC-000000000001",
         "--verify" => "cargo-test",
         "--criteria" => "A measurable thing.",
         "--reason" => "a reason",
@@ -8643,7 +8898,12 @@ const GLOB_FLAGS: [(&str, &str); 3] = [
 /// path if it is called `--scope`" — is exactly what would let the next
 /// `--under <glob>` through in silence, which is the failure this whole task is
 /// a correction of.
-const NOT_A_PATH: [&str; 20] = [
+const NOT_A_PATH: [&str; 22] = [
+    // Entity ids, both of them: what a document rests on is another entity of
+    // this corpus, never a file (ADR-5a690829388d). The scope is what names
+    // paths on a spec, and it is in GLOB_FLAGS.
+    "--reference",
+    "--drop-reference",
     "--limit",
     "--criteria",
     "--ttl",

--- a/crates/ank-core/src/model.rs
+++ b/crates/ank-core/src/model.rs
@@ -387,6 +387,16 @@ pub struct Spec {
     pub author: Option<String>,
     pub status: SpecStatus,
     pub scope: Vec<String>,
+    /// The documents and decisions this one rests on (§3, ADR-5a690829388d).
+    ///
+    /// A declared field and never a sentence: a specification cut into documents
+    /// drifts unless the coherence between them is verified, and verifying it
+    /// means the citation has to sit somewhere a parser can reach. What a
+    /// reference resolving to nothing, to a draft or to a superseded document
+    /// costs is `check`'s business — the kind that may be named included. Here
+    /// it is a list of identifiers, on the reading `about` already gets: a
+    /// corpus is not made unreadable by one citation.
+    pub references: Vec<EntityId>,
     pub supersedes: Option<EntityId>,
     /// Hash of the document and scope at acceptance (set by `accept`).
     pub ratified: Option<String>,

--- a/crates/ank-core/src/parse.rs
+++ b/crates/ank-core/src/parse.rs
@@ -95,6 +95,11 @@ struct SpecFm {
     author: Option<String>,
     status: SpecStatus,
     scope: Vec<String>,
+    // Absent before the field existed, and `default` rather than `Option`
+    // because an empty list and an absent one are the same statement: this
+    // document cites nothing. The serializer omits it either way.
+    #[serde(default)]
+    references: Vec<String>,
     supersedes: Option<String>,
     ratified: Option<String>,
     #[serde(default)]
@@ -357,6 +362,15 @@ fn parse_spec_fm(fm: &str, body: &str) -> Result<Spec> {
         raw.schema,
     )?;
     let supersedes = raw.supersedes.as_deref().map(EntityId::parse).transpose()?;
+    // Checked here for what it is — an identifier — and for nothing more. Which
+    // kinds a specification may cite, and whether the corpus holds the target
+    // at all, are `check` findings (§3): a rule enforced at parse time would
+    // make one citation cost the whole corpus its readability.
+    let references = raw
+        .references
+        .iter()
+        .map(|s| EntityId::parse(s))
+        .collect::<Result<Vec<_>>>()?;
 
     Ok(Spec {
         id,
@@ -366,6 +380,7 @@ fn parse_spec_fm(fm: &str, body: &str) -> Result<Spec> {
         author: raw.author,
         status: raw.status,
         scope: raw.scope,
+        references,
         supersedes,
         ratified: raw.ratified,
         verified: raw.verified,

--- a/crates/ank-core/src/registry.rs
+++ b/crates/ank-core/src/registry.rs
@@ -98,6 +98,14 @@ static ADR_FIELDS: &[FieldSpec] = &[
 /// describes, an ADR binds. `see` goes with it — it exists to point at the
 /// reference code a positive *constraint* needs, and a kind with no constraint
 /// has nothing for it to serve.
+///
+/// `references` takes the position `blocked_by` takes on a task — immediately
+/// after the perimeter, before the succession — because it is the same shape of
+/// thing: a declared dependency, resolved locally. It is **optional** where
+/// `blocked_by` is required, and the asymmetry is a decision: a task always
+/// states whether it has blockers, while a document that cites nothing has
+/// nothing to state, and emitting `[]` on every spec written before the field
+/// existed would make each of them non-canonical at the release that added it.
 static SPEC_FIELDS: &[FieldSpec] = &[
     req("id"),
     req("type"),
@@ -107,6 +115,7 @@ static SPEC_FIELDS: &[FieldSpec] = &[
     opt("author"),
     req("status"),
     req("scope"),
+    opt("references"),
     opt("supersedes"),
     opt("ratified"),
     opt("verified"),
@@ -318,6 +327,14 @@ impl Fields for Spec {
             "author" => Scalar(self.author.as_deref()?),
             "status" => Bare(self.status.as_str().to_string()),
             "scope" => Seq(&self.scope),
+            // Omitted when empty, never written `[]`: see the table above for
+            // why this one does not follow `blocked_by`.
+            "references" => {
+                if self.references.is_empty() {
+                    return None;
+                }
+                Flow(self.references.iter().map(|r| r.to_string()).collect())
+            }
             "supersedes" => Bare(self.supersedes.as_ref()?.to_string()),
             "ratified" => Scalar(self.ratified.as_deref()?),
             "verified" => {

--- a/crates/ank-core/tests/golden.rs
+++ b/crates/ank-core/tests/golden.rs
@@ -307,6 +307,50 @@ fn a_spec_carries_a_lifecycle_and_declares_no_constraint() {
     assert!(s.body.contains("The document itself."));
 }
 
+/// A spec declares what it rests on in a field, and the format does no more
+/// than read it (§3, ADR-5a690829388d).
+///
+/// The two halves are one decision. A citation has to be a field or the
+/// coherence between documents cannot be verified at all; and it has to stay a
+/// *plain* field here, because deciding at parse time whether a target exists,
+/// is accepted or is of a citable kind would make one bad citation cost the
+/// whole corpus its readability. The fixture cites one entity this directory
+/// holds and one it does not, and both parse.
+#[test]
+fn a_spec_declares_its_references_and_the_parser_only_reads_them() {
+    let dir = golden_dir("valid");
+    let s = parse_spec(&fs::read_to_string(dir.join("SPEC-19c4f0a83b2e.md")).unwrap()).unwrap();
+
+    let cited: Vec<String> = s.references.iter().map(|r| r.to_string()).collect();
+    assert_eq!(cited, ["SPEC-3f81c9d0a2b7", "ADR-19d0e2f4a6b8"]);
+    // The two kinds a specification may cite, and the order is the file's: a
+    // flow list is a sequence, not a set, and the round-trip rests on it.
+    assert_eq!(s.references[0].kind(), EntityKind::Spec);
+    assert_eq!(s.references[1].kind(), EntityKind::Adr);
+
+    // Resolution is `check`'s question and not the parser's, which is what
+    // makes the unresolved entry above legal here.
+    assert!(!dir.join("SPEC-3f81c9d0a2b7.md").is_file());
+    assert!(dir.join("ADR-19d0e2f4a6b8.md").is_file());
+
+    // Omitted when empty, never `[]`. A spec written before the field existed
+    // must survive a rewrite unchanged, and the round-trip test above is what
+    // proves it does; this states the rule the emitter follows.
+    // On the frontmatter and not on the file: the body of this fixture
+    // discusses the field in prose, as it discusses the absent `constraint`.
+    let mut bare = s.clone();
+    bare.references.clear();
+    let front = serialize_spec(&bare);
+    let front = front.split("\n---\n").next().unwrap();
+    assert!(!front.lines().any(|l| l.starts_with("references:")));
+
+    // The position is the table's: after the perimeter, before the succession.
+    let out = serialize_spec(&s);
+    let at = |needle: &str| out.find(needle).unwrap_or_else(|| panic!("{needle}"));
+    assert!(at("scope:") < at("references:"));
+    assert!(at("references:") < at("supersedes:"));
+}
+
 /// A log entry names the entity it is about, in a field. That is what the
 /// previous shape computed from the id instead, and the trade — an address
 /// becomes a query — is the cost the kind was accepted with (ADR-25f977377fa0).

--- a/crates/ank-core/tests/golden/valid/SPEC-19c4f0a83b2e.md
+++ b/crates/ank-core/tests/golden/valid/SPEC-19c4f0a83b2e.md
@@ -8,6 +8,7 @@ author: human:marie
 status: accepted
 scope:
   - src/auth/**
+references: [SPEC-3f81c9d0a2b7, ADR-19d0e2f4a6b8]
 supersedes: SPEC-c07d1b4a92e5
 ratified: 9f2c81b0
 verified:
@@ -21,8 +22,14 @@ The document itself.
 
 A spec carrying every optional field its row declares, so that the round trip
 pins each position: `slug` after `type`, `author` between `created` and
-`status`, `supersedes` and `ratified` after the scope, `verified` last before
-`schema`.
+`status`, `references` immediately after the scope, `supersedes` and `ratified`
+after it, `verified` last before `schema`.
+
+`references` names what this document rests on, and the two entries are the two
+kinds a specification may cite: another specification, and a decision that
+binds. One of them resolves inside this directory and the other does not, which
+is deliberate — whether a reference resolves is a `check` finding and never a
+parse error, exactly as `about` is on a log entry.
 
 What it does not carry is a `constraint`, and that absence is the whole
 justification for the kind: a spec describes, an ADR binds. The refusal is in

--- a/docs/ank-spec-v1.1.md
+++ b/docs/ank-spec-v1.1.md
@@ -408,6 +408,7 @@ author: human:marie
 status: accepted             # proposed | accepted | superseded
 scope:
   - src/auth/**
+references: [SPEC-3f81c9d0a2b7, ADR-19d0e2f4a6b8]   # what this document rests on
 supersedes: SPEC-c07d1b4a92e5
 ratified: 9f2c81b0           # hash of the document and scope at acceptance (set by accept)
 schema: 3
@@ -418,6 +419,16 @@ The document itself.
 ```
 
 **One entity per document, never one per section**, and §10's refusal is kept entire rather than worked around: a specification's authority comes from being one coherent document, its sections are not independent the way ADRs are, and cutting it into scoped fragments creates the drift one document prevents. A section is reached by reading the document. What fired is the remedy that row offered instead — distilling a section into a scoped ADR — and what it fired against is the vehicle: `constraint` is short by construction and frozen at ratification, orientation serves no rule text at all, and a perimeter is called over-constrained when constraints alone exceed half its budget (§5). A description does not fit through a channel sized for a rule, and §11's model has no sink for it either, every mechanism there being subtractive and presupposing a rule that could in principle be checked.
+
+**`references` is what makes several documents safe, and it is a declared field rather than a sentence** (ADR-5a690829388d). A specification cut into documents drifts unless the coherence between them is verified, and verifying it means the citation has to sit somewhere a parser can reach. So a spec declares what it rests on in a field of its own, `check` resolves every entry against the corpus, and three states are reported. A target the corpus does not hold is a **fault**: the reader following the reference finds nothing, which is exactly what a `blocked_by` naming nothing already is. A target that is not `accepted` is a **signal**, because two documents are legitimately written at once and refusing that would make it impossible to write the second — what it must not do is pass unmentioned. A target that is `superseded` is a **signal naming the successor**, so the repair is a citation update and not an investigation. Each of the three names the command that repairs it, and on the third that is the whole difference between a check that helps and one that scolds: the successor is known, so the message carries it. The field is optional and omitted when empty — a document that cites nothing says nothing, and emitting `[]` on every spec written before the field existed would make each of them non-canonical at the very release that introduced it.
+
+**A reference that follows the chain is not reported.** The finding on a superseded target fires only where the citing document does not also reference the end of that chain: a document that has followed the supersession has already done the thing the finding would ask for. Revising a ratified document *is* a supersession, so this is the state a split corpus produces most often, and a rule that fired anyway would fire on every correct citation the day after any document is revised.
+
+**A citation is not covered by the anchor, so the repair is an `amend` and not a supersession.** `ratified` hashes the body and the `scope`; a reference is neither of them. `amend --reference` and `--drop-reference` therefore reach an accepted document, where `--scope` on the same document is refused. That is what makes the repair each finding names actually available where it fires: revising a ratified document *is* a supersession, so the documents left citing a superseded target are usually accepted themselves, and a verb that refused them would be naming a command it turns down.
+
+**A reference names a `spec` or an `adr`, and no other kind.** A specification resting on a binding decision is ordinary and worth declaring; a task is work that finishes and an entry is a trace of a moment, so a document citing one would be citing something the corpus is designed to retire. The rule is enforced where the act can still be attributed — `new spec --reference`, `amend --reference` — and reported by `check` as a fault where a file arrived some other way. It is deliberately **not** a parse error: the format states shape, and refusing to read a whole corpus over one citation is a worse failure than naming it, which is the reading `about` already gets on a log entry.
+
+**Only what is declared is verified.** A section number written in a sentence is not a reference, and nothing scans a body for one. A check reading citations out of paragraphs would depend on how somebody phrased them, which is the drift this exists to catch, moved into the detector.
 
 **A spec declares no `constraint`, and the absence is what justifies the kind.** A spec describes, an ADR binds. An entity that did both would be an ADR with an unbounded constraint, which restates the ceiling rather than solving it. Nothing in the refusal machinery reads a spec, and a rule that must bind is still an ADR — writing one is what §11 already asks of a rule that has grown teeth.
 
@@ -682,7 +693,7 @@ ank done [<id>]             [--proof <type>:<ref>]
 ank release [<id>] --reason <r>
 ank new task --title <t> --scope <glob>... [--criteria <c>] [--blocked-by <id>...]
 ank new adr  --title <t> --scope <glob>... --constraint <c> [--supersedes <id>]
-ank new spec --title <t> --scope <glob>... [--supersedes <id>]
+ank new spec --title <t> --scope <glob>... [--supersedes <id>] [--reference <id>...]
 ank new task|adr|spec       (no flags: pre-filled template in $EDITOR)
 ank find <query>            [--type task|adr|spec|log] [--status ...] [--scope <path>] [--free]
 ank status                  [--remote]
@@ -692,6 +703,7 @@ ank close <id> --reason <r>
 ank amend <id>              [--blocked-by <id>...] [--drop-blocked-by <id>...]
                             [--scope <glob>...] [--drop-scope <glob>...]
                             [--criteria <c>]
+                            [--reference <id>...] [--drop-reference <id>...]
 ank attest <id> --proof <type>:<ref>   [--detached]
 ank edit <id>
 ank graph [<path>]
@@ -1075,6 +1087,7 @@ Summary of the invariants and signals, all mechanical:
 - actor values not matching the typed convention of §3, **reported once for the corpus and never per file**, on the same reasoning and for the same volume as the line above: the convention binds new writes, and the entities that predate it mean what they meant. A malformed actor is a finding here and never a parse error, or a rule would lock out the files it postdates;
 - an entity whose `author` is an agent and which carries **no reading by a `human:`** in `verified` (§3): a signal, one per entity, and never a fault. Nothing requires `verified`, and `check` derives what the fields state and nothing further — no score, no confidence, no ranking;
 - a corpus still in the previous per-kind layout, or still holding a work trace in the shape that preceded entries (§6), **reported once each**, naming the command that moves it: a signal and never a fault, since such a corpus parses, round-trips and answers every verb;
+- **a `references` entry of a spec that does not resolve** (§3, ADR-5a690829388d), one line per entry: a **fault** where the corpus holds no such entity, or holds one of a kind a specification does not cite — the reader following it finds nothing, and the repair is `ank amend <spec> --drop-reference <id>`; a **signal** where the target exists and is not `accepted`, naming `ank accept <id>`, since two documents are legitimately drafted at once; and a **signal** where the target is `superseded` and the citing document does not also reference the end of that chain, naming the successor and the amend that follows it. Only the declared field is read: a section number written in prose is not a reference and no finding pretends otherwise;
 - unresolved git conflict markers in `.ank/` files (§7);
 - **the corpus this checkout carries against the corpus on the default branch** (§7, ADR-47e2ac102f58), **reported once for the corpus and never per entity**: a signal naming how many entity files differ — held here and not there, there and not here, or held on both sides with different content — and the git command that closes the gap. Nothing is fetched to answer and nothing is merged: both revisions are already in this clone, and the gap is git's to close on the operator's word;
 - maintenance of the coordination plane (§7): pruning orphan refs, and completion refs whose task is `done` or `closed` on the default branch. `check` is the only command that prunes. A task carrying a completion ref for a long time without the default branch catching up is reported as a signal — that is a branch never merged, not a corpus anomaly, and the answer is human.

--- a/docs/format.md
+++ b/docs/format.md
@@ -178,16 +178,26 @@ an agent's context (§3).
 | 6 | `author` | scalar | optional |
 | 7 | `status` | bare | `proposed` \| `accepted` \| `superseded` |
 | 8 | `scope` | block sequence | mandatory, never empty; what the document governs |
-| 9 | `supersedes` | bare | optional, an entity id |
-| 10 | `ratified` | scalar | optional; set by `accept`, over the body and `scope` |
-| 11 | `verified` | block sequence of maps | optional, omitted when empty |
-| 12 | `schema` | integer | |
-| 13 | `version` | integer | |
+| 9 | `references` | flow list | optional, omitted when empty; entity ids |
+| 10 | `supersedes` | bare | optional, an entity id |
+| 11 | `ratified` | scalar | optional; set by `accept`, over the body and `scope` |
+| 12 | `verified` | block sequence of maps | optional, omitted when empty |
+| 13 | `schema` | integer | |
+| 14 | `version` | integer | |
 
 The anchor differs from an ADR's in what it covers and in nothing else: a spec
 has no field carrying its authority, so `ratified` is taken over the body and
 `scope` together. A tool that verifies one hashes the body as it hashes a
 `constraint`, under the normalisation below.
+
+`references` names the documents and decisions this one rests on, in the position
+`blocked_by` takes on a task: immediately after the perimeter, before the
+succession. It is a flow list of entity ids and it is **omitted when empty**, not
+written `[]` — a task always states whether it has blockers, and a document that
+cites nothing has nothing to state. A reader resolves each entry against the
+corpus; what a checker then reports of it is §4's business and not the format's,
+and an entry naming a kind other than `spec` or `adr` is a finding there rather
+than a parse error here (§3).
 
 ### Log entry
 


### PR DESCRIPTION
Closes TASK-50dd8f9b565c.

A spec declares what it rests on in a field of its own, `references`, and `check` resolves every entry against the corpus. This is the mechanism ADR-5a690829388d rests on: it argues that cutting a specification into documents is safe because the drift it risks is *detected* rather than deprecated, and until now that was a promise with nothing behind it. It comes before TASK-1162c24b7c75 for that reason — a corpus split before it would carry the fragmentation section 10 refused, with the detector still unwritten.

## What it reports

The precedent is `blocked_by`, followed rather than reinvented: a declared dependency, resolved locally, named when it dangles. What differs is that a specification has two states between "there" and "not there", and they do not deserve the same severity.

| target | severity | repair the finding names |
|---|---|---|
| absent from the corpus | fault | `ank amend <spec> --drop-reference <id>` |
| present, not accepted | signal | `ank accept <id>` |
| superseded | signal, naming the successor | `ank amend <spec> --reference <succ> --drop-reference <id>` |

A reference that has **already followed its chain** is not reported at all: a document citing both the replaced one and its successor has done what the finding would ask of it, and a rule firing anyway would fire on every correct citation the day after any document is revised.

Only the declared field is read. A section number written in prose is not a reference — scanning bodies for citations would make the check depend on how somebody phrased a paragraph, which is the drift this exists to catch, moved into the detector.

## Two decisions the task asked to settle explicitly

**A reference names a `spec` or an `adr`, and no other kind.** A document resting on a binding decision is ordinary and worth declaring; a task is work that finishes and an entry is a trace of a moment, so a document citing one would cite something the corpus is designed to retire. The rule is one function read by `new spec`, by `amend` and by `check` — a rule enforced at a write and reported at a read is exactly the shape that comes to disagree with itself. It is deliberately **not** a parse error: refusing to read a whole corpus over one citation is a worse failure than naming it, which is the reading `about` already gets on a log entry.

**A citation is not covered by the ratification anchor**, which hashes the body and the `scope`. So `amend --reference` and `--drop-reference` reach an accepted document where `--scope` on the same document is refused. That is what makes the repair reachable where it actually fires: revising a ratified document *is* a supersession, so the documents left citing a superseded target are usually accepted themselves, and a verb refusing them would name a command it turns down.

## Shape of the change

Specification first, then the goldens, then the code (ADR-63b59c5c26f7).

- `docs/ank-spec-v1.1.md` §3 and §4, `docs/format.md`: the field, its emission, the findings, the two flags.
- `ank-core`: `Spec.references`, in the canonical position `blocked_by` takes on a task — immediately after the perimeter, before the succession. **Optional** where `blocked_by` is required: a task always states whether it has blockers, a document that cites nothing has nothing to state, and emitting `[]` would make every spec written before the field non-canonical at the release that added it.
- `--drop-reference` matches what the entity stores instead of resolving against the corpus. That asymmetry with `--reference` is the decision: the citation worth dropping is usually one whose target the corpus has lost, and resolving it would refuse the very repair `check` names.

## Verification

`cargo test --workspace` green, `cargo fmt --check` clean, `ank check` ok.

Three integration tests drive the built binary — a criterion that talks about `check` is tested through `check`: the three cases with their severities and their exit codes, the chain already followed reporting nothing, the named repairs being commands `amend` accepts (including on an accepted document), and the kind rule at all three entry points.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NxPxixKuRX45JGV54BhRk
