### PR TITLE
Two ank processes on one corpus stop refusing each other

### DIFF
--- a/.ank/entities/LOG-51dd49145ca9.md
+++ b/.ank/entities/LOG-51dd49145ca9.md
@@ -1,0 +1,15 @@
+---
+id: LOG-51dd49145ca9
+type: log
+title: "falsification, before any fix: concurrent_readers_of_one_corpus_all_answer spawns twelve ank"
+created: 2026-08-15T18:32:25Z
+author: claude-code/opus-5
+scope:
+  - crates/ank-cli/src/index.rs
+about: TASK-e9dfaf187a1b
+seq: 0
+schema: 3
+version: 1
+---
+
+ processes on one corpus, four each of find, context and scope. Three of the twelve exited 1 with 'error[1]: index: database is locked' and the hint 'rm <repo>/.ank/index.db'. That is SQLITE_BUSY, which the connection turns into an error because no busy timeout is set. CI saw the compounded form of the same race - 'attempt to write a readonly database' and 'disk I/O error' - which is what SQLite reports once the file under an open connection has been unlinked, and open_raw unlinks it on any failure to open. So there are two defects on one path: contention is not waited out, and the cure for an unusable cache is applied to a cache that was merely busy.

--- a/.ank/entities/LOG-7e9a63e92f3f.md
+++ b/.ank/entities/LOG-7e9a63e92f3f.md
@@ -1,0 +1,15 @@
+---
+id: LOG-7e9a63e92f3f
+type: log
+title: two more defects on the same path, both hidden by the delete-and-retry. The schema bootstrap read
+created: 2026-08-15T18:41:24Z
+author: claude-code/opus-5
+scope:
+  - crates/ank-cli/src/index.rs
+about: TASK-e9dfaf187a1b
+seq: 2
+schema: 3
+version: 1
+---
+
+ the version and installed outside any transaction, so twelve processes on a fresh corpus all installed at once: 'table entities_fts already exists' and 'no such table: entities'. And wipe() dropped entities, files and meta but never entities_fts, so every reinstall over an existing index failed on the virtual table - masked because the failure deleted the file and rebuilt from nothing, which answers correctly and costs only a wasted rebuild until two processes do it at once. Both are fixed under one IMMEDIATE transaction, wipe now naming every table the schema creates.

--- a/.ank/entities/LOG-b608f94d0cfb.md
+++ b/.ank/entities/LOG-b608f94d0cfb.md
@@ -1,0 +1,15 @@
+---
+id: LOG-b608f94d0cfb
+type: log
+title: "the busy timeout alone does nothing, and measuring is what said so: with it set and the refresh"
+created: 2026-08-15T18:41:22Z
+author: claude-code/opus-5
+scope:
+  - crates/ank-cli/src/index.rs
+about: TASK-e9dfaf187a1b
+seq: 1
+schema: 3
+version: 1
+---
+
+ still on a deferred transaction, eight of twelve readers failed in under a second. SQLite refuses a read-to-write upgrade with 'database is locked' without ever calling the busy handler, to avoid deadlocking two upgraders, so the timeout is not consulted on the one path that needs it. BEGIN IMMEDIATE takes the write lock up front and the wait applies.

--- a/.ank/entities/LOG-e5cbe0162176.md
+++ b/.ank/entities/LOG-e5cbe0162176.md
@@ -1,0 +1,13 @@
+---
+id: LOG-e5cbe0162176
+type: log
+title: done, proof commit:aa2faa96a520bd5a9446056c894eb7077167b28c
+created: 2026-08-15T18:42:18Z
+author: claude-code/opus-5
+scope:
+  - crates/ank-cli/src/index.rs
+about: TASK-e9dfaf187a1b
+seq: 3
+schema: 3
+version: 1
+---

--- a/.ank/entities/TASK-01843ed0883f.md
+++ b/.ank/entities/TASK-01843ed0883f.md
@@ -1,0 +1,52 @@
+---
+id: TASK-01843ed0883f
+type: task
+slug: the-readme-describes-two-kinds-of-entity-and-the
+title: The README describes two kinds of entity, and there are four
+created: 2026-08-15T18:30:44Z
+author: claude-code/opus-5
+status: open
+scope:
+  - README.md
+blocked_by: []
+done_criteria: |
+  README.md states the four kinds the registry declares rather than two, and the sample ank context output it shows carries a specification line, which is what a perimeter actually serves now. The dogfooding paragraph says that this repository's own specification lives in .ank/ as accepted spec entities reached only through the CLI. The per-session token figure is either re-measured against the current skill/SKILL.md and corrected, or removed; whichever it is, the number in the file is one somebody measured on this revision. No claim in the file contradicts what ank find --type spec and ank context print on this repository. cargo test --workspace and ank check stay green.
+criteria_by: creator
+schema: 3
+version: 1
+---
+
+Not the recording. TASK-ab3592c8c586 asks for an asciinema under `assets/` and is
+deliberately last; this is the prose, and it has gone factually wrong in at least
+one place.
+
+**Two kinds became four.** The README says "Behind it two kinds of entity: a
+decision that constrains code, and a unit of work with what would prove it
+finished". The registry declares `task`, `adr`, `spec` and `log`, and two of them
+arrived because a case was measured rather than foreseen. A reader who takes the
+sentence at face value does not know that a specification can live in the corpus,
+which is now the repository's own strongest example.
+
+**The sample output under-sells what a perimeter serves.** It shows `CONSTRAINTS`
+and `TASKS`. A perimeter now also names the specifications governing it, one line
+each, charged beside the constraints — so the block a reader is shown is not what
+the tool prints.
+
+**The dogfooding claim is weaker than the truth.** It says the plan lives in
+`.ank/`. Since the specification became ten accepted `spec` entities, the
+document that defines the format is itself inside the corpus and reachable only
+through the CLI. That is the opening argument of the README — not a directory to
+grep, a CLI to call — demonstrated on the project's own normative text, and it is
+not claimed.
+
+**One number wants re-measuring rather than believing.** "the skill an agent loads
+costs about 58 tokens per session" predates ADR-e17e1bbd93ff, which raised the
+ceiling on `skill/SKILL.md` to 140 lines and 1200 words. Either the figure is
+still right for what it measures and should say what that is, or it is stale.
+Measure it against the file as it stands, or drop the number: a figure nobody can
+reproduce is worse than no figure, and this one sits in a paragraph whose whole
+point is that efficiency is two numbers rather than an adjective.
+
+The criterion asks for no wording in particular. What it asks is that every claim
+the page makes be one the binary would confirm on this repository, which is the
+standard the page itself sets for everything else.

--- a/.ank/entities/TASK-e9dfaf187a1b.md
+++ b/.ank/entities/TASK-e9dfaf187a1b.md
@@ -5,7 +5,7 @@ slug: two-ank-processes-on-one-corpus-race-on-the-deri
 title: Two ank processes on one corpus race on the derived index
 created: 2026-08-15T18:17:43Z
 author: claude-code/opus-5
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/src/index.rs
 blocked_by: []
@@ -13,7 +13,7 @@ done_criteria: |
   Two ank processes that read the same corpus at the same time both answer. A test in crates/ank-cli/tests/cli.rs spawns several concurrent invocations of an index-opening verb against one repository, through the built binary, and asserts that every one of them exits 0 and that none reports the index in its error. The falsification is recorded in the task's log: the same test run against the code before the fix, with what it printed. cargo test --workspace and ank check stay green.
 criteria_by: creator
 schema: 3
-version: 1
+version: 2
 ---
 
 Measured in CI on 2026-08-15, on all three platforms at once, from a change that

--- a/.ank/entities/TASK-e9dfaf187a1b.md
+++ b/.ank/entities/TASK-e9dfaf187a1b.md
@@ -5,15 +5,20 @@ slug: two-ank-processes-on-one-corpus-race-on-the-deri
 title: Two ank processes on one corpus race on the derived index
 created: 2026-08-15T18:17:43Z
 author: claude-code/opus-5
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/src/index.rs
 blocked_by: []
 done_criteria: |
   Two ank processes that read the same corpus at the same time both answer. A test in crates/ank-cli/tests/cli.rs spawns several concurrent invocations of an index-opening verb against one repository, through the built binary, and asserts that every one of them exits 0 and that none reports the index in its error. The falsification is recorded in the task's log: the same test run against the code before the fix, with what it printed. cargo test --workspace and ank check stay green.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: aa2faa96a520bd5a9446056c894eb7077167b28c
+    criteria: 6bd2ce947ecf
+    via: submitted
 schema: 3
-version: 2
+version: 3
 ---
 
 Measured in CI on 2026-08-15, on all three platforms at once, from a change that

--- a/crates/ank-cli/src/index.rs
+++ b/crates/ank-cli/src/index.rs
@@ -40,6 +40,25 @@ pub const SCHEMA_VERSION: u32 = 4;
 
 pub const DB_FILE: &str = "index.db";
 
+/// How long a contended open or write waits before giving up
+/// (TASK-e9dfaf187a1b).
+///
+/// **Bounded, and the bound is the point.** SQLite's default is to fail a
+/// contended statement immediately, which made two agents reading one corpus in
+/// the same second refuse each other — the nominal execution model of §7, since
+/// worktrees of a repository share its `.ank/`. Waiting is the right answer
+/// because every write here is a refresh of a cache: it is short, it is
+/// idempotent, and the loser of the race wants exactly what the winner is
+/// computing.
+///
+/// Five seconds against a refresh measured in milliseconds on a corpus of a few
+/// hundred entities. High enough that contention is invisible, low enough that a
+/// stale lock — a process killed mid-write — surfaces as an error a reader can
+/// act on rather than as a verb that never returns. A verb that hangs is worse
+/// than one that fails, and §4 has an exit code for an environment that will not
+/// answer.
+const BUSY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
 const SCHEMA: &str = "\
 CREATE TABLE meta (
     key   TEXT PRIMARY KEY,
@@ -85,10 +104,106 @@ CREATE VIRTUAL TABLE entities_fts USING fts5(
 /// longest text and the most likely to match by accident.
 const FTS_WEIGHTS: [f64; 4] = [8.0, 4.0, 2.0, 1.0];
 
+/// What a contended index says, and the one string both halves of the
+/// recognition share (TASK-e9dfaf187a1b).
+///
+/// A `CliError` carries no cause, so the verdict reached at the point the
+/// rusqlite error exists has to survive in the message. Stating it once, beside
+/// the two functions that write and read it, is what keeps that honest.
+const CONTENDED: &str = "another process is writing the index";
+
 fn db_error(e: rusqlite::Error, ank: &Path) -> CliError {
+    // **Contention earns a different sentence and a different next step.** The
+    // hint below is right for a cache that cannot be read and actively wrong
+    // here: deleting a database another process is writing is how one loser of
+    // a race became an error for every reader in the repository. What repairs
+    // contention is time, so the command to run next is the same command again.
+    if is_busy(&e) {
+        return CliError::new(1, format!("index: {CONTENDED} ({e})"))
+            .with_hint("re-run the command: the index is a cache and the writer is finishing");
+    }
     // The index is disposable, so the next step is always the same one and it
     // is always safe. Never generic help.
     CliError::new(1, format!("index: {e}")).with_hint(format!("rm {}", ank.join(DB_FILE).display()))
+}
+
+/// The schema questions and the schema writes, as free functions over a
+/// connection.
+///
+/// They take `&Connection` rather than `&self` so that [`Index::ensure_schema`]
+/// can put them inside a transaction: rusqlite's `Transaction` dereferences to
+/// `Connection`, so one body serves both the bootstrap and the callers that ask
+/// outside one.
+fn tables_present_in(conn: &Connection) -> rusqlite::Result<bool> {
+    let found: i64 = conn.query_row(
+        "SELECT count(*) FROM sqlite_master \
+         WHERE type = 'table' AND name IN ('meta', 'files', 'entities')",
+        [],
+        |r| r.get(0),
+    )?;
+    Ok(found == 3)
+}
+
+fn schema_version_of(conn: &Connection) -> rusqlite::Result<Option<u32>> {
+    // A missing `meta` table is not an error here: it is what a fresh file
+    // looks like, and `query_row` on an absent table would say so with an
+    // error we would then have to classify.
+    let has_meta = conn
+        .query_row(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'meta'",
+            [],
+            |r| r.get::<_, i64>(0),
+        )
+        .optional()?
+        .is_some();
+    if !has_meta {
+        return Ok(None);
+    }
+    let raw: Option<String> = conn
+        .query_row(
+            "SELECT value FROM meta WHERE key = 'schema_version'",
+            [],
+            |r| r.get(0),
+        )
+        .optional()?;
+    Ok(raw.and_then(|v| v.parse().ok()))
+}
+
+/// **Every table the schema creates, and `entities_fts` is one of them.**
+///
+/// It was missing from this list, and the delete-and-retry above is what hid
+/// it: a wipe left the virtual table standing, the reinstall below failed with
+/// `table entities_fts already exists`, the file was deleted and rebuilt from
+/// nothing, and the rebuild answered correctly. So the omission cost only a
+/// wasted rebuild until two processes did it at once — at which point the
+/// deletion was the other one's database (TASK-e9dfaf187a1b).
+fn wipe_in(conn: &Connection) -> rusqlite::Result<()> {
+    for table in ["entities_fts", "entities", "files", "meta"] {
+        conn.execute(&format!("DROP TABLE IF EXISTS {table}"), [])?;
+    }
+    Ok(())
+}
+
+fn install_schema_in(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(SCHEMA)?;
+    conn.execute(
+        "INSERT INTO meta (key, value) VALUES ('schema_version', ?1)",
+        params![SCHEMA_VERSION.to_string()],
+    )?;
+    Ok(())
+}
+
+/// SQLite reporting a lock rather than a defect.
+fn is_busy(e: &rusqlite::Error) -> bool {
+    matches!(
+        e.sqlite_error_code(),
+        Some(rusqlite::ErrorCode::DatabaseBusy | rusqlite::ErrorCode::DatabaseLocked)
+    )
+}
+
+/// The same verdict, read back off the error the caller holds.
+fn is_contention(e: &CliError) -> bool {
+    e.message.contains(CONTENDED)
 }
 
 /// An entity as the index holds it: the fields every reader needs in order to
@@ -180,6 +295,16 @@ impl Index {
         let path = ank.join(DB_FILE);
         match Self::try_open(ank, &path) {
             Ok(index) => Ok(index),
+            // **A busy database is not an unusable one, and the cure for the
+            // second is fatal to the first** (TASK-e9dfaf187a1b). Deleting the
+            // file is right for a cache that cannot be read — a foreign schema,
+            // bytes that are not a database — and it is what every other error
+            // here still gets. Applied to contention it unlinks a database that
+            // other processes hold open, and SQLite then reports their next
+            // write as `attempt to write a readonly database`: one loser of a
+            // race turned a moment of contention into an error for every reader
+            // in the repository. That is the form this defect took in CI.
+            Err(e) if is_contention(&e) => Err(e),
             Err(_) => {
                 // One retry, on a clean slate. A second failure is a real
                 // problem — a read-only directory, a full disk — and is
@@ -192,82 +317,54 @@ impl Index {
 
     fn try_open(ank: &Path, path: &Path) -> Result<Index> {
         let conn = Connection::open(path).map_err(|e| db_error(e, ank))?;
-        let index = Index {
+        // Before any statement, including the schema probe below: the probe is
+        // a read, a read takes a shared lock, and a shared lock is contended by
+        // the writer another process is in the middle of.
+        conn.busy_timeout(BUSY_TIMEOUT)
+            .map_err(|e| db_error(e, ank))?;
+        let mut index = Index {
             conn,
             ank: ank.to_path_buf(),
         };
+        index.ensure_schema()?;
+        Ok(index)
+    }
+
+    /// Brings the file up to this build's schema, **atomically against other
+    /// processes** (TASK-e9dfaf187a1b).
+    ///
+    /// The check and the installation are one transaction and have to be. Read
+    /// apart, twelve processes opening a fresh corpus all find no schema, all
+    /// install one, and eleven of them fail with `table entities_fts already
+    /// exists` or find `no such table: entities` where another had just wiped —
+    /// measured, on exactly that shape. Under `IMMEDIATE` one wins the lock and
+    /// the others re-read *after* it commits, find the schema present, and do
+    /// nothing.
+    fn ensure_schema(&mut self) -> Result<()> {
+        let tx = self
+            .conn
+            .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+            .map_err(|e| db_error(e, &self.ank))?;
         // Both halves are needed, and the second was not obvious: `meta`
         // survives a `DROP TABLE entities`, so a version check alone declares
         // a gutted index healthy and the failure surfaces later, during the
         // refresh, as a missing table.
-        if index.schema_version()? != Some(SCHEMA_VERSION) || !index.tables_present()? {
-            index.wipe()?;
-            index.install_schema()?;
+        let stale = schema_version_of(&tx).map_err(|e| db_error(e, &self.ank))?
+            != Some(SCHEMA_VERSION)
+            || !tables_present_in(&tx).map_err(|e| db_error(e, &self.ank))?;
+        if stale {
+            wipe_in(&tx).map_err(|e| db_error(e, &self.ank))?;
+            install_schema_in(&tx).map_err(|e| db_error(e, &self.ank))?;
         }
-        Ok(index)
-    }
-
-    /// Whether every table the schema declares is actually there.
-    fn tables_present(&self) -> Result<bool> {
-        let found: i64 = self
-            .conn
-            .query_row(
-                "SELECT count(*) FROM sqlite_master \
-                 WHERE type = 'table' AND name IN ('meta', 'files', 'entities')",
-                [],
-                |r| r.get(0),
-            )
-            .map_err(|e| self.err(e))?;
-        Ok(found == 3)
+        tx.commit().map_err(|e| db_error(e, &self.ank))
     }
 
     fn schema_version(&self) -> Result<Option<u32>> {
-        // A missing `meta` table is not an error here: it is what a fresh file
-        // looks like, and `query_row` on an absent table would say so with an
-        // error we would then have to classify.
-        let has_meta: bool = self
-            .conn
-            .query_row(
-                "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'meta'",
-                [],
-                |r| r.get::<_, i64>(0),
-            )
-            .optional()
-            .map_err(|e| self.err(e))?
-            .is_some();
-        if !has_meta {
-            return Ok(None);
-        }
-        let raw: Option<String> = self
-            .conn
-            .query_row(
-                "SELECT value FROM meta WHERE key = 'schema_version'",
-                [],
-                |r| r.get(0),
-            )
-            .optional()
-            .map_err(|e| self.err(e))?;
-        Ok(raw.and_then(|v| v.parse().ok()))
-    }
-
-    fn wipe(&self) -> Result<()> {
-        for table in ["entities", "files", "meta"] {
-            self.conn
-                .execute(&format!("DROP TABLE IF EXISTS {table}"), [])
-                .map_err(|e| self.err(e))?;
-        }
-        Ok(())
+        schema_version_of(&self.conn).map_err(|e| self.err(e))
     }
 
     fn install_schema(&self) -> Result<()> {
-        self.conn.execute_batch(SCHEMA).map_err(|e| self.err(e))?;
-        self.conn
-            .execute(
-                "INSERT INTO meta (key, value) VALUES ('schema_version', ?1)",
-                params![SCHEMA_VERSION.to_string()],
-            )
-            .map_err(|e| self.err(e))?;
-        Ok(())
+        install_schema_in(&self.conn).map_err(|e| self.err(e))
     }
 
     fn err(&self, e: rusqlite::Error) -> CliError {
@@ -290,9 +387,19 @@ impl Index {
         let known = self.known_hashes()?;
         let mut done = Refreshed::default();
 
+        // **`IMMEDIATE`, and the busy timeout does not work without it**
+        // (TASK-e9dfaf187a1b). A deferred transaction takes a read lock at the
+        // first statement and asks to upgrade at the first write; SQLite
+        // refuses that upgrade with `database is locked` **without calling the
+        // busy handler at all**, because waiting there could deadlock two
+        // upgraders against each other. So the timeout set on the connection is
+        // simply not consulted, which is what a first attempt at this fix
+        // measured: twelve concurrent readers, eight refused, in under a
+        // second. Taking the write lock at `BEGIN` is what puts the wait back
+        // on the path that needs it.
         let tx = self
             .conn
-            .transaction()
+            .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
             .map_err(|e| db_error(e, &self.ank))?;
         for (rel, file) in &on_disk {
             if known.get(rel) == Some(&file.hash) {

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -2705,6 +2705,76 @@ fn a_reference_names_a_document_or_a_decision_and_no_other_kind() {
     );
 }
 
+// ---------------------------------------------------------------------------
+// Concurrent readers of one corpus (TASK-e9dfaf187a1b)
+// ---------------------------------------------------------------------------
+
+/// **Two agents reading one corpus at the same time both get an answer.**
+///
+/// The nominal execution model is one working tree per agent (§7), and
+/// worktrees of a repository share its `.ank/` — so two agents running
+/// `ank context` inside the same second is the ordinary shape of a parallel
+/// session, not an exotic one. It did not work: measured in CI on all three
+/// platforms at once, two of three concurrent readers came back
+/// `error[1]: index: attempt to write a readonly database` and
+/// `error[1]: index: disk I/O error`.
+///
+/// The symptom names the cause. `attempt to write a readonly database` is what
+/// SQLite reports when the file underneath an open connection has been unlinked,
+/// and `open_raw` deletes the index whenever opening it fails — so one reader
+/// losing a lock race deleted the database the others were using, and the
+/// disposability rule of §6 turned a moment of contention into an error for
+/// everybody else.
+///
+/// Through the binary and with real processes, because that is the only place
+/// the defect exists: every in-process test opened one connection at a time and
+/// passed throughout.
+#[test]
+fn concurrent_readers_of_one_corpus_all_answer() {
+    let r = Repo::new();
+    for i in 0..12 {
+        r.seed_task_titled(&format!("TASK-00000000{i:04x}"), &format!("Task {i}"));
+    }
+
+    // Every verb here opens the index, and each of them refreshes it while
+    // reading (§6), so all three are writers whatever their names suggest.
+    let verbs: [&[&str]; 3] = [&["find", "Task"], &["context"], &["scope", "src"]];
+    let mut running = Vec::new();
+    for i in 0..12 {
+        running.push(
+            ank_command()
+                .args(verbs[i % verbs.len()])
+                .arg("--repo")
+                .arg(&r.0)
+                .env("ANK_AGENT", format!("agent-{i}@host"))
+                .current_dir(std::env::temp_dir())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()
+                .expect("the binary must have been built"),
+        );
+    }
+
+    let mut refused = Vec::new();
+    for (i, child) in running.into_iter().enumerate() {
+        let out = child.wait_with_output().expect("a spawned ank must finish");
+        if !out.status.success() {
+            refused.push(format!(
+                "#{i} exited {:?}: {}",
+                code(&out),
+                stderr(&out).trim()
+            ));
+        }
+    }
+    assert!(
+        refused.is_empty(),
+        "readers of one corpus refused each other. The index is derived, \
+         disposable and rebuildable (§6), so contention on it is never a reason \
+         to fail a reader:\n{}",
+        refused.join("\n")
+    );
+}
+
 /// A perimeter holding one proposal, with a budget as the only variable.
 fn proposed_fixture(budget: &str, with_proposal: bool) -> Repo {
     let r = Repo::new();

--- a/crates/ank-cli/tests/skill.rs
+++ b/crates/ank-cli/tests/skill.rs
@@ -63,14 +63,14 @@ fn push_once(verbs: &mut Vec<String>, verb: String) {
 /// have to be re-typed on every revision, and the revision that forgot would
 /// look like a passing suite.
 ///
-/// **Read once for the whole binary, and that is not an optimisation.** Three
-/// tests want this document, `cargo test` runs them on three threads, and the
-/// verbs that answer open the derived SQLite index — which today carries no
-/// busy timeout, so two of them racing on one corpus is `attempt to write a
-/// readonly database` (TASK-e9dfaf187a1b). It passed here and failed on all
-/// three platforms in CI, which is the shape of a concurrency defect and not of
-/// a flake. Reading once removes this suite from the race; the defect itself is
-/// ank's and has its own task.
+/// **Read once for the whole binary.** Three tests want this document and
+/// `cargo test` runs them on three threads, so this used to put three
+/// concurrent readers on one corpus — which is how TASK-e9dfaf187a1b was found:
+/// green here, red on all three platforms in CI, the shape of a concurrency
+/// defect rather than of a flake. That defect is fixed in the index itself and
+/// has its own test, so this is now what it looks like: eleven process spawns
+/// instead of thirty-three, for a document that does not change between three
+/// reads of it.
 fn section_4_document() -> String {
     static DOC: OnceLock<String> = OnceLock::new();
     DOC.get_or_init(read_section_4_document).clone()


### PR DESCRIPTION
Closes TASK-e9dfaf187a1b. Also files TASK-01843ed0883f, for the README prose — separate task, no code.

The nominal execution model is one working tree per agent (§7), and worktrees of a repository share its `.ank/`. So two agents running `ank context` inside the same second is the ordinary shape of a parallel session, not an exotic one. **It did not work.**

Twelve concurrent readers of one corpus — four each of `find`, `context` and `scope` — and three came back `error[1]: index: database is locked`. CI had shown the compounded form first, on all three platforms at once: `attempt to write a readonly database` and `disk I/O error`, which is what SQLite reports once the file under an open connection has been unlinked.

## Three defects on one path, and the first was hiding the other two

**The cure for an unusable cache was applied to a busy one.** `open_raw` deletes the index whenever opening it fails. That is right for a foreign schema or bytes that are not a database — the index is derived and disposable, and §6 says deleting it is always safe — and it is fatal under contention: one loser of a race unlinks the database every other reader holds open, and their next write fails as readonly. Contention is now recognised where the SQLite code still exists, carried in the message, and excluded from the delete. Its hint changed too: `re-run the command` rather than `rm <index>`, because what repairs contention is time, and the old hint told the caller to do the very thing that caused the outage.

**A busy timeout alone does nothing, and measuring is what said so.** With `busy_timeout` set and the refresh still on a deferred transaction, the same test went from three failures to **eight, in under a second**. SQLite refuses a read-to-write upgrade with `database is locked` *without ever calling the busy handler* — deliberately, since waiting there could deadlock two upgraders against each other — so the timeout was simply not consulted on the one path that needed it. `BEGIN IMMEDIATE` takes the write lock up front and the wait applies. The bound is 5 seconds against a refresh measured in milliseconds: high enough that contention is invisible, low enough that a stale lock surfaces as an error rather than as a verb that never returns.

**The schema bootstrap was not atomic, and `wipe` was incomplete.** Twelve processes opening a fresh corpus all read "no schema" and all installed one: `table entities_fts already exists`, and `no such table: entities` where another had just wiped. The check and the install are now one `IMMEDIATE` transaction, so one wins the lock and the others re-read after it commits and do nothing. And `wipe` dropped `entities`, `files` and `meta` — three tables of four, never `entities_fts` — so every reinstall over an existing index failed on the virtual table. The delete-and-retry had been hiding that since the FTS table was added, at the cost of a wasted full rebuild, which answers correctly; it only became visible when two processes did it at once and the deletion was the other one's database.

## Verification

The test spawns **twelve real processes** against one repository and asserts every one exits 0. It has to be processes: every in-process test opened one connection at a time and passed throughout.

It fails against the code before this commit — recorded in the task's log with what it printed, as the criterion required — and passed eight consecutive runs after. `cargo test --workspace` green (549 tests), `cargo fmt --check` clean, `ank check` ok.

`tests/skill.rs` keeps reading the corpus once per binary rather than once per test. That started as a way around this defect; it stays for the ordinary reason, and its comment now says so — eleven process spawns instead of thirty-three for a document that does not change between three reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NxPxixKuRX45JGV54BhRk
