### PR TITLE
Two tasks: a file no verb serves, and a check that spawns hundreds of processes

### DIFF
--- a/.ank/entities/TASK-1b3d7b61dc8f.md
+++ b/.ank/entities/TASK-1b3d7b61dc8f.md
@@ -1,0 +1,69 @@
+---
+id: TASK-1b3d7b61dc8f
+type: task
+slug: check-spawns-one-git-process-per-dead-scope-and
+title: check spawns one git process per dead scope and per ratified entity
+created: 2026-08-20T07:30:15Z
+author: claude-code/opus-5
+status: open
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/src/git.rs
+  - crates/ank-cli/tests/**
+blocked_by: []
+done_criteria: |
+  The number of git subprocesses check spawns is bounded by a constant and no longer grows with the number of dead scopes or of ratified entities, measured through the binary with a counting git ahead of the real one on PATH, on a corpus seeded with several of each so that a per-item cost is visible as a difference. The findings check, review and status report on this repository are identical to what they report before the change, subject by subject, level by level and message by message. cargo test --workspace and ank check stay green.
+criteria_by: creator
+schema: 3
+version: 1
+---
+
+Measured on 2026-08-20, on this repository, with the release binary:
+
+    ank status    49.0 s
+    ank review    48.9 s
+    ank check     43.7 s
+    ank find       5.3 s
+    ank context    4.2 s
+    ank show       0.3 s
+
+The cost is git subprocesses, not the reading of the corpus. One git call costs
+100 to 200 ms on the machine measured, and `check` makes hundreds:
+
+- **Two per dead scope.** ADR-3094538d831e requires a dead scope to be reported
+  with the rename or the deletion that killed it, and `last_change` answers it
+  with `rev-list -1 HEAD -- <path>` followed by `diff-tree`. This corpus holds
+  102 dead-scope findings, so roughly 204 processes, and each `rev-list` walks
+  history until it finds a commit touching that path -- for a path git never
+  knew, the whole history.
+- **One per ratified entity.** `signature_of` runs
+  `rev-list --max-count=1 --format=%G?%n%GF` per anchor, and each one starts gpg
+  to verify. Measured at 196 ms on a ratification commit, times about 55
+  accepted ADRs and specs.
+
+That is around 35 s of process starts, which is most of the total.
+
+**`status` pays all of it** (`status.rs:199` calls `human::inspect`), so the
+verb whose job is to say where you are is the slowest of the three. The count
+of faults and signals stays on `status`: the answer is right, it is the way it
+is obtained that is wrong.
+
+**One history walk can answer every dead scope**, since `--name-status -M -z`
+over the range already names every rename and deletion, and one `rev-list` can
+carry every ratification sha rather than one per call. Neither changes a verdict:
+the same records are read, in one pass instead of hundreds.
+
+**The criterion counts processes and not seconds** on purpose. The cost being
+optimised is process starts, so counting them measures the thing itself, and a
+count is the same on the three platforms CI runs while a clock is not: a loaded
+runner would redden correct code, and a timing test that cries wolf is a test
+people learn to skip.
+
+**Identical findings is the other half**, and it is what keeps this from being a
+rewrite that quietly answers differently. A faster `check` that changed one
+verdict would be a worse tool, and the rename reporting is exactly where an
+optimisation is tempted to approximate.
+
+Not attempted here: caching verdicts in the index. A cache on a signature is
+a correctness question -- one that lies is worse than one that is slow -- and it
+belongs to its own task if the batching above is not enough.

--- a/.ank/entities/TASK-8a80b590b356.md
+++ b/.ank/entities/TASK-8a80b590b356.md
@@ -1,0 +1,54 @@
+---
+id: TASK-8a80b590b356
+type: task
+slug: no-verb-serves-allowed-signers-and-the-adr-forbi
+title: No verb serves allowed_signers, and the ADR forbids opening it
+created: 2026-08-20T07:29:42Z
+author: claude-code/opus-5
+status: open
+scope:
+  - crates/ank-contract/**
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/tests/**
+blocked_by: []
+done_criteria: |
+  ank review names the principals .ank/allowed_signers declares and the key type of each, in the human rendering and under --json, and the JSON field is declared in the review output shape in ank-contract before it is emitted. A corpus that declares no key says so in words rather than printing an empty section, which is the advisory mode SPEC-199de7ac4730 describes. The golden fixture for review exercises the field with at least one declared principal. Reading who may ratify therefore requires opening no file under .ank/. cargo test --workspace and ank check stay green.
+criteria_by: creator
+schema: 3
+version: 1
+---
+
+Measured on 2026-08-20, while a human asked what the comments in that file
+said and no command could answer.
+
+ADR-01b6dd05f0db binds every agent: "No agent opens, greps, lists or edits a
+file under `.ank/` directly." Two files under `.ank/` are not entities,
+`config.yml` and `allowed_signers`. The first is served whole by `ank config`.
+The second is served by nothing: not `show`, whose subject is an entity; not
+`find`, which searches the index; not `config`, whose key set is closed and
+describes `config.yml`; not `check --json`, whose findings name a problem and
+never the declaration.
+
+So the one file the format requires a human to edit by hand is the one file the
+CLI cannot read. An agent asked about it has two options, both wrong: break the
+ADR, or answer nothing. That is not a gap in the ADR, which is right about what
+it asks for, it is a verb missing under it.
+
+`review` is where it belongs and no new verb is needed. SPEC-4eff92fd80ce
+describes the verb as "ratification queue, pending proposals, corpus health",
+and who may ratify is the standing half of the question `review` already asks
+about what awaits ratification. The specification is not reopened for this: §4
+enumerates no sections for the verb, and the machine surface is held to
+ADR-6fd69efb629c, which already requires the field to be declared in the table
+before a document may carry it.
+
+**Say the advisory mode out loud rather than printing nothing.** §8 gives a
+corpus with no declared key a defined behaviour: `check` does not judge
+signatures at all, because there is no allowlist to judge against and because
+git reports a perfectly signed commit as unsigned under `gpg.format = ssh` with
+no file configured. A section that renders empty in that state would tell a
+reader the opposite of what is true.
+
+Scope note: this touches `human.rs`, which the batching task also rewrites.
+They do not depend on each other and carry no `blocked_by`; taking this one
+first is the cheaper order, being the smaller of the two.


### PR DESCRIPTION
Corpus only, no code change. Two tasks, no ADR, no specification reopened, so nothing here waits on a signature.

## TASK-8a80b590b356 — no verb serves `allowed_signers`

`.ank/` holds two files that are not entities. `config.yml` is served whole by `ank config`. `allowed_signers` is served by nothing: not `show`, whose subject is an entity; not `find`, which searches the index; not `config`, whose key set is closed and describes `config.yml`; not `check --json`, whose findings name a problem and never the declaration.

Meanwhile ADR-01b6dd05f0db binds every agent: "No agent opens, greps, lists or edits a file under `.ank/` directly."

So the one file the format requires a human to edit by hand is the one file the CLI cannot read. An agent asked about it has two options and both are wrong: break the ADR, or answer nothing. That is a verb missing under the ADR, not a gap in it.

The reader goes in `review`, which SPEC-4eff92fd80ce already describes as "ratification queue, pending proposals, corpus health" — who may ratify is the standing half of the question that verb asks. No new verb, and no specification reopened: §4 enumerates no sections for `review`, and ADR-6fd69efb629c already requires a field to be declared in the table before a document may carry it.

The criterion also asks that a corpus with no declared key say so in words rather than render an empty section. §8 gives that state a defined behaviour — `check` does not judge signatures at all — and a section that rendered empty would tell a reader the opposite of what is true.

## TASK-1b3d7b61dc8f — check spawns one git process per dead scope and per ratified entity

Measured on this repository with the release binary:

| command | time |
|---|---|
| `ank status` | 49.0 s |
| `ank review` | 48.9 s |
| `ank check` | 43.7 s |
| `ank find` | 5.3 s |
| `ank context` | 4.2 s |
| `ank show` | 0.3 s |

The cost is git subprocesses, at 100 to 200 ms each on the machine measured.

- **Two per dead scope.** ADR-3094538d831e requires a dead scope to be reported with the rename or deletion that killed it, and `last_change` answers with `rev-list -1 HEAD -- <path>` then `diff-tree`. This corpus holds 102 dead-scope findings, so roughly 204 processes, and each `rev-list` walks history until it finds a commit touching that path — for a path git never knew, all of it.
- **One per ratified entity.** `signature_of` runs `rev-list --max-count=1 --format=%G?%n%GF` per anchor, and each starts gpg. Measured at 196 ms, times about 55 accepted ADRs and specs.

Around 35 s of process starts, which is most of the total. `status` pays all of it (`status.rs:199` calls `human::inspect`), so the verb whose job is to say where you are is the slowest of the three.

One `--name-status -M -z` walk answers every dead scope, and one `rev-list` can carry every ratification sha. Neither changes a verdict.

**The criterion counts processes, not seconds.** The count is the thing being optimised, and it is the same on the three platforms CI runs while a clock is not: a loaded runner would redden correct code, and a timing test that cries wolf is one people learn to skip. The other half of the criterion is that the findings stay identical subject by subject — a faster `check` that changed one verdict would be a worse tool, and rename reporting is exactly where an optimisation is tempted to approximate.

Caching verdicts in the index is named and declined: a cache that lies about a signature is worse than one that is slow, and it earns its own task if batching is not enough.

`ank check` exit 0, `ank graph` shows no cycle. The two tasks overlap on `human.rs` and carry no `blocked_by`: they do not wait on each other, and a false dependency is worse than none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014TALD31QGkPyVLi96LfAry