### PR TITLE
The release matrix builds Intel macOS, on an Intel runner

### DIFF
--- a/.ank/entities/LOG-4d8d16fcc2b4.md
+++ b/.ank/entities/LOG-4d8d16fcc2b4.md
@@ -1,0 +1,13 @@
+---
+id: LOG-4d8d16fcc2b4
+type: log
+title: done, proof commit:eeab1998d15e62ae29f66aa39086e40bd924ea1e
+created: 2026-08-16T04:27:04Z
+author: claude-code/054f
+scope:
+  - .github/workflows/release.yml
+about: TASK-054fd964221f
+seq: 2
+schema: 3
+version: 1
+---

--- a/.ank/entities/LOG-a00f1bf64922.md
+++ b/.ank/entities/LOG-a00f1bf64922.md
@@ -1,0 +1,15 @@
+---
+id: LOG-a00f1bf64922
+type: log
+title: The Intel row cannot take a -latest label, and cannot take the arm64 runner either. macos-13 was
+created: 2026-08-16T04:07:46Z
+author: claude-code/054f
+scope:
+  - .github/workflows/release.yml
+about: TASK-054fd964221f
+seq: 0
+schema: 3
+version: 1
+---
+
+ the last Intel -latest and GitHub retired it on 2025-12-04, so the choice was between cross-compiling x86_64-apple-darwin on macos-latest (arm64) and pinning an Intel image. Cross-compiling would build a binary no step in this job could run, and the test step is why the row exists: the matrix tests before it packages. So the row is macos-15-intel, the standard Intel image GitHub published as the migration path, documented as available until August 2027 when x86_64 leaves Actions entirely. That end date is a property of the row and is written in the comment beside it.

--- a/.ank/entities/LOG-a59e00ce8a0c.md
+++ b/.ank/entities/LOG-a59e00ce8a0c.md
@@ -1,0 +1,15 @@
+---
+id: LOG-a59e00ce8a0c
+type: log
+title: "discrepancy: the criterion asks that a tagged release publish the archive and its .sha256 alongside"
+created: 2026-08-16T04:08:03Z
+author: claude-code/054f
+scope:
+  - .github/workflows/release.yml
+about: TASK-054fd964221f
+seq: 1
+schema: 3
+version: 1
+---
+
+ the others, and that clause is not observable from this branch. Tagging publishes to npm and creates a public release, so I did not run it and no proof of the archive existing can come from here. What I did verify: the workflow parses, the build matrix carries four rows with one key set (os, target, archive) and unique values on each, the new row is x86_64-apple-darwin with archive tar.gz, so the packaging step takes its else branch and copies target/x86_64-apple-darwin/release/ank, tars it and writes the .sha256 exactly as the two other tar.gz rows do. The upload artefact name is the target, which stays unique, and the publish job globs dist/*.tar.gz and dist/*.sha256 after a merged download, so the new files travel with the rest. The version job is untouched and npm-smoke keeps its three rows: npm-assemble.sh matches artefacts by target substring, and x86_64-apple-darwin matches none of the three package names, so nothing it downloads changes. The end-to-end proof of the archive is a release, and only a release.

--- a/.ank/entities/TASK-054fd964221f.md
+++ b/.ank/entities/TASK-054fd964221f.md
@@ -5,15 +5,20 @@ slug: the-release-builds-an-intel-mac-binary
 title: The release builds an Intel Mac binary
 created: 2026-08-16T03:34:51Z
 author: claude-code/opus-5
-status: in_progress
+status: done
 scope:
   - .github/workflows/release.yml
 blocked_by: []
 done_criteria: |
   The release matrix builds, tests and packages x86_64-apple-darwin beside the three targets it already carries, and a tagged release publishes its archive and .sha256 alongside the others. The version job's checks are unchanged and the npm smoke job still passes on the targets it covers. cargo test --workspace and ank check stay green.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: eeab1998d15e62ae29f66aa39086e40bd924ea1e
+    criteria: 6c10c5dc1a6d
+    via: submitted
 schema: 3
-version: 2
+version: 3
 ---
 
 Every macOS channel below rests on a binary that does not exist. The matrix

--- a/.ank/entities/TASK-054fd964221f.md
+++ b/.ank/entities/TASK-054fd964221f.md
@@ -5,7 +5,7 @@ slug: the-release-builds-an-intel-mac-binary
 title: The release builds an Intel Mac binary
 created: 2026-08-16T03:34:51Z
 author: claude-code/opus-5
-status: open
+status: in_progress
 scope:
   - .github/workflows/release.yml
 blocked_by: []
@@ -13,7 +13,7 @@ done_criteria: |
   The release matrix builds, tests and packages x86_64-apple-darwin beside the three targets it already carries, and a tagged release publishes its archive and .sha256 alongside the others. The version job's checks are unchanged and the npm smoke job still passes on the targets it covers. cargo test --workspace and ank check stay green.
 criteria_by: creator
 schema: 3
-version: 1
+version: 2
 ---
 
 Every macOS channel below rests on a binary that does not exist. The matrix

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ name: release
 # produced from a branch would make "the binary for v0.1.0" a question rather
 # than an answer.
 #
-# `workflow_dispatch` builds the same three binaries and publishes nothing. The
+# `workflow_dispatch` builds the same four binaries and publishes nothing. The
 # alternative is discovering that the release pipeline is broken at the moment
 # you use it, on a tag you then have to delete -- and a tag is the one thing
 # here that is awkward to take back.
@@ -80,6 +80,23 @@ jobs:
           - os: macos-latest
             target: aarch64-apple-darwin
             archive: tar.gz
+          # An Intel runner, not `--target x86_64-apple-darwin` on the arm64
+          # one: this job tests before it packages, and a cross-compiled binary
+          # gets tested either not at all or through a translation layer nobody
+          # downloading it is running. Half the Mac install base is what the row
+          # is for, and a row that only linked would ship exactly the untested
+          # file the test step below refuses to call a release.
+          #
+          # The label is version-pinned where its siblings are `-latest`
+          # because there is no Intel `-latest` to take: `macos-13` was the
+          # last one and was retired in December 2025. `macos-15-intel` is the
+          # standard image GitHub named as its replacement, and the last x86_64
+          # image Actions will offer -- it goes away in August 2027, and this
+          # row goes with it rather than quietly moving to another arm64
+          # runner.
+          - os: macos-15-intel
+            target: x86_64-apple-darwin
+            archive: tar.gz
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             archive: zip
@@ -103,7 +120,7 @@ jobs:
           sudo apt-get install -y musl-tools
           rustup target add x86_64-unknown-linux-musl
 
-      # The criterion asks for the suite on all three, not only for a build
+      # The criterion asks for the suite on every target, not only for a build
       # that links. A binary nobody tested is not a release, it is a file.
       - name: test
         run: cargo test --workspace --target ${{ matrix.target }}
@@ -393,7 +410,7 @@ jobs:
           done
 
   publish:
-    # Only after all three. A release carrying two platforms out of three would
+    # Only after every row. A release carrying three targets out of four would
     # be worse than no release: it looks complete.
     #
     # `build` and not `npm-smoke`, deliberately: the release page is the primary


### PR DESCRIPTION
Closes TASK-054fd964221f.

## What changed

One row in the `build` matrix of `.github/workflows/release.yml`:

```yaml
- os: macos-15-intel
  target: x86_64-apple-darwin
  archive: tar.gz
```

It supplies exactly what its three siblings supply -- `os`, `target`,
`archive` -- and nothing else, so every step downstream already handles it:
the packaging step takes the `tar.gz` branch, copies
`target/x86_64-apple-darwin/release/ank`, tars it and writes the `.sha256`;
the artefact is named for the target and stays unique; the `publish` job's
`dist/*.tar.gz` and `dist/*.sha256` globs pick up the new files after the
merged download.

Three comments that counted to three now count to four. The `version` job is
untouched, and so is the `npm-smoke` matrix: `npm-assemble.sh` finds artefacts
by target substring, and `x86_64-apple-darwin` matches none of the three npm
package names, so the npm channel sees no change at all.

## Why macos-15-intel and not a -latest label

There is no Intel `-latest` left to take. `macos-13` was the last one and
GitHub retired it on 2025-12-04. `macos-15-intel` is the standard Intel image
GitHub published as the migration path; it is the last x86_64 image Actions
will offer and it goes away in August 2027. That end date is written in the
comment beside the row, so the row's expiry is discoverable where the row is.

The alternative -- `--target x86_64-apple-darwin` on the arm64 `macos-latest`
-- was rejected. This job tests before it packages, and a cross-compiled
binary gets tested either not at all or through a translation layer nobody
downloading it is running.

## What is verified, and what is not

Verified here: the workflow parses; the matrix carries four rows with one key
set and unique values on `os` and `target` (so the four job names and the four
artefact names stay distinct); the new target is the right triple; the
packaging branch handles it; `cargo test --workspace` and `ank check` are
green.

**Not verified here, and deliberately so:** the criterion also says a tagged
release publishes the archive and its `.sha256`. Tagging publishes to npm and
creates a public release, so it was not run and no proof of the archive
existing can come from this branch. That gap is recorded as a discrepancy
against the frozen criterion (`ank show TASK-054fd964221f`), which `ank check`
names. A `workflow_dispatch` run on this branch would exercise the matrix
without publishing anything, and is the cheapest way to see the row build
before a tag depends on it.

## Noticed, out of scope

`docs/agents.md:110` still says every release carries a static binary for
three targets and names them. It will be wrong once this merges. It is outside
this task's scope (`.github/workflows/release.yml`) and inside the perimeter of
the install-script and Homebrew tasks this one unblocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GLMaNqtKGEotzHiNeg4b9o
