### PR TITLE
A ratification records the actor that ran it, on the entity

### DIFF
--- a/.ank/entities/LOG-50758e7bc698.md
+++ b/.ank/entities/LOG-50758e7bc698.md
@@ -1,0 +1,13 @@
+---
+id: LOG-50758e7bc698
+type: log
+title: done, proof commit:985cdc11749756d3d4136ce841eba30290895e56
+created: 2026-08-18T04:27:28Z
+author: haksolot@vmi3223161
+scope:
+  - crates/ank-cli/src/human.rs
+about: TASK-5d38636bb4e5
+seq: 3
+schema: 3
+version: 1
+---

--- a/.ank/entities/LOG-b905874a7bc5.md
+++ b/.ank/entities/LOG-b905874a7bc5.md
@@ -1,0 +1,15 @@
+---
+id: LOG-b905874a7bc5
+type: log
+title: "correction to LOG-f402b94050ed: the discrepancy it records does not exist, and I measured it with"
+created: 2026-08-18T03:39:53Z
+author: haksolot@vmi3223161
+scope:
+  - crates/ank-cli/src/human.rs
+about: TASK-5d38636bb4e5
+seq: 2
+schema: 3
+version: 1
+---
+
+ the wrong binary. The ank on PATH is the npm 0.3.0 prebuilt, older than this tree; it reports error: TASK-34d27790dba9: dead scope 'viewer/**' and exits 8. The binary built from this checkout reports no fault at all and exits 0, on the same corpus, on a stashed clean tree at 1a9a15d as well as with this work applied. So ank check is green before and after, and the criterion's premise holds. The lesson is the one CLAUDE.md already states for Windows and which is not a Windows lesson: dogfooding measures the corpus with whatever ank is on PATH, and that is not necessarily the ank this tree builds. Measured after the change: exit 0, and the only findings this branch adds are my own two log entries and the discrepancy record above. The new self-ratification signal fires on nothing here, correctly -- every ratification in this corpus predates the reading, and nothing is migrated by a rule it predates.

--- a/.ank/entities/LOG-e66351562b79.md
+++ b/.ank/entities/LOG-e66351562b79.md
@@ -1,0 +1,15 @@
+---
+id: LOG-e66351562b79
+type: log
+title: design decided before writing code, and it is the open question in the body. The record goes on the
+created: 2026-08-18T03:26:15Z
+author: haksolot@vmi3223161
+scope:
+  - crates/ank-cli/src/human.rs
+about: TASK-5d38636bb4e5
+seq: 0
+schema: 3
+version: 1
+---
+
+ entity as a verified reading, not as a new field beside ratified. A new field is a format change: SPEC-acee5d9cb21b tabulates the optional fields of ADR and spec, revising a ratified document is a supersession, and a supersession waits on a human accept -- so a field would block this task on an act I cannot perform, and the criterion mentions no spec work. verified already exists in the format, in the registry, in the parser and in the writer: it costs no schema bump and no golden. Its declared meaning is the one this task needs -- 'somebody read this entity and stands behind it' (SPEC-acee, section 3) -- which is what a ratification is, and its by is typed by ADR-3877fef1d662, so human:marie and claude-code/opus-5 are distinguishable exactly as the criterion asks. Side effect and it is the right one: an agent ratifying an agent-authored ADR no longer silences 'written by an agent and read by no human', and a human ratifying it does.

--- a/.ank/entities/LOG-f402b94050ed.md
+++ b/.ank/entities/LOG-f402b94050ed.md
@@ -1,0 +1,15 @@
+---
+id: LOG-f402b94050ed
+type: log
+title: "discrepancy: the criterion says 'cargo test --workspace and ank check stay green', and ank check is"
+created: 2026-08-18T03:31:37Z
+author: haksolot@vmi3223161
+scope:
+  - crates/ank-cli/src/human.rs
+about: TASK-5d38636bb4e5
+seq: 1
+schema: 3
+version: 1
+---
+
+ not green on main before this task starts. Measured on a stashed, clean tree at 1a9a15d: exit 8, one fault, error: TASK-34d27790dba9: dead scope 'viewer/**': no file matches it. That task is closed and the directory was withdrawn from this repository by ADR-894defc26f3d, so the scope is dead by decision rather than by accident. It is not mine to repair under a frozen criterion and it is not caused by this work: my measure is therefore that check reports the same one fault after this change as before it, and no new finding. The self-ratification finding this task adds is a signal, so it cannot change the exit code either way.

--- a/.ank/entities/TASK-5d38636bb4e5.md
+++ b/.ank/entities/TASK-5d38636bb4e5.md
@@ -5,15 +5,20 @@ slug: accept-records-that-a-key-authorised-a-ratificat
 title: accept records that a key authorised a ratification, never who ran it
 created: 2026-08-16T19:57:10Z
 author: claude-code/opus-5
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/src/human.rs
 blocked_by: []
 done_criteria: |
   A ratification records the actor that ran it, so one an agent performed under a cached credential is distinguishable from one a human typed at the keyboard, and the record survives in the corpus rather than only in the commit. check reports the case where the actor that ratified is the actor that authored, as a signal and never as a fault, because a solo maintainer does that legitimately. The record is not a defence and the task does not add one: an actor value can be set to anything, and the bargain is the same one ADR-6b3f19e08a24 already makes. Tests cover a ratification by a human, one by an agent, and the self-ratification signal, through the binary. cargo test --workspace and ank check stay green.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 985cdc11749756d3d4136ce841eba30290895e56
+    criteria: bdd3f7e06f32
+    via: submitted
 schema: 3
-version: 2
+version: 3
 ---
 
 Three ratifications happened on 2026-08-16 -- ADR-782a3556cf2d, SPEC-93531977642f

--- a/.ank/entities/TASK-5d38636bb4e5.md
+++ b/.ank/entities/TASK-5d38636bb4e5.md
@@ -5,7 +5,7 @@ slug: accept-records-that-a-key-authorised-a-ratificat
 title: accept records that a key authorised a ratification, never who ran it
 created: 2026-08-16T19:57:10Z
 author: claude-code/opus-5
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/src/human.rs
 blocked_by: []
@@ -13,7 +13,7 @@ done_criteria: |
   A ratification records the actor that ran it, so one an agent performed under a cached credential is distinguishable from one a human typed at the keyboard, and the record survives in the corpus rather than only in the commit. check reports the case where the actor that ratified is the actor that authored, as a signal and never as a fault, because a solo maintainer does that legitimately. The record is not a defence and the task does not add one: an actor value can be set to anything, and the bargain is the same one ADR-6b3f19e08a24 already makes. Tests cover a ratification by a human, one by an agent, and the self-ratification signal, through the binary. cargo test --workspace and ank check stay green.
 criteria_by: creator
 schema: 3
-version: 1
+version: 2
 ---
 
 Three ratifications happened on 2026-08-16 -- ADR-782a3556cf2d, SPEC-93531977642f

--- a/crates/ank-cli/src/human.rs
+++ b/crates/ank-cli/src/human.rs
@@ -2171,6 +2171,40 @@ fn check_authorship(
         ));
     }
 
+    // A decision whose ratification names the actor that wrote it
+    // (TASK-5d38636bb4e5). `accept` records the actor that ran it as a reading
+    // (§3), and this is the one shape that reading exists to make legible:
+    // self-ratification is what the human act is there to prevent, and until
+    // the reading existed nothing in the corpus could say it had happened.
+    //
+    // **A signal and never a fault**, which is not a hedge. A solo maintainer
+    // writes the ADR and ratifies it, legitimately and every time; a rule that
+    // reddened over it would redden this corpus wholesale and be silenced
+    // within a week. What is worth reporting is that the two identities are the
+    // same, and the reader is who decides what that is worth.
+    //
+    // Derived from what the fields state and nothing further. The reading says
+    // an actor stands behind this entity and the anchor says it is ratified;
+    // together they are the statement below, and neither is asked to prove it
+    // — an actor value can be set to anything, exactly as ADR-6b3f19e08a24
+    // already concedes for every freeze in the system.
+    for e in &created_deliberately {
+        let Some(view) = Anchored::of(e) else {
+            continue;
+        };
+        if view.status != AdrStatus::Accepted || view.ratified.is_none() {
+            continue;
+        }
+        let Some(author) = author_of(e) else { continue };
+        if !readings_of(e).iter().any(|v| v.by == author) {
+            continue;
+        }
+        report.findings.push(Finding::signal(
+            e.id(),
+            format!("ratified by its own author ({author})"),
+        ));
+    }
+
     // Burst creation by a single identity (§3, §4). §3 accepts task flooding
     // without a quota, on the argument that the defence is visibility rather
     // than restriction. This is that visibility, and nothing more: a burst is
@@ -3275,7 +3309,7 @@ pub fn accept(
     // an ADR that stayed `proposed`. Neither test reached this line — both
     // assert refusals — which is the shape CLAUDE.md warns about, found by a
     // test that finally ran the commit.
-    promote(&mut entity, anchor.clone());
+    promote(&mut entity, anchor.clone(), identity);
 
     let mut paths = Vec::new();
 
@@ -3365,20 +3399,48 @@ fn succession_command(id: &EntityId) -> String {
     format!("ank new {} --supersedes {id}", id.kind().as_str())
 }
 
-/// Writes the promotion `accept` has just authorised.
+/// Writes the promotion `accept` has just authorised, and the reading that
+/// records who ran it.
 ///
 /// The two arms are the two kinds that carry an anchor, and nothing else about
 /// them differs here: the status is the same enum and the anchor is the same
 /// hash, computed over the text [`Anchored`] named.
-fn promote(entity: &mut Entity, anchor: String) {
+///
+/// **The reading is the record §8 was missing** (TASK-5d38636bb4e5). The
+/// signature on the ratification commit says *this key authorised it*, which is
+/// true of an agent typing under a cached passphrase as much as of a human at a
+/// keyboard, and the entity itself said nothing at all about the act: `ratified`
+/// holds a hash, `author` names whoever ran `new`. Three ratifications in this
+/// corpus were performed by an agent at the maintainer's instruction, and the
+/// corpus read back as three decisions a human stood behind.
+///
+/// It goes into `verified` rather than into a field of its own, and the choice
+/// is the field's own definition rather than an economy: `verified` records that
+/// an actor read this entity and stands behind it (§3), which is what a
+/// ratification *is*, and its `by` carries the typed-actor convention
+/// (ADR-3877fef1d662) — so `human:marie` and `claude-code/opus-5` are
+/// distinguishable, which is the whole of what this buys.
+///
+/// **It is a record and not a defence**, on the same bargain ADR-6b3f19e08a24
+/// makes everywhere else: `$ANK_AGENT` is declared and never proved, so an agent
+/// can write `human:` in front of its own name. What it buys is that an honest
+/// ratification leaves a trace, and that a reader can tell the two cases apart
+/// instead of being told they are identical.
+fn promote(entity: &mut Entity, anchor: String, by: &str) {
+    let reading = Verified {
+        by: by.to_string(),
+        at: claim::now_utc(),
+    };
     match entity {
         Entity::Adr(a) => {
             a.status = AdrStatus::Accepted;
             a.ratified = Some(anchor);
+            a.verified.push(reading);
         }
         Entity::Spec(s) => {
             s.status = AdrStatus::Accepted;
             s.ratified = Some(anchor);
+            s.verified.push(reading);
         }
         // `Anchored::of` refused these before anything was read, and stating it
         // is cheaper than a silent no-op if that ever stops being true.

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -981,6 +981,180 @@ fn a_ratification_commit_stripped_of_its_signature_is_a_fault_through_the_binary
     );
 }
 
+/// An ADR written through the binary, so it carries the `author` the signals
+/// under test read.
+///
+/// `seed_adr` writes a schema 1 file with no author at all, which is the corpus
+/// that predates the field — and every actor signal skips it by design (§3). A
+/// fixture for *who ratified what* cannot be built out of entities that say
+/// nobody wrote them, so this one goes through `new` and lets the verb resolve
+/// `$ANK_AGENT` the way a real write does.
+fn new_adr(r: &Repo, author: &str, constraint: &str) -> String {
+    let out = r.ank(
+        author,
+        &[
+            "new",
+            "adr",
+            "--title",
+            "A decision",
+            "--scope",
+            "src/**",
+            "--constraint",
+            constraint,
+        ],
+    );
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    stdout(&out)
+        .split_whitespace()
+        .nth(1)
+        .expect("created <id> <slug>")
+        .to_string()
+}
+
+/// A repository whose `src/**` exists and whose signing key is declared, which
+/// is the ground every ratification fixture below needs: a scope matching
+/// nothing is a fault of its own, and an undeclared key puts §8 in advisory
+/// mode where no signature is judged at all.
+fn ready_to_ratify() -> Repo {
+    let r = Repo::new();
+    r.enable_signing();
+    declare_signing_key(&r);
+    std::fs::create_dir_all(r.0.join("src")).unwrap();
+    std::fs::write(r.0.join("src/main.rs"), "fn main() {}\n").unwrap();
+    r
+}
+
+/// The hole TASK-5d38636bb4e5 names, closed: a ratification records the actor
+/// that ran it, and the record is in the corpus rather than only in the commit.
+///
+/// Three ratifications in this project's own corpus were typed by an agent
+/// under a passphrase the maintainer's gpg-agent had cached, at the
+/// maintainer's instruction. Every mechanism in §8 reported exactly what it was
+/// built to report, and none of them could say that: the signature says *this
+/// key authorised it*, and a cached passphrase makes that true of an agent's
+/// keystroke as well as of a human's.
+///
+/// Through the binary because that is where the identity comes from. The record
+/// is whatever `$ANK_AGENT` resolved to in the process that ran `accept`, and
+/// no unit test over `promote` reaches an environment variable.
+#[test]
+fn a_ratification_by_a_human_is_recorded_as_a_human_reading() {
+    let r = ready_to_ratify();
+    let id = new_adr(&r, "claude-code/opus-5", "Do not do X.");
+    r.git(&["add", "-A"]);
+    r.git(&["commit", "-qm", "seed"]);
+
+    let out = r.ank("human:marie", &["accept", &id]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+
+    let text = r.adr_text(&id);
+    assert!(
+        text.contains("verified:\n  - by: human:marie\n    at: "),
+        "the actor that ran accept is on the entity, typed: {text}"
+    );
+
+    // The record survives a read through the binary, which is the half that
+    // makes it a record rather than a byte in a file nobody is allowed to open.
+    let out = r.ank("claude-code/opus-5", &["show", &id]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    assert!(stdout(&out).contains("by: human:marie"), "{}", stdout(&out));
+
+    // And it is not the self-ratification case: an agent wrote the decision, a
+    // human ratified it, and that is the shape §8 exists to produce.
+    let out = r.ank("claude-code/opus-5", &["check"]);
+    assert_eq!(code(&out), 0, "{}{}", stdout(&out), stderr(&out));
+    assert!(
+        !stdout(&out).contains("ratified by its own author"),
+        "{}",
+        stdout(&out)
+    );
+
+    // The reading a human left is also what silences the signal that says an
+    // agent wrote this and nobody read it — because now somebody has.
+    assert!(
+        !stdout(&out).contains("read by no human"),
+        "a human ratification is a human reading: {}",
+        stdout(&out)
+    );
+}
+
+/// The other half of the same distinction: an agent ratifying leaves a record
+/// that says so, and it does not pass for a human one.
+///
+/// This is the case that was invisible. The commit is signed, `check` verifies
+/// it against `.ank/allowed_signers`, and the corpus used to read back as a
+/// decision a human stood behind — because the only thing recorded was the
+/// signature, and the key is not the hand that typed.
+///
+/// **The record is not a defence and this test does not pretend otherwise.**
+/// `$ANK_AGENT` is declared and never proved, so the agent below could have
+/// written `human:` in front of its own name, exactly as ADR-6b3f19e08a24
+/// already concedes for every freeze in the system. What is asserted is that an
+/// honest ratification leaves a trace a reader can tell apart.
+#[test]
+fn a_ratification_by_an_agent_is_recorded_as_an_agent_reading() {
+    let r = ready_to_ratify();
+    let id = new_adr(&r, "human:marie", "Do not do X.");
+    r.git(&["add", "-A"]);
+    r.git(&["commit", "-qm", "seed"]);
+
+    let out = r.ank("claude-code/opus-5", &["accept", &id]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+
+    let text = r.adr_text(&id);
+    assert!(
+        text.contains("verified:\n  - by: claude-code/opus-5\n    at: "),
+        "the agent that ran accept is named as one: {text}"
+    );
+    assert!(
+        !text.contains("by: human:"),
+        "nothing turns an agent's keystroke into a human act: {text}"
+    );
+
+    // The signature is real and declared, so §8 is satisfied and says nothing.
+    // That is the point: the ratification is valid, and the record is what
+    // distinguishes it from the one above rather than what refuses it.
+    let out = r.ank("human:marie", &["check"]);
+    assert_eq!(code(&out), 0, "{}{}", stdout(&out), stderr(&out));
+    assert!(!stdout(&out).contains("not signed"), "{}", stdout(&out));
+}
+
+/// Self-ratification: the entity's author is the actor that ratified it, and
+/// `check` says so as a signal.
+///
+/// **A signal and never a fault**, and the reason is in the corpus rather than
+/// in a preference. A solo maintainer writes the decision and ratifies it,
+/// legitimately and every time; a rule that reddened over it would redden this
+/// project's own corpus wholesale and be silenced within a week. What is worth
+/// reporting is that the one act meant to come from outside the entity came
+/// from inside it, and the reader is who decides what that is worth.
+#[test]
+fn ratifying_your_own_decision_is_a_signal_and_never_a_fault() {
+    let r = ready_to_ratify();
+    let id = new_adr(&r, "human:marie", "Do not do X.");
+    r.git(&["add", "-A"]);
+    r.git(&["commit", "-qm", "seed"]);
+
+    let out = r.ank("human:marie", &["accept", &id]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+
+    let out = r.ank("human:marie", &["check"]);
+    assert_eq!(
+        code(&out),
+        0,
+        "a signal is not a finding that reddens: {}{}",
+        stdout(&out),
+        stderr(&out)
+    );
+    let said = stdout(&out);
+    assert!(
+        said.contains(&format!(
+            "signal: {id}: ratified by its own author (human:marie)"
+        )),
+        "the signal names the entity and the actor: {said}"
+    );
+}
+
 /// `ank status` answers where am I, in one command (TASK-15336a0012d5).
 ///
 /// The four scenarios the task names, in order: orientation with no claim,

--- a/docs/format.md
+++ b/docs/format.md
@@ -481,6 +481,16 @@ copy in the file is written by whoever writes the file. A verifier walks the
 entity's own path history with `--full-history` and takes the first such commit
 (§3).
 
+**`accept` also records who ran it**, as a `verified` entry naming the typed
+actor and the instant. The signature on the ratification commit says that a key
+authorised the act, which is true of an agent typing under a cached passphrase as
+much as of a human at a keyboard, so the entity carries the actor as well. It is
+a record and not a defence: an actor value is declared and never proved, exactly
+as `author` is, and what it buys is that an honest ratification leaves a trace a
+reader can tell apart. `ank check` reports a decision whose ratifying actor is
+its own author as a signal, never as a fault, because a solo maintainer does that
+legitimately.
+
 **The key names what was hashed**, and there are two because there are two kinds
 that carry an anchor: `constraint+scope: <hash>` on an ADR, `body+scope: <hash>`
 on a spec. A spec declares no `constraint`, that absence being what justifies the


### PR DESCRIPTION
Closes TASK-5d38636bb4e5.

## The hole

The signature on a ratification commit says *this key authorised it*. A cached
passphrase makes that true of an agent's keystroke as much as of a human's, and
the entity said nothing at all about who typed: `ratified` holds a hash,
`author` names whoever ran `new`.

Three ratifications in this corpus were performed by an agent at the
maintainer's explicit instruction, from a phone, under a passphrase gpg-agent
had cached — ADR-782a3556cf2d, SPEC-93531977642f and SPEC-dbbd533cbc78. Every
mechanism in §8 reported exactly what it was built to report, and none of them
could say that. Read the corpus back and it said a human ratified three
decisions an agent wrote, with no trace of the delegation.

## What changed

`accept` records the actor that ran it as a `verified` reading on the entity.
The `by` carries the typed-actor convention (ADR-3877fef1d662), so
`human:marie` and `claude-code/opus-5` are distinguishable — which is the whole
of what this buys.

`check` reports a decision whose ratifying actor is its own author as a
**signal, never a fault**. A solo maintainer writes the decision and ratifies
it, legitimately and every time; a rule that reddened over it would redden this
corpus wholesale and be silenced within a week.

**It is a record and not a defence, and the task did not add one.** An actor
value is declared and never proved, the same bargain ADR-6b3f19e08a24 makes for
every freeze in the system. What it buys is that an honest ratification leaves
a trace a reader can tell apart, not that a dishonest one becomes impossible.

## Why `verified` and not a new field

The task body left the choice open: a field beside `ratified:`, or the commit
message. The criterion rules out the commit alone — the record has to survive
in the corpus — and a new field is a format change: SPEC-acee5d9cb21b tabulates
the optional fields of ADR and spec, revising a ratified document is a
supersession, and a supersession waits on a human `accept`. That would have
blocked this task on an act an agent cannot perform, and the criterion mentions
no spec work.

`verified` already exists in the format, in the registry, in the parser and in
the writer, and its declared meaning is the one this needs: *an actor read this
entity and stands behind it* (§3). No new field, no schema bump, no golden.

Side effect, and it is the right one: an agent ratifying an agent-authored ADR
no longer silences `written by an agent and read by no human`, and a human
ratifying it does.

## What the specification still does not say

SPEC-3d12 §8 is silent rather than wrong: nothing in it contradicts the record,
and nothing in it mentions that `accept` now writes a reading. The behaviour is
documented in `docs/format.md`, which is not a ratified entity. Closing that
gap is a supersession, and therefore a human act.

## Verification

Three tests through the binary — a ratification by a human, one by an agent,
and the self-ratification signal — because the record is whatever `$ANK_AGENT`
resolved to in the process that ran `accept`, and no unit test over `promote`
reaches an environment variable.

Negative-controlled: with the record removed from `promote`, all three fail and
nothing else in the suite does.

- `cargo test --workspace` — 584 passed, 0 failed
- `cargo fmt --check` — clean
- `ank check` — exit 0, and the new signal fires on nothing in this corpus,
  correctly: every ratification here predates the reading, and nothing is
  migrated by a rule it postdates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012q8GJvbpXeLoGC7ep94zgs