### PR TITLE
The npm and pi channels carry every skill, not one

### DIFF
--- a/.ank/entities/LOG-91e7add53b50.md
+++ b/.ank/entities/LOG-91e7add53b50.md
@@ -1,0 +1,17 @@
+---
+id: LOG-91e7add53b50
+type: log
+title: "Measured, not assumed: claude plugin details on the local marketplace reports Skills (4) ank,"
+created: 2026-08-19T06:12:38Z
+author: claude-code/2.0
+scope:
+  - .github/**
+  - npm/**
+  - docs/**
+about: TASK-7cbf5b62be7f
+seq: 0
+schema: 3
+version: 1
+---
+
+ ank-drift, ank-loop, ank-plan and 282 tok always-on, up from 58 with one skill; per-component on-invoke is ank 1.9k, ank-plan 740, ank-drift 560, ank-loop 630. npx skills add --list finds 4 skills through its recursive scan, so the sibling directories need no manifest entry there. Both outputs in docs/agents.md are now the real ones. The assemble script and the smoke step were replayed locally against a packed tarball: four skills carried, hashes equal.

--- a/.ank/entities/LOG-cb370a9730df.md
+++ b/.ank/entities/LOG-cb370a9730df.md
@@ -1,0 +1,15 @@
+---
+id: LOG-cb370a9730df
+type: log
+title: done, proof commit:cadc8531f0f717e1efde0b765e095a6a363a3eac
+created: 2026-08-19T06:17:47Z
+author: claude-code/2.0
+scope:
+  - .github/**
+  - npm/**
+  - docs/**
+about: TASK-7cbf5b62be7f
+seq: 1
+schema: 3
+version: 1
+---

--- a/.ank/entities/TASK-6704242b47f3.md
+++ b/.ank/entities/TASK-6704242b47f3.md
@@ -1,0 +1,30 @@
+---
+id: TASK-6704242b47f3
+type: task
+slug: the-archive-and-the-deb-carry-one-skill-of-four
+title: The archive and the .deb carry one skill of four
+created: 2026-08-19T06:12:58Z
+author: claude-code/2.0
+status: open
+scope:
+  - .github/workflows/release.yml
+  - .github/workflows/publish-apt.yml
+blocked_by: []
+done_criteria: |
+  The release archive and the .deb either carry every skill, or the decision to carry only the contract is written where the copy is made, and the check that guards the .deb contents matches whichever was chosen.
+criteria_by: creator
+schema: 3
+version: 1
+---
+
+Found while shipping TASK-7cbf5b62be7f, which covered npm and pi only. Two
+other routes still copy skill/SKILL.md alone: the release archive
+(release.yml, the package step) and the Debian package, which lands it at
+/usr/share/doc/ank/SKILL.md with a job asserting exactly that list.
+
+Not folded into that task, because it is a design question rather than an
+oversight: those two routes hand files to a human unpacking an archive or
+reading /usr/share/doc, where npm and pi hand skills to a harness that loads
+them. Carrying four policy files into a documentation directory may be the
+wrong answer. Whichever way it goes, the reason belongs beside the copy, and
+the .deb check has to agree with it.

--- a/.ank/entities/TASK-7cbf5b62be7f.md
+++ b/.ank/entities/TASK-7cbf5b62be7f.md
@@ -5,7 +5,7 @@ slug: the-npm-and-pi-channels-ship-every-skill-not-one
 title: The npm and pi channels ship every skill, not one
 created: 2026-08-19T04:49:46Z
 author: claude-code/2.0
-status: in_progress
+status: done
 scope:
   - .github/**
   - npm/**
@@ -14,8 +14,13 @@ blocked_by: [TASK-e26516d35da9]
 done_criteria: |
   npm-assemble.sh copies skill/SKILL.md and every skill/*/SKILL.md into the wrapper package under skills/<name>/SKILL.md, the release smoke job checks all four arrived, and docs/agents.md describes the by-hand route for all four skills.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: cadc8531f0f717e1efde0b765e095a6a363a3eac
+    criteria: c6d04811beea
+    via: submitted
 schema: 3
-version: 2
+version: 3
 ---
 
 The wrapper package assembles skills/ank/SKILL.md from skill/SKILL.md at pack

--- a/.ank/entities/TASK-7cbf5b62be7f.md
+++ b/.ank/entities/TASK-7cbf5b62be7f.md
@@ -5,7 +5,7 @@ slug: the-npm-and-pi-channels-ship-every-skill-not-one
 title: The npm and pi channels ship every skill, not one
 created: 2026-08-19T04:49:46Z
 author: claude-code/2.0
-status: open
+status: in_progress
 scope:
   - .github/**
   - npm/**
@@ -15,7 +15,7 @@ done_criteria: |
   npm-assemble.sh copies skill/SKILL.md and every skill/*/SKILL.md into the wrapper package under skills/<name>/SKILL.md, the release smoke job checks all four arrived, and docs/agents.md describes the by-hand route for all four skills.
 criteria_by: creator
 schema: 3
-version: 1
+version: 2
 ---
 
 The wrapper package assembles skills/ank/SKILL.md from skill/SKILL.md at pack

--- a/.github/scripts/npm-assemble.sh
+++ b/.github/scripts/npm-assemble.sh
@@ -79,15 +79,36 @@ done
 cp ../../LICENSE LICENSE
 
 # pi reads a package's skills from its pi.skills path, and its convention is
-# skills/<name>/SKILL.md. The source is skill/SKILL.md at the repository root,
-# where the freeze lives: build.rs hashes it into `ank --version` and
-# tests/skill.rs holds the file to that hash. A second copy committed beside it
-# would have no such anchor and would drift with nothing turning red, which is
-# what ADR-e3cb36646d77 refuses. So the copy is made here, from the one file, on
-# every run, and .gitignore keeps it out of the tree -- the same arrangement as
-# LICENSE on the line above. The release smoke job is what checks it arrived.
-mkdir -p skills/ank
-cp ../../skill/SKILL.md skills/ank/SKILL.md
+# skills/<name>/SKILL.md. The sources are skill/SKILL.md at the repository root
+# and every skill/<dir>/SKILL.md beside it: the contract and one policy per
+# activity (ADR-91b77f036884). Each is anchored where it lives -- build.rs
+# hashes the contract into `ank --version`, tests/skill.rs holds every skill to
+# its declared revision -- and a copy committed beside them would have no such
+# anchor and would drift with nothing turning red, which is what
+# ADR-e3cb36646d77 refuses. So the copies are made here, from the one file per
+# skill, on every run, and .gitignore keeps them out of the tree, the same
+# arrangement as LICENSE on the line above. The release smoke job is what checks
+# they arrived.
+#
+# The destination is the name the skill declares in its own frontmatter, not the
+# directory it sits in: `ank-plan` lives in `skill/plan/`, and pi installs what
+# the frontmatter calls it. Deriving it from the file means a skill added later
+# is packaged by existing, with nothing here to remember.
+skill_name() {
+  sed -n 's/^name:[[:space:]]*//p' "$1" | head -n 1
+}
+
+for src in ../../skill/SKILL.md ../../skill/*/SKILL.md; do
+  [ -f "$src" ] || continue
+  name="$(skill_name "$src")"
+  if [ -z "$name" ]; then
+    echo "$src declares no name: in its frontmatter" >&2
+    exit 1
+  fi
+  mkdir -p "skills/$name"
+  cp "$src" "skills/$name/SKILL.md"
+  echo "packaged skill $name from ${src#../../}"
+done
 
 npm pack --silent > /dev/null
 echo "assembled npm/ank at $version"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -266,24 +266,39 @@ jobs:
         shell: bash
         run: bash .github/scripts/npm-assemble.sh "0.0.0-smoke" "${{ matrix.package }}"
 
-      # The wrapper is also the pi package, and a pi package is its skill: with
+      # The wrapper is also the pi package, and a pi package is its skills: with
       # skills/ank/SKILL.md missing, `pi install npm:@haksolot/ank` installs a
       # binary and teaches nothing, while every other assertion in this job
-      # still passes. The copy is made at assembly time and never committed
-      # (npm-assemble.sh), so nothing else in the repository can notice it went
+      # still passes. The copies are made at assembly time and never committed
+      # (npm-assemble.sh), so nothing else in the repository can notice one went
       # missing. Read out of the tarball rather than off the disk, because the
       # tarball is what the registry receives -- a `files` entry that stopped
       # matching would leave the file on disk and out of the package.
-      - name: the wrapper carries the skill
+      #
+      # Every skill, not only the contract (ADR-91b77f036884): an install that
+      # receives `ank` and none of `ank-plan`, `ank-drift`, `ank-loop` teaches
+      # the rules and none of the activities. The list is walked from the tree
+      # rather than written here, so a skill added later is checked by existing,
+      # and the count is asserted so that a walk finding nothing cannot pass as
+      # a walk finding everything.
+      - name: the wrapper carries every skill
         shell: bash
         run: |
           set -e
           tgz=$(ls npm/ank/*.tgz | head -n 1)
-          packed=$(tar -xzOf "$tgz" package/skills/ank/SKILL.md | sha256sum | cut -d' ' -f1)
-          source=$(sha256sum skill/SKILL.md | cut -d' ' -f1)
-          echo "packed: $packed"
-          echo "source: $source"
-          test "$packed" = "$source"
+          checked=0
+          for src in skill/SKILL.md skill/*/SKILL.md; do
+            [ -f "$src" ] || continue
+            name=$(sed -n 's/^name:[[:space:]]*//p' "$src" | head -n 1)
+            packed=$(tar -xzOf "$tgz" "package/skills/${name}/SKILL.md" | sha256sum | cut -d' ' -f1)
+            source=$(sha256sum "$src" | cut -d' ' -f1)
+            echo "  ${name}: packed $packed"
+            echo "  ${name}: source $source"
+            test "$packed" = "$source"
+            checked=$((checked + 1))
+          done
+          echo "$checked skills carried"
+          test "$checked" -ge 4
 
       # The argument publish-npm passes, run on every dispatch and every tag,
       # with the one flag that stops short of the registry. This is the step

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -10,22 +10,28 @@ Everything below is for the cases those two do not fit.
 
 ## The skill
 
-One plain markdown file, [`../skill/SKILL.md`](../skill/SKILL.md). It is the only
-copy that exists in git, and every route below points at it rather than holding
-one of its own, so no route can fall behind it.
+Four plain markdown files, one per skill. Each is the only copy that exists in
+git, and every route below points at it rather than holding one of its own, so
+no route can fall behind it.
 
-It teaches one page: why ank is shaped as it is, then the loop
-`context -> claim -> show -> log -> done`, the three off-loop verbs `new`,
-`find` and `release`, the investigation verbs `scope`, `status` and the read
-form of `log`, the planning verbs, and the rules that are not negotiable. Its
-content is deliberately small and growing it costs an ADR.
+    ank         ../skill/SKILL.md          the contract
+    ank-plan    ../skill/plan/SKILL.md     interview a goal into ADRs, specs, tasks
+    ank-drift   ../skill/drift/SKILL.md    audit decisions against the code
+    ank-loop    ../skill/loop/SKILL.md     work the backlog autonomously
+
+[`../skill/SKILL.md`](../skill/SKILL.md) is the one an agent loads by default,
+and it is self-sufficient: why ank is shaped as it is, the verbs grouped by the
+moment each is used, and the rules that are not negotiable. It names the other
+three so an agent reaching for an activity knows what to load, and never
+depends on them being installed. The three carry a policy each and are loaded
+when the activity calls for them (ADR-91b77f036884).
 
 **What that costs a session is the frontmatter, not the page.** The projection
-below is `~58 tok` always-on, and that is the skill's `name` and `description`;
-the body is read when the skill is invoked. The ceiling on the body is kept
-anyway, because the by-hand route at the end of this page copies the whole file
-into whatever a harness loads, and some harnesses load all of it every session,
-so it bounds the worst route rather than the measured one.
+below is `~58 tok` always-on per skill, and that is a skill's `name` and
+`description`; a body is read when its skill is invoked. The ceiling on the
+bodies is kept anyway, because the by-hand route at the end of this page copies
+whole files into whatever a harness loads, and some harnesses load all of it
+every session, so it bounds the worst route rather than the measured one.
 
 One convention it carries is worth knowing before you watch an agent follow it:
 **`.ank/` is opaque to an agent, the way `.git/` is.** Reading goes through
@@ -42,7 +48,7 @@ install:
     $ npx skills add haksolot/ank --list
     Source: https://github.com/haksolot/ank.git
     Repository cloned
-    Found 1 skill
+    Found 4 skills
 
     Available Skills
     Ank
@@ -50,8 +56,18 @@ install:
         Read a repository's tasks and binding constraints, claim work, and
         finish it with proof. Use when working in a repo that has a .ank/
         directory.
+      ank-drift
+        Audit the decisions in .ank/ against the current code and report what
+        no longer holds. ...
+      ank-loop
+        Work through the open tasks in .ank/ without supervision, one claim at
+        a time. ...
+      ank-plan
+        Interview a goal into decisions and tasks recorded in .ank/. ...
 
-Drop `--list` to install it.
+    Use --skill <name> to install specific skills
+
+Drop `--list` to install them all, or name one with `--skill`.
 
 This is the widest route and the least anchored one. It finds the skill through
 its own recursive scan rather than through a manifest, `skill/` not being one of
@@ -73,10 +89,24 @@ worth asking of anything loaded on every session:
     agent can call.
 
     Component inventory
-      Skills (1)  ank
+      Skills (4)  ank, ank-drift, ank-loop, ank-plan
 
     Projected token cost
-      Always-on:   ~58 tok   added to every session
+      Always-on:   ~282 tok   added to every session
+
+    Per-component (rounded)
+      component  always-on  on-invoke
+      ank              ~50      ~1.9k
+      ank-plan         ~70       ~740
+      ank-drift        ~80       ~560
+      ank-loop         ~70       ~630
+
+**Read the two columns as what they are.** Always-on is four descriptions, paid
+by every session whether or not anything fires; on-invoke is a body, paid by
+the session that wanted it. Splitting the teaching moved cost from the second
+column to the first, which is the trade the plural skill system makes: an agent
+executing a task no longer loads the planning policy it will not use, and every
+session pays a little more to know the policies exist.
 
 ### pi
 
@@ -96,10 +126,12 @@ routes below.
 
 ### By hand
 
-The skill is one file with nothing generated in it. Where none of the routes
+Each skill is one file with nothing generated in it. Where none of the routes
 above fits your harness, copy `skill/SKILL.md` into whatever that harness loads
 and you have lost nothing: the routes exist to save you a copy, not to add
-anything to it.
+anything to it. Copy `skill/plan/SKILL.md`, `skill/drift/SKILL.md` and
+`skill/loop/SKILL.md` beside it for the activity policies, or copy none of them
+and keep the contract, which stands alone.
 
 ## The binary
 


### PR DESCRIPTION
TASK-7cbf5b62be7f, the packaging half of ADR-91b77f036884.

**`npm-assemble.sh`** walked one file. It now walks `skill/SKILL.md` and every `skill/*/SKILL.md`, packaging each under the name its own frontmatter declares (`ank-plan` lives in `skill/plan/`), so a skill added later is carried by existing.

**The smoke step** walks the same list out of the packed tarball, compares hashes per skill, and asserts the count: a walk finding nothing would otherwise pass as a walk finding everything.

**`docs/agents.md`** now carries measured outputs instead of stale ones:

    Skills (4)  ank, ank-drift, ank-loop, ank-plan
    Always-on:  ~282 tok   added to every session

up from `~58 tok` with one skill, with the per-component table beside it (`ank` ~1.9k on-invoke, the policies 560 to 740). The doc reads the two columns where they are printed: splitting the teaching moved cost from on-invoke to always-on, and an agent executing a task no longer loads the planning policy it will not use. `npx skills add --list` was run against the published repo and finds all four through its recursive scan, so the sibling directories need no manifest entry there.

### Verified locally

The assemble script and the smoke step were replayed against a real packed tarball: four skills carried, every hash equal. `bash -n` clean, the workflow YAML parses, full workspace suite green, `ank check` exit 0.

### Found on the way

**TASK-6704242b47f3** (new, open): the release archive and the `.deb` still copy `skill/SKILL.md` alone. Left out of this task deliberately, since those routes hand files to a human unpacking an archive rather than to a harness that loads skills, so whether four policy files belong in `/usr/share/doc/ank/` is a design question rather than an oversight.

TASK-7cbf5b62be7f done with `commit:cadc853` as proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RzYYt47iud9wDmKiT7UTv4