### PR TITLE
A ratification that could not be committed leaves nothing behind

### DIFF
--- a/.ank/entities/LOG-a55b6967d6f3.md
+++ b/.ank/entities/LOG-a55b6967d6f3.md
@@ -1,0 +1,14 @@
+---
+id: LOG-a55b6967d6f3
+type: log
+title: done, proof commit:30cb83076ae59fac2f01203ad0dcb045a49e48e6
+created: 2026-08-19T22:37:29Z
+author: claude-code/opus-5
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/tests/cli.rs
+about: TASK-1dbb6e7843f1
+seq: 1
+schema: 3
+version: 1
+---

--- a/.ank/entities/LOG-aa675d5fb6f0.md
+++ b/.ank/entities/LOG-aa675d5fb6f0.md
@@ -1,0 +1,16 @@
+---
+id: LOG-aa675d5fb6f0
+type: log
+title: "the fix is a rollback and not a reordering, and the reason is measurable: the ratification commit"
+created: 2026-08-19T22:37:01Z
+author: claude-code/opus-5
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/tests/cli.rs
+about: TASK-1dbb6e7843f1
+seq: 0
+schema: 3
+version: 1
+---
+
+ is a commit *of* these files, so git takes what is on disk and there is no order in which the write comes second. accept now snapshots the bytes of every path it will touch, writes, commits, and puts the bytes back when any of that fails. Falsified before it was trusted: with the fix stashed and the test unchanged, the ADR comes out 'status: accepted' carrying 'ratified: 92e0d3922328' and a verified entry, which is the incident of 2026-08-18 reproduced; with the fix in place the file is identical before and after, HEAD is unmoved, the index is empty and a second accept ratifies once signing works. Two things measured on the way. The unstage cannot be git reset: git::output holds a debug_assert on the plumbing list of ADR-b8884edcebe3 and reset is porcelain, so the index is put back by staging the restored bytes instead, which is the same operation read from the other end and needs no HEAD to exist. And the lever for a commit git refuses is gpg.format=bogus, already used by a_signature_git_cannot_read_is_reported_rather_than_passed_over: it needs no key, no agent and no passphrase, and it fails the signing alone while every other git question in the fixture still answers. cargo test --workspace: 594 passed, 0 failed. cargo fmt --check clean. ank check ok.

--- a/.ank/entities/TASK-1dbb6e7843f1.md
+++ b/.ank/entities/TASK-1dbb6e7843f1.md
@@ -5,7 +5,7 @@ slug: a-ratification-that-could-not-be-committed-leave
 title: A ratification that could not be committed leaves nothing behind
 created: 2026-08-18T18:34:43Z
 author: claude-code/opus-5
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/src/human.rs
   - crates/ank-cli/tests/cli.rs
@@ -14,7 +14,7 @@ done_criteria: |
   When the ratification commit fails, accept leaves the entity byte-for-byte as it found it: status, ratified and verified unchanged, and the exit code and message name what failed. Tested through the binary with signing configured to a key accept cannot use, asserting the file is identical before and after and that a second accept -- once signing works -- still ratifies. cargo test --workspace and ank check stay green.
 criteria_by: creator
 schema: 3
-version: 1
+version: 2
 ---
 
 Measured on 2026-08-18, ratifying ADR-768374fe6076 on this machine, where the

--- a/.ank/entities/TASK-1dbb6e7843f1.md
+++ b/.ank/entities/TASK-1dbb6e7843f1.md
@@ -5,7 +5,7 @@ slug: a-ratification-that-could-not-be-committed-leave
 title: A ratification that could not be committed leaves nothing behind
 created: 2026-08-18T18:34:43Z
 author: claude-code/opus-5
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/src/human.rs
   - crates/ank-cli/tests/cli.rs
@@ -13,8 +13,13 @@ blocked_by: []
 done_criteria: |
   When the ratification commit fails, accept leaves the entity byte-for-byte as it found it: status, ratified and verified unchanged, and the exit code and message name what failed. Tested through the binary with signing configured to a key accept cannot use, asserting the file is identical before and after and that a second accept -- once signing works -- still ratifies. cargo test --workspace and ank check stay green.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 30cb83076ae59fac2f01203ad0dcb045a49e48e6
+    criteria: c49b57954805
+    via: submitted
 schema: 3
-version: 2
+version: 3
 ---
 
 Measured on 2026-08-18, ratifying ADR-768374fe6076 on this machine, where the

--- a/crates/ank-cli/src/human.rs
+++ b/crates/ank-cli/src/human.rs
@@ -3385,36 +3385,65 @@ pub fn accept(
     // test that finally ran the commit.
     promote(&mut entity, anchor.clone(), identity);
 
+    // Every path this ratification will touch, named before any of them is
+    // written, so the snapshot below is of the corpus as `accept` found it.
     let mut paths = Vec::new();
-
-    // The target first, and the order is the argument. Between the two writes
-    // the corpus holds a target marked `superseded` whose superseder is still
-    // `proposed` — which `check_adr` calls clean in both directions, because the
-    // proposal does name it. The reverse order leaves an accepted superseder
-    // over an unmarked target, which is precisely the fault.
-    //
-    // A `Recorded` succession skips this write and keeps the commit line: the
-    // file already says what the commit is about to say, and rewriting it would
-    // bump a version to record nothing.
     if let Succession::Pending(target) = &replaced {
-        let mut target = target.clone();
-        let target_base = version_of(&target);
-        supersede(&mut target);
         paths.extend(entity_rel_paths_to_stage(repo, target.id()));
-        store.write(&target, target_base)?;
     }
     paths.extend(entity_rel_paths_to_stage(repo, &id));
-    store.write(&entity, base_version)?;
 
-    // One commit for both writes. The succession is a single act, and two
-    // commits would leave a window in which history says the constraint binds
-    // while the one it replaced still binds too.
     let replaces = match replaced.target() {
-        Some(t) => format!("supersedes: {}\n", t.id()),
+        Some(t) => format!(
+            "supersedes: {}
+",
+            t.id()
+        ),
         None => String::new(),
     };
-    let message = format!("ratify {id}\n\n{anchor_key}: {anchor}\n{replaces}by: {identity}\n");
-    let commit = commit_signed(&repo.root, &paths, &message)?;
+    let message = format!(
+        "ratify {id}
+
+{anchor_key}: {anchor}
+{replaces}by: {identity}
+"
+    );
+
+    // **The commit is the act, so a commit that does not happen leaves nothing
+    // behind** (TASK-1dbb6e7843f1). Measured on this corpus: a signing key
+    // nothing could decrypt made `git commit` fail after the entity had been
+    // written, and it came out `accepted` carrying the anchor of a ratification
+    // that does not exist. `check` reports that as a signal, generously, and
+    // `accept` will not repair it — an existing anchor is the one thing this
+    // verb refuses to overwrite, because overwriting one is how a constraint
+    // edited in place would be re-anchored (ADR-6b3f19e08a24). So the corpus was
+    // left claiming a binding decision anchored to nothing, with `ank edit` the
+    // only route out and no message naming it.
+    //
+    // Written and then rolled back rather than committed before writing, because
+    // the commit is *of* these files: git takes what is on disk, and there is no
+    // order in which the write comes second. What the rollback owes is stated in
+    // the criterion — byte for byte, `version` included, so a failed `accept`
+    // leaves nothing for the next attempt's compare-and-swap to trip over.
+    //
+    // The same argument ADR-af53d0b62a5c makes for a write whose only product is
+    // a ref, and the same one the refusal above rests on.
+    let before = snapshot(repo, &paths);
+    let commit = match write_and_commit(
+        &store,
+        repo,
+        &replaced,
+        &entity,
+        base_version,
+        &paths,
+        &message,
+    ) {
+        Ok(commit) => commit,
+        Err(e) => {
+            undo(repo, &before, &paths);
+            return Err(e);
+        }
+    };
 
     if inv.json() {
         let superseded = replaced.target().map(|t| t.id().to_string());
@@ -3884,6 +3913,98 @@ pub fn ratification_anchor(text: &str, scope: &[String]) -> String {
 /// neither has a plumbing equivalent worth rewriting, and ADR-b8884edcebe3's
 /// rule is about parsing output — nothing here is parsed but the resulting sha,
 /// which `rev-parse` supplies.
+/// The two writes and the commit that makes them binding, as one fallible step.
+///
+/// Grouped so that `accept` has a single error path to undo: a `Pending`
+/// succession writes two files, and the failure that leaves a half-performed
+/// succession behind is the one this verb has no second pass to repair.
+fn write_and_commit(
+    store: &Store,
+    repo: &Repo,
+    replaced: &Succession,
+    entity: &Entity,
+    base_version: u64,
+    paths: &[String],
+    message: &str,
+) -> Result<String> {
+    // The target first, and the order is the argument. Between the two writes
+    // the corpus holds a target marked `superseded` whose superseder is still
+    // `proposed` — which `check_adr` calls clean in both directions, because the
+    // proposal does name it. The reverse order leaves an accepted superseder
+    // over an unmarked target, which is precisely the fault.
+    //
+    // A `Recorded` succession skips this write and keeps the commit line: the
+    // file already says what the commit is about to say, and rewriting it would
+    // bump a version to record nothing.
+    if let Succession::Pending(target) = replaced {
+        let mut target = target.clone();
+        let target_base = version_of(&target);
+        supersede(&mut target);
+        store.write(&target, target_base)?;
+    }
+    store.write(entity, base_version)?;
+
+    // One commit for both writes. The succession is a single act, and two
+    // commits would leave a window in which history says the constraint binds
+    // while the one it replaced still binds too.
+    commit_signed(&repo.root, paths, message)
+}
+
+/// The bytes of every path a ratification is about to write, as they stand now.
+///
+/// `None` is a path that does not exist, which is the ordinary case for one of
+/// the two candidates `entity_rel_paths_to_stage` names: a corpus is in one
+/// layout or the other, never both.
+fn snapshot(repo: &Repo, paths: &[String]) -> Vec<(PathBuf, Option<Vec<u8>>)> {
+    paths
+        .iter()
+        .map(|rel| {
+            let abs = repo.root.join(rel);
+            let bytes = std::fs::read(&abs).ok();
+            (abs, bytes)
+        })
+        .collect()
+}
+
+/// Puts back what [`snapshot`] recorded, and unstages what `git add` staged.
+///
+/// Best-effort by construction, and it has to be: this runs on an error path,
+/// and a failure to restore cannot replace the failure the caller is already
+/// carrying — reporting the second would hide the first, which is the one that
+/// says what to fix. What it must never do is let the caller report success.
+///
+/// The reset names the same paths and no others, so anything else the caller
+/// had staged before running `accept` stays staged.
+fn undo(repo: &Repo, before: &[(PathBuf, Option<Vec<u8>>)], paths: &[String]) {
+    for (abs, bytes) in before {
+        match bytes {
+            Some(bytes) => {
+                let _ = std::fs::write(abs, bytes);
+            }
+            None => {
+                let _ = std::fs::remove_file(abs);
+            }
+        }
+    }
+    // `git add` ran before `git commit` refused, so the index still holds the
+    // write. Staged again rather than reset, and the two are the same operation
+    // read from opposite ends: what is on disk is now what was there before, so
+    // staging it puts the index back where it was — a tracked path matches HEAD
+    // again, and a path the write created is dropped from the index by the same
+    // `-A` that added it. `reset` would be the porcelain saying the same thing,
+    // with a second failure mode when there is no HEAD to reset to.
+    //
+    // Through a `Command` of its own, as `commit_signed` does below and for the
+    // same reason: this is an act on the repository, not a read of it, so it
+    // does not belong on the plumbing path whose contract is its output.
+    let mut args = vec!["add", "-A", "--"];
+    args.extend(paths.iter().map(String::as_str));
+    let _ = std::process::Command::new("git")
+        .current_dir(&repo.root)
+        .args(&args)
+        .output();
+}
+
 fn commit_signed(cwd: &Path, paths: &[String], message: &str) -> Result<String> {
     use std::process::Command;
     let run = |args: &[&str]| -> Result<()> {

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -2112,6 +2112,92 @@ fn a_signature_git_cannot_read_is_reported_rather_than_passed_over() {
     );
 }
 
+/// A ratification git refused to commit leaves nothing behind
+/// (TASK-1dbb6e7843f1).
+///
+/// Measured on this corpus on 2026-08-18, ratifying ADR-768374fe6076 on a
+/// machine whose ratification key was protected by a passphrase nothing
+/// supplied. `git commit` failed, `accept` exited 9 carrying git's message, and
+/// the ADR came out `accepted` carrying the anchor of a commit that does not
+/// exist. `check` calls that a signal, which is right for the bootstrap case
+/// the clause was written for and generous here; `accept` will not repair it,
+/// an existing anchor being the one thing it refuses to overwrite; so the only
+/// route out was `ank edit`, which no message names.
+///
+/// The lever is the `gpg.format` git rejects, the same one the test above uses
+/// and surgical for the same reason: every other question git is asked here
+/// still answers, and only the signing fails.
+///
+/// Through the binary, because what is under test is what the process leaves on
+/// disk. A unit test would be asserting about a call `accept` made rather than
+/// about a file, which is the shape CLAUDE.md warns about and the shape that let
+/// this defect through in the first place.
+#[test]
+fn a_ratification_that_could_not_be_committed_leaves_the_entity_untouched() {
+    const ADR: &str = "ADR-00000000dbb1";
+    let r = Repo::new();
+    r.enable_signing();
+    r.seed_adr(ADR, "Do not do X.", "src/**");
+    std::fs::create_dir_all(r.0.join("src")).unwrap();
+    std::fs::write(r.0.join("src/main.rs"), "fn main() {}\n").unwrap();
+    declare_signing_key(&r);
+    r.git(&["add", "-A"]);
+    r.git(&["commit", "-qm", "seed"]);
+
+    let path = r.0.join(".ank/entities").join(format!("{ADR}.md"));
+    // Read as text, and compared as text: the bytes are the assertion, and a
+    // failure printing two byte arrays says nothing a reader can act on.
+    // `read_to_string` translates no newline on any platform, so it is the same
+    // comparison spelled legibly.
+    let before = std::fs::read_to_string(&path).unwrap();
+    let head = r.git(&["rev-parse", "HEAD"]);
+
+    r.git(&["config", "gpg.format", "bogus"]);
+    let out = r.ank("marie@laptop", &["accept", ADR]);
+    let said = stderr(&out);
+    assert_ne!(code(&out), 0, "a ratification that did not happen: {said}");
+    assert!(
+        said.contains("gpg.format"),
+        "and the message names what failed, in git's own words: {said}"
+    );
+
+    // The criterion, in as many words: byte for byte, `version` included.
+    let after = std::fs::read_to_string(&path).unwrap();
+    assert_eq!(
+        after, before,
+        "the entity is what it was before the accept that failed"
+    );
+    assert!(after.contains("status: proposed"), "{after}");
+    assert!(!after.contains("ratified:"), "{after}");
+    assert!(!after.contains("verified:"), "{after}");
+    assert_eq!(
+        head,
+        r.git(&["rev-parse", "HEAD"]),
+        "and no commit was made"
+    );
+
+    // Nothing is left staged either: `git add` ran before `git commit` refused,
+    // and an index holding the write would commit it under the next commit
+    // anybody makes in this repository, which is the same corpus by another
+    // route.
+    assert_eq!(
+        r.git(&["diff", "--cached", "--name-only"]),
+        "",
+        "the write git refused to commit is not left in the index"
+    );
+
+    // And the failure cost the caller nothing but the failure: with signing
+    // working, the same command still ratifies. This is what the byte-for-byte
+    // restore buys — a `version` bumped by the failed attempt would have left
+    // the compare-and-swap of the next one refusing.
+    r.git(&["config", "gpg.format", "ssh"]);
+    let out = r.ank("marie@laptop", &["accept", ADR]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    let text = std::fs::read_to_string(&path).unwrap();
+    assert!(text.contains("status: accepted"), "{text}");
+    assert!(text.contains("ratified:"), "{text}");
+}
+
 /// A claim is not an orphan just because this checkout is too old to have
 /// heard of the task (TASK-52fbffbfdf65).
 ///


### PR DESCRIPTION
TASK-1dbb6e7843f1.

Measured on this corpus on 2026-08-18, ratifying ADR-768374fe6076 on a machine
whose ratification key was protected by a passphrase nothing supplied. git
refused the commit, `accept` exited 9 carrying git's message, and the ADR came
out `accepted` carrying the anchor of a commit that does not exist.

What makes it more than an ordering bug is that ank could not then repair it.
`check` calls the state a signal, which is right for the bootstrap case that
clause was written for and generous here; `accept` over an existing anchor
refuses with code 7 and hints at a supersession, which is correct for a decision
genuinely ratified and wrong here. The only route out was `ank edit`, and no
message names it.

## A rollback, not a reordering

The task body proposes ordering: nothing written until git has taken it. That is
not reachable, and the reason is worth stating: the ratification commit is a
commit *of* these files, so git takes what is on disk and there is no order in
which the write comes second.

So `accept` snapshots the bytes of every path it will touch, writes, commits,
and puts the bytes back when any of that fails. Byte for byte, `version`
included, which is what lets the next attempt's compare-and-swap succeed.

The index is put back by staging the restored bytes rather than by `git reset`.
The two are the same operation read from opposite ends: what is on disk is again
what was there before, so staging it returns a tracked path to HEAD and drops a
path the write created. `reset` is porcelain, forbidden on the plumbing path by
ADR-b8884edcebe3, and carries a second failure mode where there is no HEAD.

## Tested through the binary, and falsified first

The lever is `gpg.format=bogus`, the one
`a_signature_git_cannot_read_is_reported_rather_than_passed_over` already uses:
no key, no agent, no passphrase, and it fails the signing alone while every
other git question in the fixture still answers.

With the fix stashed and the test unchanged, the ADR comes out `status:
accepted` carrying `ratified: 92e0d3922328` and a `verified` entry, which is the
incident reproduced. With it in place the file is identical before and after,
HEAD is unmoved, `git diff --cached` is empty, and a second `accept` ratifies
once signing works.

## Measured

`cargo test --workspace`: 594 passed, 0 failed. `cargo fmt --check`: clean.
`ank check`: ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MJR9o7WPTriLMwZUwsNmRb
