### PR TITLE
A proposed spec waits in the queue review and status print

### DIFF
--- a/.ank/entities/LOG-29ca0da935b4.md
+++ b/.ank/entities/LOG-29ca0da935b4.md
@@ -1,0 +1,16 @@
+---
+id: LOG-29ca0da935b4
+type: log
+title: "Falsified before it was trusted: with the two filters reverted, a_proposed_spec_alone and"
+created: 2026-08-19T07:28:07Z
+author: claude-code/2.0
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/src/status.rs
+about: TASK-73e81a8a804d
+seq: 0
+schema: 3
+version: 1
+---
+
+ a_corpus_holding_both_kinds go red while a_proposed_adr_alone stays green, so the fix widens the queue rather than moving it. Replayed end to end on the corpus that produced the defect, this repository at 0e3172b where SPEC-4eff92fd80ce and SPEC-80bff12ceae8 sat proposed: ank 0.4.0 answers 'nothing proposed for ratification' and 'queue 0 proposal(s)', the rebuilt binary names both documents and counts 'queue 2 proposal(s)'. LIVE CONSTRAINTS is unchanged in both, which is the clause about the live section, measured rather than read.

--- a/.ank/entities/LOG-f13e7c365372.md
+++ b/.ank/entities/LOG-f13e7c365372.md
@@ -1,0 +1,14 @@
+---
+id: LOG-f13e7c365372
+type: log
+title: done, proof commit:3695765d20c354070798cd44f377f7b9601ed227
+created: 2026-08-19T07:28:40Z
+author: claude-code/2.0
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/src/status.rs
+about: TASK-73e81a8a804d
+seq: 1
+schema: 3
+version: 1
+---

--- a/.ank/entities/TASK-73e81a8a804d.md
+++ b/.ank/entities/TASK-73e81a8a804d.md
@@ -5,7 +5,7 @@ slug: a-proposed-spec-waits-for-a-human-where-a-human
 title: A proposed spec waits for a human where a human looks
 created: 2026-08-18T04:55:44Z
 author: claude-code/opus-5
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/src/human.rs
   - crates/ank-cli/src/status.rs
@@ -14,7 +14,7 @@ done_criteria: |
   A proposed spec appears in the ratification queue. ank review names it in the queue section beside proposed ADRs, and ank status counts it in the queue line. Measured through the binary on a corpus holding one proposed spec and one proposed ADR: both are named by review, both are counted by status, and --json carries both. review's live-constraints section is unchanged, because a spec declares no constraint and binds nothing, so it has nothing to appear there. Tests cover a proposed spec alone, a proposed ADR alone, and a corpus holding both, through the binary. cargo test --workspace and ank check stay green.
 criteria_by: creator
 schema: 3
-version: 1
+version: 2
 ---
 
 Recorded on 2026-08-15 in LOG-c57135ae45f3 and left untasked since: `review`

--- a/.ank/entities/TASK-73e81a8a804d.md
+++ b/.ank/entities/TASK-73e81a8a804d.md
@@ -5,7 +5,7 @@ slug: a-proposed-spec-waits-for-a-human-where-a-human
 title: A proposed spec waits for a human where a human looks
 created: 2026-08-18T04:55:44Z
 author: claude-code/opus-5
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/src/human.rs
   - crates/ank-cli/src/status.rs
@@ -13,8 +13,13 @@ blocked_by: []
 done_criteria: |
   A proposed spec appears in the ratification queue. ank review names it in the queue section beside proposed ADRs, and ank status counts it in the queue line. Measured through the binary on a corpus holding one proposed spec and one proposed ADR: both are named by review, both are counted by status, and --json carries both. review's live-constraints section is unchanged, because a spec declares no constraint and binds nothing, so it has nothing to appear there. Tests cover a proposed spec alone, a proposed ADR alone, and a corpus holding both, through the binary. cargo test --workspace and ank check stay green.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 3695765d20c354070798cd44f377f7b9601ed227
+    criteria: 1ab89a21920c
+    via: submitted
 schema: 3
-version: 2
+version: 3
 ---
 
 Recorded on 2026-08-15 in LOG-c57135ae45f3 and left untasked since: `review`

--- a/crates/ank-cli/src/human.rs
+++ b/crates/ank-cli/src/human.rs
@@ -3132,7 +3132,19 @@ pub fn review(
     let mut live = Vec::new();
     let mut proposed = Vec::new();
     for row in index.all()? {
-        if row.kind != EntityKind::Adr {
+        // **Both kinds `accept` promotes, because the queue is the set of
+        // documents waiting for a signature** (TASK-73e81a8a804d). A spec goes
+        // through `accept` and no other verb, over the same anchor and the same
+        // signed commit, so a proposed one is waiting exactly as a proposed ADR
+        // is. Filtering this loop on `Adr` alone told a maintainer their queue
+        // was empty while a document sat in it, which is the one answer this
+        // verb exists to give.
+        //
+        // The live section below stays ADR-only, and that is a separate
+        // question rather than an oversight: it counts the files a constraint
+        // binds, and a spec declares no constraint and binds nothing, so it has
+        // nothing to count and no line to occupy there.
+        if !matches!(row.kind, EntityKind::Adr | EntityKind::Spec) {
             continue;
         }
         // The third copy of this matching, now gone the way of the other two:
@@ -3148,7 +3160,7 @@ pub fn review(
             // dropping it from the queue would hide the one entry most in need
             // of the answer. Its dead scope is reported in its own section.
             "proposed" => proposed.push(row),
-            "accepted" => {
+            "accepted" if row.kind == EntityKind::Adr => {
                 if dead.contains(&row.id.to_string()) {
                     continue;
                 }

--- a/crates/ank-cli/src/status.rs
+++ b/crates/ank-cli/src/status.rs
@@ -214,9 +214,15 @@ pub fn run(
         })
         .count();
 
+    // Both kinds `accept` promotes, for the reason `review` states at the loop
+    // that builds the same queue (TASK-73e81a8a804d): a proposed spec is
+    // waiting for the same signature, and a count that omitted it reported an
+    // empty queue over a document sitting in one. The constraints line above
+    // stays ADR-only, because it counts what binds this perimeter and a spec
+    // declares no constraint.
     let queue = rows
         .iter()
-        .filter(|r| r.kind == EntityKind::Adr && r.status == "proposed")
+        .filter(|r| matches!(r.kind, EntityKind::Adr | EntityKind::Spec) && r.status == "proposed")
         .count();
 
     // Finished on a branch the default has not caught up with. `inspect` has

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -11945,6 +11945,156 @@ fn review_prints_the_ratification_queue_it_is_described_by() {
     );
 }
 
+/// **A proposed spec waits in the queue a human actually reads**
+/// (TASK-73e81a8a804d).
+///
+/// `accept` promotes a spec and an ADR through the same verb, over the same
+/// anchor and the same signed commit, so both are documents waiting for a
+/// signature. `review` and `status` built their queue by filtering on
+/// `EntityKind::Adr`, so a corpus holding a proposed spec was told its queue
+/// was empty by the one verb whose stated job is the queue, while `find --type
+/// spec --status proposed` named the document and `check` reported it twice.
+///
+/// Measured on this repository on 2026-08-19, which is what turned a log entry
+/// into this test: two specs sat proposed after a supersession, `review` said
+/// `nothing proposed for ratification`, and the maintainer had to be handed the
+/// two `accept` lines by hand.
+///
+/// Through the binary, because the claim is about what the two commands print
+/// on a corpus: the filter under test is reached by the render, and a unit test
+/// on the row set would pass over a surface that never printed it.
+///
+/// Three corpora, because the criterion asks for three and each one can fail
+/// alone: a spec by itself proves the kind is admitted, an ADR by itself proves
+/// nothing was traded away for it, and the pair proves the count is a sum
+/// rather than a branch.
+#[test]
+fn a_proposed_spec_alone_waits_where_review_and_status_look() {
+    const DOC: &str = "SPEC-00000000e0e0";
+
+    let r = Repo::new();
+    r.seed_docs();
+    r.seed_spec(DOC, "proposed", &[], None);
+    r.git(&["add", "-A"]);
+    r.git(&["commit", "-qm", "seed"]);
+
+    let text = stdout(&r.ank("claude-code@ank", &["review"]));
+    assert!(
+        text.contains("PROPOSED (1)") && text.contains(DOC),
+        "a proposed spec is waiting for a signature and review must name it: {text}"
+    );
+    assert!(
+        !text.contains("nothing proposed for ratification"),
+        "the queue is not empty: {text}"
+    );
+    assert!(
+        text.contains("LIVE CONSTRAINTS (0)"),
+        "a spec declares no constraint and binds nothing, so it has no line \
+         among the live ones: {text}"
+    );
+
+    let status = stdout(&r.ank("claude-code@ank", &["status"]));
+    assert!(
+        status.contains("queue 1 proposal(s)"),
+        "status and review answer one corpus: {status}"
+    );
+
+    let out = r.ank("claude-code@ank", &["review", "--json"]);
+    assert_json_only(&out, "ank review --json");
+    let json = stdout(&out);
+    assert!(
+        json.contains(&format!("\"proposed\":[{{\"id\":\"{DOC}\"")),
+        "a caller parsing review gets the spec as data too: {json}"
+    );
+    assert!(
+        json.contains("\"live\":[]"),
+        "and it is not laundered into the constraints: {json}"
+    );
+}
+
+/// The other kind alone, which is what says the fix widened the queue rather
+/// than moving it. This passed before TASK-73e81a8a804d and has to keep
+/// passing: a change that admitted specs by dropping ADRs would satisfy the
+/// test above and break the verb.
+#[test]
+fn a_proposed_adr_alone_still_waits_where_it_always_did() {
+    const DECISION: &str = "ADR-00000000e1e1";
+
+    let r = Repo::new();
+    std::fs::create_dir_all(r.0.join("src")).unwrap();
+    std::fs::write(r.0.join("src/main.rs"), "fn main() {}\n").unwrap();
+    r.seed_adr(DECISION, "Do not do X.", "src/**");
+    r.git(&["add", "-A"]);
+    r.git(&["commit", "-qm", "seed"]);
+
+    let text = stdout(&r.ank("claude-code@ank", &["review"]));
+    assert!(
+        text.contains("PROPOSED (1)") && text.contains(DECISION),
+        "{text}"
+    );
+    let status = stdout(&r.ank("claude-code@ank", &["status"]));
+    assert!(status.contains("queue 1 proposal(s)"), "{status}");
+}
+
+/// Both kinds in one corpus: the queue is their sum, and ratifying the spec
+/// leaves the live section exactly where it was.
+///
+/// That last assertion is the one keeping this fix inside its perimeter. The
+/// criterion says the live section is unchanged, and the way to measure it is
+/// not to read the code but to promote the spec and watch the constraints: a
+/// spec that had leaked into that section would appear the moment it was
+/// accepted, and the count would read 1 instead of 0.
+#[test]
+fn a_corpus_holding_both_kinds_queues_both_and_keeps_the_live_section() {
+    const DECISION: &str = "ADR-00000000e2e2";
+    const DOC: &str = "SPEC-00000000e2e2";
+
+    let r = Repo::new();
+    r.enable_signing();
+    r.seed_docs();
+    std::fs::create_dir_all(r.0.join("src")).unwrap();
+    std::fs::write(r.0.join("src/main.rs"), "fn main() {}\n").unwrap();
+    r.seed_adr(DECISION, "Do not do X.", "src/**");
+    r.seed_spec(DOC, "proposed", &[], None);
+    r.git(&["add", "-A"]);
+    r.git(&["commit", "-qm", "seed"]);
+
+    let text = stdout(&r.ank("claude-code@ank", &["review"]));
+    assert!(
+        text.contains("PROPOSED (2)"),
+        "the queue is the sum of both kinds, not one of them: {text}"
+    );
+    assert!(text.contains(DECISION) && text.contains(DOC), "{text}");
+    assert!(
+        text.contains("LIVE CONSTRAINTS (0)"),
+        "neither is accepted yet: {text}"
+    );
+
+    let status = stdout(&r.ank("claude-code@ank", &["status"]));
+    assert!(status.contains("queue 2 proposal(s)"), "{status}");
+
+    let json = stdout(&r.ank("claude-code@ank", &["review", "--json"]));
+    assert!(json.contains(DECISION) && json.contains(DOC), "{json}");
+
+    // Ratify the spec alone. The queue loses it, and the constraints do not
+    // gain it: promoting a spec adds nothing to what binds a perimeter.
+    let out = r.ank("marie@laptop", &["accept", DOC]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+
+    let text = stdout(&r.ank("claude-code@ank", &["review"]));
+    assert!(
+        text.contains("PROPOSED (1)") && text.contains(DECISION) && !text.contains(DOC),
+        "ratifying takes the spec out of the queue: {text}"
+    );
+    assert!(
+        text.contains("LIVE CONSTRAINTS (0)"),
+        "an accepted spec still declares no constraint, so the live section is \
+         unchanged by its ratification: {text}"
+    );
+    let status = stdout(&r.ank("claude-code@ank", &["status"]));
+    assert!(status.contains("queue 1 proposal(s)"), "{status}");
+}
+
 // ---------------------------------------------------------------------------
 // A proof that lives in a ref (ADR-493471d64ba0)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
TASK-73e81a8a804d, recorded on 2026-08-15 and reproduced live this session.

`review` and `status` built the ratification queue by filtering on `EntityKind::Adr`. A corpus holding a proposed spec was therefore told its queue was empty by the one verb whose stated job is the queue, while `find --type spec --status proposed` named the document and `check` reported it twice. `accept` promotes a spec through the same verb, over the same anchor and the same signed commit, so it is waiting for a signature exactly as an ADR is.

**The live-constraints section stays ADR-only**, and that is a separate question rather than an oversight: it counts the files a constraint binds, and a spec declares none. Measured rather than asserted, by ratifying the spec inside the fixture and watching the count hold at zero.

### How it was reproduced

The defect surfaced for real while finishing the skill chantier: two specs sat proposed after a supersession, `ank review` printed `nothing proposed for ratification`, and the maintainer had to be handed the two `accept` lines by hand.

Replayed at `0e3172b`, the exact corpus, in a throwaway worktree:

    old (0.4.0)   nothing proposed for ratification / queue 0 proposal(s)
    rebuilt       PROPOSED (2)
                    SPEC-4eff92fd80ce  The CLI surface
                    SPEC-80bff12ceae8  Bootstrapping, teaching and distribution
                  queue 2 proposal(s)

### Tests

Three, through the binary, as the criterion asks: a proposed spec alone, a proposed ADR alone, and a corpus holding both. **Falsified before being trusted** — with the two filters reverted, the spec test and the both-kinds test go red while the ADR-alone guard stays green, which is what says the queue widened rather than moved.

Full workspace suite green (10 binaries), `cargo fmt --check` clean, `ank check` exit 0. TASK-73e81a8a804d done with `commit:3695765` as proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RzYYt47iud9wDmKiT7UTv4