### PR TITLE
The archive carries the contract, and the package step says why

### DIFF
--- a/.ank/entities/LOG-0cbb692768e6.md
+++ b/.ank/entities/LOG-0cbb692768e6.md
@@ -1,0 +1,15 @@
+---
+id: LOG-0cbb692768e6
+type: log
+title: "the criterion offers two branches and the second is taken: the archive carries the contract alone,"
+created: 2026-08-19T22:24:24Z
+author: claude-code/opus-5
+scope:
+  - .github/workflows/release.yml
+about: TASK-6704242b47f3
+seq: 2
+schema: 3
+version: 1
+---
+
+ and the reason is written in release.yml's package step where the copy is made. What decided it, read rather than assumed: skill/SKILL.md states of itself that everything below its skills section 'suffices on its own to execute work', and it names ank-plan, ank-drift and ank-loop without naming a path to any of them, so the contract alone is not a pointer with a missing destination but the designed minimum (ADR-91b77f036884). The asymmetry with npm and pi, which ship all four since TASK-7cbf5b62be7f, is what the comment argues rather than hides: those two hand skills to a harness that loads them by name, this archive hands files to whoever unpacked it. The .deb half of this task's title is moot, TASK-6de3f29911bd having deleted the Debian packaging and TASK-091023648de0's amendment having already dropped publish-apt.yml from the scope, so release.yml is the whole perimeter. cargo test --workspace: 593 passed, 0 failed. ank check: ok.

--- a/.ank/entities/LOG-40af5e044b47.md
+++ b/.ank/entities/LOG-40af5e044b47.md
@@ -1,0 +1,13 @@
+---
+id: LOG-40af5e044b47
+type: log
+title: done, proof commit:38339484b276d6f91a45114ea9ddd304934d2e00
+created: 2026-08-19T22:24:34Z
+author: claude-code/opus-5
+scope:
+  - .github/workflows/release.yml
+about: TASK-6704242b47f3
+seq: 3
+schema: 3
+version: 1
+---

--- a/.ank/entities/TASK-6704242b47f3.md
+++ b/.ank/entities/TASK-6704242b47f3.md
@@ -5,15 +5,20 @@ slug: the-archive-and-the-deb-carry-one-skill-of-four
 title: The archive and the .deb carry one skill of four
 created: 2026-08-19T06:12:58Z
 author: claude-code/2.0
-status: in_progress
+status: done
 scope:
   - .github/workflows/release.yml
 blocked_by: []
 done_criteria: |
   The release archive either carries every skill, or the decision to carry only the contract is written where the copy is made, in release.yml's package step.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 38339484b276d6f91a45114ea9ddd304934d2e00
+    criteria: 8abec98f3a21
+    via: submitted
 schema: 3
-version: 5
+version: 6
 ---
 
 Found while shipping TASK-7cbf5b62be7f, which covered npm and pi only. Two

--- a/.ank/entities/TASK-6704242b47f3.md
+++ b/.ank/entities/TASK-6704242b47f3.md
@@ -5,7 +5,7 @@ slug: the-archive-and-the-deb-carry-one-skill-of-four
 title: The archive and the .deb carry one skill of four
 created: 2026-08-19T06:12:58Z
 author: claude-code/2.0
-status: open
+status: in_progress
 scope:
   - .github/workflows/release.yml
 blocked_by: []
@@ -13,7 +13,7 @@ done_criteria: |
   The release archive either carries every skill, or the decision to carry only the contract is written where the copy is made, in release.yml's package step.
 criteria_by: creator
 schema: 3
-version: 4
+version: 5
 ---
 
 Found while shipping TASK-7cbf5b62be7f, which covered npm and pi only. Two

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,6 +149,29 @@ jobs:
             cp "target/${{ matrix.target }}/release/ank" "dist/${name}/"
           fi
           cp README.md LICENSE "dist/${name}/"
+          # The contract alone, and not the three activity policies beside
+          # it. Deliberate, and stated here because here is where the copy
+          # is made (TASK-6704242b47f3).
+          #
+          # SKILL.md says of itself that everything below its skills
+          # section "suffices on its own to execute work", and it names
+          # ank-plan, ank-drift and ank-loop without naming a path to any
+          # of them. So an archive carrying the contract alone hands its
+          # reader nothing that points at a file the archive does not
+          # contain. What the three would add is a policy per activity,
+          # loaded when that activity fires, which is something a harness
+          # does and not something a human unpacking a tarball does.
+          #
+          # npm and pi ship all four (TASK-7cbf5b62be7f) and are right to:
+          # they hand skills to a harness that loads them by name, where
+          # this archive hands files to whoever unpacked it. The routes
+          # differ because what they deliver to differs.
+          #
+          # What would overturn this: the contract ceasing to stand alone.
+          # The day SKILL.md needs a sibling to execute work, this line
+          # becomes a copy of skill/ entire, and install.sh and install.ps1
+          # stop describing the archive as the binary beside README.md,
+          # LICENSE and SKILL.md.
           cp skill/SKILL.md "dist/${name}/"
           cd dist
           if [ "${{ matrix.archive }}" = "zip" ]; then


### PR DESCRIPTION
TASK-6704242b47f3 asks for one of two things: the release archive carries every
skill, or the decision to carry only the contract is written where the copy is
made. The second, with the argument beside the `cp`.

## What decided it

`skill/SKILL.md` states of itself that everything below its skills section
"suffices on its own to execute work", and it names `ank-plan`, `ank-drift` and
`ank-loop` without naming a path to any of them. An archive carrying the
contract alone therefore hands its reader nothing that points at a file the
archive does not contain: it is the designed minimum (ADR-91b77f036884) rather
than three quarters of a thing missing.

The asymmetry with npm and pi, which ship all four since TASK-7cbf5b62be7f, is
argued rather than left to be noticed: those routes hand skills to a harness
that loads them by name, where this archive hands files to whoever unpacked it.
The routes differ because what they deliver to differs.

The comment also names the condition that would overturn the decision, so the
next reader knows what to measure rather than what to prefer: the day the
contract stops standing alone, the line becomes a copy of `skill/` entire, and
`install.sh` and `install.ps1` stop describing the archive as the binary beside
README.md, LICENSE and SKILL.md.

## The .deb half of the title

Moot. TASK-6de3f29911bd deleted the Debian packaging, and the amendment already
recorded on this task had dropped `publish-apt.yml` from its scope, so
`release.yml` is the whole perimeter.

## Measured

`cargo test --workspace`: 593 passed, 0 failed. `ank check`: ok, 0 faults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MJR9o7WPTriLMwZUwsNmRb
