### PR TITLE
A protocol surface exposes every verb, generated from the table the CLI dispatches from

### DIFF
--- a/.ank/entities/LOG-84141c853f87.md
+++ b/.ank/entities/LOG-84141c853f87.md
@@ -1,0 +1,18 @@
+---
+id: LOG-84141c853f87
+type: log
+title: "the surface is generated and the test proves it can fail. Falsified rather than assumed: adding"
+created: 2026-08-17T23:43:21Z
+author: claude-code/2.1.233+mcp
+scope:
+  - Cargo.toml
+  - crates/ank-mcp/**
+  - crates/ank-contract/**
+  - crates/ank-cli/src/json.rs
+about: TASK-e819448560e7
+seq: 2
+schema: 3
+version: 1
+---
+
+ filter(|s| s.name != "amend") to the tool list makes the_surface_it_advertises_is_the_table_and_nothing_else fail, and the message names the failure mode ADR-372b forbids -- a curated subset. The refusal assertion reads its expected code out of spec_of("show").refuses rather than typing 2, so it cannot drift from what ank help --json publishes. Measured against the fixture: 22 tools advertised, 22 verbs in COMMANDS, in the table's order; a call to ank_find returns the CLI's own document, contract envelope included; a claim on a done task comes back exitCode 6 with error[6] illegal transition and its hint, inherited rather than re-derived. Three flags are withheld from clients and none of them is a verb: --repo because one process speaks for one corpus, --json because the server always wants the machine document, --quiet because it means nothing to a caller that reads a return value.

--- a/.ank/entities/LOG-8735df4fa44a.md
+++ b/.ank/entities/LOG-8735df4fa44a.md
@@ -1,0 +1,16 @@
+---
+id: LOG-8735df4fa44a
+type: log
+title: done, proof commit:fa55d32
+created: 2026-08-18T02:40:43Z
+author: claude-code/2.1.234+mcp
+scope:
+  - Cargo.toml
+  - crates/ank-mcp/**
+  - crates/ank-contract/**
+  - crates/ank-cli/src/json.rs
+about: TASK-e819448560e7
+seq: 3
+schema: 3
+version: 1
+---

--- a/.ank/entities/LOG-929b782fea8b.md
+++ b/.ank/entities/LOG-929b782fea8b.md
@@ -1,0 +1,18 @@
+---
+id: LOG-929b782fea8b
+type: log
+title: the scope had to gain crates/ank-contract/** and crates/ank-cli/src/json.rs, and the reason is the
+created: 2026-08-17T23:36:06Z
+author: claude-code/2.1.233+mcp
+scope:
+  - Cargo.toml
+  - crates/ank-mcp/**
+  - crates/ank-contract/**
+  - crates/ank-cli/src/json.rs
+about: TASK-e819448560e7
+seq: 1
+schema: 3
+version: 1
+---
+
+ defect TASK-2c12b027f805 fixed. The protocol surface has to write JSON, and json.rs is a private module of a binary crate, so a second surface either shares it or grows a second escaper -- which is exactly the four-escapers-that-disagreed state that task removed. So the writer moves into ank-contract and ank-cli re-exports it, the same move the verb table made. Also recorded before writing a line: the server spawns the ank binary rather than linking ank-cli. Not for convenience. This repository already argues it, in the golden harness -- captured from the process and never from a function, because what §4 promises is what leaves the process. A passthrough that spawns inherits every refusal, exit code and stderr warning by construction; one that links re-derives them and can therefore differ.

--- a/.ank/entities/LOG-d3cdcddc2a3a.md
+++ b/.ank/entities/LOG-d3cdcddc2a3a.md
@@ -1,0 +1,16 @@
+---
+id: LOG-d3cdcddc2a3a
+type: log
+title: "amended: +scope crates/ank-contract/**, +scope crates/ank-cli/src/json.rs"
+created: 2026-08-17T23:35:40Z
+author: claude-code/2.1.233+mcp
+scope:
+  - Cargo.toml
+  - crates/ank-mcp/**
+  - crates/ank-contract/**
+  - crates/ank-cli/src/json.rs
+about: TASK-e819448560e7
+seq: 0
+schema: 3
+version: 1
+---

--- a/.ank/entities/TASK-e819448560e7.md
+++ b/.ank/entities/TASK-e819448560e7.md
@@ -5,16 +5,23 @@ slug: a-protocol-surface-exposes-every-verb-generated
 title: A protocol surface exposes every verb, generated from the table the CLI dispatches from
 created: 2026-08-17T19:21:27Z
 author: claude-code/2.1.233+exposition
-status: open
+status: done
 scope:
   - Cargo.toml
   - crates/ank-mcp/**
+  - crates/ank-contract/**
+  - crates/ank-cli/src/json.rs
 blocked_by: []
 done_criteria: |
   A sibling binary in this workspace exposes every verb COMMANDS carries, generated from that table rather than listed by hand, so a verb added to the table reaches the protocol with no edit here. It refuses on state exactly as the CLI does and never on identity, and a refusal carries the CLI's exit code as its reason. It speaks for exactly one corpus, addressed the way --repo addresses one, and takes no claim the CLI would not have taken in that clone. It writes under a typed process identity. The verb list and skill/SKILL.md are untouched. A test drives the built binary as a process: the surface it advertises equals the table, and a refused call carries the code the table declares. cargo test is green and cargo fmt --check passes.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: fa55d32
+    criteria: 03526cb852b2
+    via: submitted
 schema: 3
-version: 1
+version: 5
 ---
 
 ADR-372b82af1ec7 allows this, and it allows nothing else: a full-surface

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "ank-mcp"
+version = "0.3.0"
+dependencies = [
+ "ank-contract",
+ "serde_yaml",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["crates/ank-core", "crates/ank-contract", "crates/ank-cli"]
+members = ["crates/ank-core", "crates/ank-contract", "crates/ank-cli", "crates/ank-mcp"]
 resolver = "2"

--- a/crates/ank-cli/src/main.rs
+++ b/crates/ank-cli/src/main.rs
@@ -19,7 +19,11 @@ mod config;
 mod git;
 mod identity;
 mod init;
-mod json;
+// The one writer and the one escaper, which now live in `ank-contract` so the
+// protocol surface shares them rather than growing a second pair
+// (TASK-e819448560e7). Re-exported under the path every call site already
+// names: `crate::json::Obj` is what twenty-six documents are built with.
+pub use ank_contract::json;
 mod paint;
 mod repo;
 mod store;

--- a/crates/ank-contract/src/json.rs
+++ b/crates/ank-contract/src/json.rs
@@ -93,7 +93,7 @@ impl Obj {
     /// conformance test walks every fixture in `tests/golden-json/` and there is
     /// one per verb, so a verb that forgot is a verb whose golden fails.
     pub fn document() -> Obj {
-        Obj::new().num("contract", ank_contract::CONTRACT_VERSION)
+        Obj::new().num("contract", crate::CONTRACT_VERSION)
     }
 
     fn key(&mut self, key: &str) {

--- a/crates/ank-contract/src/lib.rs
+++ b/crates/ank-contract/src/lib.rs
@@ -44,6 +44,7 @@
 pub const CONTRACT_VERSION: u32 = 1;
 
 pub mod exit;
+pub mod json;
 pub mod renews;
 pub mod shape;
 pub mod verbs;

--- a/crates/ank-mcp/Cargo.toml
+++ b/crates/ank-mcp/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "ank-mcp"
+version = "0.3.0"
+edition = "2021"
+# The workspace floor, for the reason ank-core's manifest gives: one lockfile,
+# one build.
+rust-version = "1.95"
+# Apache-2.0, like the whole tree (ADR-9f03438f5422).
+license = "Apache-2.0"
+description = "The Ank protocol surface: every verb the CLI dispatches, over MCP, generated from one table."
+
+[[bin]]
+name = "ank-mcp"
+path = "src/main.rs"
+
+[dependencies]
+# The table this surface is generated from, and the writer it shares with the
+# CLI (ADR-6fd69efb629c). A verb the table does not carry is a verb neither
+# surface has, which is the whole condition ADR-372b82af1ec7 set.
+ank-contract = { path = "../ank-contract" }
+# **No new crate enters the tree for this.** JSON-RPC has to be *read*, and
+# nothing here wrote a parser before: `ank-contract::json` writes and does not
+# read. `serde_yaml` is already a dependency of `ank-core` and `ank-cli`, and
+# YAML 1.2 is a superset of JSON, so a request on one line parses as flow YAML.
+# §13 spends a dependency only on necessity, and the same reasoning already
+# carries the conformance test that reads the JSON goldens.
+serde_yaml = "0.9"

--- a/crates/ank-mcp/src/call.rs
+++ b/crates/ank-mcp/src/call.rs
@@ -1,0 +1,150 @@
+//! Running a verb, which means running **the binary** and not a copy of it.
+//!
+//! **The passthrough spawns `ank`.** That is the whole design and it is not
+//! convenience: this repository already argues the point in its golden harness,
+//! where every fixture is "captured from the process and never from a function,
+//! because what §4 promises is what leaves the process". A surface that spawns
+//! inherits every refusal, every exit code, every stderr warning and every
+//! `--json` document by construction. A surface that linked `ank-cli` would
+//! re-derive them, and anything re-derived can differ.
+//!
+//! So there is no dispatch here. There is an argv, built from the table, and a
+//! process.
+
+use ank_contract::json::Obj;
+use ank_contract::{CommandSpec, ExitCode};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Where the `ank` binary is, given that this one is its sibling.
+///
+/// Beside this executable first, because ADR-372b82af1ec7 says the protocol
+/// surface ships from this repository as a sibling binary: the two travel
+/// together, so the copy next to us is the copy we were released with. `PATH` is
+/// the fallback, and `ANK_BIN` overrides both for a caller that has a reason.
+///
+/// Getting this wrong silently would be the worst failure available here: a
+/// server answering from a different build than the one beside it would report
+/// verbs the installed CLI does not have.
+pub fn ank_binary() -> PathBuf {
+    if let Some(explicit) = std::env::var_os("ANK_BIN") {
+        return PathBuf::from(explicit);
+    }
+    let exe = if cfg!(windows) { "ank.exe" } else { "ank" };
+    if let Ok(here) = std::env::current_exe() {
+        if let Some(dir) = here.parent() {
+            let beside = dir.join(exe);
+            if beside.is_file() {
+                return beside;
+            }
+        }
+    }
+    PathBuf::from("ank")
+}
+
+/// What one call produced.
+pub struct Outcome {
+    pub code: i32,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+impl Outcome {
+    /// Whether the call refused. A refusal is a fact about the corpus, and it is
+    /// reported to the client as an error result carrying the code rather than as
+    /// a protocol error: the request was well formed and the answer is no.
+    pub fn refused(&self) -> bool {
+        self.code != ExitCode::Ok.code()
+    }
+
+    /// The MCP result. `structuredContent` carries the document the verb
+    /// returned, `content` the same bytes as text for a client that reads only
+    /// that, and `isError` says a refusal happened without hiding what it was.
+    ///
+    /// The exit code is always present, including on success, because a caller
+    /// that has to branch on it should not have to tell absence from zero. `check`
+    /// exits 8 with findings and that is not a failure of the call.
+    pub fn to_result(&self) -> String {
+        let text = match self.stdout.trim().is_empty() {
+            true => self.stderr.trim(),
+            false => self.stdout.trim(),
+        };
+        let block = Obj::new().str("type", "text").str("text", text).finish();
+        let mut doc = Obj::new()
+            .array("content", [block])
+            .bool("isError", self.refused())
+            .num("exitCode", self.code);
+        if !self.stderr.trim().is_empty() {
+            // Warnings live on stderr precisely so a caller's parser keeps
+            // reading stdout (§4). Carried separately here for the same reason.
+            doc = doc.str("stderr", self.stderr.trim());
+        }
+        doc.finish()
+    }
+}
+
+/// The argv for a call, from the table and the client's arguments.
+///
+/// `--repo` and `--json` are the server's, added here and never accepted from a
+/// caller: one process speaks for one corpus, and the machine document is the
+/// only shape this surface can describe.
+pub fn argv(spec: &CommandSpec, repo: &Path, args: &Arguments) -> Vec<String> {
+    let mut out = vec![spec.name.to_string()];
+    out.extend(args.positionals.iter().cloned());
+    for (name, values) in &args.flags {
+        for value in values {
+            out.push(format!("--{name}"));
+            if !value.is_empty() {
+                out.push(value.clone());
+            }
+        }
+    }
+    if !spec.refuses_globals.contains(&"--repo") {
+        out.push("--repo".to_string());
+        out.push(repo.display().to_string());
+    }
+    out.push("--json".to_string());
+    out
+}
+
+/// A call's arguments, already validated against the table.
+#[derive(Default)]
+pub struct Arguments {
+    pub positionals: Vec<String>,
+    /// Flag name without dashes, and its values. A switch carries one empty
+    /// string, which is what makes `argv` above emit the flag and no value.
+    pub flags: Vec<(String, Vec<String>)>,
+}
+
+/// Runs the verb and returns what the process said.
+///
+/// The identity is the server's and is typed (§3, ADR-3877d2b7c0f5). One stdio
+/// server serves one client, so one process is one caller: nothing here pools
+/// several clients under a single identity, which ADR-372b82af1ec7 forbids, and
+/// nothing holds a claim on a client's behalf either. The claim a call takes is
+/// the claim the CLI would have taken in that clone, on the same ref, arbitrated
+/// by the same compare-and-swap.
+pub fn run(spec: &CommandSpec, repo: &Path, args: &Arguments) -> std::io::Result<Outcome> {
+    let out = Command::new(ank_binary())
+        .args(argv(spec, repo, args))
+        .env("ANK_AGENT", identity())
+        .current_dir(repo)
+        .output()?;
+    Ok(Outcome {
+        code: out.status.code().unwrap_or(1),
+        stdout: String::from_utf8_lossy(&out.stdout).to_string(),
+        stderr: String::from_utf8_lossy(&out.stderr).to_string(),
+    })
+}
+
+/// The typed identity this process writes under.
+///
+/// `$ANK_AGENT` from the environment wins, so a deployment that already names its
+/// agents keeps naming them; otherwise the process names itself and its version,
+/// which is the convention of §3 rather than a hostname.
+pub fn identity() -> String {
+    std::env::var("ANK_AGENT")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .unwrap_or_else(|| format!("ank-mcp/{}", env!("CARGO_PKG_VERSION")))
+}

--- a/crates/ank-mcp/src/main.rs
+++ b/crates/ank-mcp/src/main.rs
@@ -1,0 +1,257 @@
+//! The Ank protocol surface: every verb, over MCP, generated from one table.
+//!
+//! ADR-372b82af1ec7 permits this and permits nothing else: a full-surface
+//! passthrough or no surface at all. It supersedes ADR-1713af205186, whose
+//! refusal is kept whole as the shape of what is now allowed. The proposal that
+//! ADR rejected exposed four verbs out of twenty-two, which rebuilt under a
+//! second protocol the agent-surface split that had been abolished once already,
+//! and rebuilt the worse half of it: a caller reached through the protocol could
+//! not amend, could not propose an ADR, could not check the corpus.
+//!
+//! **Nothing in this crate names a verb.** [`tools`] walks
+//! [`ank_contract::COMMANDS`], and [`call`] spawns the binary. What this surface
+//! has is what the CLI dispatches, and it cannot be otherwise without an edit to
+//! the table both consume.
+//!
+//! **One process speaks for one corpus.** Addressed once, at startup, the way
+//! `--repo` addresses one. A per-call repository would make one server several
+//! corpora and invent an arbitration `refs/ank/*` cannot carry, which is the one
+//! thing ADR-372b82af1ec7 spells out at length: claims stay per repository, and a
+//! deployment over several is several servers.
+//!
+//! **This does not make a protocol the preferred route.** §2's common denominator
+//! is shell, that is still what the skill teaches, and this exists for the client
+//! that has no shell at all.
+
+mod call;
+mod tools;
+
+use ank_contract::json::{string, Obj};
+use ank_contract::ExitCode;
+use std::io::{BufRead, Write};
+use std::path::PathBuf;
+
+/// The MCP revision this server implements.
+const PROTOCOL_VERSION: &str = "2025-06-18";
+
+fn main() {
+    let repo = match corpus() {
+        Ok(path) => path,
+        Err(message) => {
+            // The one refusal that happens before any client is listening, so it
+            // goes where a person will see it and carries §4's environment code.
+            eprintln!("error[{}]: {message}", ExitCode::Environment);
+            eprintln!("  -> ank-mcp --repo <path to a directory holding .ank/>");
+            std::process::exit(ExitCode::Environment.code());
+        }
+    };
+
+    let stdin = std::io::stdin();
+    let mut stdout = std::io::stdout();
+    for line in stdin.lock().lines() {
+        let Ok(line) = line else { break };
+        if line.trim().is_empty() {
+            continue;
+        }
+        if let Some(reply) = handle(&line, &repo) {
+            let _ = writeln!(stdout, "{reply}");
+            let _ = stdout.flush();
+        }
+    }
+}
+
+/// The corpus this process speaks for, from `--repo` or the working directory.
+///
+/// Resolved once and never again: the value is what every call is given, so a
+/// server cannot drift between corpora while a client holds a claim in one.
+fn corpus() -> Result<PathBuf, String> {
+    let mut args = std::env::args().skip(1);
+    let mut given: Option<PathBuf> = None;
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--repo" | "-r" => match args.next() {
+                Some(path) => given = Some(PathBuf::from(path)),
+                None => return Err("--repo needs a path".to_string()),
+            },
+            "--version" | "-V" => {
+                println!("ank-mcp {}", env!("CARGO_PKG_VERSION"));
+                std::process::exit(0);
+            }
+            other => return Err(format!("unknown argument '{other}'")),
+        }
+    }
+    let root = match given {
+        Some(path) => path,
+        None => std::env::current_dir().map_err(|e| e.to_string())?,
+    };
+    match root.join(".ank").is_dir() {
+        true => Ok(root),
+        false => Err(format!("no .ank/ under {}", root.display())),
+    }
+}
+
+/// One JSON-RPC message in, at most one out.
+///
+/// `None` for a notification, which is a message with no `id` and must never be
+/// answered: a reply to one is a protocol error on our side, and the client that
+/// sent `notifications/initialized` is waiting for nothing.
+fn handle(line: &str, repo: &std::path::Path) -> Option<String> {
+    let request: serde_yaml::Value = match serde_yaml::from_str(line) {
+        Ok(value) => value,
+        // Unparseable and therefore unattributable: no id to answer against, so
+        // the only honest reply is the one JSON-RPC reserves for it.
+        Err(e) => return Some(error(None, -32700, &format!("parse error: {e}"))),
+    };
+    let method = request.get("method").and_then(|m| m.as_str()).unwrap_or("");
+    let id = request.get("id").cloned().filter(|v| !v.is_null());
+    let id_json = id.as_ref().map(render_id);
+
+    if id_json.is_none() {
+        // A notification. `initialized` is the only one that matters and it wants
+        // silence, not acknowledgement.
+        return None;
+    }
+
+    match method {
+        "initialize" => Some(result(
+            id_json,
+            &Obj::new()
+                .str("protocolVersion", PROTOCOL_VERSION)
+                .obj("capabilities", Obj::new().obj("tools", Obj::new()))
+                .obj(
+                    "serverInfo",
+                    Obj::new()
+                        .str("name", "ank-mcp")
+                        .str("version", env!("CARGO_PKG_VERSION")),
+                )
+                .str(
+                    "instructions",
+                    "Every verb the ank CLI dispatches is a tool here, generated \
+                     from one table. Start with ank_context: it answers what binds \
+                     this perimeter and what is claimable. This server speaks for \
+                     one corpus, fixed when it started.",
+                )
+                .finish(),
+        )),
+        "ping" => Some(result(id_json, &Obj::new().finish())),
+        "tools/list" => Some(result(
+            id_json,
+            &Obj::new().raw("tools", &tools::list()).finish(),
+        )),
+        "tools/call" => Some(call_tool(id_json, request.get("params"), repo)),
+        other => Some(error(id_json, -32601, &format!("no such method '{other}'"))),
+    }
+}
+
+/// `tools/call`, which is the only method that reaches the corpus.
+fn call_tool(
+    id: Option<String>,
+    params: Option<&serde_yaml::Value>,
+    repo: &std::path::Path,
+) -> String {
+    let params = match params {
+        Some(p) => p,
+        None => return error(id, -32602, "tools/call needs params"),
+    };
+    let name = params.get("name").and_then(|n| n.as_str()).unwrap_or("");
+    let Some(spec) = tools::verb_of(name) else {
+        // Not a refusal on state and not a curated subset: a name this surface
+        // never advertised. The table is what it advertised.
+        return error(id, -32602, &format!("no such tool '{name}'"));
+    };
+
+    let mut args = call::Arguments::default();
+    if let Some(map) = params.get("arguments").and_then(|a| a.as_mapping()) {
+        for (key, value) in map {
+            let Some(key) = key.as_str() else { continue };
+            if key == "arguments" {
+                if let Some(list) = value.as_sequence() {
+                    for item in list {
+                        args.positionals.push(scalar(item));
+                    }
+                } else {
+                    args.positionals.push(scalar(value));
+                }
+                continue;
+            }
+            let flag = format!("--{key}");
+            // **Validated against the table, and refused by name when it is not
+            // there.** A flag the verb does not take would otherwise reach the
+            // CLI and be refused there, which is the same answer arriving less
+            // usefully: the client asked this surface, so this surface says the
+            // name is wrong.
+            let Some(known) = ank_contract::find_flag(spec, &flag) else {
+                return error(id, -32602, &format!("{} takes no {flag}", spec.name));
+            };
+            if !tools::client_flag(&flag) {
+                return error(
+                    id,
+                    -32602,
+                    &format!("{flag} belongs to the server: one process, one corpus"),
+                );
+            }
+            let values = match (known.takes_value, value.as_sequence()) {
+                (false, _) => vec![String::new()],
+                (true, Some(list)) => list.iter().map(scalar).collect(),
+                (true, None) => vec![scalar(value)],
+            };
+            args.flags.push((key.to_string(), values));
+        }
+    }
+
+    match call::run(spec, repo, &args) {
+        Ok(outcome) => result(id, &outcome.to_result()),
+        // The binary itself could not be run. That is the environment and not the
+        // corpus, and §4 keeps the two apart on purpose.
+        Err(e) => error(
+            id,
+            -32603,
+            &format!("cannot run {}: {e}", call::ank_binary().display()),
+        ),
+    }
+}
+
+/// A scalar argument as the string the command line will carry.
+fn scalar(value: &serde_yaml::Value) -> String {
+    match value {
+        serde_yaml::Value::String(s) => s.clone(),
+        serde_yaml::Value::Bool(b) => b.to_string(),
+        serde_yaml::Value::Number(n) => n.to_string(),
+        other => serde_yaml::to_string(other)
+            .unwrap_or_default()
+            .trim()
+            .to_string(),
+    }
+}
+
+/// The request id, rendered back exactly as JSON-RPC requires: a string stays a
+/// string and a number stays a number, because a client matching replies by
+/// identity would not recognise a retyped one.
+fn render_id(id: &serde_yaml::Value) -> String {
+    match id {
+        serde_yaml::Value::String(s) => string(s),
+        serde_yaml::Value::Number(n) => n.to_string(),
+        other => string(&scalar(other)),
+    }
+}
+
+fn result(id: Option<String>, payload: &str) -> String {
+    let mut doc = Obj::new().str("jsonrpc", "2.0");
+    if let Some(id) = id {
+        doc = doc.raw("id", &id);
+    }
+    doc.raw("result", payload).finish()
+}
+
+fn error(id: Option<String>, code: i32, message: &str) -> String {
+    let mut doc = Obj::new().str("jsonrpc", "2.0");
+    match id {
+        Some(id) => doc = doc.raw("id", &id),
+        None => doc = doc.null("id"),
+    }
+    doc.obj(
+        "error",
+        Obj::new().num("code", code).str("message", message),
+    )
+    .finish()
+}

--- a/crates/ank-mcp/src/tools.rs
+++ b/crates/ank-mcp/src/tools.rs
@@ -1,0 +1,139 @@
+//! The tool list, generated from the verb table (ADR-372b82af1ec7).
+//!
+//! **Nothing here names a verb.** The list is [`COMMANDS`] walked, so a verb the
+//! table gains reaches this surface with no edit in this crate, and a verb it
+//! does not carry is a verb this surface does not have. That is the condition
+//! ADR-1713af205186 wrote for itself and ADR-372b82af1ec7 answered: not a
+//! curated subset, not parity kept by review, generated.
+//!
+//! What a tool advertises is what the table already knows: the summary as the
+//! description, the positionals and flags as the input schema, the refusals with
+//! their exit codes so a client can see what a call will refuse *before* making
+//! it, and the shape of the document that comes back.
+
+use ank_contract::json::Obj;
+use ank_contract::{CommandSpec, COMMANDS};
+
+/// The three global flags, which are the server's business and never the
+/// client's.
+///
+/// This is not a curated subset: no verb is hidden and every verb takes exactly
+/// the arguments the table gives it. What is withheld is the three flags that
+/// would let a caller contradict the process it is talking to.
+///
+/// `--repo` because the server speaks for **exactly one corpus**, addressed once
+/// at startup: a per-call repository would make one process several corpora,
+/// which is the merged claim space ADR-372b82af1ec7 forbids in as many words.
+/// `--json` because the server always wants the machine document and a client
+/// asking for the human one would get a shape nothing describes. `--quiet` means
+/// nothing to a caller that reads a return value rather than a terminal.
+pub const SERVER_FLAGS: [&str; 3] = ["--repo", "--json", "--quiet"];
+
+/// Whether a flag is the client's to pass.
+pub fn client_flag(name: &str) -> bool {
+    !SERVER_FLAGS.contains(&name)
+}
+
+/// A tool name. `ank_<verb>`, because a bare verb collides with every other
+/// server a client has loaded, and `ank context` is not a legal tool name.
+pub fn tool_name(spec: &CommandSpec) -> String {
+    format!("ank_{}", spec.name)
+}
+
+/// The verb a tool name refers to, or `None` for a name this surface never
+/// advertised.
+pub fn verb_of(tool: &str) -> Option<&'static CommandSpec> {
+    ank_contract::spec_of(tool.strip_prefix("ank_")?)
+}
+
+/// The description a client reads: what the verb does, then what it refuses on
+/// and with which code.
+///
+/// The refusals are in the description because MCP has nowhere else to put them
+/// and because they are the half a caller needs first. A client that can see
+/// `7: the task is blocked` before calling does not have to learn it from a
+/// failure.
+fn description(spec: &CommandSpec) -> String {
+    let mut out = String::from(spec.summary);
+    for note in spec.notes {
+        out.push_str("\n\nNote: ");
+        out.push_str(note);
+    }
+    if !spec.refuses.is_empty() {
+        out.push_str("\n\nRefuses on state, never on identity:");
+        for refusal in spec.refuses {
+            out.push_str(&format!("\n  {} (exit {})", refusal.when, refusal.code));
+        }
+    }
+    if let Some(shape) = spec.output.first() {
+        out.push_str("\n\nReturns a document carrying: contract");
+        for field in shape.fields {
+            out.push_str(", ");
+            out.push_str(field.name);
+        }
+        if spec.output.len() > 1 {
+            out.push_str(&format!(
+                "\n{} different documents, depending on the call; ank help --json describes each.",
+                spec.output.len()
+            ));
+        }
+    }
+    out
+}
+
+/// The JSON Schema of a call, derived from the table's own account of the verb.
+///
+/// Positionals arrive as `arguments`, an array of strings, because that is what
+/// they are on the command line and inventing names for them here would be a
+/// second description of the same thing. Flags arrive under their own names,
+/// without the leading dashes, since a JSON key beginning with `--` is a key
+/// every client would have to quote.
+fn input_schema(spec: &CommandSpec) -> String {
+    let mut props = Obj::new();
+    if spec.max_positionals > 0 || !spec.subcommands.is_empty() {
+        let mut items = Obj::new().str("type", "string");
+        if !spec.subcommands.is_empty() {
+            items = items.raw(
+                "enum",
+                &ank_contract::json::strings(spec.subcommands.iter().copied()),
+            );
+        }
+        props = props.obj(
+            "arguments",
+            Obj::new()
+                .str("type", "array")
+                .obj("items", items)
+                .str("description", spec.positional_help),
+        );
+    }
+    for flag in spec.flags.iter().filter(|f| f.listed) {
+        let name = flag.name.trim_start_matches('-');
+        if !client_flag(flag.name) {
+            continue;
+        }
+        let value = match (flag.takes_value, flag.repeatable) {
+            (false, _) => Obj::new().str("type", "boolean"),
+            (true, false) => Obj::new().str("type", "string"),
+            (true, true) => Obj::new()
+                .str("type", "array")
+                .obj("items", Obj::new().str("type", "string")),
+        };
+        props = props.obj(name, value);
+    }
+    Obj::new()
+        .str("type", "object")
+        .obj("properties", props)
+        .finish()
+}
+
+/// Every verb, as a tool.
+pub fn list() -> String {
+    let tools = COMMANDS.iter().map(|spec| {
+        Obj::new()
+            .str("name", &tool_name(spec))
+            .str("description", &description(spec))
+            .raw("inputSchema", &input_schema(spec))
+            .finish()
+    });
+    ank_contract::json::array(tools)
+}

--- a/crates/ank-mcp/tests/mcp.rs
+++ b/crates/ank-mcp/tests/mcp.rs
@@ -1,0 +1,251 @@
+//! The server, driven as a process.
+//!
+//! Driven rather than called, for the reason the CLI's own golden harness gives:
+//! what a protocol promises is what leaves the process. A test that called
+//! `tools::list()` would prove the function and not the surface, and the surface
+//! is what a client without a shell talks to.
+//!
+//! Two claims are asserted here and both come from the table rather than from a
+//! list written beside it. The advertised tools **equal** `COMMANDS`, so a verb
+//! added there reaches this surface with no edit in this crate and a verb removed
+//! stops being advertised. And a refused call carries **the code the table
+//! declares for that refusal**, read out of `spec.refuses` rather than typed as a
+//! number, so the assertion cannot drift from what `ank help --json` publishes.
+
+use ank_contract::{ExitCode, COMMANDS};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+fn bin(name: &str) -> PathBuf {
+    // The sibling rule the server itself follows: `ank` sits beside `ank-mcp`
+    // because ADR-372b82af1ec7 ships them together. In a test tree that is
+    // `target/<profile>/`, which is also where cargo puts both.
+    let mcp = PathBuf::from(env!("CARGO_BIN_EXE_ank-mcp"));
+    let dir = mcp.parent().expect("a built binary has a directory");
+    let exe = if cfg!(windows) {
+        format!("{name}.exe")
+    } else {
+        name.to_string()
+    };
+    dir.join(exe)
+}
+
+/// A corpus with one task, built through the binary rather than by writing files.
+fn corpus() -> PathBuf {
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let root = std::env::temp_dir().join(format!(
+        "ank-mcp-it-{}-{}",
+        std::process::id(),
+        SEQ.fetch_add(1, Ordering::Relaxed)
+    ));
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    std::fs::write(root.join("src/main.rs"), "fn main() {}\n").unwrap();
+
+    let git = |args: &[&str]| {
+        let out = Command::new("git")
+            .args(args)
+            .current_dir(&root)
+            .output()
+            .expect("git is a hard dependency of this repository");
+        assert!(
+            out.status.success(),
+            "git {args:?}: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    };
+    git(&["init", "-q", "-b", "main"]);
+    git(&["config", "user.email", "test@ank.local"]);
+    git(&["config", "user.name", "Test"]);
+    git(&["config", "commit.gpgsign", "false"]);
+
+    let ank = bin("ank");
+    assert!(
+        ank.is_file(),
+        "the CLI must be built beside the server: cargo build --workspace"
+    );
+    let run = |args: &[&str]| {
+        let out = Command::new(&ank)
+            .args(args)
+            .current_dir(&root)
+            .env("ANK_AGENT", "test@ank.local")
+            .output()
+            .expect("the binary must have been built");
+        assert!(
+            out.status.success(),
+            "ank {args:?}: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    };
+    run(&["init"]);
+    run(&["config", "default_branch", "main"]);
+    run(&[
+        "new",
+        "task",
+        "--title",
+        "A task to find",
+        "--scope",
+        "src/**",
+        "--criteria",
+        "A verifiable criterion.",
+    ]);
+    git(&["add", "-A"]);
+    git(&["commit", "-qm", "a corpus"]);
+    root
+}
+
+/// Sends every request, closes stdin, and returns the reply lines in order.
+fn talk(repo: &Path, requests: &[&str]) -> Vec<String> {
+    let mut child = Command::new(bin("ank-mcp"))
+        .arg("--repo")
+        .arg(repo)
+        .env("ANK_BIN", bin("ank"))
+        .env("ANK_AGENT", "test@ank.local")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("the server must have been built");
+    {
+        let stdin = child.stdin.as_mut().expect("piped");
+        for request in requests {
+            writeln!(stdin, "{request}").expect("the server must accept a request");
+        }
+    }
+    let out = child.wait_with_output().expect("the server must finish");
+    assert!(
+        out.status.success(),
+        "the server exited {:?}: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| l.to_string())
+        .collect()
+}
+
+/// A crude field read, deliberately: pulling one value out of a reply needs no
+/// parser, and a parser here would be a second reading of the surface under test.
+fn field(line: &str, key: &str) -> Option<String> {
+    let needle = format!("\"{key}\":");
+    let start = line.find(&needle)? + needle.len();
+    let rest = &line[start..];
+    let rest = rest.trim_start();
+    if let Some(stripped) = rest.strip_prefix('"') {
+        let end = stripped.find('"')?;
+        return Some(stripped[..end].to_string());
+    }
+    let end = rest
+        .find(|c: char| c == ',' || c == '}')
+        .unwrap_or(rest.len());
+    Some(rest[..end].trim().to_string())
+}
+
+#[test]
+fn the_surface_it_advertises_is_the_table_and_nothing_else() {
+    let repo = corpus();
+    let replies = talk(
+        &repo,
+        &[
+            r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{}}}"#,
+            r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#,
+            r#"{"jsonrpc":"2.0","id":2,"method":"tools/list"}"#,
+        ],
+    );
+
+    // The notification must not have been answered: two requests carried an id,
+    // so two replies is the whole of what a correct server sends.
+    assert_eq!(
+        replies.len(),
+        2,
+        "a notification was answered, which is a protocol error on our side: {replies:?}"
+    );
+    assert_eq!(field(&replies[0], "name").as_deref(), Some("ank-mcp"));
+
+    let listed: Vec<String> = replies[1]
+        .split("\"name\":\"ank_")
+        .skip(1)
+        .map(|s| s.split('"').next().unwrap_or("").to_string())
+        .collect();
+    let table: Vec<String> = COMMANDS.iter().map(|c| c.name.to_string()).collect();
+    assert_eq!(
+        listed, table,
+        "the advertised surface is not the table, in the table's order. \
+         ADR-372b82af1ec7 allows a full-surface passthrough and nothing else, so \
+         any difference here is either a curated subset or a list somebody wrote \
+         by hand"
+    );
+
+    let _ = std::fs::remove_dir_all(&repo);
+}
+
+#[test]
+fn a_refused_call_carries_the_code_the_table_declares() {
+    let repo = corpus();
+
+    // The expectation comes out of the table, not out of this file: `show`
+    // declares that it refuses an unknown id, and with which code.
+    let show = ank_contract::spec_of("show").expect("show is a verb");
+    let declared = show
+        .refuses
+        .iter()
+        .find(|r| r.code == ExitCode::NotFound)
+        .expect("show declares a refusal for an entity that is not there");
+
+    let replies = talk(
+        &repo,
+        &[
+            r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"ank_show","arguments":{"arguments":["TASK-000000000000"]}}}"#,
+        ],
+    );
+    assert_eq!(replies.len(), 1, "{replies:?}");
+    let reply = &replies[0];
+
+    assert_eq!(
+        field(reply, "exitCode").as_deref(),
+        Some(declared.code.code().to_string().as_str()),
+        "a refusal must carry the code the table declares for it ({}): {reply}",
+        declared.when
+    );
+    assert_eq!(
+        field(reply, "isError").as_deref(),
+        Some("true"),
+        "a refusal is an error result and not a silent success: {reply}"
+    );
+    // The refusal is the CLI's own, inherited rather than re-derived: the
+    // self-correcting hint travels with it.
+    assert!(
+        reply.contains("error[2]") && reply.contains("ank find"),
+        "the CLI's own error and its hint must survive the passthrough: {reply}"
+    );
+
+    let _ = std::fs::remove_dir_all(&repo);
+}
+
+#[test]
+fn the_server_refuses_a_flag_that_would_make_it_two_corpora() {
+    let repo = corpus();
+    let replies = talk(
+        &repo,
+        &[
+            r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"ank_find","arguments":{"repo":"/somewhere/else"}}}"#,
+            r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"ank_find","arguments":{"nonsense":"x"}}}"#,
+        ],
+    );
+    assert!(
+        replies[0].contains("belongs to the server"),
+        "--repo must be refused by name: one process speaks for one corpus \
+         (ADR-372b82af1ec7): {}",
+        replies[0]
+    );
+    assert!(
+        replies[1].contains("takes no --nonsense"),
+        "a flag the verb does not take is refused by name, against the table: {}",
+        replies[1]
+    );
+    let _ = std::fs::remove_dir_all(&repo);
+}


### PR DESCRIPTION
`ank-mcp`, a sibling binary in this workspace, exposes every verb the CLI
dispatches over MCP. ADR-372b82af1ec7 permits a full-surface passthrough or no
surface at all, and its condition is met: `ank-contract` holds the table both
surfaces consume and the shape of every document a verb returns.

**Nothing in the crate names a verb.** The tool list is `COMMANDS` walked, so a
verb the table gains reaches the protocol with no edit here, and a verb it does
not carry is a verb this surface does not have.

**One process speaks for one corpus**, addressed once at startup the way `--repo`
addresses one. A per-call repository would make one server several corpora and
invent an arbitration `refs/ank/*` cannot carry. Three globals are withheld from
clients and none of them is a verb: `--repo`, `--json`, `--quiet`.

**It refuses on state, never on identity.** A call spawns the CLI beside it and
returns what the CLI returned: the document unchanged, envelope included, and on
refusal the exit code as the reason rather than a message re-derived here. Writes
go out under a typed identity, and one stdio server is one client.

`json.rs` moved from `ank-cli` to `ank-contract` and is re-exported under the path
the call sites already name, so the two surfaces share one writer. No new crate
enters the tree: JSON-RPC is read with `serde_yaml`, already present, since YAML
1.2 is a superset of JSON.

The test drives the built binary as a process and was falsified before it was
trusted: hiding one verb from the list makes it fail, naming the curated subset
ADR-372b forbids.

```
tools advertised   22, against 22 verbs in COMMANDS, in the table's order
refusal            a claim on a done task returns exitCode 6, error[6] with its hint
verb list          untouched; skill/SKILL.md untouched
cargo test         579 passed, 0 failed
cargo fmt --check  clean
ank check          exit 0, 0 faults
```

Closes TASK-e819448560e7, proof `commit:fa55d32`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUXxdu36kBeqRJ2DchTi2K
