### PR TITLE
A deletion git records lowers a dead scope to a signal

### DIFF
--- a/.ank/entities/ADR-3094538d831e.md
+++ b/.ank/entities/ADR-3094538d831e.md
@@ -1,0 +1,114 @@
+---
+id: ADR-3094538d831e
+type: adr
+slug: a-dead-scope-is-reported-with-the-rename-or-the
+title: A dead scope is reported with the rename or the deletion that killed it
+created: 2026-08-15T21:56:55Z
+author: claude-code/ec57
+status: proposed
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/src/git.rs
+  - docs/**
+constraint: |
+  A dead scope is reported with the rename that killed it, whenever git can name
+  one. check walks the history of the dead path, and when the last commit touching
+  it recorded a rename it names the new path, the commit, and the exact command
+  that repairs the entity.
+  
+  A dead scope whose path git records as deleted is reported with the commit that
+  removed it, on the same terms. A deletion is an answer git gives: the commit is
+  named, dated and readable, so the reader can follow it, and the severity is
+  lowered exactly as a rename lowers it. It names no destination, so it proposes
+  nothing: there is nowhere for the scope to move to, and a command that refuses on
+  the spot is worse than no command. The rename is asked first, so a removal git
+  paired with an addition stays a rename.
+  
+  The severity only ever lowers, and only where git answers. A death git cannot
+  name is unchanged: a path no commit ever carried, a move under the similarity
+  threshold, a history too shallow to hold the commit. There the reader has
+  nothing, and the finding stays what it already is.
+  
+  It proposes and never repairs. No scope is edited automatically, under any
+  circumstance.
+  
+  The proposal names a command that will not refuse on the spot. amend cannot
+  change the scope of an accepted ADR, whose scope is hashed into its ratification
+  commit, so for an accepted ADR the proposal is a supersession and says so.
+  
+  It costs git, so it runs on a dead scope and on nothing else, and is skipped in
+  silence where there is no repository to ask.
+  
+  What is covered is the scope field. A path, a symbol or a function named in a
+  body is prose, and no finding pretends otherwise.
+supersedes: ADR-97beaf55e73a
+schema: 3
+version: 1
+---
+
+## Context
+
+ADR-97beaf55e73a is carried forward whole and revised in one place. Its rename
+clause is above unchanged, and so is everything that surrounds it: the refusal to
+repair, the proposal that must not refuse on the spot, the cost clause, and the
+line between a scope and prose. What is added is the case it left out.
+
+It lowers a dead scope from a fault to a signal wherever git can say where the
+path went, and its reasoning is explicit: the fault is for "the death git cannot
+explain, where the reader has nothing", because "a fault nobody can clear is a
+finding readers learn to skip". A deletion is not that case. Git records the
+commit that removed a path as plainly as it records a rename, and the reader can
+see it, date it and read its message. The condition the decision already states
+is met; only the implementation disagreed, because the walk asked for a rename
+and a deletion is not one.
+
+## What it fixes, measured
+
+Retiring the dogfooding hook deleted .claude/, which killed the .claude/**
+scope of a task that was already done. amend refuses a finished task, so no verb
+could clear the finding: the corpus would have carried one permanent fault and
+check would have exited 8 for ever. That is exactly the finding readers learn to
+skip, arrived at through the one door the decision meant to close.
+
+## What must not move
+
+A path git has nothing to say about. A typo, a glob that matched nothing from the
+day it was written, a history truncated by a shallow clone: the reader still has
+nothing, and the fault is what that is for. The third state added for a shallow
+clone is the precedent, and the shape it gave is the shape kept here: an answer
+git cannot give is different from an answer it gives, and only the second lowers
+the severity.
+
+## Why it proposes nothing
+
+A rename names a place, so there is a scope to move to and a command that moves
+it. A deletion names none. The entity that scoped the path recorded where work
+happened, which is a fact about the past a later deletion does not falsify, and a
+finished task's scope is not amendable anyway. So the note names the commit and
+stops, which is what ADR-97beaf55e73a already requires of a proposal that would
+be refused on the spot.
+
+## Plumbing
+
+The same two plumbing calls, deliberately: rev-list for the last commit touching
+the dead path, then diff-tree -M --name-status on that commit. The deletion is
+read out of the same record the rename is read out of, one walk for both, because
+the alignment of that output is the only difficulty and a second reader of it is
+a second thing to keep in step.
+
+A glob is asked about through its literal prefix, as it already is. The prefix is
+not the scope, so the deleted paths are confronted with the glob itself before
+anything is reported: a commit that deleted src/notes.md says nothing about
+src/**/*.rs, and reporting on the prefix alone would be a claim git did not make.
+
+## Rejected
+
+**Reading an empty rev-list as a deletion.** It is the same conflation the
+shallow-clone state exists to prevent: a path git never knew and a path git
+watched die produce the same empty answer, and only one of them may lower a
+severity. The deletion is read from a record that names it, or it is not read at
+all.
+
+**Proposing a scope for a deleted path.** There is no destination to propose, and
+inventing a nearby one would be the automatic repair section 11 forbids and the
+command-that-refuses the error style forbids, at once.

--- a/.ank/entities/LOG-3c4f114b0b92.md
+++ b/.ank/entities/LOG-3c4f114b0b92.md
@@ -1,0 +1,17 @@
+---
+id: LOG-3c4f114b0b92
+type: log
+title: Two things the fix turned on. First, a glob cannot be answered by asking git about its literal
+created: 2026-08-15T21:57:41Z
+author: claude-code/ec57
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/src/git.rs
+  - crates/ank-cli/tests/cli.rs
+about: TASK-ec579d3a566e
+seq: 1
+schema: 3
+version: 1
+---
+
+ prefix alone: a prefix is not the scope, and a commit that deleted src/notes.md says nothing about src/**/*.rs. So deletions_under returns the deleted paths and the caller confronts them with the glob itself, where the rename path could stop at the prefix because a directory rename is one answer about one directory. Second, three tests in cli.rs encoded the old rule as an assertion - a_deleted_file_leaves_the_finding_exactly_as_it_was, the deleted half of a_finished_tasks_dead_scope_faults_only_when_git_cannot_explain_it, and the closing block of the shallow-clone test, which used a deletion as its still-a-fault control. All three were revised to keep their point with the case that did not move: a path no commit ever carried. The shallow-clone control is the one that mattered - its whole purpose is that lowering must not buy the green by giving up the check, and it now uses a scope naming a path git never knew.

--- a/.ank/entities/LOG-57b104a1eff8.md
+++ b/.ank/entities/LOG-57b104a1eff8.md
@@ -1,0 +1,17 @@
+---
+id: LOG-57b104a1eff8
+type: log
+title: "falsification, before any change: the new binary test"
+created: 2026-08-15T21:35:52Z
+author: claude-code/ec57
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/src/git.rs
+  - crates/ank-cli/tests/cli.rs
+about: TASK-ec579d3a566e
+seq: 0
+schema: 3
+version: 1
+---
+
+ a_scope_deleted_by_a_commit_is_a_signal_and_a_scope_git_never_knew_is_a_fault fails on its first assertion, and what check printed over a done task scoping a file a later commit deleted is: "error: TASK-00000000de1e: dead scope 'src/gone.rs': no file matches it", with no note under it, and "check: 1 fault(s) - 1 tasks, 0 adr, 4 signal(s)". The process exits 8 where the criterion requires 0. The finding carries no note at all, which is the mechanism: scope_moved asks git only for a rename, a deletion is not a rename, so the note is empty, explained is false and the severity is never lowered.

--- a/.ank/entities/LOG-61e707af65f6.md
+++ b/.ank/entities/LOG-61e707af65f6.md
@@ -1,0 +1,15 @@
+---
+id: LOG-61e707af65f6
+type: log
+title: done, proof commit:e0442b6
+created: 2026-08-15T21:58:50Z
+author: claude-code/ec57
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/src/git.rs
+  - crates/ank-cli/tests/cli.rs
+about: TASK-ec579d3a566e
+seq: 2
+schema: 3
+version: 1
+---

--- a/.ank/entities/TASK-ec579d3a566e.md
+++ b/.ank/entities/TASK-ec579d3a566e.md
@@ -5,7 +5,7 @@ slug: a-dead-scope-git-records-as-deleted-is-a-signal
 title: A dead scope git records as deleted is a signal, not a fault
 created: 2026-08-15T21:29:04Z
 author: claude-code/opus-5
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/src/human.rs
   - crates/ank-cli/src/git.rs
@@ -15,7 +15,7 @@ done_criteria: |
   A dead scope whose path git records as deleted is reported as a signal naming the commit that removed it, on the terms ADR-97beaf55e73a already gives a rename, and a death git cannot name at all stays a fault. An ADR superseding ADR-97beaf55e73a carries its rename clause forward unchanged and states the deletion case, arriving proposed. A test in crates/ank-cli/tests/cli.rs drives the built binary over a repository where a finished task scopes a path a later commit deleted, and asserts the finding is a signal naming that commit and that the process exits 0; a second case, a scope naming a path that never existed, is asserted to stay a fault and to exit 8. The test fails against the code before the change, and what it printed is recorded in this task's log. cargo test --workspace and ank check are green.
 criteria_by: creator
 schema: 3
-version: 1
+version: 2
 ---
 
 Found by retiring the dogfooding hook (TASK-10b8a29fd853). Deleting `.claude/`

--- a/.ank/entities/TASK-ec579d3a566e.md
+++ b/.ank/entities/TASK-ec579d3a566e.md
@@ -5,7 +5,7 @@ slug: a-dead-scope-git-records-as-deleted-is-a-signal
 title: A dead scope git records as deleted is a signal, not a fault
 created: 2026-08-15T21:29:04Z
 author: claude-code/opus-5
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/src/human.rs
   - crates/ank-cli/src/git.rs
@@ -14,8 +14,13 @@ blocked_by: []
 done_criteria: |
   A dead scope whose path git records as deleted is reported as a signal naming the commit that removed it, on the terms ADR-97beaf55e73a already gives a rename, and a death git cannot name at all stays a fault. An ADR superseding ADR-97beaf55e73a carries its rename clause forward unchanged and states the deletion case, arriving proposed. A test in crates/ank-cli/tests/cli.rs drives the built binary over a repository where a finished task scopes a path a later commit deleted, and asserts the finding is a signal naming that commit and that the process exits 0; a second case, a scope naming a path that never existed, is asserted to stay a fault and to exit 8. The test fails against the code before the change, and what it printed is recorded in this task's log. cargo test --workspace and ank check are green.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: e0442b6
+    criteria: 1297f275e644
+    via: submitted
 schema: 3
-version: 2
+version: 3
 ---
 
 Found by retiring the dogfooding hook (TASK-10b8a29fd853). Deleting `.claude/`

--- a/crates/ank-cli/src/git.rs
+++ b/crates/ank-cli/src/git.rs
@@ -640,6 +640,52 @@ pub fn directory_rename_of(cwd: &Path, prefix: &str) -> Result<Option<Rename>> {
     }))
 }
 
+/// The commit that removed `path`, when the last change git records to it is a
+/// deletion.
+///
+/// The other half of the question [`rename_of`] asks, put to the same two
+/// plumbing calls and read out of the same record. A deletion is as plainly
+/// recorded as a rename — the reader can see the commit, date it and read its
+/// message — so it is an answer git gives, and it is not the silence
+/// [`rename_of`] returns for a move under the similarity threshold, a shallow
+/// clone or a path git never knew.
+///
+/// Asked after `rename_of` and never instead of it: a commit that removes a file
+/// and adds a similar one is recorded as a rename, and the rename is the better
+/// answer. `None` here keeps its meaning — git has nothing to say — which is
+/// what the caller must go on reporting as a fault.
+pub fn deletion_of(cwd: &Path, path: &str) -> Result<Option<String>> {
+    let Some((sha, diff)) = last_change(cwd, path)? else {
+        return Ok(None);
+    };
+    Ok(deletes(&diff, path).then(|| sha.chars().take(12).collect()))
+}
+
+/// The last commit to touch `prefix`, and the paths under it that commit
+/// deleted.
+///
+/// What serves a glob, exactly as [`directory_rename_of`] does and for the same
+/// reason: `rev-list` answers about a path and has no answer for `src/**`, so
+/// the caller asks about the literal prefix instead.
+///
+/// The paths are returned rather than reduced to a yes, and that is the whole
+/// difference from [`deletion_of`]. A prefix is not the scope: `src/**/*.rs` asks
+/// about `src`, and a commit that deleted `src/notes.md` there says nothing about
+/// the scope that died. Only the caller holds the glob, so only the caller can
+/// say whether a deleted path is one this scope covered — and reporting on the
+/// prefix alone would be a claim git did not make.
+pub fn deletions_under(cwd: &Path, prefix: &str) -> Result<Option<(String, Vec<String>)>> {
+    let Some((sha, diff)) = last_change(cwd, prefix)? else {
+        return Ok(None);
+    };
+    let under = format!("{prefix}/");
+    let deleted: Vec<String> = records(&diff)
+        .filter(|(status, src, _)| status.starts_with('D') && src.starts_with(under.as_str()))
+        .map(|(_, src, _)| src.to_string())
+        .collect();
+    Ok(Some((sha.chars().take(12).collect(), deleted)))
+}
+
 /// The last commit that touched `path`, and what it changed.
 ///
 /// `rev-list -1 HEAD -- <path>` is that commit. `diff-tree` on it is what says
@@ -688,23 +734,46 @@ fn last_change(cwd: &Path, path: &str) -> Result<Option<(String, String)>> {
 /// two when the status is a rename or a copy. The letter carries a similarity
 /// score (`R100`), which is why the test is on the first byte.
 fn rename_target(text: &str, from: &str) -> Option<String> {
-    let mut fields = text.split('\0').filter(|f| !f.is_empty());
-    while let Some(status) = fields.next() {
-        let renamed = status.starts_with('R');
-        let Some(src) = fields.next() else {
-            return None;
-        };
-        if !renamed && !status.starts_with('C') {
-            continue;
-        }
-        let Some(dst) = fields.next() else {
-            return None;
-        };
-        if renamed && src == from {
-            return Some(dst.to_string());
+    for (status, src, dst) in records(text) {
+        if status.starts_with('R') && src == from {
+            return dst.map(str::to_string);
         }
     }
     None
+}
+
+/// The records `--name-status -z` emitted, as a status, a source and the
+/// destination a rename or a copy carries.
+///
+/// One walk for every question asked of a commit, because the alignment is the
+/// only difficulty here: a status carries one path, or two when it is `R` or
+/// `C`, and a reader that miscounts one record misaligns every record after it —
+/// which is how the answer becomes wrong for a path nobody asked about. Output
+/// cut mid-record ends the walk, and never panics: git truncated by a broken
+/// pipe answers nothing, which is what every caller here already means by
+/// `None`.
+fn records(text: &str) -> impl Iterator<Item = (&str, &str, Option<&str>)> {
+    let mut fields = text.split('\0').filter(|f| !f.is_empty());
+    std::iter::from_fn(move || {
+        let status = fields.next()?;
+        let src = fields.next()?;
+        let pair = status.starts_with('R') || status.starts_with('C');
+        let dst = match pair {
+            true => Some(fields.next()?),
+            false => None,
+        };
+        Some((status, src, dst))
+    })
+}
+
+/// Whether `text` records `path` as deleted.
+///
+/// Pure, and split out for the same reason as [`rename_target`]: it is a shape
+/// of git's output. `D` is the whole test — a deletion carries one path, and a
+/// removal git paired with an addition is an `R` this never sees, because
+/// [`rename_of`] is asked first and answers it.
+fn deletes(text: &str, path: &str) -> bool {
+    records(text).any(|(status, src, _)| status.starts_with('D') && src == path)
 }
 
 /// The one directory `text` records every file under `prefix` as moving to.
@@ -721,25 +790,16 @@ fn rename_target(text: &str, from: &str) -> Option<String> {
 fn moved_prefix(text: &str, prefix: &str) -> Option<String> {
     let under = format!("{prefix}/");
     let mut found: Option<String> = None;
-    let mut fields = text.split('\0').filter(|f| !f.is_empty());
-    while let Some(status) = fields.next() {
-        let renamed = status.starts_with('R');
-        let Some(src) = fields.next() else {
-            return None;
-        };
-        if !renamed && !status.starts_with('C') {
-            continue;
-        }
-        let Some(dst) = fields.next() else {
-            return None;
-        };
-        if !renamed {
+    for (status, src, dst) in records(text) {
+        if !status.starts_with('R') {
             continue;
         }
         let Some(rel) = src.strip_prefix(under.as_str()) else {
             continue;
         };
-        let dest = dst.strip_suffix(rel).and_then(|d| d.strip_suffix('/'))?;
+        let dest = dst
+            .and_then(|d| d.strip_suffix(rel))
+            .and_then(|d| d.strip_suffix('/'))?;
         match &found {
             None => found = Some(dest.to_string()),
             Some(seen) if seen == dest => {}
@@ -1458,5 +1518,106 @@ mod tests {
     fn a_repository_with_no_head_answers_nothing_rather_than_failing() {
         let t = Temp::new_repo();
         assert_eq!(rename_of(&t.0, "src/old.rs").unwrap(), None);
+        assert_eq!(deletion_of(&t.0, "src/old.rs").unwrap(), None);
+        assert_eq!(deletions_under(&t.0, "src").unwrap(), None);
+    }
+
+    /// The record a deletion is read out of, and the two it must not be read out
+    /// of: a modification and the source of a rename both name a path that is
+    /// still somewhere.
+    #[test]
+    fn a_deletion_is_read_by_its_path_and_a_path_still_somewhere_is_not_one() {
+        let text = "M\0a.rs\0D\0gone.rs\0R100\0old.rs\0new.rs\0D\0also.rs\0";
+        assert!(deletes(text, "gone.rs"));
+        assert!(
+            deletes(text, "also.rs"),
+            "a deletion past a rename must be found, so the two-path record is \
+             stepped over as two"
+        );
+        assert!(!deletes(text, "a.rs"), "a modified file was not deleted");
+        assert!(
+            !deletes(text, "old.rs"),
+            "the source of a rename is somewhere, and calling it deleted would \
+             lose the place the reader can follow"
+        );
+        assert!(!deletes("", "gone.rs"));
+        assert!(
+            !deletes("D\0", "gone.rs"),
+            "output cut mid-record answers nothing, and must not panic"
+        );
+    }
+
+    /// The commit that removed a path, on a real deletion and on the two
+    /// silences: a path git never knew, and a path that moved.
+    #[test]
+    fn a_deleted_path_names_the_commit_that_removed_it_and_a_moved_one_does_not() {
+        let t = Temp::new_repo();
+        t.commit("src/gone.rs", "fn gone() {}\n");
+        t.commit("src/kept.rs", "fn kept() {}\n");
+        std::fs::remove_file(t.0.join("src/gone.rs")).unwrap();
+        t.porcelain(&["add", "-A"]);
+        t.porcelain(&["commit", "-qm", "delete it"]);
+        let sha = run(&t.0, &["rev-parse", "HEAD"]).unwrap();
+
+        let removed = deletion_of(&t.0, "src/gone.rs")
+            .unwrap()
+            .expect("git records the deletion");
+        assert!(
+            sha.starts_with(&removed),
+            "the commit named must be the one that removed it: {removed} is not \
+             a prefix of {sha}"
+        );
+        assert_eq!(
+            deletion_of(&t.0, "src/kept.rs").unwrap(),
+            None,
+            "a file that is still there was not deleted"
+        );
+        assert_eq!(
+            deletion_of(&t.0, "src/never.rs").unwrap(),
+            None,
+            "a path git never knew is the silence the caller reports as a fault"
+        );
+
+        // A rename is recorded as one record and never as a deletion, so the
+        // caller that asks for the rename first is never contradicted here.
+        std::fs::rename(t.0.join("src/kept.rs"), t.0.join("src/moved.rs")).unwrap();
+        t.porcelain(&["add", "-A"]);
+        t.porcelain(&["commit", "-qm", "move it"]);
+        assert_eq!(deletion_of(&t.0, "src/kept.rs").unwrap(), None);
+    }
+
+    /// The directory question, which serves a glob: the paths a commit deleted
+    /// under a prefix, for the caller to confront with the glob it holds.
+    #[test]
+    fn the_paths_a_commit_deleted_under_a_prefix_are_returned_for_the_caller_to_filter() {
+        let t = Temp::new_repo();
+        t.commit("tools/hook.sh", "#!/bin/sh\n");
+        t.commit("tools/notes.md", "# notes\n");
+        std::fs::remove_dir_all(t.0.join("tools")).unwrap();
+        t.porcelain(&["add", "-A"]);
+        t.porcelain(&["commit", "-qm", "remove the directory"]);
+        let sha = run(&t.0, &["rev-parse", "HEAD"]).unwrap();
+
+        let (named, deleted) = deletions_under(&t.0, "tools")
+            .unwrap()
+            .expect("git records the commit that touched the prefix");
+        assert!(sha.starts_with(&named), "{named} is not a prefix of {sha}");
+        assert_eq!(
+            deleted,
+            vec!["tools/hook.sh".to_string(), "tools/notes.md".to_string()],
+            "every path deleted under the prefix is returned, because only the \
+             caller knows which of them the glob matched"
+        );
+
+        // A prefix git never knew, and one whose last commit deleted nothing:
+        // the second is the case that would let a claim be made about a
+        // directory that is still there.
+        assert_eq!(deletions_under(&t.0, "absent").unwrap(), None);
+        t.commit("src/lib.rs", "// x\n");
+        let (_, none) = deletions_under(&t.0, "src").unwrap().expect("a commit");
+        assert!(
+            none.is_empty(),
+            "a commit that added a file under the prefix deleted nothing: {none:?}"
+        );
     }
 }

--- a/crates/ank-cli/src/human.rs
+++ b/crates/ank-cli/src/human.rs
@@ -972,46 +972,90 @@ fn check_scope_alive(
     }
 }
 
-/// The note under a dead scope: where git says the path went, and what repairs
-/// the entity (ADR-97beaf55e73a).
+/// The note under a dead scope: what git says happened to the path, and what
+/// repairs the entity (ADR-97beaf55e73a).
 ///
-/// Empty for everything git cannot explain, which is most of what can go wrong
-/// with a scope. **Silence here is not evidence.** A deletion, a move under the
-/// similarity threshold and a typo that never named a real file all produce the
+/// Two deaths git records, and it is asked about both: a rename, which names
+/// where the path went and what moves the scope after it, and a deletion, which
+/// names the commit that removed it and proposes nothing.
+///
+/// Empty for everything git still cannot explain. **Silence here is not
+/// evidence.** A move under the similarity threshold, a rename made by a merge,
+/// a truncated history and a typo that never named a real file all produce the
 /// same nothing, so no wording below may suggest which — the reader is left
 /// exactly where they stand today, and the finding above says all that is known.
 fn scope_moved(entity: &Entity, glob: &str, root: &Path) -> Vec<String> {
     // A git failure is not a corpus fault and must never become one: the scope
     // is dead either way, and that is already reported. What is lost is the
     // explanation, which is exactly what `None` means everywhere else here.
-    let (asked, moved, to) = match literal_prefix(glob) {
-        // A path. The common entry, and the one git answers directly: 343 of the
-        // 462 scope entries in this repository's own corpus name one file with
-        // no wildcard.
-        None => {
-            let Ok(Some(moved)) = git::rename_of(root, glob) else {
-                return Vec::new();
-            };
-            let to = moved.to.clone();
-            (glob.to_string(), moved, to)
-        }
-        // A glob. git has no answer for "where did `src/**` go", so the question
-        // put to it is about the literal prefix, and the wildcard tail is carried
-        // across to the proposal unchanged.
-        Some((prefix, tail)) => {
-            let Ok(Some(moved)) = git::directory_rename_of(root, &prefix) else {
-                return Vec::new();
-            };
-            let to = format!("{}{tail}", moved.to);
-            (prefix, moved, to)
-        }
+    //
+    // A path is the common entry, and the one git answers directly: 343 of the
+    // 462 scope entries in this repository's own corpus name one file with no
+    // wildcard. A glob has no answer of its own — git has none for "where did
+    // `src/**` go" — so the question put to it is about the literal prefix, and
+    // the wildcard tail is carried across to the proposal unchanged.
+    let (asked, tail) = match literal_prefix(glob) {
+        None => (glob.to_string(), String::new()),
+        Some((prefix, tail)) => (prefix, tail),
     };
-    let mut note = vec![format!(
-        "git records {asked} renamed to {} in {}",
-        moved.to, moved.sha
-    )];
-    note.extend(repair(entity, glob, &to));
-    note
+    let directory = !tail.is_empty();
+    let moved = match directory {
+        false => git::rename_of(root, &asked),
+        true => git::directory_rename_of(root, &asked),
+    };
+    // The rename is asked first, and a deletion is only ever the answer git gave
+    // when it recorded no rename: a commit that removed a file and added a
+    // similar one is a rename, and the rename is the more useful of the two —
+    // it names a place the reader can follow.
+    if let Ok(Some(moved)) = moved {
+        let to = format!("{}{tail}", moved.to);
+        let mut note = vec![format!(
+            "git records {asked} renamed to {} in {}",
+            moved.to, moved.sha
+        )];
+        note.extend(repair(entity, glob, &to));
+        return note;
+    }
+    scope_deleted(glob, &asked, directory, root)
+}
+
+/// The same note for the other death git records: the commit that deleted the
+/// path.
+///
+/// **It proposes nothing, and the asymmetry with a rename is the point.** A
+/// rename names a place, so there is a scope to move to and a command that moves
+/// it. A deletion names none: the files are gone, no scope would match them
+/// again, and the entity that scoped them recorded where work happened, which a
+/// later deletion does not falsify. So the note names the commit and stops.
+///
+/// Empty for everything git still cannot explain — a path that never existed, a
+/// move under the similarity threshold, a shallow clone — and the caller goes on
+/// reporting those as a fault. **Silence here is still not evidence.**
+fn scope_deleted(glob: &str, asked: &str, directory: bool, root: &Path) -> Vec<String> {
+    if !directory {
+        let Ok(Some(sha)) = git::deletion_of(root, asked) else {
+            return Vec::new();
+        };
+        return vec![format!("git records {asked} deleted in {sha}")];
+    }
+    // A prefix is not the scope. `src/**/*.rs` asks git about `src`, and a commit
+    // that deleted `src/notes.md` there killed nothing this scope covered — so
+    // the deleted paths are confronted with the glob itself, and a commit that
+    // touched the prefix without removing anything the scope matched explains
+    // nothing.
+    let Ok(Some((sha, deleted))) = git::deletions_under(root, asked) else {
+        return Vec::new();
+    };
+    let one = [glob.to_string()];
+    let Ok(one) = ScopeSet::new(&one) else {
+        return Vec::new();
+    };
+    match deleted.iter().any(|p| one.matches(p)) {
+        true => vec![format!(
+            "git records the files {glob} matched deleted in {sha}"
+        )],
+        false => Vec::new(),
+    }
 }
 
 /// The part of a glob git can be asked about, and the wildcard tail that is not.

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -5735,6 +5735,125 @@ fn an_unattested_task_is_not_reported_until_the_default_branch_carries_it() {
     );
 }
 
+const REMOVED_SCOPE: &str = "TASK-00000000de1e";
+const REMOVED_TREE: &str = "TASK-00000000d132";
+const NEVER_SCOPE: &str = "TASK-00000000f00d";
+
+/// The same `done` seed with a scope of its own, which is the only field a
+/// dead-scope fixture varies.
+fn seed_done_scoped(r: &Repo, id: &str, scope: &str) {
+    seed_done(r, id, "  - type: commit\n    ref: abc1234\n");
+    let text = r
+        .task_text(id)
+        .replace("  - src/**", &format!("  - {scope}"));
+    std::fs::write(r.0.join(".ank/entities").join(format!("{id}.md")), text).unwrap();
+}
+
+/// A dead scope whose path git records as deleted is a signal naming the commit
+/// that removed it; a death git cannot name at all stays a fault
+/// (TASK-ec579d3a566e).
+///
+/// Both halves, because only the pair says anything. A check that stopped
+/// checking would pass the first assertion and fail the second, and the corpus
+/// this exists for is one where the second case is the whole point: a path git
+/// never knew leaves the reader with nothing, which is what the fault is for.
+///
+/// Through the binary, because the criterion is about what the process prints
+/// and what it exits with, and because the exit code is the thing a pipeline
+/// reads.
+#[test]
+fn a_scope_deleted_by_a_commit_is_a_signal_and_a_scope_git_never_knew_is_a_fault() {
+    let r = Repo::new();
+    std::fs::create_dir_all(r.0.join("src")).unwrap();
+    std::fs::write(r.0.join("src/lib.rs"), "// x\n").unwrap();
+    std::fs::write(r.0.join("src/gone.rs"), "pub fn gone() {}\n").unwrap();
+    seed_done_scoped(&r, REMOVED_SCOPE, "src/gone.rs");
+    // And the glob, which is the shape the real instance has: a task that put a
+    // directory there, and a later commit that removed the directory. git has no
+    // answer for "where did `tools/**` go", so this is asked about the literal
+    // prefix and is a different path through the code, not a second spelling of
+    // the same one.
+    std::fs::create_dir_all(r.0.join("tools")).unwrap();
+    std::fs::write(r.0.join("tools/hook.sh"), "#!/bin/sh\n").unwrap();
+    seed_done_scoped(&r, REMOVED_TREE, "tools/**");
+    r.git(&["add", "-A"]);
+    r.git(&["commit", "-qm", "seed"]);
+
+    // The commit that kills both scopes, and it deletes and nothing else: an
+    // addition alongside it could be paired by rename detection, and the finding
+    // under test would be the rename one.
+    std::fs::remove_file(r.0.join("src/gone.rs")).unwrap();
+    std::fs::remove_dir_all(r.0.join("tools")).unwrap();
+    r.git(&["add", "-A"]);
+    r.git(&["commit", "-qm", "remove the file"]);
+    let sha: String = r.head().chars().take(12).collect();
+
+    let out = r.ank("claude-code@ank", &["check"]);
+    let said = format!("{}{}", stdout(&out), stderr(&out));
+    assert_eq!(
+        code(&out),
+        0,
+        "a death git can name is a signal, and exit 8 here is a fault no verb \
+         clears: {said}"
+    );
+    let reported: Vec<&str> = said
+        .lines()
+        .filter(|l| l.contains("dead scope 'src/gone.rs'"))
+        .collect();
+    assert_eq!(reported.len(), 1, "exactly one finding names it:\n{said}");
+    assert!(
+        reported[0].starts_with(&format!("signal: {REMOVED_SCOPE}:")),
+        "a deletion git records lowers the severity: {said}"
+    );
+    assert!(
+        said.contains(&format!("git records src/gone.rs deleted in {sha}")),
+        "the note names the commit that removed it, or the reader still has \
+         nothing: {said}"
+    );
+    let tree: Vec<&str> = said
+        .lines()
+        .filter(|l| l.contains("dead scope 'tools/**'"))
+        .collect();
+    assert_eq!(tree.len(), 1, "exactly one finding names it:\n{said}");
+    assert!(
+        tree[0].starts_with(&format!("signal: {REMOVED_TREE}:")),
+        "a glob whose files git records as deleted is lowered too: {said}"
+    );
+    assert!(
+        said.contains(&format!(
+            "git records the files tools/** matched deleted in {sha}"
+        )),
+        "and its note names the same commit: {said}"
+    );
+
+    // The half that must not move. A path git has nothing to say about is where
+    // the reader is left with nothing, and lowering that too would be a check
+    // that stopped checking.
+    seed_done_scoped(&r, NEVER_SCOPE, "src/never_written.rs");
+    r.git(&["add", "-A"]);
+    r.git(&["commit", "-qm", "a scope naming a path that never existed"]);
+
+    let out = r.ank("claude-code@ank", &["check"]);
+    let said = format!("{}{}", stdout(&out), stderr(&out));
+    assert_eq!(
+        code(&out),
+        8,
+        "a death git cannot name is still a fault: {said}"
+    );
+    assert!(
+        said.contains(&format!(
+            "error: {NEVER_SCOPE}: dead scope 'src/never_written.rs'"
+        )),
+        "the unexplained death is the fault: {said}"
+    );
+    assert!(
+        said.contains(&format!(
+            "signal: {REMOVED_SCOPE}: dead scope 'src/gone.rs'"
+        )),
+        "and the explained one is still a signal: {said}"
+    );
+}
+
 const DETACHED: &str = "TASK-00000000d1ed";
 const LIVE_ANCHOR: &str = "TASK-00000000a11e";
 
@@ -10439,42 +10558,79 @@ fn a_renamed_file_names_where_it_went_and_the_command_that_repairs_it() {
     );
 }
 
-/// The other half of the criterion, and the one that must add nothing.
+/// The other death git records, and the note it earns (TASK-ec579d3a566e).
 ///
-/// A deletion, a move under the similarity threshold and a scope that never
-/// named a real file are one silence to git. The reader is left exactly where
-/// they stand today — no proposal, and above all no sentence asserting the file
-/// was deleted, because this code cannot know that.
+/// A deletion is not the silence a move under the similarity threshold is: git
+/// names the commit that removed the path as plainly as it names a rename, and
+/// the reader can date it and read its message. So the note says so — and
+/// proposes nothing, because a deletion names no place a scope could be moved to
+/// and a command that fails on the spot is the one thing the error style
+/// forbids.
+///
+/// **The silence still has to exist**, so the second half is the death git
+/// cannot name at all: a scope that never named a real file, where the reader
+/// really does have nothing.
 #[test]
-fn a_deleted_file_leaves_the_finding_exactly_as_it_was() {
+fn a_deleted_file_names_the_commit_that_removed_it_and_proposes_nothing() {
     let deleted = moved_fixture("src/old.rs", None);
+    let head = deleted.git(&["rev-parse", "HEAD"]);
     let out = deleted.ank("claude-code@ank", &["check"]);
-    assert_eq!(code(&out), 8, "{}", stderr(&out));
+    assert_eq!(
+        code(&out),
+        0,
+        "a death git records is a signal, and the fault it used to be is one no \
+         verb clears: {}",
+        stderr(&out)
+    );
     let text = stdout(&out);
     assert!(
         text.contains("dead scope 'src/old.rs': no file matches it"),
-        "{text}"
+        "the wording does not move with the severity: {text}"
+    );
+    let note = proposal(&text).unwrap_or_else(|| panic!("the deletion is named: {text}"));
+    assert_eq!(
+        note.len(),
+        1,
+        "a deletion names nowhere to move the scope to, so the note stops after \
+         the commit: {note:?}"
+    );
+    let named = note[0].rsplit(' ').next().unwrap();
+    assert!(
+        note[0] == format!("git records src/old.rs deleted in {named}") && head.starts_with(named),
+        "the note names the commit that removed it, and the commit is {head}: {note:?}"
+    );
+    assert!(
+        !text.contains("renamed"),
+        "a deletion went nowhere, and no rename may be invented for it: {text}"
+    );
+
+    // And the silence, which must not move. A path git has nothing to say about
+    // leaves the reader with nothing, which is what the fault is for.
+    let r = Repo::new();
+    std::fs::create_dir_all(r.0.join("src")).unwrap();
+    std::fs::write(r.0.join("src/kept.rs"), SIMILAR).unwrap();
+    r.seed_adr(DEAD_ADR, "Do not do X.", "src/never.rs");
+    r.git(&["add", "-A"]);
+    r.git(&["commit", "-qm", "seed"]);
+    let out = r.ank("claude-code@ank", &["check"]);
+    let text = stdout(&out);
+    assert_eq!(
+        code(&out),
+        8,
+        "a death git cannot name is still a fault: {text}{}",
+        stderr(&out)
     );
     assert_eq!(
         proposal(&text),
         None,
-        "git cannot explain a deletion, and nothing may be proposed: {text}"
+        "git has nothing to say about it, and nothing may be invented: {text}"
     );
     for word in ["renamed", "delet", "removed"] {
         assert!(
             !text.contains(word),
-            "'{word}' claims to know what became of the file: {text}"
+            "'{word}' claims to know what became of a file git never knew: {text}"
         );
     }
-
-    // What makes the silence mean something: the same corpus and the same
-    // finding, differing by the rename and by nothing else.
-    let renamed = moved_fixture("src/old.rs", Some("src/new.rs"));
-    assert!(
-        proposal(&stdout(&renamed.ank("claude-code@ank", &["check"]))).is_some(),
-        "the renamed fixture must be explained, or the deleted one proves \
-         nothing about the walk"
-    );
 }
 
 /// `amend` refuses the scope of an accepted ADR with code 6, so proposing it
@@ -10591,41 +10747,54 @@ fn finished_task_scoped(r: &Repo, glob: &str) {
 
 /// The severity rule, on the state where it decides something.
 ///
-/// Two fixtures differing by one act, because a single one proves the exit code
-/// and not the reason for it. **Renamed:** git names the commit, so the corpus
-/// is outdated in a way the reader can follow rather than broken — a signal.
-/// **Deleted:** git explains nothing, the reader has nothing, and the fault is
-/// what says so.
+/// Three fixtures differing by one act, because a single one proves the exit
+/// code and not the reason for it. **Renamed:** git names the commit and where
+/// the path went, so the corpus is outdated in a way the reader can follow
+/// rather than broken — a signal. **Deleted:** git names the commit that removed
+/// it just as plainly, so the reader can follow that too — a signal
+/// (TASK-ec579d3a566e). **Never there:** git has nothing to say, the reader has
+/// nothing, and the fault is what says so.
+///
+/// The third case is what makes the first two mean anything: a walk that stopped
+/// asking would lower all three.
 ///
 /// Through the binary because the exit code is the whole claim, and no unit test
 /// of the severity reaches it.
 #[test]
 fn a_finished_tasks_dead_scope_faults_only_when_git_cannot_explain_it() {
-    for (to, expected) in [(Some("src/new.rs"), 0), (None, 8)] {
+    for (act, expected) in [("rename", 0), ("delete", 0), ("never", 8)] {
         let r = Repo::new();
         std::fs::create_dir_all(r.0.join("src")).unwrap();
         std::fs::write(r.0.join("src/old.rs"), SIMILAR).unwrap();
-        finished_task_scoped(&r, "src/old.rs");
+        // The scope of the third fixture names a path no commit ever carried,
+        // and the file beside it is what keeps the corpus otherwise ordinary.
+        let scope = match act {
+            "never" => "src/absent.rs",
+            _ => "src/old.rs",
+        };
+        finished_task_scoped(&r, scope);
         r.git(&["add", "-A"]);
         r.git(&["commit", "-qm", "seed"]);
-        match to {
-            Some(to) => std::fs::rename(r.0.join("src/old.rs"), r.0.join(to)).unwrap(),
-            None => std::fs::remove_file(r.0.join("src/old.rs")).unwrap(),
+        match act {
+            "rename" => std::fs::rename(r.0.join("src/old.rs"), r.0.join("src/new.rs")).unwrap(),
+            "delete" => std::fs::remove_file(r.0.join("src/old.rs")).unwrap(),
+            // Nothing dies here: the scope was never alive.
+            _ => {}
         }
         r.git(&["add", "-A"]);
-        r.git(&["commit", "-qm", "move it"]);
+        r.git(&["commit", "-qm", "move it", "--allow-empty"]);
 
         let out = r.ank("claude-code@ank", &["check"]);
         let text = stdout(&out);
-        assert_eq!(code(&out), expected, "to={to:?}: {text}{}", stderr(&out));
+        assert_eq!(code(&out), expected, "act={act}: {text}{}", stderr(&out));
         assert!(
-            text.contains("dead scope 'src/old.rs': no file matches it"),
+            text.contains(&format!("dead scope '{scope}': no file matches it")),
             "the wording does not move with the severity: {text}"
         );
         assert_eq!(
             proposal(&text).is_some(),
-            to.is_some(),
-            "to={to:?}: the explanation and the severity are the same fact: {text}"
+            expected == 0,
+            "act={act}: the explanation and the severity are the same fact: {text}"
         );
     }
 }
@@ -10796,14 +10965,21 @@ fn a_shallow_clone_cannot_explain_a_dead_scope_and_says_so_instead_of_faulting()
     }
 
     // And the fault survives where git does have the history and records
-    // nothing, or this would have bought the green by giving up the check.
-    let deleted = moved_fixture("src/old.rs", None);
-    let whole = clone_of(&deleted, None);
-    let out = deleted.ank_at("claude-code@ank", &["check"], &whole);
+    // nothing, or this would have bought the green by giving up the check. A
+    // path no commit ever carried is that case: a deletion is an answer git
+    // gives (TASK-ec579d3a566e), and this is the one it cannot.
+    let unknown = Repo::new();
+    std::fs::create_dir_all(unknown.0.join("src")).unwrap();
+    std::fs::write(unknown.0.join("src/kept.rs"), SIMILAR).unwrap();
+    unknown.seed_adr(DEAD_ADR, "Do not do X.", "src/absent.rs");
+    unknown.git(&["add", "-A"]);
+    unknown.git(&["commit", "-qm", "seed"]);
+    let whole = clone_of(&unknown, None);
+    let out = unknown.ank_at("claude-code@ank", &["check"], &whole);
     assert_eq!(
         code(&out),
         8,
-        "a deletion git can see is still a fault: {}",
+        "a path git never knew is still a fault: {}",
         stdout(&out)
     );
 }


### PR DESCRIPTION
TASK-ec579d3a566e.

`check` asked git one question about a dead scope -- was the path renamed --
and read every other answer as silence. A deletion is not silence: git names the
commit that removed a path as plainly as it names a rename, and the reader can
see it, date it and read its message. The condition ADR-97beaf55e73a already
states was met, and only the walk disagreed.

What that cost is measurable. Retiring the dogfooding hook (#149) deletes
`.claude/`, which kills the `.claude/**` scope of the finished task that put the
directory there. `amend` refuses a `done` task, so the corpus would carry a
fault no verb can clear and `ank check` would exit 8 for ever -- exactly the
finding readers learn to skip that the decision exists to prevent. #149 is held
until this lands.

## What changes

- `git::deletion_of` names the commit that removed a path, and
  `git::deletions_under` returns the paths a commit deleted under a prefix. Both
  read the record `rename_of` already reads, through one shared walk of
  `diff-tree -M --name-status -z` -- the alignment of that output is the only
  difficulty there, and a second reader of it would be a second thing to keep in
  step.
- `scope_moved` asks for the rename first and falls back to the deletion. It
  proposes nothing: a deletion names nowhere for a scope to move to, and a
  command that refuses on the spot is what the error style forbids.
- A glob is confronted with the paths deleted under its literal prefix before
  anything is reported. A prefix is not the scope: a commit that deleted
  `src/notes.md` says nothing about `src/**/*.rs`.

## What does not change

The severity rule still only ever lowers, and only where git answers. A path no
commit ever carried, a move under the similarity threshold, a history too
shallow to hold the commit: there the reader has nothing, and the fault is what
that is for.

The binary test asserts both halves -- a deleted scope is a signal naming the
commit and exits 0, a scope naming a path that never existed stays a fault and
exits 8 -- because a test that only proved the noise went away would pass on a
check that stopped checking. It was run against the code before the change and
its output is in the task log. Three existing tests encoded the old rule and
were revised to keep their point with the case that did not move; the
shallow-clone control, whose whole purpose is that lowering must not buy the
green by giving up the check, now uses a scope git never knew.

## The decision

ADR-3094538d831e supersedes ADR-97beaf55e73a and arrives **proposed**. It
carries the rename clause forward unchanged, along with everything around it,
and states the deletion case. Ratifying it is a human act on the default branch.

`cargo test --workspace` and `ank check` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GDZP3DKtuaU8gwdhmiw6ni