### PR TITLE
The skill teaches investigation too, and says why before how

### DIFF
--- a/.ank/entities/ADR-5dd7b4a9c875.md
+++ b/.ank/entities/ADR-5dd7b4a9c875.md
@@ -1,0 +1,146 @@
+---
+id: ADR-5dd7b4a9c875
+type: adr
+slug: the-skill-teaches-investigation-too-and-says-why
+title: The skill teaches investigation too, and says why before how
+created: 2026-08-15T19:04:57Z
+author: claude-code/opus-5
+status: proposed
+scope:
+  - skill/SKILL.md
+  - crates/ank-cli/tests/skill.rs
+  - crates/ank-cli/src/cli.rs
+  - docs/**
+constraint: |
+  The CLI exposes one surface: every verb is available to every caller, and the
+  CLI refuses on state, never on identity. The only hard authority line is the
+  signed ratification commit produced by accept. The verbs themselves do not
+  change.
+  
+  ank help lists every verb. No verb is hidden, and there is no second listing to
+  ask for. The listing is grouped by the moment a verb is reached for, under
+  lowercase headings, and within a group the order stays section 4's. A group says
+  when a verb is used and never who may use it; a heading that sorted callers would
+  be the wall this project has already refused twice.
+  
+  SKILL.md teaches three modes, and its content remains frozen by revision hash.
+  The loop: context, claim, show, log, done, with new, find and release off-loop.
+  Planning: new adr, amend, review, graph, check, find --status open.
+  Investigation: context on a path, scope, find, show, log read with no message,
+  status, check on a path, and find --type spec for the specification the corpus
+  carries. It states why before how -- two planes joined by scope, and anchoring
+  rather than trust. accept stays described and never invited; close, attest and
+  edit stay untaught. The ceiling is at most 180 lines and 1500 words, and the
+  frontmatter description does not grow: it is the only part a session pays for
+  whether or not the skill is invoked.
+supersedes: ADR-f61e2d2c75e8
+schema: 3
+version: 1
+---
+
+## Context
+
+`skill/SKILL.md` is the only description of ank most agents will ever read, and
+ADR-f61e2d2c75e8 froze it at two modes: the loop, and the planning that fills
+it. Two things have made that shape too small, and one of them arrived this
+week.
+
+**The file never says why.** It opens on where the files live and goes straight
+to the verbs. Nothing in it says that constraints and work are two planes joined
+only by scope, or that nothing in the system is trusted because everything is
+anchored. An agent taught only the moves knows what to type and not what any of
+it protects — and an agent that does not know what a rule protects is the one
+that works around it, politely, in good faith. The freeze was written to keep
+the file small; it also kept out the twenty lines that make the rest of it make
+sense.
+
+**Two verbs exist for a question the skill does not let an agent ask.**
+`ank scope <path>` answers *what governs this file* and `ank status` answers
+*where am I*. Both were shipped, both are outside the taught set, and the
+question they answer is the one an agent actually arrives with — before it has
+chosen a task, and often instead of choosing one. The read form of `ank log
+<id>` is the third: it is how the next holder learns where the last one stopped,
+which is the whole reason `release --reason` is mandatory, and the skill teaches
+the write form only.
+
+**And the specification is now in the corpus.** ADR-5a690829388d split it into
+ten `spec` entities, ratified and anchored. The normative answer to *what is the
+rule* is one `ank find --type spec` and one `ank show` away, from inside the
+tool, under the same rule that closes `.ank/` to direct reads. The skill does
+not mention the kind at all, so an agent holding it has no route to the document
+that defines what it is doing.
+
+## What is added, and what is not
+
+Investigation joins the loop and planning as a third mode: `context` on a path,
+`scope`, `find`, `show`, the read form of `log`, `status`, `check` on a path,
+and `find --type spec`. Every one of them is a reader. That is the line this ADR
+draws — the mode adds nothing that writes, so the thing being taught is how to
+arrive informed, not a new way to change the corpus.
+
+`close`, `attest` and `edit` stay untaught, on the reason ADR-f61e2d2c75e8 gave
+and this ADR keeps: nothing has decided they are worth what every session pays
+for them. `accept` stays described and never invited — the skill says what it is
+so that an agent knows where its authority ends, and never shows the command.
+
+**Being untold is still not being refused.** The freeze constrains the
+documentation and not the dispatch table, exactly as before. An agent that types
+`ank edit` gets the editor.
+
+## The ceiling moves, and the measurement is why
+
+At most **180 lines and 1500 words**, up from 140 and 1200. A ceiling raised to
+accommodate whatever was just written is not a ceiling, so the number rests on a
+measurement rather than on the length of the draft.
+
+What is loaded on every session is the **frontmatter**, not the body:
+`claude plugin details ank` projects `Always-on: ~58 tok added to every session`,
+which is the `name` and the `description`, and the body is read when the skill
+is invoked. So on the harness this project is developed against, the body costs
+nothing until it is used.
+
+That is **not** a licence to let it grow, and the ceiling is kept for the case
+it was always really protecting: `docs/agents.md` documents a by-hand route that
+copies `skill/SKILL.md` into "whatever that harness loads", and some harnesses
+load the whole file every session. The ceiling therefore protects the worst
+route rather than the best one, and it is stated here so that the next person to
+move it knows which case they are trading against.
+
+The **`description` does not grow**, and that is the half of this with teeth: it
+is the only part every session pays for whether or not the skill is ever
+invoked. Words go in the body, where they are paid for by the sessions that
+wanted them.
+
+## Rejected
+
+**Teaching investigation with the verbs already taught** — `context`, `find`,
+`show`, `graph`, `check` — which would have needed no ADR at all, on the
+precedent of the two additions that added neither a verb nor a flag. It was the
+cheaper path and it leaves out `scope` and `status`, which are the two verbs
+built for the question. A mode assembled out of what was already permitted, and
+missing exactly the tools for the job, is a workaround wearing the shape of a
+decision.
+
+**Raising the ceiling to fit and saying no more.** The number without the
+measurement is the thing this project refuses everywhere else: `8000 (default)`
+is printed as a default for the same reason.
+
+**Growing the `description` to say the skill now covers investigation.** It
+reads as free and is the one thing that is not: it is the always-on half. An
+agent that needs to know invokes the skill and finds out in the first four
+lines.
+
+## Consequences
+
+`crates/ank-cli/tests/skill.rs` loses `status` and `scope` from the list of
+verbs the file must not name, gains a test for the investigation verbs beside
+the ones for the loop and planning, and carries the new ceiling. The revision
+hash in `metadata.revision` moves, as it does on any edit, and
+`the_binary_names_the_skill_revision_it_was_built_alongside` keeps the binary
+and the file agreeing.
+
+Section 4 of the specification states the frozen content and section 9 states
+what the file carries, so both move — as supersessions, since an accepted spec
+whose body is edited is reported `altered`. The four documents citing the CLI
+surface follow the chain afterwards with `amend --reference`, which is the
+mechanism ADR-5a690829388d asked for, used for the first time.

--- a/.ank/entities/LOG-33740d3c7ea0.md
+++ b/.ank/entities/LOG-33740d3c7ea0.md
@@ -1,0 +1,17 @@
+---
+id: LOG-33740d3c7ea0
+type: log
+title: "measured, on the first supersession of a spec document: revising one passage of section 4 cost a"
+created: 2026-08-15T19:16:35Z
+author: claude-code/opus-5
+scope:
+  - skill/SKILL.md
+  - crates/ank-cli/tests/skill.rs
+  - docs/agents.md
+about: TASK-1e2e47327d71
+seq: 0
+schema: 3
+version: 1
+---
+
+ successor entity of 65496 bytes to carry 5281 bytes of changed text, about 12x. That is the price the whole-document kind was accepted with - the anchor covers the body, so any revision is a new document - and it is worth recording rather than felt. It is not yet an argument for a finer seam: the ten documents were cut where a reader can read one alone, and cutting them where a writer would edit least would be optimising the wrong side. What it does argue is that a document nobody can revise without re-emitting it should stay small enough that re-emitting is cheap, which the CLI surface at 472 lines is at the edge of.

--- a/.ank/entities/LOG-e10f0d4e090e.md
+++ b/.ank/entities/LOG-e10f0d4e090e.md
@@ -1,0 +1,15 @@
+---
+id: LOG-e10f0d4e090e
+type: log
+title: done, proof commit:b32f93942f8f73334bf81de81268bb5e80ff1e5e
+created: 2026-08-15T19:17:20Z
+author: claude-code/opus-5
+scope:
+  - skill/SKILL.md
+  - crates/ank-cli/tests/skill.rs
+  - docs/agents.md
+about: TASK-1e2e47327d71
+seq: 1
+schema: 3
+version: 1
+---

--- a/.ank/entities/SPEC-cd0d3377b37f.md
+++ b/.ank/entities/SPEC-cd0d3377b37f.md
@@ -1,0 +1,487 @@
+---
+id: SPEC-cd0d3377b37f
+type: spec
+slug: the-cli-surface
+title: The CLI surface
+created: 2026-08-15T19:07:03Z
+author: claude-code/opus-5
+status: proposed
+scope:
+  - crates/ank-cli/**
+references: [SPEC-acee5d9cb21b, SPEC-89070ce7f3b8, SPEC-3d12e76d9fa2, SPEC-6aed60cd3717]
+supersedes: SPEC-c33e07a82cc4
+schema: 3
+version: 2
+---
+
+One of the ten documents that carry the Ank specification (ADR-5a690829388d).
+This one carries **§4 without two of its halves**: the one surface and what the
+skill teaches, the verbs, the refusals and their exit codes, the commands block,
+configuration, short forms, self-correcting errors, and the catalogue `check`
+prints.
+
+## Why two halves left, and why the rest did not
+
+§4 was the longest section in the monolith and the only one this decomposition
+splits. Two passages sitting inside it failed the test in the direction nobody
+looks for — not *this cannot be read alone*, but *this is read by documents that
+are not this one*.
+
+**The presentation grammar left.** Its alphabet and its palette are declared
+before any code uses them, they read alone, and their dependencies point away
+from the verbs: the palette is keyed on the statuses the data model declares and
+on the markers synchronisation writes, not on anything in the verb table it sat
+inside. A passage whose dependencies lie outside the document holding it is a
+passage in the wrong document.
+
+**The proof half left**, and joined §8. Proofs, named verifiers and the trust
+hierarchy answer the same question §8 answers about identity — what is a claim
+about the world worth, and who validated it. The data model reads it for the
+`proof` field, synchronisation reads it for detached proofs, and a passage two
+documents depend on should not be buried inside a third.
+
+**The catalogue of `check` stayed.** It is the strongest candidate for a document
+of its own and it fails the test cleanly: nearly every finding restates a rule
+that lives elsewhere and cites the section that states it, so read alone it is an
+index of things it does not contain. An index that cannot be read without the
+things it indexes is not a document, and this one belongs beside the verb that
+prints it.
+
+Everything else here is one subject: what the caller may type, what comes back,
+and on what state it is refused. `config` and the short-form table are part of it
+for the same reason the exit codes are — they are the surface, not a mechanism
+behind it.
+
+## What it rests on
+
+- **The data model** — every verb here acts on the fields it declares.
+- **Presentation** — the grammar of what these verbs print.
+- **Proof, anchoring and authority** — what `done` requires and why a refusal is
+  never on identity.
+- **The attention budget** — `context`'s two modes, and the over-constrained
+  finding this catalogue reports.
+
+---
+
+## 4. CLI surface
+
+**Ank exposes one surface** (ADR-e17e1bbd93ff, superseding ADR-c656cbcc33a9). Every verb is available to every caller, and the CLI refuses on state, never on identity. Git has more than a hundred commands, every one of them reachable by anybody who types it, and stays learnable because of what a newcomer is taught first — not because the porcelain sorts callers into classes. Ank borrows that shape.
+
+The memorisation budget is real; it is simply not the binary's job. It is spent on documentation, and it is enforced where it operates: what an agent is taught is the loop and the planning that fills it, and the content of what teaches it is frozen. What a human may type is everything.
+
+### What the skill teaches, and the freeze on SKILL.md
+
+```
+Loop:          context → claim → show → log → done
+Off-loop:      new, find, release
+Planning:      new adr, amend, review, graph, check, find --status open
+Investigation: context <path>, scope, find, show, log <id>, status, check <path>
+```
+
+**This is the entire content of SKILL.md, and that content is frozen** (ADR-5dd7b4a9c875, superseding ADR-f61e2d2c75e8, which carried the freeze forward from ADR-e17e1bbd93ff unchanged). What the file teaches is what an agent knows, so growing it costs a superseding ADR and a human signature — the same price a verb list once cost. The freeze constrains the documentation, not the dispatch table: an agent that runs `ank edit` gets the editor; it was simply never told the verb existed, and being untold is not being refused.
+
+**Three modes, because an agent that can only execute is half an agent, and one that cannot look is working blind.** The loop is how work gets done; planning is how the work that gets done comes to exist — deciding which tasks should exist, in what order, under which constraints. ADR-c656cbcc33a9 taught the loop alone, and an agent taught by it could not propose a decision, correct a graph, or notice that the corpus had gone incoherent: `ank new adr` was never mentioned, so an agent seeing an architectural problem had no documented path from the observation to a recorded ADR. Planning is the highest-leverage activity in the corpus, and a badly shaped backlog wastes more downstream than the teaching costs upstream.
+
+**Investigation is the third, and it is the one an agent needs first.** Before choosing a task — and often instead of choosing one — the question is *what governs this file* and *where am I*. `scope <path>` answers the first and `status` the second, both shipped and neither taught, so an agent holding the skill had the question and not the verb. The read form of `log <id>` is the third: it is how the next holder learns where the last one stopped, which is the whole reason `release --reason` is mandatory. And `find --type spec` reaches the specification itself, which is an entity of the corpus since ADR-5a690829388d — the normative answer is one `show` away, from inside the tool, under the rule that closes `.ank/` to direct reads. **Every verb the mode adds is a reader**: it teaches how to arrive informed, and adds no way to change anything.
+
+**The file says why before it says how.** It opened on where the files live and went straight to the verbs, which taught the moves and not what they protect: that constraints and work are two planes joined only by scope, and that nothing here is trusted because everything is anchored. An agent that does not know what a rule protects is the one that works around it, in good faith.
+
+**The ceiling is at most 180 lines and 1500 words**, up from 140 and 1200, and it stays a ceiling to notice drift rather than a target to fill. The number rests on a measurement, because a ceiling raised to accommodate what was just written is not a ceiling. What every session pays for is the **frontmatter** and not the body — `claude plugin details ank` projects `Always-on: ~58 tok`, which is the `name` and the `description` — and the body is read when the skill is invoked. The ceiling is kept anyway, for the case it was always protecting: §9's by-hand route copies the whole file into whatever a harness loads, and some load all of it every session. So it bounds the worst route rather than the best one, and the `description` does not grow at all, being the one part paid for whether or not the skill is ever used.
+
+**`accept` is described and never invited.** The skill says what it is — a human act, signed, on the default branch only — so that a planning agent knows where its own authority ends, and it never shows the command as something to run. That is the one hard authority line in the system (§8, §12), and describing it is what makes it legible rather than mysterious. `close`, `attest` and `edit` stay outside for the ordinary reason: nothing has decided they are worth what every session pays for them.
+
+That distinction is the whole revision. ADR-3859eb46bdc3 froze an *agent surface* at these same eight verbs and sent everything else to a human side, but the split it protected was never a boundary — the CLI told callers apart by `$ANK_AGENT`, a variable the caller sets itself (§8). A wall whose bricks are self-declared identity is a sign, not a wall. What the freeze actually protected was the token budget, and that protection moves here, where it holds without pretending to be a check.
+
+`show` is in the loop by that route, and the reasoning is worth keeping because it is the argument any addition to SKILL.md has to beat. It sat outside at first, as the only unbounded reader in the system. That argument was about output size, and §5 answers size with a budget and a truncation notice that says what it cut. What it did not answer is the body: `context` serves the criterion and the constraints, never the prose that justifies them, and the prose is where the reasoning an agent is supposed to inherit actually lives. With `.ank/` closed to direct reads (ADR-01b6dd05f0db), withholding it entirely was the worse trade.
+
+### The rest of the surface
+
+These verbs are the rest of the surface. Four of them — `review`, `check`, `amend` and `graph` — are what the planning mode above teaches, and the others are outside what the skill teaches rather than withheld from anyone: none of the refusals below consults who is calling, and an agent that types one gets its answer.
+
+```
+review    ratification queue, pending proposals, corpus health
+accept    promotes a proposed ADR or spec to accepted (produces the signed commit,
+          §8, §12; requires the default branch)
+check     mechanical invariants, exit code usable in CI
+close     closes a task that will never be done (--reason mandatory)
+amend     changes `blocked_by`, `scope`, and a `done_criteria` no live claim freezes
+attest    appends a proof to a finished task: the one write §3 allows after `done`
+status    where am I: branch, claim, perimeter, queue, findings
+edit      opens an entity in the editor and validates what comes back
+graph     the `blocked_by` DAG in readable text
+scope     what covers a path
+```
+
+`review` and `accept` are not comfort features: **the entire authority model of ADRs depends on them**. Without them an agent creates in `proposed` and nothing ever becomes binding.
+
+`review` filters by default on **live scopes**; entities with a dead scope are grouped into a cleanup section with `close` suggested. An ageing corpus therefore produces an explicit closure queue rather than diffuse noise.
+
+**`accept` only runs on the default branch** (§7), and there is no way around it — no `--force`. An ADR ratified on a feature branch would be binding only on that branch: a constraint of variable geometry, and a ratification hash that depends on the reading context, which is exactly the ambiguity Ank eliminates everywhere else. The legitimate use case — introducing a constraint and the code that applies it in the same PR — is already covered by the model: the ADR is created in `proposed`, travels with the code, and is accepted only once it has reached the default branch. An unratified constraint binds nobody, so nothing is lost by waiting, and that is what makes the prohibition sustainable while strict. Off the default branch, `accept` exits with **code 7** — missing prerequisite, not illegal transition: the promotion is legal, the place is not.
+
+```
+$ ank accept 19d0
+error[7]: accept requires the default branch (current: feat/opaque-sessions, default: main)
+  -> git switch main && ank accept 19d0
+```
+
+**`amend` covers the three fields a plan actually changes on**, `blocked_by`, `scope` and `done_criteria`, and covers nothing else. A subtask discovered after a task was filed is a `blocked_by` added to something that already exists; a scope found to omit the files the work must touch is a scope corrected before the task can be claimed at all. Both are ordinary, both were done by hand until this verb existed, and an edit done by hand is indistinguishable in the resulting file from any other edit done by hand — which is the argument that put `attest` on this surface too.
+
+It **adds and removes explicitly** and never takes a replacement list: a verb given the whole list silently drops whatever the caller forgot to repeat. It refuses a `done` or `closed` task, since §3 allows exactly one write after completion and that write is `attest`'s. And it refuses the `scope` of an accepted ADR or spec, whose `scope` is hashed into the ratification commit (§8) — changing a ratified decision is a succession, and succession has its own verb. The two are refused on the same terms and for the same reason, and a spec's anchor simply reaches wider: it covers the body as well, so what an ADR keeps editable after ratification a spec does not (§3).
+
+Amending the `scope` of a task under a live claim is **allowed and warned about**. The claim record anchors the hash of the constraints that scope selects (§7), so the change moves what binds the work in progress. Refusing would be wrong — a scope discovered false mid-task is exactly the situation the verb exists for — and allowing it silently would be worse.
+
+**`amend --criteria` is refused while a live claim freezes the criterion, and allowed the rest of the time.** That is the same state test `edit` already applies (below), and stating it once for both is the point: a criterion under no claim is anchored by nothing, so there is no freeze to respect and nothing for `check` to notice. Under a live claim the refusal is code 6 and names `release --reason`, which is what a criterion discovered wrong mid-work actually calls for.
+
+The route exists because a criterion can turn out **unmeasurable rather than wrong**, and that case had no continuation. Measured on this corpus: a task whose criterion ended on a clause about `gh api community/profile` reporting `issue_template`, which is `null` for any repository using an `ISSUE_TEMPLATE/` directory — the layout that task existed to produce (TASK-7c2fa14284ff). The work was finished and correct; the measurement never could be. The release was right and happened, and then the corrected criterion had two ways back in and both were wrong: a hand edit, which the tool exists to make unnecessary, or `claim --criteria`, which recorded a creator's correction as the claimer's.
+
+**`amend` does not touch `criteria_by`.** That field answers one question — was this criterion set at claim time, by the party the freeze constrains (§3) — and an amend is not a claim. Writing `claimer` there for a correction made under no claim would launder the correction into exactly the shape the signal exists to expose; writing `creator` would assert something about the caller, which no refusal and no field here does. What records the amend is the log entry, as it does for `scope` and `blocked_by`.
+
+**`claim --criteria` sets a criterion, and never replaces one.** On a task that already carries one it is refused, code 6, naming `ank amend <id> --criteria`. §3 gives the flag one job — a task cannot be claimed without a criterion, and the refusal for the empty case names the command that sets it and claims in the same call — and silently overwriting an existing one is not that job. It also keeps `criteria_by: claimer` meaning exactly one thing: nobody wrote a criterion for this task before the agent that took it.
+
+Everything else (editing fields, reordering, deleting) goes through **`ank edit`**, which is the paved road rather than a gate: it opens the same file in the same editor and validates what comes back. Below it, the direct edit remains possible, since the format is the specification and the CLI is not a gatekeeper. The actor matters there and is not decoration: ADR-01b6dd05f0db closes `.ank/` to direct reads and writes *by an agent*, and leaves **a human** with an editor every power they had. Written without the subject, that sentence reads as a general permission and hands back what the ADR withdrew.
+
+### Refusals are on state
+
+The binary refuses, and what it refuses on is always a fact about the corpus or the repository, never a fact about the caller.
+
+| Refusal | Code |
+|---|---|
+| frozen field diverged from its anchoring hash, or illegal transition | 6 |
+| claim held by another agent, or task already finished on another branch | 4 |
+| task blocked, no `done_criteria`, `accept` off the default branch, or a live claim already held by the calling identity | 7 |
+| proof missing or invalid | 5 |
+
+That list is the guarantee. A state refusal applies to every caller equally and means the same thing to all of them, which is what makes it worth writing an exit code for; a refusal conditioned on identity would mean whatever the caller declared itself to be. `$ANK_AGENT` names who acted — it goes into the log, into the claim ref and into `check`'s signals — and it is never consulted to decide whether a verb runs.
+
+**The one hard line of authority is the signed ratification commit** (§8, §12), and it holds precisely because it is not a role check: `accept` produces it, `check` verifies it against `allowed_signers`, and an anchor no key covers is reported as unverifiable. That is a proof requirement, the same shape as every other anchor in the system. Everything else that looks like permission is policy, and policy lives above the binary (§8).
+
+### Four verbs and two forms, for the reader at the keyboard
+
+With the surface no longer a boundary, verbs serving human ergonomics enter it without ceremony. None of them introduces state: each one composes what `context`, `find`, `review` and `check` already derive, or wraps a write that was being done by hand anyway.
+
+**`status`** answers *where am I* in one call: the branch, the identity in effect and where it came from, the active claim and its expiry, the constraints on the current perimeter, the ratification queue, completion refs the default branch has not caught up with (§7), and the corpus findings `check` would report. It **degrades with a warning** rather than failing when there is no remote or no determinable default branch — the parts that need neither are still worth printing. Terse `git status` register, and it ends with the next command to run, like every other output here.
+
+The identity line names its **source** and not only its value, for the reason `config` prints `8000 (default)` rather than `8000`: `$ANK_AGENT` names a session, the `<user>@<hostname>` fallback names a machine, and only the second is a trap — two sessions in one checkout that both let it fall back are one agent to every ref the tool writes. Nothing else on that path says so, since a `log` or a `done` from the wrong identity is refused on state, correctly talking about the claim somebody else holds (§8). Under `--json` the two are separate fields, `value` and `source`, on the terms `config` already set.
+
+**`edit <id>`** opens the entity in the editor named by `$EDITOR`, validates the result on save, and writes it back in canonical form (§3). **A change to a frozen field is refused by naming the command that legally performs it**: `release --reason` for a `done_criteria` frozen at claim, `new adr --supersedes` for the `constraint` of a ratified ADR. Frozen means anchored *now*: a `done_criteria` no live claim covers is not refused here, which is the same state test `amend --criteria` applies above and the reason the two agree by construction rather than by restatement. An invalid result leaves the entity untouched and says why, so a mistyped frontmatter costs a re-edit and never a corrupt file. This is the argument that put `amend` and `attest` on this surface, generalised: an edit performed by hand is indistinguishable, in the resulting file, from any other edit performed by hand, and chaperoning it through the tool strengthens the invariants instead of relaxing them.
+
+**`graph [<path>]`** prints the `blocked_by` DAG in readable text, restricted by an optional path the way `context` is, with `--json` for the raw edges. It **names the perimeter it drew** and says so explicitly when that perimeter holds no task. The ordering of §5 already walks these edges to count what a task unblocks, and this makes the same structure visible to a reader. `show` surfaces the narrow case from the same derivation: on a task it lists what that task **directly unblocks** alongside its blockers, one line each with status. Both are computed from the corpus at read time and stored nowhere — a stored reverse edge is a second copy of `blocked_by` that can disagree with the first.
+
+**`scope <path>`** lists every entity whose declared scope matches the path, grouped by type, one line each with its status, and says so explicitly when nothing matches. The resolution is the **same glob matching `context` uses**, resolved deterministically against the filesystem, so the answer is the one that will actually bind. It is the `check-ignore` of Ank: a dead or over-broad scope is otherwise visible only after the fact, through `check`, and this makes glob resolution observable before an entity is written wrong.
+
+**`new` without its mandatory flags opens a pre-filled template** in `$EDITOR` instead of failing, validates the result, and refuses to write an entity that would not pass validation. The `git commit` pattern: no `-m`, an editor. **The flag form is unchanged and remains the scripted path** — it is what SKILL.md teaches and what an agent uses, and nothing about the interactive form reaches it.
+
+**`log <id>` with no message reads** the entity's entries, newest first, and requires no claim. An entity nobody has logged against reads as an empty log, never as an error. `log` with a message keeps writing and renewing the claim, unchanged (§3). The disambiguation is stated rather than inferred: an argument that resolves to an entity id is a read, anything else is a message, and a message that also resolves to an id is an error naming both readings rather than picking one. This closes the one place the git intuition was betrayed — `git log` reads — without renaming the verb.
+
+**`$EDITOR` unset is an environment failure, not a task failure**: `edit` and the interactive form of `new` exit with **code 9** and name the flag form as the way through, consistent with how `sh` not found is treated below. Nothing falls back to a guessed editor.
+
+### HEAD
+
+Borrowed from git, and probably the highest-yield borrowing. `claim` sets a "current task" pointer per agent. Subsequent commands do without an ID:
+
+```
+$ ank claim 8f3a
+claimed TASK-8f3a migrate-auth-sessions -> HEAD
+
+$ ank log "jwt.verify removed from session.ts"
+$ ank done
+```
+
+The agent cannot get the identifier wrong, and every iteration saves a context round trip.
+
+**HEAD is not stored, it is derived**: it is the task on which the current agent holds an active claim. Nothing to synchronise, nothing to clean up, no state that can become inconsistent with the real claim.
+
+This assumes and enforces **one active claim at a time per agent**. That is a useful constraint in itself: an agent must finish or release before moving on, which prevents task hoarding and keeps work in progress readable by others.
+
+**Enforcing it is what `claim` does**, and for a long time this paragraph said so while the binary only warned. A `claim` made while the calling identity already holds a live claim on another task refuses with **code 7**, naming the task held, its expiry, and both ways through:
+
+```
+$ ank claim 8f3a
+error[7]: claude-code@host-3 holds a live claim on TASK-51c2 (expires in 24m)
+  -> ank release --reason "<why>"   (a second session on this machine sets its own ANK_AGENT)
+```
+
+**Code 7 and not 4.** The task asked for is available; it is the caller that is not. 4 means "take something else" and the reaction called for here is the opposite — finish or hand back what is already held — so the code that carries "missing prerequisite" is the one that says it.
+
+**The second way out is not decoration**, and it is why this hint carries a parenthetical the way the "another ready task" hints do. The default identity is `<user>@<hostname>` (§8), so two sessions in one working tree read as one agent, and the session being refused may never have claimed anything: it is being answered about somebody else's claim, and `ANK_AGENT` is the only thing that separates the two. That is also why the message names the identity rather than addressing the caller as the holder — under a shared identity, telling it "you already hold" would be false.
+
+The refusal comes **after** the refusals about the task itself — no criterion, blocked, already claimed elsewhere, illegal transition. An agent told to release the work it holds, for a task that would have refused it anyway, has been made to pay for nothing.
+
+The refusal is on state and not on identity, in the sense of the table above: what is read is the coordination plane — which refs exist and who holds them — and the answer is the same for every caller. A **lapsed** claim is not a live one, so pickup after expiry (§3) is untouched, and an agent returning to a task whose lease ran out claims it exactly as before.
+
+**It does not make the state unreachable, and nothing here assumes it does.** The CLI is not a gatekeeper (§7, §12): a ref written by hand, a claim taken by an earlier binary, or a claim that lapsed and was revived all produce one identity holding two live claims. What `log`, `release` and `done` do when they meet it is settled in §3, not here.
+
+The optional ID on `log`, `done` and `release` is therefore redundant in the nominal case: it exists for explicitness in scripts, and it **must name a task this agent holds a live claim on**, otherwise error 6. It is never a way to act on somebody else's task. Holding one claim, that is the same rule as "must match HEAD"; holding several — the state §3 describes and this section refuses to create — it is what names which of them a verb acts on.
+
+### Pickup and abandonment
+
+`release` closes a real gap: an agent that finds it cannot do the task otherwise has only TTL expiry, which means thirty minutes of dead work for everyone else.
+
+```
+$ ank release --reason "needs access to the staging Redis store"
+released TASK-8f3a -> open
+```
+
+**`--reason` is mandatory.** `release` is the delegation mechanism between agents: the reason goes into the log, and the next agent to claim the task receives the recent log in its `context`, so it resumes where the previous one stopped instead of starting from scratch. A silent release is exactly the gap this verb exists to close — the tool refuses it, with the full command as an example.
+
+### Commands
+
+```
+ank context [<path>]        [--json] [--limit N]
+ank claim <id>              [--criteria <c>: sets an absent one, never replaces] [--ttl 30m]
+ank show <id>
+ank log [<id>] [<message>]  (id alone reads; a message writes)
+ank done [<id>]             [--proof <type>:<ref>]
+ank release [<id>] --reason <r>
+ank new task --title <t> --scope <glob>... [--criteria <c>] [--blocked-by <id>...]
+ank new adr  --title <t> --scope <glob>... --constraint <c> [--supersedes <id>]
+ank new spec --title <t> --scope <glob>... [--supersedes <id>] [--reference <id>...]
+ank new task|adr|spec       (no flags: pre-filled template in $EDITOR)
+ank find <query>            [--type task|adr|spec|log] [--status ...] [--scope <path>] [--free]
+ank status                  [--remote]
+ank review [<path>]
+ank accept <id>
+ank close <id> --reason <r>
+ank amend <id>              [--blocked-by <id>...] [--drop-blocked-by <id>...]
+                            [--scope <glob>...] [--drop-scope <glob>...]
+                            [--criteria <c>]
+                            [--reference <id>...] [--drop-reference <id>...]
+ank attest <id> --proof <type>:<ref>   [--detached]
+ank edit <id>
+ank graph [<path>]
+ank scope <path>
+ank check [<path>]
+ank migrate                 (the previous log directory becomes entries; the command `check` names)
+ank config <key> [<value>]  [--unset]   (a value writes; the key alone reads)
+ank init [<path>]           (§9)
+ank help [<verb>]           (§9)
+
+ank --version               (the build itself: version, commit and skill revision, no verb, no repository)
+```
+
+**This block is the whole dispatch table**, and that is a property worth stating rather than assuming: `attest`, `init` and `help` were reachable in the binary while appearing nowhere here, so a reader comparing the two documents could not tell which one was wrong (TASK-5c868c20472f). `init` and `help` are specified in §9 and listed here only so the list is complete; `ank help` prints these verbs, minus whatever is not yet implemented, grouped by the moment each is reached for and in this order inside a group, which is what ADR-f61e2d2c75e8 requires of it. It prints one short description beside each verb rather than the verb's flag names, and the rules that description answers to are in §9.
+
+**`ank context` with no argument** covers the whole repository. It is the first call an agent should make, before it even knows which path it works on — an agent launched on "fix the login bug" does not yet know its perimeter.
+
+**`context` with an active claim is always in execution mode** (§5). A path argument is then ignored, with a warning line: `active claim on TASK-8f3a, execution context (release to explore elsewhere)`. Exploring another perimeter mid-task is precisely what the one-claim-per-agent rule discourages.
+
+`--limit` applies **only to tasks**, never to constraints.
+
+**`find` is subject to the same cap as `context`**, one line per result, and it announces what it cut. A search command without a budget is a context-explosion vector at least as effective as a badly bounded `context`. `--scope <path>` filters by scope match — it is the command the truncation counters point to (§5).
+
+**Scope overlap is reported and never refused** (ADR-052accd6e3b2). `claim` prints one line per live claim held by another identity whose scope meets the scope of the task being taken — the holder, the task, and the ground the two have in common — and then takes the task: the exit code is 0 and the claim stands. The line names paths rather than the fact of an overlap, because `crates/ank-cli/**` against `crates/ank-cli/tests/**` overlaps on everything under the second, and "these overlap" leaves the reader exactly where they started. Where both globs are literal the answer is a path; where one is a pattern the answer is the narrower pattern, written as a glob rather than expanded into a file list that would be wrong the moment a file is added.
+
+Refusing on it is the mistake, not the omission. Scope overlap is coarse: one held task scoped `crates/ank-cli/tests/**` locks every task that touches any test, and refusing would make the glob a mutex — which pushes agents to declare narrower scopes than the truth to get past it, the one failure mode a guard must not have. A **lapsed** claim is not a live one here either, exactly as in the refusals above: the signal would otherwise fire on abandoned work forever.
+
+**Every `elsewhere` line of `status` carries the title of the task it names**, after the id. The rows are already loaded where the line is built, so the join costs nothing, and without it a reader holds an id and has to run `show` once per claim to learn what anybody is doing — which is the question the section exists to answer.
+
+**`status --remote` is the only opt-in to the network outside `claim`** (ADR-47e2ac102f58). Without it, `status` describes the plane this clone has, as §7 says every verb but `claim` does; no network call is made at all. With it, the claims namespace is read off origin with `ls-remote` — read, never fetched, because writing refs into a clone as a side effect of a question would be a reader sanitising the plane underneath everybody else. What that costs is said on the line rather than papered over: `ls-remote` carries ref names and objects, never contents, so a claim seen only on origin is named with its id and the title the corpus already carries, is marked as being only there, and is never given a holder this clone cannot read. With no remote, or one that cannot be reached, the flag **warns once and answers on the local plane** instead of failing (§2).
+
+**`status` says how far this checkout's corpus is from the default branch**, on one line, whether or not it has drifted (§4, ADR-47e2ac102f58). The count comes out of the same inspection `check` renders, so there is one answer and not two, and it is a comparison of two revisions this clone already holds — `status` without `--remote` still makes no network call. Where the question could not be asked the line is absent, which is the one case `check`'s own signal covers in words.
+
+`find --free` is the same computation for the agent choosing rather than taking: it keeps the open tasks whose scope meets no live claim, and **says how many it hid**. A filter that silently returns two candidates out of seven is a filter that will be trusted for the wrong reason. Without the flag, `find` is unchanged.
+
+**Without the flag, a listing counts the open rows a `claim` would refuse, and names it.** `--status` filters on the status the file carries and the markers come from the coordination plane (§7), so a checkout behind the default branch lists ten rows under `--status open` that all read `[finished:… on …]` — every row correct, and the whole answering a question the reader was not asking. Measured: the reader concluded the filter was broken. The markers say it one row at a time; the line says it once and names `--free`, which is the service the truncation counter and the hidden count already perform for their own filters. It counts **open tasks alone**, because that is all `--free` keeps: a `--status done` listing carries `[finished:…]` too until `check` prunes the ref, and sending that reader to `--free` would name a command answering something else — the rule §7 states for hints, applied to a listing. Nothing is dropped, which is why the word is not *hidden*: the rows were listed, and only their number is restated.
+
+**Writing to `log` requires holding the claim**; reading it requires nothing. It is the task's anchoring register: if anyone can write to it, it stops being a reliable trace of what the holder did — that is a state condition on the claim, not a condition on who is calling, and it is why `log <id>` with no message is a read available to everybody. Someone who wants to annotate without holding the task edits the body of the entity, which is already the normal route for anything that is not a state transition.
+
+Commands that take a perimeter take **paths**, uniformly: `review [<path>]`, `check [<path>]` and `graph [<path>]` share the same semantics as `context`, and `scope <path>` resolves against the same globs.
+
+**A path is normalised before it is matched, and a directory has one meaning however it is typed.** Separators are unified to `/`, repeated and trailing ones collapse, `.` disappears and `..` is resolved lexically — so `docs`, `docs/`, `docs\`, `./docs`, `.\docs\` and `docs/../docs` are one perimeter. A path naming nothing inside the repository, because it is absolute or because it climbs above the root, is **refused with the command to run next**; it is never answered. Case is not folded, deliberately: `DOCS` matches nothing here and matches nothing on Linux, and folding it on Windows alone would give one corpus two meanings depending on the machine reading it.
+
+The rule is not cosmetic, and it is written down because its absence was not obvious. Measured on this repository against `docs/`, which five accepted ADRs bind: `docs` answered five, `docs\` answered **four**, `./docs` answered zero (TASK-df4c39031583). The zeros announce themselves. The four does not — it is the form Windows tab-completion produces, it looks like an answer, and it withholds a binding rule from an agent that has no way to know one is missing. A perimeter resolved two ways is a constraint set that depends on typing.
+
+**The rule is about every path and every glob a caller supplies, not about the positional ones.** It covers flag values — `find --scope`, `new --scope`, `amend --scope` and `--drop-scope` — and a glob typed into the `$EDITOR` template, on the same terms: normalised before it reaches matching or is written into an entity, refused with the command to run next when it names nothing inside the repository. A glob normalising to nothing names the repository root, which is a perimeter and not a pattern; it is refused by name, with `**` as the pattern that means what was meant.
+
+Stating it as a property rather than as a list of verbs is the correction TASK-8dd89053fa33 exists for, and the reason is instructive. TASK-df4c39031583 measured the defect, fixed it, and wrote a criterion naming four verbs where the property was general. The fix satisfied that text exactly and its proof is real; the flag values were simply never in it, and the freeze then made the enumeration authoritative. Re-measured with `docs/` present: `--scope docs` and `docs/` answered eight tasks, `docs\` answered **five**, `./docs` and `.\docs\` answered none.
+
+`new --scope` was worse than a wrong answer, because it persisted. It stored `.\docs\` verbatim into the entity, where it matches nothing on any platform for the life of the corpus, and `check` then reported the consequence as `scope '.\docs\' matches no file yet: work not started, or a typo`. It was not a typo — it was the form the caller's own shell completed, which `new` accepted without a word. **A tool that writes what it cannot read back has no way to tell the two apart later**, which is why the normalisation belongs before storage and not in the reader.
+
+Global flags, deliberately limited to three: `--json`, `--quiet`, `--repo <path>`. Every global flag is a memorisation cost. `--json` is available on every command without exception: full scriptability is an invariant, not an option.
+
+**`--repo <path>` names a repository that already exists**, and that is the whole of what it means: it short-circuits the walk up of §6 without ever contradicting it, so the path it is given carries a `.ank/` or the flag fails. `init` is therefore the one verb that refuses it by name (§9), because `init` is what creates the `.ank/` the flag requires — and where the target is not the current directory, `ank init <path>` is how it is said. The refusal exists because the alternative was measured: accepting it, `init` initialised the *current* repository, appended the pointer paragraph to an `AGENTS.md` the caller was not editing, reported success, and left the named directory empty (TASK-b8a12d60686d). A flag that means an existing repository on twenty verbs and a directory to create on the twenty-first is the same defect as a `-s` meaning `--status` in one verb and `--scope` in another: not a saving, a silent wrong answer.
+
+### Configuration
+
+`.ank/config.yml` is read and written through `ank config` (ADR-e64dfaafd578). ADR-01b6dd05f0db closed `.ank/` to agents and stopped at the configuration, which left six errors telling their caller to open a file the same tool forbids them to open. This is the verb those errors name instead.
+
+```
+$ ank config claim_ttl_max
+2h
+$ ank config context_budget
+8000 (default)
+$ ank config verifiers.cargo-test.run "cargo test --workspace"
+verifiers.cargo-test.run (unset) -> cargo test --workspace
+$ ank config --unset default_branch
+default_branch main -> (unset)
+```
+
+**The key set is closed**, and it is the set the parser knows:
+
+| Key | Value |
+|---|---|
+| `schema` | the format revision of the file |
+| `context_budget` | tokens, default `8000` |
+| `claim_ttl_max` | duration, default `2h` |
+| `claim_ttl_default` | duration, default `30m`; what `claim` grants without `--ttl`, capped by `claim_ttl_max` (§3) |
+| `default_branch` | branch name; unset falls back to `refs/remotes/origin/HEAD` (§7) |
+| `peers.<name>` | the path to a peer corpus's root, read and never written (§7) |
+| `verifiers.<name>.run` | the command line, §4 |
+| `verifiers.<name>.timeout` | duration, default `10m` |
+
+Nested values are addressed by dotted path, and `<name>` is any verifier name — writing `verifiers.<name>.run` for a name the file does not carry is how a verifier is declared. `peers.<name>` works the same way and is how a peer is declared, which is what keeps the closed key set closed: federation adds a key rather than removing the strictness that refuses an unknown one. `verifiers.<name>` addresses the whole block and is legal for `--unset` alone, which is what makes declaring one reversible; reading it, or writing a value to it, is refused by name with `verifiers.<name>.run` to type instead. `roles` and `identities` are keys the parser knows and this verb does not address: their values are structured, the surgery below has no safe edit for them, and they are refused by name rather than guessed at. A key the parser does not know is refused by name too, with the set it does know, and nothing is written.
+
+**Reading prints the value in effect, and marks a resolved default as one.** `context_budget` on a file that does not carry it is `8000 (default)`, not `8000` — the difference between "the tool's value" and "this repository's value" is the whole question a reader is asking, and a release that moves a default moves the first and not the second. A key with no value in effect is `(unset)`. The marker is on the human surface only: `--json` carries `value` and `source` as separate fields, which is what a script reads.
+
+**Writing is text surgery, and never a round-trip through a serializer.** The file is a repository artifact, reviewed like code: comments, blank lines, key order and quoting style survive a write untouched, and every key other than the one named is byte-identical afterwards. A serializer would return `verifiers`, `roles` and `identities` alphabetised, drop every comment, and — the reason this is not a matter of taste — write out every field carrying a default. An unset key means "follows the tool"; a written one means "pinned here", and a round-trip that materialises the defaults converts every repository that ever ran one `ank config` into one that silently pins the old values the day a default moves. **No default is ever materialised**: a key the file did not carry is still absent after a write to another key.
+
+Two edits touch a byte outside the line named, and both are the parent of the key being written rather than a byte beside it: `verifiers: {}` becomes a block mapping when the first verifier is declared into it, and a block mapping becomes `verifiers: {}` when the last one is removed. Without the first, the file `ank init` writes could never receive a verifier; without the second, `verifiers:` would be left with no children, which is not an empty map but a parse error.
+
+**A form the surgery cannot edit safely is refused by name, never rewritten.** A `run` written as a block or folded scalar — `|` or `>` — is one: its resolved string depends on line structure the replacement would flatten, and `verify::definition_hash` is taken over the resolved value, so flattening it would move a hash that anchors historical proofs. The refusal names the key and says to edit the file by hand, which a human always may. Quoting alone is safe and stays safe: the hash is over the resolved string and over the timeout in seconds, so `run: cargo test` and `run: "cargo test"` hash identically, as do `600s` and `10m`.
+
+**A write that would produce a file the parser cannot read fails, and leaves the file as it was.** The result is parsed before anything is written, so the check is not a repair after the fact. The test is differential and has to be: it refuses a write that *introduces* a parse failure, not one performed on a file that already had one. A file carrying an unknown key fails every other verb, and a repair verb that refused to run on it would refuse exactly where it is needed — so on a file that did not parse to begin with, the write goes through and the parse error is reported as a warning rather than a refusal.
+
+**`ank config` runs without a parsed configuration**, as `init` and `help` do (§9). `startup` loads `config.yml` for every other verb, so a file that does not parse fails all of them — `check` included. A verb that exists to repair the file and is disabled by exactly the file it repairs is not a verb; the caller who most needs it is the one whose configuration does not load.
+
+This constrains the agent and not the human. A human with an editor keeps every power they had, and the file stays reviewable text in the repository.
+
+### Short forms
+
+Every long flag keeps its form. Short forms are an addition and never a replacement (ADR-962c25797569): single-dash, single-letter, and this table is the whole of them.
+
+| Short | Long | Legal on |
+|---|---|---|
+| `-j` | `--json` | every verb |
+| `-q` | `--quiet` | every verb |
+| `-r` | `--repo` | every verb |
+| `-b` | `--blocked-by` | `new`, `amend` |
+| `-c` | `--criteria` | `claim`, `new`, `amend` |
+| `-l` | `--limit` | `context` |
+| `-p` | `--proof` | `done`, `attest` |
+| `-s` | `--status` | `find` |
+| `-t` | `--type` | `find` |
+| `-u` | `--unset` | `config` |
+| `-v` | `--verify` | `new` |
+
+**The letter is the first letter of the long flag, and one letter has one meaning in every verb.** Where several long flags begin with the same letter, exactly one takes it and the others keep only their long form. That is the whole rule, and it is worth the flags it costs: a `-s` meaning `--status` in `find` and `--scope` in `new` would not be a saving but a silent wrong answer, since `ank find -s open` would filter on a scope named `open` and return nothing at all. A short form is only useful if it can be typed without checking which verb it is being typed at.
+
+The long flags left without one, with the letter that would have been theirs: `--body` and `--drop-blocked-by` (`b`), `--constraint` (`c`), `--reason` (`r`), `--scope`, `--supersedes` and `--drop-scope` (`s`), `--title` and `--ttl` (`t`). The three globals take their letter ahead of everything else, because they are legal on every verb and a letter they did not hold everywhere would be a letter nobody could rely on — that is what leaves `--reason` on its long form, `r` being `--repo`'s.
+
+A short form takes its value both ways, exactly as the long form does: `ank find -s open` and `ank find -s=open`.
+
+**Bundling is refused, and the refusal names the flags to type instead.** `-st` is not `-s -t`, because a parser that accepts bundling has to decide what `-sopen` means, and every answer to that is a guess about the caller's intent:
+
+```
+$ ank find bug -st task
+error[1]: '-st' bundles short flags
+  -> ank find -s <v> -t <v>
+```
+
+**A single dash is a flag, which is what makes `--` matter.** It was already the only way to write a positional beginning with a dash; short forms make it reachable rather than theoretical, since `ank log "-1 rebuilt the index"` now names a flag where it used to name a message. An argument that begins with a dash and contains whitespace is refused as what it is — no flag contains a space — and the refusal names the escape:
+
+```
+$ ank log "-1 rebuilt the index"
+error[1]: '-1 rebuilt the index' is not a flag: it contains a space
+  -> ank log -- "-1 rebuilt the index"
+```
+
+Values are untouched by any of this. A flag's value is taken verbatim, whichever form the flag was typed in, so `ank release --reason "-x"` and `ank find bug -s=-x` both pass their dash through and only a positional ever needs escaping.
+
+**Verbs are never abbreviated.** `ank cl` is not `ank claim`, and it is `unknown command 'cl'` naming the verbs. A prefix that resolves today stops resolving the day a second verb shares it, which would make a working script break on a release that added a verb.
+
+`ank help <verb>` shows both forms; `ank help` does not, and the listing is unchanged (§9). The overview buys its token economy by staying short, and the detail is one call away for the caller who wants it.
+
+**`ank --version` is not a fourth global flag**, and the limit above is untouched. The three modify a verb; this one replaces it — there is no `ank check --version`, and asking for the build while also asking for something else is not a question anyone has. It prints the crate version, the commit the binary was built from and the revision of the `skill/SKILL.md` it was built alongside, on one line, and exits 0.
+
+It answers **before the foundation**, like `help` and for a sharper reason: the caller who needs it is the one holding an artifact they cannot identify. A version that required a resolved repository, a git of 2.34 and a readable `config.yml` would fall silent in exactly the situation it exists for. Outside any git repository, in a directory with no `.ank/`, it still prints and still exits 0.
+
+The commit is embedded at build time through `rev-parse`, which §8's plumbing rule already allows, and is `unknown` when the build had no checkout to ask — a source tarball, a vendored dependency. Naming the absence beats inventing a value, and it beats the silence that made TASK-1ea38a17d854 cost an investigation to conclude that the binary in hand predated the feature being measured for.
+
+**What the stamp guarantees, and on which builds.** It names the commit the build script last ran at, and the script reruns whenever the commit moves — including a commit that changes no source file, which is the case that catches a binary quietly left behind. It does not depend on the source having changed. The files a commit moves are located through `rev-parse --git-path` rather than assumed at `.git/`, so a linked worktree and a packed ref are covered rather than hoped for; on a detached HEAD the sha lives in the HEAD file, which is watched on its own account. A release, built from a fresh checkout, is exact by construction. The stamp is not a claim about the working tree: uncommitted edits are invisible to it, and a binary built from a dirty tree names the commit it was based on, not the code it contains (TASK-0b26c8b5bfc5).
+
+**The skill revision, and what it lets a reader do offline.** The third value is `skill <rev>`, where `<rev>` is the short form of the same freeze hash that anchors a frozen `done_criteria` (§3), taken over the body of `skill/SKILL.md` — the same value that file declares under `metadata.revision`, computed at build time from the file rather than typed. An agent has both halves in hand and nothing else: the skill is loaded into its context, the binary is on its `PATH`. Comparing the two strings tells it, with no repository and no network, whether the instructions it is following predate the tool it is holding. That is the check TASK-1ea38a17d854 needed and did not have, and the case that motivated it was measured (TASK-b495234f192c): an installed `SKILL.md` two commits behind a tree that had just withdrawn the invitation to read `.ank/` by hand. The hash covers the body and not the frontmatter, so the revision the frontmatter carries does not change its own input. It is `unknown` on a build with no `skill/` to read, for the same reason and with the same honesty as the commit.
+
+
+### Exit codes
+
+The semantics are carried by the code so that the shell can route without parsing output.
+
+| Code | Meaning |
+|---|---|
+| 0 | ok |
+| 1 | generic error |
+| 2 | entity not found, or ambiguous prefix |
+| 3 | version conflict — re-read and retry |
+| 4 | task unavailable — claim held by another agent, or task already finished on another branch (§7) |
+| 5 | proof missing or invalid |
+| 6 | illegal transition, or frozen field modified (hash diverged) |
+| 7 | missing prerequisite — no criterion, task blocked, `accept` off the default branch, or a live claim already held by the calling identity |
+| 8 | `check`: invariants violated (reserved for `check`, for CI) |
+| 9 | environment unavailable — not a task failure |
+
+Codes 3 and 4 are the ones the agentic loop must know how to handle. 3 literally means "redo `context`, somebody moved". 4 means "take something else", and its two causes call for the same reaction, which is the reason for uniting them under a single code: in both cases the task is not to be taken, and the message says which one to take instead. `check` exits 0 when the corpus is healthy and 8 when it has findings — never 1, so that CI can distinguish a sick corpus from a broken tool.
+
+9 covers the environment broadly and not only the verifiers': `sh` not found (§4), git absent or older than 2.34 (§12), default branch indeterminable (§7), a detached proof whose ref never reached the remote (§7). What they have in common is that none of them is a failure of the agent's work — it is an environment to repair, and confusing it with a 1 or a 5 would send the agent to fix sound code.
+
+### Self-correcting errors
+
+Never generic help, always the exact command to run next. One well-designed error round trip costs less than three blind attempts.
+
+```
+$ ank done
+error[5]: proof required to move TASK-8f3a to done
+  done_criteria: "Auth integration tests pass, and no reference
+                  to jwt.verify remains in src/auth/"
+  -> ank done --proof commit:<sha>
+```
+
+```
+$ ank claim 8f3a
+error[4]: TASK-8f3a held by codex@host-9 (expires in 12m)
+  -> ank claim 51c2   (another ready task in this scope)
+```
+
+```
+$ ank claim 51c2
+error[7]: TASK-51c2 has no done_criteria
+  -> ank claim 51c2 --criteria "<verifiable criterion>"
+```
+
+
+### Scope of `check`
+
+Summary of the invariants and signals, all mechanical:
+
+- expired claims, `blocked_by` cycles, broken supersede chains, dead scopes (no file matched, and see below), over-constrained scopes (§5);
+- frozen fields diverging from their anchoring hash — `done_criteria` against the claim, `constraint`/`scope` against the ratification commit, and the signature on that commit against `allowed_signers` (§8): an anchor read from a commit nobody signed anchors nothing;
+- weak proofs (`assertion`, unverified), `done` tasks modified beyond appending a proof;
+- a `commit:` proof naming **no commit this clone can reach** — rebased away, a branch never fetched — reported as a signal naming the task and the reference, one line per detached reference, never a fault and never re-anchored (see the trust hierarchy above). Skipped outright where the clone cannot see: shallow, or reaching no commit at all, since a truncated clone would otherwise have every commit proof in the corpus reported at once;
+- behavioural signals, reported without being faults: blockers created by the holder after claiming (`author` of the blocker is the current holder and its `created` is later than the claim), criterion set by the claimer, verifier modified inside the task's activity window or proof hash diverging from its definition, scope test files modified by the task that invokes them, burst creation by a single identity (**more than 10 entities by one `author` within an hour**, through `created`), implausible `created` (in the future, or well before the commit that introduces the file — the field is declarative, git is the anchor), repeated claim renewals with no modification to the scope files (possible hoarding; a best-effort signal, since another agent's tree is not observable), constraint accepted after the claim of a task in progress, tasks blocked by a `closed` task;
+- a **discrepancy recorded against a frozen criterion** (§3) — a log entry whose message opens with `discrepancy:` — reported as a signal on the task, at any status, and never as a fault: it says a holder measured one part of the criterion wrong and kept the criterion anyway, which is a judgement and not a corpus defect, and a criterion that actually moved is the divergence fault above. **One finding per task, with the entries listed under it**, because the task is what is being judged; and it is worth most on a `done` one, where it is the only thing telling a reader that the proof was produced under a disagreement. A log this reading cannot parse is said out loud on the same task rather than counted as no record, since a check that reports nothing because it read nothing is the quiet failure §4 refuses everywhere else;
+- a `done` task carrying no `test` proof **that anything validated** — none at all, or only ones a caller submitted — once the **default branch** carries it as `done`: the completion rests on a local run and nothing external anchors it. Read on `via` and not on the type (see the trust hierarchy above), so a submitted reference is named in the finding rather than counted by it, and an entry predating `via` counts as it always did. A signal and never a fault — the corpus is intact, the record is thin, and exiting 8 would redden CI on the very merge that introduces the task. The gate on the default branch is what makes it actionable: before the merge there is no run to cite, and reporting there would name work the reader cannot do. The window between the merge landing and its run going green is left to fire, since the statement is true when printed and clears when someone attests; buying that quiet would cost a grace constant, and the constants below are justified for flooding alone;
+- entities predating `author`, **reported once for the corpus and never per file**: they are skipped by the two signals above, and saying so once is what keeps that fact visible. One line per file would add a line for every entity written before the field existed — the volume that teaches a reader to stop reading `check`;
+- actor values not matching the typed convention of §3, **reported once for the corpus and never per file**, on the same reasoning and for the same volume as the line above: the convention binds new writes, and the entities that predate it mean what they meant. A malformed actor is a finding here and never a parse error, or a rule would lock out the files it postdates;
+- an entity whose `author` is an agent and which carries **no reading by a `human:`** in `verified` (§3): a signal, one per entity, and never a fault. Nothing requires `verified`, and `check` derives what the fields state and nothing further — no score, no confidence, no ranking;
+- a corpus still in the previous per-kind layout, or still holding a work trace in the shape that preceded entries (§6), **reported once each**, naming the command that moves it: a signal and never a fault, since such a corpus parses, round-trips and answers every verb;
+- **a `references` entry of a spec that does not resolve** (§3, ADR-5a690829388d), one line per entry: a **fault** where the corpus holds no such entity, or holds one of a kind a specification does not cite — the reader following it finds nothing, and the repair is `ank amend <spec> --drop-reference <id>`; a **signal** where the target exists and is not `accepted`, naming `ank accept <id>`, since two documents are legitimately drafted at once; and a **signal** where the target is `superseded` and the citing document does not also reference the end of that chain, naming the successor and the amend that follows it. Only the declared field is read: a section number written in prose is not a reference and no finding pretends otherwise;
+- unresolved git conflict markers in `.ank/` files (§7);
+- **the corpus this checkout carries against the corpus on the default branch** (§7, ADR-47e2ac102f58), **reported once for the corpus and never per entity**: a signal naming how many entity files differ — held here and not there, there and not here, or held on both sides with different content — and the git command that closes the gap. Nothing is fetched to answer and nothing is merged: both revisions are already in this clone, and the gap is git's to close on the operator's word;
+- maintenance of the coordination plane (§7): pruning orphan refs, and completion refs whose task is `done` or `closed` on the default branch. `check` is the only command that prunes. A task carrying a completion ref for a long time without the default branch catching up is reported as a signal — that is a branch never merged, not a corpus anomaly, and the answer is human.
+
+**A dead scope git can explain is a signal, and the severity rule only ever lowers.** Structural death is reported as a signal for an open or `in_progress` task — work not started, or a typo — and as a fault for an ADR or a finished task, which claimed to touch files that are not there. On top of that, and only for the entities that would fault, a second question is asked: did git record where the path went (ADR-97beaf55e73a)? A yes lowers the fault to a signal. Nothing here raises a severity, so an open task whose dead scope git cannot explain is a signal exactly as before.
+
+The reason is that the two states are not the same fact. When git names the commit that moved the path, the corpus is not broken — it is outdated in a way the reader can see and follow, which is what the rename walk was built to show. When git cannot explain it, the reader has nothing, and that is what the fault is for. Without the split, any directory rename reddens a corpus permanently: `amend` refuses a `done` task, so such a task gets the rename named and no repair command (§3), and a fault nobody can clear is a finding readers learn to skip.
+
+**A history that cannot answer is a third state, and it is not a fault.** A shallow clone holds no commit that could record where a path went, so the question the paragraph above asks has three answers and not two: git names the rename, git has the history and records none, or git has no history to consult. The last is reported as a signal saying so, naming the command that deepens the clone, and it is never rendered as a rename that did not happen nor as a defect in the corpus. This is the answer §3 already gives for a ratification anchor a shallow clone cannot verify, and for the same reason — a check that cries divergence over the shape of a clone is a check people learn to ignore. It follows that a pipeline running `check` must check out the history the walk needs, or it reports that it cannot verify and verifies nothing, which is worse than the failure it replaces because it is quiet.
+
+**The walk serves a glob through its literal prefix.** `rev-list` answers about a path and has no answer for "where did `src/**` go", so a glob is asked about the part of it before the first wildcard, truncated at the last separator: `.ank/adr/**` asks about `.ank/adr`. A prefix whose files git records as renamed into one directory is explained by that directory, and the repair proposal keeps the wildcard tail — `.ank/adr/**` becomes `.ank/entities/**`. Sources landing in more than one destination, or under a rename that also changed a file's name, produce no explanation: silence is never evidence, and "the prefix moved mostly there" is not a statement this document authorises anyone to print.
+
+**Drift is counted in entity files, never in commits.** How far this corpus has drifted from the default branch is a question about two trees, and `rev-list` answers a different one: a default branch can move ten times without touching `.ank/`, so a count in commits would fire on every merge and mean nothing. What is counted is entity files that differ, which is what a reader can act on — and it is one line for the corpus rather than one per file, the volume rule this section has already applied twice above.
+
+**Unable to compare is not "nothing has moved", and the two are never printed the same way.** The question is skipped in silence where it cannot be asked at all: no repository (the coordination half already says so once), or no resolvable default branch (the line about pruning already says so once). It is said out loud where it was asked and refused — a `default_branch` naming no commit in this clone — because a mistyped branch name rendered as silence is a reader told the corpus is level by a check that never looked. A repository with no commit at all is neither: that is the nominal state of one freshly `ank init`-ed, there is nothing to compare against yet, and it is silent.
+
+**The same fact reaches `status` on one line**, out of the same inspection pass rather than computed a second way, because two answers able to disagree is the defect that surface exists to avoid. `status` prints it whether or not there is drift — a reader who has to tell "level" from "not asked" by the absence of a line is reading silence, which is the thing this section refuses everywhere else.
+
+**The two signals that need `author`, and why they are signals.** A blocker written by the agent currently holding the task is the shape of an agent building itself an excuse — but it is also the shape of an agent doing exactly what §3 asks, since a discovered subtask *is* a new task with a `blocked_by`. Only a reader knows which, so it is reported and never refused. Burst creation is the same argument at the corpus scale: §3 accepts task flooding without a quota, on the grounds that the defence is visibility rather than restriction, and this is that visibility.
+
+**The numbers are constants, not configuration.** More than 10 entities by one `author` within an hour: a threshold high enough that a session filing the four tasks of a plan passes in silence, low enough that a runaway loop is named within minutes. They live in the tool rather than in `config.yml` because a repository that can raise its own flooding threshold has a flooding threshold that will be raised the first time it fires — and the signal costs nothing to ignore, which is what makes it safe to leave unadjustable.

--- a/.ank/entities/SPEC-eddf356ce1a9.md
+++ b/.ank/entities/SPEC-eddf356ce1a9.md
@@ -1,0 +1,116 @@
+---
+id: SPEC-eddf356ce1a9
+type: spec
+slug: bootstrapping-teaching-and-distribution
+title: Bootstrapping, teaching and distribution
+created: 2026-08-15T19:07:03Z
+author: claude-code/opus-5
+status: proposed
+scope:
+  - skill/**
+  - npm/**
+  - crates/ank-cli/src/init.rs
+  - .github/workflows/**
+references: [SPEC-cd0d3377b37f, SPEC-9f510cad4be6]
+supersedes: SPEC-fa2f8c49dba4
+schema: 3
+version: 2
+---
+
+One of the ten documents that carry the Ank specification (ADR-5a690829388d).
+This one carries **§9 entire**: how the skill is installed and what its token
+economy buys, what `ank help` owes its caller, what `init` writes and what it
+refuses, and how the binary is distributed.
+
+## Why the help surface is here and not with the verbs
+
+The obvious boundary would put `ank help` in the CLI surface, beside the verbs it
+lists. It is here, and the reason is what this document is about.
+
+The surface document says **what a verb does and on what state it refuses**. This
+one says **what the caller is told, and by which of three surfaces** — SKILL.md
+carries the mental model, `ank help` carries the surface, the error carries the
+next command. That division of labour is the subject here, and every rule below
+is a consequence of it: a description names a flag only to offer it or to refuse
+it, because a description is a fourth surface able to misinform; the listing
+prints the same sentence the per-verb page does, because two strings are two
+things to keep true; an unknown verb is a code 2 and never a fallback to the
+general listing.
+
+Read the other way, the test holds too. The verb semantics are readable without
+knowing how they are announced, and the announcement rules are readable without
+the verb table — they are rules about a surface, not about any particular verb.
+
+**Bootstrapping, teaching and distribution are one subject** for the same reason:
+they are everything that happens on a machine that does not have Ank yet, and
+they are governed by one economy. The skill is loaded permanently, so its content
+is frozen and its size is a ceiling. `ank help` is loaded on demand, so it carries
+the detail. `init` writes the few files that make a repository a corpus. npm
+carries the binary inside the package because the workstation this channel exists
+for cannot download an executable. Cut anywhere and one of those loses the reason
+it is shaped that way.
+
+## What it rests on
+
+- **The CLI surface** — the verbs, flags and refusals `ank help` is required to
+  print faithfully.
+- **Implementation, and the decisions that bound it** — the platforms and the
+  licence the distribution channels carry.
+
+---
+
+## 9. Bootstrapping
+
+Skill installation leans on the existing ecosystem rather than a home-made mechanism:
+
+```
+npx skills add <owner>/ank
+```
+
+Skills install from repositories rather than npm packages: the identifier is `owner/repo`, there is no bare name. The skill's repository is therefore called simply `ank`. Installation happens through a symlink, and a `skills-lock.json` versioned in the repository reproduces the same set of skills on every machine in the team — consistent with the rest of the design, where everything that matters is in the repository.
+
+The `skills` CLI handles multi-agent detection (Claude Code, Codex, Cursor, OpenCode, and many others) and creates links from each agent to a canonical copy — exactly the desired design, already maintained by a third party.
+
+**Token economy, and what is actually always-on.** The content of SKILL.md is frozen (§4) because what it teaches is what every agent knows: it carries the loop, the planning that fills it, the investigation that precedes both, and the mental model behind all three — nothing else, and growing that costs a superseding ADR (ADR-5dd7b4a9c875). Flag details and the rest of the surface stay in `ank help`, loaded on demand.
+
+**What a session pays for unconditionally is the frontmatter, not the body**, and the distinction is worth stating because the ceiling was justified without it. Measured on the plugin route: `claude plugin details ank` reports `Always-on: ~58 tok added to every session`, which is the `name` and the `description`; the body is read when the skill is invoked. The `description` is therefore the expensive line in the file and does not grow. The **ceiling on the body is kept regardless**, because the by-hand route below copies the whole file into whatever a harness loads and some harnesses load all of it every session: the ceiling bounds the worst route rather than the best one, and a number that protected only the measured case would be a number that stops protecting the moment somebody installs it differently.
+
+**`ank help` lists every verb, grouped by the moment a verb is reached for** (ADR-f61e2d2c75e8, superseding ADR-e17e1bbd93ff on this clause alone): every verb with a one-line description, under a lowercase heading, and inside a group the order stays §4's. No verb is hidden and there is no second listing to ask for. A group says **when** a verb is used and never **who** may use it — a heading named after a caller is the claim §4 withdraws, and it is the one this grouping cannot make: `check` sits under keeping the corpus honest whether a human or an agent types it. The order alone carried what a heading would have said while the surface was five verbs; at twenty-one it carries it only to a reader who already knows the order is meaningful, which is precisely what a first reader does not know. `ank help <verb>` answers about that verb alone: what it does, its usage, its flags with their value placeholders, the globals, and **the state conditions on which it refuses, each with its exit code**. An unknown verb is a **code 2** and never a fallback to the general listing — an agent that asked about one verb and received all sixteen has to work out that its question went unanswered.
+
+**The refusals belong here because nothing else owns them.** §4 carries a whole subsection on refusing by state rather than by identity, and that is a promise to the reader of this document; the caller of the binary had no surface stating which states, or what code came back. The division of labour §9 bets on — SKILL.md carries the mental model, `ank help` carries the surface, the error carries the next command — only holds if the middle one answers *what will this refuse*. It did not, and a session of dogfooding fell through the gap five times, recovering through the source each time. In another repository ank arrives as a binary and a SKILL.md: there is no source to fall through to, and the same five become dead ends.
+
+Three consequences, each of which was one of those five:
+
+- **A flag that is always refused is not a flag.** `ank help` lists what a caller can use; a name the verb rejects by design belongs in the refusals, not in the flag list. Listing it is worse than silence, because the caller reads an offer.
+- **A requirement that lives in the state is stated as one.** `done` needs a proof it cannot always produce for itself, and the grammar of one — `<type>:<ref>`, where the type is `commit`, `human-review`, `assertion` or `test` — is part of the surface, not part of the error that fires once the caller has already guessed wrong.
+- **Where a value is interpreted, say by what.** `$EDITOR` is a command line run through `sh`, not a program name. A caller told `EDITOR=vi` reasonably supplies a GUI editor, gets no `--wait`, and the editor returns before anything is typed: ank writes the file back unedited and nothing anywhere says so.
+
+The listing and the per-verb page stay two surfaces, and **the listing carries one short description per verb**. It used to carry the verb and its flag names, which is the shape that says what none of them does: `--criteria` beside `amend` names a flag without saying what the verb is for, and a caller choosing between twenty-one verbs is choosing on the usage line alone. Git's listing answers that question in one line each, and this one now does too.
+
+**The description takes the place of the flag names.** They are one `ank help <verb>` away, where they carry their value placeholders and the refusals that qualify them — a bare flag name in an overview is the least informative thing the line could hold, and keeping both would double the height of the listing, which is the token economy this paragraph used to invoke for saying nothing at all. An economy that sends the caller to the source is not one: recovering what a description would have carried cost one session more than twenty lines of reading `human.rs`, `done.rs` and `editor.rs`, plus a scratch repository (TASK-fe130d2b732c).
+
+**The description states what the verb refuses wherever the refusal is what distinguishes it.** This is not a stylistic preference, it is what makes the line honest here: ank's verbs refuse on state (§4), so a description naming only a purpose is a fourth surface able to misinform. `change a task's scope, blockers or criteria` would have confirmed the defect TASK-84cfad83c308 recorded rather than caught it; `change a task's scope or blockers, and a criterion no live claim freezes` is the same line doing the work. Each description is the one-line compression of what `ank help <verb>` already says, never a second text with its own opinion.
+
+**A description names a flag only to offer it or to refuse it, never by accident.** Every `--flag` a description mentions is either one the verb offers, or one it names as refused — `creates .ank/ here or at <path>; refuses --repo` is honest, `changes blockers, scope or --criteria` on a verb that rejects `--criteria` is the defect. The rule is mechanical, and a test walks both surfaces through the binary: it reads the flags and the refusals `ank help <verb> --json` already carries and fails when a description advertises something absent from the first. It is *a flag that is always refused is not a flag*, applied to the surface where a caller reads fastest and checks least.
+
+**The listing prints the same sentence the per-verb page does**, and that is what makes the compression a compression rather than a second text. Two strings would be two things to keep true, and the one that drifts is the one nobody reads twice — which is how `amend` came to advertise a criterion edit the binary refused always (TASK-84cfad83c308). There is one description per verb, `ank help` prints it beside the verb, and `ank help <verb>` prints it above the flags and the refusals that qualify it.
+
+**None of this is a claim about who a verb is for** (ADR-f61e2d2c75e8, superseding ADR-e17e1bbd93ff). A description says what a verb does, and the heading above it says when that verb is reached for; neither sorts callers, which is the claim §4 withdrew and the only one either could make. Both carry what the order alone never could: the order is meaningful only to a reader who already knows it is, and a description is what that reader does not have to know.
+
+`ank init` keeps a narrow perimeter: create `.ank/`, write `config.yml`, add the `refs/ank/*` refspec (§7), place a pointer in `AGENTS.md`, write a `.gitattributes` (§2) and a `.gitignore` (§6).
+
+**`init` takes its target positionally, and refuses `--repo` by name.** `ank init <path>` initialises `<path>`; with no argument it initialises the current directory. `--repo` names a repository that already carries a `.ank/` (§4), which is precisely what this verb is run to produce, so it is refused with `ank init <path>` as the command to type — the shape §9 requires of every refusal, and the reason this one is a refusal rather than a second spelling of the target. `--json` and `--quiet` are unaffected: they say how to answer, not what to act on. Being a refusal by design, `--repo` is absent from what `ank help init` offers and present in what it says the verb refuses, per the rule above.
+
+**What `init` writes, `ank config` maintains** (§4). `config.yml` is written through the verb rather than by hand: it is the last thing under `.ank/` that ADR-01b6dd05f0db left an agent no route to, and the six errors that used to say "add it under `verifiers:` in `.ank/config.yml`" now name the command. `config` joins `init` and `help` as the third verb that runs without the foundation, and for the same reason those two do — the caller who needs it is the one whose environment is wrong, and a repair verb gated on the thing it repairs answers nobody.
+
+Both git files are written at the root of the initialised directory, and both carry a single line added idempotently to whatever is already there. The `.gitignore` line is `.ank/index.db`: §6 calls the index derived, disposable and gitignored, and the third adjective is only true of a repository where something wrote the rule. It goes at the root rather than inside `.ank/` for the same reason `.gitattributes` does — one place to look for what `init` changed — and because ADR-01b6dd05f0db makes `.ank/` opaque to agents, so a rule hidden there could not be read by the agent asking why the index is tracked.
+
+**Binary distribution**: the skill says *how* to use Ank, it does not install the CLI. Plan for `curl | sh` and Homebrew in addition to npm.
+
+**npm is the first channel implemented**, and it is implemented for one reason that shapes it entirely: the workstation whose firewall blocks downloading a bare executable but lets the registry through. The binaries therefore travel **inside** the packages — one package per target, listed as `optionalDependencies` on a wrapper that carries `os` and `cpu`, so npm installs exactly the one that matches. **No `postinstall` download**, because a `postinstall` that fetched the binary would die behind the very firewall the channel exists to cross, and would do it after the install appeared to succeed. The wrapper resolves and executes; it forwards the child's exit code unchanged, since the codes above are an interface an agent branches on, and it reserves 9 — the environment code — for its own failures. The package name is scoped, `@haksolot/ank`: the bare name was taken on the registry before this project existed, and the scope is the closest thing to the name the project actually has (ADR-85e6664c67d8).
+
+**A prerelease never becomes what a bare install resolves to.** The dist-tag is derived from the version and from nothing else: a version carrying a prerelease identifier — a hyphen after the patch, `0.2.0-rc1` — publishes under `next`, and every other version publishes under `latest`. `npm install @haksolot/ank` therefore resolves to the newest release and never to a candidate, while `npm install @haksolot/ank@next` fetches the candidate for whoever asks for it by name. Shipping a candidate stays possible, which is why this is a derivation and not a refusal.
+
+Derived rather than chosen when the tag is pushed, because a flag someone has to remember while tagging is a flag that is eventually forgotten, and this one fails silently: npm 10 applied `latest` to a prerelease without a word, so `v0.2.0-rc1` would have put a release candidate on every machine running a bare install, and nothing would have said so. The rule is **written once and read by both the rehearsal and the publish** — a smoke job passing different flags from the publish rehearses nothing, and the publish is the one step in the pipeline that cannot be taken back. Build metadata is not a prerelease identifier: `1.2.3+build` is a release, and the derivation strips it before looking for the hyphen.
+
+The GitHub release follows the same reading of the same version, and is marked as a prerelease when it is one. Two channels describing one tag differently is how a reader ends up trusting whichever they happened to open.

--- a/.ank/entities/TASK-1e2e47327d71.md
+++ b/.ank/entities/TASK-1e2e47327d71.md
@@ -1,0 +1,61 @@
+---
+id: TASK-1e2e47327d71
+type: task
+slug: skill-md-teaches-three-modes-and-says-why
+title: SKILL.md teaches three modes, and says why
+created: 2026-08-15T19:02:45Z
+author: claude-code/opus-5
+status: in_progress
+scope:
+  - skill/SKILL.md
+  - crates/ank-cli/tests/skill.rs
+  - docs/agents.md
+blocked_by: []
+done_criteria: |
+  skill/SKILL.md teaches three modes rather than two: the loop, planning, and investigation, the third naming ank status, ank scope <path> and the read form of ank log <id>, and pointing at the specification in the corpus through ank find --type spec. It opens by saying why ank is shaped as it is - constraints and work as two planes joined by scope, and anchoring rather than trust - so an agent can tell what the loop protects. The file stays within the ceiling the superseding ADR declares, and crates/ank-cli/tests/skill.rs asserts that ceiling, the three modes and the verbs that stay untaught. A spec entity superseding SPEC-c33e07a82cc4 and one superseding SPEC-fa2f8c49dba4 state the same content, and an ADR superseding ADR-f61e2d2c75e8 carries its ank help clause forward unchanged. cargo test --workspace and ank check are green.
+criteria_by: creator
+schema: 3
+version: 2
+---
+
+The skill is the only description of ank most agents will ever read, and it is
+behind the tool in two ways.
+
+**It never says why.** It opens on where the files live and goes straight to the
+verbs. An agent that does not know that constraints and work are two planes
+joined only by scope, or that nothing here is trusted because everything is
+anchored, follows the loop without knowing what any of it protects — and an
+agent that does not know what a rule protects is the one that works around it.
+
+**It has no investigation mode.** `ank status` and `ank scope <path>` exist for
+the question an agent actually arrives with — what governs this file, and where
+am I — and the skill teaches neither. Nor the read form of `ank log <id>`, which
+is how the next holder learns where the last one stopped. And the specification
+is now ten accepted `spec` entities in the corpus: the normative answer is one
+`ank show` away and the skill does not say so.
+
+**The freeze is not an obstacle here, it is the mechanism working.** ADR-f61e2d2c75e8
+enumerates what may be taught and says two modes, so a third costs a superseding
+ADR and a human signature. That is what the freeze is for: this is a change to
+what every agent is taught on every session, and it should cost a signature.
+
+What the successor must carry forward unchanged is the `ank help` grouping
+clause: ADR-f61e2d2c75e8 is about two things, and only one of them is being
+revised — exactly as it carried ADR-e17e1bbd93ff's freeze forward when it was
+written for the help listing.
+
+**Two spec documents move too, and editing them is not an option.** §4 states
+the three-line mode block, "this is the entire content of SKILL.md" and the
+ceiling; §9 states that the file carries the loop, the planning that fills it
+"and nothing else". Both become false. An accepted spec whose body moves is
+reported `altered` by `check`, because its ratification commit hashes the body
+and the scope — so each is a supersession, and the four documents citing the CLI
+surface follow the chain afterwards with `amend --reference`.
+
+The ceiling moves, and the ADR records the measurement rather than the wish.
+What is always-on is the frontmatter — `claude plugin details ank` projects
+about 58 tokens, which is the name and the description — and the body is loaded
+when the skill is invoked. The by-hand route copies the whole file into whatever
+the harness loads, so the ceiling protects that case and not the Claude Code
+one. The `description` therefore does not grow: it is the only part every
+session pays for whether or not the skill is used.

--- a/.ank/entities/TASK-1e2e47327d71.md
+++ b/.ank/entities/TASK-1e2e47327d71.md
@@ -5,7 +5,7 @@ slug: skill-md-teaches-three-modes-and-says-why
 title: SKILL.md teaches three modes, and says why
 created: 2026-08-15T19:02:45Z
 author: claude-code/opus-5
-status: in_progress
+status: done
 scope:
   - skill/SKILL.md
   - crates/ank-cli/tests/skill.rs
@@ -14,8 +14,13 @@ blocked_by: []
 done_criteria: |
   skill/SKILL.md teaches three modes rather than two: the loop, planning, and investigation, the third naming ank status, ank scope <path> and the read form of ank log <id>, and pointing at the specification in the corpus through ank find --type spec. It opens by saying why ank is shaped as it is - constraints and work as two planes joined by scope, and anchoring rather than trust - so an agent can tell what the loop protects. The file stays within the ceiling the superseding ADR declares, and crates/ank-cli/tests/skill.rs asserts that ceiling, the three modes and the verbs that stay untaught. A spec entity superseding SPEC-c33e07a82cc4 and one superseding SPEC-fa2f8c49dba4 state the same content, and an ADR superseding ADR-f61e2d2c75e8 carries its ank help clause forward unchanged. cargo test --workspace and ank check are green.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: b32f93942f8f73334bf81de81268bb5e80ff1e5e
+    criteria: a1b4d8e1f0d5
+    via: submitted
 schema: 3
-version: 2
+version: 3
 ---
 
 The skill is the only description of ank most agents will ever read, and it is

--- a/crates/ank-cli/tests/skill.rs
+++ b/crates/ank-cli/tests/skill.rs
@@ -76,6 +76,16 @@ fn section_4_document() -> String {
     DOC.get_or_init(read_section_4_document).clone()
 }
 
+/// **A proposed successor is not the specification yet, and this is where that
+/// bites.** While a supersession is in flight two documents carry the block —
+/// the ratified one and its replacement — and the suite has to read the one the
+/// corpus is actually held to. `accept` is what makes a document binding, so
+/// the ratified one wins, and after ratification the question does not arise
+/// again: the predecessor is `superseded` and carries nothing anybody reads.
+///
+/// The fallback to *any* document that carries it is for the corpus that has
+/// none accepted at all — a fresh split, a bootstrap — where reading the draft
+/// is better than refusing to read.
 fn read_section_4_document() -> String {
     let ids = ank(&["find", "--type", "spec", "--json"]);
     let mut carrying: Vec<String> = Vec::new();
@@ -89,15 +99,29 @@ fn read_section_4_document() -> String {
             carrying.push(body);
         }
     }
+    // `superseded` is filtered out with `proposed` rather than kept beside
+    // `accepted`: a replaced document is not what the corpus is held to either,
+    // and letting one through would make the suite read the surface out of the
+    // document that was just retired.
+    let ratified: Vec<String> = carrying
+        .iter()
+        .filter(|body| body.lines().any(|l| l.trim_end() == "status: accepted"))
+        .cloned()
+        .collect();
+    let mut candidates = if ratified.is_empty() {
+        carrying
+    } else {
+        ratified
+    };
     assert_eq!(
-        carrying.len(),
+        candidates.len(),
         1,
-        "exactly one spec document must carry §4's Commands block, and {} do: \
-         the block is what this suite reads the surface out of, so neither zero \
-         nor two is a state it can guess its way through",
-        carrying.len()
+        "exactly one ratified spec document must carry §4's Commands block, and \
+         {} do: the block is what this suite reads the surface out of, so \
+         neither zero nor two is a state it can guess its way through",
+        candidates.len()
     );
-    carrying.pop().expect("one document carries the block")
+    candidates.pop().expect("one document carries the block")
 }
 
 /// The binary, run from this crate's directory so that the walk of §6 resolves
@@ -296,6 +320,21 @@ const LOOP_VERBS: [&str; 8] = [
 /// recording one — and `ank new task` alone does not carry it.
 const PLANNING_VERBS: [&str; 5] = ["review", "graph", "check", "amend", "new adr"];
 
+/// Investigation: how an agent arrives informed (ADR-5dd7b4a9c875).
+///
+/// The two that carry the mode are `scope` and `status`: they answer *what
+/// governs this file* and *where am I*, they were shipped long before this, and
+/// an agent taught only the loop had the question and not the verb. `find
+/// --type spec` is the third, and it is what the corpus gained when the
+/// specification became entities of it (ADR-5a690829388d) — the normative
+/// answer reachable from inside the tool.
+///
+/// `log` is deliberately absent from this list although the mode teaches its
+/// read form: the string `ank log` is already required by the loop, so
+/// asserting it here would assert nothing. What guards the read form is
+/// `the_skill_teaches_the_read_form_of_log` below.
+const INVESTIGATION_VERBS: [&str; 3] = ["scope", "status", "find --type spec"];
+
 #[test]
 fn the_skill_carries_the_whole_loop() {
     let text = skill();
@@ -332,6 +371,59 @@ fn the_skill_carries_the_planning_mode() {
     }
 }
 
+/// The third mode ADR-5dd7b4a9c875 added, asserted on the same terms as the
+/// other two: the verb is named, because an agent only knows the verbs this
+/// file names.
+#[test]
+fn the_skill_carries_the_investigation_mode() {
+    let text = skill();
+    for verb in INVESTIGATION_VERBS {
+        assert!(
+            text.contains(&format!("ank {verb}")),
+            "SKILL.md never shows `ank {verb}`: an agent that cannot ask what \
+             governs a file, or where it is, investigates by guessing"
+        );
+    }
+}
+
+/// **The read form of `log` is taught, and it is the half that is easy to lose**
+/// (ADR-5dd7b4a9c875).
+///
+/// `ank log "<message>"` writes and renews the claim; `ank log <id>` reads, needs
+/// no claim, and is where the previous holder said why they handed the task
+/// back. The loop already forces the write form to appear, so a test on `ank
+/// log` alone would pass on a file that teaches only writing — which is exactly
+/// the state this mode was added to end.
+#[test]
+fn the_skill_teaches_the_read_form_of_log() {
+    let text = skill();
+    assert!(
+        text.contains("ank log <id>"),
+        "SKILL.md shows `ank log` only as a write: the read form is how a \
+         holder inherits what the last one learned, and an agent that has not \
+         been told about it repeats them"
+    );
+}
+
+/// **The file says why before it says how** (ADR-5dd7b4a9c875).
+///
+/// Asserted by the two things the argument has to establish rather than by any
+/// phrasing, on the standard the accept and styling tests already set: a test
+/// pinned to one sentence fails on a correct rewrite and reports it as a
+/// removal. An agent that knows the moves and not what they protect is the one
+/// that works around them in good faith.
+#[test]
+fn the_skill_says_what_the_rules_protect() {
+    let text = skill();
+    for token in ["two planes", "anchored"] {
+        assert!(
+            text.contains(token),
+            "SKILL.md does not say {token:?}: it teaches the verbs without the \
+             model behind them, which is the gap ADR-5dd7b4a9c875 closed"
+        );
+    }
+}
+
 /// **`accept` is described and never invited** (ADR-e17e1bbd93ff).
 ///
 /// The two halves are one rule and neither works alone. The skill must say what
@@ -363,20 +455,27 @@ fn the_skill_describes_accept_without_inviting_it() {
 /// loaded on demand. The number is a ceiling to notice drift, not a target to
 /// fill.
 ///
-/// It moved from 80/700 to 140/1200 with ADR-e17e1bbd93ff, and moved because a
-/// decision said so — which is the only way it is allowed to move. A ceiling
-/// raised to accommodate whatever was just written is not a ceiling.
+/// It moved from 80/700 to 140/1200 with ADR-e17e1bbd93ff and to 180/1500 with
+/// ADR-5dd7b4a9c875, and each time because a decision said so — which is the
+/// only way it is allowed to move. A ceiling raised to accommodate whatever was
+/// just written is not a ceiling.
+///
+/// The last move carries a measurement the earlier ones did not: what a session
+/// pays for unconditionally is the frontmatter, `~58 tok` of `name` and
+/// `description`, and the body is read when the skill is invoked. The ceiling
+/// is kept for the by-hand route, which copies the whole file into whatever a
+/// harness loads — it bounds the worst route rather than the measured one.
 #[test]
 fn the_skill_stays_within_one_page() {
     let text = skill();
     let lines = text.lines().count();
     let words = text.split_whitespace().count();
     assert!(
-        lines <= 140,
-        "SKILL.md is {lines} lines: it is loaded permanently, so growth costs \
-         every session in every repo. Move detail to `ank help`."
+        lines <= 180,
+        "SKILL.md is {lines} lines: a harness that loads the whole file pays \
+         for every one of them, every session. Move detail to `ank help`."
     );
-    assert!(words <= 1200, "SKILL.md is {words} words, over the ceiling");
+    assert!(words <= 1500, "SKILL.md is {words} words, over the ceiling");
 }
 
 /// These verbs run for whoever types them -- nothing here is refused to an
@@ -385,17 +484,22 @@ fn the_skill_stays_within_one_page() {
 /// would grow what every session pays for, by habit rather than by decision,
 /// which is how a permanently loaded file actually grows.
 ///
-/// The list shrinks only by decision, and it has twice. `show` left it when it
-/// moved into the loop, back when the loop was still called a surface;
+/// The list shrinks only by decision, and it has three times. `show` left it
+/// when it moved into the loop, back when the loop was still called a surface;
 /// `review`, `check` and `amend` left it with ADR-e17e1bbd93ff, which bought
-/// planning with a raised ceiling and said so. `accept` is the interesting
-/// survivor: the skill now *describes* it, and still must not show the command,
-/// so it stays here while `the_skill_describes_accept_without_inviting_it`
-/// holds the other half. Everything remaining costs a succession.
+/// planning with a raised ceiling and said so; `status` and `scope` left it
+/// with ADR-5dd7b4a9c875, which bought investigation the same way. `accept` is
+/// the interesting survivor: the skill now *describes* it, and still must not
+/// show the command, so it stays here while
+/// `the_skill_describes_accept_without_inviting_it` holds the other half.
+///
+/// What is left is `close`, `attest` and `edit`, and they are left for the
+/// ordinary reason rather than by oversight: nothing has decided they are worth
+/// what every session pays for them. Each one costs a succession.
 #[test]
 fn the_skill_teaches_nothing_beyond_what_is_frozen() {
     let text = skill();
-    for verb in ["accept", "close", "attest", "edit", "status", "scope"] {
+    for verb in ["accept", "close", "attest", "edit"] {
         assert!(
             !text.contains(&format!("ank {verb}")),
             "SKILL.md shows `ank {verb}`, which is outside the content it is \

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -14,10 +14,18 @@ One plain markdown file, [`../skill/SKILL.md`](../skill/SKILL.md). It is the onl
 copy that exists in git, and every route below points at it rather than holding
 one of its own — so no route can fall behind it.
 
-It teaches one page: the loop `context -> claim -> show -> log -> done`, the
-three off-loop verbs `new`, `find` and `release`, the planning verbs, and the
-rules that are not negotiable. It is loaded on every session, which is why its
-content is deliberately small and why growing it costs an ADR.
+It teaches one page: why ank is shaped as it is, then the loop
+`context -> claim -> show -> log -> done`, the three off-loop verbs `new`,
+`find` and `release`, the investigation verbs `scope`, `status` and the read
+form of `log`, the planning verbs, and the rules that are not negotiable. Its
+content is deliberately small and growing it costs an ADR.
+
+**What that costs a session is the frontmatter, not the page.** The projection
+below is `~58 tok` always-on, and that is the skill's `name` and `description`;
+the body is read when the skill is invoked. The ceiling on the body is kept
+anyway, because the by-hand route at the end of this page copies the whole file
+into whatever a harness loads, and some harnesses load all of it every session —
+so it bounds the worst route rather than the measured one.
 
 One convention it carries is worth knowing before you watch an agent follow it:
 **`.ank/` is opaque to an agent, the way `.git/` is.** Reading goes through

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -2,18 +2,68 @@
 name: ank
 description: Read a repository's tasks and binding constraints, claim work, and finish it with proof. Use when working in a repo that has a .ank/ directory.
 metadata:
-  revision: "3f350ad26459"
+  revision: "6ddced7793f9"
 ---
 
 # ank
 
 Tasks and architecture decisions live as files in `.ank/`, attached to the code
-they constrain. Two modes: executing work, and shaping the work that exists.
-`context` starts both.
+they constrain and reached through one CLI. Three modes: understanding what
+governs a perimeter, executing work, and shaping the work that exists. `context`
+starts all three.
 
-    Loop:      ank context -> ank claim <id> -> ank show <id> -> ank log "<msg>" -> ank done
-    Off-loop:  ank new, ank find, ank release --reason "<r>"
-    Planning:  ank new adr, ank amend, ank review, ank graph, ank check
+    Loop:          ank context -> ank claim <id> -> ank show <id> -> ank log "<msg>" -> ank done
+    Off-loop:      ank new, ank find, ank release --reason "<r>"
+    Investigation: ank scope <path>, ank status, ank log <id>, ank find --type spec
+    Planning:      ank new adr, ank amend, ank review, ank graph, ank check
+
+## Why it is shaped this way
+
+**Constraints and work are two planes, joined only by scope.** A decision is not
+the parent of a task; it is a rule with a glob, and it binds work that did not
+exist when it was written. So there is no hierarchy to traverse and no label to
+keep tidy — and a glob is confronted with the filesystem, where a label is only
+ever confronted with somebody remembering it.
+
+**Nothing is trusted, everything is anchored.** The criterion you have to meet is
+frozen by hash the moment you claim it, `done` runs the declared verifiers itself
+instead of believing a report, and a proof records the route by which it arrived.
+None of that is a wall: you can edit any file. It is that every freeze is
+anchored where the editor cannot reach, so an edit becomes *visible* rather than
+effective.
+
+**Which is why the tool is not a gatekeeper and never pretends to be one.** It
+refuses on state — a task already held, a criterion that moved, a proof missing —
+and never on who is asking. What it owes you in exchange is that every refusal
+names the exact command that resolves it.
+
+## Investigation
+
+Before choosing work, and often instead of choosing it: what governs this file,
+and where am I.
+
+**`ank context <path>`** — what binds a perimeter and what is claimable inside
+it. The loop's first verb, given a path rather than a claim.
+
+**`ank scope <path>`** — every entity whose scope matches that path, whatever its
+kind, with its status. This is *why is this file constrained, and by what*,
+answered before you write anything rather than after `check` complains.
+
+**`ank find <query>`** — titles, scopes and criteria. `ank find --type spec`
+reaches the specification, which is an entity of this corpus like any other, so
+the normative answer is one `ank show` away instead of a document to go hunting
+for.
+
+**`ank log <id>`** — an entity's entries, newest first. No claim needed and no
+message to pass: this is the read form. It is where the last holder wrote what
+they tried and why they handed it back, and reading it is how you avoid
+repeating them.
+
+**`ank status`** — where you are: the branch, the identity in effect and where it
+came from, the claim you hold, the perimeter, what is waiting for ratification,
+and how far this checkout has drifted from the default branch.
+
+**`ank check [path]`** — what is already known to be wrong, before you add to it.
 
 ## The loop
 
@@ -44,8 +94,8 @@ agent that grades itself can simply be wrong.
 entity attached to nothing is invisible. A subtask you discover is a new task
 with a `blocked_by`, never a softened criterion.
 
-**`ank find <query>`** — search titles, scopes and criteria. `ank find --status
-open` lists what remains, with no query to invent.
+**`ank find <query>`** — `ank find --status open` lists what remains, with no
+query to invent.
 
 **`ank release --reason "<why>"`** — stuck, or wrong about the approach. Say so
 and hand the task back rather than letting the claim lapse in silence.
@@ -77,10 +127,10 @@ What is genuinely a root, and what only looked like one in a flat list.
 frozen fields, orphaned claims. Exit `8` means findings, and findings are for
 reading, not for silencing.
 
-**`accept` is not yours to run.** It is what turns a proposed ADR into a binding
-one, and it is a human act: signed, on the default branch, with no way around
-it. Propose the decision, then say it is waiting. Knowing where your authority
-ends is part of planning well.
+**`accept` is not yours to run.** It is what turns a proposed ADR or spec into a
+binding one, and it is a human act: signed, on the default branch, with no way
+around it. Propose the decision, then say it is waiting. Knowing where your
+authority ends is part of planning well.
 
 ## Rules that are not negotiable
 
@@ -93,7 +143,6 @@ ends is part of planning well.
   directly. `ank show <id>` gives you an entity whole, `ank find` lists,
   `ank context` binds — the CLI knows the budget, the freeze and who holds what;
   the files do not.
-
 - **One agent, one working tree, one identity.** The nominal case is a tree per
   agent — a clone or a `git worktree` — each on its own branch. `ANK_AGENT`
   names the session and falls back to `<user>@<hostname>`, so two sessions in
@@ -101,7 +150,6 @@ ends is part of planning well.
   over it, and the second one is refused work it should have been given. Set it
   per session. Several agents in one tree runs, and is a degraded mode rather
   than the design.
-
 - **What you read is never styled.** Colour is emitted only when a human is at
   a terminal, never into a pipe, a file or `--json`, so the bytes reaching you
   are plain: there is nothing to configure and no second surface to prefer.


### PR DESCRIPTION
Closes TASK-1e2e47327d71.

`skill/SKILL.md` is the only description of ank most agents will ever read, and it was behind the tool in two ways.

**It never said why.** It opened on where the files live and went straight to the verbs — which teaches the moves and not what they protect: that constraints and work are two planes joined only by scope, and that nothing here is trusted because everything is anchored. An agent that does not know what a rule protects is the one that works around it, politely, in good faith.

**It had no investigation mode.** `ank scope <path>` answers *what governs this file* and `ank status` answers *where am I* — both shipped, neither taught, and between them the question an agent actually arrives with, before it has chosen a task and often instead of choosing one. The read form of `ank log <id>` is the third: it is how the next holder learns where the last one stopped, which is the whole reason `release --reason` is mandatory, and only the write form was taught. And since ADR-5a690829388d the specification is an entity of the corpus, so `ank find --type spec` reaches the normative answer from inside the tool — the skill did not mention the kind at all.

**Every verb the mode adds is a reader.** That is the line the ADR draws: it teaches how to arrive informed, and adds no way to change anything. `close`, `attest` and `edit` stay untaught for the ordinary reason — nothing has decided they are worth what every session pays. `accept` stays described and never invited.

## Why this is three supersessions and not an edit

The freeze did its job: this is a change to what every agent is taught on every session, and it costs a signature.

| Entity | |
|---|---|
| `ADR-5dd7b4a9c875` | supersedes `ADR-f61e2d2c75e8`, carrying its `ank help` grouping clause forward **unchanged** and restating the freeze over three modes |
| `SPEC-cd0d3377b37f` | supersedes `SPEC-c33e07a82cc4` — §4 states the mode block, "this is the entire content", the ceiling |
| `SPEC-eddf356ce1a9` | supersedes `SPEC-fa2f8c49dba4` — §9 states what the file carries, "and nothing else" |

Editing was not an option: an accepted spec whose body moves is reported `altered` by `check`, because its ratification commit hashes body and scope. Both successors were produced by splicing one revised passage into the body read back out of the predecessor, and the rest was verified byte-identical — only the passage that became false moved.

All three arrive `proposed`, which `check` reports as signals and never faults. **Ratifying them is a human act on the default branch**, after this merges. The three documents still citing the old CLI surface then follow the chain with `ank amend --reference` — the mechanism #143 built, firing for the first time.

## The ceiling moves to 180 / 1500, on a measurement

A ceiling raised to fit what was just written is not a ceiling, so the number rests on something measurable: `claude plugin details ank` projects `Always-on: ~58 tok`, and that is the frontmatter `name` and `description` — the body is read when the skill is invoked. The ceiling is kept anyway for the by-hand route, which copies the whole file into "whatever that harness loads", and some harnesses load all of it every session. **It bounds the worst route rather than the measured one**, and that sentence is now in the ADR, in §4 and in §9 rather than left to be rediscovered.

The `description` does not grow — it is the only part a session pays for whether or not the skill is ever invoked. The file lands at **167 lines / 1381 words**.

## One test had to learn something

`read_section_4_document` asserted that exactly one spec document carries §4's `Commands` block. During a supersession, two do — the ratified one and its replacement — and it failed, correctly, saying that neither zero nor two is a state it can guess its way through. It now prefers the ratified document, because a proposed successor is not the specification yet and `accept` is what makes it so. `superseded` is filtered out with `proposed` rather than kept beside `accepted`, or the suite would read the surface out of the document that was just retired.

## Verification

`cargo test --workspace` green (552), `cargo fmt --check` clean, `ank check` ok with no fault. New tests: the investigation verbs are named, the read form of `log` is taught (asserted separately, since the loop already forces the string `ank log` to appear), and the file says what the rules protect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NxPxixKuRX45JGV54BhRk
