### PR TITLE
Ank is Apache-2.0 whole, and the format/tool split is abandoned

### DIFF
--- a/.ank/entities/ADR-9f03438f5422.md
+++ b/.ank/entities/ADR-9f03438f5422.md
@@ -1,0 +1,96 @@
+---
+id: ADR-9f03438f5422
+type: adr
+slug: ank-is-apache-2-0-whole-and-the-format-tool-spli
+title: Ank is Apache-2.0 whole, and the format/tool split is abandoned
+created: 2026-08-17T19:38:57Z
+author: claude-code/2.1.233+exposition
+status: proposed
+scope:
+  - LICENSE
+  - README.md
+  - CLAUDE.md
+  - crates/**
+  - npm/**
+  - Formula/**
+  - bucket/**
+  - packaging/**
+  - package.json
+constraint: |
+  Ank is Apache-2.0, whole. Every crate in the workspace, the binary as
+  distributed, and the licence text at the root of the repository: no part of it is
+  copyleft, and there is no format/tool split any more. Every channel that declares
+  a licence declares that one -- the npm packages, the Homebrew formula, the Scoop
+  manifest, the winget locale, the release metadata -- and the documentation states
+  it in one place, with no second answer left anywhere else to contradict it. A
+  declaration that disagrees with this one is a defect, and grep is the check.
+  
+  Relicensing is prospective and says so: a release already made under GPL-3.0
+  stays available under GPL-3.0 to whoever received it, and nothing in the tree
+  claims to withdraw that.
+supersedes: ADR-68018cda382c
+schema: 3
+version: 1
+---
+
+## What this supersedes
+
+ADR-68018cda382c drew a line: `ank-core`, and any crate existing so another
+program can read or write the format, Apache-2.0; `ank-cli` copyleft. Its
+argument was that "the parser is not the part worth defending with copyleft; the
+tool is". This reverses the second half of that sentence and keeps the first.
+
+## Why the line did not hold its own weight
+
+**It moved outward within a day of being drawn.** `ank-contract` -- the verb
+table, the refusals, the exit codes -- is not the format, so ADR-68018cda382c did
+not reach it. It was born Apache-2.0 anyway (TASK-0549e0f960ef), because the
+README's promise about "the tools that read them" was as false of it as of the
+parser. That is the same boundary being redrawn twice in one direction, which is
+usually a boundary in the wrong place rather than a boundary that needs moving
+again.
+
+**What the copyleft was defending is already published.** `docs/format.md`, the
+ten specification entities, `crates/ank-core/tests/golden/` and
+`crates/ank-cli/tests/golden-json/` exist precisely so that a reimplementation is
+cheap, and `docs/integrating.md` now hands a client the machine contract in full
+(TASK-af4a6db95aab). A competitor who wants an ank-compatible tool without our
+code has a paved road. Copyleft on the implementation therefore did not deter the
+competitor it was written for; it deterred the honest embedder, who is the
+reader this project actually wants.
+
+**And it reached fewer people than it appeared to.** Ank is invoked as a process,
+and invoking a program is not linking it, so the copyleft never bound the
+pipelines, agents and wrappers that call `ank`. Its real subjects were the people
+who wanted to fork it or vendor it into their own tool -- early contributors, in
+other words.
+
+## What is given up, stated plainly
+
+A proprietary fork of ank becomes permitted. That is a real loss and it is not
+being minimised: ADR-68018cda382c's reasoning was sound on its own terms, and
+this decision judges the trade differently rather than finding an error in it.
+What tips it is that the defence was buying little against the thing it feared
+and costing something against the thing the project needs, which is people
+building on it.
+
+## Why Apache-2.0 and not MIT
+
+The patent grant, and consistency: two crates already carry Apache-2.0, and one
+permissive licence across the whole tree is one thing to reason about instead of
+two.
+
+## What it costs, measured
+
+Nothing to negotiate. Every commit in this repository is authored by one person
+under three git identities -- `Haksolot`, `Sean Lamet`, `Ankor` -- plus a CI bot
+on three commits. `CONTRIBUTING.md` carries no CLA and no DCO, and no outside
+contributor appears in the history, so there is no third-party copyright to
+consult. That is the usual reason a relicensing never happens, and it does not
+apply here.
+
+`Co-Authored-By` trailers name an assistant, which is not a copyright holder.
+
+Irreversible for what is already released, which is why it is written down rather
+than done as a chore: a version distributed under GPL-3.0 stays available under
+GPL-3.0 to everyone who received it, and this decision is prospective only.

--- a/.ank/entities/LOG-1686ae5b48db.md
+++ b/.ank/entities/LOG-1686ae5b48db.md
@@ -1,0 +1,18 @@
+---
+id: LOG-1686ae5b48db
+type: log
+title: "released: the criterion is wrong entire, not in one clause: it pins 'ank-cli still declares"
+created: 2026-08-17T19:37:22Z
+author: claude-code/2.1.233+exposition
+scope:
+  - crates/ank-core/**
+  - LICENSE
+  - README.md
+  - crates/ank-contract/**
+about: TASK-5218783cf860
+seq: 1
+schema: 3
+version: 1
+---
+
+ GPL-3.0-only', which is the format/tool split ADR-68018cda382c decided and which the project is now moving away from. Everything permissive means there is no split to preserve, so the task's shape is gone rather than one of its clauses. A superseding ADR carries the new decision and a new task carries the work; the two LICENSE texts and ank-core's manifest change survive into it unchanged.

--- a/.ank/entities/LOG-d0abfa202b57.md
+++ b/.ank/entities/LOG-d0abfa202b57.md
@@ -1,0 +1,16 @@
+---
+id: LOG-d0abfa202b57
+type: log
+title: "amended: +scope crates/ank-contract/**"
+created: 2026-08-17T19:32:25Z
+author: claude-code/2.1.233+exposition
+scope:
+  - crates/ank-core/**
+  - LICENSE
+  - README.md
+  - crates/ank-contract/**
+about: TASK-5218783cf860
+seq: 0
+schema: 3
+version: 1
+---

--- a/.ank/entities/LOG-f5a9b6572d0d.md
+++ b/.ank/entities/LOG-f5a9b6572d0d.md
@@ -1,0 +1,18 @@
+---
+id: LOG-f5a9b6572d0d
+type: log
+title: "closed: superseded by TASK-47beb64fd204 under ADR-9f03438f5422: this task existed to make the"
+created: 2026-08-17T19:39:38Z
+author: claude-code/2.1.233+exposition
+scope:
+  - crates/ank-core/**
+  - LICENSE
+  - README.md
+  - crates/ank-contract/**
+about: TASK-5218783cf860
+seq: 2
+schema: 3
+version: 1
+---
+
+ format/tool split true of the crates as published, and the split is abandoned. Its criterion pinned ank-cli as GPL-3.0-only, which the new decision reverses, so there is nothing left of it to finish.

--- a/.ank/entities/TASK-47beb64fd204.md
+++ b/.ank/entities/TASK-47beb64fd204.md
@@ -1,0 +1,62 @@
+---
+id: TASK-47beb64fd204
+type: task
+slug: every-licence-declaration-in-the-tree-says-apach
+title: Every licence declaration in the tree says Apache-2.0
+created: 2026-08-17T19:39:22Z
+author: claude-code/2.1.233+exposition
+status: open
+scope:
+  - LICENSE
+  - README.md
+  - CLAUDE.md
+  - crates/**
+  - npm/**
+  - Formula/**
+  - bucket/**
+  - packaging/**
+  - package.json
+blocked_by: []
+done_criteria: |
+  No file in the tree declares GPL, and grep is the check: the root LICENSE carries the Apache-2.0 text, all three crate manifests declare Apache-2.0 and each crate carries that text beside it, and every channel that declares a licence says Apache-2.0 -- the four npm package.json files and the root one, the Homebrew formula, the Scoop manifest, the winget locale. README.md, CLAUDE.md and npm/ank/README.md state one licence with no second answer, and the README badge agrees. The tree says somewhere a reader will find it that the change is prospective and that a release already made under GPL-3.0 stays available under it. cargo test is green, cargo fmt --check passes, and ank check reports no fault.
+criteria_by: creator
+schema: 3
+version: 1
+---
+
+ADR-9f03438f5422 requires it. This is the mechanical half; the decision and what
+it gives up are in the ADR, and it must be accepted on the default branch before
+this is claimed.
+
+The inventory, measured on 2026-08-17 -- fifteen declarations in eleven files,
+plus the licence text at the root:
+
+    LICENSE                                       the GPL-3.0 text itself
+    crates/ank-cli/Cargo.toml                     license = "GPL-3.0-only"
+    crates/ank-core/Cargo.toml                    license = "GPL-3.0-only"
+    crates/ank-contract/Cargo.toml                already Apache-2.0, no text beside it
+    package.json                                  "license": "GPL-3.0-only"
+    npm/ank/package.json                          "license": "GPL-3.0-only"
+    npm/ank-win32-x64/package.json                "license": "GPL-3.0-only"
+    npm/ank-linux-x64-musl/package.json           "license": "GPL-3.0-only"
+    npm/ank-darwin-arm64/package.json             "license": "GPL-3.0-only"
+    Formula/ank.rb                                license "GPL-3.0-only"
+    bucket/ank.json                               "license": "GPL-3.0-only"
+    packaging/winget/Haksolot.Ank.locale.en-US.yaml   License: GPL-3.0-only
+    README.md                                     badge, and the Licence section
+    npm/ank/README.md                             the same sentence, again
+    CLAUDE.md                                     "Ank is a CLI (Rust, GPL-3.0)"
+
+Two things to get right rather than fast.
+
+**The Apache text is copied, never typed.** A licence retyped is a licence
+altered. `bitflags` 2.13.1 and `bstr` 1.12.1 ship byte-identical copies, 10847
+bytes, and agreeing with each other is the check that neither was edited.
+
+**The prospective clause is not decoration.** Whoever received a GPL-3.0 release
+keeps it under GPL-3.0, and the tree must not read as though that were withdrawn.
+Say it once, where a reader looking for the licence will find it.
+
+`crates/ank-contract/**` is in the perimeter for a defect this repository shipped
+on the day the crate was created: the manifest declares Apache-2.0 and no licence
+text sits beside it, so it asserts terms a reader cannot read.

--- a/.ank/entities/TASK-5218783cf860.md
+++ b/.ank/entities/TASK-5218783cf860.md
@@ -5,17 +5,18 @@ slug: the-format-crates-are-apache-2-0-as-published-no
 title: The format crates are Apache-2.0 as published, not only as promised
 created: 2026-08-17T19:21:02Z
 author: claude-code/2.1.233+exposition
-status: open
+status: closed
 scope:
   - crates/ank-core/**
   - LICENSE
   - README.md
+  - crates/ank-contract/**
 blocked_by: []
 done_criteria: |
   ank-core declares Apache-2.0 in its manifest and carries the licence text where a reader of the crate finds it. ank-cli still declares GPL-3.0-only. The README's licence section names which licence covers which crate, so the promise it already makes -- that the tools which read the format are not derivative works -- is true of the crates as they are published. cargo test is green, cargo fmt --check passes, and ank check reports no fault.
 criteria_by: creator
 schema: 3
-version: 1
+version: 5
 ---
 
 ADR-68018cda382c requires it, and the README has been making the promise for


### PR DESCRIPTION
Proposes **ADR-9f03438f5422**, superseding ADR-68018cda382c, and the task that carries it. No code changes here: the decision lands first, because it cannot be a chore.

## Why this is not just an edit

**The corpus refuses it as one.** ADR-68018cda382c is accepted and ratified, and its constraint says in terms: *"`ank-cli` stays GPL-3.0-only."* A ratified constraint is anchored in its ratification commit and `amend` exits 6 on it. The only route is a supersession with a human signature.

**And it is irreversible for what is already released.** It also reverses an argument rather than correcting a mistake — ADR-68018cda382c held that the parser was not worth defending with copyleft and the tool was. The new decision keeps the first half and reverses the second.

## The reasoning, in short

- **The boundary moved outward twice in one direction, within a day.** `ank-contract` is not the format, so ADR-68018cda382c did not reach it — and it was born Apache-2.0 anyway, because the README's promise about "the tools that read them" was as false of it as of the parser. A boundary redrawn twice the same way is usually in the wrong place.
- **What the copyleft defended is already published.** `docs/format.md`, the ten spec entities, both golden suites, and now `docs/integrating.md`. A competitor wanting an ank-compatible tool without our code has a paved road; the copyleft deterred the honest embedder instead.
- **It reached fewer people than it appeared to.** ank is invoked as a process, and invoking a program is not linking it, so it never bound the pipelines, agents and wrappers that call `ank`.

**What is given up, stated rather than minimised:** a proprietary fork of ank becomes permitted.

## The fact that decides, measured before proposing

| | |
|---|---|
| human authors in the history | 3 identities — `Haksolot`, `Sean Lamet`, `Ankor` — one person |
| bot commits | 3 (`github-actions`) |
| CLA or DCO in `CONTRIBUTING.md` | none |
| outside contributors | none |

So there is no third-party copyright to consult. That is the usual reason a relicensing never happens, and it does not apply here.

`Co-Authored-By` trailers name an assistant, which is not a copyright holder.

## What comes next

**TASK-47beb64fd204** carries the mechanical half and lists the inventory it has to clear — fifteen declarations in eleven files, plus the licence text at the root. It must not be claimed until this ADR is accepted on `main`.

Two things it flags for whoever takes it: the Apache text is **copied, never typed** (`bitflags` 2.13.1 and `bstr` 1.12.1 ship byte-identical copies, and agreeing with each other is the check that neither was edited), and the prospective clause is not decoration — whoever received a GPL-3.0 release keeps it under GPL-3.0, and the tree must not read as though that were withdrawn.

## And one task was closed

**TASK-5218783cf860** was claimed an hour ago under the old decision, and its frozen criterion pinned `ank-cli` as GPL-3.0-only. That is not one clause going wrong but the shape of the task going away, so it was released with its reason and then closed. Its scopes all name existing files, so closing it creates no dead scope.

## Verification

    ank check   exit 0, 0 faults

The `supersedes … not yet a succession` line is expected and clears on acceptance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F1RRkJoQsHeGL1oRq7G7AX
