### PR TITLE
The fixture-coverage task is handed back with its design measured

### DIFF
--- a/.ank/entities/LOG-031c5f8890f3.md
+++ b/.ank/entities/LOG-031c5f8890f3.md
@@ -1,0 +1,15 @@
+---
+id: LOG-031c5f8890f3
+type: log
+title: measured before starting, and it is larger than the criterion's one line suggests -- the design, so
+created: 2026-08-17T21:19:43Z
+author: claude-code/2.1.233+exposition
+scope:
+  - crates/ank-cli/tests/**
+about: TASK-e89613d66284
+seq: 0
+schema: 3
+version: 1
+---
+
+ the next holder does not re-derive it. What each of the fourteen needs: a spec and an accepted ADR scoped src/** (seed_spec hardcodes docs/**, so both need new seeders); a blocking chain A->ID->B for show.blocked_by, show.unblocks and graph.edges (seed_task writes blocked_by: [] and needs a variant); a log entity about ID for show.log and log-read.entries; a claim on ID by AGENT to make status report a standing claim at all; a claim by another identity for status.elsewhere, which the CLI allows; a forged second claim ref under AGENT for status.also_held, because claim refuses a second live claim by one identity -- the field exists for two machines pushing under one identity, and set_expiry already shows how to rewrite a ref's blob; a forged YAML record state: proof, task, proofs[{proof:{type,reference},identity,attested}] on refs/ank/proof/ID for show.detached_proofs, the alternative being a real remote and attest --detached; and for check.findings[].charge a constraint of about 250 characters together with context_budget: 400, since the limit is half the budget -- tuning the budget rather than writing 4000 characters is what keeps the fixture readable. help.verbs[].refuses stays unreachable: the empty ones are the verbs that refuse on nothing, and no corpus can make context refuse. The cost the criterion chose and I did not notice when writing it: claiming ID puts context into execution mode, so all 26 fixtures change values, and those fixtures are the legible per-verb examples TASK-155e built them to be.

--- a/.ank/entities/LOG-6627bdfb115d.md
+++ b/.ank/entities/LOG-6627bdfb115d.md
@@ -1,0 +1,15 @@
+---
+id: LOG-6627bdfb115d
+type: log
+title: "released: handed back unstarted, with the design measured and logged rather than a half-built"
+created: 2026-08-17T21:19:59Z
+author: claude-code/2.1.233+exposition
+scope:
+  - crates/ank-cli/tests/**
+about: TASK-e89613d66284
+seq: 1
+schema: 3
+version: 1
+---
+
+ fixture left behind. The criterion is right and stays as it is; what I misjudged when writing it is the blast radius -- populating the arrays means claiming a task in the shared golden corpus, which puts context into execution mode and re-values all twenty-six fixtures, and those are the legible per-verb examples a client reads. That is careful work with a diff to read in full, and the tail of a long session is the wrong place for it.

--- a/.ank/entities/TASK-e89613d66284.md
+++ b/.ank/entities/TASK-e89613d66284.md
@@ -13,7 +13,7 @@ done_criteria: |
   The list asserted by every_golden_conforms_to_the_shape_its_verb_declares is empty: every array in the golden corpus carries at least one row, so no element shape is declared without a fixture that confronts it. The fixtures are seeded to produce those rows rather than the assertion being relaxed. cargo test is green and cargo fmt --check passes.
 criteria_by: creator
 schema: 3
-version: 1
+version: 3
 ---
 
 The conformance test of TASK-155e98c184ed checks each fixture against the shape


### PR DESCRIPTION
Corpus only — no fixture code. TASK-e89613d66284 was claimed, measured and released, and the measurement is the deliverable.

## Why released rather than done

The criterion is right and is untouched. What I misjudged when writing it this morning is the blast radius.

Populating those fourteen arrays means, among other things, **claiming a task inside the shared `golden_repo()`** — and a claimed task puts `context` into execution mode, so all twenty-six fixtures change values. Those fixtures are the legible per-verb examples TASK-155e98c184ed built them to be: a client reads them to learn what comes back. A cascading re-value of all of them is careful work with a diff that has to be read in full, and the tail of a long session is the wrong place for it.

## What the log now carries

So the next holder starts from measurement rather than the same rediscovery:

| shape | what it needs |
|---|---|
| `context.specs`, `scope.specs` | a spec scoped `src/**` — `seed_spec` hardcodes `docs/**` |
| `show.blocked_by`, `show.unblocks`, `graph.edges` | a chain A→ID→B — `seed_task` writes `blocked_by: []` |
| `show.log`, `log-read.entries` | a log entity `about: ID` |
| `status.elsewhere` | a claim by another identity — the CLI allows it |
| `status.also_held` | **forged**: `claim` refuses a second live claim by one identity. The field exists for two machines pushing under one, and `set_expiry` already shows how to rewrite a ref's blob |
| `show.detached_proofs` | a hand-written `state: proof` record, or a real remote and `attest --detached` |
| `check.findings[].charge` | a ~250-character constraint **with** `context_budget: 400` — the limit is half the budget, and tuning the budget rather than writing four thousand characters is what keeps the fixture readable |
| `context.constraints`, `review.live` | an **accepted** ADR — `seed_adr` writes `proposed` |

`help.verbs[].refuses` stays unreachable, and the reason is structural: the empty ones are the verbs that refuse on nothing, and no corpus can make `context` refuse. The task body already sanctioned naming that one alone, with its reason, rather than relaxing the check.

## Verification

    ank check   exit 0, 0 faults

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F1RRkJoQsHeGL1oRq7G7AX
