### PR TITLE
The variable reaches git with no shell in between, and the comment says so

### DIFF
--- a/.ank/entities/LOG-2259e1eed0b8.md
+++ b/.ank/entities/LOG-2259e1eed0b8.md
@@ -1,0 +1,15 @@
+---
+id: LOG-2259e1eed0b8
+type: log
+title: The failure the criterion describes is real, and it is the three-slash form that carries it.
+created: 2026-08-15T23:40:58Z
+author: claude-code/5052
+scope:
+  - crates/ank-cli/tests/cli.rs
+about: TASK-5052971b8e9c
+seq: 3
+schema: 3
+version: 1
+---
+
+ Measured by putting that form back into file_url() for the length of one pair of runs and taking it out again. With MSYS_NO_PATHCONV=1: both shallow-clone tests fail, and git prints "fatal: '/C:/Users/seanl/AppData/Local/Temp/ank-cli-it-27340-0' does not appear to be a git repository" for the URL "file:///C:/Users/seanl/AppData/Local/Temp/ank-cli-it-27340-0" -- git read the URL back as a path. With the variable unset, the same two tests pass in 5.44s. So the variable, and not the git version, is what moves the result, and the two-slash form on main is what makes the result not depend on it.

--- a/.ank/entities/LOG-3192083f0b56.md
+++ b/.ank/entities/LOG-3192083f0b56.md
@@ -1,0 +1,15 @@
+---
+id: LOG-3192083f0b56
+type: log
+title: "Measurement 2 of 2, same tree, same machine, MSYS_NO_PATHCONV unset (env -u): cargo test"
+created: 2026-08-15T23:39:46Z
+author: claude-code/5052
+scope:
+  - crates/ank-cli/tests/cli.rs
+about: TASK-5052971b8e9c
+seq: 1
+schema: 3
+version: 1
+---
+
+ --workspace exits 0. 287 / 213 / 15 / 18 / 28 / 0 passed, zero failed. The suite is green in both environments before any change of mine.

--- a/.ank/entities/LOG-435cbc900bf1.md
+++ b/.ank/entities/LOG-435cbc900bf1.md
@@ -1,0 +1,15 @@
+---
+id: LOG-435cbc900bf1
+type: log
+title: "Measurement 1 of 2, tree unmodified, Windows 11, git 2.54.0.windows.1, MSYS_NO_PATHCONV=1 exported:"
+created: 2026-08-15T23:39:36Z
+author: claude-code/5052
+scope:
+  - crates/ank-cli/tests/cli.rs
+about: TASK-5052971b8e9c
+seq: 0
+schema: 3
+version: 1
+---
+
+ cargo test --workspace exits 0. 287 passed / 213 passed / 15 passed / 18 passed / 28 passed / 0, zero failed in every target. This is the run the criterion expects to fail, and it does not.

--- a/.ank/entities/LOG-63970c873816.md
+++ b/.ank/entities/LOG-63970c873816.md
@@ -1,0 +1,15 @@
+---
+id: LOG-63970c873816
+type: log
+title: No shell stands between the harness and git, and the variable reaches git anyway. The suite spawns
+created: 2026-08-15T23:41:09Z
+author: claude-code/5052
+scope:
+  - crates/ank-cli/tests/cli.rs
+about: TASK-5052971b8e9c
+seq: 4
+schema: 3
+version: 1
+---
+
+ git with Command::new("git") -- spawn() at crates/ank-cli/tests/cli.rs sets two env vars and nothing else, no cmd.exe, no sh. The falsification above ran through that path, so git.exe reads MSYS_NO_PATHCONV itself rather than a shell rewriting the argument before git sees it. That is the half a reader is most likely to get wrong: a test harness using Command is not immune, and it is the sentence fix/clone-url-msys-pathconv holds that the merged comment did not.

--- a/.ank/entities/LOG-6d0c9f7b7954.md
+++ b/.ank/entities/LOG-6d0c9f7b7954.md
@@ -1,0 +1,15 @@
+---
+id: LOG-6d0c9f7b7954
+type: log
+title: "Both runs repeated on the tree as it now stands, comment included. MSYS_NO_PATHCONV=1: exit 0, 287"
+created: 2026-08-15T23:57:58Z
+author: claude-code/5052
+scope:
+  - crates/ank-cli/tests/cli.rs
+about: TASK-5052971b8e9c
+seq: 6
+schema: 3
+version: 1
+---
+
+ / 213 / 15 / 18 / 28 / 0 passed, zero failed. MSYS_NO_PATHCONV unset: exit 0, the same six counts, zero failed. cargo fmt --check is clean. The suite is green in both environments before and after the change, which is what the two-slash form is for.

--- a/.ank/entities/LOG-7028ad1c473f.md
+++ b/.ank/entities/LOG-7028ad1c473f.md
@@ -1,0 +1,13 @@
+---
+id: LOG-7028ad1c473f
+type: log
+title: done, proof commit:58ae6470e9f0904325a810f3a3bc8c06bbb88317
+created: 2026-08-15T23:59:28Z
+author: claude-code/5052
+scope:
+  - crates/ank-cli/tests/cli.rs
+about: TASK-5052971b8e9c
+seq: 7
+schema: 3
+version: 1
+---

--- a/.ank/entities/LOG-a9400f5afab8.md
+++ b/.ank/entities/LOG-a9400f5afab8.md
@@ -1,0 +1,15 @@
+---
+id: LOG-a9400f5afab8
+type: log
+title: The spawn sweep reads prose as well as code, and my first draft of the comment tripped it.
+created: 2026-08-15T23:47:13Z
+author: claude-code/5052
+scope:
+  - crates/ank-cli/tests/cli.rs
+about: TASK-5052971b8e9c
+seq: 5
+schema: 3
+version: 1
+---
+
+ nothing_spawns_a_process_outside_the_one_door counts the literal needle in include_str!("cli.rs"), so naming the constructor inside a doc comment made the count 2 and failed the assertion, with no second spawn site anywhere. Rephrased to name git_command and spawn instead of the constructor. Worth knowing before writing about spawning in this file: the sweep cannot tell a comment from a call, and that is the price of a needle it assembles so it never matches itself.

--- a/.ank/entities/LOG-ce54ee81a7da.md
+++ b/.ank/entities/LOG-ce54ee81a7da.md
@@ -1,0 +1,15 @@
+---
+id: LOG-ce54ee81a7da
+type: log
+title: "discrepancy: the criterion assumes the current helper builds file:/// and strips the path's leading"
+created: 2026-08-15T23:39:57Z
+author: claude-code/5052
+scope:
+  - crates/ank-cli/tests/cli.rs
+about: TASK-5052971b8e9c
+seq: 2
+schema: 3
+version: 1
+---
+
+ slash, and that a run with MSYS_NO_PATHCONV set fails against it. Measured: origin/main already builds the two-slash form. crates/ank-cli/tests/cli.rs carries a file_url() helper, one line, format!("file://{}", path.replace('\', "/")), landed by TASK-143a310de8b6 with an argument longer than the one on fix/clone-url-msys-pathconv. Both runs above are green, so there is no failure to put on record against the tree as it stands. The rest of the criterion is finished: the form is argued where the helper builds it, and what fix/clone-url-msys-pathconv still holds that the merged comment does not is carried over.

--- a/.ank/entities/TASK-5052971b8e9c.md
+++ b/.ank/entities/TASK-5052971b8e9c.md
@@ -5,7 +5,7 @@ slug: clone-of-builds-a-file-url-git-refuses-once-msys
 title: clone_of builds a file:// URL git refuses once MSYS_NO_PATHCONV is set
 created: 2026-08-15T20:56:17Z
 author: claude-code/opus-5
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/tests/cli.rs
 blocked_by: []
@@ -13,7 +13,7 @@ done_criteria: |
   The clone helper in crates/ank-cli/tests/cli.rs builds a URL git accepts whether MSYS_NO_PATHCONV is set or not. cargo test --workspace passes on Windows in both environments, run twice and both runs recorded in the task's log with what they printed; the run with the variable set is the one that fails against the current helper. The form chosen is argued where the helper builds it, so the next reader does not rediscover the cause. ank check stays green.
 criteria_by: creator
 schema: 3
-version: 1
+version: 2
 ---
 
 Recovered from `fix/clone-url-msys-pathconv`, a local branch carrying a measured

--- a/.ank/entities/TASK-5052971b8e9c.md
+++ b/.ank/entities/TASK-5052971b8e9c.md
@@ -5,15 +5,20 @@ slug: clone-of-builds-a-file-url-git-refuses-once-msys
 title: clone_of builds a file:// URL git refuses once MSYS_NO_PATHCONV is set
 created: 2026-08-15T20:56:17Z
 author: claude-code/opus-5
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/tests/cli.rs
 blocked_by: []
 done_criteria: |
   The clone helper in crates/ank-cli/tests/cli.rs builds a URL git accepts whether MSYS_NO_PATHCONV is set or not. cargo test --workspace passes on Windows in both environments, run twice and both runs recorded in the task's log with what they printed; the run with the variable set is the one that fails against the current helper. The form chosen is argued where the helper builds it, so the next reader does not rediscover the cause. ank check stays green.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 58ae6470e9f0904325a810f3a3bc8c06bbb88317
+    criteria: 4f2f9f5ce598
+    via: submitted
 schema: 3
-version: 2
+version: 3
 ---
 
 Recovered from `fix/clone-url-msys-pathconv`, a local branch carrying a measured

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -10975,6 +10975,15 @@ fn a_glob_is_explained_only_when_its_prefix_moved_to_one_place() {
 /// environment an agent's shell happens to export, which is how two sessions
 /// reported this test red while a third watched it pass (TASK-143a310de8b6).
 ///
+/// **No shell is needed for the variable to reach git**, which is the half of
+/// the cause a reader is most likely to reason away: `git_command` builds a
+/// bare `Command` through `spawn`, with no interpreter in between, so an
+/// argument nothing rewrote still comes out refused. `git.exe` reads
+/// `MSYS_NO_PATHCONV` itself. Measured against a three-slash form put back for
+/// one pair of runs (TASK-5052971b8e9c): with the variable set both
+/// shallow-clone tests fail on `fatal: '/C:/...' does not appear to be a git
+/// repository`, and with it unset the same two pass.
+///
 /// **One function and not one expression per caller**, because that measurement
 /// is the whole of what makes it right: a second site deriving the URL again is
 /// a second chance to write the three-slash form back in.


### PR DESCRIPTION
TASK-5052971b8e9c. Scope: `crates/ank-cli/tests/cli.rs`.

## What was measured before anything was touched

The criterion asks for the suite on Windows twice, with `MSYS_NO_PATHCONV` set and unset, and expects the run with the variable set to fail. It does not. Windows 11, git 2.54.0.windows.1:

| run | `MSYS_NO_PATHCONV` | result |
| --- | --- | --- |
| 1 | `=1` | exit 0 — 287 / 213 / 15 / 18 / 28 / 0 passed, zero failed |
| 2 | unset | exit 0 — same six counts, zero failed |

Both are on the task's log, and so is the discrepancy: `origin/main` already builds the two-slash form through `file_url()`, landed by TASK-143a310de8b6 with an argument longer than the one on `fix/clone-url-msys-pathconv`. There was no failure left to put on record against the tree as it stands.

## The failure is real, and one sentence about it was missing

Putting the three-slash form back into `file_url()` for the length of one pair of runs, then taking it out again:

- with the variable set, both shallow-clone tests fail — `fatal: '/C:/Users/.../ank-cli-it-27340-0' does not appear to be a git repository` for the URL `file:///C:/Users/.../ank-cli-it-27340-0`, git having read the URL back as a path;
- with it unset, the same two pass in 5.44s.

That ran through a git this suite spawns with no interpreter in between, so `git.exe` reads `MSYS_NO_PATHCONV` itself and a harness that never goes near a shell is not immune. That is the half a reader reasons away, it is what `fix/clone-url-msys-pathconv` held and the merged comment did not, and it is now beside the helper. **The URL the helper builds is unchanged — this is a comment.**

## Green

Repeated on the tree as it stands: `cargo test --workspace` exits 0 with the variable set and with it unset, `cargo fmt --check` is clean, `ank check` reports `ok`.

Proof: `commit:58ae6470e9f0904325a810f3a3bc8c06bbb88317`.

One aside worth the next reader's time, logged: `nothing_spawns_a_process_outside_the_one_door` sweeps `include_str!("cli.rs")` for its needle, so naming the constructor inside a doc comment fails it with no second spawn site anywhere. The comment names `git_command` and `spawn` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W38SnuRhatTB3b7xPvy78b
