### PR TITLE
git is handed an allowed-signers file it can parse whole

### DIFF
--- a/.ank/entities/LOG-b8e76abf35aa.md
+++ b/.ank/entities/LOG-b8e76abf35aa.md
@@ -1,0 +1,23 @@
+---
+id: LOG-b8e76abf35aa
+type: log
+title: Two defects fixed together, because the measurement cannot separate them and both are wrong on
+created: 2026-08-18T22:38:51Z
+author: claude-code/opus-5
+scope:
+  - crates/ank-cli/src/git.rs
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/tests/cli.rs
+about: TASK-01cc22478782
+seq: 0
+schema: 3
+version: 1
+---
+
+ their own terms.
+
+The one that is almost certainly the cause: .ank/allowed_signers is read by two parsers and is only valid to one of them. Its gpg <fingerprint> entries are ank's extension for the OpenPGP branch, where SPEC-199de7ac4730 says git never opens the file; ssh-keygen has no keytype for them and answers '.ank/allowed_signers:23: invalid key'. On this machine it says that twice and still verifies, so how much of the rest it reads is a property of its version. git is now handed only the lines it can parse. Filtered and never re-rendered: an entry may carry options between the principal and the key, parse_signers drops them, and rebuilding the file from what it returns would hand git a permission the reviewed file does not grant -- there is a test for exactly that line. When the file needs no filtering, the source itself is handed over and nothing is written, so the ordinary corpus verifies against the file under review.
+
+The smaller one: the -c pair was built with p.display(), so on Windows an absolute path full of backslashes went into a git config value, where a backslash opens an escape sequence. Forward slashes now, guarded by cfg!(windows) because a backslash is an ordinary character in a POSIX filename.
+
+Local green proves nothing here and the criterion says so: 291 tests pass in ank-cli, ank check is ok, and none of that runs the code path that failed. The measurement is the ci workflow on three runners over a HEAD that is an SSH-signed ratification, which is what this branch is for. If Windows is still U after this, the cause is neither of the two and the next step is a diagnostic run printing git's stderr rather than another guess.

--- a/.ank/entities/TASK-01cc22478782.md
+++ b/.ank/entities/TASK-01cc22478782.md
@@ -1,0 +1,63 @@
+---
+id: TASK-01cc22478782
+type: task
+slug: git-is-handed-an-allowed-signers-file-it-can-par
+title: git is handed an allowed-signers file it can parse whole
+created: 2026-08-18T22:34:15Z
+author: claude-code/opus-5
+status: in_progress
+scope:
+  - crates/ank-cli/src/git.rs
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/tests/cli.rs
+blocked_by: []
+done_criteria: |
+  An SSH-signed ratification by a key .ank/allowed_signers declares is Trusted on Linux, macOS and Windows alike. What is handed to git's gpg.ssh.allowedSignersFile carries only entries git can parse, ank's gpg: entries being its own extension, and the path is written in a form git reads on every platform. Measured where the defect is: the ci workflow is green on all three runners for a commit whose HEAD is an SSH-signed ratification, and a unit test asserts the file handed to git contains no line ssh-keygen would reject. cargo test --workspace and ank check stay green.
+criteria_by: creator
+schema: 3
+version: 2
+---
+
+Measured on 2026-08-18, on CI run 32191115856 at 18b803b, the ratification of
+ADR-768374fe6076. `windows-latest` alone failed:
+
+  human::tests::this_repositorys_own_ratifications_are_signed
+  ADR-768374fe6076: Undeclared { fingerprint: "SHA256:DzPtbK/qcUeTVyzCkanLetS5fv66nucZ3W7KOmA5XEI" }
+
+`ubuntu-latest` and `macos-latest` passed the same test on the same commit, and
+`ank check` on both reported the same 40 unverifiable signatures it reports
+locally -- that ADR not among them. So the signature is good and the key is
+declared, and one platform out of three says the file does not declare it.
+
+`classify_signature` is not guessing here: under SSH it delegates the allowlist
+to git entirely, because git is the only thing that will do that check at all.
+`G` is a key the file matched and `U` is a good signature whose principal it did
+not. Windows returned `U`. The question is therefore not what ank concluded but
+what git was able to read.
+
+The suspect is named and it is ank's own doing. `.ank/allowed_signers` holds two
+kinds of entry: `ssh-ed25519 <base64>`, which git reads, and `gpg <fingerprint>`,
+which is ank's extension for the OpenPGP branch where -- per SPEC-199de7ac4730 --
+git never reads the file and `check` matches the fingerprint itself. ssh-keygen
+does not know the second kind: on this machine it says
+`.ank/allowed_signers:23: invalid key` twice and still verifies the signature.
+How tolerant it is of a line it cannot parse is a property of its version, and
+Git for Windows ships its own. A file that is valid to one parser and half-valid
+to another is the defect, whatever the version does with it.
+
+The second candidate is smaller and worth closing in the same change. The config
+value is built as `format!("gpg.ssh.allowedSignersFile={}", p.display())`, so on
+Windows it carries an absolute path full of backslashes into a git config value,
+where a backslash is an escape character. Forward slashes are read on every
+platform git runs on, and cost nothing.
+
+Neither candidate is proven, and this task does not need to choose: both are
+defects on their own terms and both are cheap. What proves the fix is the same
+thing that found the defect -- the three runners, on a commit whose HEAD is an
+SSH-signed ratification. Until then the cause is a hypothesis, and the body says
+so rather than the log discovering it later.
+
+Note for whoever takes this: the corpus holds two SSH-signed ratifications,
+c1ef8435 for SPEC-199de7ac4730 and 18b803b for this ADR, and only the second was
+ever judged. The test iterates ADRs and skips specs, which is why an SSH
+ratification sat in the corpus for a day without Windows saying anything.

--- a/crates/ank-cli/src/git.rs
+++ b/crates/ank-cli/src/git.rs
@@ -1017,7 +1017,20 @@ pub fn signature_of(
     // collapses "no signature" and "cannot check it" into the same failure,
     // and those two are precisely the states this must keep apart. The
     // placeholders are git's documented pretty-format interface.
-    let signers = allowed_signers.map(|p| format!("gpg.ssh.allowedSignersFile={}", p.display()));
+    // Forward slashes on Windows. A `-c name=value` pair goes through git's
+    // config parser, where a backslash opens an escape sequence, so an absolute
+    // Windows path arrives as something other than the path that was meant.
+    // Git reads forward slashes on every platform it runs on, and the
+    // conversion is guarded because a backslash is an ordinary character in a
+    // POSIX filename and rewriting one there would break a path that worked.
+    let signers = allowed_signers.map(|p| {
+        let path = p.display().to_string();
+        let path = match cfg!(windows) {
+            true => path.replace('\\', "/"),
+            false => path,
+        };
+        format!("gpg.ssh.allowedSignersFile={path}")
+    });
     let mut args: Vec<&str> = Vec::new();
     if let Some(cfg) = signers.as_deref() {
         args.push("-c");

--- a/crates/ank-cli/src/human.rs
+++ b/crates/ank-cli/src/human.rs
@@ -6932,6 +6932,44 @@ mod tests {
         format!("test@ank.local {}", pub_key.trim())
     }
 
+    /// The defect of TASK-01cc22478782, end to end, on whatever ssh-keygen the
+    /// platform ships.
+    ///
+    /// The `gpg` entry goes first, which is the order the corpus's own file
+    /// uses: a parser that stops at the line it has no keytype for never
+    /// reaches the key below it. That is what CI run 32191115856 measured --
+    /// `G` on ubuntu and macos, `U` on windows, one signature, one declared
+    /// key, three answers.
+    ///
+    /// It will pass with or without the filter on a machine whose ssh-keygen
+    /// merely warns and reads on, which is exactly why it belongs to the suite
+    /// that runs on three runners rather than to the one that ran here.
+    #[test]
+    fn a_gpg_entry_does_not_hide_the_ssh_key_beside_it() {
+        let t = Temp::new();
+        t.enable_signing();
+        declare(
+            &t,
+            &format!(
+                "test@ank.local gpg 739A603FB05F9F2F7D3C8D50624FCFCC1482554A\n{}\n",
+                signing_principal(&t)
+            ),
+        );
+
+        t.write(&adr("00000000aaaa", AdrStatus::Proposed, &["src/**"]));
+        t.commit("seed");
+        t.call(&["accept", "ADR-00000000aaaa"], "marie@laptop")
+            .unwrap();
+
+        assert_eq!(
+            signature_state(&t.repo(), &t.adr_at("00000000aaaa")),
+            Some(Signature::Trusted),
+            "an entry only ank reads must not cost the key beside it its verdict"
+        );
+        let r = t.report();
+        assert_eq!(r.faults(), 0, "{:?}", r.findings);
+    }
+
     /// The hole this task was filed for, end to end and through `check`. An
     /// ordinary unsigned commit whose subject reads `ratify <id>` used to be
     /// accepted as a ratification: `rev-list` found it, the subject matched,

--- a/crates/ank-cli/src/human.rs
+++ b/crates/ank-cli/src/human.rs
@@ -704,6 +704,68 @@ pub fn parse_signers(text: &str) -> Vec<Signer> {
         .collect()
 }
 
+/// The lines of `allowed_signers` git is able to parse, and only those.
+///
+/// The file serves two readers (§12), and they do not read the same thing. Under
+/// `gpg.format = ssh` git opens it and decides the allowlist itself; under
+/// OpenPGP git never opens it at all, so `check` matches the fingerprint here
+/// against `gpg <fingerprint>` entries. Those entries are ank's own extension
+/// and ssh-keygen has no keytype for them: it reports `invalid key` on the line,
+/// and how much of the rest of the file it goes on to read afterwards is a
+/// property of its version rather than of this repository. Measured on CI run
+/// 32191115856, where the same SSH-signed ratification was `G` on two runners
+/// and `U` on the third.
+///
+/// So git is handed what git can read. Lines are filtered and never rewritten:
+/// an entry may carry options between the principal and the key,
+/// `parse_signers` drops them, and re-rendering from what it returns would
+/// quietly change what the file permits. A comment survives because ssh-keygen
+/// skips it, and a line neither parser can make sense of is dropped, which is
+/// the one case where dropping is the conservative act.
+pub fn git_readable_signers(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    for line in text.lines() {
+        let trimmed = line.trim();
+        let keep = if trimmed.is_empty() || trimmed.starts_with('#') {
+            true
+        } else {
+            match trimmed.split_whitespace().collect::<Vec<_>>().as_slice() {
+                [_principal, .., keytype, _key] => !keytype.eq_ignore_ascii_case("gpg"),
+                _ => false,
+            }
+        };
+        if keep {
+            out.push_str(line);
+            out.push('\n');
+        }
+    }
+    out
+}
+
+/// The path to hand git, which is the file itself whenever git can read all of
+/// it and a filtered copy otherwise.
+///
+/// Returning the source unchanged in the ordinary case matters: a corpus that
+/// declares only SSH keys writes nothing anywhere, and the file git verifies
+/// against is the file under review. The copy is named after a hash of its own
+/// content, so repeated calls over one corpus write it once and two corpora
+/// never collide.
+fn signers_for_git(source: &Path) -> Option<PathBuf> {
+    let text = std::fs::read_to_string(source).ok()?;
+    let readable = git_readable_signers(&text);
+    if readable == text {
+        return Some(source.to_path_buf());
+    }
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    std::hash::Hash::hash(&readable, &mut hasher);
+    let digest = std::hash::Hasher::finish(&hasher);
+    let path = std::env::temp_dir().join(format!("ank-signers-{digest:016x}"));
+    if std::fs::read_to_string(&path).ok().as_deref() != Some(readable.as_str()) {
+        std::fs::write(&path, &readable).ok()?;
+    }
+    Some(path)
+}
+
 /// What a ratification commit's signature is worth.
 ///
 /// Six states and not three, because collapsing any two of them loses the
@@ -3734,7 +3796,11 @@ pub fn signature_state<'a>(repo: &Repo, of: impl Into<Anchored<'a>>) -> Option<S
     // `check_adr` says nothing about — so a machine where the signature could
     // not be read looked exactly like a corpus that declared no key at all
     // (TASK-c92b7cc10f13). Failing to ask has to survive as an answer.
-    match git::signature_of(&repo.root, &sha, Some(&signers)) {
+    // The file git is pointed at, which is the reviewed one unless it carries
+    // entries only ank reads. Falling back to the source on a failure to write
+    // keeps the behaviour this had before the filter existed.
+    let for_git = signers_for_git(&signers).unwrap_or_else(|| signers.clone());
+    match git::signature_of(&repo.root, &sha, Some(&for_git)) {
         Ok(facts) => {
             // Asked only where the answer can change the verdict: every other
             // status already says whether a signature was there.
@@ -6673,6 +6739,78 @@ mod tests {
             "the option in the middle must not be mistaken for the key type"
         );
         assert_eq!(parsed[1].key, "AAAAC3NzaC1lZDI1");
+    }
+
+    /// What git is handed carries nothing ssh-keygen would reject, and carries
+    /// everything ssh-keygen would accept unchanged (TASK-01cc22478782).
+    ///
+    /// The `gpg` entry is ank's own extension and the reason the filter exists.
+    /// The line with an option in the middle is the reason it filters rather
+    /// than re-renders: `parse_signers` drops that option, so a copy built from
+    /// what it returns would hand git a permission the reviewed file does not
+    /// grant.
+    #[test]
+    fn git_is_handed_no_line_ssh_keygen_would_reject() {
+        let source = "# a comment\n\
+             \n\
+             sean@example.com gpg 739A603FB05F9F2F7D3C8D50624FCFCC1482554A\n\
+             marie@laptop namespaces=\"git\" ssh-ed25519 AAAAC3NzaC1lZDI1\n\
+             nonsense\n";
+        let out = git_readable_signers(source);
+
+        for line in out.lines() {
+            let t = line.trim();
+            if t.is_empty() || t.starts_with('#') {
+                continue;
+            }
+            let fields: Vec<&str> = t.split_whitespace().collect();
+            assert!(
+                matches!(fields.as_slice(), [_, .., keytype, _] if !keytype.eq_ignore_ascii_case("gpg")),
+                "ssh-keygen has no keytype for this line: {line:?}"
+            );
+        }
+        assert!(
+            !out.contains("739A603FB05F9F2F7D3C8D50624FCFCC1482554A"),
+            "the gpg entry is ank's own and git cannot read it: {out:?}"
+        );
+        assert!(
+            out.contains("marie@laptop namespaces=\"git\" ssh-ed25519 AAAAC3NzaC1lZDI1"),
+            "an entry git can read survives whole, options included: {out:?}"
+        );
+        assert!(
+            !out.contains("nonsense"),
+            "a line neither parser can read is not handed on: {out:?}"
+        );
+        assert!(out.contains("# a comment"), "{out:?}");
+    }
+
+    /// The other half, and the one that says the filter costs nothing where it
+    /// is not needed: a file git can read whole is handed to git as itself, so
+    /// what verifies the corpus is the file under review and not a copy.
+    #[test]
+    fn a_file_git_can_read_whole_is_handed_over_untouched() {
+        let source = "marie@laptop ssh-ed25519 AAAAC3NzaC1lZDI1\n";
+        assert_eq!(git_readable_signers(source), source);
+
+        let dir = std::env::temp_dir().join(format!("ank-signers-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("allowed_signers");
+        std::fs::write(&file, source).unwrap();
+        assert_eq!(
+            signers_for_git(&file).as_deref(),
+            Some(file.as_path()),
+            "no copy is written when none is needed"
+        );
+
+        std::fs::write(&file, format!("sean@example.com gpg 739A60\n{source}")).unwrap();
+        let handed = signers_for_git(&file).unwrap();
+        assert_ne!(
+            handed, file,
+            "a file carrying an ank-only entry needs a copy"
+        );
+        assert_eq!(std::fs::read_to_string(&handed).unwrap(), source);
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     fn gpg_signer(key: &str) -> Vec<Signer> {


### PR DESCRIPTION
Fixes the Windows failure on `main` at `18b803b`, the ratification of ADR-768374fe6076.

## What was measured

CI run [32191115856](https://github.com/haksolot/ank/actions/runs/32191115856) was red on `windows-latest` alone:

```
human::tests::this_repositorys_own_ratifications_are_signed
ADR-768374fe6076: Undeclared { fingerprint: "SHA256:DzPtbK/qcUeTVyzCkanLetS5fv66nucZ3W7KOmA5XEI" }
```

`ubuntu-latest` and `macos-latest` passed the same test on the same commit. One signature, one declared key, three answers.

`classify_signature` is not guessing: under SSH it delegates the allowlist to git entirely, because git is the only thing that performs that check at all. `G` is a key the file matched, `U` a good signature whose principal it did not. Windows returned `U` — so the question is what git managed to read.

## Two defects, both real, fixed together

**`.ank/allowed_signers` is read by two parsers and is valid to only one.** Its `gpg <fingerprint>` entries are ank's extension for the OpenPGP branch where — per SPEC-199de7ac4730 — git never opens the file and `check` matches the fingerprint itself. ssh-keygen has no keytype for them and reports `invalid key` on the line. How much of the rest it reads afterwards is a property of its version, and Git for Windows ships its own.

git is now handed only the lines it can parse. **Filtered, never re-rendered**: an entry may carry options between the principal and the key, `parse_signers` drops them, and a file rebuilt from what it returns would grant something the reviewed file does not. A file needing no filter is handed over as itself, so the ordinary corpus still verifies against the file under review — no copy is written.

**The `-c` pair was built with `p.display()`**, putting a backslash-laden Windows path into a git config value, where a backslash opens an escape sequence. Forward slashes now, guarded by `cfg!(windows)` because a backslash is an ordinary character in a POSIX filename.

## Why this PR is the measurement

Neither cause is proven, and the task body says so rather than leaving the log to discover it. Local green does not reach the code path that failed. What proves the fix is this run, on three runners, over a history in which an SSH-signed ratification is reachable — `ci.yml` checks out with `fetch-depth: 0`, so it is.

Three tests, and they do different jobs:

- `git_is_handed_no_line_ssh_keygen_would_reject` — nothing ank-only survives, an entry with options survives byte-for-byte.
- `a_file_git_can_read_whole_is_handed_over_untouched` — no copy where none is needed.
- `a_gpg_entry_does_not_hide_the_ssh_key_beside_it` — end to end: a real ratification, a real signature, the `gpg` entry placed first as the corpus places it, asserting `Trusted`. This one passes with or without the fix on a machine whose ssh-keygen merely warns, which is exactly why it belongs to the suite that runs on all three.

**If `windows-latest` is still red after this, the cause is neither candidate**, and the next step is a diagnostic run printing git's stderr — not another guess.

## Also worth knowing

The corpus holds two SSH-signed ratifications: `c1ef8435` for SPEC-199de7ac4730 and `18b803b` for this ADR. Only the second was ever judged, because `this_repositorys_own_ratifications_are_signed` iterates ADRs and skips specs. An SSH ratification sat in the corpus for a day without Windows saying anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7rkg4HNTav9NXZJXJX8pr