### PR TITLE
The skill says how to work beside another agent, not only how not to be one

### DIFF
--- a/.ank/entities/LOG-de645e0c321f.md
+++ b/.ank/entities/LOG-de645e0c321f.md
@@ -1,0 +1,14 @@
+---
+id: LOG-de645e0c321f
+type: log
+title: done, proof commit:df0c20246ae7c66e93d70de15f208a83010d85fd
+created: 2026-08-16T20:17:43Z
+author: claude-code/opus-5
+scope:
+  - skill/SKILL.md
+  - crates/ank-cli/tests/skill.rs
+about: TASK-182a7f58cdd6
+seq: 1
+schema: 3
+version: 1
+---

--- a/.ank/entities/LOG-fb9de148c745.md
+++ b/.ank/entities/LOG-fb9de148c745.md
@@ -1,0 +1,26 @@
+---
+id: LOG-fb9de148c745
+type: log
+title: "discrepancy: the criterion requires \"a superseding ADR carries the change and arrives proposed; the"
+created: 2026-08-16T20:13:55Z
+author: claude-code/opus-5
+scope:
+  - skill/SKILL.md
+  - crates/ank-cli/tests/skill.rs
+about: TASK-182a7f58cdd6
+seq: 0
+schema: 3
+version: 1
+---
+
+ skill is not edited without it", and that clause rests on a premise this corpus contradicts.
+
+What I assumed when writing it: that any edit to SKILL.md grows what it teaches, and ADR-5dd7b4a9c875 makes growth cost a superseding ADR and a signature.
+
+What I measured: the freeze is narrower than that, and crates/ank-cli/tests/skill.rs says so in as many words. The doc comment on the_skill_states_the_execution_model_it_assumes reads "Not a superseding ADR, and the reason is measured rather than assumed. What ADR-e17e1bbd93ff freezes is which *verbs* the file teaches, which the_skill_teaches_nothing_beyond_what_is_frozen enforces, plus the ceiling below. This adds neither a verb nor a flag." TASK-e3f4b6295b23 added the entire execution-model paragraph on exactly those terms, and TASK-21031b516bb2 added the styling guarantee the same way. The recipe the file records is: ceiling held, revision regenerated, a test to keep it.
+
+This change is that same register. It names status, claim and graph, all three already taught, and adds no flag. The ceiling holds at 173 lines and 1489 words against 180 and 1500 -- written to fit, because the ceiling test says a ceiling raised to accommodate whatever was just written is not a ceiling. metadata.revision is regenerated to 89529c87fb02, and the_skill_says_how_to_choose_work_beside_another_agent keeps the teaching against tokens no other line supplies.
+
+So the ADR is not written, and the rest of the criterion is met whole. Writing one anyway would supersede a ratified decision to change nothing in it, which is worse than the gap it would close: it would put a signature on a document whose only content is that the previous one still holds.
+
+Measured against 1510 words at first, not 1482: wc -w and the test disagree by 28 on this file, and the test's count is the one that decides. I trimmed against the wrong number once before noticing.

--- a/.ank/entities/TASK-182a7f58cdd6.md
+++ b/.ank/entities/TASK-182a7f58cdd6.md
@@ -5,7 +5,7 @@ slug: the-skill-says-how-to-work-beside-another-agent
 title: The skill says how to work beside another agent, not only how not to be one
 created: 2026-08-16T20:09:10Z
 author: claude-code/opus-5
-status: in_progress
+status: done
 scope:
   - skill/SKILL.md
   - crates/ank-cli/tests/skill.rs
@@ -13,8 +13,13 @@ blocked_by: []
 done_criteria: |
   SKILL.md tells an agent how to pick work when others are running: that status names what another agent holds, that claim names a live claim whose scope intersects and takes the task anyway rather than refusing, that graph shows what blocked_by orders, and that taking nothing is an available answer when nothing open is both unblocked and clear. It says a branch is cut fresh from the default branch and why, and that ank commits nothing but accept. The ceiling is unchanged at 180 lines and 1500 words and the file is within it, measured by the existing test rather than asserted. metadata.revision names the new body hash. A superseding ADR carries the change and arrives proposed; the skill is not edited without it. cargo test --workspace and ank check stay green.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: df0c20246ae7c66e93d70de15f208a83010d85fd
+    criteria: 82cda8266f53
+    via: submitted
 schema: 3
-version: 2
+version: 3
 ---
 
 The skill already says "one agent, one working tree, one identity", and that is

--- a/.ank/entities/TASK-182a7f58cdd6.md
+++ b/.ank/entities/TASK-182a7f58cdd6.md
@@ -1,0 +1,48 @@
+---
+id: TASK-182a7f58cdd6
+type: task
+slug: the-skill-says-how-to-work-beside-another-agent
+title: The skill says how to work beside another agent, not only how not to be one
+created: 2026-08-16T20:09:10Z
+author: claude-code/opus-5
+status: in_progress
+scope:
+  - skill/SKILL.md
+  - crates/ank-cli/tests/skill.rs
+blocked_by: []
+done_criteria: |
+  SKILL.md tells an agent how to pick work when others are running: that status names what another agent holds, that claim names a live claim whose scope intersects and takes the task anyway rather than refusing, that graph shows what blocked_by orders, and that taking nothing is an available answer when nothing open is both unblocked and clear. It says a branch is cut fresh from the default branch and why, and that ank commits nothing but accept. The ceiling is unchanged at 180 lines and 1500 words and the file is within it, measured by the existing test rather than asserted. metadata.revision names the new body hash. A superseding ADR carries the change and arrives proposed; the skill is not edited without it. cargo test --workspace and ank check stay green.
+criteria_by: creator
+schema: 3
+version: 2
+---
+
+The skill already says "one agent, one working tree, one identity", and that is
+half of what an agent needs when it is not alone. The other half is in the
+corpus and reaches no reader: ADR-052accd6e3b2 decided that two live claims
+whose scopes intersect are *named* at claim time and never refused, and
+ADR-47e2ac102f58 made `status` report the drift between this checkout and the
+default branch. Both are decisions about working in parallel, both produce
+output an agent is meant to act on, and the skill teaches neither.
+
+**What that costs today.** An agent that reaches for the first open task takes
+one whose scope overlaps work already running, and finds out at review. An
+agent on a stale base is green locally and red on the machine that merges. Both
+failures are silent at the moment they are made and expensive at the moment
+they surface, which is the shape of failure a permanently loaded file exists to
+prevent.
+
+**The addition is a reading, not a rule.** Nothing here refuses anything: the
+tool already declines to be a gatekeeper, and this changes none of that. It
+says which verbs answer the question -- `status` for what another agent holds,
+`claim` for an intersecting scope, `graph` for what `blocked_by` orders -- and
+that taking nothing is an available answer. An idle session is cheaper than two
+agents rewriting one perimeter, and an agent with no instruction to stop will
+not stop.
+
+**The ceiling does not move, and that is deliberate.** It stands at 180 lines
+and 1500 words; the file is at 167 and 1381. The test that holds it says a
+ceiling raised to accommodate whatever was just written is not a ceiling, so
+this is written to fit rather than measured and then excused. If it does not
+fit, the answer is shorter prose or a different place for it, never a larger
+number.

--- a/crates/ank-cli/tests/skill.rs
+++ b/crates/ank-cli/tests/skill.rs
@@ -577,6 +577,49 @@ fn the_skill_states_the_execution_model_it_assumes() {
     }
 }
 
+/// **The skill says how to choose work when other agents are running**
+/// (TASK-182a7f58cdd6).
+///
+/// The file already stated the arrangement — a tree per agent, an identity per
+/// session — which is how *not* to become the second agent in one perimeter. It
+/// said nothing about being one legitimately, and two ratified decisions
+/// produce exactly the output that case needs: ADR-052accd6e3b2 names a live
+/// claim whose scope intersects yours at claim time and takes the task anyway,
+/// and ADR-47e2ac102f58 makes `status` report this checkout's drift from the
+/// default branch. Both are answers to a question the skill never told anyone
+/// to ask, so the answers reached no reader.
+///
+/// The failures that costs are silent when made and expensive when they
+/// surface: a task picked off the top of a list overlaps work already running
+/// and is found at review, and a branch cut from a stale base is green here and
+/// red on the machine that merges.
+///
+/// Not a superseding ADR, on the same measurement as the test above. What is
+/// frozen is which *verbs* the file teaches plus the ceiling, and this adds
+/// neither a verb nor a flag: `status`, `claim` and `graph` are all taught
+/// already, and what is new is which question to put to them. The ceiling held
+/// at 173 lines and 1489 words of 180 and 1500 — written to fit rather than
+/// measured and then excused.
+///
+/// Asserted on tokens no other line of the file supplies, so a rewrite that
+/// keeps the teaching passes and a deletion fails. `graph` and `status` would
+/// each have been the natural choice and are deliberately not used: the file
+/// names both verbs elsewhere, so a test resting on them would stay green over
+/// a deleted paragraph.
+#[test]
+fn the_skill_says_how_to_choose_work_beside_another_agent() {
+    let text = skill();
+    for token in ["intersects", "unblocked", "collide"] {
+        assert!(
+            text.contains(token),
+            "SKILL.md does not say {token:?}: an agent that has loaded only this \
+             file knows it should have a tree of its own, and not how to pick a \
+             task when somebody else already holds one — nor that taking none \
+             is an available answer"
+        );
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Which revision is installed (TASK-b495234f192c)
 // ---------------------------------------------------------------------------

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -2,7 +2,7 @@
 name: ank
 description: Read a repository's tasks and binding constraints, claim work, and finish it with proof. Use when working in a repo that has a .ank/ directory.
 metadata:
-  revision: "6ddced7793f9"
+  revision: "89529c87fb02"
 ---
 
 # ank
@@ -143,13 +143,19 @@ authority ends is part of planning well.
   directly. `ank show <id>` gives you an entity whole, `ank find` lists,
   `ank context` binds — the CLI knows the budget, the freeze and who holds what;
   the files do not.
-- **One agent, one working tree, one identity.** The nominal case is a tree per
-  agent — a clone or a `git worktree` — each on its own branch. `ANK_AGENT`
-  names the session and falls back to `<user>@<hostname>`, so two sessions in
-  one tree are one agent to the refs: they share a claim instead of arbitrating
-  over it, and the second one is refused work it should have been given. Set it
-  per session. Several agents in one tree runs, and is a degraded mode rather
-  than the design.
+- **One agent, one working tree, one identity.** A tree per agent — a clone or a
+  `git worktree` — each on a branch cut fresh from the default one: `status`
+  names the drift, and a stale base turns a green tree red elsewhere. Set
+  `ANK_AGENT` per session; it falls back to `<user>@<hostname>`, so two sessions
+  in one tree are one agent to the refs, sharing a claim instead of arbitrating
+  over it — a degraded mode rather than the design. ank commits nothing but
+  `accept`: one branch per task, and the default branch is where work arrives.
+- **Take the task that cannot collide, or take none.** `status` says what another
+  agent holds; `claim` names a live claim whose scope intersects yours and takes
+  the task anyway, a fact to read and not an error to refuse; `graph` shows what
+  `blocked_by` orders. Read all three first. When nothing open is both unblocked
+  and clear, take nothing and say so: an idle session is cheaper than two agents
+  rewriting one perimeter.
 - **What you read is never styled.** Colour is emitted only when a human is at
   a terminal, never into a pipe, a file or `--json`, so the bytes reaching you
   are plain: there is nothing to configure and no second surface to prefer.


### PR DESCRIPTION
`TASK-182a7f58cdd6`.

`SKILL.md` already stated the arrangement — a tree per agent, an identity per
session — which is how *not* to become the second agent in one perimeter. It
said nothing about being one legitimately, and two ratified decisions produce
exactly the output that case needs:

- `ADR-052accd6e3b2` names a live claim whose scope intersects yours at claim
  time and takes the task anyway, because that is a fact to read and not an
  error to refuse.
- `ADR-47e2ac102f58` makes `status` report this checkout's drift from the
  default branch.

Both answer a question the skill never told anyone to ask, so the answers
reached no reader. What that costs is silent when made and expensive when it
surfaces: a task picked off the top of a list overlaps work already running and
is found at review, and a branch cut from a stale base is green locally and red
on the machine that merges.

**Two bullets now.** The first gains where a branch comes from and why, and that
ank commits nothing but `accept`. The second is new: `status` says what another
agent holds, `claim` names an intersecting scope and takes the task anyway,
`graph` shows what `blocked_by` orders — and when nothing open is both unblocked
and clear, **taking nothing is the answer**. An agent with no instruction to
stop will not stop.

Nothing here refuses anything. The addition is a reading, not a rule.

## No superseding ADR, and the reason is measured

I told the maintainer this would cost one. It does not, and the answer was
already written in `crates/ank-cli/tests/skill.rs`: what is frozen is which
*verbs* the file teaches, plus the ceiling. This adds neither a verb nor a flag
— `status`, `claim` and `graph` are all taught already — and the same door was
used by `TASK-e3f4b6295b23` for the execution-model paragraph and
`TASK-21031b516bb2` for the styling guarantee, each on the recipe that file
records: ceiling held, revision regenerated, a test to keep it.

| | |
|---|---|
| ceiling | **173** lines of 180, **1489** words of 1500 |
| revision | `6ddced7793f9` → `89529c87fb02` |
| test | `the_skill_says_how_to_choose_work_beside_another_agent` |

Written to fit rather than measured and then excused, because the test guarding
the ceiling says *a ceiling raised to accommodate whatever was just written is
not a ceiling*. The new test rests on `intersects`, `unblocked` and `collide` —
tokens no other line of the file supplies, so a rewrite that keeps the teaching
passes and a deletion fails. `graph` and `status` were the natural choices and
are deliberately unused: the file names both elsewhere, so a test resting on
them would stay green over a deleted paragraph.

**The criterion required that ADR**, because I froze the wrong premise into it
when I wrote the task. The discrepancy is recorded against the criterion rather
than edited out of it, and `ank check` names it.

`cargo test --workspace` green (562 tests), `cargo fmt --check` green,
`ank check` 0 faults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014fRJYcKeTA9yXwLdQsyxXE