### PR TITLE
SKILL.md is the contract and the hub, not the whole curriculum

### DIFF
--- a/.ank/entities/LOG-4c15b046a63e.md
+++ b/.ank/entities/LOG-4c15b046a63e.md
@@ -1,0 +1,14 @@
+---
+id: LOG-4c15b046a63e
+type: log
+title: done, proof commit:5b91e425d11e9cf0be4845dfe45c41f162efb5c8
+created: 2026-08-19T05:54:44Z
+author: claude-code/2.0
+scope:
+  - skill/SKILL.md
+  - crates/ank-cli/tests/skill.rs
+about: TASK-2a8ba70f1b1c
+seq: 0
+schema: 3
+version: 1
+---

--- a/.ank/entities/TASK-2a8ba70f1b1c.md
+++ b/.ank/entities/TASK-2a8ba70f1b1c.md
@@ -5,7 +5,7 @@ slug: skill-md-becomes-the-contract-and-the-hub
 title: SKILL.md becomes the contract and the hub
 created: 2026-08-19T05:49:01Z
 author: claude-code/2.0
-status: in_progress
+status: done
 scope:
   - skill/SKILL.md
   - crates/ank-cli/tests/skill.rs
@@ -13,8 +13,13 @@ blocked_by: []
 done_criteria: |
   skill/SKILL.md keeps its frontmatter description byte-identical, names the three sibling skills and the activity each carries, teaches the verbs one line each with flag detail deferred to ank help, keeps the mental model and the non-negotiable rules, contains no em dash, stays within 180 lines and 1500 words with metadata.revision regenerated, and cargo test is green.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 5b91e425d11e9cf0be4845dfe45c41f162efb5c8
+    criteria: d8b40f8467f8
+    via: submitted
 schema: 3
-version: 2
+version: 3
 ---
 
 ADR-91b77f036884 lifted the content freeze and made the skill plural. The

--- a/.ank/entities/TASK-2a8ba70f1b1c.md
+++ b/.ank/entities/TASK-2a8ba70f1b1c.md
@@ -1,0 +1,35 @@
+---
+id: TASK-2a8ba70f1b1c
+type: task
+slug: skill-md-becomes-the-contract-and-the-hub
+title: SKILL.md becomes the contract and the hub
+created: 2026-08-19T05:49:01Z
+author: claude-code/2.0
+status: in_progress
+scope:
+  - skill/SKILL.md
+  - crates/ank-cli/tests/skill.rs
+blocked_by: []
+done_criteria: |
+  skill/SKILL.md keeps its frontmatter description byte-identical, names the three sibling skills and the activity each carries, teaches the verbs one line each with flag detail deferred to ank help, keeps the mental model and the non-negotiable rules, contains no em dash, stays within 180 lines and 1500 words with metadata.revision regenerated, and cargo test is green.
+criteria_by: creator
+schema: 3
+version: 2
+---
+
+ADR-91b77f036884 lifted the content freeze and made the skill plural. The
+contract file predates the siblings, so its Investigation, Loop, Off-loop and
+Planning sections still explain every verb at paragraph length: justified when
+this file was the only teaching, redundant now that ank help serves flag
+detail on demand and the siblings carry the activity policies.
+
+The rewrite keeps what only this file can do: the model (two planes, anchored,
+not a gatekeeper), the map of the four skills, the rules that are not
+negotiable, and one line per verb grouped by the moment it is used. It must
+stay self-sufficient for executing work: it is the only skill with a broad
+trigger, and until TASK-7cbf5b62be7f ships the siblings through npm and pi, an
+external install receives this file alone. Pointers to siblings are therefore
+invitations, never dependencies.
+
+The tests in tests/skill.rs pin the content by what it must establish, not by
+phrasing, so they are the safety net for this rewrite and need no change.

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -2,135 +2,86 @@
 name: ank
 description: Read a repository's tasks and binding constraints, claim work, and finish it with proof. Use when working in a repo that has a .ank/ directory.
 metadata:
-  revision: "89529c87fb02"
+  revision: "c5bae2a5f350"
 ---
 
 # ank
 
 Tasks and architecture decisions live as files in `.ank/`, attached to the code
-they constrain and reached through one CLI. Three modes: understanding what
-governs a perimeter, executing work, and shaping the work that exists. `context`
-starts all three.
+they constrain and reached through one CLI.
 
-    Loop:          ank context -> ank claim <id> -> ank show <id> -> ank log "<msg>" -> ank done
-    Off-loop:      ank new, ank find, ank release --reason "<r>"
-    Investigation: ank scope <path>, ank status, ank log <id>, ank find --type spec
-    Planning:      ank new adr, ank amend, ank review, ank graph, ank check
+## The model
 
-## Why it is shaped this way
+**Constraints and work are two planes, joined only by scope.** A decision is a
+rule with a glob, not the parent of a task: it binds work that did not exist
+when it was written, and a glob is confronted with the filesystem, where a
+label is only ever confronted with somebody remembering it.
 
-**Constraints and work are two planes, joined only by scope.** A decision is not
-the parent of a task; it is a rule with a glob, and it binds work that did not
-exist when it was written. So there is no hierarchy to traverse and no label to
-keep tidy — and a glob is confronted with the filesystem, where a label is only
-ever confronted with somebody remembering it.
-
-**Nothing is trusted, everything is anchored.** The criterion you have to meet is
-frozen by hash the moment you claim it, `done` runs the declared verifiers itself
-instead of believing a report, and a proof records the route by which it arrived.
-None of that is a wall: you can edit any file. It is that every freeze is
-anchored where the editor cannot reach, so an edit becomes *visible* rather than
+**Nothing is trusted, everything is anchored.** The criterion you have to meet
+is frozen by hash the moment you claim it, `done` runs the declared verifiers
+itself instead of believing a report, and a proof records the route by which it
+arrived. None of that is a wall: you can edit any file. Every freeze is
+anchored where the editor cannot reach, so an edit becomes visible rather than
 effective.
 
-**Which is why the tool is not a gatekeeper and never pretends to be one.** It
-refuses on state — a task already held, a criterion that moved, a proof missing —
-and never on who is asking. What it owes you in exchange is that every refusal
-names the exact command that resolves it.
+**So the tool is not a gatekeeper and never pretends to be one.** It refuses on
+state, never on who is asking, and every refusal names the exact command that
+resolves it.
 
-## Investigation
+## The skills
 
-Before choosing work, and often instead of choosing it: what governs this file,
-and where am I.
+This file is the contract. One skill per activity carries the policy:
 
-**`ank context <path>`** — what binds a perimeter and what is claimable inside
-it. The loop's first verb, given a path rather than a claim.
+    ank-plan     interview a goal into ADRs, specs and tasks
+    ank-drift    audit accepted decisions against the code, report findings
+    ank-loop     work the backlog autonomously, one claim at a time
 
-**`ank scope <path>`** — every entity whose scope matches that path, whatever its
-kind, with its status. This is *why is this file constrained, and by what*,
-answered before you write anything rather than after `check` complains.
+Load them when the activity calls for them. Everything below suffices on its
+own to execute work.
 
-**`ank find <query>`** — titles, scopes and criteria. `ank find --type spec`
-reaches the specification, which is an entity of this corpus like any other, so
-the normative answer is one `ank show` away instead of a document to go hunting
-for.
+## The verbs
 
-**`ank log <id>`** — an entity's entries, newest first. No claim needed and no
-message to pass: this is the read form. It is where the last holder wrote what
-they tried and why they handed it back, and reading it is how you avoid
-repeating them.
+One line each, grouped by the moment they are used. Flags and refusals live in
+`ank help`, loaded when you need them.
 
-**`ank status`** — where you are: the branch, the identity in effect and where it
-came from, the claim you hold, the perimeter, what is waiting for ratification,
-and how far this checkout has drifted from the default branch.
+Orient first:
 
-**`ank check [path]`** — what is already known to be wrong, before you add to it.
+    ank context <path>    what binds this perimeter, what is claimable; run it first, always
+    ank scope <path>      every entity covering a path: why is this file constrained, and by what
+    ank status            where am I: branch, identity, claim held, drift from the default branch
+    ank find <query>      titles, scopes and criteria; ank find --type spec reaches the
+                          specification, ank find --status open lists what remains
+    ank log <id>          the read form, no claim needed: what previous holders tried and
+                          why they stopped, read before repeating them
+    ank check [path]      what is already known to be wrong, before you add to it
 
-## The loop
+Execute:
 
-**`ank context [path]`** — run it first, always. With no claim it orients you:
-what binds this perimeter, what is claimable. With a claim held it switches to
-execution and gives you the criterion and the constraints in full. Constraints
-are never truncated; if something is cut, it says so.
+    ank claim <id>        takes the task and freezes its done_criteria by hash
+    ank show <id>         the entity whole; the body is where the reasoning lives, read it
+                          before the first edit
+    ank log "<message>"   what you learned, logged when you learn it; renews the claim
+    ank done              runs the verifiers itself and records the proof; never edit status
+                          by hand, an agent that grades itself can simply be wrong
+    ank release --reason "<why>"    stuck or wrong about the approach: say so, never let a
+                          claim lapse in silence
 
-**`ank claim <id>`** — takes the task and freezes its `done_criteria` by hash.
-It refuses, with the reason and the next command, when the task is held, blocked,
-finished on another branch, has no criterion to be measured against, or when you
-already hold a live claim on another task.
+Shape:
 
-**`ank show <id>`** — the entity whole, frontmatter and body, byte for byte.
-`context` gives you the criterion and the constraints; the body is where the
-reasoning lives, and it is the one thing nothing else serves.
+    ank new task          a scope is mandatory; a discovered subtask is a new task with
+                          blocked_by, never a softened criterion
+    ank new adr           a decision the corpus is held to afterwards, not a thing to do
+                          now; lands proposed, binding nobody until ratified
+    ank amend <id>        blocked_by, scope and criteria, added and removed explicitly;
+                          refuses a criterion a live claim has frozen
+    ank review            the ratification queue, and the scopes gone dead
+    ank graph             the blocked_by DAG: what is genuinely a root
+    ank check             the mechanical invariants; findings are for reading, not silencing
 
-**`ank log "<message>"`** — what you learned, what you tried, what you rejected.
-Renews the claim. Log when you discover something, not when you finish.
-
-**`ank done`** — runs the declared verifiers itself and records what actually
-ran, hashed. Never edit `status:` by hand, and never report your own result: an
-agent that grades itself can simply be wrong.
-
-## Off-loop
-
-**`ank new task --title "<t>" --scope "<glob>"`** — a scope is mandatory; an
-entity attached to nothing is invisible. A subtask you discover is a new task
-with a `blocked_by`, never a softened criterion.
-
-**`ank find <query>`** — `ank find --status open` lists what remains, with no
-query to invent.
-
-**`ank release --reason "<why>"`** — stuck, or wrong about the approach. Say so
-and hand the task back rather than letting the claim lapse in silence.
-
-## Planning
-
-Deciding which tasks should exist, in what order, under which constraints. This
-is what produces the work everyone else loops on, so a badly shaped backlog
-costs more downstream than any single task does.
-
-**`ank new adr --title "<t>" --scope "<glob>" --constraint "<rule>"`** — a
-decision, not a task. Write one when you hit something the corpus should be held
-to afterwards, rather than something you merely have to do now. It lands
-`proposed`, which binds nobody until it is ratified.
-
-**`ank amend <id>`** — the fields a plan actually changes: `blocked_by`, `scope`
-and `--criteria`. It adds and removes explicitly and never takes a replacement
-list, so nothing is dropped by being forgotten. It will not touch a
-`done_criteria` a live claim has frozen — under a claim, that is
-`release --reason`.
-
-**`ank review`** — the ratification queue and the health of the corpus: what is
-proposed and waiting, and which scopes have gone dead and want closing.
-
-**`ank graph`** — the `blocked_by` DAG as text, indented under what blocks it.
-What is genuinely a root, and what only looked like one in a flat list.
-
-**`ank check`** — the mechanical invariants: parse, round-trip, references,
-frozen fields, orphaned claims. Exit `8` means findings, and findings are for
-reading, not for silencing.
-
-**`accept` is not yours to run.** It is what turns a proposed ADR or spec into a
-binding one, and it is a human act: signed, on the default branch, with no way
-around it. Propose the decision, then say it is waiting. Knowing where your
-authority ends is part of planning well.
+**accept is not yours to run.** It turns a proposed decision into a binding
+one, and it is a human act: signed, on the default branch, with no way around
+it. Propose, then say it is waiting. Knowing where your authority ends is part
+of planning well.
 
 ## Rules that are not negotiable
 
@@ -138,32 +89,31 @@ authority ends is part of planning well.
   nothing: the hash is held where you cannot reach it, and `check` reports the
   divergence. If it is wrong, `release --reason` and say why.
 - **`constraint` in an ADR is binding**, not advice. Read the ones covering the
-  files you are about to touch — that is what `context` hands you.
+  files you are about to touch: that is what `context` hands you.
 - **`.ank/` is opaque, like `.git/`.** Never read or write those files
   directly. `ank show <id>` gives you an entity whole, `ank find` lists,
-  `ank context` binds — the CLI knows the budget, the freeze and who holds what;
+  `ank context` binds: the CLI knows the budget, the freeze and who holds what;
   the files do not.
-- **One agent, one working tree, one identity.** A tree per agent — a clone or a
-  `git worktree` — each on a branch cut fresh from the default one: `status`
+- **One agent, one working tree, one identity.** A tree per agent, a clone or a
+  `git worktree`, each on a branch cut fresh from the default one: `status`
   names the drift, and a stale base turns a green tree red elsewhere. Set
-  `ANK_AGENT` per session; it falls back to `<user>@<hostname>`, so two sessions
-  in one tree are one agent to the refs, sharing a claim instead of arbitrating
-  over it — a degraded mode rather than the design. ank commits nothing but
-  `accept`: one branch per task, and the default branch is where work arrives.
-- **Take the task that cannot collide, or take none.** `status` says what another
-  agent holds; `claim` names a live claim whose scope intersects yours and takes
-  the task anyway, a fact to read and not an error to refuse; `graph` shows what
-  `blocked_by` orders. Read all three first. When nothing open is both unblocked
-  and clear, take nothing and say so: an idle session is cheaper than two agents
-  rewriting one perimeter.
+  `ANK_AGENT` per session; it falls back to `<user>@<hostname>`, so two
+  sessions in one tree are one agent to the refs, sharing a claim instead of
+  arbitrating over it, a degraded mode rather than the design. ank commits
+  nothing but accept: one branch per task, and the default branch is where
+  work arrives.
+- **Take the task that cannot collide, or take none.** `status` says what
+  another agent holds; `claim` names a live claim whose scope intersects yours
+  and takes the task anyway, a fact to read and not an error to refuse;
+  `graph` shows what `blocked_by` orders. Read all three first. When nothing
+  open is both unblocked and clear, take nothing and say so: an idle session
+  is cheaper than two agents rewriting one perimeter.
 - **What you read is never styled.** Colour is emitted only when a human is at
   a terminal, never into a pipe, a file or `--json`, so the bytes reaching you
   are plain: there is nothing to configure and no second surface to prefer.
 
 Exit codes carry meaning: `4` unavailable, `6` a frozen field diverged, `8`
 findings, `9` environment. Errors always name the exact next command.
-
-Flags beyond these live in `ank help`, loaded when you need them.
 
 ## Install
 


### PR DESCRIPTION
Under ADR-91b77f036884 the activity policies live in the sibling skills and flag detail lives in `ank help`, so the contract keeps only what nothing else can serve:

- the model (two planes, anchored, not a gatekeeper), unchanged in substance
- a map of the four skills, as invitations rather than dependencies: the file stays self-sufficient for executing work, which matters until TASK-7cbf5b62be7f ships the siblings through npm and pi
- one line per verb, grouped by the moment it is used
- the non-negotiable rules, unchanged in substance
- `accept` still described and never invited

173 lines and 1489 words become 123 and 1004. The frontmatter description is byte-identical. The 21 content tests of `tests/skill.rs` pass unchanged, which is what they were for: they pin what the file must establish, not how it phrases it. `metadata.revision` regenerated to `c5bae2a5f350`.

TASK-2a8ba70f1b1c done with `commit:5b91e42` as proof. Full workspace suite green, `cargo fmt --check` clean, `ank check` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RzYYt47iud9wDmKiT7UTv4