### PR TITLE
This repository is its own Homebrew tap

### DIFF
--- a/.ank/entities/LOG-a3778e46df14.md
+++ b/.ank/entities/LOG-a3778e46df14.md
@@ -1,0 +1,17 @@
+---
+id: LOG-a3778e46df14
+type: log
+title: "what a pull request can and cannot prove here. Proved locally: the .sha256 asset of the linux-musl"
+created: 2026-08-16T05:18:20Z
+author: claude-code/7498
+scope:
+  - Formula/ank.rb
+  - .github/workflows/publish-brew.yml
+  - .github/scripts/brew-formula.sh
+about: TASK-7498998a8514
+seq: 2
+schema: 3
+version: 1
+---
+
+ archive matches sha256sum over the archive bytes themselves, and the formula carries that number, so the read-never-typed chain is verified end to end rather than asserted; the archive wraps one directory holding ank, README.md, SKILL.md and LICENSE, which is what makes bin.install/doc.install/pkgshare.install resolve after Homebrew stages; the derivation is deterministic across runs and the committed formula equals it, which is the assertion job's check run by hand; --require-all refuses v0.2.0 and writes no file, a version with no release exits 1, a missing version and an unknown flag exit 2; and a stubbed four-archive release renders both macOS blocks with correct Ruby nesting, which is the release path no live release can exercise yet. Not provable from a pull request: brew tap, brew install and ank --version on an Intel Mac, because no published release carries the archive -- the arm64 row does run the full loop on macos-latest, and the Intel row reports the gap into the step summary rather than skipping quietly. Also not provable here: the release half of the workflow, which needs a published release; the same limit TASK-054fd964221f recorded. One defect this found and fixed: the coverage grep matched the triple anywhere in the file, so it read the comment naming the missing archive as the block it apologises for, and would have installed a URL that is not there -- it matches the url line now.

--- a/.ank/entities/LOG-a60ab3397439.md
+++ b/.ank/entities/LOG-a60ab3397439.md
@@ -1,0 +1,15 @@
+---
+id: LOG-a60ab3397439
+type: log
+title: done, proof commit:d3d097326c5133ddc6b6d6e796ca659e3088ebe2
+created: 2026-08-16T05:19:19Z
+author: claude-code/7498
+scope:
+  - Formula/ank.rb
+  - .github/workflows/publish-brew.yml
+  - .github/scripts/brew-formula.sh
+about: TASK-7498998a8514
+seq: 3
+schema: 3
+version: 1
+---

--- a/.ank/entities/LOG-ab349ec15e77.md
+++ b/.ank/entities/LOG-ab349ec15e77.md
@@ -1,0 +1,17 @@
+---
+id: LOG-ab349ec15e77
+type: log
+title: "discrepancy: the criterion assumes a release the formula can cover for both macOS architectures."
+created: 2026-08-16T04:48:21Z
+author: claude-code/7498
+scope:
+  - Formula/ank.rb
+  - .github/workflows/publish-brew.yml
+  - .github/scripts/brew-formula.sh
+about: TASK-7498998a8514
+seq: 1
+schema: 3
+version: 1
+---
+
+ Measured: the Intel row landed in release.yml on 2026-08-15T21:24Z, four days after v0.2.0 was cut on 2026-08-11T23:42Z, and no published release carries an x86_64-apple-darwin archive -- v0.2.0, v0.1.3 and v0.1.2 all return zero assets matching it. The matrix builds four targets; no tag has been spent on that matrix yet. So the derivation covers three targets and requires all three at release time, while the formula committed today is derived from v0.2.0 and carries the two archives v0.2.0 actually published. The Intel branch appears on the first tag cut from the current matrix, with no edit to the formula, the script or the workflow.

--- a/.ank/entities/TASK-7498998a8514.md
+++ b/.ank/entities/TASK-7498998a8514.md
@@ -5,7 +5,7 @@ slug: this-repository-is-its-own-homebrew-tap
 title: This repository is its own Homebrew tap
 created: 2026-08-16T03:35:18Z
 author: claude-code/opus-5
-status: open
+status: done
 scope:
   - Formula/ank.rb
   - .github/workflows/publish-brew.yml
@@ -14,8 +14,13 @@ blocked_by: [TASK-054fd964221f]
 done_criteria: |
   Formula/ank.rb installs the released binary for both macOS architectures and for Linux, with the sha256 of each archive taken from the .sha256 the release publishes rather than typed. A workflow triggered on a published release rewrites the formula for the new version and commits it to the default branch. A CI job on macOS runs brew tap against this repository's URL, brew install ank, and asserts ank --version prints the released version. cargo test --workspace and ank check stay green.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: d3d097326c5133ddc6b6d6e796ca659e3088ebe2
+    criteria: 1a31ca3e698b
+    via: submitted
 schema: 3
-version: 2
+version: 4
 ---
 
 **A tap and not homebrew-core, and the reason is measured.** Homebrew's

--- a/.github/scripts/brew-formula.sh
+++ b/.github/scripts/brew-formula.sh
@@ -1,0 +1,317 @@
+#!/usr/bin/env bash
+#
+# Renders Formula/ank.rb from a published GitHub release.
+#
+#   brew-formula.sh <version> [output] [--require-all]
+#
+# This repository is its own Homebrew tap: `brew tap <user>/<name> <url>` takes
+# an arbitrary URL, so Formula/ank.rb in this tree is a working tap and no
+# satellite repository exists to keep in step (ADR-782a3556cf2d, carrying
+# ADR-e3cb36646d77 forward).
+#
+# Formula/ank.rb is therefore a derived file that happens to be committed, and
+# the design of publish-brew.yml follows from that: the derivation lives here,
+# a release runs it and commits the result, and every other run runs it and
+# asserts the committed file is exactly what it produced. A hand edit turns
+# that job red rather than failing on somebody's machine.
+#
+# **The hash is read, never typed.** Every archive on the release page carries a
+# `.sha256` beside it, and that asset is the only source of the numbers below. A
+# constant written here is a constant that goes stale one tag later, and it is
+# the one defect in a formula that shows up nowhere except on the machine of
+# whoever runs the install: `brew install` verifies the checksum itself, so a
+# wrong number is a failed download reported by a user rather than a red job.
+#
+# `--require-all` refuses a release missing any archive the formula covers, and
+# publish-brew.yml passes it on a release event and nowhere else. The asymmetry
+# is the decision. A tag cut from today's matrix builds all four targets, so at
+# release time a missing archive is a broken release and never a fact about the
+# formula. Between releases the last release is whatever it was, and it is not
+# this script's business to wish otherwise: v0.2.0 was cut on 2026-08-11, the
+# Intel macOS row landed in release.yml on 2026-08-15, and a formula that
+# pointed at an x86_64 archive v0.2.0 never published would 404 on the user's
+# machine. A branch omitted is a branch a user can read; a branch pointing at
+# nothing is the failure this formula was written to avoid.
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+usage: brew-formula.sh <version> [output] [--require-all]
+
+  <version>       the released version, without the leading v (e.g. 0.2.0)
+  [output]        where to write the formula (default: Formula/ank.rb)
+  --require-all   fail if the release is missing any archive the formula covers
+
+Reads each sha256 from the .sha256 asset the release publishes. Needs `gh`
+authenticated against the repository; GH_REPO overrides which one.
+USAGE
+}
+
+require_all=0
+positional=()
+for arg in "$@"; do
+  case "$arg" in
+    --require-all) require_all=1 ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    -*)
+      echo "brew-formula.sh: unknown flag '$arg'" >&2
+      usage >&2
+      exit 2
+      ;;
+    *) positional+=("$arg") ;;
+  esac
+done
+
+# `${positional[0]:-}` and not `"${positional[@]}"`: this also runs on the macOS
+# runner's bash 3.2, where expanding an empty array under `set -u` is an error.
+version="${positional[0]:-}"
+output="${positional[1]:-Formula/ank.rb}"
+
+if [ -z "$version" ]; then
+  echo "brew-formula.sh: no version given." >&2
+  usage >&2
+  exit 2
+fi
+version="${version#v}"
+
+repo="${GH_REPO:-haksolot/ank}"
+server="${GITHUB_SERVER_URL:-https://github.com}"
+repo_url="${server}/${repo}"
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+# The directory handed to `gh` is not always the directory handed to `cut`.
+# Under Git Bash on Windows, gh.exe is a native binary, so MSYS rewrites the
+# POSIX path it is given -- and gets it wrong here: `gh release download`
+# reports success having written the asset somewhere this script never looks,
+# which reads exactly like an asset the release did not carry. That is the one
+# failure this script must never confuse with a fact about the release, so the
+# spelling is asked for rather than assumed. cygpath exists only where the
+# question does.
+gh_tmp="$tmp"
+if command -v cygpath >/dev/null 2>&1; then
+  gh_tmp=$(cygpath -w "$tmp")
+fi
+
+# hash_for <archive-with-extension>
+#
+# Prints the sha256 and returns 0. Prints nothing and returns 0 for an archive
+# the release did not carry, so the caller decides whether absence is a fact or
+# a failure. Returns 1 for everything else, and a caller that ignores that is a
+# caller writing a formula out of an error message.
+#
+# Anything that came back and is not a sha256 is always a failure: a truncated
+# download, an HTML error page saved to disk, or a checksum file that changed
+# shape would each yield a formula Homebrew reports as a mismatched download
+# rather than as a broken formula.
+hash_for() {
+  local archive="$1" hash
+
+  if ! gh release download "v${version}" \
+    --repo "$repo" \
+    --pattern "${archive}.sha256" \
+    --dir "$gh_tmp" \
+    --clobber >/dev/null 2>&1; then
+    # A release that is not there at all is not the same fact as an archive a
+    # release did not carry, and only the second one is ever tolerated.
+    if ! gh release view "v${version}" --repo "$repo" >/dev/null 2>&1; then
+      echo "brew-formula.sh: ${repo} has no release v${version}." >&2
+      echo "  a formula is derived from a tag: cut it, or pass a version that has one." >&2
+      return 1
+    fi
+    return 0
+  fi
+
+  # `sha256sum` wrote the line, so it is "<hash>  <name>" and the hash is the
+  # first space-separated field in either of its two output modes.
+  hash=$(cut -d' ' -f1 <"${tmp}/${archive}.sha256")
+  if ! printf '%s' "$hash" | grep -Eq '^[0-9a-f]{64}$'; then
+    echo "brew-formula.sh: the .sha256 asset of ${archive} did not yield a sha256: '${hash}'" >&2
+    echo "  check the asset at ${repo_url}/releases/tag/v${version}" >&2
+    return 1
+  fi
+  printf '%s' "$hash"
+}
+
+# The three archives the formula covers. Windows is a release target too and is
+# deliberately not one of them: Homebrew does not install there, and the Scoop
+# bucket is that channel.
+darwin_arm_archive="ank-${version}-aarch64-apple-darwin.tar.gz"
+darwin_intel_archive="ank-${version}-x86_64-apple-darwin.tar.gz"
+linux_intel_archive="ank-${version}-x86_64-unknown-linux-musl.tar.gz"
+
+echo "deriving the formula for ${version} from ${repo_url}" >&2
+
+# `|| exit 1` rather than leaning on `set -e`: a failing command substitution
+# does trip it, but the mechanism is subtle enough that a later edit could
+# quietly turn a hard failure into an empty string, which is the one value this
+# script treats as normal.
+darwin_arm_sha=$(hash_for "$darwin_arm_archive") || exit 1
+darwin_intel_sha=$(hash_for "$darwin_intel_archive") || exit 1
+linux_intel_sha=$(hash_for "$linux_intel_archive") || exit 1
+
+missing=()
+if [ -z "$darwin_arm_sha" ]; then missing+=("$darwin_arm_archive"); fi
+if [ -z "$darwin_intel_sha" ]; then missing+=("$darwin_intel_archive"); fi
+if [ -z "$linux_intel_sha" ]; then missing+=("$linux_intel_archive"); fi
+
+if [ "${#missing[@]}" -gt 0 ]; then
+  echo "v${version} carries no archive for:" >&2
+  for m in "${missing[@]}"; do echo "  $m" >&2; done
+  if [ "$require_all" -eq 1 ]; then
+    echo >&2
+    echo "a release builds every row of the matrix in .github/workflows/release.yml," >&2
+    echo "so an archive missing from a release is a broken release and not a formula" >&2
+    echo "this script may narrow. read the build jobs of the release run for v${version}." >&2
+    exit 1
+  fi
+  echo "  omitted from the formula rather than pointed at: a URL that 404s fails" >&2
+  echo "  on the user's machine, where nothing here can see it." >&2
+fi
+
+# A formula with no url at all is not a formula, and the diagnostic Homebrew
+# prints for one is worse than saying so here.
+if [ "${#missing[@]}" -eq 3 ]; then
+  echo "brew-formula.sh: v${version} carries none of the archives the formula covers." >&2
+  echo "  there is nothing to install from: read ${repo_url}/releases/tag/v${version}" >&2
+  exit 1
+fi
+
+# The note is part of the derived file on purpose. `brew cat` is where a user
+# lands after an install that found nothing for their machine, and a sentence
+# naming the release is the answer to the question they arrived with.
+coverage_note=""
+if [ "${#missing[@]}" -gt 0 ]; then
+  coverage_note="
+#
+# v${version} published no archive for:"
+  for m in "${missing[@]}"; do
+    coverage_note="${coverage_note}
+#   ${m}"
+  done
+  coverage_note="${coverage_note}
+# so this formula carries no block for it. That is a row of the release matrix
+# and not a decision here: the first tag cut with that row restores the block,
+# derived, with no edit to this file or to the script that writes it."
+fi
+
+# platform_block <indent> <archive> <sha>
+#
+# Empty for an archive the release did not carry, which leaves the omission
+# visible in the diff rather than buried inside a conditional.
+platform_block() {
+  local indent="$1" archive="$2" sha="$3"
+  if [ -z "$sha" ]; then
+    return 0
+  fi
+  printf '%surl "%s/releases/download/v%s/%s"\n' "$indent" "$repo_url" "$version" "$archive"
+  printf '%ssha256 "%s"' "$indent" "$sha"
+}
+
+macos_arm=$(platform_block '      ' "$darwin_arm_archive" "$darwin_arm_sha")
+macos_intel=$(platform_block '      ' "$darwin_intel_archive" "$darwin_intel_sha")
+linux_intel=$(platform_block '      ' "$linux_intel_archive" "$linux_intel_sha")
+
+macos_section=""
+if [ -n "$macos_arm" ]; then
+  macos_section="    on_arm do
+${macos_arm}
+    end"
+fi
+if [ -n "$macos_intel" ]; then
+  if [ -n "$macos_section" ]; then
+    macos_section="${macos_section}
+
+"
+  fi
+  macos_section="${macos_section}    on_intel do
+${macos_intel}
+    end"
+fi
+
+os_blocks=""
+if [ -n "$macos_section" ]; then
+  os_blocks="  on_macos do
+${macos_section}
+  end"
+fi
+if [ -n "$linux_intel" ]; then
+  if [ -n "$os_blocks" ]; then
+    os_blocks="${os_blocks}
+
+"
+  fi
+  os_blocks="${os_blocks}  on_linux do
+    on_intel do
+${linux_intel}
+    end
+  end"
+fi
+
+mkdir -p "$(dirname "$output")"
+
+# Written at column 0 because a heredoc keeps every byte it is given, and the
+# indentation below is Ruby's rather than the shell's.
+cat >"$output" <<RUBY
+# typed: false
+# frozen_string_literal: true
+
+# Derived from the GitHub release by .github/scripts/brew-formula.sh, which
+# .github/workflows/publish-brew.yml runs on every pull request and asserts this
+# file is exactly what deriving it produces. A hand edit turns that job red
+# instead of failing on somebody's machine -- in particular a sha256, which is
+# read from the .sha256 asset the release publishes and is never typed.
+#
+# This repository is its own tap, and there is no satellite to keep in step
+# (ADR-782a3556cf2d):
+#
+#   brew tap ${repo} ${repo_url}
+#   brew install ${repo}/ank
+#
+# It is a tap and not homebrew-core because core's gate is notability -- of the
+# order of 75 stars or 30 forks, with a track record -- and this repository has
+# 1 star, 0 forks and three weeks of history. That is their documented door and
+# not a judgement about the tool. The move costs a change of source and not a
+# rewrite: the platform blocks below become one url and sha256 on the source
+# tarball plus \`system "cargo", "install", *std_cargo_args\`, and the rest of
+# this file stands.${coverage_note}
+class Ank < Formula
+  desc "Tasks and architecture decisions in your repo, behind one CLI agents can call"
+  homepage "${repo_url}"
+  version "${version}"
+  license "GPL-3.0-only"
+
+${os_blocks}
+
+  # The archive wraps its contents in a directory named after itself and
+  # Homebrew stages inside it, so these are the names as packaged by the
+  # \`package\` step of release.yml. SKILL.md travels with the binary because a
+  # channel shipping ank and not what it teaches has shipped half of it.
+  def install
+    bin.install "ank"
+    doc.install "README.md"
+    pkgshare.install "SKILL.md"
+  end
+
+  # \`ank --version\` prints "ank <version> (<commit>, skill <hash>)", so the
+  # assertion is on the version token: pinning the whole line would make every
+  # commit of a release a change to this file.
+  test do
+    assert_match(/\A\s*ank\s+#{Regexp.escape(version.to_s)}(\s|\z)/,
+                 shell_output("#{bin}/ank --version"))
+  end
+
+  # For the move to core, and for anyone watching the tap: the newest tag is
+  # what this formula tracks.
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+end
+RUBY
+
+echo "wrote ${output}" >&2

--- a/.github/workflows/publish-brew.yml
+++ b/.github/workflows/publish-brew.yml
@@ -1,0 +1,302 @@
+name: publish-brew
+
+# `brew tap <user>/<name> <url>` takes an arbitrary URL, so this repository is
+# its own tap and no satellite exists to keep in step (ADR-782a3556cf2d,
+# carrying ADR-e3cb36646d77 forward). It is a tap and not homebrew-core because
+# core's gate is notability, which is out of reach today and is measured in
+# TASK-7498998a8514 -- nothing here is thrown away when the numbers change.
+#
+# `Formula/ank.rb` is therefore a derived file that happens to be committed, and
+# the whole design of this workflow follows from that: the derivation lives in
+# .github/scripts/brew-formula.sh, a release runs it and commits the result, and
+# every other run runs it and asserts the committed file is exactly what it
+# produced. A hand edit turns this workflow red rather than failing on
+# somebody's machine.
+#
+# The same shape as publish-scoop.yml, deliberately: two channels doing one job
+# two ways is how a reader ends up trusting whichever they opened. Where it
+# differs it is because the formula covers three archives rather than one, so
+# the derivation is a script the two halves share and a maintainer can run,
+# instead of a step inlined in the YAML.
+on:
+  release:
+    types: [published]
+  # The formula, the script that writes it and this file are the only inputs,
+  # so they are the only paths worth spending a macOS runner on.
+  pull_request:
+    paths:
+      - "Formula/**"
+      - ".github/scripts/brew-formula.sh"
+      - ".github/workflows/publish-brew.yml"
+  push:
+    branches: [main]
+    paths:
+      - "Formula/**"
+      - ".github/scripts/brew-formula.sh"
+      - ".github/workflows/publish-brew.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Two releases rewriting the same file on the default branch would race, and the
+# loser would push a formula for the older tag, so every release shares one
+# group. Never cancelled: a tag is not something you get to publish twice.
+# Everything else is grouped by ref, because a pull request holding up another
+# pull request buys nothing.
+concurrency:
+  group: publish-brew-${{ github.event_name == 'release' && 'release' || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  formula:
+    name: the formula is derived
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      version: ${{ steps.derive.outputs.version }}
+
+    steps:
+      # On a release the derived formula is committed to the default branch, so
+      # the checkout has to be that branch and not the tag: committing onto a
+      # detached tag would produce a commit no branch contains.
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event_name == 'release' && github.event.repository.default_branch || '' }}
+
+      - name: derive
+        id: derive
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          EVENT: ${{ github.event_name }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+
+          # A release derives the formula for the tag it published. Every other
+          # run derives it for the version the committed formula already claims,
+          # which is what makes the assertion below meaningful: the file is
+          # compared with the derivation of its own version, so a hash typed by
+          # hand, a URL pointing at another version, or a platform block that
+          # drifted from the release matrix are all differences.
+          if [ "$EVENT" = "release" ]; then
+            version="${TAG#v}"
+          else
+            version=$(sed -n 's/^  version "\([^"]*\)".*/\1/p' Formula/ank.rb | head -n 1)
+          fi
+          if [ -z "$version" ]; then
+            echo "no version to derive from: the release tag was empty and Formula/ank.rb" >&2
+            echo "declares no version. read .github/scripts/brew-formula.sh --help" >&2
+            exit 1
+          fi
+
+          # `--require-all` on a release and nowhere else. A tag cut from the
+          # matrix in release.yml builds every target the formula covers, so at
+          # release time a missing archive is a broken release; between releases
+          # the last release is whatever it was, and narrowing the formula to
+          # fit it is honest where inventing a URL is not.
+          require=""
+          if [ "$EVENT" = "release" ]; then
+            require="--require-all"
+          fi
+
+          bash .github/scripts/brew-formula.sh "$version" Formula/ank.rb $require
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          cat Formula/ank.rb
+
+      # The half that runs on a pull request. Deriving a file and never
+      # comparing it would leave the committed formula unverified until the next
+      # release, which is exactly one release too late.
+      - name: the committed formula is that derivation
+        if: github.event_name != 'release'
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! git diff --exit-code -- Formula/ank.rb; then
+            {
+              echo ""
+              echo "Formula/ank.rb is not what deriving it for ${{ steps.derive.outputs.version }} produces."
+              echo "it is a generated file: take the diff above as the fix, by running"
+              echo "  bash .github/scripts/brew-formula.sh ${{ steps.derive.outputs.version }}"
+              echo "or bump its version field to a tag that has a release."
+            } >&2
+            exit 1
+          fi
+          echo "Formula/ank.rb is exactly the derivation for ${{ steps.derive.outputs.version }}"
+
+      # The other half. Committed rather than published to a registry because
+      # the tap *is* this repository: a user's `brew update` is a `git pull` of
+      # the default branch, so the default branch is the channel.
+      - name: commit it to the default branch
+        if: github.event_name == 'release'
+        shell: bash
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- Formula/ank.rb; then
+            echo "the formula already describes ${{ steps.derive.outputs.version }}; nothing to commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Formula/ank.rb
+          git commit -m "brew: ank ${{ steps.derive.outputs.version }}"
+          # The branch may have moved while the release was building. Rebasing
+          # one commit that touches one generated file is safe; failing the push
+          # is not, because the tag has already been spent.
+          git pull --rebase origin "${{ github.event.repository.default_branch }}"
+          git push origin "HEAD:${{ github.event.repository.default_branch }}"
+
+  # A formula nobody installed from is a formula nobody tested. The criterion is
+  # about the binary, so this reaches it through `brew install` rather than
+  # through the fields of a Ruby file: the sha256 is verified by the download
+  # itself, which is the whole reason it is derived rather than typed.
+  install:
+    name: brew install (${{ matrix.arch }})
+    needs: formula
+    runs-on: ${{ matrix.os }}
+    strategy:
+      # A missing architecture is the information we came for.
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            arch: arm64
+            triple: aarch64-apple-darwin
+          # The same reasoning as the Intel row of release.yml: half the Mac
+          # install base, and a branch nobody installed from is a branch that
+          # fails on the user's machine rather than here. `macos-15-intel` is
+          # the last x86_64 image Actions will offer, and this row goes away
+          # with it in August 2027 rather than quietly moving to arm64.
+          - os: macos-15-intel
+            arch: x86_64
+            triple: x86_64-apple-darwin
+
+    env:
+      HOMEBREW_NO_ANALYTICS: 1
+      HOMEBREW_NO_AUTO_UPDATE: 1
+      HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
+
+    steps:
+      # Unshallowed: on anything but a release the checkout below is pushed into
+      # a local tap repository, and git refuses to push out of a shallow clone.
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event_name == 'release' && github.event.repository.default_branch || '' }}
+          fetch-depth: 0
+
+      # A release always produces a formula covering every architecture --
+      # `--require-all` above is what guarantees it -- so this can only be false
+      # between releases, and only for an archive the last release did not
+      # carry. It is reported rather than skipped silently: the step summary
+      # names the architecture and the release, and the row turns into a real
+      # install by itself on the first tag that carries the archive.
+      - name: the formula covers this architecture
+        id: coverage
+        shell: bash
+        run: |
+          set -euo pipefail
+          # The `url` line and not the triple anywhere in the file: when an
+          # archive is missing the formula says so in a comment naming it, and a
+          # bare match would read that sentence as the block it is apologising
+          # for -- then install, and fail on a URL that is not there.
+          if grep -q "^ *url \".*${{ matrix.triple }}" Formula/ank.rb; then
+            echo "covered=1" >> "$GITHUB_OUTPUT"
+            echo "Formula/ank.rb carries a url for ${{ matrix.triple }}"
+            exit 0
+          fi
+          echo "covered=0" >> "$GITHUB_OUTPUT"
+          {
+            echo "### brew install ${{ matrix.arch }}: nothing to install"
+            echo ""
+            echo "\`Formula/ank.rb\` carries no block for \`${{ matrix.triple }}\`, because"
+            echo "v${{ needs.formula.outputs.version }} published no archive for it."
+            echo ""
+            echo "The archive is a row of the matrix in \`.github/workflows/release.yml\`."
+            echo "The first tag cut with that row makes this a real install, with no edit"
+            echo "to the formula, the script or this workflow."
+          } | tee -a "$GITHUB_STEP_SUMMARY"
+
+      - name: the tap to add
+        id: tap
+        if: steps.coverage.outputs.covered == '1'
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "release" ]; then
+            # The formula job has just pushed to the default branch, so the
+            # published tap is reachable at the URL a user would type. This is
+            # the full loop, and it is only provable here: on any other event
+            # the formula under test is not on the default branch yet.
+            source="${{ github.server_url }}/${{ github.repository }}"
+          else
+            # What is under test is the commit in hand, which no URL serves yet.
+            # `brew tap` clones whatever git URL it is given, so the commit is
+            # served as one: a bare repository beside the checkout is this
+            # repository at this commit, minus the network, which is not the
+            # part being tested. The push is explicit because a checkout can be
+            # detached and a clone follows HEAD.
+            source="${RUNNER_TEMP}/ank-tap.git"
+            git init --bare --initial-branch=main "$source"
+            git push "$source" HEAD:refs/heads/main
+          fi
+          echo "the tap source is $source"
+          echo "source=$source" >> "$GITHUB_OUTPUT"
+
+      # The tap name is the one a user types, on both branches: `brew install
+      # haksolot/ank/ank` has to be the same sentence whether the formula came
+      # from the network or from the commit under test, or the rehearsal
+      # rehearses a command nobody runs.
+      - name: brew tap
+        if: steps.coverage.outputs.covered == '1'
+        shell: bash
+        run: |
+          set -euo pipefail
+          brew tap "${{ github.repository }}" "${{ steps.tap.outputs.source }}"
+          brew tap-info "${{ github.repository }}"
+
+      # `brew install` verifies the sha256 itself: a formula whose hash does not
+      # match the asset fails right here.
+      - name: brew install ank
+        shell: bash
+        if: steps.coverage.outputs.covered == '1'
+        run: |
+          set -euo pipefail
+          brew install "${{ github.repository }}/ank"
+
+      # The criterion in as many words. `ank --version` prints
+      # "ank <version> (<commit>, skill <hash>)", so the assertion is on the
+      # version token and not on the whole line: pinning the line would make
+      # every commit of the release a change to this file.
+      #
+      # `$(brew --prefix)/bin/ank` and not a bare `ank`: the assertion is about
+      # the binary this install put on disk, and a bare name would pass on any
+      # other ank that happened to be on PATH.
+      - name: ank --version names the released version
+        if: steps.coverage.outputs.covered == '1'
+        shell: bash
+        run: |
+          set -euo pipefail
+          expected="${{ needs.formula.outputs.version }}"
+          binary="$(brew --prefix)/bin/ank"
+          test -x "$binary"
+          actual=$("$binary" --version)
+          echo "expected: ank $expected"
+          echo "ank --version: $actual"
+          case "$actual" in
+            "ank $expected" | "ank $expected "*) ;;
+            *)
+              echo "the installed binary does not name $expected" >&2
+              exit 1
+              ;;
+          esac
+
+      # The formula carries a `test do` block, and a test block nothing runs is
+      # decoration. This is what would run it in homebrew-core.
+      - name: brew test ank
+        if: steps.coverage.outputs.covered == '1'
+        shell: bash
+        run: brew test "${{ github.repository }}/ank"

--- a/Formula/ank.rb
+++ b/Formula/ank.rb
@@ -1,0 +1,73 @@
+# typed: false
+# frozen_string_literal: true
+
+# Derived from the GitHub release by .github/scripts/brew-formula.sh, which
+# .github/workflows/publish-brew.yml runs on every pull request and asserts this
+# file is exactly what deriving it produces. A hand edit turns that job red
+# instead of failing on somebody's machine -- in particular a sha256, which is
+# read from the .sha256 asset the release publishes and is never typed.
+#
+# This repository is its own tap, and there is no satellite to keep in step
+# (ADR-782a3556cf2d):
+#
+#   brew tap haksolot/ank https://github.com/haksolot/ank
+#   brew install haksolot/ank/ank
+#
+# It is a tap and not homebrew-core because core's gate is notability -- of the
+# order of 75 stars or 30 forks, with a track record -- and this repository has
+# 1 star, 0 forks and three weeks of history. That is their documented door and
+# not a judgement about the tool. The move costs a change of source and not a
+# rewrite: the platform blocks below become one url and sha256 on the source
+# tarball plus `system "cargo", "install", *std_cargo_args`, and the rest of
+# this file stands.
+#
+# v0.2.0 published no archive for:
+#   ank-0.2.0-x86_64-apple-darwin.tar.gz
+# so this formula carries no block for it. That is a row of the release matrix
+# and not a decision here: the first tag cut with that row restores the block,
+# derived, with no edit to this file or to the script that writes it.
+class Ank < Formula
+  desc "Tasks and architecture decisions in your repo, behind one CLI agents can call"
+  homepage "https://github.com/haksolot/ank"
+  version "0.2.0"
+  license "GPL-3.0-only"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/haksolot/ank/releases/download/v0.2.0/ank-0.2.0-aarch64-apple-darwin.tar.gz"
+      sha256 "834f36627fc8325b0d3c46d2be62f39f6b6f53246ee754255c94952471297623"
+    end
+  end
+
+  on_linux do
+    on_intel do
+      url "https://github.com/haksolot/ank/releases/download/v0.2.0/ank-0.2.0-x86_64-unknown-linux-musl.tar.gz"
+      sha256 "9d45670ecf3c9472aa1f542a9d6a33b6f476040cb25e4a189417ca03db1aee01"
+    end
+  end
+
+  # The archive wraps its contents in a directory named after itself and
+  # Homebrew stages inside it, so these are the names as packaged by the
+  # `package` step of release.yml. SKILL.md travels with the binary because a
+  # channel shipping ank and not what it teaches has shipped half of it.
+  def install
+    bin.install "ank"
+    doc.install "README.md"
+    pkgshare.install "SKILL.md"
+  end
+
+  # `ank --version` prints "ank <version> (<commit>, skill <hash>)", so the
+  # assertion is on the version token: pinning the whole line would make every
+  # commit of a release a change to this file.
+  test do
+    assert_match(/\A\s*ank\s+#{Regexp.escape(version.to_s)}(\s|\z)/,
+                 shell_output("#{bin}/ank --version"))
+  end
+
+  # For the move to core, and for anyone watching the tap: the newest tag is
+  # what this formula tracks.
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+end


### PR DESCRIPTION
Closes TASK-7498998a8514.

`brew tap` takes an arbitrary URL, so `Formula/ank.rb` in this tree is a working
tap and no satellite repository exists to keep in step (ADR-782a3556cf2d). It is
a tap and not homebrew-core because core's gate is notability -- of the order of
75 stars or 30 forks, with a track record -- against 1 star, 0 forks and three
weeks of history. Nothing here is thrown away when the numbers change: the move
to core is a change of source, not a rewrite.

    brew tap haksolot/ank https://github.com/haksolot/ank
    brew install haksolot/ank/ank

## The hash is derived, never typed

`Formula/ank.rb` is a derived file that happens to be committed.
`.github/scripts/brew-formula.sh` reads every sha256 out of the `.sha256` asset
the release publishes beside each archive. A constant in the formula is a
constant that goes stale one tag later, and it is the one defect here that shows
up nowhere except on the machine of whoever runs the install.

`publish-brew.yml` runs that script on a release and commits the result, and
runs it on every pull request to assert the committed file is exactly what it
produced. A hand edit turns a job red instead of failing on a user's machine.

Same shape as `publish-scoop.yml`, deliberately. It differs in one way: the
derivation is a script rather than an inlined step, because the formula covers
three archives rather than one and a maintainer can run a script.

## What this pull request proves, and what it cannot

Proved, on the macOS runner: `brew tap` against this repository, `brew install`,
and `ank --version` naming the released version, on **arm64**. `brew install`
verifies the sha256 itself, which is the point of deriving it. `brew test` runs
the formula's own test block. On a pull request the commit under test is served
as a bare repository beside the checkout, because no URL serves it yet; on a
release the URL is the real one.

Proved locally, and worth stating because CI cannot reach it:

- the `.sha256` asset of the linux-musl archive matches `sha256sum` over the
  archive bytes, and the formula carries that number -- the chain is verified
  end to end rather than asserted;
- the archive wraps one directory holding `ank`, `README.md`, `SKILL.md` and
  `LICENSE`, which is what makes the `install` block resolve;
- the derivation is deterministic, and the committed formula equals it;
- `--require-all` refuses v0.2.0 and writes no file; a version with no release
  exits 1; a missing version and an unknown flag exit 2;
- a stubbed four-archive release renders both macOS blocks with correct
  nesting -- the release path no live release can exercise yet.

**Not provable here: `brew install` on an Intel Mac.** The Intel row landed in
`release.yml` four days after v0.2.0 was cut, so no published release carries an
`x86_64-apple-darwin` archive. Recorded as a discrepancy against the frozen
criterion rather than worked around.

The formula therefore carries the two archives v0.2.0 actually published, and
the script omits a branch rather than pointing it at a URL that 404s -- a
formula whose Intel branch resolves to nothing fails on the user's machine
instead of here. `--require-all` is passed on a release and nowhere else, so a
missing archive fails the release half, where it can only mean a broken release.
The Intel block appears on the first tag cut from the current matrix, with no
edit to the formula, the script or the workflow. The Intel CI row reports the
gap into the step summary rather than skipping quietly, and becomes a real
install by itself.

Also not provable from a pull request: the release half of the workflow, which
needs a published release. The same limit TASK-054fd964221f recorded.

## Green

`cargo test --workspace` (561 tests, 0 failed) and `ank check` (ok, 0 faults).

Scope held to `Formula/ank.rb`, `.github/workflows/publish-brew.yml` and
`.github/scripts/brew-formula.sh`. `install.sh` and the documentation belong to
other tasks and are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015DnNXkwh3wk8bVkzPneiFK
