### PR TITLE
No em dash in the prose a human reads

### DIFF
--- a/.ank/entities/LOG-71c70c9d713f.md
+++ b/.ank/entities/LOG-71c70c9d713f.md
@@ -1,0 +1,19 @@
+---
+id: LOG-71c70c9d713f
+type: log
+title: "discrepancy: the criterion says grep finds no em dash in any docs/*.md, and four survive. Two in"
+created: 2026-08-17T22:51:34Z
+author: claude-code/2.1.233+docs
+scope:
+  - README.md
+  - docs/**
+  - CONTRIBUTING.md
+  - SECURITY.md
+  - npm/**
+about: TASK-a070ea7c72f2
+seq: 1
+schema: 3
+version: 1
+---
+
+ docs/format.md, lines 344 and 431, are examples of the log line grammar, which the same document defines two paragraphs above as 'a dash and a space, the timestamp, a space, the identity, a space, an em dash, a space, the message' -- rewriting them would document a grammar ank-core does not accept, and there is an invalid golden fixture for a log line the grammar refuses. Two in docs/getting-started.md, lines 377 and 389, are pasted output of ank check, whose summary line the binary prints as 'check: ok - N tasks' with an em dash; that string lives in human.rs, outside this task's perimeter, and rewriting pasted output falsifies it. 166 became 4. Measured on the way: the binary prints an em dash at six sites, of which three render the log grammar and three are free prose, so the two in getting-started clear the day human.rs does.

--- a/.ank/entities/LOG-84ff576265cf.md
+++ b/.ank/entities/LOG-84ff576265cf.md
@@ -1,0 +1,17 @@
+---
+id: LOG-84ff576265cf
+type: log
+title: done, proof commit:a5bc931
+created: 2026-08-17T22:53:38Z
+author: claude-code/2.1.233+docs
+scope:
+  - README.md
+  - docs/**
+  - CONTRIBUTING.md
+  - SECURITY.md
+  - npm/**
+about: TASK-a070ea7c72f2
+seq: 2
+schema: 3
+version: 1
+---

--- a/.ank/entities/TASK-a070ea7c72f2.md
+++ b/.ank/entities/TASK-a070ea7c72f2.md
@@ -5,7 +5,7 @@ slug: no-em-dash-in-the-prose-a-human-reads
 title: No em dash in the prose a human reads
 created: 2026-08-17T22:14:29Z
 author: claude-code/2.1.233+docs
-status: in_progress
+status: done
 scope:
   - README.md
   - docs/**
@@ -16,8 +16,13 @@ blocked_by: [TASK-5982cf959b16, TASK-529f81e51669]
 done_criteria: |
   grep finds no em dash in README.md, in any docs/*.md, in CONTRIBUTING.md, in SECURITY.md, in npm/README.md or in npm/ank/README.md. Each was rewritten in context rather than substituted: no bare hyphen stands where an em dash did unless the sentence reads correctly with one. skill/SKILL.md and .ank/ are untouched, proven by their counts being unchanged.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: a5bc931
+    criteria: 110f8c2ca1be
+    via: submitted
 schema: 3
-version: 3
+version: 4
 ---
 
 232 of them across the prose a person reads.

--- a/.ank/entities/TASK-a070ea7c72f2.md
+++ b/.ank/entities/TASK-a070ea7c72f2.md
@@ -5,7 +5,7 @@ slug: no-em-dash-in-the-prose-a-human-reads
 title: No em dash in the prose a human reads
 created: 2026-08-17T22:14:29Z
 author: claude-code/2.1.233+docs
-status: open
+status: in_progress
 scope:
   - README.md
   - docs/**
@@ -17,7 +17,7 @@ done_criteria: |
   grep finds no em dash in README.md, in any docs/*.md, in CONTRIBUTING.md, in SECURITY.md, in npm/README.md or in npm/ank/README.md. Each was rewritten in context rather than substituted: no bare hyphen stands where an em dash did unless the sentence reads correctly with one. skill/SKILL.md and .ank/ are untouched, proven by their counts being unchanged.
 criteria_by: creator
 schema: 3
-version: 2
+version: 3
 ---
 
 232 of them across the prose a person reads.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ The third is the same line as the `check-repo` verifier in `.ank/config.yml`, on
 purpose: a CI that validated `.ank/` differently from `ank done` would let a
 corpus pass one and fail the other. Exit 8 means findings, and findings are a
 failure. Two further jobs build the workspace on the declared MSRV and prove
-that the minor below it fails — see the MSRV section.
+that the minor below it fails. See the MSRV section.
 
 Run all three locally before opening a pull request. They are the same commands
 in both places.
@@ -53,7 +53,7 @@ so with `ank release --reason "<why>"`.
 **Never edit `status:` by hand.** `ank done` runs the declared verifiers and
 writes the proof of what actually ran, hashed. Setting the field yourself
 produces a task that claims to be finished with nothing behind the claim, and an
-agent — or a human — that grades its own work can simply be wrong.
+agent, or a human, that grades its own work can simply be wrong.
 
 **`.ank/` is reached through the CLI, not by opening the files**
 (ADR-01b6dd05f0db). `ank show <id>` gives an entity whole, `ank find` lists,
@@ -69,14 +69,14 @@ visible to anyone else.
 **A contributor without push access to `refs/ank/*` runs at level 0.** The claim
 is real and it is entirely local: nobody upstream can see it, and nobody
 upstream is prevented from claiming the same task. That is the design working as
-specified, not a defect — level 0 is the default mode and needs no
+specified, not a defect: level 0 is the default mode and needs no
 configuration.
 
 The consequence is procedural. From a fork, coordination happens **in the issue
 or in the pull request**: say which task you are taking before you start, and
 say it where a maintainer can read it. `ank claim` still does its job in your
-clone — it freezes the criterion, which is the half that protects your work —
-but it announces nothing.
+clone, freezing the criterion, which is the half that protects your work.
+It announces nothing.
 
 ## Changing the format
 
@@ -84,17 +84,17 @@ The format is the specification, and `ank-core` is its reference
 implementation. Every format change happens in this order, and it is ratified
 (ADR-63b59c5c26f7):
 
-1. **the specification** — the `spec` document that states the rule, which for a
+1. **the specification**: the `spec` document that states the rule, which for a
    format change is *The data model*, one of the ten `ank find --type spec`
    lists. No field exists in the code without existing there first.
-2. **the goldens** — `crates/ank-core/tests/golden/`. `valid/` must round-trip
+2. **the goldens**: `crates/ank-core/tests/golden/`. `valid/` must round-trip
    byte for byte once normalised, `invalid/` must be rejected with the expected
    error.
 3. **the code**.
 
 The round-trip is byte-identical on canonical form; valid but non-canonical
 input is read correctly and normalised on first rewrite. CRLF is read, never
-written — one golden is in CRLF on purpose and must come back in LF.
+written, and one golden is in CRLF on purpose and must come back in LF.
 
 ## The MSRV is measured, never chosen
 
@@ -111,7 +111,7 @@ upward against the tree, and re-measuring means re-running that walk:
 cargo +<toolchain> build --workspace --locked --ignore-rust-version
 ```
 
-An unexpectedly successful build names a number to lower — it does not lower it.
+An unexpectedly successful build names a number to lower. It does not lower it.
 If a job goes red here, read the diagnostic and open an issue or a task; the
 walk is what decides, and a human runs the walk.
 
@@ -120,7 +120,7 @@ walk is what decides, and a human runs the walk.
 English is the only language of the project (ADR-d3a8dcf38817): prose,
 identifiers, comments, CLI output, error messages, entity titles, bodies, slugs
 and log entries. Non-English text is a finding, not a matter of taste. The one
-exception is a string whose meaning is its literal value — an external proof
+exception is a string whose meaning is its literal value: an external proof
 reference, a quoted third-party message, a fixture asserting a byte sequence.
 
 ## Style
@@ -141,7 +141,7 @@ reference, a quoted third-party message, a fixture asserting a byte sequence.
 
 A suspected vulnerability goes to [private advisory
 reporting](https://github.com/haksolot/ank/security/advisories/new), never to a
-public issue — [SECURITY.md](SECURITY.md) says what is in scope and what section
+public issue. [SECURITY.md](SECURITY.md) says what is in scope and what section
 1 already answers.
 
 Anything else is an issue. The forms ask for what the tool already produces: the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,8 @@ Three consequences are worth naming out loud, because each one looks like a
 hole to anyone who assumed otherwise.
 
 **The roles in `.ank/config.yml` are advisory.** They declare intent where a
-reader can see it, and an unknown identity — including `$ANK_AGENT` being
-absent — falls back to the least-privileged role. What they never do is make
+reader can see it, and an unknown identity, including `$ANK_AGENT` being
+absent, falls back to the least-privileged role. What they never do is make
 the CLI refuse. A refusal derived from `$ANK_AGENT` would be a refusal the
 caller lifts by exporting a different string, and shipping that as a guarantee
 is worse than shipping no guarantee at all. Declaring yourself `human` in the
@@ -22,8 +22,8 @@ config confers no authority; the signature is what carries it.
 **The CLI is a reference implementation, not a gatekeeper.** The format is the
 specification, so any tool can read and write `.ank/`. Immutability is
 therefore *verifiable, not defended*: every freeze is anchored by a hash in an
-artifact the file's editor does not control — the claim record, the
-ratification commit, the proof entry — and `ank check` is what compares. A
+artifact the file's editor does not control (the claim record, the
+ratification commit, the proof entry) and `ank check` is what compares. A
 direct edit is not prevented. It is noticed.
 
 **Enforcement, where it is real, lives outside ank.** A harness `PreToolUse`
@@ -46,7 +46,7 @@ An agent running on a developer machine whose git signing is configured and
 unlocked can produce a valid signed commit. The defence against that case is
 operational rather than cryptographic: keep the ratification key behind a
 passphrase or hardware touch-to-sign, distinct from the everyday commit key if
-needed. That limitation is consistent with section 1 — drift, not an adversary.
+needed. That limitation is consistent with section 1: drift, not an adversary.
 
 **With no signing configured at all, the hard line is gone and nothing replaces
 it.** Roles were already advisory, and the ratification anchor becomes a hash
@@ -54,7 +54,7 @@ in a commit message anyone can write. `ank check` displays that rather than
 hiding it, and it distinguishes a fault from a signal: a signature present with
 no local public key is reported as *not verified, and not refused*, because a
 clone without the key is a correct repository on an incomplete machine. The
-rule underneath is the one to remember when reading any ank output — **a
+rule underneath is the one to remember when reading any ank output: **a
 verification that degrades to success is not a verification**.
 
 ## 3. Verifiers run only what the repository accepted
@@ -70,7 +70,7 @@ code review like any other change.
 Editing `config.yml` to replace a verifier with `true` remains possible, and
 two mechanisms make it visible rather than impossible. The proof records a hash
 of the definition that actually ran, so a verifier weakened before or after the
-`done` — in the same commit or another — is detectable. And `check` reports the
+`done`, in the same commit or another, is detectable. And `check` reports the
 pattern directly: a verifier modified inside the task's activity window, or a
 proof hash diverging from the definition in force at the `done` commit.
 
@@ -86,7 +86,7 @@ ship in the next release rather than in a backport.
 | Version | Supported |
 |---|---|
 | 0.1.2 (latest) | yes |
-| earlier 0.1.x | no — upgrade |
+| earlier 0.1.x | no, upgrade |
 
 Ank requires **git 2.34 or newer** and checks at startup.
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,7 +1,7 @@
 # Handing ank to an agent
 
 The skill says *how* to use ank; it does not install the binary. Those are two
-separate acts, and this page covers both — the routes that reach an agent, and
+separate acts, and this page covers both: the routes that reach an agent, and
 the binary channels the two commands in the README do not cover.
 
 If you only want the short version, it is in the README: `npm install -g
@@ -12,7 +12,7 @@ Everything below is for the cases those two do not fit.
 
 One plain markdown file, [`../skill/SKILL.md`](../skill/SKILL.md). It is the only
 copy that exists in git, and every route below points at it rather than holding
-one of its own — so no route can fall behind it.
+one of its own, so no route can fall behind it.
 
 It teaches one page: why ank is shaped as it is, then the loop
 `context -> claim -> show -> log -> done`, the three off-loop verbs `new`,
@@ -24,19 +24,19 @@ content is deliberately small and growing it costs an ADR.
 below is `~58 tok` always-on, and that is the skill's `name` and `description`;
 the body is read when the skill is invoked. The ceiling on the body is kept
 anyway, because the by-hand route at the end of this page copies the whole file
-into whatever a harness loads, and some harnesses load all of it every session —
+into whatever a harness loads, and some harnesses load all of it every session,
 so it bounds the worst route rather than the measured one.
 
 One convention it carries is worth knowing before you watch an agent follow it:
 **`.ank/` is opaque to an agent, the way `.git/` is.** Reading goes through
 `ank show`, `ank find` and `ank context`; writing goes through the verbs. The CLI
-knows what the files do not — the context budget, the frozen criterion, who holds
+knows what the files do not: the context budget, the frozen criterion, who holds
 which claim. A human with an editor keeps every power they had.
 
 ### The `skills` CLI
 
-Detects what you run — Claude Code, Codex, Cursor, OpenCode and some thirty more
-— and links each one to a single copy. Ask it what it found before you let it
+Detects what you run (Claude Code, Codex, Cursor, OpenCode and some thirty more)
+and links each one to a single copy. Ask it what it found before you let it
 install:
 
     $ npx skills add haksolot/ank --list
@@ -54,8 +54,8 @@ install:
 Drop `--list` to install it.
 
 This is the widest route and the least anchored one. It finds the skill through
-its own recursive scan rather than through a manifest — `skill/` is not one of
-the directories it looks in by name — so it works because the fallback works. If
+its own recursive scan rather than through a manifest, `skill/` not being one of
+the directories it looks in by name, so it works because the fallback works. If
 a future version of that CLI narrows its search, this is the route that breaks
 first, and the hand copy below is the answer.
 
@@ -98,7 +98,7 @@ routes below.
 
 The skill is one file with nothing generated in it. Where none of the routes
 above fits your harness, copy `skill/SKILL.md` into whatever that harness loads
-and you have lost nothing — the routes exist to save you a copy, not to add
+and you have lost nothing: the routes exist to save you a copy, not to add
 anything to it.
 
 ## The binary
@@ -109,9 +109,9 @@ repository rather than by a satellite somebody keeps in step
 (ADR-782a3556cf2d): the tap, the bucket and the apt index all live here, and
 each is derived from a published release rather than updated by hand.
 
-**A release binary.** Every release carries a static binary for three targets —
+**A release binary.** Every release carries a static binary for three targets,
 `x86_64-unknown-linux-musl`, `aarch64-apple-darwin` and `x86_64-pc-windows-msvc`
-— each with a `.sha256` beside it. Take the archive for your platform from the
+each with a `.sha256` beside it. Take the archive for your platform from the
 [releases page](https://github.com/haksolot/ank/releases/latest), check the hash,
 unpack it, and put `ank` on your `PATH`.
 
@@ -156,13 +156,13 @@ downloading a bare executable but lets the registry through:
     npx @haksolot/ank --version
     npm install -g @haksolot/ank
 
-The binary is inside the package — one package per platform, installed through
+The binary is inside the package: one package per platform, installed through
 `optionalDependencies`, and no `postinstall` fetches anything. A `postinstall`
 download would die behind the very firewall this channel exists to cross, and
 would do it after the install looked like it had worked.
 
-It covers `linux x64`, `darwin arm64` and `win32 x64`. On anything else — an
-Intel Mac, a linux arm64 box — the wrapper exits 9 and names `cargo install`,
+It covers `linux x64`, `darwin arm64` and `win32 x64`. On anything else, an
+Intel Mac or a linux arm64 box, the wrapper exits 9 and names `cargo install`,
 which is the honest answer rather than a silent failure.
 
 **From source:**
@@ -174,8 +174,8 @@ It is `--git` because nothing publishes to crates.io. That puts `ank` in
 
 **What is not a way to install ank yet**, named here so you do not go looking.
 `winget install Haksolot.Ank` does not work: the manifest is derived from the
-release and proved on every run of the pipeline — validated and installed from
-on a Windows runner — but it reaches `microsoft/winget-pkgs` only when a release
+release and proved on every run of the pipeline, validated and installed from
+on a Windows runner, but it reaches `microsoft/winget-pkgs` only when a release
 is next published, and the registry reviews it after that. Arch is not served at
 all.
 
@@ -194,7 +194,7 @@ in history, and nothing forces them to be the same one.
 
 ## One agent, one working tree, one identity
 
-The nominal case is a tree per agent — a clone or a `git worktree` — each on its
+The nominal case is a tree per agent, a clone or a `git worktree`, each on its
 own branch.
 
 `$ANK_AGENT` names the session, and falls back to `<user>@<hostname>`. That
@@ -208,7 +208,7 @@ should have been given.
 Several agents in one tree runs, and it is a degraded mode rather than the
 design. What arbitrates properly is a `git worktree` per agent, because every
 worktree of a repository shares `refs/ank/`, so the compare-and-swap settles
-them. Separate clones are arbitrated only when there is a remote — that is what
+them. Separate clones are arbitrated only when there is a remote, which is what
 the push carries.
 
 Identity here is declared, not proved. `$ANK_AGENT` is set by the caller, so it
@@ -232,7 +232,7 @@ prints the DAG when you want the shape rather than the next move.
 
 **One branch per task.** Each agent claims its task, works in its own tree on
 its own branch, and finishes there. `ank done` proves the task in the working
-tree it ran in — the verifiers ran against those files and the proof records
+tree it ran in: the verifiers ran against those files and the proof records
 their hash. It does not prove the change merges, or that the combined system
 works. That gap is held by the refs, not by convention: `done` turns the claim
 ref into a completion record naming the commit and the branch, every other tree
@@ -243,7 +243,7 @@ branch says the task is done.
 **Integration is a task.** When several tasks form one change, the whole is
 verified the way the parts were: an ordinary task, `blocked_by` each part, with
 its own criterion and its own verifiers. This is the spec's model rather than a
-workaround — `blocked_by` is a DAG with no rollup precisely because a parent
+workaround: `blocked_by` is a DAG with no rollup precisely because a parent
 that completes when its children do is completion without proof, and the seam
 between the parts is exactly where integration regressions live. The
 integration task becomes ready when the last part finishes; whoever claims it
@@ -267,9 +267,9 @@ nowhere else.
 
 ## Where to go next
 
-- [getting-started.md](getting-started.md) — install to a first finished task,
+- [getting-started.md](getting-started.md): install to a first finished task,
   with real output, including the refusals a fresh repository will give you.
-- [format.md](format.md) — the file format, for anyone writing a tool that reads
+- [format.md](format.md): the file format, for anyone writing a tool that reads
   or writes `.ank/`.
 - The specification, the source of truth for everything above, which lives as
   ten `spec` documents in `.ank/`: `ank find --type spec` lists them and

--- a/docs/alternatives.md
+++ b/docs/alternatives.md
@@ -7,7 +7,7 @@ what each comparison costs it.
 
 RAG answers *what looks relevant to this query*; `ank context src/auth/` answers
 *what applies to this path*. The first ranks by similarity, the second is a
-set-membership test — and for a constraint that is the whole point, because a rule
+set-membership test, and for a constraint that is the whole point, because a rule
 that should have bound but ranked seventh did not bind, and nothing says so. No
 embeddings, no index service, no re-indexing per commit.
 
@@ -17,13 +17,13 @@ that was never found.
 
 ## Against an LLM-maintained wiki
 
-Karpathy's [pattern][wiki] is three layers — raw sources, a wiki the model owns, a
-schema file — and three operations: ingest, query, lint. Ank has that shape and
+Karpathy's [pattern][wiki] is three layers (raw sources, a wiki the model owns, a
+schema file) and three operations: ingest, query, lint. Ank has that shape and
 differs on what the middle layer *is*.
 
 A wiki page is derived from sources and can be regenerated if lost; an ADR records
 a choice that has none. Somebody decided opaque sessions over JWTs, and the record
-is the only copy — nothing can re-ingest its way back to it. Hence hash-anchored
+is the only copy, and nothing can re-ingest its way back to it. Hence hash-anchored
 and signed at ratification rather than rewritten, and a lint that is mechanical
 rather than a model re-reading for contradictions.
 
@@ -33,7 +33,7 @@ Google's [Open Knowledge Format][okf] is the closest relative, reached
 independently: markdown with YAML frontmatter, no server, no SDK, identity carried
 by the path, the format as the contract so producer and consumer stay swappable.
 Its v0.2 trust signals are the same instinct as ank's proofs, and ank has adopted
-two outright — the actor convention and `verified`.
+two outright: the actor convention and `verified`.
 
 One axis diverges, deliberately on both sides. OKF tells consumers never to reject
 a document for what it lacks; ank rejects an unknown field. OKF optimises for
@@ -44,7 +44,7 @@ accepted-but-malformed file is a rule that silently stopped applying.
 ## What it costs to run
 
 Two numbers rather than an adjective. The skill costs about 58 tokens in every
-session, which is its frontmatter — the `name` and `description` a harness keeps
+session, which is its frontmatter: the `name` and `description` a harness keeps
 loaded whether or not the skill is ever invoked, the body being read only when it
 is. And orientation is bounded at 8000 characters.
 

--- a/docs/format.md
+++ b/docs/format.md
@@ -1,18 +1,17 @@
 # The file format
 
-For anyone writing a tool that reads or writes `.ank/` — an editor plugin, an
+For anyone writing a tool that reads or writes `.ank/`: an editor plugin, an
 exporter, a linter, a second implementation.
 
 The format is the specification, and the CLI is a reference implementation of
 it rather than a gatekeeper. Nothing here needs `ank` to be installed or asks
 your tool to call it.
 
-**This document is not normative.** Section 3 of the specification is — *The
-data model*, one of the ten `spec` documents in `.ank/` that
-`ank find --type spec` lists — and where the two disagree the
-specification is right and this page is a bug. What you will find here instead
-is the mechanical half a writer has to reproduce exactly — the field order, the
-emission rules, the quoting predicate — which the specification states as
+**This document is not normative.** Section 3 of the specification is: *The data
+model*, one of the ten `spec` documents in `.ank/` that `ank find --type spec`
+lists. Where the two disagree the specification is right and this page is a bug. What you will find here instead
+is the mechanical half a writer has to reproduce exactly, the field order, the
+emission rules and the quoting predicate, which the specification states as
 properties rather than as a list, plus a pointer to the section that argues each
 one.
 
@@ -30,7 +29,7 @@ run against.
       entities/SPEC-<hex>.md
       entities/LOG-<hex>.md  one entry of the work trace, written once
       log/<ID>.md            the previous shape of the trace, read and never written
-      index.db               derived, disposable, belongs in .gitignore — never a source of truth
+      index.db               derived, disposable, belongs in .gitignore, never a source of truth
 
 Flat, deliberately: attachment happens through the `scope` field, not through
 location (§3). A file's name is its id; nothing resolves through the directory
@@ -43,7 +42,7 @@ path is computed from the id with no lookup: every entity is at
 `.ank/entities/<ID>.md`, whatever its kind, log entries included.
 
 **An entity's entries are a query, not a path.** They are the entities of kind
-`log` whose `about` names it — so finding them means reading the directory, or
+`log` whose `about` names it, so finding them means reading the directory, or
 your own index, where the previous shape let you compute one address. That is the
 one thing this layout gives up, and it is deliberate (§3).
 
@@ -57,7 +56,7 @@ flat directory are at `tasks/TASK-<hex>.md` and `adr/ADR-<hex>.md`, with the log
 inside the task body; corpora written between that revision and this one carry
 the trace as one file per entity under `.ank/log/`. A reader **must accept all of
 them**; a writer **must never produce them**. A corpus holding several layouts is
-one corpus, and nothing in it is counted twice — if an id resolves in both, decide
+one corpus, and nothing in it is counted twice: if an id resolves in both, decide
 and document which wins rather than silently preferring one, and an entity's
 entries are the union of the two sources. `ank check` reports a corpus still in a
 previous shape as a signal, not a fault, naming the command that moves it: such a
@@ -69,7 +68,7 @@ but the flat layout.
 
 **Identifiers** are `TASK-`, `ADR-`, `SPEC-` or `LOG-` followed by exactly 12
 hexadecimal characters, lowercase on output and accepted in either case on
-input. They hash the act of creation — timestamp, identity, title, entropy —
+input. They hash the act of creation (timestamp, identity, title, entropy)
 never the content, so they survive every edit (§3). A tool that resolves short
 prefixes must require at least 4 hex characters and must fail on an ambiguous
 one, listing the candidates. Guessing is the one behaviour the format rules out
@@ -103,7 +102,7 @@ alphabetical and not negotiable; it is this.
 A kind is declared **once**, as a row of a registry: the name written in `type`,
 the id prefix, the status values, which fields are required and which optional,
 and the canonical order (§3). The two tables below are that registry written out.
-Reproduce them as data — a table your serializer walks — rather than as one
+Reproduce them as data, a table your serializer walks, rather than as one
 emitter per kind; the order is the single thing most easily lost by rewriting two
 straight-line emitters as a generic loop, and it is what the round-trip rests on.
 
@@ -136,11 +135,11 @@ refusals answer different questions: `priorty:` in a `task` is a typo, and
 A `proof` entry emits its own keys in order: `type`, `ref`, then `tree`,
 `criteria`, `verifier` and `via`, each omitted when absent. `type` is one of
 `test`, `commit`, `human-review`, `assertion`. `via` is one of `verifier`,
-`attested`, `submitted` — the route by which the entry arrived — and its absence
+`attested`, `submitted`, the route by which the entry arrived, and its absence
 means the entry was written before the field existed, never a fourth route.
 
 A `verified` entry emits `by`, then `at`. Both are required in an entry that
-exists at all — an entry missing either is rejected — while the list itself is
+exists at all, an entry missing either being rejected, while the list itself is
 optional on every kind.
 
 ### ADR
@@ -194,7 +193,7 @@ has no field carrying its authority, so `ratified` is taken over the body and
 `references` names the documents and decisions this one rests on, in the position
 `blocked_by` takes on a task: immediately after the perimeter, before the
 succession. It is a flow list of entity ids and it is **omitted when empty**, not
-written `[]` — a task always states whether it has blockers, and a document that
+written `[]`: a task always states whether it has blockers, and a document that
 cites nothing has nothing to state. A reader resolves each entry against the
 corpus; what a checker then reports of it is §4's business and not the format's,
 and an entry naming a kind other than `spec` or `adr` is a finding there rather
@@ -220,7 +219,7 @@ than a parse error here (§3).
 **No `status`, and that is not an omission**: an entry is written once and has
 nothing to transition to, so the registry declares the kind without one and your
 parser must not require it. `version` stays, and on this kind it is a detector
-rather than a counter — an entry above 1 has been rewritten, which the format
+rather than a counter: an entry above 1 has been rewritten, which the format
 says should not happen.
 
 **Optional fields are omitted, never emitted empty.** An entity with no author
@@ -230,7 +229,7 @@ forbids that.
 
 ### Actors
 
-Every field naming an actor — `author`, and the `by` of a `verified` entry — is
+Every field naming an actor, `author` and the `by` of a `verified` entry, is
 typed: `human:<id>` is a person, `<producer>/<version>` is an agent,
 `process:<id>` is an automated process (§3).
 
@@ -244,7 +243,7 @@ anything.
 
 ## Emission rules
 
-**Literal blocks** carry the multi-line fields — `done_criteria` and
+**Literal blocks** carry the multi-line fields, `done_criteria` and
 `constraint`. Two spaces of indent, and the chomping indicator records whether
 the value ends in a newline: `|` when it does, `|-` when it does not.
 
@@ -266,7 +265,7 @@ the value ends in a newline: `|` when it does, `|-` when it does not.
         at: 2026-07-27T09:40:00Z
 
 **Scalars are emitted bare when that is unambiguous and quoted otherwise**,
-conservatively — when in doubt, quote. The reference implementation emits a
+conservatively: when in doubt, quote. The reference implementation emits a
 scalar bare only when all of these hold: it is non-empty; it contains no
 newline, no `": "` and no `" #"`; it does not end in `:` or a space; it does not
 begin with any of
@@ -282,8 +281,8 @@ writer round-trip.
 
     serialize(parse(x)) == x, byte for byte, when x is in canonical form
 
-Valid but non-canonical input — another acceptable YAML form, superfluous
-quotes, CRLF — is read correctly and **normalised on first rewrite** (§3). That
+Valid but non-canonical input (another acceptable YAML form, superfluous
+quotes, CRLF) is read correctly and **normalised on first rewrite** (§3). That
 is what lets a human or a third-party tool write a file without knowing the
 canonical form, without making that form an authoritative variant.
 
@@ -307,7 +306,7 @@ finds every field it already knew.
 
 The log is what makes that bump necessary, and it is the case the field exists
 for. A reader that does not know the log has left the body opens a task file,
-finds no `## Log` section, and shows an empty history for a task that has one —
+finds no `## Log` section, and shows an empty history for a task that has one,
 silently, with nothing reading anywhere as an error. Refusing on the version says
 the one true thing before any of that happens.
 
@@ -326,9 +325,9 @@ the one true thing: this file is newer than this tool. The argument is in §3.
 rejected naming the kind, which is the same honest refusal by a different
 mechanism, so a tool that does not know `spec` or `log` stops on that entity and
 says which kind stopped it. The `spec` and `log` kinds are therefore readable at
-any version in the range, and the one case no bump could reach — a reader that
+any version in the range, and the one case no bump could reach, a reader that
 opens a task file alone and looks for its entries where an older shape kept them
-— is covered by continuing to read that shape for one window (§6).
+is covered by continuing to read that shape for one window (§6).
 
 ## The log
 
@@ -338,7 +337,7 @@ message in `title`, and what it is about in `about`, and it is written once and
 never modified. A correction is a new entry naming the one it corrects.
 
 The line grammar has not changed, and it is now how an entry is **printed**
-rather than how it is stored — a dash and a space, the timestamp, a space, the
+rather than how it is stored: a dash and a space, the timestamp, a space, the
 identity, a space, an em dash, a space, the message:
 
     - 2026-07-26T14:02Z claude-code/1.4.2 — jwt.verify removed from session.ts
@@ -349,8 +348,8 @@ nothing about it is reinterpreted: only where it lives has moved, twice.
 **A message longer than a line is split across `title` and the body, and the
 split is lossless.** One line of at most **100 characters** is the whole of the
 `title`, and the body is empty. Longer, the title runs to the last space at or
-before character 100 and at or after character 50 — the limit itself where there
-is no such space, and the first newline where one comes earlier — and the body is
+before character 100 and at or after character 50, the limit itself where there
+is no such space and the first newline where one comes earlier, and the body is
 a newline, the remainder verbatim, a newline.
 
 **The message is the exact concatenation of the two.** The separating space
@@ -377,7 +376,7 @@ wherever entities are listed. **So print the head of the message with a trailing
 `…` when there is more**, and let a reader ask for the entry itself to see the
 whole. Machine output carries the whole message: a parser reads no page.
 
-Any kind may be logged against — a task, an ADR, a spec — and **an entity with no
+Any kind may be logged against, whether a task, an ADR or a spec, and **an entity with no
 entries has an empty log, never an error**. Do not write one to record that there
 is nothing to record.
 
@@ -389,7 +388,7 @@ order or anything else outside it.
 resolution, and writing an entry costs a few hundred milliseconds, so several
 entries inside one second is the ordinary case: measured on four entries written
 about one task, 12 runs of 12 put all four in the same second, and 10 of those
-12 came back in the wrong order when the identifier was the only tiebreak — a
+12 came back in the wrong order when the identifier was the only tiebreak: a
 hash of the act of creation, which carries no order at all. An append-only file
 carried insertion order for free; a set of files does not.
 
@@ -397,7 +396,7 @@ carried insertion order for free; a set of files does not.
 see on the entries already about that subject, or 0 if there are none.** That
 requires reading them first, which is a bounded read and the same query you need
 to display them. Two writers who cannot see each other will produce the same
-value; that is correct rather than broken — they were concurrent, `created`
+value; that is correct rather than broken, since they were concurrent, `created`
 separates them when their instants differ, and the identifier settles the rest.
 Never treat equal `seq` as a conflict, and never rewrite an entry to renumber
 it.
@@ -405,7 +404,7 @@ it.
 **An entry read out of one of the previous layouts takes the 0-based index of
 its line in the file**, which is the order that file recorded. Since `created`
 is read first, a file whose lines contradict their own timestamps is reordered
-by the timestamps — measured on the reference corpus, one file of 178 stores its
+by the timestamps: measured on the reference corpus, one file of 178 stores its
 lines newest-first. The guarantee is therefore exact: across distinct instants
 the timestamps order the entries, and within one instant the line order does.
 
@@ -420,7 +419,7 @@ The rule that used to union log sections by timestamp is gone, and the reason
 once recorded for dropping it was wrong: git does not union two appends by
 itself, it conflicts on them, unless a repository configures `merge=union` for
 the path (§7). What has been protecting the corpus all along is one file per
-entity, and an entry that is an entity extends that to the trace — there is no
+entity, and an entry that is an entity extends that to the trace: there is no
 file for two parties to append to.
 
 **One convention lives in the message, and it is where a disproved criterion is
@@ -430,8 +429,8 @@ was measured instead (§3):
 
     - 2026-08-14T18:16Z claude-code/03fd — discrepancy: the criterion assumes tests/skill.rs passes untouched; two tests there read `ank help`
 
-It is a convention on the message and never on the grammar — `released: <reason>`
-is the same kind and older — so it costs no field, no schema bump and no
+It is a convention on the message and never on the grammar, `released: <reason>`
+being the same kind and older, so it costs no field, no schema bump and no
 migration, and every log a corpus already holds stays valid. It changes nothing
 mechanically: the criterion is untouched, its hash still anchors it, and `done`
 still verifies against that hash. A tool that reads the log should surface such
@@ -473,7 +472,7 @@ has two states and the record it points at says which: a `claim` (holder,
 expiry, the frozen criterion hash, the hash of applicable constraints) or a
 `completed` record (commit, branch, identity, timestamp) written by `done`. A
 task that is `in_progress` in the file with no ref behind it is simply one whose
-claim expired — legal, and re-claimable (§7).
+claim expired: legal, and re-claimable (§7).
 
 **The ratification anchor is a commit message.** `accept` writes `ratified:` into
 the entity *and* produces a commit whose subject is `ratify <id>` and whose body
@@ -484,8 +483,8 @@ entity's own path history with `--full-history` and takes the first such commit
 
 **The key names what was hashed**, and there are two because there are two kinds
 that carry an anchor: `constraint+scope: <hash>` on an ADR, `body+scope: <hash>`
-on a spec. A spec declares no `constraint` — that absence is what justifies the
-kind — so the authority is carried by the whole document, and a commit claiming
+on a spec. A spec declares no `constraint`, that absence being what justifies the
+kind, so the authority is carried by the whole document, and a commit claiming
 `constraint+scope` over one would name a field the file does not have. A reader
 accepts either key; a writer writes the one its kind carries.
 
@@ -500,7 +499,7 @@ from each line, trailing blank lines are removed.
 
 - **The criterion freeze**, recorded by `claim`: `hash(normalize(done_criteria))`.
 - **The ratification anchor**, recorded by `accept`: the normalised anchored
-  text, a newline, then each `scope` glob trimmed and followed by a newline —
+  text, a newline, then each `scope` glob trimmed and followed by a newline,
   hashed as one buffer. The anchored text is an ADR's `constraint` and a spec's
   body, which is the one place the two anchors differ and what the commit key
   above says.
@@ -512,7 +511,7 @@ any file; what it cannot do is make the recorded hash agree afterwards.
 
 `version` is an integer incremented on every write, and it is an intra-tree
 compare-and-swap: read, compare, write, under a file lock, with the write done
-atomically (write-then-rename). It protects one working tree — a human and an
+atomically (write-then-rename). It protects one working tree: a human and an
 agent sharing a checkout. Between clones, git's own compare-and-swap at push
 time is what arbitrates (§7).
 
@@ -521,7 +520,7 @@ time is what arbitrates (§7).
 `crates/ank-core/tests/golden/` is a reusable suite, and it is small enough to
 port in an afternoon:
 
-- `valid/` — every file must parse, and re-serialising it must reproduce the
+- `valid/`: every file must parse, and re-serialising it must reproduce the
   input byte for byte **once line endings are normalised**. One file,
   `TASK-c71f0e5a9b23.md`, is in CRLF on purpose and must come back in LF; that
   is the only file for which the assertion is against the normalised input
@@ -529,9 +528,9 @@ port in an afternoon:
   stay: a file written before a field existed must survive a rewrite unchanged,
   and if one of them moves, the version bump has silently become a migration.
   Every kind carries one: a log entry is an ordinary entity fixture like any
-  other, and a fixture in the previous shape — a whole log keyed by the id of
-  the entity it belongs to — stays for as long as that shape is read.
-- `invalid/` — every file must be **rejected with the right error**, not merely
+  other, and a fixture in the previous shape, a whole log keyed by the id of
+  the entity it belongs to, stays for as long as that shape is read.
+- `invalid/`: every file must be **rejected with the right error**, not merely
   rejected. Each case names a distinct failure: no frontmatter, a bad id, an
   unknown schema, an unknown kind, an unknown field inside a known kind, a bad
   status, a type mismatch, an empty scope, an invalid glob, `criteria_by`
@@ -554,4 +553,4 @@ writes still looks fine until something else reads it.
   body which sections it carries: §3 for the data model and
   canonical form, §6 for storage, §7 for the coordination plane, §8 for identity
   and ratification. `ank show <id>` prints one whole.
-- [getting-started.md](getting-started.md) — if you also want to use the tool.
+- [getting-started.md](getting-started.md): if you also want to use the tool.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -19,7 +19,7 @@ the tool refuses, the refusal is shown as it appears.
 ## Install
 
 Put `ank` on your `PATH`. [agents.md](agents.md) carries every route with its
-trade-offs — a release binary and its checksum, npm, or building from source —
+trade-offs (a release binary and its checksum, npm, or building from source)
 and the shortest of them is one line of npm. Whichever you took, check it
 answers:
 
@@ -40,7 +40,7 @@ Worth stating once, because it costs time exactly where nobody expects it: **a
 globally installed `ank` tracks the published release, not the tree you have
 checked out.** The two are the same file only on the day of a release.
 
-For most repositories that is the whole story — you are using Ank, not changing
+For most repositories that is the whole story: you are using Ank, not changing
 it, and the published binary is the one you want. It matters when you are
 working *on* a repository whose corpus is written by a binary newer than yours:
 somebody else's release, or your own tree if you are contributing to Ank
@@ -49,7 +49,7 @@ versions, and both print the same `ank 0.2.0`. Only the commit separates them,
 which is why `--version` carries it.
 
 Contributors hit the sharper form of this. Building from source puts a binary in
-`target/`, and running that one is what tests a change — but on Windows a
+`target/`, and running that one is what tests a change. But on Windows a
 running executable cannot be relinked, so a command that rebuilds the tree while
 `target/debug/ank` is the process running it fails on the lock. The habit that
 avoids it is to copy the built binary somewhere outside `target/` and run the
@@ -67,7 +67,7 @@ first:
       -> the binary is older than the corpus: ank --version names the build, npm install -g @haksolot/ank replaces it
       TASK-0000  [open] Ordinary task
 
-It warns and still answers — the entities this build does understand are worth
+It warns and still answers, because the entities this build does understand are worth
 having, and a corpus mid-migration is a real state rather than a broken one.
 The other half, an old binary reading an old corpus, is not detectable: nothing
 in the files says a newer format exists. That one is `--version` and the
@@ -85,7 +85,7 @@ From the root of a git repository:
     pointer added to AGENTS.md
     refspec added: +refs/ank/*:refs/ank/*
 
-Six effects, and re-running changes nothing — `init` is idempotent and says
+Six effects, and re-running changes nothing: `init` is idempotent and says
 `already initialised, nothing to do`. The `.gitattributes` line keeps `.ank/`
 in LF on checkout: on Windows git would otherwise convert back to CRLF
 everything the tool has just written, on every clone. The `.gitignore` line is
@@ -94,7 +94,7 @@ whenever it is missing, so committing it would only track a binary that every
 command rewrites. The refspec is what makes claims travel, since hosts do not
 fetch non-standard refs on their own.
 
-Both git files are appended to, never replaced — an existing `.gitignore`
+Both git files are appended to, never replaced, so an existing `.gitignore`
 keeps everything already in it.
 
 One edit to make now, before the first real command.
@@ -167,7 +167,7 @@ constraint ratified on a feature branch would bind on that branch alone.
 
 A task names verifiers; it never carries a shell command. The definitions live
 in `.ank/config.yml`, under the repository's own review, and they go in through
-the same verb — writing a `run` for a name the file does not carry is how a
+the same verb: writing a `run` for a name the file does not carry is how a
 verifier is declared:
 
     $ ank config verifiers.auth-tests.run "sh tests/auth.sh"
@@ -184,7 +184,7 @@ which is what the file then carries:
         run: "! grep -rq jwt.verify src/auth/"
 
 `ank config --unset verifiers.no-jwt` takes one back out. Reading a key says
-where the value comes from — this repository, or a default the tool resolved:
+where the value comes from, this repository or a default the tool resolved:
 
     $ ank config verifiers.auth-tests.run
     sh tests/auth.sh
@@ -240,14 +240,14 @@ ends with the next command, as every output here does.
 
 Three things happened. The task moved to `in_progress`. A claim ref appeared at
 `refs/ank/claims/TASK-820d259af6a7`, which is what arbitrates two people or two
-agents reaching for the same task — git's compare-and-swap, one winner. And the
+agents reaching for the same task: git's compare-and-swap, one winner. And the
 `done_criteria` was frozen: its hash went into the claim record, where the
 file's editor cannot reach it.
 
 The freeze is the rule worth internalising. Editing the criterion to make the
 work fit does not unblock anything; `done` compares against the recorded hash
 and refuses, and `check` reports the divergence. If the criterion is genuinely
-wrong, hand the task back — `ank release --reason "<why>"` — and say so.
+wrong, hand the task back with `ank release --reason "<why>"` and say so.
 
 `claim` also sets HEAD, so the following commands need no id. One claim at a
 time, per person and per agent.
@@ -263,7 +263,7 @@ Claiming a second task while you already hold one is refused:
 If you meant it, the first way out is the one to take: finish the task you hold
 or hand it back. If the refusal surprises you, it is almost certainly two
 terminals: `$ANK_AGENT` unset resolves to `<user>@<hostname>`, so two sessions
-on one machine are the same agent as far as the refs can tell — they would see
+on one machine are the same agent as far as the refs can tell, so they would see
 each other's claims and renew them. Give every concurrent session an identity
 of its own:
 
@@ -272,15 +272,15 @@ of its own:
 That is why the refusal names the identity rather than calling you its holder:
 under a shared identity, the session being refused may have claimed nothing at
 all. Identity is declared, never proved, and it is deliberately not bound to the
-session — a PID or a TTY in it would mean losing your claim to a restarted
+session: a PID or a TTY in it would mean losing your claim to a restarted
 terminal. Parallel agents, each with its own `ANK_AGENT`, are the supported
 case; one ref per task is what arbitrates them.
 
 An expired claim is not a live one, so this never stands between you and a task
-whose lease ran out — yours or anybody's.
+whose lease ran out, yours or anybody's.
 
-How parallel sessions assemble into one change — a branch per task, `done` as a
-local proof, integration as a task of its own — is in [agents.md](agents.md),
+How parallel sessions assemble into one change, with a branch per task, `done` as
+a local proof and integration as a task of its own, is in [agents.md](agents.md),
 under "Parallel work and integration".
 
 Run `ank context` again and the output inverts: no other task, the full
@@ -296,7 +296,7 @@ criterion, and the constraints matching this task's scope.
     CONSTRAINTS (1 active)
       ADR-06d2  Do not introduce self-contained JWTs for user auth. Every session goes through the Redis store.
 
-`ank show 820d` gives you the entity whole — frontmatter, body and log — which
+`ank show 820d` gives you the entity whole, frontmatter, body and log, which
 is where the reasoning behind a task lives.
 
 ## Work, and log what you learn
@@ -311,7 +311,7 @@ if it expires because a build ran long, the task stays `in_progress` and you
 re-acquire silently, provided nobody took it over.
 
 **Each entry is an entity of its own**, which is why the line names one. The
-task's own file is not touched at all — no frontmatter, no version bump — and two
+task's own file is not touched at all, no frontmatter and no version bump, and two
 agents writing at once write two files, so there is nothing for a merge to
 resolve. Any kind may be logged against, an ADR included, and writing about
 something that is not a task asks for no claim: there is none to hold.
@@ -333,7 +333,7 @@ This is the point of the tool. Ank ran the verifiers itself and wrote what
 actually ran: one proof entry each, carrying the hash of the verifier
 definition that executed, the HEAD commit, and a hash of the scope files'
 content at that moment. Nobody reported their own result. Never set
-`status: done` by hand — a status written by the party being measured measures
+`status: done` by hand: a status written by the party being measured measures
 nothing.
 
 A task with no `verify` takes the other branch, and `--proof` becomes
@@ -351,8 +351,8 @@ agent could have altered; `assertion:"..."` guarantees nothing and is marked
 weak, which is what keeps it from quietly becoming the default path.
 
 **The type is half the answer, and the entry records the other half.** Every
-proof carries `via` — `verifier` when Ank ran the verifier itself, `attested`
-when it arrived on `refs/ank/proof/<id>`, `submitted` when a caller typed it —
+proof carries `via`: `verifier` when Ank ran the verifier itself, `attested`
+when it arrived on `refs/ank/proof/<id>`, `submitted` when a caller typed it,
 because a run reference is the strongest thing in that list when a pipeline
 wrote it and the weakest when somebody typed it. Typing `--proof
 test:<run-id>` is still accepted and still recorded; what it does not do is
@@ -390,7 +390,7 @@ refused with the commit and the branch named. Commit, and the ref is pruned:
 
 `check` is what you put in CI. It validates parsing, byte-for-byte round-trip,
 `blocked_by` references, frozen fields against their anchors, and it prunes the
-coordination plane. **Exit 8 means findings; signals exit 0** — a signal is
+coordination plane. **Exit 8 means findings; signals exit 0**, because a signal is
 something a reader should see, not a failure.
 
 ## When a command refuses
@@ -401,13 +401,13 @@ anything, and the message always ends with the exact command to run next.
 | Code | Meaning |
 |---|---|
 | 2 | entity not found, or ambiguous prefix |
-| 3 | version conflict — re-read and retry |
-| 4 | task unavailable — held by someone else, or finished on another branch |
+| 3 | version conflict, re-read and retry |
+| 4 | task unavailable, held by someone else or finished on another branch |
 | 5 | proof missing or invalid |
 | 6 | illegal transition, or a frozen field diverged |
-| 7 | missing prerequisite — no criterion, task blocked, `accept` off the default branch |
+| 7 | missing prerequisite: no criterion, task blocked, `accept` off the default branch |
 | 8 | `check` found something |
-| 9 | environment — git too old, `sh` missing, default branch indeterminable |
+| 9 | environment: git too old, `sh` missing, default branch indeterminable |
 
 Code 9 is the one to read carefully: it says the environment is broken, not
 that your work is wrong. Fix the machine, not the code.
@@ -420,10 +420,10 @@ those and you can write the pipeline for a CI system nobody here has heard of.
 
 `ank check` is the verb a pipeline runs. It exits:
 
-- **0** — the corpus is healthy. Signals exit 0 too: they are observations, not
+- **0**, the corpus is healthy. Signals exit 0 too: they are observations, not
   faults, and reddening a build over one teaches a team to stop reading `check`.
-- **8** — findings. This is the failure a pipeline exists to catch.
-- **9** — the environment, not the corpus: git too old, `sh` missing, the default
+- **8**, findings. This is the failure a pipeline exists to catch.
+- **9**, the environment and not the corpus: git too old, `sh` missing, the default
   branch indeterminable. Nothing is wrong with the files, and a pipeline that
   collapses 9 into "the check failed" sends somebody to fix sound work.
 
@@ -483,7 +483,7 @@ needs it.
 **There is no `--format github`, and there never will be.** Annotations,
 folding markers and job summaries are one vendor's protocol, and putting them in
 the binary would couple the tool to a company. A pipeline that wants annotations
-pipes `--json` into whatever produces them — which is exactly the arrangement
+pipes `--json` into whatever produces them, which is exactly the arrangement
 that lets the fourth vendor work without anybody shipping a release for it.
 
 ### Anchoring a run
@@ -494,10 +494,10 @@ pipeline can anchor the same task to a run anybody can re-read:
     ank attest <id> --proof test:<run-id> --detached
 
 `--detached` writes the proof to `refs/ank/proof/<id>` and touches no file, so
-the pipeline produces **no commit** — it needs no write access to the branch and
+the pipeline produces **no commit**: it needs no write access to the branch and
 cannot race the merge.
 
-The proof is a ref, so it has to reach the remote to be worth anything — and
+The proof is a ref, so it has to reach the remote to be worth anything, and
 because the ref is the whole of what this verb produces, a push that did not
 land is a failure and not a warning: `attest --detached` exits **9** and names
 the push to run. Nothing special is needed to notice it, which is the point:
@@ -511,8 +511,8 @@ reads the code.
 
 ## Handing the loop to an agent
 
-Four routes install the same file — the `skills` CLI, the Claude Code plugin,
-`pi`, and copying one markdown file by hand — and they are walked with their real
+Four routes install the same file (the `skills` CLI, the Claude Code plugin,
+`pi`, and copying one markdown file by hand) and they are walked with their real
 output in [agents.md](agents.md), along with `$ANK_AGENT` and what changes when
 more than one agent works the same repository.
 
@@ -525,9 +525,9 @@ loaded on every session, which is why its content is deliberately small.
 
 ## Where to go next
 
-- [agents.md](agents.md) — the four routes that reach an agent, the binary
+- [agents.md](agents.md): the four routes that reach an agent, the binary
   channels beyond npm, and what running several agents actually requires.
-- [format.md](format.md) — the file format and canonical form, for anyone
+- [format.md](format.md): the file format and canonical form, for anyone
   writing a tool that reads or writes `.ank/`.
 - The specification, the source of truth for everything above: ten `spec`
   documents in `.ank/`, read with `ank find --type spec` and `ank show <id>`.

--- a/docs/integrating.md
+++ b/docs/integrating.md
@@ -6,7 +6,7 @@ seen this repository.
 [getting-started.md](getting-started.md) already covers the **pipeline** case,
 and covers it well: run `ank check`, route on the exit code, parse `--json`. If
 that is what you are building, read the "Running ank in a pipeline" section there
-and stop. This document is for what a pipeline does not need — a board, an
+and stop. This document is for what a pipeline does not need: a board, an
 editor plugin, a dashboard, an agent harness, anything that reads a corpus and
 shows it to somebody.
 
@@ -57,9 +57,9 @@ It leads every `--json` document, and it is the field to read before deciding yo
 can read the rest.
 
 Within one version a document may **gain** a field, and may never lose, rename or
-retype one. So parse leniently — an unknown field is not a breaking change and
-your parser must not refuse one — and treat a change of this number as the signal
-to look again.
+retype one. So parse leniently, because an unknown field is not a breaking change
+and your parser must not refuse one, and treat a change of this number as the
+signal to look again.
 
 It is not the version of the binary. `ank --version` says which build is in hand;
 this says which shapes came out of it, and a release that changes no document
@@ -75,7 +75,7 @@ are stable, and `ank help --json` publishes which verb returns which.
 | 0 | ok |
 | 1 | generic error |
 | 2 | entity not found, or an ambiguous prefix |
-| 3 | version conflict — re-read and retry |
+| 3 | version conflict, re-read and retry |
 | 4 | the task is unavailable: held by another agent, or finished on another branch |
 | 5 | a proof is missing or invalid |
 | 6 | the act is illegal from the state the entity is in, or a frozen field diverged |
@@ -87,7 +87,7 @@ Two of them are the ones a loop must handle. **3** means "somebody moved, read
 again". **4** means "take something else".
 
 **6 and 7 are two codes on purpose.** In 6 the state forbids what you asked; in 7
-the thing you asked for is legal and something it depends on is absent — `accept`
+the thing you asked for is legal and something it depends on is absent. `accept`
 off the default branch is a 7, because the promotion is legal and the place is
 not. A client that conflates them reacts wrongly to one of the two.
 
@@ -114,11 +114,11 @@ under-reports **silently**.
 The file is the entity. The *state* is the file together with three things that
 are not in it:
 
-- `refs/ank/claims/<id>` — who holds the task and until when. A claim lives in a
+- `refs/ank/claims/<id>`, who holds the task and until when. A claim lives in a
   git ref and never in the file, so two clones arbitrate through the remote
   rather than through a field somebody has to merge.
-- `refs/ank/proof/<id>` — proofs a pipeline attested without making a commit.
-- the **log entities** whose `about` names the task — one file per entry, stored
+- `refs/ank/proof/<id>`, proofs a pipeline attested without making a commit.
+- the **log entities** whose `about` names the task, one file per entry, stored
   beside the entities and not inside them:
 
       $ cat .ank/entities/LOG-bc49fad834f1.md
@@ -170,8 +170,8 @@ the file, byte for byte, so nothing is lost by going through the verb.
 a reader that walks `.ank/` is reading one of the three sources and will report a
 held task as free.
 
-If you do read the files — a viewer with no binary to call, a parser in another
-language — then read all three, and read the refs correctly: most of them are in
+If you do read the files, whether from a viewer with no binary to call or a parser
+in another language, then read all three, and read the refs correctly: most of them are in
 `.git/packed-refs` rather than under `.git/refs/`, and a reader that walks only
 the loose ones finds almost none of them.
 
@@ -192,22 +192,22 @@ A dashboard refreshing every thirty seconds must not call it. `ank status`,
 pipeline runs deliberately.
 
 **Two planes, and only one of them is precious.** What `check` prunes is the
-**coordination** plane — the refs that say who holds what — and losing a ref
+**coordination** plane, the refs that say who holds what, and losing a ref
 there loses a fact nothing else carries. Separately, every verb that reads the
 corpus may write a **disposable** one: a SQLite index beside the files, which
 stores a content hash per file and reindexes whatever diverged when it is opened.
 That is why an entity edited by hand or arrived through `git checkout` shows up
 on the next read with no reindex command to forget. Deleting that index is always
-safe, and it is never the source of truth — but it does mean a "read" verb
+safe, and it is never the source of truth. But it does mean a "read" verb
 touches the disk, which is worth knowing before you point twenty pollers at one
 working tree.
 
-It is also one of the two verbs that walk git history — `review` is the other,
-and they share the inspection — to say where a dead scope went. That makes both
+It is also one of the two verbs that walk git history, `review` being the other
+and sharing the same inspection, to say where a dead scope went. That makes both
 of them slower than a read, and it is a second reason not to put either on a
 timer. Only `check` prunes, so only `check` writes; but neither is a poll.
 
-Exit 8 is findings — faults. Signals leave it 0, and that is deliberate:
+Exit 8 is findings, meaning faults. Signals leave it 0, and that is deliberate:
 reddening a build over an observation teaches a team to stop reading `check`.
 
     $ ank check --json
@@ -216,16 +216,16 @@ reddening a build over an observation teaches a team to stop reading `check`.
 ## The conformance suite is offered to you
 
 Two sets of fixtures in this repository are yours to reuse. The first says so in
-its own header — "any third-party tool that claims to read or write the format
-can reuse the `tests/golden/` directory" — and the second is offered here, which
+its own header ("any third-party tool that claims to read or write the format
+can reuse the `tests/golden/` directory") and the second is offered here, which
 is the only place it is said:
 
-- **`crates/ank-core/tests/golden/`** — the file format. Valid files that must
+- **`crates/ank-core/tests/golden/`**: the file format. Valid files that must
   round-trip byte for byte in canonical form, and invalid ones with the error
   each must produce. If you are writing a parser in another language, this is
   what tells you it is right, and [format.md](format.md) is what it is checking
   against.
-- **`crates/ank-cli/tests/golden-json/`** — the machine surface. One fixture per
+- **`crates/ank-cli/tests/golden-json/`**: the machine surface. One fixture per
   document the CLI returns, captured from the process rather than from a
   function, so what they pin is what leaves the binary. If you are writing a
   client, these are the exact bytes to write it against.

--- a/npm/README.md
+++ b/npm/README.md
@@ -16,7 +16,7 @@ That is the whole point of this channel rather than a detail of it. The driving
 case is the corporate workstation whose firewall blocks downloading a bare
 executable but lets the npm registry through; a `postinstall` script that
 fetched the binary would die behind exactly the firewall this package exists to
-cross. `bin/ank` is therefore a resolver, never a downloader — it finds the
+cross. `bin/ank` is therefore a resolver, never a downloader: it finds the
 platform package with `require.resolve` and executes what it finds.
 
 **The Linux package declares no `libc`.** The build is `x86_64-unknown-linux-musl`
@@ -28,7 +28,7 @@ not because it restricts where it runs.
 **The wrapper forwards the exit code unchanged.** Section 4 of the specification
 gives 4, 6, 8 and 9 distinct meanings that an agent branches on. A wrapper that
 collapsed them into 0 and 1 would break every caller reading them, which is why
-`bin/ank` exits with the child's status and reserves 9 — the environment code —
+`bin/ank` exits with the child's status and reserves 9, the environment code,
 for its own failures.
 
 ## What is not in git
@@ -48,6 +48,6 @@ only ever the last released one.
 `release.yml` does it on a `v*` tag, with `NPM_TOKEN` from the repository
 secrets and `--access public`, which a scoped package needs on its first
 publish. On `workflow_dispatch` the same job assembles the packages, installs
-them from the tarballs on all three platforms and runs `ank --version` — the
+them from the tarballs on all three platforms and runs `ank --version`, so the
 pipeline is proved before a tag depends on it, and a tag is the one thing here
 that is awkward to take back.

--- a/npm/ank/README.md
+++ b/npm/ank/README.md
@@ -15,7 +15,7 @@ This package carries the CLI. The skill an agent loads is a separate install, an
 [the documentation](https://github.com/haksolot/ank) covers both, along with the
 specification and the source.
 
-Apache-2.0 — your `.ank/` files, the third-party tools that read or write them,
+Apache-2.0. Your `.ank/` files, the third-party tools that read or write them,
 and anything you build on top are yours. Ank was GPL-3.0-only until 0.3.0, and
 the change is prospective: a release you already received under GPL-3.0 stays
 available to you under GPL-3.0.


### PR DESCRIPTION
TASK-a070ea7c72f2, the last of the three. **166 became 4.**

## Rewritten, never substituted

An em dash is not a character with a replacement. Depending on the sentence it was a colon where the second half explains the first, brackets where it was an aside, a comma where it was a pause, or a full stop where two sentences had been joined. `sed 's/—/-/'` would have produced prose uglier than what it replaced and occasionally wrong, so each one was read in its sentence.

Nine files. The README was already at zero, having been rewritten in TASK-5982cf959b16.

## Four survive, and the criterion asked for none

Recorded in LOG-71c70c9d713f rather than quietly tolerated.

**`docs/format.md` 344 and 431** are examples of the log line grammar, which that same document defines two paragraphs above: *a dash and a space, the timestamp, a space, the identity, **an em dash**, a space, the message*. Rewriting them would document a grammar `ank-core` does not accept, and there is an invalid golden fixture for a log line the grammar refuses. **That em dash is the format, not the prose style.**

**`docs/getting-started.md` 377 and 389** are pasted output of `ank check`, whose summary the binary prints as `check: ok — N tasks`. That string lives in `human.rs`, outside this task's perimeter, and rewriting pasted output falsifies it.

## Measured on the way, and worth its own task

The binary prints an em dash at **six sites**. Three render the log grammar and cannot move without a format migration. Three are free prose, `check`'s summary among them. The two survivors in `getting-started.md` clear the day those three do, and that is a small task against `crates/ank-cli/src/human.rs`, `graph.rs` and `context.rs` plus about sixteen test assertions.

## Untouched, as the task said

| | | |
|---|---|---|
| `skill/SKILL.md` | 28 | content frozen by ADR-5dd7b4a9c875, revision hashed into `ank --version` and held by `tests/skill.rs` |
| `.ank/` entities | many | reached only through the CLI, and anchored by hash where ratified |
| `CLAUDE.md` | 22 | instructions to an agent rather than prose a reader browses |

## Verification

    ank check           exit 0, 0 faults
    cargo fmt --check   clean
    every relative link in the documentation still resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F1RRkJoQsHeGL1oRq7G7AX
