### PR TITLE
The skill is plural: ank-plan, ank-drift, ank-loop beside the contract

### DIFF
--- a/.ank/entities/ADR-91b77f036884.md
+++ b/.ank/entities/ADR-91b77f036884.md
@@ -1,0 +1,125 @@
+---
+id: ADR-91b77f036884
+type: adr
+slug: the-skill-is-plural-and-the-freeze-becomes-an-an
+title: The skill is plural, and the freeze becomes an anchor
+created: 2026-08-19T04:49:10Z
+author: claude-code/2.0
+status: proposed
+scope:
+  - skill/**
+  - crates/ank-cli/tests/skill.rs
+  - .claude-plugin/**
+  - docs/**
+constraint: |
+  The skill system is plural. skill/SKILL.md is the contract: the three modes,
+  the rules and why, loaded by every agent. Sibling skills live under skill/,
+  one directory per skill, each teaching one activity: plan, drift, loop. A
+  sibling states that the contract applies and never restates it; a rule
+  written twice is the drift this system exists to catch.
+  
+  No skill's content is frozen by revision hash any more. Content evolves under
+  normal review, without a superseding ADR per edit. Three anchors survive the
+  freeze: every skill declares metadata.revision as the hash of its own body,
+  recomputed by test; the binary names the contract skill's revision it was
+  built alongside; and accept stays described and never invited, in any skill
+  that mentions it.
+  
+  The frontmatter description is the only part every session pays for, invoked
+  or not. It names the activity that should trigger the load and nothing else,
+  and it does not grow without a measurement. Bodies stay within 180 lines and
+  1500 words per skill.
+supersedes: ADR-5dd7b4a9c875
+schema: 3
+version: 1
+---
+
+## Context
+
+ADR-5dd7b4a9c875 froze the content of skill/SKILL.md by revision hash: three
+modes, a ceiling, and a supersession per change. The freeze bought discipline
+while the skill was the only teaching surface the project had, and it worked:
+the file says why before how, and every growth it ever had arrived priced.
+
+It now blocks the next thing. Three activities have outgrown the file, and
+none of them can enter it:
+
+- Planning as an interview. Turning a goal into decisions needs a policy the
+  contract cannot carry: read the corpus before asking, recommend before
+  asking, one frontier of questions at a time, and write the outcome as
+  entities. That is a policy for a moment, not a rule for every session.
+- Drift review. Confronting accepted decisions with the code they claim to
+  describe is its own activity, with its own trigger and its own output:
+  findings for a human, never edits.
+- The autonomous loop. Chaining open tasks without supervision needs the
+  opposite policy from planning: no questions to the human, no architecture
+  invented, release rather than redesign. Planning and the loop cannot share
+  one prompt without contradicting it.
+
+One file teaching all four would trigger imprecisely and instruct
+contradictorily. Growing it is not the answer, and the freeze that priced
+growth per edit is not either. What was load-bearing in the freeze was never
+the lock: it was the anchors.
+
+## What changes
+
+skill/ becomes the skill system: SKILL.md stays the contract every agent
+loads, and three siblings each teach one activity.
+
+    skill/SKILL.md    the contract: modes, rules, why. Unchanged today.
+    skill/plan/       ank-plan: interview a goal into ADRs, specs, tasks.
+    skill/drift/      ank-drift: audit the corpus against the code, report.
+    skill/loop/       ank-loop: consume planned tasks, never redesign them.
+
+Content edits stop costing a supersession. The revision hash stops being a
+lock and stays an anchor: declared in every skill, recomputed by test, and
+ank --version still names the contract revision the binary was built
+alongside, so a stale installed copy still has nothing to hide behind.
+
+A sibling opens by stating the contract applies and adds only its policy.
+Duplication between skill files is the failure mode this layout must not
+create: a rule stated twice drifts, and drift between two files that teach
+the same corpus is exactly what TASK-b495234f192c measured the cost of.
+
+## What survives the freeze, and why
+
+- The revision anchor, because TASK-b495234f192c measured the failure it
+  catches: an installed copy, nine hours stale, instructing against a
+  ratified decision, with nothing by which anyone could notice.
+- The description budget, because the frontmatter is the one part every
+  session pays for whether or not the skill fires. A description now has a
+  second job: it is the trigger. It names the activity exactly, so the right
+  skill loads at the right moment, and it does not grow without a
+  measurement.
+- The ceiling, 180 lines and 1500 words, now per skill: it bounds the
+  by-hand route where a harness loads whole files.
+- accept described and never invited, in every skill that mentions it: the
+  authority boundary does not soften because the files multiplied.
+
+## Rejected
+
+- A minimal unfreeze now, architecture later. Lifting a constraint without
+  stating its replacement leaves a vacuum where the freeze was, and the next
+  edit falls into it. One decision carries both or it carries neither.
+- One skill with modes. Planning says interview the human; the loop forbids
+  it. Two policies in one prompt read as one contradictory policy, and one
+  description covering both activities triggers on neither precisely.
+- ank plan, ank drift and ank loop as verbs. Judgment is not dispatch: the
+  CLI refuses on state and never on identity, and it stays a set of
+  primitives the skills reach for. A deterministic sub-step may become a
+  primitive the day a skill proves the need, never before.
+- Keeping the per-edit supersession. It is the cost that kept planning out
+  of the teaching surface for as long as the surface existed.
+
+## Consequences
+
+tests/skill.rs keeps every assertion it has: they stop enforcing a freeze
+and start guarding editorial choices, movable by review instead of by ADR.
+It gains the sibling anchor: every skill/*/SKILL.md declares a revision the
+test recomputes. .claude-plugin/plugin.json lists the four directories.
+
+The npm and pi channels ship one skill today and must ship four; a task
+carries it. Sections 4 and 9 of the specification state the frozen-content
+regime and follow by supersession once this ADR is ratified; a task carries
+that too. docs/agents.md documents the by-hand route for one file and
+follows with the packaging change.

--- a/.ank/entities/LOG-7310fa7a4a7e.md
+++ b/.ank/entities/LOG-7310fa7a4a7e.md
@@ -1,0 +1,17 @@
+---
+id: LOG-7310fa7a4a7e
+type: log
+title: "Siblings anchored like the contract: metadata.revision recomputed by test, ceiling per skill,"
+created: 2026-08-19T04:53:51Z
+author: claude-code/2.0
+scope:
+  - skill/**
+  - .claude-plugin/**
+  - crates/ank-cli/tests/skill.rs
+about: TASK-e26516d35da9
+seq: 0
+schema: 3
+version: 1
+---
+
+ contract-deference and no-ank-accept asserted, manifest listing asserted. find --status open --free is what ank-loop teaches for collision-free picking; the flag already existed and no skill named it.

--- a/.ank/entities/LOG-aa941a58ff40.md
+++ b/.ank/entities/LOG-aa941a58ff40.md
@@ -1,0 +1,15 @@
+---
+id: LOG-aa941a58ff40
+type: log
+title: done, proof commit:980dbc4ab932aff28f0e4d67f5863f50492ad0b9
+created: 2026-08-19T05:27:30Z
+author: claude-code/2.0
+scope:
+  - skill/**
+  - .claude-plugin/**
+  - crates/ank-cli/tests/skill.rs
+about: TASK-e26516d35da9
+seq: 1
+schema: 3
+version: 1
+---

--- a/.ank/entities/TASK-7cbf5b62be7f.md
+++ b/.ank/entities/TASK-7cbf5b62be7f.md
@@ -1,0 +1,26 @@
+---
+id: TASK-7cbf5b62be7f
+type: task
+slug: the-npm-and-pi-channels-ship-every-skill-not-one
+title: The npm and pi channels ship every skill, not one
+created: 2026-08-19T04:49:46Z
+author: claude-code/2.0
+status: open
+scope:
+  - .github/**
+  - npm/**
+  - docs/**
+blocked_by: [TASK-e26516d35da9]
+done_criteria: |
+  npm-assemble.sh copies skill/SKILL.md and every skill/*/SKILL.md into the wrapper package under skills/<name>/SKILL.md, the release smoke job checks all four arrived, and docs/agents.md describes the by-hand route for all four skills.
+criteria_by: creator
+schema: 3
+version: 1
+---
+
+The wrapper package assembles skills/ank/SKILL.md from skill/SKILL.md at pack
+time (npm-assemble.sh), and the by-hand route in docs/agents.md copies the one
+file. ADR-91b77f036884 makes the skill plural, so both channels must carry the
+siblings or an installer gets the contract without the policies. Same
+arrangement as today: copies made at pack time from the one source per skill,
+never committed, smoke-checked on release.

--- a/.ank/entities/TASK-afb7ed8189cf.md
+++ b/.ank/entities/TASK-afb7ed8189cf.md
@@ -1,0 +1,25 @@
+---
+id: TASK-afb7ed8189cf
+type: task
+slug: sections-4-and-9-follow-the-skill-system-s-new-r
+title: Sections 4 and 9 follow the skill system's new regime
+created: 2026-08-19T04:49:46Z
+author: claude-code/2.0
+status: open
+scope:
+  - skill/**
+  - docs/**
+blocked_by: []
+done_criteria: |
+  The ratified spec documents stating the frozen-content skill regime (sections 4 and 9) are superseded by documents stating the plural, anchored-not-frozen regime of ADR-91b77f036884, the documents citing them follow through amend --reference, and ank check is green.
+criteria_by: creator
+schema: 3
+version: 1
+---
+
+ADR-5dd7b4a9c875 moved sections 4 and 9 of the specification to state the
+frozen content of SKILL.md. ADR-91b77f036884 supersedes the freeze, so once it
+is ratified the corpus carries two contradictory statements until the spec
+documents follow. Blocked in practice on ratification: superseding an accepted
+spec toward a regime a proposed ADR states would put the cart before the
+signature. Start it only after accept.

--- a/.ank/entities/TASK-e26516d35da9.md
+++ b/.ank/entities/TASK-e26516d35da9.md
@@ -5,7 +5,7 @@ slug: three-sibling-skills-plan-drift-loop
 title: "Three sibling skills: plan, drift, loop"
 created: 2026-08-19T04:49:28Z
 author: claude-code/2.0
-status: in_progress
+status: done
 scope:
   - skill/**
   - .claude-plugin/**
@@ -14,8 +14,13 @@ blocked_by: []
 done_criteria: |
   skill/plan/SKILL.md, skill/drift/SKILL.md and skill/loop/SKILL.md exist, each within 180 lines and 1500 words, each opening by stating that the ank contract applies, each declaring a metadata.revision equal to the hash of its own body, verified by a test in crates/ank-cli/tests/skill.rs; .claude-plugin/plugin.json lists the four skill directories; cargo test is green.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 980dbc4ab932aff28f0e4d67f5863f50492ad0b9
+    criteria: c229c52ed148
+    via: submitted
 schema: 3
-version: 2
+version: 3
 ---
 
 ADR-91b77f036884 (proposed) states the architecture: the contract stays in

--- a/.ank/entities/TASK-e26516d35da9.md
+++ b/.ank/entities/TASK-e26516d35da9.md
@@ -1,0 +1,44 @@
+---
+id: TASK-e26516d35da9
+type: task
+slug: three-sibling-skills-plan-drift-loop
+title: "Three sibling skills: plan, drift, loop"
+created: 2026-08-19T04:49:28Z
+author: claude-code/2.0
+status: in_progress
+scope:
+  - skill/**
+  - .claude-plugin/**
+  - crates/ank-cli/tests/skill.rs
+blocked_by: []
+done_criteria: |
+  skill/plan/SKILL.md, skill/drift/SKILL.md and skill/loop/SKILL.md exist, each within 180 lines and 1500 words, each opening by stating that the ank contract applies, each declaring a metadata.revision equal to the hash of its own body, verified by a test in crates/ank-cli/tests/skill.rs; .claude-plugin/plugin.json lists the four skill directories; cargo test is green.
+criteria_by: creator
+schema: 3
+version: 2
+---
+
+ADR-91b77f036884 (proposed) states the architecture: the contract stays in
+skill/SKILL.md, and three siblings each teach one activity. This task writes
+the siblings and wires them into the plugin manifest and the test suite.
+
+The writing standard is deletion over explanation: every line must change an
+agent's behavior, nothing is said twice across the four files, and the
+frontmatter description of each sibling names the activity that should
+trigger the load, exactly, because the description is the trigger. No em
+dashes anywhere in the four files.
+
+ank-plan: interview a goal into entities. Read the corpus before asking,
+recommend before asking, one frontier of independent questions per round,
+stop when nothing important is silently assumed, then write each settled
+decision as exactly one kind of entity. Proposed ADRs and specs wait for a
+human accept.
+
+ank-drift: audit accepted decisions against the code their scopes cover.
+Findings with evidence, ordered by impact, recommendation per finding.
+Never an edit, never an uninvited supersession: the output is a report.
+
+ank-loop: consume planned tasks. Pick what cannot collide, claim, implement,
+log, done with proof, repeat. Release rather than redesign when a task is
+underplanned; no questions to the human, no architecture invented; stop and
+report when nothing claimable is safe.

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -16,5 +16,5 @@
     "coordination",
     "agent"
   ],
-  "skills": ["./skill"]
+  "skills": ["./skill", "./skill/plan", "./skill/drift", "./skill/loop"]
 }

--- a/crates/ank-cli/tests/skill.rs
+++ b/crates/ank-cli/tests/skill.rs
@@ -693,6 +693,123 @@ fn the_skill_says_which_revision_it_is() {
 }
 
 // ---------------------------------------------------------------------------
+// The siblings, anchored the same way (ADR-91b77f036884, TASK-e26516d35da9)
+// ---------------------------------------------------------------------------
+
+/// The sibling skills beside the contract: every `skill/<dir>/SKILL.md`, as
+/// `(dir, content)`. Discovered rather than listed, so a skill added later is
+/// anchored by the tests below without anyone remembering to enrol it.
+fn sibling_skills() -> Vec<(String, String)> {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../skill");
+    let mut found = Vec::new();
+    for entry in fs::read_dir(&root).expect("skill/ must exist") {
+        let path = entry.expect("skill/ must be readable").path();
+        let md = path.join("SKILL.md");
+        if path.is_dir() && md.is_file() {
+            found.push((
+                path.file_name()
+                    .expect("a directory has a name")
+                    .to_string_lossy()
+                    .to_string(),
+                fs::read_to_string(&md).unwrap_or_else(|e| panic!("{}: {e}", md.display())),
+            ));
+        }
+    }
+    found.sort();
+    found
+}
+
+/// The three activities ADR-91b77f036884 names. A sibling beyond these is
+/// allowed and anchored like the rest; one of these missing is the skill
+/// system shipping a contract without its policies.
+#[test]
+fn the_three_sibling_skills_exist() {
+    let names: Vec<String> = sibling_skills().into_iter().map(|(n, _)| n).collect();
+    for expected in ["drift", "loop", "plan"] {
+        assert!(
+            names.contains(&expected.to_string()),
+            "skill/{expected}/SKILL.md is missing: ADR-91b77f036884 names it as \
+             one of the three policies beside the contract"
+        );
+    }
+}
+
+/// Each sibling is anchored exactly as the contract is: a declared revision the
+/// test recomputes, because TASK-b495234f192c measured what an unanchored
+/// installed copy costs and the failure does not care which file it happens to.
+#[test]
+fn every_sibling_skill_says_which_revision_it_is() {
+    for (name, text) in sibling_skills() {
+        let (front, body) = split_skill(&text);
+        let declared = declared_revision(&front)
+            .unwrap_or_else(|| panic!("skill/{name}/SKILL.md declares no metadata.revision"));
+        let actual = ank_core::freeze_hash_short(&body);
+        assert_eq!(
+            declared, actual,
+            "skill/{name}/SKILL.md was edited without its revision: set \
+             metadata.revision to \"{actual}\""
+        );
+    }
+}
+
+/// The ceiling of ADR-91b77f036884 is per skill, for the by-hand route where a
+/// harness loads whole files.
+#[test]
+fn every_sibling_skill_stays_within_one_page() {
+    for (name, text) in sibling_skills() {
+        let lines = text.lines().count();
+        let words = text.split_whitespace().count();
+        assert!(
+            lines <= 180,
+            "skill/{name}/SKILL.md is {lines} lines, over the 180 ceiling"
+        );
+        assert!(
+            words <= 1500,
+            "skill/{name}/SKILL.md is {words} words, over the 1500 ceiling"
+        );
+    }
+}
+
+/// A sibling states the contract applies and adds its own policy; it never
+/// restates the rules, and it never shows the one command that is not an
+/// agent's to run. Two files teaching one rule drift, and the drift between an
+/// installed skill and a ratified decision is the measured failure this whole
+/// suite exists around.
+#[test]
+fn every_sibling_defers_to_the_contract_and_never_invites_accept() {
+    for (name, text) in sibling_skills() {
+        assert!(
+            text.contains("contract"),
+            "skill/{name}/SKILL.md never says the contract applies: a policy \
+             that restates the rules is a second copy waiting to drift"
+        );
+        assert!(
+            !text.contains("ank accept"),
+            "skill/{name}/SKILL.md shows `ank accept`: described, never invited \
+             holds in every skill that mentions it (ADR-91b77f036884)"
+        );
+    }
+}
+
+/// The plugin manifest is how a harness finds the skills, so a sibling the
+/// manifest does not list ships to nobody.
+#[test]
+fn the_plugin_manifest_lists_every_skill_directory() {
+    let manifest = repo_file(".claude-plugin/plugin.json");
+    assert!(
+        manifest.contains("\"./skill\""),
+        ".claude-plugin/plugin.json does not list ./skill, the contract"
+    );
+    for (name, _) in sibling_skills() {
+        assert!(
+            manifest.contains(&format!("\"./skill/{name}\"")),
+            ".claude-plugin/plugin.json does not list ./skill/{name}: the \
+             sibling exists and no harness will find it"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Whether the two halves agree (TASK-ecda4070354f)
 // ---------------------------------------------------------------------------
 

--- a/skill/drift/SKILL.md
+++ b/skill/drift/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: ank-drift
+description: Audit the decisions in .ank/ against the current code and report what no longer holds. Use when asked whether ADRs, specs, or tasks are still accurate, after a milestone, or when the corpus and the code seem to disagree.
+metadata:
+  revision: "36cf5808e95e"
+---
+
+# ank-drift
+
+Decisions age. The corpus says what was true when each one was ratified; the
+code says what is true now. This skill compares the two and reports. It never
+rewrites.
+
+The ank skill is the contract and applies here in full. This file adds the
+audit policy only.
+
+## Gather
+
+    ank review              what is proposed, and which scopes have gone dead
+    ank check               what is already known to be wrong
+    ank find --type adr     the decisions; --type spec, the rules
+    ank graph               an order that may no longer make sense
+    ank log <id>            what executors recorded against the entity
+
+Logs are the richest source: a discrepancy entry is a finding somebody already
+made for you, recorded mid-task and read by nobody since.
+
+Then read the code each scope covers. ank scope <path> names what claims to
+govern a file; the file says whether the claim still holds.
+
+## Judge
+
+For each accepted decision, three questions:
+
+- Does the constraint still describe the system?
+- Does the assumption it rests on still hold?
+- Does anything now contradict it: another entity, the code, a test?
+
+Evidence or it is not a finding. Name the entity, quote the assumption, point
+at the code, test or log that breaks it.
+
+## Report
+
+Findings ordered by impact, each in this shape:
+
+    ADR-xxxx  assumed:    what the decision took as true
+              measured:   what the repository shows now
+              evidence:   file, test, or log entry
+              recommend:  supersede, keep, or needs a decision
+
+Never edit an accepted entity and never write the superseding one uninvited.
+Superseding is planning: hand the findings to the human, and what they decide
+enters through ank-plan.

--- a/skill/loop/SKILL.md
+++ b/skill/loop/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: ank-loop
+description: Work through the open tasks in .ank/ without supervision, one claim at a time. Use when asked to work the backlog, chain tasks, or run autonomously in a repository with a .ank/ directory.
+metadata:
+  revision: "735328589adf"
+---
+
+# ank-loop
+
+The backlog was planned so this loop would not have to think about
+architecture. Consume tasks. Never redesign them.
+
+The ank skill is the contract and applies here in full: own worktree, fresh
+branch from the default branch, ANK_AGENT set, criterion frozen at claim.
+This file adds the loop policy only.
+
+## One pass
+
+    ank status                       where you are, what others hold
+    ank graph                        what is genuinely unblocked
+    ank find --status open --free    open tasks no live claim overlaps
+    pick one task                    see below
+    ank claim <id>
+    ank show <id>                    the body carries the reasoning; read it first
+    work; ank log "<discovery>" as you learn, not when you finish
+    ank done                         with its proof
+    next pass
+
+## Picking
+
+Three tests, all mandatory: unblocked in the graph, criterion executable as
+written, scope clear of every live claim. When no open task passes all three,
+stop and say so. An idle loop is cheaper than two agents rewriting one
+perimeter.
+
+## When a task is not ready
+
+A task is underplanned when its criterion is ambiguous, rests on a false
+premise, or needs a decision no ADR has made. Do not invent the architecture.
+Do not soften the criterion.
+
+    one clause rests on a false premise    ank log "discrepancy: <assumed> vs <measured>", finish the rest
+    the whole criterion is wrong           ank release --reason "<why>", move on
+    a decision is missing                  ank release --reason "<which>", flag it for planning, move on
+
+Work you discover is a new task with blocked_by, left for a later pass. Never
+a detour in this one.
+
+## Never in the loop
+
+No questions to a human. No new ADRs or specs. No edit to any criterion.
+
+The loop ends when nothing claimable is safe or the human returns. Leave the
+report: what finished, what was released and why, and what planning owes the
+backlog.

--- a/skill/plan/SKILL.md
+++ b/skill/plan/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: ank-plan
+description: Interview a goal into decisions and tasks recorded in .ank/. Use when someone brings a feature, change, or problem to plan before implementation in a repository with a .ank/ directory.
+metadata:
+  revision: "03d408e5e20f"
+---
+
+# ank-plan
+
+Planning turns an intention into entities the loop can consume: decisions as
+ADRs, rules as specs, work as tasks, order as blocked_by. The interview is how
+uncertainty leaves the plan before an executor meets it.
+
+The ank skill is the contract and applies here in full. This file adds the
+planning policy only.
+
+## Read before asking
+
+Never ask a question the repository answers. Before the first question:
+
+    ank context <path>      what already binds this perimeter
+    ank find <query>        what already exists near the goal
+    ank find --type spec    the specification itself
+    ank scope <path>        everything covering the files in play
+    ank log <id>            what previous holders learned
+
+Then read the code the goal touches. A question answered by reading, asked
+anyway, teaches the human to stop answering.
+
+## The interview
+
+Work the frontier: the decisions whose prerequisites are already settled.
+Everything downstream of an open decision waits.
+
+For each decision on the frontier:
+
+1. Check the repository has not already made it.
+2. Recommend one option, and say why.
+3. Ask.
+
+One round holds only questions independent of each other. Fold the answers in,
+recompute the frontier, repeat. Stop when the frontier is empty: nothing
+important left silently assumed.
+
+A question only running code can answer is not a question. It is a task with
+an experiment for a criterion.
+
+## Write the plan into the corpus
+
+Each settled decision becomes exactly one kind of entity:
+
+    a durable architectural decision    ank new adr     lands proposed
+    a normative rule                    ank new spec    lands proposed
+    concrete bounded work               ank new task    scope and criteria mandatory
+    an ordering between tasks           ank amend --blocked-by
+    a passing observation               ank log
+
+A done_criteria states what a verifier can check, not what an executor should
+attempt. If the criterion will not write, the decision is not settled: back to
+the frontier.
+
+## Where planning ends
+
+Proposed ADRs and specs bind nobody until a human ratifies them: a signed
+accept, on the default branch. Say what is waiting and stop. Then ank graph
+and ank check on the result: a cycle, an orphan or a finding is a plan not
+finished.


### PR DESCRIPTION
## What this carries

- **ADR-91b77f036884** (proposed) supersedes ADR-5dd7b4a9c875: the content freeze is lifted, skill content evolves under normal review, and three anchors survive it: `metadata.revision` recomputed by test on every skill, the binary naming the contract revision it was built alongside, and `accept` described but never invited. The description budget and the 180-line / 1500-word ceiling stay, per skill.
- **Three sibling skills**, one policy each, deferring to the contract in `skill/SKILL.md`:
  - `skill/plan/` (`ank-plan`): interview a goal into ADRs, specs, tasks and blocked_by; read the corpus before asking, recommend before asking, one frontier of independent questions per round.
  - `skill/drift/` (`ank-drift`): audit accepted decisions against the code their scopes cover; findings with evidence, never an edit.
  - `skill/loop/` (`ank-loop`): consume planned tasks; pick what cannot collide, release rather than redesign, no questions to a human.
- **tests/skill.rs** gains six tests anchoring the siblings the way the contract is anchored; `.claude-plugin/plugin.json` lists all four directories.
- **TASK-e26516d35da9** done with `commit:980dbc4` as proof; TASK-7cbf5b62be7f (packaging ships all four skills) and TASK-afb7ed8189cf (spec sections 4 and 9 follow, after ratification) remain open.

## After merge

Ratifying ADR-91b77f036884 is a human act, on the default branch.

## Verification

590 workspace tests green, `cargo fmt --check` clean, `ank check` exit 0 (signals only, including the expected "proposed: not yet a succession" on the supersession).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RzYYt47iud9wDmKiT7UTv4