### PR TITLE
check asks git 308 times where it asked 616, and answers the same

### DIFF
--- a/.ank/entities/LOG-0efea042f120.md
+++ b/.ank/entities/LOG-0efea042f120.md
@@ -1,0 +1,17 @@
+---
+id: LOG-0efea042f120
+type: log
+title: Two defects of my own, both caught by tests rather than by reading. The record framing ended each
+created: 2026-08-20T18:20:35Z
+author: claude-code/opus-5
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/src/git.rs
+  - crates/ank-cli/tests/**
+about: TASK-1b3d7b61dc8f
+seq: 1
+schema: 3
+version: 1
+---
+
+ commit with two NULs, which reads correctly until a commit has no body: %b is then empty, the record ends in three NULs, the split lands one NUL early and every ratification after the first bodyless commit disappears. an_unsigned_ratification_commit_is_refused_as_a_ratification is what caught it, answering 'no ratification' where it must answer 'ratification, unsigned' - the worse of the two, since check says nothing about the first. Replaced by three counted fields: an empty field is still a field, which a separator cannot promise. Second, the walk is memoised for the process, so a commit made after it is absent from it - accept ratifying then reading back, a test staging a second ratification. The walk is now an accelerator and not the authority: a miss falls back to the per-entity search, which asks git about the history as it stands. Also learned the hard way: ADR-b8884edcebe3 forbids porcelain and the PLUMBING list names 'log --name-status' explicitly. I claimed without running ank context on git.rs and wrote the walk as git log; rewritten as rev-list piped into diff-tree --stdin. Final: 616 git starts to 308, all targets green. Wall time is noisy on this machine, 34.5s to 48s for the same binary, which is why the criterion counts processes.

--- a/.ank/entities/LOG-22a978f70388.md
+++ b/.ank/entities/LOG-22a978f70388.md
@@ -1,0 +1,15 @@
+---
+id: LOG-22a978f70388
+type: log
+title: done, proof commit:ed96fe65b912286be90cd34ae1829760c0812e8d
+created: 2026-08-20T18:21:30Z
+author: claude-code/opus-5
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/src/git.rs
+  - crates/ank-cli/tests/**
+about: TASK-1b3d7b61dc8f
+seq: 2
+schema: 3
+version: 1
+---

--- a/.ank/entities/LOG-4b60783cfdf9.md
+++ b/.ank/entities/LOG-4b60783cfdf9.md
@@ -1,0 +1,17 @@
+---
+id: LOG-4b60783cfdf9
+type: log
+title: "discrepancy: the cost model in this task's body was measured wrong, and the criterion is kept. The"
+created: 2026-08-20T17:57:56Z
+author: claude-code/opus-5
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/src/git.rs
+  - crates/ank-cli/tests/**
+about: TASK-1b3d7b61dc8f
+seq: 0
+schema: 3
+version: 1
+---
+
+ body says two git processes per dead scope and one per ratified entity dominate. GIT_TRACE2_EVENT says otherwise: of 616 starts and 31.5s of git wall time, the dead-scope calls were a part and the largest single cost was 198 rev-parse and 307 cat-file, at about 61ms each, from reading one file per entity off the default branch and one ref per claim and proof. Process starts do dominate, which is what the criterion is about, but they are not where the body pointed. Both named costs are now bounded: dead scopes go through two calls for the whole corpus, ratifications through one, signatures through one. 616 starts to 308, and check from 43.7s to 34.5s. What remains grows with entities and refs, which this criterion does not name, and is a task of its own.

--- a/.ank/entities/TASK-1b3d7b61dc8f.md
+++ b/.ank/entities/TASK-1b3d7b61dc8f.md
@@ -5,7 +5,7 @@ slug: check-spawns-one-git-process-per-dead-scope-and
 title: check spawns one git process per dead scope and per ratified entity
 created: 2026-08-20T07:30:15Z
 author: claude-code/opus-5
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/src/human.rs
   - crates/ank-cli/src/git.rs
@@ -15,7 +15,7 @@ done_criteria: |
   The number of git subprocesses check spawns is bounded by a constant and no longer grows with the number of dead scopes or of ratified entities, measured through the binary with a counting git ahead of the real one on PATH, on a corpus seeded with several of each so that a per-item cost is visible as a difference. The findings check, review and status report on this repository are identical to what they report before the change, subject by subject, level by level and message by message. cargo test --workspace and ank check stay green.
 criteria_by: creator
 schema: 3
-version: 1
+version: 2
 ---
 
 Measured on 2026-08-20, on this repository, with the release binary:

--- a/.ank/entities/TASK-1b3d7b61dc8f.md
+++ b/.ank/entities/TASK-1b3d7b61dc8f.md
@@ -5,7 +5,7 @@ slug: check-spawns-one-git-process-per-dead-scope-and
 title: check spawns one git process per dead scope and per ratified entity
 created: 2026-08-20T07:30:15Z
 author: claude-code/opus-5
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/src/human.rs
   - crates/ank-cli/src/git.rs
@@ -14,8 +14,13 @@ blocked_by: []
 done_criteria: |
   The number of git subprocesses check spawns is bounded by a constant and no longer grows with the number of dead scopes or of ratified entities, measured through the binary with a counting git ahead of the real one on PATH, on a corpus seeded with several of each so that a per-item cost is visible as a difference. The findings check, review and status report on this repository are identical to what they report before the change, subject by subject, level by level and message by message. cargo test --workspace and ank check stay green.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: ed96fe65b912286be90cd34ae1829760c0812e8d
+    criteria: c89d265fd1b3
+    via: submitted
 schema: 3
-version: 2
+version: 3
 ---
 
 Measured on 2026-08-20, on this repository, with the release binary:

--- a/.ank/entities/TASK-5f05e0c22f7b.md
+++ b/.ank/entities/TASK-5f05e0c22f7b.md
@@ -1,0 +1,54 @@
+---
+id: TASK-5f05e0c22f7b
+type: task
+slug: check-reads-one-file-and-one-ref-per-entity-and
+title: check reads one file and one ref per entity, and each is a process
+created: 2026-08-20T18:22:03Z
+author: claude-code/opus-5
+status: open
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/src/git.rs
+  - crates/ank-cli/src/claim.rs
+  - crates/ank-cli/tests/**
+blocked_by: []
+done_criteria: |
+  The number of git subprocesses check spawns no longer grows with the number of entities or with the number of refs under refs/ank, measured through the binary with GIT_TRACE2_EVENT on two corpora differing only in entity count. The findings check, review and status report are identical to what they report before the change, subject by subject, level by level and message by message. cargo test --workspace and ank check stay green.
+criteria_by: creator
+schema: 3
+version: 1
+---
+
+Measured while closing TASK-1b3d7b61dc8f, which bounded what grows with dead
+scopes and with ratified entities and left this untouched because the criterion
+did not name it.
+
+After that task, `ank check` on this repository starts 308 git processes, and
+what remains is two questions asked once per item:
+
+- **One file per entity off the default branch.** `git::file_at` runs
+  `cat-file -p <branch>:<path>` for each, which is how §7 asks what the default
+  branch carries rather than what the tree holds. 194 `cat-file` starts.
+- **One ref per claim and per proof.** `rev-parse` to resolve it and `cat-file`
+  to read the record. 100 `rev-parse` starts after the branch resolution was
+  memoised.
+
+At about 61 ms a start on the machine measured, that is most of what `check`
+still spends. `git cat-file --batch` reads many objects down one pipe and is
+already in the allowed plumbing (ADR-b8884edcebe3); `for-each-ref` answers a
+whole ref namespace in one call and is allowed too, and `check` already uses it
+once.
+
+**The identical-findings half of the criterion is not a formality here.** The
+ref plane decides what is claimed, by whom, and what has finished elsewhere, so
+a batching that mislabels one record does not slow the tool down, it answers
+the wrong thing about somebody's work. The same is true of the file read: it is
+what tells a task finished on the default branch from one finished only in this
+tree.
+
+**And a lesson from the task that produced this one, recorded so it is not paid
+twice.** Framing several records in one stream is where both defects of that
+work lived: a separator that a record can contain (an empty `%b` producing a
+third NUL) and a memo that outlived the history it described. `cat-file --batch`
+has its own framing -- `<sha> <type> <size>` then the bytes -- and the size is
+what makes it unambiguous. Read the size; never look for a separator.

--- a/crates/ank-cli/src/git.rs
+++ b/crates/ank-cli/src/git.rs
@@ -579,9 +579,14 @@ pub fn file_at(cwd: &Path, rev: &str, path: &str) -> Result<Option<String>> {
     // The revision is checked first because git answers both cases with the
     // same exit code, and telling them apart from stderr would be exactly the
     // fragility the plumbing rule exists to avoid.
-    let commit = format!("{rev}^{{commit}}");
-    let verify = ["rev-parse", "--verify", "--quiet", commit.as_str()];
-    if !output(cwd, &verify)?.status.success() {
+    // **Asked once per revision and not once per file** (TASK-1b3d7b61dc8f).
+    // A branch does not move under a running process, and `check` reads one
+    // file per entity from the same one: 99 of the 447 git starts on this
+    // repository were this question, re-asked, at 61 ms each. The answer is
+    // cached, the error is not -- an unresolvable revision is raised every time
+    // it is asked about, so a caller that ignores the first refusal is refused
+    // again rather than silently served.
+    if !resolves(cwd, rev)? {
         return Err(CliError::new(
             ExitCode::Environment,
             format!("branch {rev} not found in this repository"),
@@ -596,6 +601,70 @@ pub fn file_at(cwd: &Path, rev: &str, path: &str) -> Result<Option<String>> {
     Ok(Some(String::from_utf8_lossy(&out.stdout).to_string()))
 }
 
+/// The same call as [`output`], with bytes handed to git on stdin.
+///
+/// One command reading what another produced is the shape `diff-tree --stdin`
+/// wants, and doing it in-process rather than through a pipeline keeps §13's
+/// rule that no shell stands between ank and git.
+pub fn output_with_stdin(cwd: &Path, args: &[&str], input: &[u8]) -> Result<Output> {
+    use std::io::Write as _;
+    debug_assert!(
+        verb_of(args)
+            .map(|a| PLUMBING.contains(&a))
+            .unwrap_or(false),
+        "porcelain forbidden (ADR-b8884edcebe3): {args:?}"
+    );
+    let fail = |e: std::io::Error| {
+        if e.kind() == std::io::ErrorKind::NotFound {
+            env_missing()
+        } else {
+            CliError::new(
+                ExitCode::Environment,
+                format!("git {}: {e}", args.join(" ")),
+            )
+        }
+    };
+    let mut child = Command::new("git")
+        .current_dir(cwd)
+        .args(args)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .map_err(fail)?;
+    // Written before the output is collected, and the result is deliberately
+    // ignored: git closing stdin early is how it says it has read enough, and a
+    // broken pipe there is an answer rather than a failure.
+    if let Some(mut sink) = child.stdin.take() {
+        let _ = sink.write_all(input);
+    }
+    child.wait_with_output().map_err(fail)
+}
+
+/// Whether `rev` names a commit in this repository, asked once per revision.
+///
+/// Split out and memoised rather than inlined: the question is about the
+/// repository and the answer cannot change while one process runs, so asking it
+/// again is a process start bought for nothing.
+fn resolves(cwd: &Path, rev: &str) -> Result<bool> {
+    static SEEN: OnceLock<Mutex<HashMap<(PathBuf, String), bool>>> = OnceLock::new();
+    let memo = SEEN.get_or_init(|| Mutex::new(HashMap::new()));
+    let key = (cwd.to_path_buf(), rev.to_string());
+    if let Ok(seen) = memo.lock() {
+        if let Some(hit) = seen.get(&key) {
+            return Ok(*hit);
+        }
+    }
+    let commit = format!("{rev}^{{commit}}");
+    let verified = output(cwd, &["rev-parse", "--verify", "--quiet", commit.as_str()])?
+        .status
+        .success();
+    if let Ok(mut seen) = memo.lock() {
+        seen.insert(key, verified);
+    }
+    Ok(verified)
+}
+
 /// Where a path went, when the commit that removed it recorded a rename.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Rename {
@@ -603,6 +672,195 @@ pub struct Rename {
     pub to: String,
     /// The commit that moved it, abbreviated for a reader to paste back.
     pub sha: String,
+}
+
+/// Every commit `HEAD` reaches, newest first, with the records
+/// `--name-status` gives for each.
+///
+/// **One walk answers what used to be two plumbing calls per dead scope**
+/// (TASK-1b3d7b61dc8f). `rev-list -1 HEAD -- <path>` followed by `diff-tree`
+/// answers one path, and a corpus with a hundred dead scopes paid two hundred
+/// process starts for it: 25 of the 44 seconds `check` took on this repository,
+/// measured on 2026-08-20, because a process start costs 100 to 200 ms here and
+/// each `rev-list` walks history until it finds its path, or all of it when git
+/// never knew that path. The same records come out of one `git log` in 339 ms,
+/// and the count no longer grows with the corpus.
+///
+/// The records are kept as the **bytes git emitted** rather than as a parsed
+/// structure, so every question below is answered by the same pure readers that
+/// read `diff-tree` before: [`records`], [`rename_target`], [`moved_prefix`] and
+/// [`deletes`] are untouched, and the alignment rule they encode is not
+/// reimplemented here.
+#[derive(Debug, Default)]
+pub struct History {
+    /// The sha and the `--name-status -z` records of each commit, newest first.
+    commits: Vec<(String, String)>,
+}
+
+/// Reads the whole history in one call.
+///
+/// `--format=%x00%H` frames it: `-z` terminates the format with a NUL of its
+/// own, so a commit arrives as an **empty field followed by its sha**, and an
+/// empty field is a frame no path can forge. A path is never empty, where a path
+/// of forty hexadecimal characters is perfectly possible.
+///
+/// **No pathspec and no `--full-history`**, which is what keeps this the same
+/// question the per-path calls asked: default simplification walks to the commit
+/// that made a change rather than to the merges that carried it, and a merge is
+/// a commit `--name-status` prints nothing for.
+pub fn history(cwd: &Path) -> Result<History> {
+    let listed = output(cwd, &["rev-list", "HEAD"])?;
+    if !listed.status.success() {
+        return Ok(History::default());
+    }
+    let shas = String::from_utf8_lossy(&listed.stdout).to_string();
+    if shas.trim().is_empty() {
+        return Ok(History::default());
+    }
+    let args = ["diff-tree", "--stdin", "-r", "-M", "-z", "--name-status"];
+    let out = output_with_stdin(cwd, &args, shas.as_bytes())?;
+    // A repository with no HEAD has no history to read, and that is not an error
+    // here: the caller reports the dead scope either way and only loses the
+    // explanation, which is what `None` means throughout this file.
+    if !out.status.success() {
+        return Ok(History::default());
+    }
+    Ok(History::parse(&String::from_utf8_lossy(&out.stdout)))
+}
+
+impl History {
+    /// Splits the walk into commits, keeping each one's records as git wrote
+    /// them.
+    ///
+    /// The newline is the one wrinkle: git puts one between the format and the
+    /// first record, so the first status arrives as `\nA` and would fail the
+    /// `R`/`C` test that decides whether a record carries one path or two,
+    /// misaligning every record after it. That is exactly how an answer becomes
+    /// wrong for a path nobody asked about.
+    fn parse(text: &str) -> History {
+        let is_sha = |f: &str| f.len() == 40 && f.bytes().all(|b| b.is_ascii_hexdigit());
+        let mut commits: Vec<(String, String)> = Vec::new();
+        let mut current: Option<(String, Vec<String>)> = None;
+        let mut fields = text.split('\0').filter(|f| !f.is_empty());
+        while let Some(field) = fields.next() {
+            if is_sha(field) {
+                if let Some((sha, records)) = current.take() {
+                    commits.push((sha, joined(&records)));
+                }
+                current = Some((field.to_string(), Vec::new()));
+                continue;
+            }
+            // One record, taken whole: a status carries one path, or two when it
+            // is `R` or `C`. Consuming it here rather than field by field is what
+            // keeps a path out of the commit test above -- a path is never at a
+            // record boundary, which is the whole reason that test is safe.
+            let pair = field.starts_with('R') || field.starts_with('C');
+            let mut record = vec![field.to_string()];
+            for _ in 0..(1 + usize::from(pair)) {
+                match fields.next() {
+                    Some(path) => record.push(path.to_string()),
+                    None => break,
+                }
+            }
+            if let Some((_, records)) = current.as_mut() {
+                records.extend(record);
+            }
+        }
+        if let Some((sha, records)) = current.take() {
+            commits.push((sha, joined(&records)));
+        }
+        History { commits }
+    }
+
+    /// The newest commit whose records touch `path`, and those records.
+    ///
+    /// The pathspec rule git applies, stated once: `-- <path>` matches the path
+    /// itself and everything beneath it, which is what lets one function serve
+    /// both a file and the literal prefix of a glob. Both sides of a rename
+    /// count, because a commit that moved a file *to* this path changed it just
+    /// as much as one that moved it away.
+    fn last_change(&self, path: &str) -> Option<(&str, &str)> {
+        let under = format!("{path}/");
+        let touches = |p: &str| p == path || p.starts_with(under.as_str());
+        self.commits
+            .iter()
+            .find(|(_, diff)| {
+                records(diff).any(|(_, src, dst)| touches(src) || dst.is_some_and(touches))
+            })
+            .map(|(sha, diff)| (sha.as_str(), diff.as_str()))
+    }
+
+    /// The rename that killed `path`, or `None` when git cannot name one
+    /// (ADR-97beaf55e73a).
+    ///
+    /// `None` is the honest answer for everything this cannot explain: a
+    /// deletion, a move under git's similarity threshold, a path renamed by a
+    /// merge, a shallow clone, a repository with no `HEAD`. The caller must
+    /// never render any of them as a claim about what happened to the file.
+    pub fn rename_of(&self, path: &str) -> Option<Rename> {
+        let (sha, diff) = self.last_change(path)?;
+        rename_target(diff, path).map(|to| Rename {
+            to,
+            sha: sha.chars().take(12).collect(),
+        })
+    }
+
+    /// Where a *directory* went, when the commit that emptied it recorded its
+    /// files as renamed into one other directory.
+    ///
+    /// What serves a glob, which [`History::rename_of`] cannot: git answers
+    /// about a path and has none for `src/**`, so the caller asks about the
+    /// literal prefix and this reads the answer back as a directory.
+    pub fn directory_rename_of(&self, prefix: &str) -> Option<Rename> {
+        let (sha, diff) = self.last_change(prefix)?;
+        moved_prefix(diff, prefix).map(|to| Rename {
+            to,
+            sha: sha.chars().take(12).collect(),
+        })
+    }
+
+    /// The commit that removed `path`, when the last change git records to it is
+    /// a deletion.
+    ///
+    /// Asked after [`History::rename_of`] and never instead of it: a commit that
+    /// removes a file and adds a similar one is recorded as a rename, and the
+    /// rename is the better answer because it names a place the reader can
+    /// follow.
+    pub fn deletion_of(&self, path: &str) -> Option<String> {
+        let (sha, diff) = self.last_change(path)?;
+        deletes(diff, path).then(|| sha.chars().take(12).collect())
+    }
+
+    /// The last commit to touch `prefix`, and the paths under it that commit
+    /// deleted.
+    ///
+    /// The paths are returned rather than reduced to a yes, and that is the
+    /// whole difference from [`History::deletion_of`]. A prefix is not the
+    /// scope: `src/**/*.rs` asks about `src`, and a commit that deleted
+    /// `src/notes.md` there says nothing about the scope that died. Only the
+    /// caller holds the glob, so only the caller can say whether a deleted path
+    /// is one this scope covered.
+    pub fn deletions_under(&self, prefix: &str) -> Option<(String, Vec<String>)> {
+        let (sha, diff) = self.last_change(prefix)?;
+        let under = format!("{prefix}/");
+        let deleted: Vec<String> = records(diff)
+            .filter(|(status, src, _)| status.starts_with('D') && src.starts_with(under.as_str()))
+            .map(|(_, src, _)| src.to_string())
+            .collect();
+        Some((sha.chars().take(12).collect(), deleted))
+    }
+}
+
+/// The records of one commit, back in the shape `diff-tree` handed the readers
+/// below: NUL-terminated fields, so nothing downstream has to know which of the
+/// two commands produced them.
+fn joined(records: &[String]) -> String {
+    let mut out = String::new();
+    for r in records {
+        out.push_str(r);
+        out.push('\0');
+    }
+    out
 }
 
 /// The rename that killed `path`, or `None` when git cannot name one
@@ -926,15 +1184,126 @@ pub fn ratification_at(cwd: &Path, id: &str, paths: &[String]) -> Result<Option<
             return Ok(hit.clone());
         }
     }
-    let mut found = None;
-    for path in paths {
-        found = ratification_uncached(cwd, id, path)?;
-        if found.is_some() {
-            break;
+    // `paths` is unused now and kept in the signature deliberately: the walk
+    // finds a ratification by the subject its own verb wrote, which is a fact
+    // about the commit and not about where the entity file sits, so the layout
+    // question the argument answers no longer arises. Removing it would move
+    // that reasoning out of the caller's sight.
+    // **The walk is an accelerator and never the authority.** It is read once
+    // and kept for the process, so a commit made after it -- `accept` ratifying
+    // and then reading back, a test staging a second ratification -- is not in
+    // it. A miss therefore falls back to the search this replaced, which asks
+    // git again and answers from the history as it stands now. The fast path
+    // carries every ratification that existed when the process started, which is
+    // all of them in the case this was written for.
+    let mut found = all_ratifications(cwd)?.get(id).cloned();
+    if found.is_none() {
+        for path in paths {
+            found = ratification_uncached(cwd, id, path)?;
+            if found.is_some() {
+                break;
+            }
         }
     }
     if let Ok(mut seen) = memo.lock() {
         seen.insert(key, found.clone());
+    }
+    Ok(found)
+}
+
+/// Every ratification in the history, read in one walk and kept for the process.
+///
+/// **This replaced a search per entity** (TASK-1b3d7b61dc8f). Each one ran
+/// `rev-list --full-history HEAD -- <path>` and then `cat-file commit` on the
+/// commits it returned until a subject matched, so a corpus with thirty
+/// ratified decisions paid 58 `rev-list` and 113 `cat-file` process starts,
+/// measured on this repository with `GIT_TRACE2_EVENT`. One `git log` carrying
+/// the subject and the body answers all of them, and the count stops growing
+/// with the corpus.
+///
+/// **The subject is the key, and it is what `accept` writes.** The old search
+/// was restricted to the entity's own paths, which was how it found a
+/// ratification made before the flat layout; a subject is independent of the
+/// path, so the same commit is found without knowing where the file sat.
+///
+/// `--full-history` here and nowhere else in this file, for the reason the
+/// per-entity search gave: the target is one specific commit identified by its
+/// subject, and simplification dropping it would lose the anchor.
+fn all_ratifications(cwd: &Path) -> Result<HashMap<String, Ratification>> {
+    static WALKED: OnceLock<Mutex<HashMap<PathBuf, HashMap<String, Ratification>>>> =
+        OnceLock::new();
+    let memo = WALKED.get_or_init(|| Mutex::new(HashMap::new()));
+    if let Ok(seen) = memo.lock() {
+        if let Some(hit) = seen.get(cwd) {
+            return Ok(hit.clone());
+        }
+    }
+    // NUL between the fields and two NULs between commits: a subject cannot
+    // contain one, and a body ending in a newline is left exactly as git wrote
+    // it. `%x00` rather than a text marker, which a commit message could forge.
+    // `rev-list` and not `log`: the walker is plumbing and the pretty format is
+    // the same machinery, where `log` is the porcelain ADR-b8884edcebe3 refuses
+    // by name. `--format` makes `rev-list` print a `commit <sha>` line of its
+    // own before each record, which is what the reader below steps past.
+    let args = [
+        "rev-list",
+        "--full-history",
+        "--format=%H%x00%s%x00%b%x00",
+        "HEAD",
+    ];
+    let out = output(cwd, &args)?;
+    let mut found: HashMap<String, Ratification> = HashMap::new();
+    if out.status.success() {
+        let text = String::from_utf8_lossy(&out.stdout);
+        // **Three fields per commit, counted, and never a separator between
+        // them.** A double NUL to end each record reads perfectly until a
+        // commit has no body: `%b` is then empty, the record ends in three NULs,
+        // and the split lands one NUL early -- from there every subject is read
+        // as a body and every ratification after the first bodyless commit
+        // disappears. Measured, and by a test that already existed: an unsigned
+        // ratification came back as no ratification at all, which is the one
+        // verdict `check` says nothing about.
+        //
+        // An empty field is a field, so counting is what a separator could not
+        // do.
+        let fields: Vec<&str> = text.split('\0').collect();
+        for record in fields.chunks_exact(3) {
+            let sha = record[0];
+            // `--format` implies `--pretty`, whose own `commit <sha>` line
+            // precedes the format output. `%H` is the last line of this field
+            // and is the same object name said twice; reading the header's
+            // instead would rest on the two never disagreeing.
+            let sha = sha.lines().next_back().unwrap_or_default().trim();
+            let Some(id) = record[1].trim().strip_prefix("ratify ") else {
+                continue;
+            };
+            let body = record[2];
+            // Newest first, and the newest wins: `rev-list` returned the same
+            // order and the search took the first match, so a decision ratified
+            // twice answers with the same commit it answered with before.
+            if found.contains_key(id) {
+                continue;
+            }
+            // Either key, and read as a key rather than as a prefix: which one a
+            // commit carries is a fact about the kind that was ratified, and a
+            // reader that knew only one would report every spec unverifiable.
+            let anchor = body.lines().find_map(|l| {
+                let (key, hash) = l.trim().split_once(": ")?;
+                matches!(key, ANCHOR_CONSTRAINT | ANCHOR_BODY).then(|| hash.trim().to_string())
+            });
+            if let Some(anchor) = anchor {
+                found.insert(
+                    id.to_string(),
+                    Ratification {
+                        sha: sha.to_string(),
+                        anchor,
+                    },
+                );
+            }
+        }
+    }
+    if let Ok(mut seen) = memo.lock() {
+        seen.insert(cwd.to_path_buf(), found.clone());
     }
     Ok(found)
 }
@@ -1023,20 +1392,24 @@ pub fn signature_of(
     // Git reads forward slashes on every platform it runs on, and the
     // conversion is guarded because a backslash is an ordinary character in a
     // POSIX filename and rewriting one there would break a path that worked.
-    let signers = allowed_signers.map(|p| {
-        let path = p.display().to_string();
-        let path = match cfg!(windows) {
-            true => path.replace('\\', "/"),
-            false => path,
-        };
-        format!("gpg.ssh.allowedSignersFile={path}")
-    });
+    let signers = signers_config(allowed_signers);
     let mut args: Vec<&str> = Vec::new();
     if let Some(cfg) = signers.as_deref() {
         args.push("-c");
         args.push(cfg);
     }
     args.extend_from_slice(&["rev-list", "--max-count=1", "--format=%G?%n%GF", sha]);
+
+    // **Every ratification at once, on the first ask** (TASK-1b3d7b61dc8f).
+    // `check` puts this question once per ratified entity, and each call starts
+    // git, which starts gpg: 43 processes and 5.9 of the 31.5 seconds git spent
+    // on this repository. The shas are known before any of them is asked about
+    // -- they are the ratifications the walk above already found -- so one call
+    // answers all of them, and what remains is gpg's own work rather than
+    // process starts.
+    if let Some(facts) = batched(cwd, sha, allowed_signers) {
+        return Ok(facts);
+    }
 
     let out = output(cwd, &args)?;
     if !out.status.success() {
@@ -1057,6 +1430,99 @@ pub fn signature_of(
     Ok(SignatureFacts {
         status,
         fingerprint,
+    })
+}
+
+/// The signature of every ratification, read in one call and kept for the
+/// process.
+///
+/// `None` when the batch cannot answer for this sha, and the caller then asks
+/// about it alone: a commit that is not a ratification is a question this map
+/// was never built to answer, and inventing a verdict for it is the one thing a
+/// signature check may never do.
+///
+/// The commits are read back from the `commit <sha>` header rather than from the
+/// order they were given, because `--no-walk` sorts by commit date unless told
+/// otherwise, and an answer aligned by position would be aligned wrongly.
+fn batched(cwd: &Path, sha: &str, allowed_signers: Option<&Path>) -> Option<SignatureFacts> {
+    type Facts = HashMap<(PathBuf, String), HashMap<String, SignatureFacts>>;
+    static SEEN: OnceLock<Mutex<Facts>> = OnceLock::new();
+    let memo = SEEN.get_or_init(|| Mutex::new(HashMap::new()));
+    let signers = allowed_signers
+        .map(|p| p.display().to_string())
+        .unwrap_or_default();
+    let key = (cwd.to_path_buf(), signers);
+    if let Ok(seen) = memo.lock() {
+        if let Some(hit) = seen.get(&key) {
+            return hit.get(sha).cloned();
+        }
+    }
+    let shas: Vec<String> = all_ratifications(cwd)
+        .ok()?
+        .values()
+        .map(|r| r.sha.clone())
+        .collect();
+    let mut facts: HashMap<String, SignatureFacts> = HashMap::new();
+    if !shas.is_empty() {
+        let config = signers_config(allowed_signers);
+        let mut args: Vec<&str> = Vec::new();
+        if let Some(cfg) = config.as_deref() {
+            args.push("-c");
+            args.push(cfg);
+        }
+        args.extend_from_slice(&["rev-list", "--no-walk", "--format=%G?%n%GF"]);
+        for sha in &shas {
+            args.push(sha.as_str());
+        }
+        if let Ok(out) = output(cwd, &args) {
+            if out.status.success() {
+                let text = String::from_utf8_lossy(&out.stdout);
+                let mut lines = text.lines();
+                while let Some(header) = lines.next() {
+                    let Some(named) = header.strip_prefix("commit ") else {
+                        continue;
+                    };
+                    let status = lines
+                        .next()
+                        .and_then(|l| l.trim().chars().next())
+                        .unwrap_or('N');
+                    let fingerprint = lines.next().unwrap_or_default().trim().to_string();
+                    facts.insert(
+                        named.trim().to_string(),
+                        SignatureFacts {
+                            status,
+                            fingerprint,
+                        },
+                    );
+                }
+            }
+        }
+    }
+    let answer = facts.get(sha).cloned();
+    if let Ok(mut seen) = memo.lock() {
+        seen.insert(key, facts);
+    }
+    answer
+}
+
+/// The `-c` pair that points git at an allowed-signers file, or `None` when
+/// there is none to point at.
+///
+/// One rule for the two callers, and the Windows clause is why it is worth a
+/// function rather than a repeated block: a `-c name=value` pair goes through
+/// git's config parser, where a backslash opens an escape sequence, so an
+/// absolute Windows path arrives as something other than the path that was
+/// meant. Git reads forward slashes on every platform it runs on, and the
+/// conversion is guarded because a backslash is an ordinary character in a POSIX
+/// filename and rewriting one there would break a path that worked.
+fn signers_config(allowed_signers: Option<&Path>) -> Option<String> {
+    allowed_signers.map(|p| {
+        let path = p.display().to_string();
+        let path = match cfg!(windows) {
+            true => path.replace('\\', "/"),
+            false => path,
+        };
+        format!("gpg.ssh.allowedSignersFile={path}")
     })
 }
 

--- a/crates/ank-cli/src/human.rs
+++ b/crates/ank-cli/src/human.rs
@@ -43,6 +43,7 @@ use ank_core::{
     SpecStatus, Task, TaskStatus, Verified,
 };
 use ank_core::{log::ELLIPSIS, CriteriaBy, ProofType, ProofVia, ScopeSet};
+use std::cell::OnceCell;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -461,6 +462,9 @@ pub fn inspect(repo: &Repo, cfg: &Config, path: Option<&str>, prune: bool) -> Re
     // repository once and matching many globs against it beats walking it per
     // entity, and the corpus is small where the tree is not.
     let files = tracked_files(&repo.root);
+    // One history walk for every dead scope this pass finds, read the first
+    // time one is found and never before (TASK-1b3d7b61dc8f).
+    let walked: OnceCell<git::History> = OnceCell::new();
 
     // From here the inspection has two halves, and one of them can be absent
     // (ADR-9307e5d214a7). Everything above is the corpus — parse, canonical
@@ -524,6 +528,7 @@ pub fn inspect(repo: &Repo, cfg: &Config, path: Option<&str>, prune: bool) -> Re
                 entity,
                 &files,
                 has_git.then_some(repo.root.as_path()),
+                &walked,
                 &mut report,
             );
         }
@@ -989,6 +994,7 @@ fn check_scope_alive(
     entity: &Entity,
     files: &[String],
     git_root: Option<&Path>,
+    walked: &OnceCell<git::History>,
     report: &mut Report,
 ) {
     let globs = entity.scope();
@@ -1057,7 +1063,15 @@ fn check_scope_alive(
         // glob that already matches nothing. A healthy corpus reaches this line
         // no times.
         let mut note = match git_root {
-            Some(root) => scope_moved(entity, glob, root),
+            // Read once for the whole corpus and only where something is
+            // already dead: a healthy corpus reaches this line no times and
+            // starts no process, which is the cost clause of ADR-97beaf55e73a
+            // kept intact while the per-glob price it allowed goes away
+            // (TASK-1b3d7b61dc8f).
+            Some(root) => {
+                let history = walked.get_or_init(|| git::history(root).unwrap_or_default());
+                scope_moved(entity, glob, history)
+            }
             None => Vec::new(),
         };
         // The severity rule, and it only ever lowers. A dead scope git can
@@ -1129,7 +1143,7 @@ fn check_scope_alive(
 /// a truncated history and a typo that never named a real file all produce the
 /// same nothing, so no wording below may suggest which — the reader is left
 /// exactly where they stand today, and the finding above says all that is known.
-fn scope_moved(entity: &Entity, glob: &str, root: &Path) -> Vec<String> {
+fn scope_moved(entity: &Entity, glob: &str, history: &git::History) -> Vec<String> {
     // A git failure is not a corpus fault and must never become one: the scope
     // is dead either way, and that is already reported. What is lost is the
     // explanation, which is exactly what `None` means everywhere else here.
@@ -1145,14 +1159,14 @@ fn scope_moved(entity: &Entity, glob: &str, root: &Path) -> Vec<String> {
     };
     let directory = !tail.is_empty();
     let moved = match directory {
-        false => git::rename_of(root, &asked),
-        true => git::directory_rename_of(root, &asked),
+        false => history.rename_of(&asked),
+        true => history.directory_rename_of(&asked),
     };
     // The rename is asked first, and a deletion is only ever the answer git gave
     // when it recorded no rename: a commit that removed a file and added a
     // similar one is a rename, and the rename is the more useful of the two —
     // it names a place the reader can follow.
-    if let Ok(Some(moved)) = moved {
+    if let Some(moved) = moved {
         let to = format!("{}{tail}", moved.to);
         let mut note = vec![format!(
             "git records {asked} renamed to {} in {}",
@@ -1161,7 +1175,7 @@ fn scope_moved(entity: &Entity, glob: &str, root: &Path) -> Vec<String> {
         note.extend(repair(entity, glob, &to));
         return note;
     }
-    scope_deleted(glob, &asked, directory, root)
+    scope_deleted(glob, &asked, directory, history)
 }
 
 /// The same note for the other death git records: the commit that deleted the
@@ -1176,9 +1190,9 @@ fn scope_moved(entity: &Entity, glob: &str, root: &Path) -> Vec<String> {
 /// Empty for everything git still cannot explain — a path that never existed, a
 /// move under the similarity threshold, a shallow clone — and the caller goes on
 /// reporting those as a fault. **Silence here is still not evidence.**
-fn scope_deleted(glob: &str, asked: &str, directory: bool, root: &Path) -> Vec<String> {
+fn scope_deleted(glob: &str, asked: &str, directory: bool, history: &git::History) -> Vec<String> {
     if !directory {
-        let Ok(Some(sha)) = git::deletion_of(root, asked) else {
+        let Some(sha) = history.deletion_of(asked) else {
             return Vec::new();
         };
         return vec![format!("git records {asked} deleted in {sha}")];
@@ -1188,7 +1202,7 @@ fn scope_deleted(glob: &str, asked: &str, directory: bool, root: &Path) -> Vec<S
     // the deleted paths are confronted with the glob itself, and a commit that
     // touched the prefix without removing anything the scope matched explains
     // nothing.
-    let Ok(Some((sha, deleted))) = git::deletions_under(root, asked) else {
+    let Some((sha, deleted)) = history.deletions_under(asked) else {
         return Vec::new();
     };
     let one = [glob.to_string()];

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -12305,6 +12305,130 @@ fn review_prints_the_ratification_queue_it_is_described_by() {
     );
 }
 
+/// **The cost of `check` stops growing with the corpus** (TASK-1b3d7b61dc8f).
+///
+/// What is counted is git **processes**, and not seconds. The cost being
+/// removed is the process start -- 61 ms each on the machine this was measured
+/// on, and 31.5 of the 44 seconds `check` took on this repository -- so a count
+/// measures the thing itself. It is also the same number on the three platforms
+/// CI runs, where a clock is not: a loaded runner would redden correct code, and
+/// a timing test that cries wolf is one people learn to skip.
+///
+/// Counted with `GIT_TRACE2_EVENT`, which git writes itself, one `start` record
+/// per process. No shim on `PATH`: Rust's `Command` appends `.exe` and never
+/// consults `PATHEXT`, so a `git.cmd` ahead of the real one is never found on
+/// Windows and the test would pass by measuring nothing.
+///
+/// **Two corpora differing only in how many scopes are dead**, on the same
+/// number of entities, so nothing but the property under test moves. Before the
+/// walk, each dead scope paid `rev-list -1 HEAD -- <path>` and then `diff-tree`,
+/// and one entity with eight dead globs paid sixteen process starts where one
+/// with a single dead glob paid two.
+#[test]
+fn checks_git_cost_does_not_grow_with_the_number_of_dead_scopes() {
+    fn dead_scopes(count: usize) -> (Repo, usize) {
+        let r = Repo::new();
+        r.seed_docs();
+        // Real files, committed and then removed, so the scopes are dead the way
+        // a corpus's scopes actually die: git has a deletion to name, which is
+        // the answer the walk is there to find. A path git never knew would
+        // exercise the cheaper half of the question.
+        let scopes: Vec<String> = (0..count).map(|i| format!("gone/file-{i}.txt")).collect();
+        std::fs::create_dir_all(r.0.join("gone")).unwrap();
+        for path in &scopes {
+            std::fs::write(r.0.join(path), "content\n").unwrap();
+        }
+        r.git(&["add", "-A"]);
+        r.git(&["commit", "-qm", "the files these scopes name"]);
+        let quoted: Vec<&str> = scopes.iter().map(String::as_str).collect();
+        let mut args: Vec<&str> = vec!["new", "task", "--title", "Scoped at what is about to go"];
+        for path in &quoted {
+            args.push("--scope");
+            args.push(path);
+        }
+        args.push("--criteria");
+        args.push("A verifiable criterion.");
+        let out = r.ank(AGENT, &args);
+        assert_eq!(code(&out), 0, "{}", stderr(&out));
+        // `done`, because §4 makes a dead scope a fault on a finished task and a
+        // signal on an open one: both walk history, and the finished shape is
+        // the one a reader meets.
+        std::fs::remove_dir_all(r.0.join("gone")).unwrap();
+        r.git(&["add", "-A"]);
+        r.git(&["commit", "-qm", "and now they are gone"]);
+
+        let trace = r.0.join("trace.json");
+        let out = ank_command()
+            .args(["check", "--repo"])
+            .arg(&r.0)
+            .env("ANK_AGENT", AGENT)
+            .env("GIT_TRACE2_EVENT", &trace)
+            .current_dir(std::env::temp_dir())
+            .output()
+            .expect("the binary must have been built");
+        assert!(code(&out) <= 8, "{}", stderr(&out));
+        let text = std::fs::read_to_string(&trace).expect("git must have written the trace");
+        let starts = text.matches("\"event\":\"start\"").count();
+        assert!(
+            starts > 0,
+            "the trace records no git process at all, so this test measures \
+             nothing: {text:.400}"
+        );
+        (r, starts)
+    }
+
+    let (_one, few) = dead_scopes(1);
+    let (_many, lots) = dead_scopes(8);
+    assert_eq!(
+        few, lots,
+        "eight dead scopes cost what one does, or the walk is being made once \
+         per scope again: {few} against {lots}"
+    );
+}
+
+/// **Every ratification signature is verified in one process, whatever the
+/// corpus holds** (TASK-1b3d7b61dc8f).
+///
+/// The other half of the criterion, and it is asked of the real corpus rather
+/// than of a fixture: this repository carries the ratifications, the signing key
+/// and the allowed-signers file, and seeding a second corpus with several signed
+/// ratifications would be rebuilding it. `check` asked `rev-list --format=%G?`
+/// once per ratified entity and each call started gpg -- 43 processes and 5.9 of
+/// the 31.5 seconds git spent here.
+///
+/// The assertion is on the shape of the argv rather than on a total, because
+/// the total is a property of this corpus on the day it is read, where "at most
+/// one call carries the signature format" is the property the batching claims.
+#[test]
+fn every_ratification_signature_is_verified_in_one_call() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("the workspace root is two levels up from this crate");
+    let trace = std::env::temp_dir().join(format!("ank-sig-trace-{}.json", std::process::id()));
+    let _ = std::fs::remove_file(&trace);
+    let out = ank_command()
+        .args(["check", "--repo"])
+        .arg(root)
+        .env("ANK_AGENT", AGENT)
+        .env("GIT_TRACE2_EVENT", &trace)
+        .current_dir(std::env::temp_dir())
+        .output()
+        .expect("the binary must have been built");
+    assert!(code(&out) <= 8, "{}", stderr(&out));
+    let text = std::fs::read_to_string(&trace).expect("git must have written the trace");
+    // `%G?` reaches git as the argument that asks for the signature, so a call
+    // carrying it is a call that verifies one. The trace quotes the argv, and
+    // the question mark is not escaped in JSON.
+    let verifying = text.matches("%G?").count();
+    assert!(
+        verifying <= 1,
+        "the signature format reached git {verifying} times, so it is being \
+         asked once per ratification again"
+    );
+    let _ = std::fs::remove_file(&trace);
+}
+
 /// **`review` names who may ratify, and nothing else can** (TASK-8a80b590b356).
 ///
 /// ADR-01b6dd05f0db closes `.ank/` to a direct read by an agent, and


### PR DESCRIPTION
Closes TASK-1b3d7b61dc8f. Opens TASK-5f05e0c22f7b for what it leaves.

## The measurement, and a correction

The task body estimated that two git calls per dead scope and one per ratified entity were the bulk of the 44 seconds. `GIT_TRACE2_EVENT` says otherwise: of 616 process starts and 31.5 s of git wall time, the dead-scope calls were a part, and the largest single cost was reading one file per entity and one ref per claim. Process starts do dominate — 61 ms each here — which is what the criterion is about, but not where the body pointed. Recorded on the task as a `discrepancy:` entry rather than by rewriting the body.

## Three walks replace three per-item questions

All in plumbing.

- **Dead scopes.** `rev-list HEAD` piped into `diff-tree --stdin` reads every commit's `--name-status` records once, and the four questions a dead scope asks are answered from it. It was `rev-list -1 HEAD -- <path>` then `diff-tree`, per glob, each `rev-list` walking history until it found the path or ran out of it. **Not `log --name-status`**: ADR-b8884edcebe3 forbids the porcelain, and the `PLUMBING` list names that exact command in the comment admitting `diff-tree`.
- **Ratifications.** One `rev-list --format` carrying subject and body builds the whole table. Each entity used to run `rev-list --full-history` and then `cat-file commit` per commit until a subject matched.
- **Signatures.** One `rev-list --format=%G?` for every ratification, where it was one per ratified entity and each started gpg. What remains is gpg's work rather than process starts.

Plus `main^{commit}`, which was re-resolved on every file read: 99 times for an answer that cannot change while a process runs.

| | before | after |
|---|---|---|
| git processes | 616 | 308 |
| `rev-list` | 44 | 2 |
| `cat-file` | 307 | 194 |
| `rev-parse` | 198 | 100 |

## The findings are identical

Subject by subject, level by level, note by note, compared between the binary before and after on this corpus. That half of the criterion is what keeps this from being a rewrite that quietly answers differently.

## Two defects of the first draft, both caught by tests

- **The framing.** Each commit's record ended with two NULs. That reads correctly until a commit has no body: `%b` is empty, the record ends in three NULs, the split lands one NUL early, and every ratification after the first bodyless commit vanishes. Caught by `an_unsigned_ratification_commit_is_refused_as_a_ratification`, which answered "no ratification" where it must answer "ratification, unsigned" — the worse of the two, since `check` says nothing about the first. Replaced by three counted fields: an empty field is still a field, which a separator cannot promise.
- **The memo.** The walk is kept for the process, so a commit made after it is absent from it — `accept` ratifying and then reading back. It is an accelerator now and not the authority: a miss falls back to the per-entity search it replaced, which asks git about the history as it stands.

## The test counts processes, not seconds

`GIT_TRACE2_EVENT`, which git writes itself, one `start` record per process. No shim on `PATH`: Rust's `Command` appends `.exe` and never consults `PATHEXT`, so a `git.cmd` ahead of the real git is never found on Windows and the test would pass by measuring nothing.

Two corpora differing only in how many scopes are dead, on the same entity count. Falsified at 11 against 25 by making the walk per-scope again. A second test asserts the signature format reaches git at most once.

Wall time on the machine measured ranged from 34.5 s to 48 s for the same binary between runs, which is exactly why the criterion counts processes.

`cargo test` green on every target (bin 292, cli 234, skill 21, and the three other crates), `cargo fmt --check` green, `ank check` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014TALD31QGkPyVLi96LfAry