### PR TITLE
A control character never reaches a log entry

### DIFF
--- a/.ank/entities/LOG-20be25f8d531.md
+++ b/.ank/entities/LOG-20be25f8d531.md
@@ -1,0 +1,16 @@
+---
+id: LOG-20be25f8d531
+type: log
+title: done, proof commit:8850fe318bb8cf04bdbbd90a42ff92e69f8ced5c
+created: 2026-08-15T23:15:19Z
+author: claude-code/f391
+scope:
+  - crates/ank-core/src/log.rs
+  - crates/ank-cli/src/commands.rs
+  - crates/ank-cli/tests/cli.rs
+  - crates/ank-cli/src/entries.rs
+about: TASK-f3910718320a
+seq: 6
+schema: 3
+version: 1
+---

--- a/.ank/entities/LOG-299bd19a6430.md
+++ b/.ank/entities/LOG-299bd19a6430.md
@@ -1,0 +1,18 @@
+---
+id: LOG-299bd19a6430
+type: log
+title: "the specification needs no revision before this code, and section 4 is why: it already states a"
+created: 2026-08-15T23:14:38Z
+author: claude-code/f391
+scope:
+  - crates/ank-core/src/log.rs
+  - crates/ank-cli/src/commands.rs
+  - crates/ank-cli/tests/cli.rs
+  - crates/ank-cli/src/entries.rs
+about: TASK-f3910718320a
+seq: 5
+schema: 3
+version: 1
+---
+
+ refusal of the same family -- an argument beginning with a dash and holding whitespace is refused and "the refusal names the escape" -- while the empty-message refusal it is modelled on appears in no spec document at all. Section 3 is untouched, and measurably so: an entry carrying a control character still parses, still round-trips byte for byte, and still passes check, so what a writer may store has not moved. What moved is what this CLI writes.

--- a/.ank/entities/LOG-4596e0b7190e.md
+++ b/.ank/entities/LOG-4596e0b7190e.md
@@ -1,0 +1,17 @@
+---
+id: LOG-4596e0b7190e
+type: log
+title: "falsification: log_refuses_a_message_carrying_a_control_character in crates/ank-cli/tests/cli.rs"
+created: 2026-08-15T22:56:58Z
+author: claude-code/f391
+scope:
+  - crates/ank-core/src/log.rs
+  - crates/ank-cli/src/commands.rs
+  - crates/ank-cli/tests/cli.rs
+about: TASK-f3910718320a
+seq: 0
+schema: 3
+version: 1
+---
+
+ fails against the tree as it stands -- "assertion left == right failed: left: 0, right: 1" at cli.rs:3781. ank log handed a message holding a lone carriage return exits 0 and writes the entry; nothing on the write side looks at the message beyond refusing it empty.

--- a/.ank/entities/LOG-6eeaaa9735df.md
+++ b/.ank/entities/LOG-6eeaaa9735df.md
@@ -1,0 +1,17 @@
+---
+id: LOG-6eeaaa9735df
+type: log
+title: "discrepancy: the criterion says \"a carriage return, or any other C0 control character\" and U+000A"
+created: 2026-08-15T22:57:23Z
+author: claude-code/f391
+scope:
+  - crates/ank-core/src/log.rs
+  - crates/ank-cli/src/commands.rs
+  - crates/ank-cli/tests/cli.rs
+about: TASK-f3910718320a
+seq: 1
+schema: 3
+version: 1
+---
+
+ is C0. Section 3 builds the log split on it -- the title is cut at the first newline, the remainder is the body between exactly one newline at each end, and the round-trip test in ank-core asserts a two-line message survives byte for byte. Refusing U+000A would refuse a message the format is written to store. Measured: the refusal covers U+0000 through U+001F except U+000A, which is what "no byte outside the grammar of section 3" actually names.

--- a/.ank/entities/LOG-888deebdf311.md
+++ b/.ank/entities/LOG-888deebdf311.md
@@ -1,0 +1,17 @@
+---
+id: LOG-888deebdf311
+type: log
+title: "scope: the criterion asks for the refusal \"at the one place a log entry is built, so every verb"
+created: 2026-08-15T22:57:37Z
+author: claude-code/f391
+scope:
+  - crates/ank-core/src/log.rs
+  - crates/ank-cli/src/commands.rs
+  - crates/ank-cli/tests/cli.rs
+about: TASK-f3910718320a
+seq: 3
+schema: 3
+version: 1
+---
+
+ that writes one is covered". That place is entries::record in crates/ank-cli/src/entries.rs -- log, done, release --reason and human all call it directly, and none of them goes through a funnel in commands.rs. The rule itself belongs in ank-core/src/log.rs, which is where the message and its split live; entries.rs is the one line that calls it. Adding crates/ank-cli/src/entries.rs to the scope with amend rather than reaching outside it silently.

--- a/.ank/entities/LOG-9d68d442569a.md
+++ b/.ank/entities/LOG-9d68d442569a.md
@@ -1,0 +1,17 @@
+---
+id: LOG-9d68d442569a
+type: log
+title: "discrepancy: the criterion asserts \".ank/log/<ID>.md unchanged\", which is the address"
+created: 2026-08-15T22:57:26Z
+author: claude-code/f391
+scope:
+  - crates/ank-core/src/log.rs
+  - crates/ank-cli/src/commands.rs
+  - crates/ank-cli/tests/cli.rs
+about: TASK-f3910718320a
+seq: 2
+schema: 3
+version: 1
+---
+
+ ADR-25f977377fa0 retired -- an entry is an entity in .ank/entities/LOG-<id>.md and this binary writes no .ank/log/ at all, so that clause is satisfied vacuously. The test asserts the fact the clause meant instead: the set of entries about the task is identical before and after the refused write, and the claim record is byte-identical, so nothing was written and no claim renewed.

--- a/.ank/entities/LOG-abff19b694b3.md
+++ b/.ank/entities/LOG-abff19b694b3.md
@@ -1,0 +1,16 @@
+---
+id: LOG-abff19b694b3
+type: log
+title: "amended: +scope crates/ank-cli/src/entries.rs"
+created: 2026-08-15T22:57:40Z
+author: claude-code/f391
+scope:
+  - crates/ank-core/src/log.rs
+  - crates/ank-cli/src/commands.rs
+  - crates/ank-cli/tests/cli.rs
+  - crates/ank-cli/src/entries.rs
+about: TASK-f3910718320a
+seq: 4
+schema: 3
+version: 1
+---

--- a/.ank/entities/TASK-f3910718320a.md
+++ b/.ank/entities/TASK-f3910718320a.md
@@ -5,17 +5,23 @@ slug: a-log-entry-the-cli-writes-never-carries-a-contr
 title: A log entry the CLI writes never carries a control character
 created: 2026-08-14T21:09:06Z
 author: claude-code/f113
-status: open
+status: done
 scope:
   - crates/ank-core/src/log.rs
   - crates/ank-cli/src/commands.rs
   - crates/ank-cli/tests/cli.rs
+  - crates/ank-cli/src/entries.rs
 blocked_by: []
 done_criteria: |
   A caller message carrying a carriage return, or any other C0 control character, does not reach a log file. It is refused at the one place a log entry is built, so every verb that writes one is covered, with exit code 1, nothing written, no claim renewed, and a message naming the character by its escape and the command to run again -- the empty-message refusal of ank log is the precedent and the wording follows it. Asserted through the binary in crates/ank-cli/tests/cli.rs: ank log with an embedded carriage return exits 1 and leaves .ank/log/<ID>.md unchanged, the same message without it logs, and the resulting file holds no byte outside the grammar of section 3.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 8850fe318bb8cf04bdbbd90a42ff92e69f8ced5c
+    criteria: 2f530832246e
+    via: submitted
 schema: 3
-version: 1
+version: 4
 ---
 
 Measured on TASK-f113addd8f40, and the pipeline is what found it. `ank log`

--- a/crates/ank-cli/src/commands.rs
+++ b/crates/ank-cli/src/commands.rs
@@ -2005,6 +2005,15 @@ pub fn release(inv: &Invocation, repo: &Repo, identity: &str, out: &mut dyn Writ
                 .with_hint("ank release --reason \"needs access to the staging Redis store\""))
         }
     };
+    // The same rule as the door every entry goes through, asked here because of
+    // the order this verb writes in (TASK-f3910718320a): the transition is
+    // written first and the entry after it, so a refusal at the door alone
+    // would leave a task handed back with nothing in the corpus saying why —
+    // which is the gap `--reason` exists to close. One rule, two doors, and the
+    // command to run again is this verb's.
+    if let Some(refusal) = entries::control_refusal(&reason, "ank release --reason") {
+        return Err(refusal);
+    }
 
     let store = Store::new(&repo.ank);
     let (id, _, _, warnings) = acting_on(

--- a/crates/ank-cli/src/entries.rs
+++ b/crates/ank-cli/src/entries.rs
@@ -30,9 +30,13 @@
 //! removing the file it read — is closed by dropping a previous-layout line
 //! that an entry already carries, byte for byte.
 
-use crate::cli::Result;
+use crate::cli::{CliError, Result};
 use crate::index::Index;
 use crate::store::Store;
+// Through the module rather than the crate root, which is where the rest of the
+// log lives: `ank_core::log` is public and documented as the log's home, and a
+// re-export is a line in a file this work has no other reason to open.
+use ank_core::log::control_character;
 use ank_core::{message_fields, Entity, EntityId, EntityKind, Log, LogEntry};
 
 /// One entry as a reader receives it: the line, and the entity that carries it.
@@ -135,6 +139,35 @@ pub fn next_seq(store: &Store, index: &Index, subject: &Entity) -> Result<u64> {
         .unwrap_or(0))
 }
 
+/// The refusal a caller message carrying a control character earns, or `None`
+/// when it carries none (TASK-f3910718320a).
+///
+/// **Worded once, so that every door says the same thing**, and the rule it
+/// asks is [`ank_core::log::control_character`]'s — one place decides what a
+/// message may hold and one place says so.
+///
+/// `verb` is the command to run again, which is the caller's and not this
+/// function's: `log` takes its message as a positional and `release` takes its
+/// reason on a flag, and §4 asks a refusal for the exact command rather than
+/// for generic help. Exit code 1, the code the empty-message refusal of `log`
+/// already answers with — this is the same door and the wording follows it.
+pub fn control_refusal(message: &str, verb: &str) -> Option<CliError> {
+    let (at, c) = control_character(message)?;
+    // The escape `char::escape_debug` prints is the one a reader who typed a
+    // backtick in PowerShell can recognise: `\r`, `\t`, `\u{1b}`. Naming the
+    // byte is the whole point of refusing instead of stripping.
+    let escape = c.escape_debug();
+    Some(
+        CliError::new(
+            1,
+            format!("a log entry cannot carry {escape} (character {at})"),
+        )
+        .with_hint(format!(
+            "{verb} \"<the same message, with no {escape} in it>\""
+        )),
+    )
+}
+
 /// Writes one entry about an entity, and returns the identifier it was given.
 ///
 /// **The scope is the subject's, copied at this moment** (§3). An entry appears
@@ -158,6 +191,15 @@ pub fn record(
     created: &str,
     message: &str,
 ) -> Result<EntityId> {
+    // **The one door, so every verb that writes an entry is covered**
+    // (TASK-f3910718320a). `log`, `done`, `release --reason` and the human
+    // verbs all record through this function and through nothing else, and a
+    // check written into one of them is a check the next verb would not have.
+    // Before the identifier and before the read of `seq`: a refusal writes
+    // nothing and reserves nothing.
+    if let Some(refusal) = control_refusal(message, "ank log") {
+        return Err(refusal);
+    }
     let line = LogEntry {
         timestamp: created.to_string(),
         who: identity.to_string(),

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -3749,6 +3749,102 @@ fn log_with_an_id_and_no_message_reads_and_asks_for_no_claim() {
     );
 }
 
+/// A control character a shell put in a message never reaches the corpus
+/// (TASK-f3910718320a).
+///
+/// Through the binary because that is where it was measured, and because no
+/// module test could have caught it: the message was correct when it was typed
+/// and wrong when it arrived. PowerShell reads a backtick as its escape
+/// character, so `` `rev-list `` inside a double-quoted argument became a
+/// carriage return followed by `ev-list` before `ank` saw an argument at all.
+/// `ank log` wrote it, `ank check` called the corpus healthy, and the line
+/// endings guard of the pipeline refused the branch on all three runners.
+///
+/// Refused rather than stripped: ank records what a caller states and does not
+/// silently delete bytes from a message somebody wrote, so the refusal names
+/// the character by its escape and gives the command to run again — the
+/// empty-message refusal above is the precedent and the wording follows it.
+#[test]
+fn log_refuses_a_message_carrying_a_control_character() {
+    let r = Repo::new();
+    r.seed_task(ID, Some("A verifiable criterion."));
+    assert_eq!(code(&r.ank("claude-code@ank", &["claim", ID])), 0);
+
+    let entries_before = r.entry_ids(ID);
+    let record_before = r.claim_ref(ID).expect("the claim is live");
+
+    // The message as it actually arrived, one line with a lone carriage return
+    // in the middle of it. Built rather than written literally, so that what is
+    // under test is legible in the source instead of hiding in an escape.
+    let mangled = format!("walked the corpus with git {}ev-list", '\r');
+    let out = r.ank("claude-code@ank", &["log", &mangled]);
+    assert_eq!(code(&out), 1, "{}", stderr(&out));
+    let said = stderr(&out);
+    assert!(
+        said.contains("\\r"),
+        "the character is named by its escape: {said}"
+    );
+    assert!(
+        said.contains("ank log \""),
+        "the command to run again, never generic help: {said}"
+    );
+    assert_eq!(r.entry_ids(ID), entries_before, "nothing was written");
+    assert_eq!(
+        r.claim_ref(ID).as_deref(),
+        Some(record_before.as_str()),
+        "a refused write renews no claim"
+    );
+
+    // The same message without it logs, so what is refused is the character and
+    // not the sentence.
+    let clean = "walked the corpus with git rev-list";
+    let out = r.ank("claude-code@ank", &["log", clean]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    assert!(r.log_text(ID).contains(clean), "{}", r.log_text(ID));
+
+    // And the file that landed holds no byte outside the grammar of §3: an
+    // entity is UTF-8, its lines end in a line feed, and nothing else below
+    // U+0020 belongs in one.
+    let written = r
+        .entry_ids(ID)
+        .into_iter()
+        .find(|id| !entries_before.contains(id))
+        .expect("the clean message produced an entry");
+    let bytes = std::fs::read(r.0.join(".ank/entities").join(format!("{written}.md"))).unwrap();
+    let stray: Vec<String> = bytes
+        .iter()
+        .filter(|b| **b < 0x20 && **b != b'\n')
+        .map(|b| format!("{b:#04x}"))
+        .collect();
+    assert!(stray.is_empty(), "control bytes in {written}.md: {stray:?}");
+
+    // The other door a caller's own text goes through, and the reason it is a
+    // second door rather than the same one: `release` writes the transition
+    // first and records the reason after it, so a refusal that came only at the
+    // entry would hand the task back with nothing in the corpus saying why —
+    // the gap `--reason` exists to close.
+    let out = r.ank("claude-code@ank", &["release", "--reason", &mangled]);
+    assert_eq!(code(&out), 1, "{}", stderr(&out));
+    let said = stderr(&out);
+    assert!(
+        said.contains("\\r"),
+        "the same wording at both doors: {said}"
+    );
+    assert!(
+        said.contains("ank release --reason \""),
+        "and this verb's own command to run again: {said}"
+    );
+    assert!(
+        r.task_text(ID).contains("status: in_progress"),
+        "the transition did not happen: {}",
+        r.task_text(ID)
+    );
+    assert!(
+        r.claim_ref(ID).is_some(),
+        "and the task was not handed back"
+    );
+}
+
 /// The disambiguation of §4, exercised on all three of its branches. It is
 /// stated rather than inferred precisely so that it can be asserted this way:
 /// one question — does the argument resolve — and one answer.

--- a/crates/ank-core/src/log.rs
+++ b/crates/ank-core/src/log.rs
@@ -135,6 +135,40 @@ pub fn message_of(title: &str, body: &str) -> String {
     }
 }
 
+/// The first control character a message carries and its position, counting
+/// from 1 — or `None` when it carries none.
+///
+/// **A control character is not content, and what it earns is a refusal rather
+/// than a repair.** Ank records what a caller states and does not edit it
+/// (ADR-6b3fa9ba3a05), so deleting bytes from a message somebody wrote is the
+/// worse of the two answers; but the byte was not typed either. Measured on
+/// TASK-f113addd8f40: PowerShell reads a backtick as its escape character, so
+/// `` `rev-list `` inside a double-quoted argument reached the binary as a
+/// carriage return followed by `ev-list`. The entry was written, the round-trip
+/// carried the byte back faithfully, `check` called the corpus healthy, and the
+/// line endings guard of the pipeline refused the branch on all three runners —
+/// the only reader that noticed was the one outside the tool. A lone carriage
+/// return is not CRLF either, so `.gitattributes` normalised nothing.
+///
+/// **A line feed is not one of them**, and that is [`split_message`] rather than
+/// an exception to this rule: a title is cut at the first newline and the
+/// remainder is the body, so a message of several lines is precisely what the
+/// format is written to store. Everything else in the Unicode `Cc` category is
+/// refused — the C0 range §3 names, and C1 with it, since YAML reads two of
+/// those as line breaks and a title carrying one would not come back the way it
+/// went in.
+///
+/// The position is part of the answer because a message is not always short:
+/// the reference corpus averages 453 characters an entry, and "somewhere in
+/// this message" is the diagnostic [`parse_log_file`] already refuses to give.
+pub fn control_character(message: &str) -> Option<(usize, char)> {
+    message
+        .chars()
+        .enumerate()
+        .find(|(_, c)| c.is_control() && *c != '\n')
+        .map(|(n, c)| (n + 1, c))
+}
+
 impl Log {
     /// The message, whole. `title` when it fitted on a line, and `title`
     /// followed by what the body carries when it did not.
@@ -396,6 +430,56 @@ mod tests {
         assert_eq!(body_remainder("\n rest\n"), Some(" rest"));
         assert_eq!(body_remainder("\n rest\n\n"), Some(" rest\n"));
         assert_eq!(body_remainder("no newlines"), None);
+    }
+
+    /// The character the format cannot hold is found, named where it sits, and
+    /// the one character §3 builds the split on is not one of them.
+    #[test]
+    fn a_control_character_is_found_and_a_line_feed_is_not_one() {
+        assert_eq!(
+            control_character("walked the corpus with git \rev-list"),
+            Some((28, '\r')),
+            "counted in characters from 1, and the carriage return is the 28th"
+        );
+        assert_eq!(control_character("a\tb"), Some((2, '\t')));
+        assert_eq!(control_character("a\u{0}b"), Some((2, '\0')));
+        assert_eq!(control_character("a\u{1b}[31m"), Some((2, '\u{1b}')));
+        assert_eq!(
+            control_character("é\u{85}"),
+            Some((2, '\u{85}')),
+            "C1 too, and the position counts characters and not bytes"
+        );
+
+        assert_eq!(control_character(""), None);
+        assert_eq!(
+            control_character("jwt.verify removed from session.ts"),
+            None
+        );
+        assert_eq!(
+            control_character("a line\nand another\n"),
+            None,
+            "the split rule is written on the line feed: it is not a stray byte"
+        );
+        assert_eq!(
+            control_character("unicode — accents é, an ellipsis …"),
+            None
+        );
+    }
+
+    /// Every message the round-trip contract is stated on is a message the rule
+    /// admits: the two would otherwise disagree about what may be stored, and
+    /// the one above is the one a caller meets first.
+    #[test]
+    fn the_rule_admits_every_message_the_round_trip_promises() {
+        for message in [
+            "short",
+            "",
+            " ",
+            "a line\nand another\n",
+            "discrepancy: the criterion assumes a premise the work then disproved",
+        ] {
+            assert_eq!(control_character(message), None, "{message:?}");
+        }
     }
 
     /// The rendered line is bounded whatever the message, and the elided one is


### PR DESCRIPTION
Closes TASK-f3910718320a.

## What it fixes

Measured on TASK-f113addd8f40, and the pipeline is what found it. PowerShell
reads a backtick as its escape character, so `` `rev-list `` inside a
double-quoted argument reached the binary as a carriage return followed by
`ev-list`. `ank log` wrote it, the round-trip carried the byte back faithfully,
`ank check` called the corpus healthy, and the line endings guard of `ci.yml`
refused the branch on all three runners. A lone carriage return is not CRLF, so
`.gitattributes` normalised nothing either: the only reader that noticed was the
one outside the tool.

## The decision

**Refused rather than stripped.** Ank records what a caller states and does not
edit it (ADR-6b3f19e08a24), so deleting bytes from a message somebody wrote is
the worse of the two answers; the byte was not typed either, so the refusal
names it by its escape and gives the command to run again. The empty-message
refusal of `log` is the precedent and the wording follows it, exit code 1
included.

```
$ ank log "walked the corpus with git `rev-list"
error[1]: a log entry cannot carry \r (character 28)
  -> ank log "<the same message, with no \r in it>"
```

`ank_core::log::control_character` is the rule, and it lives with the message it
governs. **A line feed is not one of them**, and that is the split rule rather
than an exception to it: a title is cut at the first newline and the remainder
is the body, so a message of several lines is precisely what the format is
written to store. Everything else in the Unicode `Cc` category is refused.

**Two doors ask it, one wording answers.** `entries::record` is the door every
verb that writes an entry goes through — `log`, `done`, `release --reason`, and
the human verbs — which is what makes this one check rather than one per verb.
`release` asks it a second time where it reads `--reason`, because that verb
writes the transition first and records the reason after it: a refusal at the
entry alone would hand a task back with nothing in the corpus saying why, which
is the gap `--reason` exists to close.

**Section 3 is untouched, and measurably so.** An entry carrying a control
character still parses, still round-trips byte for byte, and still passes
`check`, so what a writer may store has not moved — what moved is what this CLI
writes. Section 4 already states a refusal of the same family, on an argument
beginning with a dash and holding whitespace, and names the escape there too.
Nothing rewrites the entry already in the corpus.

## Verification

`log_refuses_a_message_carrying_a_control_character` in
`crates/ank-cli/tests/cli.rs`, through the binary, was written first and failed
against the tree — exit 0 where 1 was required, the entry written. It now
asserts the refusal, that the entries about the task and the claim record are
both byte-identical after it, that the same message without the carriage return
logs, that the entity file which lands carries no byte below U+0020 other than a
line feed, and that `release --reason` refuses without handing the task back.

- `cargo test --workspace`: 561 tests, 0 failed
- `ank check`: ok, 0 faults
- `cargo fmt --all --check`: clean

## Two recorded discrepancies

The criterion is frozen and untouched; both are `discrepancy:` entries on the
task.

- It says "a carriage return, or any other C0 control character", and U+000A is
  C0. Section 3 builds the log split on it, so refusing it would refuse a
  message the format exists to store. The refusal is C0 less the line feed.
- It asserts `.ank/log/<ID>.md` unchanged, an address ADR-25f977377fa0 retired.
  This binary writes no `.ank/log/` at all, so the clause is satisfied
  vacuously; the test asserts what it meant instead.

The task's scope gained `crates/ank-cli/src/entries.rs` through `ank amend`
rather than silently: that is the one door, and no funnel in `commands.rs`
stands in front of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHH2UZHRmWvAmbGXGDKiTf
