### PR TITLE
0.x is a decision, and the version example stops going stale

### DIFF
--- a/.ank/entities/TASK-5d38636bb4e5.md
+++ b/.ank/entities/TASK-5d38636bb4e5.md
@@ -1,0 +1,47 @@
+---
+id: TASK-5d38636bb4e5
+type: task
+slug: accept-records-that-a-key-authorised-a-ratificat
+title: accept records that a key authorised a ratification, never who ran it
+created: 2026-08-16T19:57:10Z
+author: claude-code/opus-5
+status: open
+scope:
+  - crates/ank-cli/src/human.rs
+blocked_by: []
+done_criteria: |
+  A ratification records the actor that ran it, so one an agent performed under a cached credential is distinguishable from one a human typed at the keyboard, and the record survives in the corpus rather than only in the commit. check reports the case where the actor that ratified is the actor that authored, as a signal and never as a fault, because a solo maintainer does that legitimately. The record is not a defence and the task does not add one: an actor value can be set to anything, and the bargain is the same one ADR-6b3f19e08a24 already makes. Tests cover a ratification by a human, one by an agent, and the self-ratification signal, through the binary. cargo test --workspace and ank check stay green.
+criteria_by: creator
+schema: 3
+version: 1
+---
+
+Three ratifications happened on 2026-08-16 -- ADR-782a3556cf2d, SPEC-93531977642f
+and SPEC-dbbd533cbc78 -- and an agent typed all three, using a passphrase the
+maintainer's gpg-agent had cached, at the maintainer's explicit instruction from
+a phone. The commits are signed and `check` verifies them against
+`.ank/allowed_signers`, so every mechanism in section 8 reports exactly what it
+was built to report. None of them can say what actually happened.
+
+**That is the hole.** `accept` is described as the one human act, and the
+signature is what carries the claim. But the signature says *this key
+authorised it*, and a cached passphrase makes that true of an agent's keystroke
+as well as a human's. The entity records `ratified: <anchor>` and nothing else
+about the act; `author:` names whoever created the entity, which in all three
+cases was the same agent that then ratified it. Read the corpus back and it
+says a human ratified three decisions an agent wrote, with no trace of the
+delegation.
+
+**The fix is a record, not a wall**, and that is the whole point. An agent can
+set `ANK_AGENT` to anything or unset it, so nothing written here defends
+against a dishonest caller -- the same bargain ADR-6b3f19e08a24 already makes
+for every freeze in the system. What it buys is that an honest one leaves a
+trace, and that a reader can tell the two cases apart instead of being told
+they are identical.
+
+Worth deciding rather than assuming: whether the record belongs on the entity
+(a field beside `ratified:`) or in the ratification commit's own message, and
+whether `check` should say anything when the actor that ratified is the actor
+that authored. The second is the case that matters -- self-ratification is what
+the human act exists to prevent -- and it is a signal rather than a fault,
+because a solo maintainer legitimately does exactly that.

--- a/README.md
+++ b/README.md
@@ -137,7 +137,10 @@ read only when it is — and orientation is bounded at 8000 characters.
 | report a vulnerability | [Security policy](https://github.com/haksolot/ank/blob/main/SECURITY.md) |
 
 The specification is the source of truth; the others exist so it does not have to
-be a tutorial. Pre-v1, on Linux, macOS and Windows. This repository dogfoods its
+be a tutorial. Linux, macOS and Windows. The version is `0.x` on purpose rather
+than for want of finishing: the loop and the exit codes are specified and an
+agent can branch on them today, while the storage format is not frozen — and a
+major version is a promise about exactly that. This repository dogfoods its
 own format down to that source of truth: the specification is ten accepted `spec`
 entities in `.ank/`, listed by `ank find --type spec` and printed whole by
 `ank show`, reached through the CLI and never by opening the files — and the plan

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -182,7 +182,7 @@ all.
 Either way, check it answers:
 
     $ ank --version
-    ank 0.1.3 (f573bc3, skill 3f350ad26459)
+    ank <version> (<commit>, skill <revision>)
 
 Three components: the version, the commit it was built from, and **the revision
 of the skill it was built alongside**. That last one is the value


### PR DESCRIPTION
Two lines of prose and one finding.

**The README said "Pre-v1"**, which reads as unfinished. What is true is
narrower and better: the loop and the exit codes are specified and an agent can
branch on them today, while the storage format is not frozen — and a major
version is a promise about exactly that. Same fact, and it now says *why*
instead of leaving a reader to guess.

**`docs/agents.md` showed `ank 0.1.3` as the answer to `ank --version`**, two
releases behind. It is not one of the ten literals `check-version.sh` compares
against the tag — those are the manifests — so nothing noticed. The fix is not
to bump it: a literal nothing checks goes stale again on the release after next.
The example shows the shape instead, which is what the three lines under it are
actually about.

**`TASK-5d38636bb4e5`** records a hole found while ratifying, and it is worth
reading. Three ratifications happened today — `ADR-782a3556cf2d`,
`SPEC-93531977642f`, `SPEC-dbbd533cbc78` — and an agent typed all three, at the
maintainer's explicit instruction, with a passphrase `gpg-agent` had cached. The
commits are signed, `check` verifies them against `.ank/allowed_signers`, and
every mechanism in section 8 reported exactly what it was built to report. None
of them can say what actually happened: the signature means *this key authorised
it*, and `author:` names the agent that wrote all three entities before
ratifying them.

The task asks for a **record and explicitly not a wall** — an actor value can be
set to anything, which is the same bargain `ADR-6b3f19e08a24` already makes for
every freeze in the system. What it buys is that an honest caller leaves a trace
and a reader can tell the two cases apart.

`cargo fmt --check` green, `ank check` 0 faults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014fRJYcKeTA9yXwLdQsyxXE