### PR TITLE
A reader with nothing to write opens no transaction, so no wall guards it

### DIFF
--- a/.ank/entities/LOG-389b85a55aab.md
+++ b/.ank/entities/LOG-389b85a55aab.md
@@ -1,0 +1,16 @@
+---
+id: LOG-389b85a55aab
+type: log
+title: "what remains resting on the wall, stated rather than left for a reader to find: a cold corpus has"
+created: 2026-08-17T20:46:41Z
+author: claude-code/2.1.233+exposition
+scope:
+  - crates/ank-cli/src/index.rs
+  - crates/ank-cli/tests/**
+about: TASK-4111dfae8a87
+seq: 1
+schema: 3
+version: 1
+---
+
+ real work to serialise -- one process installs the schema and builds every row -- and the others wait for it, guarded by the five-second wall. That wait is bounded by the winner's bounded work rather than by a queue of readers with nothing to do, and a SQLite file lock dies with the process holding it, so it cannot outlive a crashed writer. Cold start is also a one-time event per corpus, where the contended steady state was every poll forever. I measured cold at a zero wall as well and it passed 60 of 60, but I do not claim that as structural: twelve shell spawns are staggered enough by fork overhead that they may simply not have collided. The claim I do make is the warm one, and it is the one a board polling every thirty seconds lives in.

--- a/.ank/entities/LOG-85c15dfb0b09.md
+++ b/.ank/entities/LOG-85c15dfb0b09.md
@@ -1,0 +1,16 @@
+---
+id: LOG-85c15dfb0b09
+type: log
+title: two locks were taken to write nothing, and the second was the one that mattered. refresh() opened
+created: 2026-08-17T20:46:11Z
+author: claude-code/2.1.233+exposition
+scope:
+  - crates/ank-cli/src/index.rs
+  - crates/ank-cli/tests/**
+about: TASK-4111dfae8a87
+seq: 0
+schema: 3
+version: 1
+---
+
+ an IMMEDIATE transaction before deciding whether anything had diverged, and ensure_schema() opened one on every single open before discovering the schema was already installed -- so every reader of a healthy warm corpus took the write lock twice for no writes. Measured on this tree, twelve readers with no wait allowed at all (ANK_INDEX_BUSY_MS=0): 4 refused of 60 with the schema check still inside its transaction, 0 of 120 once it was asked as a read first. Falsified rather than assumed: putting false && back in front of that read makes the new test fail with the exact CI symptom, database is locked. What replaces the wall is that a reader with nothing to write opens no transaction, so there is no lock for a deadline to guard -- not a larger constant.

--- a/.ank/entities/LOG-b4ac2e01e165.md
+++ b/.ank/entities/LOG-b4ac2e01e165.md
@@ -1,0 +1,14 @@
+---
+id: LOG-b4ac2e01e165
+type: log
+title: done, proof commit:f472579
+created: 2026-08-17T20:50:42Z
+author: claude-code/2.1.233+exposition
+scope:
+  - crates/ank-cli/src/index.rs
+  - crates/ank-cli/tests/**
+about: TASK-4111dfae8a87
+seq: 2
+schema: 3
+version: 1
+---

--- a/.ank/entities/TASK-4111dfae8a87.md
+++ b/.ank/entities/TASK-4111dfae8a87.md
@@ -5,7 +5,7 @@ slug: a-reader-is-never-refused-by-contention-and-a-ti
 title: A reader is never refused by contention, and a timeout is not what guarantees it
 created: 2026-08-17T20:02:58Z
 author: claude-code/2.1.233+exposition
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/src/index.rs
   - crates/ank-cli/tests/**
@@ -13,8 +13,13 @@ blocked_by: []
 done_criteria: |
   Twelve concurrent readers of one corpus all answer, and the guarantee does not rest on a wall-clock deadline being long enough: the test that asserts it passes on a runner loaded enough to have broken the current implementation. What replaces the deadline is stated in the code and is not a larger constant. cargo test is green on the three platforms.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: f472579
+    criteria: e4a38459159f
+    via: submitted
 schema: 3
-version: 2
+version: 3
 ---
 
 Measured on CI, 2026-08-17, run 32061737531 on `windows-latest`:

--- a/.ank/entities/TASK-4111dfae8a87.md
+++ b/.ank/entities/TASK-4111dfae8a87.md
@@ -5,7 +5,7 @@ slug: a-reader-is-never-refused-by-contention-and-a-ti
 title: A reader is never refused by contention, and a timeout is not what guarantees it
 created: 2026-08-17T20:02:58Z
 author: claude-code/2.1.233+exposition
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/src/index.rs
   - crates/ank-cli/tests/**
@@ -14,7 +14,7 @@ done_criteria: |
   Twelve concurrent readers of one corpus all answer, and the guarantee does not rest on a wall-clock deadline being long enough: the test that asserts it passes on a runner loaded enough to have broken the current implementation. What replaces the deadline is stated in the code and is not a larger constant. cargo test is green on the three platforms.
 criteria_by: creator
 schema: 3
-version: 1
+version: 2
 ---
 
 Measured on CI, 2026-08-17, run 32061737531 on `windows-latest`:

--- a/crates/ank-cli/src/index.rs
+++ b/crates/ank-cli/src/index.rs
@@ -60,6 +60,34 @@ pub const DB_FILE: &str = "index.db";
 /// answer.
 const BUSY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
+/// The wall above, in milliseconds, for the one test that has to prove the
+/// invariant does not rest on it (TASK-4111dfae8a87).
+///
+/// **A knob for a test and not for tuning**, which is why it is undocumented
+/// outside this comment and why nothing suggests it in an error. The invariant is
+/// that contention never refuses a reader (§6): the index is derived and
+/// disposable, so a reader losing a race to it has lost nothing it needed. That
+/// claim used to be tested by running twelve readers and hoping the machine was
+/// slow enough to have made them contend — a test that passes because the
+/// hardware was fast is a test that reports the hardware.
+///
+/// Set it to `1` and a five-second wall becomes a one-millisecond one, which is
+/// what an arbitrarily loaded runner is. Measured on this tree before the fix:
+/// twelve cold readers, twelve refused across three rounds. After it, on a warm
+/// index, no reader asks for the write lock at all, so the value cannot matter —
+/// and that is the difference between a guarantee and a margin.
+const BUSY_TIMEOUT_ENV: &str = "ANK_INDEX_BUSY_MS";
+
+fn busy_timeout() -> std::time::Duration {
+    match std::env::var(BUSY_TIMEOUT_ENV)
+        .ok()
+        .and_then(|v| v.parse().ok())
+    {
+        Some(ms) => std::time::Duration::from_millis(ms),
+        None => BUSY_TIMEOUT,
+    }
+}
+
 const SCHEMA: &str = "\
 CREATE TABLE meta (
     key   TEXT PRIMARY KEY,
@@ -250,6 +278,23 @@ pub struct Refreshed {
     pub unreadable: usize,
 }
 
+/// One row's worth of work, decided before the write lock is asked for.
+///
+/// It exists so that two things happen outside the transaction: the parse, which
+/// is the slowest thing this module does, and the *decision* — because a refresh
+/// with nothing to write must be able to say so without opening a transaction at
+/// all (TASK-4111dfae8a87).
+enum Write {
+    /// The file parsed and carries the id its name does: index it under `hash`.
+    Index(String, String, Box<Entity>),
+    /// A file that is an entity by name and did not parse as one, or parsed
+    /// under another id. Its hash is recorded so the failure costs one parse
+    /// rather than one per command.
+    Unreadable(String, String),
+    /// A row whose file is gone.
+    Remove(String),
+}
+
 pub struct Index {
     conn: Connection,
     ank: PathBuf,
@@ -322,7 +367,7 @@ impl Index {
         // Before any statement, including the schema probe below: the probe is
         // a read, a read takes a shared lock, and a shared lock is contended by
         // the writer another process is in the middle of.
-        conn.busy_timeout(BUSY_TIMEOUT)
+        conn.busy_timeout(busy_timeout())
             .map_err(|e| db_error(e, ank))?;
         let mut index = Index {
             conn,
@@ -343,18 +388,38 @@ impl Index {
     /// the others re-read *after* it commits, find the schema present, and do
     /// nothing.
     fn ensure_schema(&mut self) -> Result<()> {
-        let tx = self
-            .conn
-            .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
-            .map_err(|e| db_error(e, &self.ank))?;
+        // **Asked as a read first, and that is what makes a reader lock-free**
+        // (TASK-4111dfae8a87). This used to open the write transaction below
+        // unconditionally, so every process that opened the index took the write
+        // lock in order to discover it had nothing to install — the same defect
+        // the refresh had, one layer down, and the one that kept a warm corpus
+        // contended after the refresh stopped contending. Measured: twelve
+        // readers of a warm index, no wait allowed at all, four refused before
+        // this and none after.
+        //
         // Both halves are needed, and the second was not obvious: `meta`
         // survives a `DROP TABLE entities`, so a version check alone declares
         // a gutted index healthy and the failure surfaces later, during the
         // refresh, as a missing table.
-        let stale = schema_version_of(&tx).map_err(|e| db_error(e, &self.ank))?
-            != Some(SCHEMA_VERSION)
-            || !tables_present_in(&tx).map_err(|e| db_error(e, &self.ank))?;
-        if stale {
+        let healthy = |c: &Connection| -> rusqlite::Result<bool> {
+            Ok(schema_version_of(c)? == Some(SCHEMA_VERSION) && tables_present_in(c)?)
+        };
+        if healthy(&self.conn).map_err(|e| db_error(e, &self.ank))? {
+            return Ok(());
+        }
+
+        let tx = self
+            .conn
+            .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+            .map_err(|e| db_error(e, &self.ank))?;
+        // **Asked again under the lock**, because the read above is a snapshot
+        // and twelve processes opening a fresh corpus all take it before any of
+        // them installs anything. The check and the installation are one
+        // transaction and have to be: read apart, eleven of the twelve fail with
+        // `table entities_fts already exists`. What the read above buys is not
+        // atomicity — it is the eleven-out-of-twelve case where there was never
+        // anything to install.
+        if !healthy(&tx).map_err(|e| db_error(e, &self.ank))? {
             wipe_in(&tx).map_err(|e| db_error(e, &self.ank))?;
             install_schema_in(&tx).map_err(|e| db_error(e, &self.ank))?;
         }
@@ -389,6 +454,54 @@ impl Index {
         let known = self.known_hashes()?;
         let mut done = Refreshed::default();
 
+        // **Decided, and parsed, before the lock is asked for**
+        // (TASK-4111dfae8a87). What the write has to be is a function of the
+        // files and of the rows already there, and neither of those needs the
+        // write lock to be read. Doing the deciding and the parsing inside the
+        // transaction meant the lock was held for the whole of the slowest work
+        // in this function, and held by every reader, for the benefit of the
+        // ones that had something to write.
+        let mut writes: Vec<Write> = Vec::new();
+        for (rel, file) in &on_disk {
+            if known.get(rel) == Some(&file.hash) {
+                done.unchanged += 1;
+                continue;
+            }
+            match parse_entity(&file.text) {
+                Ok(entity) if entity.id() == &file.id => {
+                    writes.push(Write::Index(
+                        rel.clone(),
+                        file.hash.clone(),
+                        Box::new(entity),
+                    ));
+                }
+                // Parsed but under another id than its file name carries, or
+                // did not parse at all. The hash is still recorded, so the
+                // failure costs one parse and not one per command; `check`
+                // reports it, the index only declines to hold it.
+                _ => writes.push(Write::Unreadable(rel.clone(), file.hash.clone())),
+            }
+        }
+        for rel in known.keys() {
+            if !on_disk.contains_key(rel) {
+                writes.push(Write::Remove(rel.clone()));
+            }
+        }
+
+        // **Nothing to write, so no lock is taken at all**, and this is the
+        // clause that removes the contention rather than waiting it out
+        // (TASK-4111dfae8a87). The steady state of a corpus being *read* is that
+        // every hash matches, which is exactly the case a poller lives in — a
+        // board refreshing every thirty seconds, twelve agents running `find`.
+        // Before this, all of them opened a write transaction to write nothing,
+        // so they serialised on a lock none of them needed, and whether they
+        // answered depended on a five-second wall being wide enough for the
+        // queue. Reading takes a read lock now, which SQLite lets any number of
+        // processes hold at once.
+        if writes.is_empty() {
+            return Ok(done);
+        }
+
         // **`IMMEDIATE`, and the busy timeout does not work without it**
         // (TASK-e9dfaf187a1b). A deferred transaction takes a read lock at the
         // first statement and asks to upgrade at the first write; SQLite
@@ -403,31 +516,21 @@ impl Index {
             .conn
             .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
             .map_err(|e| db_error(e, &self.ank))?;
-        for (rel, file) in &on_disk {
-            if known.get(rel) == Some(&file.hash) {
-                done.unchanged += 1;
-                continue;
-            }
-            match parse_entity(&file.text) {
-                Ok(entity) if entity.id() == &file.id => {
-                    upsert(&tx, rel, &file.hash, &entity).map_err(|e| db_error(e, &self.ank))?;
+        for write in &writes {
+            match write {
+                Write::Index(rel, hash, entity) => {
+                    upsert(&tx, rel, hash, entity).map_err(|e| db_error(e, &self.ank))?;
                     done.indexed += 1;
                 }
-                // Parsed but under another id than its file name carries, or
-                // did not parse at all. The hash is still recorded, so the
-                // failure costs one parse and not one per command; `check`
-                // reports it, the index only declines to hold it.
-                _ => {
+                Write::Unreadable(rel, hash) => {
                     forget(&tx, rel).map_err(|e| db_error(e, &self.ank))?;
-                    remember(&tx, rel, &file.hash).map_err(|e| db_error(e, &self.ank))?;
+                    remember(&tx, rel, hash).map_err(|e| db_error(e, &self.ank))?;
                     done.unreadable += 1;
                 }
-            }
-        }
-        for rel in known.keys() {
-            if !on_disk.contains_key(rel) {
-                forget(&tx, rel).map_err(|e| db_error(e, &self.ank))?;
-                done.removed += 1;
+                Write::Remove(rel) => {
+                    forget(&tx, rel).map_err(|e| db_error(e, &self.ank))?;
+                    done.removed += 1;
+                }
             }
         }
         tx.commit().map_err(|e| db_error(e, &self.ank))?;

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -2929,6 +2929,75 @@ fn concurrent_readers_of_one_corpus_all_answer() {
     );
 }
 
+/// The same twelve readers, with **no wait allowed at all**
+/// (TASK-4111dfae8a87).
+///
+/// The test above proves the invariant on whatever machine happens to run it,
+/// and that is its weakness: it passes when the hardware was fast enough for the
+/// readers never to have met. Measured on CI, run 32061737531 on
+/// `windows-latest`, it failed with twelve refusals out of twelve on a commit
+/// that changed no code -- so the invariant was resting on a five-second wall
+/// being wider than the queue, which is a margin and not a guarantee.
+///
+/// Setting the wall to zero is what an arbitrarily loaded runner is, and it is
+/// deterministic. With it, any contention at all refuses immediately, so this
+/// passes only if the readers take no write lock -- which is the property the
+/// fix installed: a healthy schema is confirmed by a read, and a refresh with
+/// nothing to write opens no transaction. Measured on this tree: four of sixty
+/// refused before, none of a hundred and twenty after.
+///
+/// The index is warmed first, on purpose. A cold corpus has real work to
+/// serialise and one process must wait for it; what must never contend is the
+/// steady state, which is the state a board polling every thirty seconds and a
+/// dozen agents running `find` are in.
+#[test]
+fn readers_of_a_warm_corpus_take_no_write_lock() {
+    let r = Repo::new();
+    for i in 0..12 {
+        r.seed_task_titled(&format!("TASK-00000000{i:04x}"), &format!("Task {i}"));
+    }
+    // One reader with a normal wall, to build the index and leave it current.
+    let warm = r.ank("warm@host", &["find", "Task"]);
+    assert_eq!(code(&warm), 0, "warming: {}", stderr(&warm));
+
+    let verbs: [&[&str]; 3] = [&["find", "Task"], &["context"], &["scope", "src"]];
+    let mut running = Vec::new();
+    for i in 0..12 {
+        running.push(
+            ank_command()
+                .args(verbs[i % verbs.len()])
+                .arg("--repo")
+                .arg(&r.0)
+                .env("ANK_AGENT", format!("agent-{i}@host"))
+                .env("ANK_INDEX_BUSY_MS", "0")
+                .current_dir(std::env::temp_dir())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()
+                .expect("the binary must have been built"),
+        );
+    }
+
+    let mut refused = Vec::new();
+    for (i, child) in running.into_iter().enumerate() {
+        let out = child.wait_with_output().expect("a spawned ank must finish");
+        if !out.status.success() {
+            refused.push(format!(
+                "#{i} exited {:?}: {}",
+                code(&out),
+                stderr(&out).trim()
+            ));
+        }
+    }
+    assert!(
+        refused.is_empty(),
+        "a reader of a warm corpus asked for the write lock. Nothing diverged and          the schema was already installed, so there was nothing to write and no          lock to take; whatever asked for one is what makes this invariant rest          on a deadline again:
+{}",
+        refused.join("
+")
+    );
+}
+
 /// A perimeter holding one proposal, with a budget as the only variable.
 fn proposed_fixture(budget: &str, with_proposal: bool) -> Repo {
     let r = Repo::new();


### PR DESCRIPTION
TASK-4111dfae8a87. Two write locks were being taken to write nothing, and the second was the one that mattered.

## What was wrong

`refresh()` opened its `IMMEDIATE` transaction **before** deciding whether anything had diverged, and parsed every changed entity inside it — so the lock covered the slowest work in the function, and was taken by every reader for the benefit of the ones that had something to write.

`ensure_schema()` opened one on **every open**, before discovering the schema was already installed.

A reader of a healthy, warm corpus therefore took the write lock twice for zero writes, and whether it answered depended on a five-second wall being wider than the queue of readers ahead of it. That is a margin, not a guarantee — and CI collected the bill on run `32061737531`: twelve refusals out of twelve, on a commit that changed no code.

## What replaces the wall

Not a larger constant — `BUSY_TIMEOUT` is untouched at five seconds. The decision now comes before the lock:

- a healthy schema is confirmed by a **read**, and the write transaction is opened only when something must be installed (re-checked inside it, so the install stays atomic against another installer);
- a refresh with nothing to write returns **without opening a transaction**;
- the parse happens outside the transaction that does get opened.

## Measured, twelve readers, no wait allowed at all

`ANK_INDEX_BUSY_MS=0` — any contention refuses immediately.

| | refused |
|---|---|
| schema check inside its transaction | 4 of 60 |
| schema confirmed by a read first | **0 of 120** |

## Falsified rather than assumed

Putting `false &&` back in front of that read makes the new test fail with the exact symptom CI reported:

    #10 exited 1: error[1]: index: another process is writing the index (database is locked)

A test that cannot fail proves nothing. This one was made to fail before it was trusted.

`ANK_INDEX_BUSY_MS` is a knob for that test and not for tuning, and the comment beside it says so. The old test ran twelve readers and hoped the machine was slow enough for them to have met — a test that passes because the hardware was fast is a test that reports the hardware. A zero wall is what an arbitrarily loaded runner is, and it is deterministic.

## What still rests on the wall, said rather than hidden

A **cold** corpus has real work to serialise — one process installs the schema and builds every row — and the others wait for it. That wait is bounded by the winner's bounded work rather than by a queue of readers with nothing to do; a SQLite file lock dies with the process holding it, so it cannot outlive a crashed writer; and cold start happens once per corpus, where the contended steady state was every poll, forever.

Cold at a zero wall passed 60 of 60 here too. That is **not** claimed as structural: twelve shell spawns are staggered enough by fork overhead that they may simply not have collided.

## Why this one before the protocol surface

A server answering clients while an agent writes is the archetypal concurrent reader. Shipping ADR-372b82af1ec7's passthrough on top of an index that refused its readers under contention would have surfaced this at the worst moment and on the client's side. It is also the case a board polling `find` lives in, which is the reader `docs/integrating.md` was just written for.

## Verification

    cargo test          574 pass, 0 fail  (integration 217 -> 218)
    cargo fmt --check   clean
    ank check           exit 0, 0 faults

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F1RRkJoQsHeGL1oRq7G7AX
