### PR TITLE
Plan: distribution shrinks to three commands

### DIFF
--- a/.ank/entities/ADR-221aa5da440a.md
+++ b/.ank/entities/ADR-221aa5da440a.md
@@ -1,0 +1,55 @@
+---
+id: ADR-221aa5da440a
+type: adr
+slug: distribution-is-three-commands-npm-curl-sh-and-p
+title: "Distribution is three commands: npm, curl | sh, and PowerShell"
+created: 2026-08-19T16:19:26Z
+author: claude-code/5
+status: proposed
+scope:
+  - install.*
+  - npm/**
+  - .github/workflows/**
+  - docs/**
+constraint: |
+  ank installs by exactly three official routes: npm install -g @haksolot/ank on any OS, curl | sh from install.sh on Linux and macOS, and a PowerShell one-liner from install.ps1 on Windows. No package-manager channel ships: no Homebrew tap, no Scoop bucket, no apt repository, no winget manifest, no AUR package. A workflow, manifest, formula or directory whose purpose is to feed a package manager is a finding. A new channel is a supersession of this decision, never an addition beside it.
+schema: 3
+version: 1
+---
+
+## Context
+
+Five channels shipped and two more were attempted. Measured over the life of
+each: the AUR froze publisher access after a security incident and the channel
+was abandoned (LOG-58e67); the apt repository needed a GPG key, a Pages
+deployment and a rebuild script, and was declared no longer of interest by the
+owner (LOG-5e4fa); winget submits to microsoft/winget-pkgs, a registry with a
+human moderation queue this project does not control, and its first submission
+(PR 418653) sat unmerged; brew and scoop cost no third party, this repository
+being its own tap and bucket, but each still carried a workflow, a committed
+manifest, a derivation assertion and a per-release bump. None of the four ever
+published without a human republishing the release (TASK-2078ab116f63): the
+whole downstream edifice also forced a PAT into the release workflow
+(ADR-768374fe6076) just to make the release event real.
+
+## The decision
+
+Three routes, each a command served from this repository and derived from a
+published release, none owing anything to a registry with its own gatekeeper:
+
+- npm first, because it is OS-agnostic and crosses the firewall the channel
+  exists for; the binaries travel inside the packages.
+- curl | sh for Linux and macOS, from install.sh at the repository root.
+- A PowerShell one-liner for Windows, from install.ps1 at the repository root,
+  the one route that did not exist when this was decided.
+
+## Rejected
+
+Keeping the tap and the bucket because they are self-hosted. True, and not the
+point: the criterion is a small surface, not zero gatekeepers. Each retained
+channel is a workflow to keep green, a manifest to bump and an assertion to
+keep honest, and the two shell installers already cover every machine brew and
+scoop covered.
+
+Keeping winget alone. It is the one channel with an external moderation queue,
+which makes it the worst survivor, not the best.

--- a/.ank/entities/ADR-24e306277bd4.md
+++ b/.ank/entities/ADR-24e306277bd4.md
@@ -1,0 +1,45 @@
+---
+id: ADR-24e306277bd4
+type: adr
+slug: the-release-is-created-under-the-default-token
+title: The release is created under the default token
+created: 2026-08-19T16:20:17Z
+author: claude-code/5
+status: proposed
+scope:
+  - .github/workflows/release.yml
+constraint: |
+  The job that creates a GitHub release calls gh under the workflow's default GITHUB_TOKEN. contents: write is granted to that job and to no other job in the file. The repository holds no RELEASE_TOKEN secret. No workflow in this repository triggers on release: types: [published].
+supersedes: ADR-768374fe6076
+schema: 3
+version: 1
+---
+
+## Context
+
+ADR-768374fe6076 required a fine-grained PAT, RELEASE_TOKEN, for one reason
+stated in its own first paragraph: GitHub never starts a workflow run from an
+event the default GITHUB_TOKEN produced, and four publish workflows triggered
+on release: published. The credential existed to make the event real for its
+consumers.
+
+ADR-221aa5da440a removes every consumer. The three surviving install routes
+read the release page or the npm registry; none triggers on the event. A PAT
+that makes an event real for nobody is a secret to renew, a refusal branch to
+maintain, and an expiry that turns a future release red for a capability
+nothing uses.
+
+## What survives from the superseded decision
+
+Least privilege by job, now expressed the way it was before the PAT: no
+release.yml job holds contents: write except the one that publishes, and the
+build matrix, which runs code from the tree on four machines, still cannot
+reach the release. The superseded ADR moved that capability into a secret;
+this one moves it back into the permissions block, where it is readable in
+the file instead of in the repository settings.
+
+## What is dropped
+
+The requirement that channels trigger on release: published and that the
+release run asserts they started. Both clauses quantify over a set that is
+now empty, and an assertion over an empty set is a step that can only rot.

--- a/.ank/entities/ADR-8b3045cf11db.md
+++ b/.ank/entities/ADR-8b3045cf11db.md
@@ -1,0 +1,50 @@
+---
+id: ADR-8b3045cf11db
+type: adr
+slug: the-skill-has-one-source-and-every-channel-is-se
+title: The skill has one source, and every channel is served from this repository
+created: 2026-08-19T16:19:52Z
+author: claude-code/5
+status: proposed
+scope:
+  - npm/**
+  - skill/**
+  - docs/**
+  - .claude-plugin/**
+  - package.json
+  - .github/workflows/**
+  - install.*
+constraint: |
+  Every distribution channel ank offers is carried by this repository. No satellite repository holds a skill, a plugin manifest, a marketplace catalogue or a package manifest. skill/SKILL.md is the single source: a channel either points at it by path, or receives a copy produced at release time by an assembly script and excluded from git. A second copy of the skill committed to the tree is a finding. A registry a release is pushed into is not a satellite: npm is an address, and what it holds is derived from a tag by the pipeline rather than kept in step by hand. What stays forbidden is the second repository somebody maintains.
+supersedes: ADR-782a3556cf2d
+schema: 3
+version: 1
+---
+
+## Context
+
+ADR-782a3556cf2d carried two things: the no-satellite rule inherited from
+ADR-e3cb36646d77, and a licensing argument for the channels whose registry is
+a git repository, written to buy exactly one thing, the AUR. The AUR was
+abandoned when its registry froze publisher access, and ADR-221aa5da440a
+drops every package-manager channel: the tap, the bucket, the apt tree and
+the winget manifests all leave this repository. The scope entries and the
+worked examples of the old wording now name directories that no longer exist,
+so this supersession keeps the rule and sheds the dead illustration.
+
+## What survives, unchanged
+
+The rule and its test. A copy nobody derives drifts, nothing turns red, and
+one day an agent is taught the opposite of a ratified decision. The test is
+where the source of truth lives: a copy the release derives is bound to the
+commit that produced it. npm remains the worked example: a registry that
+receives a package this repository derives at release time, and holds no
+authority over it.
+
+## What is shed
+
+The tap-and-bucket paragraph and the AUR licence. They decided whether brew,
+scoop and Arch earned a satellite; ADR-221aa5da440a decides those channels do
+not exist, which answers the question further upstream. Should a future
+channel return, it re-enters through a supersession of that ADR, and this
+rule then decides where its files may live.

--- a/.ank/entities/LOG-28b71fdea4e0.md
+++ b/.ank/entities/LOG-28b71fdea4e0.md
@@ -1,0 +1,13 @@
+---
+id: LOG-28b71fdea4e0
+type: log
+title: "released: not started"
+created: 2026-08-19T16:18:47Z
+author: claude-code/5
+scope:
+  - .github/workflows/release.yml
+about: TASK-6704242b47f3
+seq: 1
+schema: 3
+version: 1
+---

--- a/.ank/entities/LOG-2fcd9214b1cd.md
+++ b/.ank/entities/LOG-2fcd9214b1cd.md
@@ -1,0 +1,19 @@
+---
+id: LOG-2fcd9214b1cd
+type: log
+title: "closed: Owner decision on 2026-08-19: every package-manager channel is dropped (brew, scoop, apt,"
+created: 2026-08-19T16:17:53Z
+author: claude-code/5
+scope:
+  - .github/workflows/release.yml
+  - .github/workflows/publish-brew.yml
+  - .github/workflows/publish-scoop.yml
+  - .github/workflows/publish-apt.yml
+  - .github/workflows/publish-winget.yml
+about: TASK-2078ab116f63
+seq: 5
+schema: 3
+version: 1
+---
+
+ winget). The four workflows this criterion measures will not exist on the next tag; the release-event fix already in release.yml goes with them. The surviving channels (npm, curl|sh, and a PowerShell one-liner to come) do not consume the release event.

--- a/.ank/entities/LOG-f4c16c50fdbd.md
+++ b/.ank/entities/LOG-f4c16c50fdbd.md
@@ -1,0 +1,13 @@
+---
+id: LOG-f4c16c50fdbd
+type: log
+title: "amended: -scope .github/workflows/publish-apt.yml, done_criteria"
+created: 2026-08-19T16:18:42Z
+author: claude-code/5
+scope:
+  - .github/workflows/release.yml
+about: TASK-6704242b47f3
+seq: 0
+schema: 3
+version: 1
+---

--- a/.ank/entities/TASK-091023648de0.md
+++ b/.ank/entities/TASK-091023648de0.md
@@ -1,0 +1,37 @@
+---
+id: TASK-091023648de0
+type: task
+slug: a-powershell-one-liner-installs-ank-on-windows
+title: A PowerShell one-liner installs ank on Windows
+created: 2026-08-19T16:21:06Z
+author: claude-code/5
+status: open
+scope:
+  - install.ps1
+  - .github/workflows/install.yml
+blocked_by: []
+done_criteria: |
+  irm https://raw.githubusercontent.com/haksolot/ank/main/install.ps1 | iex on a clean Windows machine installs the latest released binary and ank --version prints that release's version. install.yml proves the route on windows-latest by running the one-liner as written against the real release page, alongside the existing install.sh rows.
+criteria_by: creator
+schema: 3
+version: 1
+---
+
+The Windows counterpart of TASK-0f86494ecae7, and the one route of
+ADR-221aa5da440a that does not exist yet. install.sh is the model: served raw
+from the default branch, resolving the latest release, verifying the .sha256
+the release publishes, placing the binary on PATH. The PowerShell script owes
+the same properties, stated for a shell where curl, sha256sum and chmod are
+spelled differently: Invoke-WebRequest or Invoke-RestMethod, Get-FileHash,
+and a user-writable directory already on PATH or added to it with the change
+told to the user.
+
+install.yml already runs matrix rows against the release page and is
+read-only by design; the new row belongs there, not in a new workflow. The
+scope names install.ps1 before it exists, which is the signal a task is
+allowed to carry.
+
+Documentation is deliberately not in this scope: the teardown task rewrites
+the install section of docs/agents.md to exactly three routes, and two tasks
+writing one section is a collision. This task makes the route true; the next
+one makes it told.

--- a/.ank/entities/TASK-2078ab116f63.md
+++ b/.ank/entities/TASK-2078ab116f63.md
@@ -5,7 +5,7 @@ slug: a-published-release-reaches-the-four-channels-wi
 title: A published release reaches the four channels without a human republishing it
 created: 2026-08-17T02:39:57Z
 author: claude-code/opus-5
-status: open
+status: closed
 scope:
   - .github/workflows/release.yml
   - .github/workflows/publish-brew.yml
@@ -17,7 +17,7 @@ done_criteria: |
   A tag pushed to this repository produces, with no human touching the release afterwards, one run each of publish-brew, publish-scoop, publish-apt and publish-winget whose event is release. Measured on the next tag: gh run list --limit 20 --json name,event names the four with event=release, Formula/ank.rb, bucket/ank.json and packaging/winget/*.yaml carry the new version on the default branch, and the winget submit job has run.
 criteria_by: creator
 schema: 3
-version: 4
+version: 5
 ---
 
 Measured on 2026-08-16, cutting v0.3.0. The release run was green end to end: the

--- a/.ank/entities/TASK-659ebaa4f68e.md
+++ b/.ank/entities/TASK-659ebaa4f68e.md
@@ -1,0 +1,29 @@
+---
+id: TASK-659ebaa4f68e
+type: task
+slug: the-specification-names-three-install-modes
+title: The specification names three install modes
+created: 2026-08-19T16:22:04Z
+author: claude-code/5
+status: open
+scope:
+  - .ank/entities/SPEC-80bff12ceae8.md
+blocked_by: [TASK-6de3f29911bd]
+done_criteria: |
+  The successor of SPEC-80bff12ceae8, created with ank new spec --supersedes and never by editing, arrives proposed with its references re-declared. Its binary-distribution paragraph names npm, curl | sh and the PowerShell one-liner as the channels that ship, names no channel that does not ship, and cites ADR-221aa5da440a. ank check is green with no unresolved reference.
+criteria_by: creator
+schema: 3
+version: 1
+---
+
+The same move as TASK-13f9162ed61a and last for the same reason: the
+specification describes what is, so revising it before the teardown lands
+would make it lie in the other direction. A reader acts on a named channel.
+
+SPEC-80bff12ceae8 is accepted, so its body is anchored by the ratification
+commit and any in-place edit is reported altered by check. The distribution
+paragraph currently names five shipping channels plus winget and Arch as
+pending; everything else in the document (help surface, init, token economy,
+npm packaging, dist-tag derivation) stays true and travels into the successor
+unchanged. Expect citing documents to need amend --reference afterwards, as
+every supersession before this one did.

--- a/.ank/entities/TASK-6704242b47f3.md
+++ b/.ank/entities/TASK-6704242b47f3.md
@@ -8,13 +8,12 @@ author: claude-code/2.0
 status: open
 scope:
   - .github/workflows/release.yml
-  - .github/workflows/publish-apt.yml
 blocked_by: []
 done_criteria: |
-  The release archive and the .deb either carry every skill, or the decision to carry only the contract is written where the copy is made, and the check that guards the .deb contents matches whichever was chosen.
+  The release archive either carries every skill, or the decision to carry only the contract is written where the copy is made, in release.yml's package step.
 criteria_by: creator
 schema: 3
-version: 1
+version: 4
 ---
 
 Found while shipping TASK-7cbf5b62be7f, which covered npm and pi only. Two

--- a/.ank/entities/TASK-6de3f29911bd.md
+++ b/.ank/entities/TASK-6de3f29911bd.md
@@ -1,0 +1,58 @@
+---
+id: TASK-6de3f29911bd
+type: task
+slug: the-package-manager-channels-are-dismantled
+title: The package-manager channels are dismantled
+created: 2026-08-19T16:21:40Z
+author: claude-code/5
+status: open
+scope:
+  - .github/workflows/publish-brew.yml
+  - .github/workflows/publish-scoop.yml
+  - .github/workflows/publish-apt.yml
+  - .github/workflows/publish-winget.yml
+  - .github/workflows/release.yml
+  - .github/scripts/apt-repo.sh
+  - .github/scripts/brew-formula.sh
+  - .github/scripts/winget-manifests.sh
+  - Formula/**
+  - bucket/**
+  - packaging/**
+  - docs/agents.md
+blocked_by: [TASK-091023648de0]
+done_criteria: |
+  The tree carries no publish-brew, publish-scoop, publish-apt or publish-winget workflow, no Formula/, bucket/ or packaging/ directory, and none of apt-repo.sh, brew-formula.sh, winget-manifests.sh. release.yml creates the release under the workflow's default GITHUB_TOKEN, grants contents: write to the publish job and to no other, and carries no step naming RELEASE_TOKEN or asserting channel runs. PR microsoft/winget-pkgs#418653 is closed unmerged and the haksolot/winget-pkgs fork is deleted. The GitHub Pages site of this repository no longer serves an apt Release file at /deb/dists/stable/Release. gh secret list names none of APT_GPG_PRIVATE_KEY, WINGET_TOKEN, RELEASE_TOKEN. The install section of docs/agents.md names exactly three routes: npm, curl | sh, and the PowerShell one-liner. cargo test and ank check are green.
+criteria_by: creator
+schema: 3
+version: 1
+---
+
+Executes ADR-221aa5da440a, ADR-8b3045cf11db and ADR-24e306277bd4. Do not
+claim before those three are ratified: until then ADR-768374fe6076 still
+binds release.yml to the RELEASE_TOKEN this task removes, and
+ADR-782a3556cf2d still scopes the directories this task deletes.
+
+What each clause of the criterion is about:
+
+The winget exit must happen before Microsoft merges. PR 418653 is open at
+planning time; merged, it would leave a Haksolot.Ank 0.3.0 in the winget
+registry forever, pointing at release assets this project still hosts but a
+channel nobody maintains. Close the PR with a comment saying the package is
+withdrawn, then delete the fork WINGET_TOKEN pushed to.
+
+The Pages site exists only for the apt tree: publish-apt.yml is its sole
+deployer and install.sh is served from raw.githubusercontent.com, not Pages.
+An apt source list left on a user's machine must stop resolving an index
+signed by a key whose private half is about to be deleted; deploying an empty
+tree (or disabling Pages, which is one gh api call) both satisfy the
+criterion, and the choice belongs beside the change.
+
+The secrets go last, after the workflows that name them are gone, so no
+intermediate commit leaves a workflow red on a missing secret.
+
+docs/agents.md carries the brew, scoop, apt and winget sections and the
+"channels beyond npm" sentence; docs/getting-started.md names only npm and
+the release page and needs nothing. TASK-6704242b47f3 owns the skill-copy
+question inside release.yml's package step and is deliberately not folded in
+here: its scope intersects this one, so do not hold both claims at once
+unless you take them in sequence.


### PR DESCRIPTION
Owner decision of 2026-08-19: drop every package-manager channel (brew tap, scoop bucket, apt/.deb, winget; the AUR was already abandoned) and keep exactly three install routes: **npm**, **curl | sh** (Linux/macOS), and a **PowerShell one-liner** (Windows, to be written).

This PR carries the plan only, no code moves yet.

**Three ADRs, proposed, awaiting your ratification once merged:**
- `ADR-221a` Distribution is three commands: npm, curl | sh, and PowerShell
- `ADR-8b30` supersedes ADR-782a: the no-satellite / single-skill-source rule survives, the tap/bucket/AUR licensing is shed
- `ADR-24e3` supersedes ADR-7683: RELEASE_TOKEN retired, nothing consumes the release event any more

**Tasks, chained to avoid perimeter collisions:**
1. `TASK-0910` install.ps1 + proof in install.yml
2. `TASK-6de3` teardown (workflows, Formula/, bucket/, packaging/, scripts, release.yml back to the default token, winget PR 418653 closed unmerged, fork deleted, Pages apt tree gone, secrets APT_GPG_PRIVATE_KEY / WINGET_TOKEN / RELEASE_TOKEN deleted, docs to three routes) — **do not claim before the three ADRs are ratified**
3. `TASK-659e` SPEC-80bf superseded so §9 names the three modes

Also: TASK-2078 closed with reason (it measures four workflows that will not exist on the next tag), TASK-6704 amended to the archive question alone.

`ank check` exit 0, no faults; the winget PR is still open at Microsoft so the exit is clean if the teardown lands before they merge it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QStGzZotJ2zaX17dnJhXEa