### PR TITLE
The README says four kinds, and shows the block a perimeter prints

### DIFF
--- a/.ank/entities/LOG-abb2f9e71e1b.md
+++ b/.ank/entities/LOG-abb2f9e71e1b.md
@@ -1,0 +1,13 @@
+---
+id: LOG-abb2f9e71e1b
+type: log
+title: done, proof commit:059737cc20fb59d6cbeeb17aa9e5a9d645ebdae6
+created: 2026-08-15T22:19:42Z
+author: claude-code/0184
+scope:
+  - README.md
+about: TASK-01843ed0883f
+seq: 1
+schema: 3
+version: 1
+---

--- a/.ank/entities/LOG-da926e6404de.md
+++ b/.ank/entities/LOG-da926e6404de.md
@@ -1,0 +1,15 @@
+---
+id: LOG-da926e6404de
+type: log
+title: "The sample block was wrong in a third way the body did not name: it quoted its constraints over two"
+created: 2026-08-15T22:18:38Z
+author: claude-code/0184
+scope:
+  - README.md
+about: TASK-01843ed0883f
+seq: 0
+schema: 3
+version: 1
+---
+
+ lines, and a perimeter names them. constraint_section renders id and title only, and the full text is reached with show; only execution context quotes a constraint whole. Reproduced by building a throwaway repo with ank init, two accepted ADRs, one accepted spec and two tasks scoped to src/auth/ - the real block also prints open tasks before claimed ones, marks the holder as a typed actor pi/host-3, and ends on the full short id, ank claim TASK-51c2 to start. The 58 tokens survive as ADR-5dd7 measured them this week: it is the frontmatter, name and description, that a session pays whether or not the skill is invoked, and skill/SKILL.md today is 167 lines and 1408 words, inside the 180/1500 ceiling. ank find --type spec lists twelve, ten accepted and two superseded, so the README counts the accepted ten.

--- a/.ank/entities/TASK-01843ed0883f.md
+++ b/.ank/entities/TASK-01843ed0883f.md
@@ -5,7 +5,7 @@ slug: the-readme-describes-two-kinds-of-entity-and-the
 title: The README describes two kinds of entity, and there are four
 created: 2026-08-15T18:30:44Z
 author: claude-code/opus-5
-status: open
+status: in_progress
 scope:
   - README.md
 blocked_by: []
@@ -13,7 +13,7 @@ done_criteria: |
   README.md states the four kinds the registry declares rather than two, and the sample ank context output it shows carries a specification line, which is what a perimeter actually serves now. The dogfooding paragraph says that this repository's own specification lives in .ank/ as accepted spec entities reached only through the CLI. The per-session token figure is either re-measured against the current skill/SKILL.md and corrected, or removed; whichever it is, the number in the file is one somebody measured on this revision. No claim in the file contradicts what ank find --type spec and ank context print on this repository. cargo test --workspace and ank check stay green.
 criteria_by: creator
 schema: 3
-version: 1
+version: 2
 ---
 
 Not the recording. TASK-ab3592c8c586 asks for an asciinema under `assets/` and is

--- a/.ank/entities/TASK-01843ed0883f.md
+++ b/.ank/entities/TASK-01843ed0883f.md
@@ -5,15 +5,20 @@ slug: the-readme-describes-two-kinds-of-entity-and-the
 title: The README describes two kinds of entity, and there are four
 created: 2026-08-15T18:30:44Z
 author: claude-code/opus-5
-status: in_progress
+status: done
 scope:
   - README.md
 blocked_by: []
 done_criteria: |
   README.md states the four kinds the registry declares rather than two, and the sample ank context output it shows carries a specification line, which is what a perimeter actually serves now. The dogfooding paragraph says that this repository's own specification lives in .ank/ as accepted spec entities reached only through the CLI. The per-session token figure is either re-measured against the current skill/SKILL.md and corrected, or removed; whichever it is, the number in the file is one somebody measured on this revision. No claim in the file contradicts what ank find --type spec and ank context print on this repository. cargo test --workspace and ank check stay green.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 059737cc20fb59d6cbeeb17aa9e5a9d645ebdae6
+    criteria: b37b46885925
+    via: submitted
 schema: 3
-version: 2
+version: 3
 ---
 
 Not the recording. TASK-ab3592c8c586 asks for an asciinema under `assets/` and is

--- a/README.md
+++ b/README.md
@@ -26,21 +26,27 @@ way `.git/` is — not a directory to grep, a CLI to call.
 $ ank context src/auth/
 
 CONSTRAINTS (2 active)
-  ADR-3c7e  Do not introduce self-contained JWTs for user auth.
-            Every session goes through the Redis store.
-  ADR-8b41  Rate limiting mandatory on every public endpoint.
+  ADR-3c7e  No self-contained JWTs for user auth
+  ADR-8b41  Rate limiting on every public endpoint
+
+SPECIFICATIONS (1)
+  SPEC-d41f  Session and token handling
 
 TASKS (2)
-  TASK-8f3a  [claimed:pi@host-3] Migrate auth to opaque sessions
   TASK-51c2  [open] Add secret rotation
+  TASK-8f3a  [claimed:pi/host-3] Migrate auth to opaque sessions
 
-> ank claim 51c2 to start
+> ank claim TASK-51c2 to start
 ```
 
 One call, and the answer is bounded — 8000 characters by default, roughly 2000
-tokens. Behind it two kinds of entity: a decision that constrains code, and a
-unit of work with what would prove it finished. Both are plain markdown with YAML
-frontmatter, joined to the code by nothing but globs.
+tokens. Orientation names the rules rather than quoting them: which ones govern
+the path is the answer, and what one says is an `ank show` away. Behind it four
+kinds of entity: an ADR, a decision that constrains code; a spec, the normative
+text that describes rather than binds; a task, a unit of work with what would
+prove it finished; and a log entry, written once and never transitioned. All
+four are plain markdown with YAML frontmatter, joined to the code by nothing but
+globs.
 
 ## Install
 
@@ -108,8 +114,10 @@ knowledge crossing organisations, where a rejected document is knowledge lost;
 ank optimises for a criterion that cannot be quietly weakened, where an
 accepted-but-malformed file is a rule that silently stopped applying.
 
-Efficiency is two numbers rather than an adjective: the skill an agent loads
-costs about 58 tokens per session, and orientation is bounded at 8000 characters.
+Efficiency is two numbers rather than an adjective: the skill costs about 58
+tokens in every session, which is its frontmatter — the `name` and `description`
+a harness keeps loaded whether or not the skill is ever invoked, the body being
+read only when it is — and orientation is bounded at 8000 characters.
 
 ## What it is not
 
@@ -130,7 +138,10 @@ costs about 58 tokens per session, and orientation is bounded at 8000 characters
 
 The specification is the source of truth; the others exist so it does not have to
 be a tutorial. Pre-v1, on Linux, macOS and Windows. This repository dogfoods its
-own format: the plan lives in `.ank/`, and the tool reads, claims and closes its own tasks, under a [Code of Conduct](https://github.com/haksolot/ank/blob/main/CODE_OF_CONDUCT.md).
+own format down to that source of truth: the specification is ten accepted `spec`
+entities in `.ank/`, listed by `ank find --type spec` and printed whole by
+`ank show`, reached through the CLI and never by opening the files — and the plan
+is there beside it, the tool reading, claiming and closing its own tasks, under a [Code of Conduct](https://github.com/haksolot/ank/blob/main/CODE_OF_CONDUCT.md).
 
 ## Licence
 


### PR DESCRIPTION
TASK-01843ed0883f. README.md only.

The page claimed two kinds of entity. The registry declares four -- `task`,
`adr`, `spec`, `log` -- and the two that arrived late are the ones a reader
most needs, because a specification living in the corpus is now this
repository's own strongest example.

**The sample `ank context` block.** Rebuilt against real output rather than
edited. A throwaway repo (`ank init`, two accepted ADRs, one accepted spec,
two tasks scoped to `src/auth/`) prints:

- a `SPECIFICATIONS` section, which a perimeter charges beside the
  constraints and the old block did not show;
- constraints **named**, id and title on one line -- `constraint_section`
  leaves the text to `ank show`, and only execution context quotes a
  constraint whole. The old block quoted them over two lines;
- open tasks before claimed ones, the holder as a typed actor
  (`[claimed:pi/host-3]`, not `pi@host-3`);
- `> ank claim TASK-51c2 to start`, with the full short id, not `51c2`.

**The 58 tokens stay, and now say what they measure.** ADR-5dd7b4a9c875
settled it this week: the figure is the frontmatter -- the `name` and
`description` a session pays for whether or not the skill is invoked -- and
the body is read only when it is. `skill/SKILL.md` is 167 lines and 1408
words today, inside the 180/1500 ceiling, so nothing needed correcting
beyond saying what the number counts.

**The dogfooding claim was weaker than the truth.** Since ADR-5a690829388d
the specification is ten accepted `spec` entities in `.ank/`, reached only
through the CLI. That is the page's opening argument demonstrated on the
project's own normative text, and it was not claimed.

Verified: `cargo test --workspace` green (554 tests, 0 failed);
`ank check` exit 0, signals only.

Do not merge ahead of the sessions that dispatched this one -- the merge
order belongs to them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015eQfHwfPkKNxcUiX6jW9Yh
