### PR TITLE
The viewer task is blocked by the contract a reader outside this tree rests on

### DIFF
--- a/.ank/entities/LOG-84af3c967482.md
+++ b/.ank/entities/LOG-84af3c967482.md
@@ -1,0 +1,13 @@
+---
+id: LOG-84af3c967482
+type: log
+title: "amended: +blocked_by TASK-af4a6db95aab"
+created: 2026-08-17T17:09:57Z
+author: claude-code/2.1.233+exposition
+scope:
+  - viewer/**
+about: TASK-34d27790dba9
+seq: 0
+schema: 3
+version: 1
+---

--- a/.ank/entities/TASK-34d27790dba9.md
+++ b/.ank/entities/TASK-34d27790dba9.md
@@ -8,12 +8,12 @@ author: claude-code/2.1.233+integration-contract
 status: open
 scope:
   - viewer/**
-blocked_by: []
+blocked_by: [TASK-af4a6db95aab]
 done_criteria: |
   viewer/ holds one self-contained HTML file, with no build step, no backend, no network request and no dependency fetched at view time. Opened in a Chromium browser and granted the repository root, it lists the corpus's entities with their kind, status and title, shows the blocked_by graph, and names the holder and expiry of every live claim, reading loose refs under refs/ank/ and packed-refs alike. It writes no file, no ref and no claim. It is verified by opening it against this repository and against a second one.
 criteria_by: creator
 schema: 3
-version: 1
+version: 2
 ---
 
 ADR-bcb18aecb7e1 accepted this shape and created no task for it, by design.


### PR DESCRIPTION
PR #169 is closed without merging: the read-only reader ships from its own repository rather than in-tree, and this repository goes back to the machine surface. ADR-bcb18aecb7e1 is untouched — its constraint fixes the *shape* of such a reader, and living under `viewer/` was prose in its body, not the constraint.

## Why this blocks the task instead of closing it

Closing TASK-34d27790dba9 was the intended disposition. The corpus refuses it, and the refusal is measured:

| state of the task | `check` on a scope matching no file |
|---|---|
| `open` / `in_progress` | signal — "work not started, or a typo" |
| `done` / `closed` | **fault** |

`human.rs` reads the status as `!(Open | InProgress)`, and SPEC-cd0d states it in ratified prose: *a fault for an ADR or a finished task, which claimed to touch files that are not there*. No commit on the default branch ever carried `viewer/**`, so neither ADR-97beaf55e73a's rename walk nor ADR-3094538d831e's deletion clause has anything to lower the severity with, and `amend` refuses a finished task. Closing would have left `main` carrying a fault nobody can clear — and `ci.yml` runs `ank check`.

Judging a closure the way a completion is judged is a decision to take, not a defect to patch in passing: a closed task claimed nothing. It would cost an ADR and a change to a ratified specification, which is out of this perimeter.

## What this does instead

The task stays `open`, where its signal reads true — work not started, in this tree — and it is blocked on TASK-af4a6db95aab. The dependency is real rather than a device: a reader living outside this repository rests on the integration contract that task states. That is exactly what the abandoned attempt lacked, when it had to reimplement packfile reading and reconcile the result against the CLI to know it was right.

`ank claim TASK-34d2` now exits 7, so nothing offers the work again.

## Verification

    ank check   ->  exit 0, zero faults

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F1RRkJoQsHeGL1oRq7G7AX
