### PR TITLE
The integration surface is four decisions before it is any code

### DIFF
--- a/.ank/entities/ADR-372b82af1ec7.md
+++ b/.ank/entities/ADR-372b82af1ec7.md
@@ -1,0 +1,73 @@
+---
+id: ADR-372b82af1ec7
+type: adr
+slug: a-protocol-surface-is-a-generated-full-surface-p
+title: A protocol surface is a generated full-surface passthrough, or it does not exist
+created: 2026-08-17T05:14:01Z
+author: claude-code/2.1.233+integration-contract
+status: proposed
+scope:
+  - crates/ank-cli/src/cli.rs
+constraint: |
+  A protocol surface exposes every verb the CLI dispatches, generated from the same table the CLI dispatches from, or it does not exist. No curated subset, under any protocol. It refuses on state exactly as the CLI does and never on identity, and it carries the CLI's exit codes as the reason for a refusal. It speaks for exactly one corpus, addressed the way --repo addresses one: claims stay per clone, and no server arbitrates across clones -- a deployment over several repositories is several corpora addressed separately and never one merged claim space. It writes under a typed process identity. It ships from this repository, and it is a sibling binary rather than a verb, so the verb list and skill/SKILL.md are untouched.
+supersedes: ADR-1713af205186
+schema: 3
+version: 3
+---
+
+## What this supersedes, and what it keeps
+
+ADR-1713af205186 refused an MCP server, and refused with it "no subset of the
+verbs exposed over any protocol". It was right, and it was right for a reason
+that has not expired: the proposal it rejected exposed four verbs out of
+twenty-two, which rebuilds under a second protocol the agent-surface split that
+was abolished once already, and rebuilds the worse half of it -- a caller
+reached through the protocol could not amend, could not propose an ADR, could
+not check the corpus.
+
+That refusal is kept, in full, as the shape of what is now allowed. What changes
+is only that the conditions it wrote for itself are met.
+
+## Its two conditions, answered
+
+**"A full-surface passthrough, generated from the same dispatch table the CLI
+uses so it cannot fall behind."**
+
+The verb table moves into a crate that both the CLI and the protocol surface
+consume, and the surface is generated from it. Not kept in step by review, not
+tested for parity -- generated, so that a verb the table does not carry is a
+verb neither surface has, and a verb it carries is a verb both have. This is
+also what the decision on the machine surface already requires for `--json`, so
+the protocol surface inherits it rather than asking for it.
+
+**"A statement of what it does with claims."**
+
+It does nothing with them that the CLI does not. A server process speaks for one
+corpus, named the way `--repo` names one, and every claim it takes is the claim
+the CLI would have taken in that clone, on `refs/ank/claims/<id>`, arbitrated by
+the same compare-and-swap against the same remote. It does not hold a claim on a
+client's behalf, it does not pool clients under one identity, and it does not
+merge the claim spaces of two clones -- because `refs/ank/*` is per repository,
+and a server that pretended otherwise would be inventing an arbitration the refs
+cannot carry.
+
+A deployment over several repositories is therefore several corpora, addressed
+separately, presented together by whatever is above them. That is the same
+answer ADR-a1de673043b4 gives for federation, and it is the same answer for the
+same reason.
+
+## Why a sibling binary and not a verb
+
+The live one-surface decision says the verbs themselves do not change, and what
+`skill/SKILL.md` teaches is frozen by revision hash. A twenty-third verb would
+cost a second supersession and a second human signature, and would buy nothing:
+the requirement is that the surface be generated from the dispatch table, and a
+sibling binary in this workspace reads that table directly. It is the stronger
+reading of the condition, not the weaker one.
+
+## What is still true
+
+Shell remains the common denominator, and remains what the skill teaches. This
+decision does not make a protocol the preferred route for an agent that has a
+shell; it makes one exist for a client that has none, which is the narrower and
+honest claim the original ADR said was the only real one.

--- a/.ank/entities/ADR-621a7fd96ce1.md
+++ b/.ank/entities/ADR-621a7fd96ce1.md
@@ -1,0 +1,42 @@
+---
+id: ADR-621a7fd96ce1
+type: adr
+slug: a-corpus-is-addressable-and-a-reader-may-aggrega
+title: A corpus is addressable, and a reader may aggregate several
+created: 2026-08-17T05:13:26Z
+author: claude-code/2.1.233+integration-contract
+status: proposed
+scope:
+  - crates/ank-cli/src/repo.rs
+  - crates/ank-cli/src/config.rs
+  - docs/**
+constraint: |
+  A repository carries an identity a reader can key on, derived from its root commit and never from its path, so one corpus reached by two paths is one corpus and two corpora in one tree are two. A reader may hold several corpora at once and present them together; each is addressed on its own, the way --repo addresses one. Writing never crosses a corpus boundary and claims stay per repository, unchanged from ADR-a1de673043b4. Aggregation is declared and never discovered: nothing walks a filesystem looking for corpora.
+schema: 3
+version: 1
+---
+
+## Why
+
+`--repo` already addresses a corpus, and `peers.<name>` already lets a scope
+reach into another one for reading. What neither gives a reader is a name for a
+corpus that survives being moved, cloned, or opened through a symlink. A board
+showing three repositories has to key its rows on something, and a path is the
+one thing that is neither stable nor unique -- two worktrees of one repository
+share a corpus and have different paths, and two clones of different
+repositories can sit at the same path on two machines.
+
+The root commit is stable, cheap to read, and already the identity git itself
+would use. A tree with no history has no such identity and falls back to its
+path, which is the honest answer rather than a fabricated one.
+
+## What this does not change
+
+Reading crosses a corpus boundary; writing does not, and claims stay where the
+refs that arbitrate them can reach. That is ADR-a1de673043b4 and this decision
+carries it forward untouched. Aggregating three corpora in a reader is three
+readings presented together, never one corpus with three sources -- the
+distinction is what keeps a claim meaningful.
+
+Nothing here discovers a corpus. A reader is told where to look, the same way a
+repository is told who its peers are.

--- a/.ank/entities/ADR-68018cda382c.md
+++ b/.ank/entities/ADR-68018cda382c.md
@@ -1,0 +1,44 @@
+---
+id: ADR-68018cda382c
+type: adr
+slug: the-format-layer-is-permissively-licensed-and-th
+title: The format layer is permissively licensed, and the tool stays copyleft
+created: 2026-08-17T05:13:26Z
+author: claude-code/2.1.233+integration-contract
+status: proposed
+scope:
+  - crates/ank-core/**
+  - LICENSE
+  - README.md
+constraint: |
+  ank-core, and any crate that exists so another program can read or write the format, is licensed Apache-2.0. ank-cli stays GPL-3.0-only. The promise the README already makes -- that the copyleft covers the tool's code and not the format -- is a statement about licences, and it has to be true of the crates as they are published, not only of the files under .ank/.
+schema: 3
+version: 1
+---
+
+## Why
+
+The README says, and has said for some time:
+
+> The copyleft covers the tool's code, not the format: your `.ank/` files and the
+> tools that read them are not derivative works.
+
+The first half is true. The second is false as the tree stands. `ank-core` is
+the reference implementation of the format, its own header says its caller may
+be a third-party tool, and it is GPL-3.0-only. Anything that links it to read
+the format is a derivative work of it. The sentence is only true of somebody who
+reimplements the parser from `docs/format.md` and the golden suite -- which is
+the harder half of what the sentence appears to promise.
+
+An ecosystem is the point of publishing a format. The parser is not the part
+worth defending with copyleft; the tool is.
+
+## What this costs
+
+Nothing to negotiate: every commit in this repository is authored by one person,
+under three identities, plus a CI bot. There is no third-party copyright to
+consult, which is the usual reason a relicensing never happens.
+
+## What stays
+
+`ank-cli` keeps GPL-3.0-only, unchanged. The tool is what the copyleft was for.

--- a/.ank/entities/ADR-6fd69efb629c.md
+++ b/.ank/entities/ADR-6fd69efb629c.md
@@ -1,0 +1,57 @@
+---
+id: ADR-6fd69efb629c
+type: adr
+slug: the-machine-surface-is-a-versioned-contract-gene
+title: The machine surface is a versioned contract, generated from one table
+created: 2026-08-17T05:12:40Z
+author: claude-code/2.1.233+integration-contract
+status: proposed
+scope:
+  - crates/ank-cli/**
+constraint: |
+  Every --json document is produced by one writer and one escaper, and carries the contract version it was written against. The verb table, the exit codes and the output shape of every verb live in one crate that every surface consumes, so no surface can describe a verb the CLI does not dispatch, and none can drift from it. `ank help --json` is that description: verbs, flags, refusals, exit codes and output shapes, generated and never written by hand. A golden fixture pins the output of every verb, and a shape that changes without its fixture changing is a failing test. Within a contract version a document may gain a field and may never lose, rename or retype one; anything else bumps the version. No document carries a key whose name depends on the data.
+schema: 3
+version: 3
+---
+
+## Why
+
+`--json` is already available on every verb without exception, and §4 calls that
+a spec invariant rather than a convenience. The transport is guaranteed too: one
+line, stdout only, never coloured, no stray output — warnings were moved to
+stderr precisely so a caller's parser keeps reading what it already read.
+
+The payload has none of those guarantees, and the gap is not theoretical:
+
+- four different string escapers, in `cli.rs`, `commands.rs`, `context.rs` and
+  `human.rs`, which do not agree — one of them escapes a tab and the others do
+  not;
+- every document built by `format!`, so the shape of a verb's output exists only
+  in the string that produces it;
+- no version field anywhere, so a consumer cannot tell which contract it is
+  holding;
+- `accept` emits a top-level key whose name is the kind of the entity accepted,
+  which no typed client can bind;
+- `review` exits 8 while its refusals are empty and no document says so.
+
+None of that matters while the only consumer is an agent reading prose. All of
+it matters the moment something is written against it, because the first
+integration written against a shape is what freezes that shape.
+
+## What this decides, and what it does not
+
+It decides that the description is generated rather than maintained. A verb
+table written twice is a verb table that will disagree with itself, and the
+disagreement lands on whoever wrote the client, days later, as a bug they cannot
+see from their side.
+
+It does not decide what any surface beyond the CLI looks like. It is the
+condition every such surface rests on, and it is deliberately settled first, on
+its own, so that a later decision about a protocol argues about the protocol and
+not about whether the thing it exposes has a shape.
+
+## The cost, stated
+
+The envelope is a breaking change to every document. This is the moment to spend
+it: the version is 0.3.0, and no consumer outside this repository exists yet.
+Spending it later means spending it on somebody.

--- a/.ank/entities/LOG-2901673a1f0e.md
+++ b/.ank/entities/LOG-2901673a1f0e.md
@@ -1,0 +1,14 @@
+---
+id: LOG-2901673a1f0e
+type: log
+title: "amended: +blocked_by TASK-0549e0f960ef"
+created: 2026-08-17T05:15:20Z
+author: claude-code/2.1.233+integration-contract
+scope:
+  - crates/ank-cli/src/**
+  - crates/ank-cli/tests/**
+about: TASK-155e98c184ed
+seq: 0
+schema: 3
+version: 1
+---

--- a/.ank/entities/LOG-374983d7abf0.md
+++ b/.ank/entities/LOG-374983d7abf0.md
@@ -1,0 +1,14 @@
+---
+id: LOG-374983d7abf0
+type: log
+title: "amended: +scope docs/integrating.md, +scope README.md, -scope docs/**"
+created: 2026-08-17T05:16:29Z
+author: claude-code/2.1.233+integration-contract
+scope:
+  - docs/integrating.md
+  - README.md
+about: TASK-af4a6db95aab
+seq: 1
+schema: 3
+version: 1
+---

--- a/.ank/entities/LOG-538ecad1b3cf.md
+++ b/.ank/entities/LOG-538ecad1b3cf.md
@@ -1,0 +1,14 @@
+---
+id: LOG-538ecad1b3cf
+type: log
+title: "amended: +blocked_by TASK-2c12b027f805"
+created: 2026-08-17T05:15:19Z
+author: claude-code/2.1.233+integration-contract
+scope:
+  - crates/**
+  - Cargo.toml
+about: TASK-0549e0f960ef
+seq: 0
+schema: 3
+version: 1
+---

--- a/.ank/entities/LOG-7775d034a305.md
+++ b/.ank/entities/LOG-7775d034a305.md
@@ -1,0 +1,13 @@
+---
+id: LOG-7775d034a305
+type: log
+title: "amended: +blocked_by TASK-155e98c184ed"
+created: 2026-08-17T05:15:20Z
+author: claude-code/2.1.233+integration-contract
+scope:
+  - docs/**
+about: TASK-af4a6db95aab
+seq: 0
+schema: 3
+version: 1
+---

--- a/.ank/entities/LOG-f23a2a38ec4b.md
+++ b/.ank/entities/LOG-f23a2a38ec4b.md
@@ -1,0 +1,15 @@
+---
+id: LOG-f23a2a38ec4b
+type: log
+title: "amended: +scope crates/ank-cli/src/cli.rs, +scope crates/ank-contract/**, -scope crates/**"
+created: 2026-08-17T05:16:29Z
+author: claude-code/2.1.233+integration-contract
+scope:
+  - Cargo.toml
+  - crates/ank-cli/src/cli.rs
+  - crates/ank-contract/**
+about: TASK-0549e0f960ef
+seq: 1
+schema: 3
+version: 1
+---

--- a/.ank/entities/TASK-0549e0f960ef.md
+++ b/.ank/entities/TASK-0549e0f960ef.md
@@ -1,0 +1,33 @@
+---
+id: TASK-0549e0f960ef
+type: task
+slug: the-verb-table-and-the-exit-codes-live-in-a-crat
+title: The verb table and the exit codes live in a crate every surface consumes
+created: 2026-08-17T05:15:06Z
+author: claude-code/2.1.233+integration-contract
+status: open
+scope:
+  - Cargo.toml
+  - crates/ank-cli/src/cli.rs
+  - crates/ank-contract/**
+blocked_by: [TASK-2c12b027f805]
+done_criteria: |
+  A crate holds the command table, the flag and refusal types, and the exit codes as one enum rather than bare integers. ank-cli consumes it and declares none of them itself. The binary's --json output and its help text are byte for byte what they were before the extraction, proven by the goldens of the previous task. cargo test is green and cargo fmt --check passes.
+criteria_by: creator
+schema: 3
+version: 3
+---
+
+The extraction ADR-6fd69efb629c requires, done while nothing else depends on
+the crate yet, so that it is a move rather than a redesign.
+
+The table is `COMMANDS` in `crates/ank-cli/src/cli.rs`, today the single source
+of truth for verbs, flags, groups, notes and refusals, and already what
+`ank help --json` is generated from. The exit codes are bare `i32` literals
+scattered across the CLI; `StoreError::code` in `store.rs` is the one place
+they are derived from a type, and it is the model for the enum.
+
+Nothing about the output may change here. The goldens from the task this one is
+blocked on are what proves that, which is why the order is not negotiable.
+
+Requires ADR-6fd69efb629c to be accepted before it is claimed.

--- a/.ank/entities/TASK-155e98c184ed.md
+++ b/.ank/entities/TASK-155e98c184ed.md
@@ -1,0 +1,33 @@
+---
+id: TASK-155e98c184ed
+type: task
+slug: every-json-document-carries-its-contract-version
+title: Every --json document carries its contract version, and help --json describes its shape
+created: 2026-08-17T05:15:07Z
+author: claude-code/2.1.233+integration-contract
+status: open
+scope:
+  - crates/ank-cli/src/**
+  - crates/ank-cli/tests/**
+blocked_by: [TASK-0549e0f960ef]
+done_criteria: |
+  Every --json document carries the contract version it was written against. No document carries a key whose name depends on the data: accept emits a fixed key. ank help --json describes, for every verb, its flags, its refusals with their exit codes, and the shape of the document it returns, all generated from the table rather than written by hand. The goldens are updated in the same commit that changes the shapes, and cargo test is green.
+criteria_by: creator
+schema: 3
+version: 2
+---
+
+The breaking half, spent deliberately at 0.x while no consumer outside this
+repository exists.
+
+`accept` is the one document that cannot be bound by a typed client: its
+top-level key is the kind of the entity accepted, so the parser has to know the
+answer before it reads it.
+
+The shape description is the half `ank help --json` is missing. It already
+carries verbs, flags, short forms, notes and refusals, generated from the
+table; what it cannot tell a client is what comes back. Generated, not written:
+a description maintained by hand is a description that will disagree with the
+code, and the disagreement surfaces on the client's side, days later.
+
+Requires ADR-6fd69efb629c to be accepted before it is claimed.

--- a/.ank/entities/TASK-2c12b027f805.md
+++ b/.ank/entities/TASK-2c12b027f805.md
@@ -1,0 +1,37 @@
+---
+id: TASK-2c12b027f805
+type: task
+slug: one-writer-produces-every-json-document-and-a-go
+title: One writer produces every --json document, and a golden pins each one
+created: 2026-08-17T05:15:06Z
+author: claude-code/2.1.233+integration-contract
+status: open
+scope:
+  - crates/ank-cli/src/**
+  - crates/ank-cli/tests/**
+  - CLAUDE.md
+blocked_by: []
+done_criteria: |
+  One module produces every --json document the binary emits, and one function in it escapes every string; the other three escapers no longer exist in the tree. A golden fixture pins the JSON of every verb that emits it, compared byte for byte against output captured from the real binary rather than from a function. review declares its exit 8 in its CommandSpec, and ank help review prints it. cargo test is green and cargo fmt --check passes.
+criteria_by: creator
+schema: 3
+version: 1
+---
+
+Pure hardening. No document changes shape here; this task exists so that the
+next one cannot change a shape without saying so.
+
+Today four escapers produce the strings inside `--json`, in `cli.rs:1198`,
+`commands.rs:1559`, `context.rs` and `human.rs:2976`, and they do not agree --
+one escapes a tab, the others do not. Every document is assembled with
+`format!`, so a verb's output shape exists nowhere but in the string that
+prints it, and nothing fails when it changes.
+
+The goldens are the point of the task, and they must be captured through the
+binary. A fixture compared against the output of an internal function proves
+the function, and the two defects this repository has already paid for were
+both cases where the code under test was right and the real path was not.
+
+Fold in the free correction while here: CLAUDE.md cites ADR-f61e2d2c75e8 and
+ADR-c656cbcc33a9 for the one-surface rule, and both are superseded. The live
+one is ADR-5dd7b4a9c875.

--- a/.ank/entities/TASK-34d27790dba9.md
+++ b/.ank/entities/TASK-34d27790dba9.md
@@ -1,0 +1,34 @@
+---
+id: TASK-34d27790dba9
+type: task
+slug: a-single-page-opens-the-corpus-in-a-browser-and
+title: A single page opens the corpus in a browser and shows who holds what
+created: 2026-08-17T05:15:07Z
+author: claude-code/2.1.233+integration-contract
+status: open
+scope:
+  - viewer/**
+blocked_by: []
+done_criteria: |
+  viewer/ holds one self-contained HTML file, with no build step, no backend, no network request and no dependency fetched at view time. Opened in a Chromium browser and granted the repository root, it lists the corpus's entities with their kind, status and title, shows the blocked_by graph, and names the holder and expiry of every live claim, reading loose refs under refs/ank/ and packed-refs alike. It writes no file, no ref and no claim. It is verified by opening it against this repository and against a second one.
+criteria_by: creator
+schema: 3
+version: 1
+---
+
+ADR-bcb18aecb7e1 accepted this shape and created no task for it, by design.
+This is that task.
+
+One constraint the ADR does not anticipate, and it is load-bearing. The ADR
+says the page reads `.ank/` through the File System Access API, and the claims
+are not in `.ank/` -- they are blobs at `refs/ank/claims/<id>`, which git is
+free to pack into `.git/packed-refs` at any time. So the page must be granted
+the repository root rather than `.ank/`, and must read both forms of ref.
+Nothing in the ADR forbids that: what it forbids is writing.
+
+Without it the page can show the corpus and cannot show the work, which is the
+half worth looking at.
+
+This is also the first real consumer of the machine surface, and it is
+deliberately not blocked on it: a page that has to reimplement the format is
+the measurement of how far the contract still has to go.

--- a/.ank/entities/TASK-af4a6db95aab.md
+++ b/.ank/entities/TASK-af4a6db95aab.md
@@ -1,0 +1,34 @@
+---
+id: TASK-af4a6db95aab
+type: task
+slug: a-document-states-the-integration-contract-for-s
+title: A document states the integration contract for someone outside this repository
+created: 2026-08-17T05:15:07Z
+author: claude-code/2.1.233+integration-contract
+status: open
+scope:
+  - docs/integrating.md
+  - README.md
+blocked_by: [TASK-155e98c184ed]
+done_criteria: |
+  A document in docs/ states the contract for a reader who has never seen this tree: ank help --json as the entry point, the exit code table, the rule that a task's state is the file together with its claim ref, its proof ref and the log entities naming it, the warning that check writes and prunes refs so a poller must not call it, and the golden fixtures offered as the conformance suite. The README links it. Every command it shows is run and its output pasted from the run, not typed.
+criteria_by: creator
+schema: 3
+version: 3
+---
+
+`docs/getting-started.md` already says the integration surface is two things, an
+exit code and `--json`, and it says it well for a CI pipeline. What it does not
+say is what a tool needs that is not a pipeline.
+
+Three things in particular, all of which cost a reader real time to discover:
+
+- **A task's state is not in its file.** It is the file together with
+  `refs/ank/claims/<id>`, `refs/ank/proof/<id>` and the log entities whose
+  `about` names it. A tool that reads `.ank/` alone under-reports, and it
+  under-reports silently. `ank show --json` is already the verb that answers
+  whole.
+- **`ank check` writes.** It prunes claim and proof refs. Anything polling on a
+  timer must not call it.
+- **The goldens are for them too.** `crates/ank-core/tests/golden/` already
+  says so in its own header, and nothing outside that header repeats it.


### PR DESCRIPTION
Ank has one consumer today -- an agent running the loop through the binary --
and nothing for a second one to build against. This lands the decisions that a
second consumer would rest on, before any of the code that serves them.

## The four ADRs, proposed

| id | decides |
|---|---|
| `ADR-6fd69efb629c` | The machine surface is a versioned contract, generated from one table. First, because every other surface rests on it. |
| `ADR-68018cda382c` | The format layer goes Apache-2.0; `ank-cli` stays GPL-3.0-only. |
| `ADR-621a7fd96ce1` | A corpus carries an identity a reader can key on; a reader may aggregate several; writing never crosses. |
| `ADR-372b82af1ec7` | Supersedes `ADR-1713af205186`: a protocol surface is a generated full-surface passthrough, or it does not exist. |

`ADR-6fd69efb629c` is first for a measured reason. `--json` is on every verb and
the transport is guaranteed -- one line, stdout only, never coloured. The
payload has none of that: four string escapers that do not agree on a tab, every
document assembled with `format!`, no version field anywhere, no fixture pinning
any shape, and `accept` emitting a top-level key named after its own data.

`ADR-372b82af1ec7` meets the two conditions `ADR-1713af205186` wrote for itself
rather than arguing around them: a full-surface passthrough generated from the
dispatch table so it cannot fall behind, and a statement about claims -- a
server speaks for exactly one clone and arbitrates nothing across clones,
because `refs/ank/*` is per repository and pretending otherwise would invent an
arbitration the refs cannot carry. It is a sibling binary and not a verb, so the
verb list and `skill/SKILL.md` are untouched.

## The five tasks

`TASK-2c12` (one writer, one escaper, a golden per verb) -> `TASK-0549` (the
table and the exit codes move to a crate) -> `TASK-155e` (the envelope and the
shape description) -> `TASK-af4a` (the contract stated for an outsider).

`TASK-34d2`, the viewer, is deliberately unblocked: `ADR-bcb18aecb7e1` accepted
its shape and created no task by design, and a page that still has to
reimplement the format is the measurement of how far the contract has left to
go. It also records the constraint that ADR did not anticipate -- claims live in
`refs/ank/`, which git may pack, so the page needs the repository root and must
read `packed-refs` too.

`TASK-2c12` depends on no decision and is claimable as soon as this lands.

## Verification

`ank check`: 0 faults. Nothing here is code; the entities are the change.

Note for whoever accepts these: `accept` only runs on the default branch, so it
happens after this merges, not before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M6HdFXtEFTJt2x8on3RJ2L