### PR TITLE
The specification names three install modes

### DIFF
--- a/.ank/entities/LOG-0b42ae2fb7d0.md
+++ b/.ank/entities/LOG-0b42ae2fb7d0.md
@@ -1,0 +1,15 @@
+---
+id: LOG-0b42ae2fb7d0
+type: log
+title: "SPEC-b156a5571668 supersedes SPEC-80bff12ceae8, proposed, one paragraph apart: a body diff of the"
+created: 2026-08-19T22:14:14Z
+author: claude-code/opus-5
+scope:
+  - .ank/entities/SPEC-80bff12ceae8.md
+about: TASK-659ebaa4f68e
+seq: 0
+schema: 3
+version: 1
+---
+
+ two documents reports exactly one changed line, the binary-distribution paragraph, and everything else travels unchanged. Two things measured rather than assumed. The body of this task expects citing documents to need amend --reference afterwards, as every supersession before it did; nothing cites SPEC-80bff12ceae8 in a references field, and a grep over .ank/entities finds it only in its own file, in the successor's supersedes, in this task and in three log entries, so no re-pointing is owed and check answers ok with no unresolved reference. And the clause 'names no channel that does not ship' is read literally: the paragraph names none of Homebrew, Scoop, apt, winget or the AUR, not even as withdrawn, because the defect it repairs was a sentence naming winget and Arch as pending and a reader acts on a named channel. It says instead that no package manager ships ank and that none is named here, so the omission reads as deliberate, and it cites ADR-221aa5da440a for the measurement. The scope drops Formula/**, bucket/** and packaging/**, which no longer exist, and gains install.ps1.

--- a/.ank/entities/LOG-5b103352e647.md
+++ b/.ank/entities/LOG-5b103352e647.md
@@ -1,0 +1,13 @@
+---
+id: LOG-5b103352e647
+type: log
+title: done, proof commit:0873ac1d601f60c369a457034a7a93fbb4993254
+created: 2026-08-19T22:14:35Z
+author: claude-code/opus-5
+scope:
+  - .ank/entities/SPEC-80bff12ceae8.md
+about: TASK-659ebaa4f68e
+seq: 1
+schema: 3
+version: 1
+---

--- a/.ank/entities/SPEC-b156a5571668.md
+++ b/.ank/entities/SPEC-b156a5571668.md
@@ -1,0 +1,121 @@
+---
+id: SPEC-b156a5571668
+type: spec
+slug: bootstrapping-teaching-and-distribution
+title: Bootstrapping, teaching and distribution
+created: 2026-08-19T22:11:20Z
+author: claude-code/opus-5
+status: proposed
+scope:
+  - skill/**
+  - npm/**
+  - crates/ank-cli/src/init.rs
+  - .github/workflows/**
+  - install.sh
+  - install.ps1
+references: [SPEC-4eff92fd80ce, SPEC-93531977642f]
+supersedes: SPEC-80bff12ceae8
+schema: 3
+version: 2
+---
+
+One of the ten documents that carry the Ank specification (ADR-5a690829388d).
+This one carries **§9 entire**: how the skills are installed and what their token
+economy buys, what `ank help` owes its caller, what `init` writes and what it
+refuses, and how the binary is distributed.
+
+## Why the help surface is here and not with the verbs
+
+The obvious boundary would put `ank help` in the CLI surface, beside the verbs it
+lists. It is here, and the reason is what this document is about.
+
+The surface document says **what a verb does and on what state it refuses**. This
+one says **what the caller is told, and by which of three surfaces** — SKILL.md
+carries the mental model, `ank help` carries the surface, the error carries the
+next command. That division of labour is the subject here, and every rule below
+is a consequence of it: a description names a flag only to offer it or to refuse
+it, because a description is a fourth surface able to misinform; the listing
+prints the same sentence the per-verb page does, because two strings are two
+things to keep true; an unknown verb is a code 2 and never a fallback to the
+general listing.
+
+Read the other way, the test holds too. The verb semantics are readable without
+knowing how they are announced, and the announcement rules are readable without
+the verb table — they are rules about a surface, not about any particular verb.
+
+**Bootstrapping, teaching and distribution are one subject** for the same reason:
+they are everything that happens on a machine that does not have Ank yet, and
+they are governed by one economy. A skill's description is loaded permanently, so
+it is a trigger and a budget; a body is loaded when its skill fires, so its size
+is a ceiling. `ank help` is loaded on demand, so it carries
+the detail. `init` writes the few files that make a repository a corpus. npm
+carries the binary inside the package because the workstation this channel exists
+for cannot download an executable. Cut anywhere and one of those loses the reason
+it is shaped that way.
+
+## What it rests on
+
+- **The CLI surface** — the verbs, flags and refusals `ank help` is required to
+  print faithfully.
+- **Implementation, and the decisions that bound it** — the platforms and the
+  licence the distribution channels carry.
+
+---
+
+## 9. Bootstrapping
+
+Skill installation leans on the existing ecosystem rather than a home-made mechanism:
+
+```
+npx skills add <owner>/ank
+```
+
+Skills install from repositories rather than npm packages: the identifier is `owner/repo`, there is no bare name. The skill's repository is therefore called simply `ank`. Installation happens through a symlink, and a `skills-lock.json` versioned in the repository reproduces the same set of skills on every machine in the team — consistent with the rest of the design, where everything that matters is in the repository.
+
+The `skills` CLI handles multi-agent detection (Claude Code, Codex, Cursor, OpenCode, and many others) and creates links from each agent to a canonical copy — exactly the desired design, already maintained by a third party.
+
+**Token economy, and what is actually always-on.** The teaching surface is four files (§4): `skill/SKILL.md` carries the contract every agent loads, and `ank-plan`, `ank-drift` and `ank-loop` carry one activity policy each, loaded when the activity calls for them (ADR-91b77f036884). None is frozen by hash; each is anchored by a `metadata.revision` a test recomputes. Flag details and the rest of the surface stay in `ank help`, loaded on demand.
+
+**What a session pays for unconditionally is the frontmatter, not the body**, and the distinction is worth stating because the ceiling was justified without it. Measured on the plugin route: `claude plugin details ank` reports `Always-on: ~282 tok added to every session` across the four, against `~58 tok` when the surface was one file, with per-component bodies of `~1.9k` for the contract and `560` to `740` for the policies. A `description` is therefore the expensive line in a file, it is also what decides whether the right skill fires at the right moment, and it does not grow without a measurement. The **ceiling on each body is kept regardless**, because the by-hand route below copies whole files into whatever a harness loads and some harnesses load all of it every session: the ceiling bounds the worst route rather than the best one, and a number that protected only the measured case would be a number that stops protecting the moment somebody installs it differently.
+
+**The split is a trade, not a saving.** Four descriptions cost more always-on than one did; what is bought is that an agent executing a task no longer carries the planning policy it will not use, and that two policies which contradict each other by design, planning interviews the human and the loop refuses to, are never in one context at once. A single file teaching both would read as one contradictory policy, and one description covering both activities would fire precisely for neither.
+
+**`ank help` lists every verb, grouped by the moment a verb is reached for** (ADR-f61e2d2c75e8, superseding ADR-e17e1bbd93ff on this clause alone): every verb with a one-line description, under a lowercase heading, and inside a group the order stays §4's. No verb is hidden and there is no second listing to ask for. A group says **when** a verb is used and never **who** may use it — a heading named after a caller is the claim §4 withdraws, and it is the one this grouping cannot make: `check` sits under keeping the corpus honest whether a human or an agent types it. The order alone carried what a heading would have said while the surface was five verbs; at twenty-one it carries it only to a reader who already knows the order is meaningful, which is precisely what a first reader does not know. `ank help <verb>` answers about that verb alone: what it does, its usage, its flags with their value placeholders, the globals, and **the state conditions on which it refuses, each with its exit code**. An unknown verb is a **code 2** and never a fallback to the general listing — an agent that asked about one verb and received all sixteen has to work out that its question went unanswered.
+
+**The refusals belong here because nothing else owns them.** §4 carries a whole subsection on refusing by state rather than by identity, and that is a promise to the reader of this document; the caller of the binary had no surface stating which states, or what code came back. The division of labour §9 bets on — SKILL.md carries the mental model, `ank help` carries the surface, the error carries the next command — only holds if the middle one answers *what will this refuse*. It did not, and a session of dogfooding fell through the gap five times, recovering through the source each time. In another repository ank arrives as a binary and a SKILL.md: there is no source to fall through to, and the same five become dead ends.
+
+Three consequences, each of which was one of those five:
+
+- **A flag that is always refused is not a flag.** `ank help` lists what a caller can use; a name the verb rejects by design belongs in the refusals, not in the flag list. Listing it is worse than silence, because the caller reads an offer.
+- **A requirement that lives in the state is stated as one.** `done` needs a proof it cannot always produce for itself, and the grammar of one — `<type>:<ref>`, where the type is `commit`, `human-review`, `assertion` or `test` — is part of the surface, not part of the error that fires once the caller has already guessed wrong.
+- **Where a value is interpreted, say by what.** `$EDITOR` is a command line run through `sh`, not a program name. A caller told `EDITOR=vi` reasonably supplies a GUI editor, gets no `--wait`, and the editor returns before anything is typed: ank writes the file back unedited and nothing anywhere says so.
+
+The listing and the per-verb page stay two surfaces, and **the listing carries one short description per verb**. It used to carry the verb and its flag names, which is the shape that says what none of them does: `--criteria` beside `amend` names a flag without saying what the verb is for, and a caller choosing between twenty-one verbs is choosing on the usage line alone. Git's listing answers that question in one line each, and this one now does too.
+
+**The description takes the place of the flag names.** They are one `ank help <verb>` away, where they carry their value placeholders and the refusals that qualify them — a bare flag name in an overview is the least informative thing the line could hold, and keeping both would double the height of the listing, which is the token economy this paragraph used to invoke for saying nothing at all. An economy that sends the caller to the source is not one: recovering what a description would have carried cost one session more than twenty lines of reading `human.rs`, `done.rs` and `editor.rs`, plus a scratch repository (TASK-fe130d2b732c).
+
+**The description states what the verb refuses wherever the refusal is what distinguishes it.** This is not a stylistic preference, it is what makes the line honest here: ank's verbs refuse on state (§4), so a description naming only a purpose is a fourth surface able to misinform. `change a task's scope, blockers or criteria` would have confirmed the defect TASK-84cfad83c308 recorded rather than caught it; `change a task's scope or blockers, and a criterion no live claim freezes` is the same line doing the work. Each description is the one-line compression of what `ank help <verb>` already says, never a second text with its own opinion.
+
+**A description names a flag only to offer it or to refuse it, never by accident.** Every `--flag` a description mentions is either one the verb offers, or one it names as refused — `creates .ank/ here or at <path>; refuses --repo` is honest, `changes blockers, scope or --criteria` on a verb that rejects `--criteria` is the defect. The rule is mechanical, and a test walks both surfaces through the binary: it reads the flags and the refusals `ank help <verb> --json` already carries and fails when a description advertises something absent from the first. It is *a flag that is always refused is not a flag*, applied to the surface where a caller reads fastest and checks least.
+
+**The listing prints the same sentence the per-verb page does**, and that is what makes the compression a compression rather than a second text. Two strings would be two things to keep true, and the one that drifts is the one nobody reads twice — which is how `amend` came to advertise a criterion edit the binary refused always (TASK-84cfad83c308). There is one description per verb, `ank help` prints it beside the verb, and `ank help <verb>` prints it above the flags and the refusals that qualify it.
+
+**None of this is a claim about who a verb is for** (ADR-f61e2d2c75e8, superseding ADR-e17e1bbd93ff). A description says what a verb does, and the heading above it says when that verb is reached for; neither sorts callers, which is the claim §4 withdrew and the only one either could make. Both carry what the order alone never could: the order is meaningful only to a reader who already knows it is, and a description is what that reader does not have to know.
+
+`ank init` keeps a narrow perimeter: create `.ank/`, write `config.yml`, add the `refs/ank/*` refspec (§7), place a pointer in `AGENTS.md`, write a `.gitattributes` (§2) and a `.gitignore` (§6).
+
+**`init` takes its target positionally, and refuses `--repo` by name.** `ank init <path>` initialises `<path>`; with no argument it initialises the current directory. `--repo` names a repository that already carries a `.ank/` (§4), which is precisely what this verb is run to produce, so it is refused with `ank init <path>` as the command to type — the shape §9 requires of every refusal, and the reason this one is a refusal rather than a second spelling of the target. `--json` and `--quiet` are unaffected: they say how to answer, not what to act on. Being a refusal by design, `--repo` is absent from what `ank help init` offers and present in what it says the verb refuses, per the rule above.
+
+**What `init` writes, `ank config` maintains** (§4). `config.yml` is written through the verb rather than by hand: it is the last thing under `.ank/` that ADR-01b6dd05f0db left an agent no route to, and the six errors that used to say "add it under `verifiers:` in `.ank/config.yml`" now name the command. `config` joins `init` and `help` as the third verb that runs without the foundation, and for the same reason those two do — the caller who needs it is the one whose environment is wrong, and a repair verb gated on the thing it repairs answers nobody.
+
+Both git files are written at the root of the initialised directory, and both carry a single line added idempotently to whatever is already there. The `.gitignore` line is `.ank/index.db`: §6 calls the index derived, disposable and gitignored, and the third adjective is only true of a repository where something wrote the rule. It goes at the root rather than inside `.ank/` for the same reason `.gitattributes` does — one place to look for what `init` changed — and because ADR-01b6dd05f0db makes `.ank/` opaque to agents, so a rule hidden there could not be read by the agent asking why the index is tracked.
+
+**Binary distribution**: the skill says *how* to use Ank, it does not install the CLI. Three channels install it and no more (ADR-221aa5da440a): npm on any operating system, `curl | sh` from `install.sh` on Linux and macOS, and a PowerShell one-liner from `install.ps1` on Windows. Every one of them is carried by this repository rather than by a satellite (ADR-8b3045cf11db), and each is derived from a published release rather than kept in step by hand, which is the property that keeps a channel from drifting and the test that decides whether an address is a registry or a satellite: npm is an address, and what it holds comes from a tag through the pipeline rather than from somebody keeping it current. **No package manager ships ank, and none is named here.** A registry with a moderation queue of its own, or a manifest bumped once per release, is a channel this document would have to keep honest and a reader would act on; ADR-221aa5da440a carries the measurement that closed every one of them and states the rule this paragraph reports. A new channel is a supersession of that decision, never an addition beside it.
+
+**npm is the first channel implemented**, and it is implemented for one reason that shapes it entirely: the workstation whose firewall blocks downloading a bare executable but lets the registry through. The binaries therefore travel **inside** the packages — one package per target, listed as `optionalDependencies` on a wrapper that carries `os` and `cpu`, so npm installs exactly the one that matches. **No `postinstall` download**, because a `postinstall` that fetched the binary would die behind the very firewall the channel exists to cross, and would do it after the install appeared to succeed. The wrapper resolves and executes; it forwards the child's exit code unchanged, since the codes above are an interface an agent branches on, and it reserves 9 — the environment code — for its own failures. The package name is scoped, `@haksolot/ank`: the bare name was taken on the registry before this project existed, and the scope is the closest thing to the name the project actually has (ADR-85e6664c67d8).
+
+**A prerelease never becomes what a bare install resolves to.** The dist-tag is derived from the version and from nothing else: a version carrying a prerelease identifier — a hyphen after the patch, `0.2.0-rc1` — publishes under `next`, and every other version publishes under `latest`. `npm install @haksolot/ank` therefore resolves to the newest release and never to a candidate, while `npm install @haksolot/ank@next` fetches the candidate for whoever asks for it by name. Shipping a candidate stays possible, which is why this is a derivation and not a refusal.
+
+Derived rather than chosen when the tag is pushed, because a flag someone has to remember while tagging is a flag that is eventually forgotten, and this one fails silently: npm 10 applied `latest` to a prerelease without a word, so `v0.2.0-rc1` would have put a release candidate on every machine running a bare install, and nothing would have said so. The rule is **written once and read by both the rehearsal and the publish** — a smoke job passing different flags from the publish rehearses nothing, and the publish is the one step in the pipeline that cannot be taken back. Build metadata is not a prerelease identifier: `1.2.3+build` is a release, and the derivation strips it before looking for the hyphen.
+
+The GitHub release follows the same reading of the same version, and is marked as a prerelease when it is one. Two channels describing one tag differently is how a reader ends up trusting whichever they happened to open.

--- a/.ank/entities/TASK-659ebaa4f68e.md
+++ b/.ank/entities/TASK-659ebaa4f68e.md
@@ -5,15 +5,20 @@ slug: the-specification-names-three-install-modes
 title: The specification names three install modes
 created: 2026-08-19T16:22:04Z
 author: claude-code/5
-status: in_progress
+status: done
 scope:
   - .ank/entities/SPEC-80bff12ceae8.md
 blocked_by: [TASK-6de3f29911bd]
 done_criteria: |
   The successor of SPEC-80bff12ceae8, created with ank new spec --supersedes and never by editing, arrives proposed with its references re-declared. Its binary-distribution paragraph names npm, curl | sh and the PowerShell one-liner as the channels that ship, names no channel that does not ship, and cites ADR-221aa5da440a. ank check is green with no unresolved reference.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 0873ac1d601f60c369a457034a7a93fbb4993254
+    criteria: e3ae54fdf1eb
+    via: submitted
 schema: 3
-version: 2
+version: 3
 ---
 
 The same move as TASK-13f9162ed61a and last for the same reason: the

--- a/.ank/entities/TASK-659ebaa4f68e.md
+++ b/.ank/entities/TASK-659ebaa4f68e.md
@@ -5,7 +5,7 @@ slug: the-specification-names-three-install-modes
 title: The specification names three install modes
 created: 2026-08-19T16:22:04Z
 author: claude-code/5
-status: open
+status: in_progress
 scope:
   - .ank/entities/SPEC-80bff12ceae8.md
 blocked_by: [TASK-6de3f29911bd]
@@ -13,7 +13,7 @@ done_criteria: |
   The successor of SPEC-80bff12ceae8, created with ank new spec --supersedes and never by editing, arrives proposed with its references re-declared. Its binary-distribution paragraph names npm, curl | sh and the PowerShell one-liner as the channels that ship, names no channel that does not ship, and cites ADR-221aa5da440a. ank check is green with no unresolved reference.
 criteria_by: creator
 schema: 3
-version: 1
+version: 2
 ---
 
 The same move as TASK-13f9162ed61a and last for the same reason: the


### PR DESCRIPTION
TASK-659ebaa4f68e, the last of the three install-mode tasks and the one that
had to come after the teardown: the specification describes what is, so
revising it before the channels were gone would have made it lie in the other
direction.

SPEC-b156a5571668 supersedes SPEC-80bff12ceae8, written through
`ank new spec --supersedes` and never by editing the accepted document. It
arrives **proposed**: acceptance is a human act, on the default branch, and
`ank accept SPEC-b156a5571668` is what this PR is waiting on after it merges.

## One paragraph apart

A body diff of the two documents reports exactly one changed line. The
binary-distribution paragraph now names npm, `curl | sh` from `install.sh`, and
the PowerShell one-liner from `install.ps1`, cites ADR-221aa5da440a for the
rule and ADR-8b3045cf11db for the channels being carried by this repository,
and names no package manager at all. The defect it repairs was a sentence
naming winget and Arch as pending: a reader acts on a named channel, so the
paragraph says that none ships and that none is named here, rather than leaving
the omission to be noticed.

Everything else in section 9, the help surface, `init`, the token economy, npm
packaging and the dist-tag derivation, travels unchanged.

## Scope and references

The successor drops `Formula/**`, `bucket/**` and `packaging/**`, which no
longer exist, and gains `install.ps1`. Its references, SPEC-4eff92fd80ce and
SPEC-93531977642f, are re-declared.

Nothing cites SPEC-80bff12ceae8 in a `references:` field: a grep over
`.ank/entities` finds it only in its own file, in the successor's `supersedes`,
in this task and in three log entries. So no re-pointing is owed, where every
supersession before this one needed one.

## Measured

`ank check`: ok, 0 faults, no unresolved reference. No code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MJR9o7WPTriLMwZUwsNmRb
