### PR TITLE
The distribution ADR covers packaging/, before it is ratified and not after

### DIFF
--- a/.ank/entities/ADR-782a3556cf2d.md
+++ b/.ank/entities/ADR-782a3556cf2d.md
@@ -16,6 +16,7 @@ scope:
   - install.sh
   - Formula/**
   - bucket/**
+  - packaging/**
 constraint: |
   Every distribution channel ank offers is carried by this repository. No satellite
   repository holds a skill, a plugin manifest, a marketplace catalogue or a package
@@ -34,7 +35,7 @@ constraint: |
   are this repository and neither earns a satellite.
 supersedes: ADR-e3cb36646d77
 schema: 3
-version: 3
+version: 4
 ---
 
 ## Context

--- a/.ank/entities/LOG-1580dba40fff.md
+++ b/.ank/entities/LOG-1580dba40fff.md
@@ -1,0 +1,28 @@
+---
+id: LOG-1580dba40fff
+type: log
+title: packaging/** joins the scope now that packaging/winget/ and packaging/deb/ exist, and the timing is
+created: 2026-08-16T18:04:04Z
+author: claude-code/opus-5
+scope:
+  - npm/**
+  - skill/**
+  - docs/**
+  - .claude-plugin/**
+  - package.json
+  - .github/workflows/**
+  - install.sh
+  - Formula/**
+  - bucket/**
+  - packaging/**
+about: ADR-782a3556cf2d
+seq: 1
+schema: 3
+version: 1
+---
+
+ the whole point. An accepted ADR's scope is hashed into its ratification commit and frozen there, so a path added after acceptance is a path the rule never reaches. Ratified as it stood, this decision would have covered neither of the two directories its own Consequences section names.
+
+This is the second half of the repair recorded above. The scope was originally filed naming paths that did not exist, check reported four dead scopes at once, and they were dropped; install.sh, Formula/** and bucket/** came back when those channels landed. packaging/** is the last of the four, and with it the scope names every path the constraint actually describes.
+
+The AUR is what remains, and it is the one channel this decision exists to buy. Ratification waits for it: TASK-cf8e must not be claimed before this ADR is accepted, and this ADR should not be accepted before the scope covers the directory that task will write into.


### PR DESCRIPTION
`packaging/**` joins the scope of `ADR-782a3556cf2d`, which is still `proposed`.

The timing is the whole point. An accepted ADR's scope is hashed into its
ratification commit and frozen there, so a path added after acceptance is a path
the rule never reaches. Ratified as it stood, this decision would have covered
neither `packaging/winget/` nor `packaging/deb/` — the two directories its own
*Consequences* section names.

This is the last of the four paths dropped at creation, when `check` reported
them as dead scopes because they were filed before the channels existed.
`install.sh`, `Formula/**` and `bucket/**` came back as those landed; this is
`packaging/**`, and with it the scope names every path the constraint describes.

`ank scope packaging/deb/README.md` now returns the ADR, which it did not
before.

**Ratification still waits for the AUR.** That is the one channel this decision
exists to buy, and `TASK-cf8e08128cb4` must not be claimed before the ADR is
accepted — so the order is: this merges, the AUR task is written against a scope
that covers it, and the ADR is signed in between.

`ank check` reports 0 faults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014fRJYcKeTA9yXwLdQsyxXE