### PR TITLE
ank is installable with winget

### DIFF
--- a/.ank/entities/LOG-386ff0c2aa25.md
+++ b/.ank/entities/LOG-386ff0c2aa25.md
@@ -1,0 +1,18 @@
+---
+id: LOG-386ff0c2aa25
+type: log
+title: "The token clause of the criterion is now satisfied and was verified rather than assumed:"
+created: 2026-08-16T16:57:52Z
+author: claude-code/opus-5
+scope:
+  - packaging/winget/**
+  - .github/workflows/publish-winget.yml
+about: TASK-b693dc062cab
+seq: 1
+schema: 3
+version: 1
+---
+
+ haksolot/winget-pkgs exists and reports microsoft/winget-pkgs as its parent, and gh secret list shows WINGET_TOKEN on this repository as of 2026-08-16T16:57Z. Neither existed while the code was being written, which is why the submit job names both by name when they are missing instead of failing on an API 404 that reads like the fork is gone.
+
+The submit path itself has not run and cannot: it is gated on a published release, and the last tag is v0.2.0, which predates this workflow. The first tag cut after this lands is what exercises it end to end. Everything before that gate is proved on the run for PR 158: manifest validation succeeded with no warning, winget installed from the three files, and ank --version answered "ank 0.2.0 (c86eeeb, skill 3f350ad26459)".

--- a/.ank/entities/LOG-7cb18ada5e06.md
+++ b/.ank/entities/LOG-7cb18ada5e06.md
@@ -1,0 +1,22 @@
+---
+id: LOG-7cb18ada5e06
+type: log
+title: Three things the winget submission turns on, none of them obvious from the criterion.
+created: 2026-08-16T16:27:13Z
+author: claude-code/opus-5
+scope:
+  - packaging/winget/**
+  - .github/workflows/publish-winget.yml
+about: TASK-b693dc062cab
+seq: 0
+schema: 3
+version: 1
+---
+
+
+
+The pull request is built through the Git Data API and never by cloning. A fork shares its object store with the repository it came from, so a branch created on haksolot/winget-pkgs can point straight at microsoft/winget-pkgs' current head: no sync, and no clone of a registry that carries hundreds of thousands of manifests to add three files to it. Three blobs, one tree on that base, one commit, one ref update -- and one commit rather than the three the contents API would write, because three commits adding three halves of one manifest is a diff a reviewer has to reassemble.
+
+The token has to be a classic PAT with public_repo. A fine-grained token cannot act on a repository its owner does not own, and opening a request against microsoft/winget-pkgs is exactly that. The submit job says so by name when the secret is missing, because the API's own answer to a missing token here is a 404 that reads like the fork is gone.
+
+RelativeFilePath is inside the directory the archive wraps, verified against the published zip rather than inferred: ank-0.2.0-x86_64-pc-windows-msvc/ank.exe, not ank.exe. Same trap as extract_dir on the Scoop side, and it fails at install time on a user's machine rather than at validation. The derived sha256 also matches the one bucket/ank.json already carries, which is two independent derivations landing on the same number.

--- a/.ank/entities/LOG-b4b08c496676.md
+++ b/.ank/entities/LOG-b4b08c496676.md
@@ -1,0 +1,14 @@
+---
+id: LOG-b4b08c496676
+type: log
+title: done, proof commit:387382f0fd1db85f4142a86b6aeae7c91fb42c10
+created: 2026-08-16T16:58:06Z
+author: claude-code/opus-5
+scope:
+  - packaging/winget/**
+  - .github/workflows/publish-winget.yml
+about: TASK-b693dc062cab
+seq: 2
+schema: 3
+version: 1
+---

--- a/.ank/entities/TASK-b693dc062cab.md
+++ b/.ank/entities/TASK-b693dc062cab.md
@@ -5,7 +5,7 @@ slug: ank-is-installable-with-winget
 title: ank is installable with winget
 created: 2026-08-16T03:35:49Z
 author: claude-code/opus-5
-status: open
+status: done
 scope:
   - packaging/winget/**
   - .github/workflows/publish-winget.yml
@@ -13,8 +13,13 @@ blocked_by: []
 done_criteria: |
   packaging/winget carries the three manifest files winget requires, rendered for a version with the installer URL and the sha256 the release publishes. A workflow triggered on a published release renders them and opens a pull request against microsoft/winget-pkgs under a token the repository holds. A CI job on Windows validates the rendered manifests with winget validate and installs from them locally, asserting ank --version prints the released version. The pull request is opened and never merged by this repository: the registry reviews it. cargo test --workspace and ank check stay green.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 387382f0fd1db85f4142a86b6aeae7c91fb42c10
+    criteria: f85663ec0578
+    via: submitted
 schema: 3
-version: 1
+version: 3
 ---
 
 winget's registry is `microsoft/winget-pkgs`, a central index that accepts a

--- a/.github/scripts/winget-manifests.sh
+++ b/.github/scripts/winget-manifests.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+#
+# Renders packaging/winget/ from a published GitHub release.
+#
+#   winget-manifests.sh <version> [output-dir]
+#
+# winget's registry is `microsoft/winget-pkgs`, a central index that accepts a
+# manifest and holds no authority over it -- the shape ADR-782a3556cf2d names as
+# a registry rather than a satellite, and the same shape npm already has. So
+# this repository derives the manifest and opens a pull request; the registry
+# reviews it, and merging is theirs.
+#
+# The three files are winget's own requirement and not a layout chosen here. A
+# single-file manifest is no longer accepted for a new submission: a version
+# manifest names the package and the default locale, an installer manifest names
+# the archive and its hash, and a locale manifest carries everything a human
+# reads. All three repeat `PackageIdentifier` and `PackageVersion`, which is
+# three chances to disagree, which is why one script writes all three.
+#
+# They are therefore derived files that happen to be committed, exactly like
+# Formula/ank.rb and bucket/ank.json, and publish-winget.yml follows from that:
+# a release runs this script and commits the result, and every other run runs it
+# and asserts the committed files are exactly what it produced. A hand edit
+# turns that job red rather than failing on somebody's machine.
+#
+# **The hash is read, never typed.** The .sha256 asset beside the archive is the
+# only source of the number below. A constant written here is a constant that
+# goes stale one tag later, and `winget install` verifies the hash itself, so a
+# wrong one is a failed install reported by a user rather than a red job.
+#
+# There is no `--require-all` here, and the asymmetry with brew-formula.sh is
+# the decision. That script covers three archives and tolerates a release
+# missing one, because a formula narrowed to what exists is still a formula
+# somebody can install. This one covers exactly one archive -- winget installs
+# on Windows and nowhere else -- so a release without it leaves nothing to
+# render at all, and the honest report is a failure rather than a manifest with
+# no installer in it.
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+usage: winget-manifests.sh <version> [output-dir]
+
+  <version>       the released version, without the leading v (e.g. 0.2.0)
+  [output-dir]    where to write the three manifests (default: packaging/winget)
+
+Reads the sha256 from the .sha256 asset the release publishes. Needs `gh`
+authenticated against the repository; GH_REPO overrides which one.
+USAGE
+}
+
+positional=()
+for arg in "$@"; do
+  case "$arg" in
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    -*)
+      echo "winget-manifests.sh: unknown flag '$arg'" >&2
+      usage >&2
+      exit 2
+      ;;
+    *) positional+=("$arg") ;;
+  esac
+done
+
+# `${positional[0]:-}` and not `"${positional[@]}"`: expanding an empty array
+# under `set -u` is an error on the bash 3.2 the macOS runners still carry, and
+# this script has no reason to be the one that finds out.
+version="${positional[0]:-}"
+outdir="${positional[1]:-packaging/winget}"
+
+if [ -z "$version" ]; then
+  echo "winget-manifests.sh: no version given." >&2
+  usage >&2
+  exit 2
+fi
+version="${version#v}"
+
+repo="${GH_REPO:-haksolot/ank}"
+server="${GITHUB_SERVER_URL:-https://github.com}"
+repo_url="${server}/${repo}"
+
+# The identifier winget knows this package by. It is `Publisher.Package`, it is
+# the name of every file below, and it is the path the submission lands on in
+# microsoft/winget-pkgs. Changing it after a release is published is a new
+# package rather than a rename, so it is written once, here.
+identifier="Haksolot.Ank"
+
+# The one archive winget installs from, and the directory it wraps its contents
+# in. release.yml packages a zip around a directory named after the archive, so
+# the nested path below is that name and not `ank.exe` alone -- the same trap
+# `extract_dir` is on the Scoop side, and it fails at install time on a user's
+# machine rather than at validation.
+archive="ank-${version}-x86_64-pc-windows-msvc"
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+# The directory handed to `gh` is not always the directory handed to `cut`.
+# Under Git Bash on Windows, gh.exe is a native binary, so MSYS rewrites the
+# POSIX path it is given -- and gets it wrong here: `gh release download`
+# reports success having written the asset somewhere this script never looks,
+# which reads exactly like an asset the release did not carry. cygpath exists
+# only where the question does.
+gh_tmp="$tmp"
+if command -v cygpath >/dev/null 2>&1; then
+  gh_tmp=$(cygpath -w "$tmp")
+fi
+
+echo "deriving the winget manifests for ${version} from ${repo_url}" >&2
+
+if ! gh release download "v${version}" \
+  --repo "$repo" \
+  --pattern "${archive}.zip.sha256" \
+  --dir "$gh_tmp" \
+  --clobber >/dev/null 2>&1; then
+  # A release that is not there at all is not the same fact as a release that
+  # carried no Windows archive, and the command to run next differs.
+  if ! gh release view "v${version}" --repo "$repo" >/dev/null 2>&1; then
+    echo "winget-manifests.sh: ${repo} has no release v${version}." >&2
+    echo "  a manifest is derived from a tag: cut it, or pass a version that has one." >&2
+    exit 1
+  fi
+  echo "winget-manifests.sh: v${version} carries no ${archive}.zip." >&2
+  echo "  winget installs on Windows and nowhere else, so there is nothing to render." >&2
+  echo "  read the build jobs of the release run at ${repo_url}/releases/tag/v${version}" >&2
+  exit 1
+fi
+
+# `sha256sum` wrote the line, so it is "<hash>  <name>" and the hash is the
+# first space-separated field in either of its two output modes.
+hash=$(cut -d' ' -f1 <"${tmp}/${archive}.zip.sha256")
+
+# A truncated download, an HTML error page saved to disk, or a checksum file
+# that changed shape would each yield something that is not a hash, and winget
+# would report it as a mismatched download rather than as a broken manifest.
+# Named here instead.
+if ! printf '%s' "$hash" | grep -Eq '^[0-9a-f]{64}$'; then
+  echo "winget-manifests.sh: the .sha256 asset of ${archive}.zip did not yield a sha256: '${hash}'" >&2
+  echo "  check the asset at ${repo_url}/releases/tag/v${version}" >&2
+  exit 1
+fi
+
+# Upper case because that is what the registry's own tooling writes, and a
+# manifest that differs from wingetcreate's output only in the case of a hex
+# string is a diff a reviewer has to read before dismissing.
+hash=$(printf '%s' "$hash" | tr 'a-f' 'A-F')
+
+# winget shows the release date in `winget show`, and it is a fact about the
+# tag rather than about this run: read from the release, never from `date`.
+published=$(gh release view "v${version}" --repo "$repo" --json publishedAt --jq .publishedAt) || exit 1
+release_date="${published%%T*}"
+if ! printf '%s' "$release_date" | grep -Eq '^[0-9]{4}-[0-9]{2}-[0-9]{2}$'; then
+  echo "winget-manifests.sh: the release did not yield a publication date: '${published}'" >&2
+  exit 1
+fi
+
+mkdir -p "$outdir"
+
+# The note every one of the three files carries. `winget show` and a reviewer's
+# eye both land on these files, and the first question either arrives with is
+# where the numbers came from.
+header="# Derived from the GitHub release by .github/scripts/winget-manifests.sh, which
+# .github/workflows/publish-winget.yml runs on every pull request and asserts
+# this file is exactly what deriving it produces. A hand edit turns that job red
+# instead of failing on somebody's machine -- in particular the sha256, which is
+# read from the .sha256 asset the release publishes and is never typed."
+
+# Written at column 0 because a heredoc keeps every byte it is given, and the
+# indentation below is YAML's rather than the shell's.
+
+cat >"${outdir}/${identifier}.yaml" <<YAML
+# yaml-language-server: \$schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+${header}
+PackageIdentifier: ${identifier}
+PackageVersion: ${version}
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0
+YAML
+
+cat >"${outdir}/${identifier}.installer.yaml" <<YAML
+# yaml-language-server: \$schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+${header}
+PackageIdentifier: ${identifier}
+PackageVersion: ${version}
+MinimumOSVersion: 10.0.0.0
+ReleaseDate: ${release_date}
+# The release publishes a zip and not an installer, so winget unpacks it and
+# links the executable inside: \`zip\` with a \`portable\` nested type is that
+# shape. The relative path is inside the directory the archive wraps its
+# contents in, which release.yml names after the archive itself.
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: ${archive}\ank.exe
+    PortableCommandAlias: ank
+Installers:
+  - Architecture: x64
+    InstallerUrl: ${repo_url}/releases/download/v${version}/${archive}.zip
+    InstallerSha256: ${hash}
+ManifestType: installer
+ManifestVersion: 1.6.0
+YAML
+
+cat >"${outdir}/${identifier}.locale.en-US.yaml" <<YAML
+# yaml-language-server: \$schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+${header}
+PackageIdentifier: ${identifier}
+PackageVersion: ${version}
+PackageLocale: en-US
+Publisher: haksolot
+PublisherUrl: ${server}/haksolot
+PublisherSupportUrl: ${repo_url}/issues
+PackageName: ank
+PackageUrl: ${repo_url}
+License: GPL-3.0-only
+LicenseUrl: ${repo_url}/blob/main/LICENSE
+Copyright: Copyright (C) 2026 haksolot
+ShortDescription: Tasks and architecture decisions in your repo, behind one CLI agents can call
+Description: |-
+  ank keeps a project's tasks and architecture decisions in the repository
+  itself, as files an agent reads through one CLI. A decision carries a scope,
+  so it binds the work that matches it rather than the work that remembers it,
+  and a task's completion criterion is frozen by hash the moment it is claimed.
+Moniker: ank
+Tags:
+  - agent
+  - architecture
+  - cli
+  - decision-records
+  - developer-tools
+  - project-management
+  - rust
+  - tasks
+ReleaseNotesUrl: ${repo_url}/releases/tag/v${version}
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0
+YAML
+
+echo "wrote ${outdir}/${identifier}.yaml" >&2
+echo "wrote ${outdir}/${identifier}.installer.yaml" >&2
+echo "wrote ${outdir}/${identifier}.locale.en-US.yaml" >&2

--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -1,0 +1,403 @@
+name: publish-winget
+
+# winget's registry is `microsoft/winget-pkgs`, a central index that accepts a
+# manifest and holds no authority over it (ADR-782a3556cf2d). So this repository
+# derives the manifest, proves it installs, and opens a pull request. The merge
+# is theirs: a job that waited on it, or retried it, would be a pipeline waiting
+# on a human it does not employ.
+#
+# `packaging/winget/` is therefore a derived directory that happens to be
+# committed, and the shape of this workflow follows from that, the same way it
+# does for Formula/ank.rb and bucket/ank.json: the derivation lives in one
+# script, a release runs it and commits the result, and every other run runs it
+# and asserts the committed files are exactly what it produced. A hand edit
+# turns this workflow red rather than failing on somebody's machine.
+#
+# The order of the jobs is the decision the task body argues for. A manifest is
+# only proved by an install, and the pull request goes to somebody else's
+# repository: an invalid one costs a reviewer's time and comes back days later.
+# So `submit` needs `install`, and nothing leaves this repository until a
+# Windows runner has installed from these exact bytes.
+on:
+  release:
+    types: [published]
+  # The manifests, the script that writes them and this file are the only
+  # inputs, so they are the only paths worth spending a Windows runner on.
+  pull_request:
+    paths:
+      - "packaging/winget/**"
+      - ".github/scripts/winget-manifests.sh"
+      - ".github/workflows/publish-winget.yml"
+  push:
+    branches: [main]
+    paths:
+      - "packaging/winget/**"
+      - ".github/scripts/winget-manifests.sh"
+      - ".github/workflows/publish-winget.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Two releases rewriting the same files on the default branch would race, and
+# the loser would commit manifests for the older tag, so every release shares
+# one group. Never cancelled: a tag is not something you get to publish twice.
+concurrency:
+  group: publish-winget-${{ github.event_name == 'release' && 'release' || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  manifests:
+    name: the manifests are derived
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      version: ${{ steps.derive.outputs.version }}
+
+    steps:
+      # On a release the derived manifests are committed to the default branch,
+      # so the checkout has to be that branch and not the tag: committing onto
+      # a detached tag would produce a commit no branch contains.
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event_name == 'release' && github.event.repository.default_branch || '' }}
+
+      - name: derive
+        id: derive
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          EVENT: ${{ github.event_name }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+
+          # A release derives the manifests for the tag it published. Every
+          # other run derives them for the version the committed manifests
+          # already claim, which is what makes the assertion below meaningful:
+          # the files are compared with the derivation of their own version, so
+          # a hash typed by hand, a URL pointing at another version, or a nested
+          # path that drifted from the archive layout are all differences.
+          if [ "$EVENT" = "release" ]; then
+            version="${TAG#v}"
+          else
+            version=$(sed -n 's/^PackageVersion: //p' packaging/winget/Haksolot.Ank.yaml | head -1)
+          fi
+          if [ -z "$version" ]; then
+            echo "no version to derive from: the release tag and the committed manifest both came back empty." >&2
+            echo "  read packaging/winget/Haksolot.Ank.yaml" >&2
+            exit 1
+          fi
+
+          .github/scripts/winget-manifests.sh "$version"
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      # The half that runs on a pull request. Deriving files and never comparing
+      # them would leave the committed manifests unverified until the next
+      # release, which is exactly one release too late.
+      - name: the committed manifests are that derivation
+        if: github.event_name != 'release'
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! git diff --exit-code -- packaging/winget; then
+            {
+              echo ""
+              echo "packaging/winget is not what deriving it for ${{ steps.derive.outputs.version }} produces."
+              echo "these are generated files: take the diff above as the fix, or re-run"
+              echo ".github/scripts/winget-manifests.sh <version> for a tag that has a release."
+            } >&2
+            exit 1
+          fi
+          # A file the script no longer writes would leave the directory holding
+          # something no derivation produced, and `git diff` says nothing about
+          # a file nobody tracked. `--exit-code` on the whole path plus this is
+          # the pair that covers both directions.
+          if [ -n "$(git status --porcelain -- packaging/winget)" ]; then
+            git status --porcelain -- packaging/winget >&2
+            echo "packaging/winget holds a file the derivation did not write." >&2
+            exit 1
+          fi
+          echo "packaging/winget is exactly the derivation for ${{ steps.derive.outputs.version }}"
+
+      - name: commit them to the default branch
+        if: github.event_name == 'release'
+        shell: bash
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- packaging/winget; then
+            echo "the manifests already describe ${{ steps.derive.outputs.version }}; nothing to commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add packaging/winget
+          git commit -m "winget: ank ${{ steps.derive.outputs.version }}"
+          # The branch may have moved while the release was building. Rebasing
+          # one commit that touches three generated files is safe; failing the
+          # push is not, because the tag has already been spent.
+          git pull --rebase origin "${{ github.event.repository.default_branch }}"
+          git push origin "HEAD:${{ github.event.repository.default_branch }}"
+
+  # A manifest nobody installed from is a manifest nobody tested, and this one
+  # is about to be sent to somebody else's repository. `winget validate` says
+  # the YAML has the right shape; it says nothing about whether the URL exists,
+  # whether the hash matches, or whether the nested path leads to an executable.
+  # Only the install says that, and the criterion is about the binary.
+  install:
+    name: winget install
+    needs: manifests
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event_name == 'release' && github.event.repository.default_branch || '' }}
+
+      # winget ships with the runner image, but it is a Store package and it is
+      # not reliably on the PATH of a non-interactive session. Its own client
+      # module is the documented way to put a working one there, and it is the
+      # same binary rather than a second implementation.
+      - name: winget is usable here
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $apps = Join-Path $env:LOCALAPPDATA 'Microsoft\WindowsApps'
+          if (Test-Path $apps) { $env:PATH = "$apps;$env:PATH" }
+
+          if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+            "winget is not on PATH; bootstrapping it from the client module"
+            Install-Module -Name Microsoft.WinGet.Client -Force -Repository PSGallery -Scope CurrentUser
+            Repair-WinGetPackageManager -Latest
+            if (Test-Path $apps) { $env:PATH = "$apps;$env:PATH" }
+          }
+
+          winget --version
+          if ($LASTEXITCODE -ne 0) { throw "winget is not usable on this runner" }
+
+          # For every step after this one, which starts with the runner's PATH
+          # rather than with this process's.
+          $apps | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
+          # Where a portable package puts its command. Nothing is installed
+          # there yet, so the directory need not exist to be worth adding.
+          Join-Path $env:LOCALAPPDATA 'Microsoft\WinGet\Links' |
+            Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
+
+      # Installing from a local manifest is off by default, because it is the
+      # one path that runs an installer nobody in the registry reviewed. That is
+      # exactly what is being tested, so it is turned on deliberately here and
+      # nowhere else.
+      - name: local manifests are allowed
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          winget settings --enable LocalManifestFiles
+          if ($LASTEXITCODE -ne 0) { throw "winget settings --enable LocalManifestFiles failed" }
+
+      - name: winget validate
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          winget validate --manifest packaging/winget
+          # Strict on purpose. `winget validate` reports warnings with a code of
+          # its own, and a warning on a manifest about to be opened as a pull
+          # request against microsoft/winget-pkgs is a warning a reviewer would
+          # have raised days later. Read the output above; it names the field.
+          if ($LASTEXITCODE -ne 0) {
+            throw "winget validate did not pass cleanly (exit $LASTEXITCODE)"
+          }
+
+      # The install verifies the hash itself: a manifest whose InstallerSha256
+      # does not match the asset fails right here, which is the whole reason the
+      # hash is derived rather than typed.
+      - name: install ank from the manifests
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          winget install --manifest packaging/winget `
+            --disable-interactivity `
+            --accept-package-agreements `
+            --accept-source-agreements
+          if ($LASTEXITCODE -ne 0) { throw "winget install failed (exit $LASTEXITCODE)" }
+
+          # Asserted rather than left to the step after it: a portable package
+          # that installed but linked nothing fails later as "ank is not a
+          # recognised command", which sends the reader after the PATH instead
+          # of after NestedInstallerFiles.
+          $link = Join-Path $env:LOCALAPPDATA 'Microsoft\WinGet\Links\ank.exe'
+          if (-not (Test-Path $link)) {
+            throw "the install left no command at ${link}: read the winget output above, and check NestedInstallerFiles in packaging/winget/Haksolot.Ank.installer.yaml"
+          }
+
+      # The criterion in as many words. `--version` prints "ank <version>
+      # (<commit>, skill <hash>)", so the assertion is on the version token and
+      # not on the whole line: pinning the line would make every commit of the
+      # release a change to this file.
+      - name: ank --version names the released version
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $expected = '${{ needs.manifests.outputs.version }}'
+          $actual = (ank --version | Select-Object -First 1)
+          "expected: $expected"
+          "ank --version: $actual"
+          if ($actual -notmatch "^ank\s+$([regex]::Escape($expected))(\s|$)") {
+            throw "the installed binary does not name $expected"
+          }
+
+  # The only job that leaves this repository, and the only one that needs a
+  # secret. It runs on a release and never on a pull request: opening a request
+  # against microsoft/winget-pkgs for a version nobody published would be asking
+  # a stranger to review a draft.
+  submit:
+    name: the pull request is opened
+    needs: [manifests, install]
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      # Named before anything is attempted. A missing secret discovered halfway
+      # through leaves a branch pushed to a fork and no request open, and the
+      # error the API returns for it is a 404 that reads like the fork is gone.
+      - name: the token this needs
+        env:
+          WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${WINGET_TOKEN:-}" ]; then
+            {
+              echo "the WINGET_TOKEN secret is not set, so there is nothing to open the request with."
+              echo ""
+              echo "it is a classic personal access token with the 'public_repo' scope, and it has"
+              echo "to be a classic one: a fine-grained token cannot act on a repository its owner"
+              echo "does not own, and this opens a request against microsoft/winget-pkgs."
+              echo ""
+              echo "  gh secret set WINGET_TOKEN --repo ${{ github.repository }}"
+            } >&2
+            exit 1
+          fi
+          echo "the token is present"
+
+      - name: open it
+        env:
+          GH_TOKEN: ${{ secrets.WINGET_TOKEN }}
+          VERSION: ${{ needs.manifests.outputs.version }}
+          RELEASE_URL: ${{ github.event.release.html_url }}
+          SOURCE_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          upstream="microsoft/winget-pkgs"
+          identifier="Haksolot.Ank"
+          # manifests/<lowercased first letter of the publisher>/<Publisher>/<Package>/<version>
+          dest="manifests/h/Haksolot/Ank/${VERSION}"
+          branch="${identifier}-${VERSION}"
+
+          # The fork is the account the token belongs to, asked rather than
+          # configured: a second place to write the owner is a second place for
+          # it to be wrong.
+          owner=$(gh api user --jq .login)
+          fork="${owner}/winget-pkgs"
+          echo "submitting as ${owner}"
+
+          if ! gh repo view "$fork" --json name >/dev/null 2>&1; then
+            {
+              echo "${fork} does not exist, and a request to ${upstream} has to come from a fork."
+              echo ""
+              echo "  gh repo fork ${upstream} --clone=false"
+            } >&2
+            exit 1
+          fi
+
+          base=$(gh api "repos/${upstream}" --jq .default_branch)
+          head_sha=$(gh api "repos/${upstream}/git/ref/heads/${base}" --jq .object.sha)
+          base_tree=$(gh api "repos/${upstream}/git/commits/${head_sha}" --jq .tree.sha)
+          echo "${upstream}/${base} is at ${head_sha}"
+
+          # The branch is created on the fork pointing straight at the upstream
+          # head, which is what makes syncing the fork unnecessary: a fork
+          # shares its object store with the repository it came from, so that
+          # commit is already there. The alternative was measured and rejected
+          # -- cloning winget-pkgs even at depth 1 pulls hundreds of thousands
+          # of manifests across the wire to add three files to it.
+          if ! gh api -X POST "repos/${fork}/git/refs" \
+            -f "ref=refs/heads/${branch}" -f "sha=${head_sha}" >/dev/null 2>&1; then
+            # A re-run of a published release lands here. Forced onto the
+            # current upstream head rather than left where it was: a branch
+            # built on a stale base is the one thing a registry's automation
+            # rejects without reading.
+            gh api -X PATCH "repos/${fork}/git/refs/heads/${branch}" \
+              -f "sha=${head_sha}" -F force=true >/dev/null
+          fi
+
+          # One commit and not three. The contents API writes a commit per file,
+          # and three commits adding three halves of one manifest is a diff a
+          # reviewer has to reassemble.
+          tree_entries=""
+          for name in \
+            "${identifier}.yaml" \
+            "${identifier}.installer.yaml" \
+            "${identifier}.locale.en-US.yaml"; do
+            content=$(base64 -w0 "packaging/winget/${name}")
+            blob=$(gh api -X POST "repos/${fork}/git/blobs" --input - --jq .sha <<JSON
+          {"content":"${content}","encoding":"base64"}
+          JSON
+            )
+            if [ -n "$tree_entries" ]; then tree_entries="${tree_entries},"; fi
+            tree_entries="${tree_entries}{\"path\":\"${dest}/${name}\",\"mode\":\"100644\",\"type\":\"blob\",\"sha\":\"${blob}\"}"
+            echo "blob ${blob}  ${dest}/${name}"
+          done
+
+          tree=$(gh api -X POST "repos/${fork}/git/trees" --input - --jq .sha <<JSON
+          {"base_tree":"${base_tree}","tree":[${tree_entries}]}
+          JSON
+          )
+
+          commit=$(gh api -X POST "repos/${fork}/git/commits" --input - --jq .sha <<JSON
+          {"message":"New version: ${identifier} version ${VERSION}","tree":"${tree}","parents":["${head_sha}"]}
+          JSON
+          )
+          echo "commit ${commit}"
+
+          gh api -X PATCH "repos/${fork}/git/refs/heads/${branch}" \
+            -f "sha=${commit}" -F force=true >/dev/null
+
+          # A re-run must not open a second request for the same version.
+          existing=$(gh pr list --repo "$upstream" --head "${branch}" \
+            --state open --json url --jq '.[0].url // empty')
+          if [ -n "$existing" ]; then
+            echo "a request for ${identifier} ${VERSION} is already open: ${existing}"
+            exit 0
+          fi
+
+          # The title is the shape winget-pkgs' own automation reads.
+          url=$(gh pr create --repo "$upstream" \
+            --base "$base" \
+            --head "${owner}:${branch}" \
+            --title "New version: ${identifier} version ${VERSION}" \
+            --body "$(cat <<BODY
+          Automated submission from [\`${SOURCE_REPO}\`](${{ github.server_url }}/${SOURCE_REPO}) on publishing [${VERSION}](${RELEASE_URL}).
+
+          The three manifests are derived from the release by [\`.github/scripts/winget-manifests.sh\`](${{ github.server_url }}/${SOURCE_REPO}/blob/${base}/.github/scripts/winget-manifests.sh); the \`InstallerSha256\` is read from the \`.sha256\` asset published beside the archive and is never typed by hand.
+
+          Before this request was opened, a Windows runner ran \`winget validate\` on these exact bytes, installed from them with \`winget install --manifest\`, and asserted that \`ank --version\` prints ${VERSION}.
+          BODY
+          )")
+
+          echo "opened ${url}"
+          # And that is where this repository stops. The registry reviews it;
+          # nothing here merges it, polls it, or retries it.
+          {
+            echo "### winget"
+            echo ""
+            echo "Opened ${url}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -91,7 +91,10 @@ jobs:
             exit 1
           fi
 
-          .github/scripts/winget-manifests.sh "$version"
+          # Invoked through `bash` and not executed: the mode bit does not
+          # survive a checkout on Windows, where this repository is also
+          # developed, so nothing here may depend on it.
+          bash .github/scripts/winget-manifests.sh "$version"
 
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
@@ -107,8 +110,9 @@ jobs:
             {
               echo ""
               echo "packaging/winget is not what deriving it for ${{ steps.derive.outputs.version }} produces."
-              echo "these are generated files: take the diff above as the fix, or re-run"
-              echo ".github/scripts/winget-manifests.sh <version> for a tag that has a release."
+              echo "these are generated files: take the diff above as the fix, or re-derive them."
+              echo ""
+              echo "  bash .github/scripts/winget-manifests.sh ${{ steps.derive.outputs.version }}"
             } >&2
             exit 1
           fi

--- a/packaging/winget/Haksolot.Ank.installer.yaml
+++ b/packaging/winget/Haksolot.Ank.installer.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+# Derived from the GitHub release by .github/scripts/winget-manifests.sh, which
+# .github/workflows/publish-winget.yml runs on every pull request and asserts
+# this file is exactly what deriving it produces. A hand edit turns that job red
+# instead of failing on somebody's machine -- in particular the sha256, which is
+# read from the .sha256 asset the release publishes and is never typed.
+PackageIdentifier: Haksolot.Ank
+PackageVersion: 0.2.0
+MinimumOSVersion: 10.0.0.0
+ReleaseDate: 2026-08-11
+# The release publishes a zip and not an installer, so winget unpacks it and
+# links the executable inside: `zip` with a `portable` nested type is that
+# shape. The relative path is inside the directory the archive wraps its
+# contents in, which release.yml names after the archive itself.
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: ank-0.2.0-x86_64-pc-windows-msvc\ank.exe
+    PortableCommandAlias: ank
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/haksolot/ank/releases/download/v0.2.0/ank-0.2.0-x86_64-pc-windows-msvc.zip
+    InstallerSha256: 4820E561876A370D5C918369938A0CEFAB05B370E4E3195C5FCDD552B67D8F47
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/packaging/winget/Haksolot.Ank.locale.en-US.yaml
+++ b/packaging/winget/Haksolot.Ank.locale.en-US.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+# Derived from the GitHub release by .github/scripts/winget-manifests.sh, which
+# .github/workflows/publish-winget.yml runs on every pull request and asserts
+# this file is exactly what deriving it produces. A hand edit turns that job red
+# instead of failing on somebody's machine -- in particular the sha256, which is
+# read from the .sha256 asset the release publishes and is never typed.
+PackageIdentifier: Haksolot.Ank
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: haksolot
+PublisherUrl: https://github.com/haksolot
+PublisherSupportUrl: https://github.com/haksolot/ank/issues
+PackageName: ank
+PackageUrl: https://github.com/haksolot/ank
+License: GPL-3.0-only
+LicenseUrl: https://github.com/haksolot/ank/blob/main/LICENSE
+Copyright: Copyright (C) 2026 haksolot
+ShortDescription: Tasks and architecture decisions in your repo, behind one CLI agents can call
+Description: |-
+  ank keeps a project's tasks and architecture decisions in the repository
+  itself, as files an agent reads through one CLI. A decision carries a scope,
+  so it binds the work that matches it rather than the work that remembers it,
+  and a task's completion criterion is frozen by hash the moment it is claimed.
+Moniker: ank
+Tags:
+  - agent
+  - architecture
+  - cli
+  - decision-records
+  - developer-tools
+  - project-management
+  - rust
+  - tasks
+ReleaseNotesUrl: https://github.com/haksolot/ank/releases/tag/v0.2.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/packaging/winget/Haksolot.Ank.yaml
+++ b/packaging/winget/Haksolot.Ank.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+# Derived from the GitHub release by .github/scripts/winget-manifests.sh, which
+# .github/workflows/publish-winget.yml runs on every pull request and asserts
+# this file is exactly what deriving it produces. A hand edit turns that job red
+# instead of failing on somebody's machine -- in particular the sha256, which is
+# read from the .sha256 asset the release publishes and is never typed.
+PackageIdentifier: Haksolot.Ank
+PackageVersion: 0.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
`TASK-b693dc062cab`. The fifth distribution channel, and the second that
publishes into a registry rather than serving itself from this repository.

`packaging/winget/` carries the three manifests winget requires, derived from
the release by `.github/scripts/winget-manifests.sh`. They are generated files
that happen to be committed, exactly like `Formula/ank.rb` and
`bucket/ank.json`: a release runs the script and commits the result, every
other run runs it and asserts the committed files are exactly what it produced.
The `InstallerSha256` is read from the `.sha256` asset published beside the
archive and is never typed -- it matches the number `bucket/ank.json` already
carries, which is two independent derivations landing on the same hash.

`publish-winget.yml` has three jobs, and their order is the argument. A
manifest is only proved by an install, and this request goes to somebody else's
repository, so `submit` needs `install`: nothing leaves here until a Windows
runner has run `winget validate` on these exact bytes, installed from them with
`winget install --manifest`, and seen `ank --version` print the released
version. The pull request against `microsoft/winget-pkgs` is opened on a
published release and never merged, polled or retried by this repository.

Two details worth reading:

- `RelativeFilePath` points inside the directory the zip wraps its contents in,
  verified against the published archive rather than inferred. Same trap
  `extract_dir` is on the Scoop side, and it fails at install time on a user's
  machine rather than at validation.
- The request is built through the Git Data API and never by cloning. A fork
  shares its object store with the repository it came from, so the branch is
  created pointing straight at `winget-pkgs`' current head -- no sync, and no
  clone of a registry carrying hundreds of thousands of manifests in order to
  add three files to it.

The `submit` job needs `WINGET_TOKEN`, a classic personal access token with
`public_repo`. It has to be classic: a fine-grained token cannot act on a
repository its owner does not own. The job names the secret and the command
when it is missing.

`cargo test --workspace` green (561 tests), `cargo fmt --check` green,
`ank check` reports 0 faults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014fRJYcKeTA9yXwLdQsyxXE
