### PR TITLE
A closed task's dead scope is a signal, and the viewer task is closed

### DIFF
--- a/.ank/entities/LOG-723beb92a367.md
+++ b/.ank/entities/LOG-723beb92a367.md
@@ -1,0 +1,14 @@
+---
+id: LOG-723beb92a367
+type: log
+title: done, proof commit:16e827b
+created: 2026-08-17T21:39:08Z
+author: claude-code/2.1.233+exposition
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/tests/**
+about: TASK-4c031f7b44ed
+seq: 0
+schema: 3
+version: 1
+---

--- a/.ank/entities/LOG-eeca08577d0e.md
+++ b/.ank/entities/LOG-eeca08577d0e.md
@@ -1,0 +1,15 @@
+---
+id: LOG-eeca08577d0e
+type: log
+title: "closed: the reader is not built here and will not be: it ships from its own repository, and this"
+created: 2026-08-17T21:36:29Z
+author: claude-code/2.1.233+exposition
+scope:
+  - viewer/**
+about: TASK-34d27790dba9
+seq: 1
+schema: 3
+version: 1
+---
+
+ one keeps the machine surface it would rest on. ADR-bcb18aecb7e1 still authorises an in-tree viewer and wants superseding on its own terms, which is a signature and not this closure. Closable at last because a closed task's dead perimeter is a record rather than a fault (TASK-4c031f7b44ed); viewer/** names no file on the default branch and never will.

--- a/.ank/entities/TASK-34d27790dba9.md
+++ b/.ank/entities/TASK-34d27790dba9.md
@@ -5,7 +5,7 @@ slug: a-single-page-opens-the-corpus-in-a-browser-and
 title: A single page opens the corpus in a browser and shows who holds what
 created: 2026-08-17T05:15:07Z
 author: claude-code/2.1.233+integration-contract
-status: open
+status: closed
 scope:
   - viewer/**
 blocked_by: [TASK-af4a6db95aab]
@@ -13,7 +13,7 @@ done_criteria: |
   viewer/ holds one self-contained HTML file, with no build step, no backend, no network request and no dependency fetched at view time. Opened in a Chromium browser and granted the repository root, it lists the corpus's entities with their kind, status and title, shows the blocked_by graph, and names the holder and expiry of every live claim, reading loose refs under refs/ank/ and packed-refs alike. It writes no file, no ref and no claim. It is verified by opening it against this repository and against a second one.
 criteria_by: creator
 schema: 3
-version: 2
+version: 3
 ---
 
 ADR-bcb18aecb7e1 accepted this shape and created no task for it, by design.

--- a/.ank/entities/TASK-4c031f7b44ed.md
+++ b/.ank/entities/TASK-4c031f7b44ed.md
@@ -5,7 +5,7 @@ slug: a-closed-task-s-dead-scope-is-a-signal-because-a
 title: A closed task's dead scope is a signal, because a closure claimed nothing
 created: 2026-08-17T21:29:22Z
 author: claude-code/2.1.233+exposition
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/src/human.rs
   - crates/ank-cli/tests/**
@@ -13,8 +13,13 @@ blocked_by: []
 done_criteria: |
   check reports a scope matching no file as a signal on a task whose status is closed, in wording that names the closure rather than reusing the open task's 'work not started'. It stays a fault on a done task and on an ADR. A test drives the binary over both: a closed task whose scope names a path no commit ever carried leaves check at exit 0, and the existing done-task fault still exits 8. cargo test is green and cargo fmt --check passes.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 16e827b
+    criteria: acb6310ec6fd
+    via: submitted
 schema: 3
-version: 2
+version: 3
 ---
 
 `human.rs` reads the status as `!(Open | InProgress)`, so a `closed` task is

--- a/.ank/entities/TASK-4c031f7b44ed.md
+++ b/.ank/entities/TASK-4c031f7b44ed.md
@@ -1,0 +1,51 @@
+---
+id: TASK-4c031f7b44ed
+type: task
+slug: a-closed-task-s-dead-scope-is-a-signal-because-a
+title: A closed task's dead scope is a signal, because a closure claimed nothing
+created: 2026-08-17T21:29:22Z
+author: claude-code/2.1.233+exposition
+status: in_progress
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/tests/**
+blocked_by: []
+done_criteria: |
+  check reports a scope matching no file as a signal on a task whose status is closed, in wording that names the closure rather than reusing the open task's 'work not started'. It stays a fault on a done task and on an ADR. A test drives the binary over both: a closed task whose scope names a path no commit ever carried leaves check at exit 0, and the existing done-task fault still exits 8. cargo test is green and cargo fmt --check passes.
+criteria_by: creator
+schema: 3
+version: 2
+---
+
+`human.rs` reads the status as `!(Open | InProgress)`, so a `closed` task is
+judged exactly as a `done` one. Three things in SPEC-cd0d say that is wrong, and
+none of them is a matter of taste.
+
+**The justification does not reach a closure.** The rule is written as a fault
+"for an ADR or a finished task, *which claimed to touch files that are not
+there*". A `done` task did claim that. A `closed` task claimed nothing -- it
+records that the work will not happen, so its scope naming no file is the truth
+and not a broken record.
+
+**The specification prescribes `close` as the remedy.** "Entities with a dead
+scope are grouped into a cleanup section with `close` suggested. An ageing corpus
+therefore produces an explicit closure queue rather than diffuse noise." The
+implementation turns that exact act into a finding, so following the advice is
+what breaks the corpus.
+
+**And it is a fault nobody can clear**, which the same document names as the thing
+to avoid: "a fault nobody can clear is a finding readers learn to skip".
+`amend` refuses a finished task, so once closed there is no repair. ADR-97beaf55e73a
+and ADR-3094538d831e only ever *lower* severity where git can name what killed
+the path, and a path no commit ever carried gets nothing from either.
+
+Measured on this corpus, 2026-08-17: TASK-34d27790dba9 carries `viewer/**`, no
+commit on the default branch ever carried that directory, and closing the task
+turns a signal that reads true -- work not started -- into a fault that reddens
+`ank check` for good. `ci.yml` runs `check`, so the closure the corpus wants is
+the closure the corpus punishes.
+
+The wording matters and is part of the criterion. An open task's signal says "work
+not started, or a typo", which is wrong for a closure: the work may well have been
+started elsewhere, and the scope is not a typo. What a reader needs to see is that
+the task is closed and the perimeter went with it.

--- a/crates/ank-cli/src/human.rs
+++ b/crates/ank-cli/src/human.rs
@@ -892,12 +892,32 @@ fn check_scope_alive(
     // states where work *will* happen, and a task scoping a file it is about to
     // create is the normal case — this repository's own release task scopes a
     // workflow it exists to write. Making that a fault would exit 8 in CI on
-    // every repository that plans anything. A task already done or closed is
-    // judged the other way: it claimed to touch files that are not there.
+    // every repository that plans anything.
+    //
+    // **A `done` task is judged the other way, and a `closed` one is not**
+    // (TASK-4c031f7b44ed). This read `!(Open | InProgress)` and so treated the
+    // two terminal states as one. The rule §4 states is a fault for "a finished
+    // task, *which claimed to touch files that are not there*", and that clause
+    // is the whole justification: a `done` task claimed it, and a `closed` task
+    // claimed nothing — it records that the work will not happen, so a perimeter
+    // matching no file is its truth rather than its defect.
+    //
+    // Judging them alike also punished the repair §4 prescribes. `review` groups
+    // dead scopes "into a cleanup section with `close` suggested", so following
+    // that advice converted a signal into a fault — and into one nobody can
+    // clear, since `amend` refuses a finished task, which is precisely what §4
+    // calls "a finding readers learn to skip". Measured on this corpus:
+    // TASK-34d27790dba9 scopes `viewer/**`, no commit on the default branch ever
+    // carried it, and closing the task reddened `ank check` for good.
+    let status = match entity {
+        Entity::Task(t) => Some(t.status),
+        _ => None,
+    };
     let ahead_of_the_code = matches!(
-        entity,
-        Entity::Task(t) if matches!(t.status, TaskStatus::Open | TaskStatus::InProgress)
+        status,
+        Some(TaskStatus::Open) | Some(TaskStatus::InProgress)
     );
+    let retired = matches!(status, Some(TaskStatus::Closed));
     for glob in globs {
         // A scope entry naming a declared peer is about files in another
         // repository (§7, ADR-a1de673043b4), so it matches nothing in this
@@ -963,6 +983,16 @@ fn check_scope_alive(
             Finding::signal(
                 entity.id(),
                 format!("scope '{glob}' matches no file yet: work not started, or a typo"),
+            )
+        } else if retired {
+            // Its own sentence, and not the open task's. "Work not started" is
+            // wrong for a closure twice over: the work may well have been started
+            // somewhere else, and the scope is not a typo. What a reader needs is
+            // that the task is closed and the perimeter went with it, which is a
+            // record and not a repair — so nothing here names a command.
+            Finding::signal(
+                entity.id(),
+                format!("scope '{glob}' matches no file, and the task is closed: nothing is owed"),
             )
         } else {
             let message = format!("dead scope '{glob}': no file matches it");

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -3107,6 +3107,77 @@ default_branch: main
     let _ = std::fs::remove_dir_all(&second);
 }
 
+/// A closure with a perimeter that names nothing is a record, not a defect
+/// (TASK-4c031f7b44ed).
+///
+/// Driven through the binary because the thing being judged is `check`'s exit
+/// code, which is what CI routes on. Both terminal states in one test, because
+/// the point is that they are *not* the same fact: a `done` task claimed to touch
+/// files, a `closed` one claimed nothing.
+///
+/// The perimeter names a directory no commit ever carried, so neither
+/// ADR-97beaf55e73a's rename walk nor ADR-3094538d831e's deletion clause has
+/// anything to lower a severity with. That is the case with no way out, and it is
+/// the one that used to redden a corpus for good: `amend` refuses a finished task,
+/// so the fault could never be cleared.
+#[test]
+fn a_closed_task_whose_scope_names_nothing_leaves_check_green() {
+    const GONE: &str = "TASK-00000000c105";
+    let r = Repo::new();
+    r.seed_task_scoped(GONE, "nowhere/**");
+    r.git(&["add", "-A"]);
+    r.git(&["commit", "-qm", "a task whose perimeter never existed"]);
+
+    // Open, it is work not started, and green. This is the state the corpus was
+    // stuck in: honest, and permanent, because closing it was punished.
+    let out = r.ank(AGENT, &["check"]);
+    assert_eq!(code(&out), 0, "open: {}{}", stdout(&out), stderr(&out));
+    assert!(
+        stdout(&out).contains("work not started"),
+        "open: {}",
+        stdout(&out)
+    );
+
+    let out = r.ank(AGENT, &["close", GONE, "--reason", "it ships elsewhere"]);
+    assert_eq!(code(&out), 0, "close: {}", stderr(&out));
+
+    let out = r.ank(AGENT, &["check"]);
+    let said = stdout(&out);
+    assert_eq!(
+        code(&out),
+        0,
+        "a closure with a dead perimeter must not redden a corpus: {said}{}",
+        stderr(&out)
+    );
+    assert!(
+        said.contains("the task is closed: nothing is owed"),
+        "the closure needs its own sentence, not the open task's: {said}"
+    );
+    assert!(
+        !said.contains("work not started"),
+        "a closed task did not fail to start: {said}"
+    );
+
+    // `done` is the other terminal state and keeps the fault, because it *did*
+    // claim to touch those files. Same corpus, same missing directory, so the
+    // only variable is the status.
+    let text = r.task_text(GONE).replace("status: closed", "status: done");
+    std::fs::write(r.0.join(".ank/entities").join(format!("{GONE}.md")), text).unwrap();
+    let out = r.ank(AGENT, &["check"]);
+    assert_eq!(
+        code(&out),
+        8,
+        "a done task claimed to touch files that are not there: {}{}",
+        stdout(&out),
+        stderr(&out)
+    );
+    assert!(
+        stdout(&out).contains("dead scope"),
+        "done: {}",
+        stdout(&out)
+    );
+}
+
 /// A perimeter holding one proposal, with a budget as the only variable.
 fn proposed_fixture(budget: &str, with_proposal: bool) -> Repo {
     let r = Repo::new();


### PR DESCRIPTION
TASK-4c031f7b44ed, and the closure it exists to make possible.

## The defect

`human.rs` read the status as `!(Open | InProgress)`, so a `closed` task was judged exactly as a `done` one. Three things in §4 say that is wrong, and none is a matter of taste.

**The justification does not reach a closure.** The rule is a fault "for an ADR or a finished task, *which claimed to touch files that are not there*" — and that clause is the whole of it. A `done` task claimed that. A `closed` task claimed nothing: it records that the work will not happen, so a perimeter matching no file is its truth rather than its defect.

**It punished the repair §4 prescribes.** `review` groups dead scopes "into a cleanup section with `close` suggested", so following that advice converted a signal into a fault.

**And into one nobody could clear**, since `amend` refuses a finished task — which §4 itself names as the thing to avoid: *"a fault nobody can clear is a finding readers learn to skip"*.

## The closure gets its own sentence

Not the open task's. "Work not started" is wrong for a closure twice over: the work may well have been started somewhere else, and the scope is not a typo.

    signal: scope 'viewer/**' matches no file, and the task is closed: nothing is owed

Nothing names a command, because there is nothing to repair.

## Falsified before it was trusted

With `retired` forced to `false`, the new test fails on exactly the wall this repository hit this morning:

    error: dead scope 'nowhere/**': no file matches it

Both terminal states are asserted in one test, driven through the binary, because the point is that they are **not** the same fact — same corpus, same missing directory, status the only variable.

## And the viewer task is closed

TASK-34d27790dba9. The reader is not built here and will not be: it ships from its own repository, and this one keeps the machine surface it would rest on.

It was **unclosable** until now — `viewer/**` names no file on the default branch and never will, so neither ADR-97beaf55e73a's rename walk nor ADR-3094538d831e's deletion clause had anything to lower a severity with. It had been parked behind a `blocked_by` twice today, and a parking space is not a decision.

**One thing left on it, and it is yours:** ADR-bcb18aecb7e1 is accepted and still authorises an in-tree viewer under `viewer/`. That wants superseding on its own terms — a signature, not this closure.

## Verification

    cargo test          576 pass, 0 fail  (integration 219 -> 220)
    cargo fmt --check   clean
    ank check           exit 0, 0 faults

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F1RRkJoQsHeGL1oRq7G7AX
