### PR TITLE
The README is a landing page, and the arguments live where the reader is

### DIFF
--- a/.ank/entities/LOG-86328f11f8b5.md
+++ b/.ank/entities/LOG-86328f11f8b5.md
@@ -1,0 +1,14 @@
+---
+id: LOG-86328f11f8b5
+type: log
+title: done, proof commit:d4b4653
+created: 2026-08-17T23:17:56Z
+author: claude-code/2.1.233+docs
+scope:
+  - README.md
+  - docs/getting-started.md
+about: TASK-1f487b26b638
+seq: 0
+schema: 3
+version: 1
+---

--- a/.ank/entities/TASK-1f487b26b638.md
+++ b/.ank/entities/TASK-1f487b26b638.md
@@ -1,0 +1,42 @@
+---
+id: TASK-1f487b26b638
+type: task
+slug: the-readme-is-a-landing-page-and-the-arguments-l
+title: The README is a landing page, and the arguments live where the reader is
+created: 2026-08-17T23:15:17Z
+author: claude-code/2.1.233+docs
+status: in_progress
+scope:
+  - README.md
+  - docs/getting-started.md
+blocked_by: []
+done_criteria: |
+  README.md carries no command transcript and no design argument: what is left is the header and badges, the install, the problem, the demo, what it is not, the documentation table, and a licence section that says Apache-2.0 and names no previous licence. The four design arguments and the bounded-answer fact live in docs/getting-started.md instead, which also stops claiming there are only two kinds of file. Every relative link in both still resolves, and the loop is not duplicated: getting-started already teaches it with real output and the README links there.
+criteria_by: creator
+schema: 3
+version: 2
+---
+
+The README is still a slab. The loop transcript added in TASK-5982cf959b16 was
+the right content in the wrong place: `getting-started.md` already walks the same
+loop, with the same example -- auth, opaque sessions, a claim -- and its own real
+output. Two copies of one thing, and the shorter one on the page a newcomer
+judges the project by.
+
+So the README becomes a landing page. Everything that explains moves out, and
+what stays is what a stranger needs in thirty seconds: what this is, how to get
+it, what it is not, where to read more.
+
+The four arguments under *why it works this way* go to `getting-started.md`,
+after the reader has finished a task rather than before they have started one.
+That placement is the point: an argument about freezing criteria means something
+to somebody who has just frozen one.
+
+Two facts collide on arrival and have to be reconciled. `getting-started.md` says
+the corpus holds "only two of them", counting an ADR and a task; the paragraph
+arriving from the README counts four, adding a spec and a log entry. The second
+is right, and the tutorial's reason for naming two is that it only uses two.
+
+The licence section loses its history. That Ank was GPL-3.0-only until 0.3.0 is
+true, recorded in ADR-9f03438f5422 and in the commit that changed it, and it is
+not what a reader of the front page needs.

--- a/.ank/entities/TASK-1f487b26b638.md
+++ b/.ank/entities/TASK-1f487b26b638.md
@@ -5,7 +5,7 @@ slug: the-readme-is-a-landing-page-and-the-arguments-l
 title: The README is a landing page, and the arguments live where the reader is
 created: 2026-08-17T23:15:17Z
 author: claude-code/2.1.233+docs
-status: in_progress
+status: done
 scope:
   - README.md
   - docs/getting-started.md
@@ -13,8 +13,13 @@ blocked_by: []
 done_criteria: |
   README.md carries no command transcript and no design argument: what is left is the header and badges, the install, the problem, the demo, what it is not, the documentation table, and a licence section that says Apache-2.0 and names no previous licence. The four design arguments and the bounded-answer fact live in docs/getting-started.md instead, which also stops claiming there are only two kinds of file. Every relative link in both still resolves, and the loop is not duplicated: getting-started already teaches it with real output and the README links there.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: d4b4653
+    criteria: 1787d4a353d0
+    via: submitted
 schema: 3
-version: 2
+version: 3
 ---
 
 The README is still a slab. The loop transcript added in TASK-5982cf959b16 was

--- a/README.md
+++ b/README.md
@@ -29,88 +29,14 @@ Ank puts that layer in the repository, attached to the code it constrains, and
 serves it through one command surface. `.ank/` is opaque to an agent, the way
 `.git/` is: not a directory to grep, a CLI to call.
 
-## The loop
-
-What applies here, and what is takeable:
-
-```console
-$ ank context src/auth/
-
-CONSTRAINTS (1 active)
-  ADR-f848  Sessions are opaque, never self-contained JWTs
-
-TASKS (1)
-  TASK-2352  [open] Rotate a session on privilege change
-
-> ank claim TASK-2352 to start
-```
-
-Taking it freezes the criterion by hash, so editing it later to get unstuck
-unblocks nothing:
-
-```console
-$ ank claim TASK-2352
-claimed TASK-235214d1655d rotate-a-session-on-privilege-change -> HEAD
-```
-
-The same verb now answers about the one task you hold, and serves the rule that
-binds it **in full** rather than by title:
-
-```console
-$ ank context
-
-TASK-2352  Rotate a session on privilege change
-
-DONE_CRITERIA
-  Logging in at a higher privilege level issues a new identifier and invalidates the old one.
-
-CONSTRAINTS (1 active)
-  ADR-f848  A session identifier is opaque and resolved server-side. No claim travels in the token.
-```
-
-Then work. Logging what you learn is also what holds the claim, and `done` runs
-the verifiers the task declares rather than taking your word for the result:
-
-```console
-$ ank log "the old identifier has to be invalidated, not just replaced"
-logged LOG-3c812d240fe3 on TASK-235214d1655d
-
-$ ank done --proof commit:97fdae7
-proof recorded: commit -> 97fdae7
-TASK-235214d1655d -> done
-```
-
-`ank check` is the verb a pipeline runs: parse, round-trip, references, frozen
-fields, orphaned claims. It exits **0** healthy, **8** on faults, **9** when the
-environment failed rather than the work.
-
-[Getting started](https://github.com/haksolot/ank/blob/main/docs/getting-started.md) walks all of it, from `ank init` onward.
-
 <p align="center"><picture>
 <source media="(prefers-color-scheme: dark)" srcset="assets/demo-dark.gif">
 <img src="assets/demo.gif" alt="A terminal session: ank context serves a constraint saying every refusal must name the command that fixes it; ank graph shows which task is takeable; a task is claimed and its criterion frozen; the code written next produces exactly that message; ank done runs the declared verifier and records a hashed proof."></picture></p>
 
-## Why it works this way
-
-**Scope, not hierarchy.** Constraints and work are two planes joined only by globs.
-A rule written last year binds work created today, and a glob is verifiable against
-the filesystem where a label is not.
-
-**Nobody declares themselves done.** An agent that reports its own result can simply
-be wrong, so `ank done` runs the verifiers itself and records what ran, hashed.
-
-**Freezing is verifiable, not defended.** The CLI cannot stop you editing a file and
-does not pretend to. Frozen fields are anchored by a hash the editor does not
-control, and `ank check` compares.
-
-**Git does the hard parts.** Claims are git refs, so the compare-and-swap that
-arbitrates two agents is the one git already guarantees. Undo, history and recovery
-are git's. There is nothing to run.
-
-One call is bounded at 8000 characters by default, roughly 2000 tokens. Behind it
-four kinds of entity, all plain markdown with YAML frontmatter: an **ADR** that
-constrains code, a **spec** that describes without binding, a **task** with what
-would prove it finished, and a **log entry**, written once.
+Four verbs carry the loop: `ank context` for what binds here and what is takeable,
+`ank claim` to take a task and freeze its criterion, `ank log` while you work, and
+`ank done` to finish with a proof that `ank check` can verify afterwards.
+[Getting started][start] walks all of it with real output, from `ank init` onward.
 
 ## What it is not
 
@@ -122,7 +48,7 @@ would prove it finished, and a **log entry**, written once.
 
 | If you want to | Read |
 |---|---|
-| go from install to a first finished task | [Getting started](https://github.com/haksolot/ank/blob/main/docs/getting-started.md) |
+| go from install to a first finished task | [Getting started][start] |
 | hand it to an agent, whichever one you run | [Handing ank to an agent][agents] |
 | build a tool on top of ank | [Integrating with ank](https://github.com/haksolot/ank/blob/main/docs/integrating.md) |
 | write a tool that reads or writes `.ank/` | [The file format](https://github.com/haksolot/ank/blob/main/docs/format.md) |
@@ -132,7 +58,6 @@ would prove it finished, and a **log entry**, written once.
 
 The specification is the source of truth and lives as ten accepted `spec` entities
 in `.ank/`: `ank find --type spec` lists them, `ank show <id>` prints one whole.
-This repository dogfoods its own format, so the plan is in there beside them.
 
 Linux, macOS and Windows. The version is `0.x` deliberately: the loop and the exit
 codes are specified and an agent can branch on them today, while the storage format
@@ -141,10 +66,7 @@ a [Code of Conduct](https://github.com/haksolot/ank/blob/main/CODE_OF_CONDUCT.md
 
 ## Licence
 
-Apache-2.0, whole. See [LICENSE](LICENSE). Every crate, the binary as distributed
-and every channel that declares a licence say the same thing, so your `.ank/` files,
-the tools that read them, and anything you build on top are yours. Ank was
-GPL-3.0-only until 0.3.0 and the change is **prospective**: a release you already
-received stays available to you under GPL-3.0.
+Apache-2.0. See [LICENSE](LICENSE).
 
 [agents]: https://github.com/haksolot/ank/blob/main/docs/agents.md
+[start]: https://github.com/haksolot/ank/blob/main/docs/getting-started.md

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -115,9 +115,11 @@ remote has none. It refuses rather than guessing:
       -> git remote set-head origin -a
       -> or ank config default_branch <name>
 
-## The two kinds of file
+## The two kinds this page uses
 
-Flat in `.ank/`, markdown with YAML frontmatter, and only two of them.
+Flat in `.ank/`, markdown with YAML frontmatter. Four kinds exist and this page
+needs two of them; the other two are a **spec**, normative text that describes
+rather than binds, and a **log entry**, written once and never transitioned.
 
 An **ADR** is a decision that constrains code. Its `constraint` is the one
 field injected into an agent's context, so it is short and imperative; the body
@@ -523,14 +525,44 @@ The shortest of them, which detects what you run and links it to a single copy:
 That installs the skill, not the binary. The skill teaches one page, and it is
 loaded on every session, which is why its content is deliberately small.
 
+## Why it works this way
+
+You have now done the loop once, which is the right moment for the four claims
+underneath it. Each one is a property of the tool rather than a convention you
+are asked to keep.
+
+**Scope, not hierarchy.** Constraints and work are two planes joined only by
+globs. A rule written last year binds work created today, and a glob is
+verifiable against the filesystem where a label is not. There is no epic, no
+parent and no rollup to keep in step.
+
+**Nobody declares themselves done.** An agent that reports its own result can
+simply be wrong, so `ank done` runs the verifiers itself and records what
+actually ran, hashed. That is why the previous section refused a `done` with no
+proof rather than trusting the caller.
+
+**Freezing is verifiable, not defended.** The CLI cannot stop you editing a file
+and does not pretend to. Frozen fields are anchored by a hash the editor does not
+control, and `ank check` compares. Editing a criterion to unblock yourself
+unblocks nothing; it makes the divergence visible.
+
+**Git does the hard parts.** Claims are git refs, so the compare-and-swap that
+arbitrates two agents is the one git already guarantees. Undo, history and
+recovery are git's, and there is no server to run.
+
+One call is bounded at 8000 characters by default, roughly 2000 tokens, which is
+the constraint every one of those choices is paid for by: what `context` serves
+has to fit in a context window beside the code.
+
 ## Where to go next
 
 - [agents.md](agents.md): the four routes that reach an agent, the binary
   channels beyond npm, and what running several agents actually requires.
 - [format.md](format.md): the file format and canonical form, for anyone
   writing a tool that reads or writes `.ank/`.
+- [alternatives.md](alternatives.md): how this compares to retrieval, an
+  LLM-maintained wiki, and OKF.
 - The specification, the source of truth for everything above: ten `spec`
   documents in `.ank/`, read with `ank find --type spec` and `ank show <id>`.
-  They argue the design; they
-  are not a tutorial.
+  They argue the design; they are not a tutorial.
 - `ank help` lists every verb, `ank help <verb>` answers about one.


### PR DESCRIPTION
TASK-1f487b26b638. **150 lines to 72.**

## The transcript was the right content in the wrong place

`getting-started.md` already walks the same loop, with the same example (auth, opaque sessions, a claim) and its own real output. Two copies of one thing, and the shorter one sat on the page a stranger judges the project by.

What is left is what a stranger needs in thirty seconds: what this is, how to get it, the demo, what it is not, where to read more. Four verbs are named in one sentence with a link, instead of shown in five code blocks.

## The arguments moved to where they can be weighed

The four design claims are in `getting-started.md` now, **at the end rather than the beginning**. An argument about freezing criteria means something to somebody who has just frozen one; on a landing page it is a claim a reader has no way to weigh. The bounded-answer fact goes with them, since it is the constraint the other four are paid for by.

## Two facts collided on arrival, and are reconciled

`getting-started.md` said the corpus holds *"only two of them"*, counting an ADR and a task. The paragraph arriving from the README counts four. The section is now **The two kinds this page uses**, and it names the spec and the log entry as the two it does not need.

That contradiction predates this change and would have shipped as a visible one the moment the paragraph landed.

## The licence section loses its history

That Ank was GPL-3.0-only until 0.3.0 is true, and it is recorded in ADR-9f03438f5422 and in the commit that changed it. It is not what a reader of the front page needs, and it made the section three times the length of the fact it carries.

    ## Licence

    Apache-2.0. See LICENSE.

## Two small repairs found on the way

A line wrap this session's em dash purge had left broken in `getting-started.md`, and `alternatives.md` missing from its closing list.

## Verification

    ank check   exit 0, 0 faults
    README      72 lines, 0 em dashes, no transcript, no argument, no GPL
    links       every relative target and every reference definition resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F1RRkJoQsHeGL1oRq7G7AX
