### PR TITLE
init honours --json, and the sweep reaches a verb that succeeds

### DIFF
--- a/.ank/entities/LOG-646ad49dce67.md
+++ b/.ank/entities/LOG-646ad49dce67.md
@@ -1,0 +1,16 @@
+---
+id: LOG-646ad49dce67
+type: log
+title: "falsified rather than asserted: with the --json branch of init::run disabled, both the sweep"
+created: 2026-08-17T06:51:59Z
+author: claude-code/2.1.233+integration-contract
+scope:
+  - crates/ank-cli/src/init.rs
+  - crates/ank-cli/tests/cli.rs
+about: TASK-9e63827380a1
+seq: 0
+schema: 3
+version: 1
+---
+
+ (no_verb_puts_anything_but_json_on_stdout_under_json) and the golden for init go red, and both go green again when it is restored. The sweep's hole was never assert_json_only returning early on an empty stdout -- that is correct for a refusal -- it was that the fixture could only ever make init refuse, so the empty case was the only one it saw.

--- a/.ank/entities/LOG-bdd7e1990a61.md
+++ b/.ank/entities/LOG-bdd7e1990a61.md
@@ -1,0 +1,14 @@
+---
+id: LOG-bdd7e1990a61
+type: log
+title: done, proof commit:93fb8e2fd1367e6798264115a75f81b533759b9a
+created: 2026-08-17T06:52:51Z
+author: claude-code/2.1.233+integration-contract
+scope:
+  - crates/ank-cli/src/init.rs
+  - crates/ank-cli/tests/cli.rs
+about: TASK-9e63827380a1
+seq: 1
+schema: 3
+version: 1
+---

--- a/.ank/entities/TASK-9e63827380a1.md
+++ b/.ank/entities/TASK-9e63827380a1.md
@@ -5,7 +5,7 @@ slug: init-honours-json-and-the-sweep-reaches-a-verb-t
 title: init honours --json, and the sweep reaches a verb that succeeds
 created: 2026-08-17T06:11:09Z
 author: claude-code/2.1.233+integration-contract
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/src/init.rs
   - crates/ank-cli/tests/cli.rs
@@ -13,8 +13,13 @@ blocked_by: []
 done_criteria: |
   ank init --json emits one JSON document on stdout and nothing else, naming what it created, wrote and added. The sweep that asserts no verb puts anything but JSON on stdout reaches init in a directory with no corpus, so a verb that succeeds is swept and not only one that refuses. A golden pins the document. cargo test is green.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 93fb8e2fd1367e6798264115a75f81b533759b9a
+    criteria: cd47a57d4d15
+    via: submitted
 schema: 3
-version: 2
+version: 3
 ---
 
 Found while capturing the goldens for TASK-2c12b027f805, not by reading the

--- a/.ank/entities/TASK-9e63827380a1.md
+++ b/.ank/entities/TASK-9e63827380a1.md
@@ -5,7 +5,7 @@ slug: init-honours-json-and-the-sweep-reaches-a-verb-t
 title: init honours --json, and the sweep reaches a verb that succeeds
 created: 2026-08-17T06:11:09Z
 author: claude-code/2.1.233+integration-contract
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/src/init.rs
   - crates/ank-cli/tests/cli.rs
@@ -14,7 +14,7 @@ done_criteria: |
   ank init --json emits one JSON document on stdout and nothing else, naming what it created, wrote and added. The sweep that asserts no verb puts anything but JSON on stdout reaches init in a directory with no corpus, so a verb that succeeds is swept and not only one that refuses. A golden pins the document. cargo test is green.
 criteria_by: creator
 schema: 3
-version: 1
+version: 2
 ---
 
 Found while capturing the goldens for TASK-2c12b027f805, not by reading the

--- a/crates/ank-cli/src/init.rs
+++ b/crates/ank-cli/src/init.rs
@@ -62,15 +62,27 @@ pub fn run(inv: &Invocation, cwd: &Path, out: &mut dyn Write) -> Result<i32> {
     // not a repository.
     git::ensure_usable(&target)?;
     let report = init_at(&target)?;
-    for line in report.lines_terse() {
-        let _ = writeln!(out, "{line}");
+    // `--json` is available on every command without exception (§4), and this
+    // verb was the exception: it printed its prose and ignored the flag. The
+    // sweep never caught it because a `Repo` fixture already carries a `.ank/`,
+    // so `init` refused, stdout was empty, and an empty stdout is what a
+    // refusal is supposed to leave (TASK-9e63827380a1).
+    if inv.json() {
+        let _ = writeln!(out, "{}", report.json());
+    } else if !inv.quiet() {
+        for line in report.lines_terse() {
+            let _ = writeln!(out, "{line}");
+        }
     }
     Ok(0)
 }
 
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct Report {
-    pub created_dirs: bool,
+    /// The directories this run made, in the order they were made. A list and
+    /// not a flag: the flag named both whenever either was missing, so a run
+    /// that created one of the two reported creating a directory it found.
+    pub created_dirs: Vec<String>,
     pub wrote_config: bool,
     pub wrote_gitattributes: bool,
     pub wrote_gitignore: bool,
@@ -79,12 +91,60 @@ pub struct Report {
 }
 
 impl Report {
+    /// The same six effects as [`lines_terse`], grouped by the verb that
+    /// applies to them, and always the same shape: three lists, empty when
+    /// there is nothing in them, so a parser reads one document and not two.
+    ///
+    /// `changed` is the question a script actually asks — whether there is
+    /// anything to commit — and it is answered rather than left to be derived
+    /// from the emptiness of three lists.
+    ///
+    /// [`lines_terse`]: Report::lines_terse
+    pub fn json(&self) -> String {
+        let mut wrote: Vec<&str> = Vec::new();
+        if self.wrote_config {
+            wrote.push(".ank/config.yml");
+        }
+        if self.wrote_gitattributes {
+            wrote.push(".gitattributes");
+        }
+        if self.wrote_gitignore {
+            wrote.push(".gitignore");
+        }
+        // Where each was added, not what was added: the caller who wants to
+        // inspect the result needs the address, and the two addresses are of
+        // different kinds — a file and a git config key.
+        let mut added: Vec<&str> = Vec::new();
+        if self.wrote_agents_pointer {
+            added.push("AGENTS.md");
+        }
+        if self.added_refspec {
+            added.push("remote.origin.fetch");
+        }
+        crate::json::Obj::new()
+            .strings("created", &self.created_dirs)
+            .strings("wrote", &wrote)
+            .strings("added", &added)
+            .bool("changed", self.changed())
+            .finish()
+    }
+
+    /// Whether this run had any effect at all.
+    pub fn changed(&self) -> bool {
+        !self.created_dirs.is_empty()
+            || self.wrote_config
+            || self.wrote_gitattributes
+            || self.wrote_gitignore
+            || self.wrote_agents_pointer
+            || self.added_refspec
+    }
+
     /// Terse output, `git status` style: one line per real effect, nothing for
     /// what was already in place.
     pub fn lines_terse(&self) -> Vec<String> {
         let mut v = Vec::new();
-        if self.created_dirs {
-            v.push("created .ank/entities .ank/log".to_string());
+        if !self.created_dirs.is_empty() {
+            v.push(format!("created {}", self.created_dirs.join(" ")));
         }
         if self.wrote_config {
             v.push("wrote .ank/config.yml".to_string());
@@ -127,7 +187,7 @@ pub fn init_at(root: &Path) -> Result<Report> {
         let dir = ank.join(sub);
         if !dir.is_dir() {
             fs::create_dir_all(&dir).map_err(|e| io(&dir, e))?;
-            report.created_dirs = true;
+            report.created_dirs.push(format!("{}/{sub}", repo::ANK_DIR));
         }
     }
 
@@ -242,7 +302,7 @@ mod tests {
         let t = Temp::new_repo();
         let r = init_at(&t.0).unwrap();
 
-        assert!(r.created_dirs);
+        assert_eq!(r.created_dirs, vec![".ank/entities", ".ank/log"]);
         assert!(t.0.join(".ank/entities").is_dir());
         assert!(t.0.join(".ank/log").is_dir());
 

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -10456,7 +10456,49 @@ fn no_verb_puts_anything_but_json_on_stdout_under_json() {
         args.push("--json");
         let out = r.ank_edit("claude-code@ank", &args, None);
         assert_json_only(&out, &format!("`ank {}`", args.join(" ")));
+
+        // **And once more where the verb can succeed**, for the one verb this
+        // fixture can only ever make refuse (TASK-9e63827380a1). `Repo` carries
+        // a `.ank/`, which is what `init` exists to produce, so above it always
+        // refuses; a refusal leaves stdout empty, and an empty stdout is what
+        // `assert_json_only` returns early on. The sweep therefore proved that
+        // `init` refuses cleanly and had never once seen it succeed — which is
+        // exactly where it printed six lines of prose under `--json`.
+        //
+        // A sweep that only ever reaches a verb's refusal has a hole the shape
+        // of that verb's success.
+        if verb == "init" {
+            let fresh = fresh_git_dir("sweep-init");
+            let out = ank_command()
+                .args(["init", "--json"])
+                .env("ANK_AGENT", "claude-code@ank")
+                .current_dir(&fresh)
+                .output()
+                .expect("the binary must have been built");
+            assert_eq!(code(&out), 0, "init must succeed here: {}", stderr(&out));
+            assert_json_only(&out, "`ank init --json` where it succeeds");
+            let _ = std::fs::remove_dir_all(&fresh);
+        }
     }
+}
+
+/// A git repository with no corpus in it, for the verbs whose success needs
+/// one. Named by the caller so two of them never collide.
+fn fresh_git_dir(what: &str) -> PathBuf {
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let p = std::env::temp_dir().join(format!(
+        "ank-cli-{what}-{}-{}",
+        std::process::id(),
+        SEQ.fetch_add(1, Ordering::Relaxed)
+    ));
+    let _ = std::fs::remove_dir_all(&p);
+    std::fs::create_dir_all(&p).unwrap();
+    let out = git_command(&p)
+        .args(["init", "-q", "-b", "main"])
+        .output()
+        .expect("git must be installed: it is a hard dependency");
+    assert!(out.status.success(), "git init: {}", stderr(&out));
+    p
 }
 
 #[test]
@@ -14036,9 +14078,24 @@ fn json_golden_verbs_needing_their_own_environment() {
     assert_eq!(code(&out), 0, "migrate: {}", stderr(&out));
     golden("migrate", &stdout(&out));
 
-    // `init` is the one verb with no golden here, and deliberately: it does
-    // not honour `--json` at all, it prints its six human lines. Capturing
-    // these fixtures is what found that, and TASK-9e63827380a1 owns it. A
-    // fixture named `init.json` holding prose would pin the defect as if it
-    // were the contract.
+    // init, which refuses --repo by name and so is run from a directory. Two
+    // fixtures and not one: the second run is the idempotent case, and the
+    // shape it returns is the point — three empty lists and `changed: false`,
+    // so a parser reads one document and never two.
+    let fresh = fresh_git_dir("golden-init");
+    let init_json = |dir: &Path| {
+        ank_command()
+            .args(["init", "--json"])
+            .env("ANK_AGENT", AGENT)
+            .current_dir(dir)
+            .output()
+            .expect("the binary must have been built")
+    };
+    let out = init_json(&fresh);
+    assert_eq!(code(&out), 0, "init: {}", stderr(&out));
+    golden("init", &stdout(&out));
+    let out = init_json(&fresh);
+    assert_eq!(code(&out), 0, "init, again: {}", stderr(&out));
+    golden("init-again", &stdout(&out));
+    let _ = std::fs::remove_dir_all(&fresh);
 }

--- a/crates/ank-cli/tests/golden-json/init-again.json
+++ b/crates/ank-cli/tests/golden-json/init-again.json
@@ -1,0 +1,1 @@
+{"created":[],"wrote":[],"added":[],"changed":false}

--- a/crates/ank-cli/tests/golden-json/init.json
+++ b/crates/ank-cli/tests/golden-json/init.json
@@ -1,0 +1,1 @@
+{"created":[".ank/entities",".ank/log"],"wrote":[".ank/config.yml",".gitattributes",".gitignore"],"added":["AGENTS.md","remote.origin.fetch"],"changed":true}


### PR DESCRIPTION
TASK-9e63827380a1. `ank init --json` printed its six human lines and no
document, against §4's invariant that `--json` is available on every command
without exception. Found while capturing the goldens for TASK-2c12b027f805, not
by reading the code.

## Why it survived

The sweep `no_verb_puts_anything_but_json_on_stdout_under_json` *does* iterate
every verb the listing offers, `init` included. But its fixture is a `Repo`,
which already carries a `.ank/` -- so `init` refuses, a refusal writes to stderr
and leaves stdout empty, and `assert_json_only` returns early on the empty case.

The sweep has only ever proved that `init` refuses cleanly. It had never once
seen it succeed, and success is where the prose was.

`assert_json_only` is not the bug and is unchanged: returning early on an empty
stdout is exactly right for a refusal. The sweep now runs `init` a second time
in a fresh git repository with no corpus, so a verb that succeeds is swept.

## The document

```json
{"created":[".ank/entities",".ank/log"],"wrote":[".ank/config.yml",".gitattributes",".gitignore"],"added":["AGENTS.md","remote.origin.fetch"],"changed":true}
```

The six effects grouped by the verb that applies to them, always the same shape
-- three lists, empty when there is nothing in them -- plus `changed`, which is
the question a script actually asks. The idempotent re-run returns
`{"created":[],"wrote":[],"added":[],"changed":false}`, and both are pinned as
goldens, because that second shape is the point.

## One correctness fix carried with it

`Report::created_dirs` was a single flag for two directories, so a run that
created only `.ank/log` reported creating `.ank/entities` too. Harmless in prose;
a lie in a document that names what it made. It is now a list, and
`lines_terse` joins it.

## Verification

Falsified rather than asserted: with the `--json` branch of `init::run`
disabled, the sweep **and** the `init` golden both go red, and both go green when
it is restored. `cargo test --workspace`: 571 passed, 0 failed.
`cargo fmt --check` clean. `ank check`: 0 faults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M6HdFXtEFTJt2x8on3RJ2L