### PR TITLE
Bump the ten version literals to 0.4.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ank",
   "description": "Tasks and architecture decisions in your repo, behind one CLI any coding agent can call.",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": {
     "name": "haksolot",
     "url": "https://github.com/haksolot"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "ank-cli"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "ank-contract",
  "ank-core",
@@ -30,7 +30,7 @@ version = "0.3.0"
 
 [[package]]
 name = "ank-core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "globset",
  "hex",

--- a/crates/ank-cli/Cargo.toml
+++ b/crates/ank-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ank-cli"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 # Measured on 2026-08-01 by walking toolchains upward against this tree, which
 # is the only way this number means anything: 1.78, 1.91, 1.92, 1.93 and 1.94

--- a/crates/ank-core/Cargo.toml
+++ b/crates/ank-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ank-core"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 # Measured, not assumed: see the note in ank-cli's manifest. This crate's own
 # code needs far less, but the workspace resolves one lockfile and builds as a

--- a/npm/ank-darwin-arm64/package.json
+++ b/npm/ank-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haksolot/ank-darwin-arm64",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "The ank binary for macOS on Apple silicon.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/haksolot/ank",

--- a/npm/ank-linux-x64-musl/package.json
+++ b/npm/ank-linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haksolot/ank-linux-x64-musl",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "The ank binary for Linux x86_64, statically linked against musl.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/haksolot/ank",

--- a/npm/ank-win32-x64/package.json
+++ b/npm/ank-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haksolot/ank-win32-x64",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "The ank binary for Windows x86_64.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/haksolot/ank",

--- a/npm/ank/package.json
+++ b/npm/ank/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haksolot/ank",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "The stupid coordination tool: tasks and architecture decisions in your repo, behind one CLI any coding agent can call.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/haksolot/ank",
@@ -39,8 +39,8 @@
     "node": ">=18"
   },
   "optionalDependencies": {
-    "@haksolot/ank-darwin-arm64": "0.3.0",
-    "@haksolot/ank-linux-x64-musl": "0.3.0",
-    "@haksolot/ank-win32-x64": "0.3.0"
+    "@haksolot/ank-darwin-arm64": "0.4.0",
+    "@haksolot/ank-linux-x64-musl": "0.4.0",
+    "@haksolot/ank-win32-x64": "0.4.0"
   }
 }


### PR DESCRIPTION
Prepares the tag. `check-version.sh 0.4.0` agrees with all ten literals across the seven files, and `check-version-fixtures.sh` — the positive control that proves the checker still refuses what it should — passes.

## Why minor and not patch

Behaviour changed since v0.3.0; it did not only get repaired.

| | |
|---|---|
| `check` | a dead scope on a **closed** task is a signal where it was a fault — this changes the verdict a corpus somebody routes CI on |
| `accept` | writes `verified: by/at`, recording who ran the ratification |
| SPEC-199de7ac4730 | proof, anchoring and authority reworked |
| `release.yml` | publishes under `RELEASE_TOKEN`, and a `channels` job goes red when the four do not start |
| fix | the allowed-signers file handed to git is one git can parse (the Windows failure at `18b803b`) |

Only the last is a pure repair.

## What happens after this merges

The tag is what exercises everything above for the first time: `publish` under a credential that is not the default token, the gate that refuses a tag when `RELEASE_TOKEN` is missing, and the `channels` job that asserts the four runs exist with `event=release`. `TASK-2078ab116f63` is measured on that run and not before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7rkg4HNTav9NXZJXJX8pr