### PR TITLE
check no longer asks a superseded document to follow a chain

### DIFF
--- a/.ank/entities/LOG-36f4bf087dfb.md
+++ b/.ank/entities/LOG-36f4bf087dfb.md
@@ -1,0 +1,16 @@
+---
+id: LOG-36f4bf087dfb
+type: log
+title: "fix measured on this corpus itself: the new binary reports 103 signals where the installed one"
+created: 2026-08-15T21:18:40Z
+author: claude-code/a6c6
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/tests/cli.rs
+about: TASK-a6c643216f51
+seq: 2
+schema: 3
+version: 1
+---
+
+ reports 104, and the one that left is exactly 'SPEC-fa2f8c49dba4: references SPEC-c33e07a82cc4, which is superseded by SPEC-cd0d3377b37f' -- the finding this task was opened from. The three live citers that followed the chain are unaffected, and check stays exit 0. The skip is placed at the head of check_references and covers the whole reference half, so a retired document is asked nothing whatever its citations resolve to.

--- a/.ank/entities/LOG-53f3d2f4e378.md
+++ b/.ank/entities/LOG-53f3d2f4e378.md
@@ -1,0 +1,16 @@
+---
+id: LOG-53f3d2f4e378
+type: log
+title: "falsified against the current binary: check reports all three reference states against a citer that"
+created: 2026-08-15T21:01:17Z
+author: claude-code/a6c6
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/tests/cli.rs
+about: TASK-a6c643216f51
+seq: 1
+schema: 3
+version: 1
+---
+
+ is itself superseded. SPEC-00000000f006 (status superseded, replaced by SPEC-00000000a007) drew 'error: references SPEC-00000000ffff, which does not exist', 'signal: references SPEC-00000000b002, which is not accepted' and 'signal: references SPEC-00000000c003, which is superseded by SPEC-00000000d004 (ank amend SPEC-00000000f006 --reference ... --drop-reference ...)' -- the last naming a repair that would bump the version of a retired document. Every target was counted twice, once for the live citer and once for the retired one. The new test a_superseded_document_is_not_asked_to_follow_a_chain fails on the first assertion.

--- a/.ank/entities/LOG-7daf722a1750.md
+++ b/.ank/entities/LOG-7daf722a1750.md
@@ -1,0 +1,14 @@
+---
+id: LOG-7daf722a1750
+type: log
+title: done, proof commit:f6208b5
+created: 2026-08-15T21:19:57Z
+author: claude-code/a6c6
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/tests/cli.rs
+about: TASK-a6c643216f51
+seq: 3
+schema: 3
+version: 1
+---

--- a/.ank/entities/TASK-a6c643216f51.md
+++ b/.ank/entities/TASK-a6c643216f51.md
@@ -5,7 +5,7 @@ slug: check-asks-a-superseded-document-to-follow-a-cha
 title: check asks a superseded document to follow a chain
 created: 2026-08-15T19:25:42Z
 author: claude-code/opus-5
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/src/human.rs
   - crates/ank-cli/tests/cli.rs
@@ -14,7 +14,7 @@ done_criteria: |
   A spec whose own status is superseded produces no reference finding: check skips the citer that has itself been replaced, for the absent target, the unaccepted one and the superseded one alike. A test in crates/ank-cli/tests/cli.rs drives the built binary over a corpus holding a superseded document that cites a superseded one, and asserts that nothing is reported against it while the same reference from a live document still is. cargo test --workspace and ank check stay green.
 criteria_by: creator
 schema: 3
-version: 2
+version: 3
 ---
 
 Measured the first time a spec document was superseded (TASK-1e2e47327d71).

--- a/.ank/entities/TASK-a6c643216f51.md
+++ b/.ank/entities/TASK-a6c643216f51.md
@@ -5,7 +5,7 @@ slug: check-asks-a-superseded-document-to-follow-a-cha
 title: check asks a superseded document to follow a chain
 created: 2026-08-15T19:25:42Z
 author: claude-code/opus-5
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/src/human.rs
   - crates/ank-cli/tests/cli.rs
@@ -13,8 +13,13 @@ blocked_by: []
 done_criteria: |
   A spec whose own status is superseded produces no reference finding: check skips the citer that has itself been replaced, for the absent target, the unaccepted one and the superseded one alike. A test in crates/ank-cli/tests/cli.rs drives the built binary over a corpus holding a superseded document that cites a superseded one, and asserts that nothing is reported against it while the same reference from a live document still is. cargo test --workspace and ank check stay green.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: f6208b5
+    criteria: 1e770fe1f37b
+    via: submitted
 schema: 3
-version: 3
+version: 4
 ---
 
 Measured the first time a spec document was superseded (TASK-1e2e47327d71).

--- a/crates/ank-cli/src/human.rs
+++ b/crates/ank-cli/src/human.rs
@@ -1658,11 +1658,27 @@ fn check_spec(
 /// finding would ask of it, and a rule that fired anyway would fire on every
 /// correct citation the day after any document is revised.
 ///
+/// **A citer that is itself superseded is asked nothing at all**
+/// (TASK-a6c643216f51). Every case above reads the target's state; this one
+/// reads the citing document's, and it comes first because a retired document
+/// owes no repair whatever its citations resolve to. A superseded entity is
+/// history: it records what was decided and what it rested on *at the time*, and
+/// following a chain would make it cite a document written after it was retired.
+/// The finding is worse than unactionable — `amend` reaches the references of
+/// any spec, so a reader following the instruction bumps the `version` of a
+/// document that is supposed to be settled, which is the shape of a late edit
+/// `check` reports everywhere else. Measured on this corpus the first time a
+/// spec was replaced: three live citers followed the chain, and the fourth had
+/// been retired in the same operation.
+///
 /// Only the declared field is read. A section number written in a sentence is
 /// not a reference, and scanning bodies for citations would make the check
 /// depend on how somebody phrased a paragraph — which is the drift this exists
 /// to catch, moved into the detector.
 fn check_references(s: &Spec, entities: &[(PathBuf, Entity)], report: &mut Report) {
+    if s.status == SpecStatus::Superseded {
+        return;
+    }
     let find = |id: &EntityId| entities.iter().find(|(_, e)| e.id() == id).map(|(_, e)| e);
     for target in &s.references {
         // The kind rule, read from the id and before any lookup: an id states

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -2653,6 +2653,81 @@ fn the_repair_a_reference_finding_names_is_one_amend_accepts() {
     );
 }
 
+const RETIRED: &str = "SPEC-00000000f006";
+const HEIR: &str = "SPEC-00000000a007";
+
+/// The same three states, cited twice: once by a live document, once by one
+/// that has itself been replaced.
+fn retired_citer_fixture() -> Repo {
+    let r = Repo::new();
+    r.seed_docs();
+    r.seed_spec(CITING, "proposed", &[GONE, DRAFT, REPLACED], None);
+    r.seed_spec(DRAFT, "proposed", &[], None);
+    r.seed_spec(REPLACED, "superseded", &[], None);
+    r.seed_spec(SUCCESSOR, "accepted", &[], Some(REPLACED));
+    r.seed_spec(RETIRED, "superseded", &[GONE, DRAFT, REPLACED], None);
+    r.seed_spec(HEIR, "accepted", &[SUCCESSOR], Some(RETIRED));
+    r
+}
+
+/// **A citer that is itself superseded is not asked to follow anything**
+/// (TASK-a6c643216f51).
+///
+/// Measured the first time a spec was replaced: three live documents followed
+/// the chain, which is ADR-5a690829388d working as designed, and the fourth had
+/// been retired in the same operation. What the finding asked of it was that a
+/// document nobody reads any more be edited to cite one written after it was
+/// retired — and the repair it named would have worked, bumping the `version` of
+/// a document that is supposed to be settled.
+///
+/// A superseded entity is history: it records what was decided and what it
+/// rested on at the time. So the whole reference half is skipped for it — the
+/// absent target, the unaccepted one and the superseded one alike — and what
+/// must not move is the live case, which is the entire reason the signal exists.
+///
+/// Through the binary, because the claim is about what `check` prints and about
+/// the exit code that print then carries to a pipeline.
+#[test]
+fn a_superseded_document_is_not_asked_to_follow_a_chain() {
+    let r = retired_citer_fixture();
+    let out = r.ank("claude-code@ank", &["check"]);
+    let said = stdout(&out);
+
+    // Nothing whatsoever against the retired citer, and nothing naming it.
+    assert!(
+        findings_about(&said, RETIRED).is_empty(),
+        "a superseded document was asked to repair its citations: {said}"
+    );
+
+    // The three states it cites are reported once each, and the once is the
+    // live document: a citation is counted for the reader who can still act on
+    // it, and never twice.
+    for target in [GONE, DRAFT] {
+        let about = findings_about(&said, target);
+        assert_eq!(
+            about.len(),
+            1,
+            "only the live citer owes a repair for {target}: {said}"
+        );
+        assert!(about[0].contains(CITING), "{said}");
+    }
+    let about: Vec<String> = findings_about(&said, REPLACED)
+        .into_iter()
+        .filter(|l| l.contains("references"))
+        .collect();
+    assert_eq!(about.len(), 1, "{said}");
+    assert!(about[0].starts_with("signal:"), "{said}");
+    assert!(about[0].contains(CITING), "{said}");
+    assert!(
+        about[0].contains(&format!("superseded by {SUCCESSOR}")),
+        "the live case still names the successor: {said}"
+    );
+
+    // The live fault reaches the process. Skipping the retired citer silences a
+    // finding, never a corpus.
+    assert_eq!(code(&out), 8, "{said}");
+}
+
 /// A specification cites a spec or an adr, and nothing that is meant to be
 /// retired. The rule is one function, read by the two writers and by `check`.
 #[test]


### PR DESCRIPTION
`check` skips the reference half for a citing document whose own status is
`superseded` — for the absent target, the unaccepted one and the superseded one
alike.

Measured the first time a spec was replaced (TASK-1e2e47327d71): four documents
cited `SPEC-c33e07a82cc4`, three of them live, and they followed the chain with
the command the finding named. The fourth, `SPEC-fa2f8c49dba4`, had been
superseded in the same operation. What the finding asked of it was that a
retired document be edited to cite one written after it was retired — and the
repair it named would have worked, since `amend` reaches the references of any
spec, so a reader following the instruction bumps the `version` of a document
that is supposed to be settled.

The live case is untouched: a `proposed` or `accepted` document citing a
superseded one is exactly what the signal exists for.

## Verification

The test failed first against the current binary, with all three states reported
against the retired citer:

```
error:  SPEC-...f006: references SPEC-...ffff, which does not exist
signal: SPEC-...f006: references SPEC-...b002, which is not accepted
signal: SPEC-...f006: references SPEC-...c003, which is superseded by SPEC-...d004
```

Both falsification and fix are recorded in the task log.

- `a_superseded_document_is_not_asked_to_follow_a_chain` drives the built binary
  over a corpus where a superseded document and a live one cite the same three
  targets, and asserts nothing is reported against the retired one while the
  live one still owes each repair, exit 8 included.
- `cargo test --workspace`: 554 passed, 0 failed.
- `ank check`: exit 0. On this corpus the fix removes one signal and one only —
  103 where the build on `main` reports 104 — and it is the
  `SPEC-fa2f8c49dba4` line above.
- `cargo fmt --check`: clean.

TASK-a6c643216f51

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UiaSWPnaxwpUCfC15nN3jh
