### PR TITLE
A release is published under a credential that starts the channels

### DIFF
--- a/.ank/entities/ADR-768374fe6076.md
+++ b/.ank/entities/ADR-768374fe6076.md
@@ -5,7 +5,7 @@ slug: a-release-is-published-under-a-credential-that-i
 title: A release is published under a credential that is not the default token
 created: 2026-08-18T18:16:52Z
 author: claude-code/opus-5
-status: accepted
+status: proposed
 scope:
   - .github/workflows/release.yml
   - .github/workflows/publish-brew.yml
@@ -18,9 +18,8 @@ constraint: |
   Every distribution channel this repository serves triggers on release: types: [published] and reads its version from github.event.release.tag_name. A channel may not be reached by workflow_run, by repository_dispatch, or by any other chain: those produce runs whose event is not release, and the event is what the channel's trigger and this repository's measurement both name.
   
   A workflow that publishes a release asserts, in the same run, that the channels it exists to feed have started on that tag, and is red when they have not.
-ratified: ab3b9ed512ae
 schema: 3
-version: 2
+version: 3
 ---
 
 Measured on 2026-08-16, cutting v0.3.0. The release run was green end to end and

--- a/.ank/entities/ADR-768374fe6076.md
+++ b/.ank/entities/ADR-768374fe6076.md
@@ -1,0 +1,73 @@
+---
+id: ADR-768374fe6076
+type: adr
+slug: a-release-is-published-under-a-credential-that-i
+title: A release is published under a credential that is not the default token
+created: 2026-08-18T18:16:52Z
+author: claude-code/opus-5
+status: accepted
+scope:
+  - .github/workflows/release.yml
+  - .github/workflows/publish-brew.yml
+  - .github/workflows/publish-scoop.yml
+  - .github/workflows/publish-apt.yml
+  - .github/workflows/publish-winget.yml
+constraint: |
+  The job that creates a GitHub release calls gh under a credential other than the workflow's default GITHUB_TOKEN, held as the repository secret RELEASE_TOKEN: a fine-grained personal access token scoped to this repository with Contents: write and nothing else. No job in release.yml is granted contents: write, and no step falls back to the default token when the secret is absent -- the run refuses the tag before the matrix is spent, naming the command that sets it.
+  
+  Every distribution channel this repository serves triggers on release: types: [published] and reads its version from github.event.release.tag_name. A channel may not be reached by workflow_run, by repository_dispatch, or by any other chain: those produce runs whose event is not release, and the event is what the channel's trigger and this repository's measurement both name.
+  
+  A workflow that publishes a release asserts, in the same run, that the channels it exists to feed have started on that tag, and is red when they have not.
+ratified: ab3b9ed512ae
+schema: 3
+version: 2
+---
+
+Measured on 2026-08-16, cutting v0.3.0. The release run was green end to end and
+not one of publish-brew, publish-scoop, publish-apt or publish-winget started.
+The cause is a GitHub rule and not a defect in any of the five files: a workflow
+run is never started by an event the default `GITHUB_TOKEN` produced, which is
+what stops a workflow triggering itself. So `gh release create` under
+`${{ github.token }}` publishes the files and reaches nothing, and the release
+had to be completed by hand -- `gh release edit --draft=true` then `--draft=false`
+from the maintainer's own token -- which is a human standing at the tag and not a
+pipeline.
+
+Two strategies were available and only one survives the measurement this project
+makes. Chaining inside Actions -- `workflow_run` on the completion of `release`,
+or a `repository_dispatch` from the publish job -- needs no second credential,
+and produces runs whose event is `workflow_run` or `repository_dispatch`. That is
+not a nuance: the four channels trigger on `release: published` and derive from
+`github.event.release.tag_name`, so chaining would mean rewriting the branch of
+each of them that carries `--require-all` and commits to the default branch, in
+exchange for runs that no longer say which release they served. The event is the
+join between a tag and what a tag reached, and giving it up costs more than the
+credential does.
+
+So: a credential. The shape was the maintainer's to choose and was chosen as a
+fine-grained PAT rather than a GitHub App. The App mints a token that expires in
+an hour, which is the better exposure, at the price of an App to create, install
+and hold two secrets for. This repository already carries a PAT of exactly this
+shape for the winget fork (`WINGET_TOKEN`, LOG-386ff0c2aa25), so the second one
+is another instance of an object the maintainer already renews rather than a new
+class of thing to learn. That trade is recorded here because it is the part a
+future reader would otherwise have to guess, and because the day the PAT is one
+secret too many, the App is what replaces it and this is the paragraph that
+should be rewritten.
+
+What the constraint refuses is the quiet failure, twice over. A step that fell
+back to `github.token` when `RELEASE_TOKEN` was missing would publish a release
+and start nothing, green -- the exact defect, restored by the mechanism meant to
+be forgiving. And a release run that ends at `gh release create` cannot tell
+whether anything downstream of it happened, which is why v0.3.0 was invisible
+until somebody looked at a channel and found it at the previous version. The
+assertion in the same run is the same decision ADR-af53d0b62a5c made about a ref
+that does not reach the remote: a write whose only product is elsewhere is not
+finished until the elsewhere is checked.
+
+The write capability moves with the credential. `release.yml` used to grant
+`contents: write` to its publish job and to nothing else, on the argument that
+`build` -- which runs code from the tree on four machines -- must not be able to
+reach the release. With the release created under `RELEASE_TOKEN`, that argument
+is served better: no job holds write at all, and the one capability in the file
+is a secret named in one step's `env`.

--- a/.ank/entities/LOG-1b742efde8c6.md
+++ b/.ank/entities/LOG-1b742efde8c6.md
@@ -1,0 +1,23 @@
+---
+id: LOG-1b742efde8c6
+type: log
+title: Not closable here, and it was known before the work started. The criterion is measured on a tag --
+created: 2026-08-18T18:21:20Z
+author: claude-code/opus-5
+scope:
+  - .github/workflows/release.yml
+  - .github/workflows/publish-brew.yml
+  - .github/workflows/publish-scoop.yml
+  - .github/workflows/publish-apt.yml
+  - .github/workflows/publish-winget.yml
+about: TASK-2078ab116f63
+seq: 3
+schema: 3
+version: 1
+---
+
+ 'gh run list names the four with event=release', the three manifests carrying the new version on the default branch, the winget submit job having run -- and none of that can be observed until two acts only the maintainer can perform: gh secret set RELEASE_TOKEN with a fine-grained PAT on this repository, Contents: write, and then a tag pushed. Everything in this tree that the criterion depends on is written and verified: cargo fmt --check passes, cargo test --workspace is 584 passed 0 failed, and the two new scripts were falsified against fixtures rather than merely read.
+
+Recorded here rather than left to the next holder to rediscover: the first run under RELEASE_TOKEN is also the first exercise of the channels job, and if the four do start while --branch fails to match the tag, that job is red on a release that actually worked. The diagnostic it prints separates the two cases by name, and the fix in that case is this file, not the token.
+
+Also discovered, and not in this perimeter: closing TASK-cf8e08128cb4 took check from one fault to three, because a closed task's dead scopes are reported at fault severity forever. Filed as TASK-305cf978d37d rather than repaired by amending a closed task's scope, which would silence check by making the entity lie about what it was about.

--- a/.ank/entities/LOG-58e671ed808a.md
+++ b/.ank/entities/LOG-58e671ed808a.md
@@ -1,0 +1,16 @@
+---
+id: LOG-58e671ed808a
+type: log
+title: "closed: The AUR channel is abandoned: the maintainer has no publisher access to the registry and no"
+created: 2026-08-18T18:06:14Z
+author: haksolot@vmi3223161
+scope:
+  - packaging/aur/**
+  - .github/workflows/publish-aur.yml
+about: TASK-cf8e08128cb4
+seq: 2
+schema: 3
+version: 1
+---
+
+ longer wants the channel. Closed by owner decision, not by any obstacle in this tree.

--- a/.ank/entities/LOG-5e4fa588af0e.md
+++ b/.ank/entities/LOG-5e4fa588af0e.md
@@ -1,0 +1,15 @@
+---
+id: LOG-5e4fa588af0e
+type: log
+title: "closed: Closed by owner decision, alongside the AUR task: the apt channel is no longer of interest,"
+created: 2026-08-18T18:06:30Z
+author: haksolot@vmi3223161
+scope:
+  - .github/workflows/publish-apt.yml
+about: TASK-1674d5b73761
+seq: 0
+schema: 3
+version: 1
+---
+
+ so the release-event deploy gap it records is not worth measuring.

--- a/.ank/entities/LOG-70fa0918b92e.md
+++ b/.ank/entities/LOG-70fa0918b92e.md
@@ -1,0 +1,17 @@
+---
+id: LOG-70fa0918b92e
+type: log
+title: "released: The criterion is wrong entire, not in one clause: it asks for a decision that 16e827b"
+created: 2026-08-18T18:30:41Z
+author: claude-code/opus-5
+scope:
+  - crates/ank-cli/src/repo.rs
+  - crates/ank-cli/src/commands.rs
+  - crates/ank-cli/tests/cli.rs
+about: TASK-305cf978d37d
+seq: 1
+schema: 3
+version: 1
+---
+
+ already made and for a test that cli.rs already carries. Released rather than amended, because there is nothing here to weaken or to strengthen -- the task should not exist. See LOG-e8be2b60525c for the measurement, and note that it was written from a stale binary rather than from the tree.

--- a/.ank/entities/LOG-72548976473e.md
+++ b/.ank/entities/LOG-72548976473e.md
@@ -1,0 +1,23 @@
+---
+id: LOG-72548976473e
+type: log
+title: release.yml carries the fix in three places, and the third is the one the criterion did not ask
+created: 2026-08-18T18:16:18Z
+author: claude-code/opus-5
+scope:
+  - .github/workflows/release.yml
+  - .github/workflows/publish-brew.yml
+  - .github/workflows/publish-scoop.yml
+  - .github/workflows/publish-apt.yml
+  - .github/workflows/publish-winget.yml
+about: TASK-2078ab116f63
+seq: 2
+schema: 3
+version: 1
+---
+
+ for. The publish job reads secrets.RELEASE_TOKEN instead of github.token, and loses the contents: write it used to hold -- with the release created under a PAT, a write on the default token would be a capability nothing uses. The version job, which already exists to refuse before the matrix is spent, now also refuses a tag when RELEASE_TOKEN is empty: a fallback to the default token would republish the exact defect, green and silent. And a new channels job polls for the four runs after publishing, because v0.3.0 was green end to end while none of the four had started -- the same shape as ADR-af53, a write whose only product is elsewhere failing when it does not arrive.
+
+Falsified rather than assumed, on the two new scripts extracted from the YAML and run against fixtures: the credential gate exits 0 on a dispatch, 1 on a tag with no token, 0 on a tag with one; the channels guard exits 0 on four release-event runs on this tag, and 1 on three of four, on four runs whose event is workflow_run, on four on the previous tag, and on none. The workflow_run fixture is the one that matters: it is the strategy the criterion ruled out, and the guard is red on it.
+
+The first draft filtered one gh run list listing with a --jq expression; jq is not installed on this machine, so that expression was untestable anywhere but on a tag. Replaced by --workflow, --event and --branch, three documented flags a fake gh can answer, and the check compares against the literal [] gh prints for no match -- a --json call that failed prints nothing at all, so a broken call cannot read as a run that started. On the deadline the same question is asked once more without --branch, as a diagnostic only: a run that never started and a run on the wrong ref are the same silence and have opposite fixes.

--- a/.ank/entities/LOG-b7a70d98a7f3.md
+++ b/.ank/entities/LOG-b7a70d98a7f3.md
@@ -1,0 +1,17 @@
+---
+id: LOG-b7a70d98a7f3
+type: log
+title: "closed: Already done by 16e827b, decision and test both, and verified by building ank from this"
+created: 2026-08-18T18:30:43Z
+author: claude-code/opus-5
+scope:
+  - crates/ank-cli/src/repo.rs
+  - crates/ank-cli/src/commands.rs
+  - crates/ank-cli/tests/cli.rs
+about: TASK-305cf978d37d
+seq: 2
+schema: 3
+version: 1
+---
+
+ tree: check answers ok and exits 0 on this corpus. The task was written from a binary older than the fix, so it recorded the old binary's verdict as the corpus's state.

--- a/.ank/entities/LOG-d1fe257e5674.md
+++ b/.ank/entities/LOG-d1fe257e5674.md
@@ -1,0 +1,19 @@
+---
+id: LOG-d1fe257e5674
+type: log
+title: "released: Handed back rather than held: the work in this tree is complete and verified, and the"
+created: 2026-08-18T18:25:40Z
+author: claude-code/opus-5
+scope:
+  - .github/workflows/release.yml
+  - .github/workflows/publish-brew.yml
+  - .github/workflows/publish-scoop.yml
+  - .github/workflows/publish-apt.yml
+  - .github/workflows/publish-winget.yml
+about: TASK-2078ab116f63
+seq: 4
+schema: 3
+version: 1
+---
+
+ criterion is measured on a tag, so nothing further can happen here until the maintainer sets RELEASE_TOKEN and pushes one. Holding the claim through that wait would say an agent is working on it when nobody is. Whoever takes it next takes a measurement and not an implementation -- read LOG-72548976473e for what was built and falsified, and LOG-1b742efde8c6 for the one way the new channels job can be red on a release that actually worked.

--- a/.ank/entities/LOG-d42047ba325f.md
+++ b/.ank/entities/LOG-d42047ba325f.md
@@ -1,0 +1,19 @@
+---
+id: LOG-d42047ba325f
+type: log
+title: measured before choosing between the two candidate fixes, and the criterion chooses for us. It
+created: 2026-08-18T05:32:59Z
+author: claude-code/opus-5
+scope:
+  - .github/workflows/release.yml
+  - .github/workflows/publish-brew.yml
+  - .github/workflows/publish-scoop.yml
+  - .github/workflows/publish-apt.yml
+  - .github/workflows/publish-winget.yml
+about: TASK-2078ab116f63
+seq: 0
+schema: 3
+version: 1
+---
+
+ requires 'one run each of publish-brew, publish-scoop, publish-apt and publish-winget whose event is release', verified with gh run list --json name,event. A workflow_run chain produces runs whose event is workflow_run; a repository_dispatch produces repository_dispatch. Neither can ever satisfy that clause, whatever else they get right -- so the second candidate in the body is ruled out by the frozen criterion rather than by preference, and the four workflows keep reading github.event.release.tag_name. Only a real release: published event gives event=release, and only a credential other than the default GITHUB_TOKEN produces one, because GitHub does not start a workflow run from an event the default token created. What is left to choose is the shape of that credential, not the strategy: a long-lived PAT with contents: write, or a GitHub App whose private key is a secret and whose installation token is minted per run and expires in an hour. The second is the same trade the body priced, at a shorter exposure. Both need an act only the maintainer can perform, and the criterion is measured on a tag, so this task cannot close without a release being cut.

--- a/.ank/entities/LOG-e8be2b60525c.md
+++ b/.ank/entities/LOG-e8be2b60525c.md
@@ -1,0 +1,21 @@
+---
+id: LOG-e8be2b60525c
+type: log
+title: "discrepancy: this task's premise is false entire, and the fault is in how it was measured rather"
+created: 2026-08-18T18:30:30Z
+author: claude-code/opus-5
+scope:
+  - crates/ank-cli/src/repo.rs
+  - crates/ank-cli/src/commands.rs
+  - crates/ank-cli/tests/cli.rs
+about: TASK-305cf978d37d
+seq: 0
+schema: 3
+version: 1
+---
+
+ than in the corpus. Commit 16e827b, 'A closed task's dead scope is a signal, and the viewer task is closed', already made exactly the choice the criterion asked for -- the severity is lowered for TaskStatus::Closed and kept for Done, on the argument the criterion itself reached independently: a done task claimed to touch those files and a closed one claimed nothing. The test the criterion required also already exists and is stronger than what was asked: cli.rs::a_closed_task_whose_scope_names_nothing_leaves_check_green drives the binary, asserts exit 0 and the sentence 'the task is closed: nothing is owed' after close, asserts the open task still says 'work not started', and asserts exit 8 once the same entity is flipped to done, so the status is the only variable.
+
+What produced the finding was a stale binary. The ank on PATH is 0.3.0 built at 635c8b1, which git merge-base --is-ancestor confirms predates 16e827b. Built from this tree instead, ank check answers 'ok -- 225 tasks, 49 adr, 212 signal(s)' and exits 0: no fault at all, neither TASK-cf8e08128cb4's two nor TASK-34d27790dba9's one.
+
+So the three faults reported earlier in this session, and the sentence about them in the commit message of 0f12cba, are wrong. Nothing in the corpus needs repair. What is real, and is not this task, is that ank check is the gate CI routes on, and a binary older than the tree answers it with confidence and no warning -- ank --version knows the commit it was built at, and check never compares it with anything.

--- a/.ank/entities/LOG-ecc3a4444cb4.md
+++ b/.ank/entities/LOG-ecc3a4444cb4.md
@@ -1,0 +1,19 @@
+---
+id: LOG-ecc3a4444cb4
+type: log
+title: Credential shape chosen by the maintainer, the strategy having already been chosen by the
+created: 2026-08-18T18:09:11Z
+author: claude-code/opus-5
+scope:
+  - .github/workflows/release.yml
+  - .github/workflows/publish-brew.yml
+  - .github/workflows/publish-scoop.yml
+  - .github/workflows/publish-apt.yml
+  - .github/workflows/publish-winget.yml
+about: TASK-2078ab116f63
+seq: 1
+schema: 3
+version: 1
+---
+
+ criterion: a fine-grained PAT scoped to this repository with Contents: write, held as RELEASE_TOKEN, used by the publish job of release.yml for gh release create and for nothing else. The GitHub App was priced and declined -- it buys a token that expires in an hour at the cost of an App to create, install and hold two secrets for, and this repository already carries a PAT of the same shape (WINGET_TOKEN, LOG-386ff0c2aa25), so the second credential is the same kind of object the maintainer already renews rather than a new class of thing. The four publish workflows are unchanged: they already trigger on release: published and already read github.event.release.tag_name, which is exactly what the ruled-out chaining would have forced them to stop doing.

--- a/.ank/entities/TASK-1674d5b73761.md
+++ b/.ank/entities/TASK-1674d5b73761.md
@@ -5,7 +5,7 @@ slug: the-apt-tree-reaches-pages-from-a-release-not-on
 title: The apt tree reaches Pages from a release, not only from a dispatch
 created: 2026-08-17T02:42:13Z
 author: claude-code/opus-5
-status: open
+status: closed
 scope:
   - .github/workflows/publish-apt.yml
 blocked_by: [TASK-2078ab116f63]
@@ -13,7 +13,7 @@ done_criteria: |
   A run of publish-apt whose event is release deploys the tree to Pages: the job named 'the tree is published to Pages' concludes success on that run, and 'apt-get install ank' runs after it rather than being skipped. Measured on the next tag, or on a release re-published by hand, by gh run view on the publish-apt run for that tag.
 criteria_by: creator
 schema: 3
-version: 1
+version: 2
 ---
 
 Measured on 2026-08-16, on the publish-apt run that a re-published v0.3.0

--- a/.ank/entities/TASK-1dbb6e7843f1.md
+++ b/.ank/entities/TASK-1dbb6e7843f1.md
@@ -1,0 +1,50 @@
+---
+id: TASK-1dbb6e7843f1
+type: task
+slug: a-ratification-that-could-not-be-committed-leave
+title: A ratification that could not be committed leaves nothing behind
+created: 2026-08-18T18:34:43Z
+author: claude-code/opus-5
+status: open
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/tests/cli.rs
+blocked_by: []
+done_criteria: |
+  When the ratification commit fails, accept leaves the entity byte-for-byte as it found it: status, ratified and verified unchanged, and the exit code and message name what failed. Tested through the binary with signing configured to a key accept cannot use, asserting the file is identical before and after and that a second accept -- once signing works -- still ratifies. cargo test --workspace and ank check stay green.
+criteria_by: creator
+schema: 3
+version: 1
+---
+
+Measured on 2026-08-18, ratifying ADR-768374fe6076 on this machine, where the
+ratification key is protected by a passphrase nothing supplied.
+
+`accept` exited 9 with git's message -- `Load key ".../gh_signing": incorrect
+passphrase supplied to decrypt private key?`, `fatal: failed to write commit
+object`. No commit was made. The entity, however, had already been written: it
+came out `status: accepted` carrying `ratified: ab3b9ed512ae`, the correct
+constraint+scope anchor for a ratification that does not exist. `verified` was
+never written, so the entity did not even record who supposedly ran it.
+
+`check` names the state exactly -- "ratified, but no ratification commit is
+reachable: the freeze cannot be verified" -- and names it as a signal, which is
+right for the bootstrap case that clause was written for and generous here: this
+corpus was claiming a binding decision anchored to nothing.
+
+What makes it more than a cosmetic ordering bug is that ank cannot then repair
+it. `accept` over an existing anchor refuses with exit 7 and hints at
+`ank new adr --supersedes`, which is correct for a decision genuinely ratified
+and wrong here: it would succeed a ratification that never happened. The two
+tests around this, `accept_ratifies_an_adr_accepted_by_hand_and_never_anchored`
+and `accept_refuses_an_adr_that_already_carries_an_anchor`, are each right about
+the case they cover, and the failed-commit state falls between them -- accepted,
+anchored, and unreachable. It was repaired here through `ank edit`, which is a
+route out but not one the failure names.
+
+The fix is ordering: the commit is the act, so nothing about the entity is
+written until git has taken it. That is the same argument ADR-af53d0b62a5c makes
+for a write whose only product is a ref, and the same one the refusal above rests
+on -- a refusal "that had rewritten either would be the laundering it exists to
+prevent", in the words of the test. A failure should be held to what the refusal
+already is.

--- a/.ank/entities/TASK-2078ab116f63.md
+++ b/.ank/entities/TASK-2078ab116f63.md
@@ -17,7 +17,7 @@ done_criteria: |
   A tag pushed to this repository produces, with no human touching the release afterwards, one run each of publish-brew, publish-scoop, publish-apt and publish-winget whose event is release. Measured on the next tag: gh run list --limit 20 --json name,event names the four with event=release, Formula/ank.rb, bucket/ank.json and packaging/winget/*.yaml carry the new version on the default branch, and the winget submit job has run.
 criteria_by: creator
 schema: 3
-version: 1
+version: 4
 ---
 
 Measured on 2026-08-16, cutting v0.3.0. The release run was green end to end: the

--- a/.ank/entities/TASK-305cf978d37d.md
+++ b/.ank/entities/TASK-305cf978d37d.md
@@ -5,7 +5,7 @@ slug: a-dead-scope-on-a-task-closed-as-never-to-be-don
 title: A dead scope on a task closed as never-to-be-done is not a fault
 created: 2026-08-18T18:21:09Z
 author: claude-code/opus-5
-status: open
+status: closed
 scope:
   - crates/ank-cli/src/repo.rs
   - crates/ank-cli/src/commands.rs
@@ -15,7 +15,7 @@ done_criteria: |
   ank check does not report a dead scope on a task whose status is closed as an error. The behaviour is decided rather than assumed: either the finding is lowered to a signal for a closed task, or ADR-3094538d831e is superseded to say why a closed task is not the case it excludes. A test through the binary closes a task whose scope names a path no commit ever carried and asserts the severity, and asserts unchanged that an open task with the same scope keeps whatever severity it has today. cargo test --workspace and ank check stay green on the tree.
 criteria_by: creator
 schema: 3
-version: 1
+version: 4
 ---
 
 Measured on 2026-08-18, closing TASK-cf8e08128cb4 on the maintainer's decision

--- a/.ank/entities/TASK-305cf978d37d.md
+++ b/.ank/entities/TASK-305cf978d37d.md
@@ -1,0 +1,52 @@
+---
+id: TASK-305cf978d37d
+type: task
+slug: a-dead-scope-on-a-task-closed-as-never-to-be-don
+title: A dead scope on a task closed as never-to-be-done is not a fault
+created: 2026-08-18T18:21:09Z
+author: claude-code/opus-5
+status: open
+scope:
+  - crates/ank-cli/src/repo.rs
+  - crates/ank-cli/src/commands.rs
+  - crates/ank-cli/tests/cli.rs
+blocked_by: []
+done_criteria: |
+  ank check does not report a dead scope on a task whose status is closed as an error. The behaviour is decided rather than assumed: either the finding is lowered to a signal for a closed task, or ADR-3094538d831e is superseded to say why a closed task is not the case it excludes. A test through the binary closes a task whose scope names a path no commit ever carried and asserts the severity, and asserts unchanged that an open task with the same scope keeps whatever severity it has today. cargo test --workspace and ank check stay green on the tree.
+criteria_by: creator
+schema: 3
+version: 1
+---
+
+Measured on 2026-08-18, closing TASK-cf8e08128cb4 on the maintainer's decision
+that the AUR channel is abandoned. `check` reported one fault before the closure
+and three after it, the two new ones being the closed task's own scopes:
+
+  error: TASK-cf8e08128cb4: dead scope '.github/workflows/publish-aur.yml'
+  error: TASK-cf8e08128cb4: dead scope 'packaging/aur/**'
+
+Neither path ever existed. The task was written before the work and closed
+instead of being done, so its scope names files no commit ever carried -- which
+is precisely the case ADR-3094538d831e keeps at fault severity, and for a good
+reason: "a death git cannot explain, where the reader has nothing". Git is asked
+and has no answer, so the finding does not lower.
+
+The reasoning is right about a live task and inverted about this one. An open
+task whose scope names a path that does not exist yet is a task about files still
+to be written, and a fault there is information. A closed task's scope will never
+be filled by anyone -- that is what closing it means -- so the fault is permanent
+by construction, and permanent by construction is the definition ADR-3094538d831e
+itself gives of the finding to avoid: "a fault nobody can clear is a finding
+readers learn to skip".
+
+The repair must not be to amend the scope. Pointing a closed task at a path that
+happens to exist would silence `check` by making the entity lie about what it was
+about, and the scope is the only thing that says where the abandoned work would
+have gone. The two honest shapes are both in the criterion: lower the severity for
+a closed task, or supersede the ADR to argue that a closed task is not an
+exception. This task refuses to choose between them and requires that the choice
+be recorded either way.
+
+Worth noticing while measuring: the severity today is a function of status, and
+the transition that produced these faults was `close`. Whether `done` and the
+other terminal statuses behave the same way has not been checked.

--- a/.ank/entities/TASK-cf8e08128cb4.md
+++ b/.ank/entities/TASK-cf8e08128cb4.md
@@ -5,7 +5,7 @@ slug: ank-is-installable-from-the-aur
 title: ank is installable from the AUR
 created: 2026-08-16T03:36:21Z
 author: claude-code/opus-5
-status: open
+status: closed
 scope:
   - packaging/aur/**
   - .github/workflows/publish-aur.yml
@@ -14,7 +14,7 @@ done_criteria: |
   packaging/aur carries a PKGBUILD template rendered from a tag, naming the released archive and the sha256 the release publishes. A workflow triggered on a published release renders it, regenerates .SRCINFO, and pushes both to the AUR under an SSH key held in Actions secrets. A CI job in an Arch container builds the rendered package with makepkg, installs it with pacman -U, and asserts ank --version prints the released version. Nothing in packaging/aur is edited by hand between releases: the job derives the file. cargo test --workspace and ank check stay green.
 criteria_by: creator
 schema: 3
-version: 3
+version: 4
 ---
 
 **This task exists because of ADR-782a3556cf2d and must not be claimed before it

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,11 @@ on:
       - "v*"
   workflow_dispatch:
 
-# Read everywhere except the one job that publishes. `build` never needs write:
-# if it is ever compromised, it cannot reach the release.
+# Read everywhere, including the job that publishes. The release is created
+# under RELEASE_TOKEN and not under the default token (see `publish` below), so
+# there is no job left in this workflow whose `GITHUB_TOKEN` can write: the one
+# write capability here is a secret named in one step's `env`, and `build` --
+# the job that runs code from the tree on four machines -- cannot reach it.
 permissions:
   contents: read
 
@@ -59,6 +62,34 @@ jobs:
             exit 0
           fi
           bash .github/scripts/check-version.sh "${GITHUB_REF_NAME#v}"
+
+      # Checked here rather than in `publish`, for the reason the job itself
+      # exists: a credential missing at the end has already spent the matrix,
+      # and the release would then either fail with the tag gone or -- worse --
+      # succeed under the default token and start nothing. The secret is never
+      # printed; `-n` on a masked value tests presence and reveals nothing.
+      - name: the release credential is present
+        env:
+          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        shell: bash
+        run: |
+          set -e
+          if [ "${GITHUB_REF_TYPE:-branch}" != "tag" ]; then
+            echo "no tag on this run: nothing will be published, so nothing needs the token."
+            exit 0
+          fi
+          if [ -z "$RELEASE_TOKEN" ]; then
+            echo "RELEASE_TOKEN is not set on this repository."
+            echo "the release would be created under the default token, and GitHub starts"
+            echo "no workflow run from an event that token produced -- so publish-brew,"
+            echo "publish-scoop, publish-apt and publish-winget would never fire."
+            echo
+            echo "  gh secret set RELEASE_TOKEN"
+            echo
+            echo "a fine-grained PAT on this repository, Contents: write, and nothing else."
+            exit 1
+          fi
+          echo "RELEASE_TOKEN is set."
 
   build:
     name: ${{ matrix.os }}
@@ -421,8 +452,10 @@ jobs:
     # And only for a tag. A dispatch run builds and stops there.
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
+    # No `contents: write`, deliberately, where this job used to carry it: the
+    # release is created under RELEASE_TOKEN, so the default token in this job
+    # has nothing left to write with. Granting it write as well would leave a
+    # capability nothing uses.
 
     steps:
       # Checked out for one file: the dist-tag derivation of §9, which decides
@@ -438,9 +471,23 @@ jobs:
       # `gh` is on the runner already. A third-party release action would be
       # one more supply-chain dependency for a call this short -- the same
       # reasoning that keeps a toolchain action out of ci.yml.
+      # `RELEASE_TOKEN` and not `github.token`, which is the whole of
+      # TASK-2078ab116f63: GitHub does not start a workflow run from an event
+      # the default token produced -- the rule that stops a workflow triggering
+      # itself. So a release created under it publishes eight files and starts
+      # none of publish-brew, publish-scoop, publish-apt or publish-winget,
+      # which is what happened on v0.3.0 and had to be undone by hand with a
+      # draft toggle from the maintainer's own token. Those four trigger only on
+      # `release: published`, and only a credential that is not the default one
+      # produces that event.
+      #
+      # A fine-grained PAT scoped to this repository with `Contents: write`.
+      # The `version` job refuses the tag when it is missing, so this step is
+      # never reached without it and never falls back to the default token: a
+      # fallback would republish the exact defect, silently and green.
       - name: publish
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: |
           set -e
@@ -460,3 +507,102 @@ jobs:
             --generate-notes \
             $prerelease \
             dist/*.tar.gz dist/*.zip dist/*.sha256
+
+  # The release's only product downstream of this workflow is four runs, and
+  # until now their absence was invisible: v0.3.0 was green end to end while
+  # none of the four had started. So the run that publishes is also the run that
+  # says whether publishing reached anything -- the same shape as ADR-af53, a
+  # write whose only product is elsewhere failing when it does not arrive.
+  #
+  # It cannot undo the release and does not try to: the tag is spent either way.
+  # What it changes is that the next time the trigger breaks, a red release run
+  # names it on the day it happens instead of a channel being noticed months
+  # later at the version it stopped at.
+  channels:
+    name: channels
+    needs: publish
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    # `actions: read` is what listing runs needs, and it is the only thing this
+    # job reads. It publishes nothing, so it holds no write of any kind.
+    permissions:
+      contents: read
+      actions: read
+
+    steps:
+      # The criterion of TASK-2078ab116f63 in as many words: one run each of the
+      # four, whose event is `release`, on this tag.
+      #
+      # Asked as three `gh run list` filters rather than as one `--jq`
+      # expression over the whole listing. Both would answer, and only one can
+      # be exercised anywhere but here: `--workflow`, `--event` and `--branch`
+      # are flags with fixtures behind them, where a jq program filtering on
+      # `.event` is a string this file would be the first and only place to run.
+      # `--branch` takes the tag: a `release` event runs at the ref it
+      # published, which is the same fact TASK-1674d5b73761 recorded from the
+      # other side.
+      #
+      # `--workflow <file>.yml` and not the display name: the file name is what
+      # this repository controls, and a `name:` renamed upstairs would make this
+      # job green by looking for a workflow that no longer exists.
+      #
+      # Polled rather than read once: GitHub queues the four asynchronously and
+      # `gh release create` returns before they appear. Five minutes is far past
+      # what queuing costs and well short of anything a human would wait for.
+      - name: the four channels started on this release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -e
+          expected="publish-brew publish-scoop publish-apt publish-winget"
+          deadline=$((SECONDS + 300))
+          while :; do
+            missing=""
+            for w in $expected; do
+              # `[]` and not an empty string: gh prints an empty JSON array when
+              # nothing matches, and a `--json` that failed would print nothing
+              # at all -- so comparing against `[]` cannot read a broken call as
+              # a run that started.
+              found=$(gh run list --workflow "$w.yml" --event release \
+                --branch "$GITHUB_REF_NAME" --limit 1 --json databaseId)
+              if [ "$found" = "[]" ]; then
+                missing="$missing $w"
+              fi
+            done
+            if [ -z "$missing" ]; then
+              echo "all four started on $GITHUB_REF_NAME with event=release."
+              exit 0
+            fi
+            if [ "$SECONDS" -ge "$deadline" ]; then
+              echo "missing after $((SECONDS))s:$missing"
+              echo
+              # Which of the two failures this is. A run that started on the
+              # wrong ref and a run that never started are the same silence
+              # through the filters above, and they have opposite fixes -- one
+              # is this file, the other is the token. So the same question is
+              # asked once more without `--branch`, as a diagnostic and never as
+              # a verdict: the criterion is about runs on this tag.
+              for w in $missing; do
+                anywhere=$(gh run list --workflow "$w.yml" --event release \
+                  --limit 1 --json databaseId)
+                if [ "$anywhere" = "[]" ]; then
+                  echo "  $w: no release-event run at all"
+                else
+                  echo "  $w: a release-event run exists but not on $GITHUB_REF_NAME"
+                fi
+              done
+              echo
+              echo "the release was published and the channels it exists to feed did not run."
+              echo "the usual cause is the release having been created under the default token,"
+              echo "which starts no workflow run at all. check that the secret the publish job"
+              echo "above reads is a fine-grained PAT on this repository with Contents: write:"
+              echo
+              echo "  gh secret list"
+              echo "  gh run view $GITHUB_RUN_ID --log"
+              exit 1
+            fi
+            echo "waiting on:$missing"
+            sleep 15
+          done


### PR DESCRIPTION
## What this fixes

v0.3.0 was green end to end while none of `publish-brew`, `publish-scoop`, `publish-apt` or `publish-winget` started. GitHub starts no workflow run from an event the default `GITHUB_TOKEN` produced, so `gh release create` under `${{ github.token }}` publishes eight files and reaches nothing. The release had to be completed by hand with a draft toggle from the maintainer's own token.

The frozen criterion of TASK-2078ab116f63 chose the strategy: it requires four runs *whose event is `release`*, and neither `workflow_run` nor `repository_dispatch` can ever produce that. So the fix is a credential, and the shape chosen is a fine-grained PAT.

## Three changes in `release.yml`

- **`publish`** reads `secrets.RELEASE_TOKEN` instead of `github.token`, and loses the `contents: write` it used to hold. No job in the file can write with the default token any more: the one write capability is a secret named in one step's `env`, out of reach of `build`, which runs code from the tree on four machines.
- **`version`** refuses a tag when `RELEASE_TOKEN` is missing, before the matrix is spent, and never falls back — a fallback would republish the defect, green and silent.
- **`channels`** (new) polls for the four runs after publishing and is red when they did not start. This is what was missing: the release run had no way to say whether publishing reached anything. Same shape as ADR-af53d0b62a5c, a write whose only product is elsewhere.

## Falsified, not assumed

Both new scripts were extracted from the YAML and run against fixtures with a stub `gh`:

| fixture | expected | got |
|---|---|---|
| four `release` runs on this tag | pass | pass |
| three of four | fail | fail |
| four `workflow_run` runs | fail | fail |
| four on the previous tag | fail | fail |
| none | fail | fail |

The `workflow_run` fixture is the one that matters: it is the strategy the criterion rules out. The credential gate was falsified the same way — refuses a tag with no token, passes with one, skips on a dispatch.

A first draft filtered one listing with a `--jq` expression; `jq` is not installed on the maintainer's machine, so that expression was untestable anywhere but on a tag. Replaced by `--workflow`, `--event` and `--branch`, three documented flags a stub can answer.

## Also in this branch

- `TASK-cf8e08128cb4` (AUR) and `TASK-1674d5b73761` (apt) closed on the maintainer's decision.
- `TASK-305cf978d37d` was filed and closed in the same session: it reported a `check` fault on closed tasks that does not exist. `16e827b` had already fixed it and `cli.rs` already tests it — the reading came from an `ank` binary older than the fix. Recorded in `LOG-e8be2b60525c` rather than repaired by editing the corpus to match a wrong reading.
- `ADR-768374fe6076` carries the decision and arrives **proposed**. An `accept` attempted on this machine exited 9 on a passphrase-protected key, having already promoted the entity — it was restored with `ank edit`, and the ordering defect is filed as `TASK-1dbb6e7843f1`.

## Still needed after merge, by a human

1. `ank accept ADR-768374fe6076` on `main`, with the ratification passphrase.
2. `gh secret set RELEASE_TOKEN` — a fine-grained PAT on this repository, `Contents: write`.
3. A tag. `TASK-2078ab116f63` stays open until then: its criterion is measured on one.

Note: the three commits are unsigned. The signing key is the passphrase-protected one above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7rkg4HNTav9NXZJXJX8pr