### PR TITLE
The specification says which channels ship, and which do not

### DIFF
--- a/.ank/entities/LOG-007fc7a76753.md
+++ b/.ank/entities/LOG-007fc7a76753.md
@@ -1,0 +1,15 @@
+---
+id: LOG-007fc7a76753
+type: log
+title: "amended: -blocked_by TASK-cf8e08128cb4"
+created: 2026-08-16T19:04:01Z
+author: claude-code/opus-5
+scope:
+  - .ank/entities/SPEC-9f510cad4be6.md
+  - .ank/entities/SPEC-eddf356ce1a9.md
+  - docs/agents.md
+about: TASK-13f9162ed61a
+seq: 2
+schema: 3
+version: 1
+---

--- a/.ank/entities/LOG-2827a2e8f38c.md
+++ b/.ank/entities/LOG-2827a2e8f38c.md
@@ -1,0 +1,22 @@
+---
+id: LOG-2827a2e8f38c
+type: log
+title: Parked on an external freeze, not on anything in this repository. The maintainer reports that
+created: 2026-08-16T19:03:36Z
+author: claude-code/opus-5
+scope:
+  - packaging/aur/**
+  - .github/workflows/publish-aur.yml
+about: TASK-cf8e08128cb4
+seq: 0
+schema: 3
+version: 1
+---
+
+ publishing to the AUR is frozen following a recent security incident on the registry, measured 2026-08-16. Nothing here is wrong: ADR-782a3556cf2d was ratified the same day and its scope covers packaging/**, so the decision this task waited on is in place and the perimeter it will write into is bound.
+
+What is ready when the freeze lifts. AUR_SSH_PRIVATE_KEY is held in Actions secrets, ed25519, generated in a throwaway directory that was destroyed, fingerprint SHA256:tpMyweUaIh3bJ+MKpxZkZMx2MQswWYTQSMUYGJkvKIw. What is missing is the AUR account itself with that public half registered on it; the key can push nowhere until it exists.
+
+The criterion is untouched and stays frozen. This is a release for being stuck, in the sense the skill means -- say so and hand it back rather than letting the claim lapse in silence -- and not a judgement about the criterion, which remains right. The shape to build is the one winget already proved: everything up to the push testable in a container, and only the final push needing the credential.
+
+One consequence for the plan. TASK-13f9 was blocked by this task among six, and the other five are done. Waiting on a frozen registry to say that six channels ship would produce exactly the failure that task's body warns about in the other direction: a specification that is behind while a reader acts on it. The blocker is dropped there and the AUR is simply not named as shipping, because it does not.

--- a/.ank/entities/LOG-68cd273e6988.md
+++ b/.ank/entities/LOG-68cd273e6988.md
@@ -1,0 +1,16 @@
+---
+id: LOG-68cd273e6988
+type: log
+title: "released: the AUR is frozen to publishers after a security incident on the registry, measured"
+created: 2026-08-16T19:03:49Z
+author: claude-code/opus-5
+scope:
+  - packaging/aur/**
+  - .github/workflows/publish-aur.yml
+about: TASK-cf8e08128cb4
+seq: 1
+schema: 3
+version: 1
+---
+
+ 2026-08-16; the criterion is right and untouched, and the account the SSH key would push to cannot be created yet

--- a/.ank/entities/LOG-eab6b3213391.md
+++ b/.ank/entities/LOG-eab6b3213391.md
@@ -1,0 +1,15 @@
+---
+id: LOG-eab6b3213391
+type: log
+title: done, proof commit:efe4d1481d594d6403ee51e98742805d347a2b5c
+created: 2026-08-16T19:14:36Z
+author: claude-code/opus-5
+scope:
+  - .ank/entities/SPEC-9f510cad4be6.md
+  - .ank/entities/SPEC-eddf356ce1a9.md
+  - docs/agents.md
+about: TASK-13f9162ed61a
+seq: 4
+schema: 3
+version: 1
+---

--- a/.ank/entities/LOG-f72971c1a40d.md
+++ b/.ank/entities/LOG-f72971c1a40d.md
@@ -1,0 +1,23 @@
+---
+id: LOG-f72971c1a40d
+type: log
+title: I breached ADR-01b6dd05f0db while doing this task and am recording it rather than leaving it
+created: 2026-08-16T19:11:05Z
+author: claude-code/opus-5
+scope:
+  - .ank/entities/SPEC-9f510cad4be6.md
+  - .ank/entities/SPEC-eddf356ce1a9.md
+  - docs/agents.md
+about: TASK-13f9162ed61a
+seq: 3
+schema: 3
+version: 1
+---
+
+ invisible. To find which documents cite the two specs being superseded, I ran grep over .ank/entities/ directly. That is exactly the file-level read the decision forbids, and nothing in the tree refused me: the constraint is verifiable, not defended. I redid the same question through the CLI -- ank find --type spec, then ank show on each to read its references field -- and the answer was the same, which is not the point. The point is that check cannot see this and only a record can.
+
+The reference graph, read properly. SPEC-9f510cad4be6 is cited by SPEC-3d12e76d9fa2 and by SPEC-eddf356ce1a9; SPEC-eddf356ce1a9 is cited by nothing live. So the order was: create the successor to 9f51 first, create the successor to eddf citing it, then amend SPEC-3d12e76d9fa2 to point at the successor and drop the old id.
+
+A correction to what the task body assumed, measured today. It expected section 13 to be "behind" by omitting apt and the AUR. Five channels install ank as of now -- npm, curl | sh, Homebrew, Scoop, apt -- and winget is not one of them: the manifest is derived and proved on every run, but it reaches microsoft/winget-pkgs only when a release is next published, and no release has happened since it landed. Listing winget beside the five would have been precisely the failure the body warns against, a document announcing a channel nobody can install from. Both successors name it as not yet installable instead, and say the same of Arch.
+
+The successor to eddf carries a wider scope than its predecessor: install.sh, Formula/**, bucket/** and packaging/** join skill/**, npm/**, init.rs and the workflows. This is a document about distribution that did not reach four of the directories the channels live in, which is the same gap ADR-782a3556cf2d had before its scope was amended. A successor is the only moment it can be fixed, for the same reason: acceptance hashes the scope.

--- a/.ank/entities/SPEC-3d12e76d9fa2.md
+++ b/.ank/entities/SPEC-3d12e76d9fa2.md
@@ -10,10 +10,10 @@ scope:
   - crates/ank-cli/src/done.rs
   - crates/ank-cli/src/verify.rs
   - .ank/allowed_signers
-references: [SPEC-acee5d9cb21b, SPEC-183d297253ac, SPEC-9f510cad4be6]
+references: [SPEC-acee5d9cb21b, SPEC-183d297253ac, SPEC-93531977642f]
 ratified: 2a7a2e8d824b
 schema: 3
-version: 3
+version: 4
 ---
 
 One of the ten documents that carry the Ank specification (ADR-5a690829388d).

--- a/.ank/entities/SPEC-93531977642f.md
+++ b/.ank/entities/SPEC-93531977642f.md
@@ -1,0 +1,111 @@
+---
+id: SPEC-93531977642f
+type: spec
+slug: implementation-and-the-decisions-that-bound-it
+title: Implementation, and the decisions that bound it
+created: 2026-08-16T19:08:03Z
+author: claude-code/opus-5
+status: proposed
+scope:
+  - crates/**
+  - Cargo.toml
+  - LICENSE
+references: [SPEC-183d297253ac, SPEC-3d12e76d9fa2]
+supersedes: SPEC-9f510cad4be6
+schema: 3
+version: 1
+---
+
+One of the ten documents that carry the Ank specification (ADR-5a690829388d).
+This one carries **§12 and §13**: Rust and hand-written argument parsing, the git
+plumbing rule and the minimum version, who commits, recovery — and the licence,
+the platforms, and what remains deferred to v1.1.
+
+## Why the final decisions are not a document of their own
+
+§13 is nine lines and it would have made the eleventh entity, which is the
+fragmentation this decomposition refuses. It belongs here rather than anywhere
+else because **each of its three decisions is a constraint on the implementation
+and on nothing else**, and two of them are load-bearing for rules stated a few
+paragraphs above.
+
+The platforms are the clearest case. §12 says the portability of the plumbing
+comes from git rather than from a library, identical on all three operating
+systems, and that git is also what provides the verifiers' `sh` on Windows. §13
+is what makes that sentence a commitment instead of an observation: Linux, macOS
+and Windows, native in v1. Read apart, one is an argument resting on a promise
+kept in another document.
+
+The licence is the same shape. It is chosen on a criterion about distributing the
+CLI's code, and it explicitly does not cover the format or a user's `.ank/` files
+— which is the promise "the format is the specification" made in §2, held at the
+legal layer. That is a decision about what this implementation is, not about what
+Ank is for, so it does not belong in the intent document either.
+
+The line about what stays deferred to v1.1 is a pointer into the register, and it
+stays with the implementation because what is deferred there — the merge driver —
+is an implementation and its one fixed rule is stated in synchronisation.
+
+**What is not here** is the distribution channel itself. npm, the dist-tag
+derivation and the release are bootstrapping's, because they are about how the
+binary reaches a machine rather than about how it is built.
+
+## What it rests on
+
+- **Synchronisation** — git as a hard dependency, required per verb, and the
+  refs the plumbing writes.
+- **Proof, anchoring and authority** — the signing that decides the plumbing
+  question, and the one commit Ank produces.
+
+---
+
+## 12. Implementation
+
+**Rust.** Justified here for two reasons aligned with the goals: a static binary with no runtime (agent agnosticism means imposing nothing on the host environment), and a type system that makes the state machine's invariants — illegal transitions, frozen fields — checkable at compile time rather than at run time.
+
+The "suitable ecosystem" argument used to be third here; it is withdrawn rather than watered down. It rested on `gix` and `clap`, both rejected — git plumbing goes through the binary (below), argument parsing is written by hand (below) — leaving only `rusqlite` and `globset`, whose equivalents exist in every candidate language. That is not what decides it.
+
+**Argument parsing is written by hand**, with no library. The reason is not saving a dependency but character-level control over two surfaces read by agents: the self-correcting errors (§4), which a generic parser would replace with its own messages, and `ank help`, which §9 says carries the flag details — generated help is verbose, and its cost is paid on every call that triggers it. Neither argument depends on the surface being frozen, which it is not (§4): the cost of hand-written parsing is paid once per verb, and the verbs share one parser, so what grows is linear and small against a `help` and an error surface that stay exactly as written.
+
+The real cost is iteration speed on a design that is still moving. Mitigation: freeze and implement the **format parser** first, independently of the CLI. It is the stable part and the only one interoperability depends on.
+
+### Git plumbing
+
+Ank calls the **git binary**, never a library reimplementation. `gix`, considered in order to avoid depending on the system binary, would save nothing: git is a hard dependency anyway (§7). The decisive argument is elsewhere — `accept` and `check` rest on signing. Producing a signed commit and verifying it against `allowed_signers` (§8) is three lines of plumbing with `git commit -S` and `git verify-commit`; it is a cryptographic project with a library, for a result at best equivalent and at worst subtly different from what the user will check by hand.
+
+**Plumbing only**: `update-ref`, `for-each-ref`, `symbolic-ref`, `rev-parse`, `rev-list`, `merge-base`, `verify-commit`, `hash-object`, `cat-file`. Never porcelain — its output offers no stability contract across versions, and parsing it would be exactly the debt that resorting to the binary is meant to avoid.
+
+Three entries are new and serve the ref lifecycle and the default branch (§7). `for-each-ref` enumerates `refs/ank/*` — pruning without enumeration is not implementable, and that gap predated revision e: `check` was already supposed to prune orphan refs. `symbolic-ref` reads `refs/remotes/origin/HEAD` and the current branch. `merge-base --is-ancestor` serves reachability, which feeds the diagnostic and never the pruning decision (§7). `cat-file`, already present, gains a use: reading a task file as it appears on the default branch.
+
+The rule that matters is not the enumeration but its criterion: a command enters this list only if its output is stable by contract across git versions. That criterion is what excludes porcelain, and it excludes it by its reason rather than by its name — a closed list goes stale at every new need, as this one just did.
+
+**Minimum version: git 2.34.** That is the version introducing SSH signing and `gpg.ssh.allowedSignersFile`; below it, `accept` and `check` cannot fulfil their contract. Too old a version exits with **code 9** — an environment to repair, not a task failure — with the upgrade link.
+
+**The check is per verb, and never at startup** (ADR-9307e5d214a7). A verb that coordinates — `claim`, `log`, `done`, `release`, `close`, `accept`, `attest`, `init` — requires git 2.34 or newer inside a repository, and exits 9 naming the command when git is missing, too old, or the working directory is outside a repository. A verb that only reads or writes the corpus requires none of it and answers on the files alone: `show`, `find`, `graph`, `scope`, `new`, `amend` and `context` need a parser, not an arbiter. `check` runs the invariants that need no git — parse, round-trip, `blocked_by` references, glob validity, filename against id — and skips the coordination half, saying so in exactly one line rather than refusing.
+
+The distinction is not between git and something else, it is between coordinating and reading. A gate standing in front of the dispatch rather than in front of the operation made a binary that could not validate a corpus unless that corpus sat in a git repository — which is smaller than what §14 claims for the format, and smaller than the golden suite is published as. Repository resolution never depended on git and does not gain it: the walk up for `.ank/` is what §6 describes.
+
+### Ank and git: who commits
+
+**Ank never commits, with one exception.** The writes of `new`, `log`, `done` and `release` land in the working tree and propagate at the pace of the agent's commits, together with its code — the organisational state and the code it describes travel together, which is exactly the tool's promise. Accepted consequence: at level 1, another clone sees a transition only once the commit is pushed; real-time coordination, meanwhile, goes through claims, which depend on no commit. At level 0 — the only level that ships — that coordination reaches the working trees sharing one `refs/ank/`, and no further (§7).
+
+The exception is **`accept`, which produces the signed ratification commit itself**, containing only the promoted ADR's file (and, where applicable, the replaced ADR moving to `superseded`). The authority model rests on this commit; leaving it to the caller's discretion would make it optional.
+
+That is also why `accept` is the only command carrying a branch precondition (§4): it is the only one writing into history rather than into the working tree. The other commands have no need to know which branch they run on — their write travels with the agent's code and will be arbitrated at merge time like any file. A ratification commit, by contrast, cannot wait for the merge to become authoritative: it is authoritative as soon as it exists, on the branch where it exists.
+
+### Recovery
+
+Ank implements no undo mechanism, no trash and no history of its own, and that is deliberate: **git is already all of those**. A mistaken `done`, an ADR superseded in error, a deleted file are all recovered with the tools the user already knows.
+
+The consequence to respect in the implementation: every operation must produce a clean, readable diff. The log format is chosen precisely for that, and it still is after two moves (§3): a log entry is written and never revised, so it is an added file and nothing else in the diff, and a transition is a minimal frontmatter diff on the entity alone. The property to keep is the one the original section-at-the-end of the task file was reaching for — one act, one legible change — and what it took to keep it was getting the trace out of the file whose fields are frozen.
+
+
+## 13. Final decisions
+
+**Licence: GPL-3.0.** The criterion applied: modification and commercialisation are free, but a distributed fork must publish its sources — that is the definition of strong copyleft. Two honest clarifications about what the GPL actually guarantees: the obligation to publish is triggered only by *distribution* (a fork kept internal is not bound, and no classic licence imposes that), and it covers the CLI's code, not the format — users' `.ank/` files and the third-party tools that read or write them are not derivative works, which preserves "the format is the specification". A hosted service built on Ank is not bound (the network clause would be the AGPL); for a local CLI that case is marginal, and the AGPL would slow adoption for nothing.
+
+**Platforms: Linux, macOS, Windows, native in v1.** Rust cross-compiles all three without friction, and the portability of the plumbing comes not from a library but from git itself, identical on all three operating systems — git is also what provides the verifiers' `sh` on Windows (§4). One external dependency, present everywhere, rather than a per-platform reimplementation. **Distribution**: `curl | sh`, npm, Homebrew, Scoop, and an apt repository this project hosts. Every channel is carried by this repository and none by a satellite (ADR-782a3556cf2d); the apt repository serves `amd64` alone, which is the release matrix rather than a decision of this section. Two are not installable yet and are named as such rather than listed beside the rest: a winget manifest is derived and proved on every run but reaches `microsoft/winget-pkgs` only when a release is next published, and Arch is not served at all.
+
+**Deferred to v1.1, shape frozen now**: the `.ank/` merge driver (one rule fixed in §7, `version` = max + 1, automated at the first real conflicts; the log rule beside it is gone, and the reason recorded for dropping it was itself wrong — §7 says what actually holds). `ank attest` was on this list and is not any more: it ships in v1 (§10), and what remains deferred is a CI calling it unprompted, which is an integration and not a verb.
+
+No open points remain: the format, the agent loop, the three platforms and levels 0 and 1 are fully specified.

--- a/.ank/entities/SPEC-dbbd533cbc78.md
+++ b/.ank/entities/SPEC-dbbd533cbc78.md
@@ -1,0 +1,120 @@
+---
+id: SPEC-dbbd533cbc78
+type: spec
+slug: bootstrapping-teaching-and-distribution
+title: Bootstrapping, teaching and distribution
+created: 2026-08-16T19:08:15Z
+author: claude-code/opus-5
+status: proposed
+scope:
+  - skill/**
+  - npm/**
+  - crates/ank-cli/src/init.rs
+  - .github/workflows/**
+  - install.sh
+  - Formula/**
+  - bucket/**
+  - packaging/**
+references: [SPEC-cd0d3377b37f, SPEC-93531977642f]
+supersedes: SPEC-eddf356ce1a9
+schema: 3
+version: 1
+---
+
+One of the ten documents that carry the Ank specification (ADR-5a690829388d).
+This one carries **§9 entire**: how the skill is installed and what its token
+economy buys, what `ank help` owes its caller, what `init` writes and what it
+refuses, and how the binary is distributed.
+
+## Why the help surface is here and not with the verbs
+
+The obvious boundary would put `ank help` in the CLI surface, beside the verbs it
+lists. It is here, and the reason is what this document is about.
+
+The surface document says **what a verb does and on what state it refuses**. This
+one says **what the caller is told, and by which of three surfaces** — SKILL.md
+carries the mental model, `ank help` carries the surface, the error carries the
+next command. That division of labour is the subject here, and every rule below
+is a consequence of it: a description names a flag only to offer it or to refuse
+it, because a description is a fourth surface able to misinform; the listing
+prints the same sentence the per-verb page does, because two strings are two
+things to keep true; an unknown verb is a code 2 and never a fallback to the
+general listing.
+
+Read the other way, the test holds too. The verb semantics are readable without
+knowing how they are announced, and the announcement rules are readable without
+the verb table — they are rules about a surface, not about any particular verb.
+
+**Bootstrapping, teaching and distribution are one subject** for the same reason:
+they are everything that happens on a machine that does not have Ank yet, and
+they are governed by one economy. The skill is loaded permanently, so its content
+is frozen and its size is a ceiling. `ank help` is loaded on demand, so it carries
+the detail. `init` writes the few files that make a repository a corpus. npm
+carries the binary inside the package because the workstation this channel exists
+for cannot download an executable. Cut anywhere and one of those loses the reason
+it is shaped that way.
+
+## What it rests on
+
+- **The CLI surface** — the verbs, flags and refusals `ank help` is required to
+  print faithfully.
+- **Implementation, and the decisions that bound it** — the platforms and the
+  licence the distribution channels carry.
+
+---
+
+## 9. Bootstrapping
+
+Skill installation leans on the existing ecosystem rather than a home-made mechanism:
+
+```
+npx skills add <owner>/ank
+```
+
+Skills install from repositories rather than npm packages: the identifier is `owner/repo`, there is no bare name. The skill's repository is therefore called simply `ank`. Installation happens through a symlink, and a `skills-lock.json` versioned in the repository reproduces the same set of skills on every machine in the team — consistent with the rest of the design, where everything that matters is in the repository.
+
+The `skills` CLI handles multi-agent detection (Claude Code, Codex, Cursor, OpenCode, and many others) and creates links from each agent to a canonical copy — exactly the desired design, already maintained by a third party.
+
+**Token economy, and what is actually always-on.** The content of SKILL.md is frozen (§4) because what it teaches is what every agent knows: it carries the loop, the planning that fills it, the investigation that precedes both, and the mental model behind all three — nothing else, and growing that costs a superseding ADR (ADR-5dd7b4a9c875). Flag details and the rest of the surface stay in `ank help`, loaded on demand.
+
+**What a session pays for unconditionally is the frontmatter, not the body**, and the distinction is worth stating because the ceiling was justified without it. Measured on the plugin route: `claude plugin details ank` reports `Always-on: ~58 tok added to every session`, which is the `name` and the `description`; the body is read when the skill is invoked. The `description` is therefore the expensive line in the file and does not grow. The **ceiling on the body is kept regardless**, because the by-hand route below copies the whole file into whatever a harness loads and some harnesses load all of it every session: the ceiling bounds the worst route rather than the best one, and a number that protected only the measured case would be a number that stops protecting the moment somebody installs it differently.
+
+**`ank help` lists every verb, grouped by the moment a verb is reached for** (ADR-f61e2d2c75e8, superseding ADR-e17e1bbd93ff on this clause alone): every verb with a one-line description, under a lowercase heading, and inside a group the order stays §4's. No verb is hidden and there is no second listing to ask for. A group says **when** a verb is used and never **who** may use it — a heading named after a caller is the claim §4 withdraws, and it is the one this grouping cannot make: `check` sits under keeping the corpus honest whether a human or an agent types it. The order alone carried what a heading would have said while the surface was five verbs; at twenty-one it carries it only to a reader who already knows the order is meaningful, which is precisely what a first reader does not know. `ank help <verb>` answers about that verb alone: what it does, its usage, its flags with their value placeholders, the globals, and **the state conditions on which it refuses, each with its exit code**. An unknown verb is a **code 2** and never a fallback to the general listing — an agent that asked about one verb and received all sixteen has to work out that its question went unanswered.
+
+**The refusals belong here because nothing else owns them.** §4 carries a whole subsection on refusing by state rather than by identity, and that is a promise to the reader of this document; the caller of the binary had no surface stating which states, or what code came back. The division of labour §9 bets on — SKILL.md carries the mental model, `ank help` carries the surface, the error carries the next command — only holds if the middle one answers *what will this refuse*. It did not, and a session of dogfooding fell through the gap five times, recovering through the source each time. In another repository ank arrives as a binary and a SKILL.md: there is no source to fall through to, and the same five become dead ends.
+
+Three consequences, each of which was one of those five:
+
+- **A flag that is always refused is not a flag.** `ank help` lists what a caller can use; a name the verb rejects by design belongs in the refusals, not in the flag list. Listing it is worse than silence, because the caller reads an offer.
+- **A requirement that lives in the state is stated as one.** `done` needs a proof it cannot always produce for itself, and the grammar of one — `<type>:<ref>`, where the type is `commit`, `human-review`, `assertion` or `test` — is part of the surface, not part of the error that fires once the caller has already guessed wrong.
+- **Where a value is interpreted, say by what.** `$EDITOR` is a command line run through `sh`, not a program name. A caller told `EDITOR=vi` reasonably supplies a GUI editor, gets no `--wait`, and the editor returns before anything is typed: ank writes the file back unedited and nothing anywhere says so.
+
+The listing and the per-verb page stay two surfaces, and **the listing carries one short description per verb**. It used to carry the verb and its flag names, which is the shape that says what none of them does: `--criteria` beside `amend` names a flag without saying what the verb is for, and a caller choosing between twenty-one verbs is choosing on the usage line alone. Git's listing answers that question in one line each, and this one now does too.
+
+**The description takes the place of the flag names.** They are one `ank help <verb>` away, where they carry their value placeholders and the refusals that qualify them — a bare flag name in an overview is the least informative thing the line could hold, and keeping both would double the height of the listing, which is the token economy this paragraph used to invoke for saying nothing at all. An economy that sends the caller to the source is not one: recovering what a description would have carried cost one session more than twenty lines of reading `human.rs`, `done.rs` and `editor.rs`, plus a scratch repository (TASK-fe130d2b732c).
+
+**The description states what the verb refuses wherever the refusal is what distinguishes it.** This is not a stylistic preference, it is what makes the line honest here: ank's verbs refuse on state (§4), so a description naming only a purpose is a fourth surface able to misinform. `change a task's scope, blockers or criteria` would have confirmed the defect TASK-84cfad83c308 recorded rather than caught it; `change a task's scope or blockers, and a criterion no live claim freezes` is the same line doing the work. Each description is the one-line compression of what `ank help <verb>` already says, never a second text with its own opinion.
+
+**A description names a flag only to offer it or to refuse it, never by accident.** Every `--flag` a description mentions is either one the verb offers, or one it names as refused — `creates .ank/ here or at <path>; refuses --repo` is honest, `changes blockers, scope or --criteria` on a verb that rejects `--criteria` is the defect. The rule is mechanical, and a test walks both surfaces through the binary: it reads the flags and the refusals `ank help <verb> --json` already carries and fails when a description advertises something absent from the first. It is *a flag that is always refused is not a flag*, applied to the surface where a caller reads fastest and checks least.
+
+**The listing prints the same sentence the per-verb page does**, and that is what makes the compression a compression rather than a second text. Two strings would be two things to keep true, and the one that drifts is the one nobody reads twice — which is how `amend` came to advertise a criterion edit the binary refused always (TASK-84cfad83c308). There is one description per verb, `ank help` prints it beside the verb, and `ank help <verb>` prints it above the flags and the refusals that qualify it.
+
+**None of this is a claim about who a verb is for** (ADR-f61e2d2c75e8, superseding ADR-e17e1bbd93ff). A description says what a verb does, and the heading above it says when that verb is reached for; neither sorts callers, which is the claim §4 withdrew and the only one either could make. Both carry what the order alone never could: the order is meaningful only to a reader who already knows it is, and a description is what that reader does not have to know.
+
+`ank init` keeps a narrow perimeter: create `.ank/`, write `config.yml`, add the `refs/ank/*` refspec (§7), place a pointer in `AGENTS.md`, write a `.gitattributes` (§2) and a `.gitignore` (§6).
+
+**`init` takes its target positionally, and refuses `--repo` by name.** `ank init <path>` initialises `<path>`; with no argument it initialises the current directory. `--repo` names a repository that already carries a `.ank/` (§4), which is precisely what this verb is run to produce, so it is refused with `ank init <path>` as the command to type — the shape §9 requires of every refusal, and the reason this one is a refusal rather than a second spelling of the target. `--json` and `--quiet` are unaffected: they say how to answer, not what to act on. Being a refusal by design, `--repo` is absent from what `ank help init` offers and present in what it says the verb refuses, per the rule above.
+
+**What `init` writes, `ank config` maintains** (§4). `config.yml` is written through the verb rather than by hand: it is the last thing under `.ank/` that ADR-01b6dd05f0db left an agent no route to, and the six errors that used to say "add it under `verifiers:` in `.ank/config.yml`" now name the command. `config` joins `init` and `help` as the third verb that runs without the foundation, and for the same reason those two do — the caller who needs it is the one whose environment is wrong, and a repair verb gated on the thing it repairs answers nobody.
+
+Both git files are written at the root of the initialised directory, and both carry a single line added idempotently to whatever is already there. The `.gitignore` line is `.ank/index.db`: §6 calls the index derived, disposable and gitignored, and the third adjective is only true of a repository where something wrote the rule. It goes at the root rather than inside `.ank/` for the same reason `.gitattributes` does — one place to look for what `init` changed — and because ADR-01b6dd05f0db makes `.ank/` opaque to agents, so a rule hidden there could not be read by the agent asking why the index is tracked.
+
+**Binary distribution**: the skill says *how* to use Ank, it does not install the CLI. Five channels install it today — npm, `curl | sh`, Homebrew, Scoop, and an apt repository on this project's own GitHub Pages — and every one of them is carried by this repository rather than by a satellite (ADR-782a3556cf2d): the repository is its own tap and its own bucket, and the apt index is served from the same Pages site as everything else. Each is derived from a published release rather than kept in step by hand, which is the property that keeps a channel from drifting and the test that decides whether an address is a registry or a satellite. Two are not yet a way to install and are named as such: a winget manifest is derived and proved on every run but is submitted to `microsoft/winget-pkgs` only when a release is next published, and Arch is not served.
+
+**npm is the first channel implemented**, and it is implemented for one reason that shapes it entirely: the workstation whose firewall blocks downloading a bare executable but lets the registry through. The binaries therefore travel **inside** the packages — one package per target, listed as `optionalDependencies` on a wrapper that carries `os` and `cpu`, so npm installs exactly the one that matches. **No `postinstall` download**, because a `postinstall` that fetched the binary would die behind the very firewall the channel exists to cross, and would do it after the install appeared to succeed. The wrapper resolves and executes; it forwards the child's exit code unchanged, since the codes above are an interface an agent branches on, and it reserves 9 — the environment code — for its own failures. The package name is scoped, `@haksolot/ank`: the bare name was taken on the registry before this project existed, and the scope is the closest thing to the name the project actually has (ADR-85e6664c67d8).
+
+**A prerelease never becomes what a bare install resolves to.** The dist-tag is derived from the version and from nothing else: a version carrying a prerelease identifier — a hyphen after the patch, `0.2.0-rc1` — publishes under `next`, and every other version publishes under `latest`. `npm install @haksolot/ank` therefore resolves to the newest release and never to a candidate, while `npm install @haksolot/ank@next` fetches the candidate for whoever asks for it by name. Shipping a candidate stays possible, which is why this is a derivation and not a refusal.
+
+Derived rather than chosen when the tag is pushed, because a flag someone has to remember while tagging is a flag that is eventually forgotten, and this one fails silently: npm 10 applied `latest` to a prerelease without a word, so `v0.2.0-rc1` would have put a release candidate on every machine running a bare install, and nothing would have said so. The rule is **written once and read by both the rehearsal and the publish** — a smoke job passing different flags from the publish rehearses nothing, and the publish is the one step in the pipeline that cannot be taken back. Build metadata is not a prerelease identifier: `1.2.3+build` is a release, and the derivation strips it before looking for the hyphen.
+
+The GitHub release follows the same reading of the same version, and is marked as a prerelease when it is one. Two channels describing one tag differently is how a reader ends up trusting whichever they happened to open.

--- a/.ank/entities/TASK-13f9162ed61a.md
+++ b/.ank/entities/TASK-13f9162ed61a.md
@@ -5,7 +5,7 @@ slug: the-specification-says-which-channels-ship
 title: The specification says which channels ship
 created: 2026-08-16T03:36:21Z
 author: claude-code/opus-5
-status: in_progress
+status: done
 scope:
   - .ank/entities/SPEC-9f510cad4be6.md
   - .ank/entities/SPEC-eddf356ce1a9.md
@@ -14,8 +14,13 @@ blocked_by: [TASK-0f86494ecae7, TASK-7498998a8514, TASK-e38b9597ee30, TASK-b693d
 done_criteria: |
   The specification names the channels that ship and does not name as planned anything that already ships. Section 13's distribution list carries every channel that installs ank, and section 9's binary-distribution paragraph stops saying to plan for what exists. Each revised document is a successor entity created with ank new spec --supersedes, never an edit, and each arrives proposed with its references re-declared. ank check is green with no unresolved reference.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: efe4d1481d594d6403ee51e98742805d347a2b5c
+    criteria: 784e9882890c
+    via: submitted
 schema: 3
-version: 5
+version: 6
 ---
 
 Section 13 reads `Distribution: curl | sh, Homebrew, Scoop/winget, npm` and

--- a/.ank/entities/TASK-13f9162ed61a.md
+++ b/.ank/entities/TASK-13f9162ed61a.md
@@ -5,17 +5,17 @@ slug: the-specification-says-which-channels-ship
 title: The specification says which channels ship
 created: 2026-08-16T03:36:21Z
 author: claude-code/opus-5
-status: open
+status: in_progress
 scope:
   - .ank/entities/SPEC-9f510cad4be6.md
   - .ank/entities/SPEC-eddf356ce1a9.md
   - docs/agents.md
-blocked_by: [TASK-0f86494ecae7, TASK-7498998a8514, TASK-e38b9597ee30, TASK-b693dc062cab, TASK-07e021f95aa3, TASK-cf8e08128cb4]
+blocked_by: [TASK-0f86494ecae7, TASK-7498998a8514, TASK-e38b9597ee30, TASK-b693dc062cab, TASK-07e021f95aa3]
 done_criteria: |
   The specification names the channels that ship and does not name as planned anything that already ships. Section 13's distribution list carries every channel that installs ank, and section 9's binary-distribution paragraph stops saying to plan for what exists. Each revised document is a successor entity created with ank new spec --supersedes, never an edit, and each arrives proposed with its references re-declared. ank check is green with no unresolved reference.
 criteria_by: creator
 schema: 3
-version: 3
+version: 5
 ---
 
 Section 13 reads `Distribution: curl | sh, Homebrew, Scoop/winget, npm` and

--- a/.ank/entities/TASK-cf8e08128cb4.md
+++ b/.ank/entities/TASK-cf8e08128cb4.md
@@ -14,7 +14,7 @@ done_criteria: |
   packaging/aur carries a PKGBUILD template rendered from a tag, naming the released archive and the sha256 the release publishes. A workflow triggered on a published release renders it, regenerates .SRCINFO, and pushes both to the AUR under an SSH key held in Actions secrets. A CI job in an Arch container builds the rendered package with makepkg, installs it with pacman -U, and asserts ank --version prints the released version. Nothing in packaging/aur is edited by hand between releases: the job derives the file. cargo test --workspace and ank check stay green.
 criteria_by: creator
 schema: 3
-version: 1
+version: 3
 ---
 
 **This task exists because of ADR-782a3556cf2d and must not be claimed before it

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -104,13 +104,51 @@ anything to it.
 ## The binary
 
 The README names npm because it is the shortest line that works on most
-machines. Three others exist.
+machines. Several others exist, and every one of them is carried by this
+repository rather than by a satellite somebody keeps in step
+(ADR-782a3556cf2d): the tap, the bucket and the apt index all live here, and
+each is derived from a published release rather than updated by hand.
 
 **A release binary.** Every release carries a static binary for three targets —
 `x86_64-unknown-linux-musl`, `aarch64-apple-darwin` and `x86_64-pc-windows-msvc`
 — each with a `.sha256` beside it. Take the archive for your platform from the
 [releases page](https://github.com/haksolot/ank/releases/latest), check the hash,
 unpack it, and put `ank` on your `PATH`.
+
+**`curl | sh`**, for the machine no package manager on this list serves:
+
+    curl -fsSL https://raw.githubusercontent.com/haksolot/ank/main/install.sh | sh
+
+It reads your platform from `uname`, fetches the archive and the `.sha256`
+published beside it, and refuses before unpacking if the two disagree. On a
+platform no release carries it refuses by name and lists what does exist, rather
+than ending in silence.
+
+**Homebrew**, on macOS and Linux. This repository is its own tap, so the URL is
+part of the command:
+
+    brew tap haksolot/ank https://github.com/haksolot/ank
+    brew install haksolot/ank/ank
+
+**Scoop**, on Windows, for the same reason and in the same shape:
+
+    scoop bucket add ank https://github.com/haksolot/ank
+    scoop install ank/ank
+
+**apt**, on Debian and Ubuntu, from a repository this project hosts on its own
+GitHub Pages:
+
+    sudo install -d -m 0755 /etc/apt/keyrings
+    curl -fsSL https://haksolot.github.io/ank/deb/ank-archive-keyring.asc |
+      sudo tee /etc/apt/keyrings/ank-archive-keyring.asc > /dev/null
+    echo "deb [signed-by=/etc/apt/keyrings/ank-archive-keyring.asc] https://haksolot.github.io/ank/deb stable main" |
+      sudo tee /etc/apt/sources.list.d/ank.list > /dev/null
+    sudo apt-get update
+    sudo apt-get install -y ank
+
+`amd64` only, which is the release matrix rather than a decision about apt. The
+key that signs the index is a distribution key and never this project's
+ratification key.
 
 **npm**, which is the channel to reach for on a machine whose firewall blocks
 downloading a bare executable but lets the registry through:
@@ -133,6 +171,13 @@ which is the honest answer rather than a silent failure.
 
 It is `--git` because nothing publishes to crates.io. That puts `ank` in
 `~/.cargo/bin`, and needs Rust 1.95 or newer and a C compiler.
+
+**What is not a way to install ank yet**, named here so you do not go looking.
+`winget install Haksolot.Ank` does not work: the manifest is derived from the
+release and proved on every run of the pipeline — validated and installed from
+on a Windows runner — but it reaches `microsoft/winget-pkgs` only when a release
+is next published, and the registry reviews it after that. Arch is not served at
+all.
 
 Either way, check it answers:
 


### PR DESCRIPTION
`TASK-13f9162ed61a`.

Section 13 read `Distribution: curl | sh, Homebrew, Scoop/winget, npm` and
section 9 said to *plan for* `curl | sh` and Homebrew. The first omitted apt,
the second called shipped work a plan, and both named winget as if it installed
anything.

**Five channels install ank today**: npm, `curl | sh`, Homebrew, Scoop, and an
apt repository this project hosts. Winget is not one of them, and is named as
such rather than listed beside them — the manifest is derived and proved on
every run of the pipeline, but it reaches `microsoft/winget-pkgs` only when a
release is next published. Listing it with the five would have been exactly the
failure this task's body warns about: *a document that announces a channel
nobody can install from is worse than one that is behind, because a reader acts
on it.* Arch is said to be unserved for the same reason.

| entity | |
|---|---|
| `SPEC-93531977642f` | supersedes `SPEC-9f510cad4be6` — §13's distribution list |
| `SPEC-dbbd533cbc78` | supersedes `SPEC-eddf356ce1a9` — §9's binary-distribution paragraph |
| `SPEC-3d12e76d9fa2` | amended to cite the successor rather than the id it superseded |

Both are successors and never edits, because an accepted spec whose body moves
is reported `altered`, its ratification commit having hashed the body and the
scope. Both arrive `proposed`; the supersession completes when they are
ratified, which is yours.

The successor to the distribution spec carries a **wider scope** than its
predecessor — `install.sh`, `Formula/**`, `bucket/**` and `packaging/**` join
what was there. It was a document about distribution that did not reach four of
the directories the channels live in, which is the gap `ADR-782a3556cf2d` had
before its own scope was amended, and a successor is the only moment it can be
closed: acceptance hashes the scope.

`docs/agents.md` gains the four channels it was missing, with the commands that
actually work, and a closing paragraph naming what is *not* a way to install ank
yet so a reader does not go looking.

`TASK-cf8e08128cb4` was dropped from this task's blockers and logged as parked:
the AUR is frozen to publishers at the registry, and waiting on it to say five
other channels exist would produce the same failure in the other direction.

**One thing worth reading in the log**: I breached `ADR-01b6dd05f0db` while
doing this, by grepping `.ank/entities/` directly to find the citing documents.
I redid it through the CLI and got the same answer, which is not the point —
`check` cannot see that, so it is recorded on the task.

`cargo test --workspace` green (561 tests), `cargo fmt --check` green,
`ank check` 0 faults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014fRJYcKeTA9yXwLdQsyxXE