### PR TITLE
TASK-07e021f95aa3 done: ank installs from an apt repository this project hosts

### DIFF
--- a/.ank/entities/LOG-49008e5ed484.md
+++ b/.ank/entities/LOG-49008e5ed484.md
@@ -1,0 +1,22 @@
+---
+id: LOG-49008e5ed484
+type: log
+title: The Pages clause is measured rather than promised. Run 31962693816, a workflow_dispatch on main,
+created: 2026-08-16T17:52:30Z
+author: claude-code/opus-5
+scope:
+  - packaging/deb/**
+  - .github/workflows/publish-apt.yml
+about: TASK-07e021f95aa3
+seq: 2
+schema: 3
+version: 1
+---
+
+ deployed the tree and then installed from it over the network -- which is why the dispatch was made to deploy at all: publishing was otherwise provable only by cutting a tag, and a channel whose hosting is first exercised by a release is a channel whose hosting is first exercised in front of users.
+
+What that run showed, in order. Pages served index.html, Release.gpg and InRelease, 200 each. Added without the key, apt refused: "Missing key 307CF7403388668AC8C18C9EAD44831D7AB3E0C1, which is needed to verify signature" then "The repository ... is not signed" -- the negative control naming the exact fingerprint of the key it lacked, which is a stronger answer than the one it was written to accept. Added with the key, apt fetched InRelease and Packages, downloaded ank amd64 0.2.0 [2227 kB] from haksolot.github.io, and the installed binary answered "ank 0.2.0 (c86eeeb, skill 3f350ad26459)".
+
+Verified again from outside CI, by hand: the four URLs return 200, InRelease is a clearsigned document, and Packages lists all five versions with no Depends field -- the static musl build carrying nothing from the archive, which is the one control field that would be silently wrong if the binary were ever built differently.
+
+The task is closed after this rather than before it. Every other clause was green on the pull request, and this one needed the merge first because workflow_dispatch only exists on the default branch; closing first and measuring after would have been grading myself on the only clause not yet measured.

--- a/.ank/entities/LOG-f87c9d5430b9.md
+++ b/.ank/entities/LOG-f87c9d5430b9.md
@@ -1,0 +1,14 @@
+---
+id: LOG-f87c9d5430b9
+type: log
+title: done, proof commit:80c473b
+created: 2026-08-16T17:52:43Z
+author: claude-code/opus-5
+scope:
+  - packaging/deb/**
+  - .github/workflows/publish-apt.yml
+about: TASK-07e021f95aa3
+seq: 3
+schema: 3
+version: 1
+---

--- a/.ank/entities/TASK-07e021f95aa3.md
+++ b/.ank/entities/TASK-07e021f95aa3.md
@@ -5,7 +5,7 @@ slug: ank-installs-from-an-apt-repository-this-project
 title: ank installs from an apt repository this project hosts
 created: 2026-08-16T03:35:49Z
 author: claude-code/opus-5
-status: in_progress
+status: done
 scope:
   - packaging/deb/**
   - .github/workflows/publish-apt.yml
@@ -13,8 +13,13 @@ blocked_by: []
 done_criteria: |
   A release produces a .deb carrying the static binary, its licence and its man-less documentation, with control fields naming the architecture and the version. A workflow triggered on a published release rebuilds the pool and the index, signs the Release file with a key held in Actions secrets, and publishes the tree to GitHub Pages. A CI job in a Debian container adds the repository and its public key, runs apt-get install ank, and asserts ank --version prints the released version. The key is a distribution key and never the ratification key. cargo test --workspace and ank check stay green.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 80c473b
+    criteria: db004d850e64
+    via: submitted
 schema: 3
-version: 2
+version: 3
 ---
 
 The binary is a static musl build, so the package depends on no libc and the


### PR DESCRIPTION
The corpus transition for the apt channel, merged in #159. It is a separate
pull request because the last clause of the criterion could only be measured
after that one landed: `workflow_dispatch` exists only on the default branch,
so the Pages deployment was not provable from the feature branch. Closing first
and measuring after would have been grading myself on the only clause not yet
measured.

Run [31962693816](https://github.com/haksolot/ank/actions/runs/31962693816), a
dispatch on `main`, deployed the tree and then installed from it over the
network:

- Pages served `index.html`, `Release.gpg` and `InRelease` — 200 each.
- Added **without** the key, apt refused: `Missing key
  307CF7403388668AC8C18C9EAD44831D7AB3E0C1, which is needed to verify
  signature`, then `The repository ... is not signed`. The negative control
  named the exact fingerprint of the key it lacked, which is a stronger answer
  than the one it was written to accept.
- Added **with** the key, apt fetched `InRelease` and `Packages`, downloaded
  `ank amd64 0.2.0 [2227 kB]` from `haksolot.github.io`, and the installed
  binary answered `ank 0.2.0 (c86eeeb, skill 3f350ad26459)`.

Verified again by hand from outside CI: the four URLs return 200, `InRelease`
is a clearsigned document, and `Packages` lists all five versions with no
`Depends` field.

The repository is live at <https://haksolot.github.io/ank/>.

`ank check` reports 0 faults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014fRJYcKeTA9yXwLdQsyxXE