### PR TITLE
Release 0.4.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ank",
   "description": "Tasks and architecture decisions in your repo, behind one CLI any coding agent can call.",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "author": {
     "name": "haksolot",
     "url": "https://github.com/haksolot"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "ank-cli"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "ank-contract",
  "ank-core",
@@ -30,7 +30,7 @@ version = "0.3.0"
 
 [[package]]
 name = "ank-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "globset",
  "hex",

--- a/crates/ank-cli/Cargo.toml
+++ b/crates/ank-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ank-cli"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 # Measured on 2026-08-01 by walking toolchains upward against this tree, which
 # is the only way this number means anything: 1.78, 1.91, 1.92, 1.93 and 1.94

--- a/crates/ank-core/Cargo.toml
+++ b/crates/ank-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ank-core"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 # Measured, not assumed: see the note in ank-cli's manifest. This crate's own
 # code needs far less, but the workspace resolves one lockfile and builds as a

--- a/npm/ank-darwin-arm64/package.json
+++ b/npm/ank-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haksolot/ank-darwin-arm64",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "The ank binary for macOS on Apple silicon.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/haksolot/ank",

--- a/npm/ank-linux-x64-musl/package.json
+++ b/npm/ank-linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haksolot/ank-linux-x64-musl",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "The ank binary for Linux x86_64, statically linked against musl.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/haksolot/ank",

--- a/npm/ank-win32-x64/package.json
+++ b/npm/ank-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haksolot/ank-win32-x64",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "The ank binary for Windows x86_64.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/haksolot/ank",

--- a/npm/ank/package.json
+++ b/npm/ank/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haksolot/ank",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "The stupid coordination tool: tasks and architecture decisions in your repo, behind one CLI any coding agent can call.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/haksolot/ank",
@@ -39,8 +39,8 @@
     "node": ">=18"
   },
   "optionalDependencies": {
-    "@haksolot/ank-darwin-arm64": "0.4.0",
-    "@haksolot/ank-linux-x64-musl": "0.4.0",
-    "@haksolot/ank-win32-x64": "0.4.0"
+    "@haksolot/ank-darwin-arm64": "0.4.1",
+    "@haksolot/ank-linux-x64-musl": "0.4.1",
+    "@haksolot/ank-win32-x64": "0.4.1"
   }
 }


### PR DESCRIPTION
Version bump only, no behaviour change. What 0.4.1 carries over 0.4.0 is what landed on `main` since the tag: PR #204, #205, #206 and the ratification of SPEC-b156a5571668.

## What changed since v0.4.0

- **Six readers declare the refusals they perform** (#204, TASK-106dccc7f71c). `context`, `find`, `review`, `graph`, `scope` and `check` refused on states they declared nowhere: a path naming nothing inside the repository, `context --limit` given something that is not a number, `find --type` given a kind the registry does not declare, `scope` given no path at all. They are on the pages now, with their codes, so `ank help <verb>` answers the question before the call rather than after. `status` keeps an empty list because it refuses on nothing, and the table says why.
- **SPEC-b156a5571668 ratified**, superseding SPEC-80bff12ceae8.
- **The golden shape walk reads declarations rather than instances** (#206, TASK-fbdf25e30058). Test-only.

## The bump

Ten literals across seven files: the two published crates, the four npm manifests with their pinned `optionalDependencies`, and the plugin manifest. `Cargo.lock` follows.

```
$ bash .github/scripts/check-version.sh 0.4.1
version 0.4.1 agrees with all 10 version literals
```

`cargo test --workspace` green, `cargo fmt --check` green.

The tag goes on after this merges: the `version` job gates the build by comparing the tag with these manifests, so the order matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014TALD31QGkPyVLi96LfAry