### PR TITLE
Three ratified decisions get the tasks that carry them

### DIFF
--- a/.ank/entities/TASK-5218783cf860.md
+++ b/.ank/entities/TASK-5218783cf860.md
@@ -1,0 +1,46 @@
+---
+id: TASK-5218783cf860
+type: task
+slug: the-format-crates-are-apache-2-0-as-published-no
+title: The format crates are Apache-2.0 as published, not only as promised
+created: 2026-08-17T19:21:02Z
+author: claude-code/2.1.233+exposition
+status: open
+scope:
+  - crates/ank-core/**
+  - LICENSE
+  - README.md
+blocked_by: []
+done_criteria: |
+  ank-core declares Apache-2.0 in its manifest and carries the licence text where a reader of the crate finds it. ank-cli still declares GPL-3.0-only. The README's licence section names which licence covers which crate, so the promise it already makes -- that the tools which read the format are not derivative works -- is true of the crates as they are published. cargo test is green, cargo fmt --check passes, and ank check reports no fault.
+criteria_by: creator
+schema: 3
+version: 1
+---
+
+ADR-68018cda382c requires it, and the README has been making the promise for
+some time:
+
+> The copyleft covers the tool's code, not the format: your `.ank/` files and the
+> tools that read them are not derivative works.
+
+The first half is true. The second is false as the tree stands: `ank-core` is the
+reference implementation of the format, its own header says its caller may be a
+third-party tool, and it is GPL-3.0-only. Anything linking it to read the format
+is a derivative work of it, so the sentence holds only for somebody who
+reimplements the parser from `docs/format.md` and the golden suite -- the harder
+half of what it appears to offer.
+
+`ank-contract` was born Apache-2.0 rather than relicensed (TASK-0549e0f960ef),
+and the reasoning is in its manifest. This task is the other half, and the older
+one.
+
+Two things it is not. It does not touch the root `LICENSE`, which covers the tool
+and stays GPL-3.0: what the copyleft defends is the store, the claim arbitration
+and `check`'s invariants, none of which are in `ank-core`. And it costs no
+negotiation -- every commit here is authored by one person under three
+identities plus a CI bot, so there is no third-party copyright to consult, which
+is the usual reason a relicensing never happens.
+
+The badge in the README header says `licence-GPL--3.0` and will need to say
+something true of a workspace with two licences in it.

--- a/.ank/entities/TASK-d55cef0b0ef1.md
+++ b/.ank/entities/TASK-d55cef0b0ef1.md
@@ -1,0 +1,43 @@
+---
+id: TASK-d55cef0b0ef1
+type: task
+slug: a-corpus-is-addressable-by-an-identity-that-surv
+title: A corpus is addressable by an identity that survives being moved, cloned or symlinked
+created: 2026-08-17T19:21:48Z
+author: claude-code/2.1.233+exposition
+status: open
+scope:
+  - crates/ank-cli/src/repo.rs
+  - crates/ank-cli/src/status.rs
+  - crates/ank-cli/tests/**
+blocked_by: []
+done_criteria: |
+  A repository carries an identity derived from its root commit and never from its path, so two worktrees of one repository answer the same value and two clones of different repositories answer different ones. ank status --json carries it, and a test drives the binary to prove both halves: one repository reached by two paths is one corpus, two corpora in one tree are two. A tree with no history answers a declared fallback rather than inventing a value, and the fallback is documented where the field is. The field is gained within contract version 1, which permits gaining and forbids losing, so CONTRACT_VERSION does not move and the goldens are updated in the same commit. cargo test is green and cargo fmt --check passes.
+criteria_by: creator
+schema: 3
+version: 1
+---
+
+ADR-621a7fd96ce1 requires it. `--repo` already addresses a corpus and `peers.<name>`
+already lets a scope reach into another one for reading; what neither gives a
+reader is a name for a corpus that survives being moved, cloned, or opened
+through a symlink.
+
+A board showing three repositories has to key its rows on something, and a path
+is the one thing that is neither stable nor unique: two worktrees of one
+repository share a corpus and have different paths, and two clones of different
+repositories can sit at the same path on two machines. The root commit is stable,
+cheap to read, and already the identity git itself would use.
+
+**This is the first field gained under the contract**, and it is worth doing as
+the demonstration of what that promise means. ADR-6fd69efb629c says a document
+may gain a field within a version and may never lose, rename or retype one. So
+`CONTRACT_VERSION` stays at 1, `status`'s declared shape grows a row, its golden
+grows a key, and a client written yesterday against `ank status --json` keeps
+working -- which is the whole of what the version was spent to buy
+(TASK-155e98c184ed).
+
+What the ADR does not ask for, and what must not be built: nothing walks a
+filesystem looking for corpora. Aggregation is declared. Writing never crosses a
+corpus boundary and claims stay per repository, unchanged from ADR-a1de673043b4.
+The identity is a key for a reader, not a route for a writer.

--- a/.ank/entities/TASK-e819448560e7.md
+++ b/.ank/entities/TASK-e819448560e7.md
@@ -1,0 +1,56 @@
+---
+id: TASK-e819448560e7
+type: task
+slug: a-protocol-surface-exposes-every-verb-generated
+title: A protocol surface exposes every verb, generated from the table the CLI dispatches from
+created: 2026-08-17T19:21:27Z
+author: claude-code/2.1.233+exposition
+status: open
+scope:
+  - Cargo.toml
+  - crates/ank-mcp/**
+blocked_by: []
+done_criteria: |
+  A sibling binary in this workspace exposes every verb COMMANDS carries, generated from that table rather than listed by hand, so a verb added to the table reaches the protocol with no edit here. It refuses on state exactly as the CLI does and never on identity, and a refusal carries the CLI's exit code as its reason. It speaks for exactly one corpus, addressed the way --repo addresses one, and takes no claim the CLI would not have taken in that clone. It writes under a typed process identity. The verb list and skill/SKILL.md are untouched. A test drives the built binary as a process: the surface it advertises equals the table, and a refused call carries the code the table declares. cargo test is green and cargo fmt --check passes.
+criteria_by: creator
+schema: 3
+version: 1
+---
+
+ADR-372b82af1ec7 allows this, and it allows nothing else: a full-surface
+passthrough or no surface at all. It supersedes ADR-1713af205186, whose refusal
+is kept whole as the shape of what is now permitted -- the proposal that ADR
+rejected exposed four verbs out of twenty-two, which rebuilds under a second
+protocol the agent-surface split abolished once already, and rebuilds the worse
+half of it.
+
+**The condition it set is now met**, which is why this task exists and could not
+have existed a day ago. `ank-contract` holds the table both surfaces consume
+(TASK-0549e0f960ef), and it holds the shape of every document a verb returns
+(TASK-155e98c184ed). So the protocol surface is *generated* rather than kept in
+step by review: a verb the table does not carry is a verb neither surface has.
+
+**MCP first, and the name follows the workspace convention.** It is the protocol
+ADR-1713af205186 refused and the one whose conditions ADR-372b82af1ec7 answered,
+and the client that genuinely gains something is the one with no shell at all.
+Nothing here makes a protocol the preferred route for an agent that has a shell:
+§2's common denominator is unchanged, and it is still what the skill teaches.
+
+**What it must not do**, all of it from the constraint rather than from taste: no
+curated subset under any protocol; no refusal on identity; no claim held on a
+client's behalf; no pooling of clients under one identity; and no merging of the
+claim spaces of two clones, because `refs/ank/*` is per repository and a server
+pretending otherwise would be inventing an arbitration the refs cannot carry. A
+deployment over several repositories is several corpora addressed separately,
+which is the answer ADR-a1de673043b4 gives for federation and the answer
+ADR-621a7fd96ce1 gives for keying them.
+
+A sibling binary rather than a twenty-third verb: the live one-surface decision
+freezes what `skill/SKILL.md` teaches, so a verb would cost a second supersession
+and a second human signature and buy nothing. The requirement is that the surface
+be generated from the dispatch table, and a binary in this workspace reads that
+table directly.
+
+Distribution is not in scope here. TASK-2078e0d1b0a7 already owns what a
+published release reaches, and a second binary is a clause of that rather than a
+project of its own.


### PR DESCRIPTION
ADR-68018cda382c, ADR-372b82af1ec7 and ADR-621a7fd96ce1 were ratified on `main` and nothing in the corpus carried them. An accepted constraint with no task is a decision that binds and never lands — and `check` does not notice, because it verifies references, freezes and scopes, not whether a decision was acted on.

| task | decision | perimeter |
|---|---|---|
| TASK-5218783cf860 | ADR-68018cda382c | `ank-core` is Apache-2.0 **as published**, not only as promised |
| TASK-e819448560e7 | ADR-372b82af1ec7 | a protocol surface, generated from the table |
| TASK-d55cef0b0ef1 | ADR-621a7fd96ce1 | a corpus identity that survives being moved or cloned |

None is blocked; the order between them is appetite, not dependency.

## Two of them are shaped by what just landed

**The protocol surface could not have been written a day ago.** ADR-372b82af1ec7 keeps ADR-1713af205186's refusal whole and permits a surface only on conditions the tree did not meet — a table both surfaces consume, so the passthrough is *generated* rather than reviewed into agreement. TASK-0549e0f960ef put that table in a crate and TASK-155e98c184ed put the output shapes in it. The condition is met, so this is a task rather than a proposal.

**The corpus identity is the first field gained under the contract**, and it is worth doing as the demonstration of what that promise means. ADR-6fd69efb629c says a document may gain a field within a version and may never lose, rename or retype one. So `CONTRACT_VERSION` stays at `1` while `status` grows a key, its declared shape grows a row, its golden grows a field — and a client written against it yesterday keeps working. That is the whole of what the breaking change was spent to buy.

## The relicensing is the oldest debt

The README has promised for some time that "the copyleft covers the tool's code, not the format: your `.ank/` files and *the tools that read them* are not derivative works". The second half is false while `ank-core` is GPL-3.0-only, since anything linking it to read the format is a derivative work of it. `ank-contract` was born Apache-2.0 rather than relicensed (TASK-0549e0f960ef) and its manifest argues why; this is the other half, and the older one.

Note for whoever takes it: the README badge says `licence-GPL--3.0` and will have to say something true of a workspace carrying two licences.

## Verification

    ank check   exit 0, 0 faults

Three signals, all expected and none to be "repaired": two perimeters are wide because the work is wide, and `crates/ank-mcp/**` matches no file because the work has not started.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F1RRkJoQsHeGL1oRq7G7AX
