### PR TITLE
Two more fronts, because one second leaves room for neither

### DIFF
--- a/.ank/entities/TASK-097883a2c09f.md
+++ b/.ank/entities/TASK-097883a2c09f.md
@@ -1,0 +1,59 @@
+---
+id: TASK-097883a2c09f
+type: task
+slug: ten-seconds-of-check-are-ank-s-own-and-nobody-ha
+title: Ten seconds of check are ank's own, and nobody has profiled them
+created: 2026-08-20T18:32:42Z
+author: claude-code/opus-5
+status: open
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/src/context.rs
+  - crates/ank-cli/src/index.rs
+  - crates/ank-core/src/scope.rs
+  - crates/ank-cli/tests/**
+blocked_by: []
+done_criteria: |
+  Where the time that is not git goes is measured and recorded before anything is changed, attributing it to named phases rather than guessed at. Every phase the measurement shows to be superlinear in the corpus, or to repeat work that one pass could do once, is made to do that work once. The findings check, review, context, find, scope and graph report are identical to what they report before the change, subject by subject and row by row. cargo test --workspace and ank check stay green.
+criteria_by: creator
+schema: 3
+version: 1
+---
+
+Measured on 2026-08-20, on this repository, after TASK-1b3d7b61dc8f:
+`ank check` spends 24.7 seconds in git and about ten more that are ank's own.
+Those ten are untouched by every batching done so far, and they do not go away
+by asking git less.
+
+Two facts frame it:
+
+- `ank show`, which reads one entity and starts five git processes, costs one
+  second. Five starts are 0.3 s here, so roughly 0.7 s of that is fixed cost
+  paid before any corpus is read.
+- `find`, `graph` and `scope` each cost around ten seconds and start a hundred
+  processes. Batching the coordination plane will take the git half; what is
+  left is this.
+
+**A budget of one second leaves nothing for ten seconds of anything**, which is
+why this is its own task rather than a refinement of the batching ones.
+
+**The measurement comes first and the criterion says so.** What follows is a
+suspect and not a conclusion:
+
+`check_scope_alive` compiles a `ScopeSet` per glob, inside the loop over an
+entity's scope, and confronts it with every tracked file. This corpus carries
+462 scope entries across 292 entities and about 1100 tracked files, so that is
+462 glob compilations and half a million match attempts, and `in_perimeter`
+compiles again for every entity that `context`, `find` and `scope` filter.
+Compiling a glob set is not free, and none of these compilations is reused.
+
+If the profile confirms it, the shape of the answer is one compilation per
+distinct glob and one pass over the file list. If the profile says something
+else, the profile is right and this paragraph is wrong -- which is exactly why
+the criterion asks for the measurement to be recorded rather than for this
+suspect to be fixed.
+
+**Identical output is half the criterion**, for the same reason it was in the
+batching task: a faster reader that answers differently about which entity
+covers which file has broken the one mechanism attaching decisions to code
+(ADR-0bb7ea8991bc and the scope model of §3).

--- a/.ank/entities/TASK-dbef284a166c.md
+++ b/.ank/entities/TASK-dbef284a166c.md
@@ -1,0 +1,59 @@
+---
+id: TASK-dbef284a166c
+type: task
+slug: every-ratification-is-verified-by-gpg-on-every-r
+title: Every ratification is verified by gpg on every run, and the verdict cannot change
+created: 2026-08-20T18:31:47Z
+author: claude-code/opus-5
+status: open
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/src/git.rs
+  - crates/ank-cli/src/index.rs
+  - crates/ank-cli/tests/**
+blocked_by: []
+done_criteria: |
+  A signature verdict already computed for a commit is not computed again: check run twice on an unchanged corpus starts gpg on the second run for no ratification it verified on the first, measured through the binary. The verdict is keyed on the commit and on the content of .ank/allowed_signers, so declaring a key changes every key that depends on it. A cache that cannot be read or that does not match its key is recomputed and never trusted, and no cached state can turn a signature check into a pass it did not earn: the four outcomes SPEC-199de7ac4730 lists are reported from a cache exactly as they are from git. cargo test --workspace and ank check stay green.
+criteria_by: creator
+schema: 3
+version: 1
+---
+
+Measured on 2026-08-20, after TASK-1b3d7b61dc8f batched the calls: the whole
+corpus is verified in one `rev-list`, and that one process costs 4.5 seconds.
+It is not process startup any more, it is gpg doing real work, forty-three
+times, inside git.
+
+Nothing else in this repository can remove it. Batching is done. A signature is
+a cryptographic operation and it takes what it takes.
+
+**But it never needs doing twice.** A ratification commit is immutable, so the
+question "is this object signed by a declared key" has an answer that cannot
+change while the commit, the allowed-signers file and the local keyring stay as
+they are. Two of those three are in the repository and hashable; the third is
+the one that moves.
+
+`.ank/index.db` is where it belongs. §6 calls the index derived, disposable and
+gitignored, which is exactly the standing a cache may have: losing it costs a
+recomputation and never a wrong answer.
+
+**The danger is the whole subject, and it is why this was refused once already
+(TASK-1b3d7b61dc8f left it out deliberately).** A cache that lies about a
+signature is worse than one that is slow, because the thing being cached is the
+one anchor §8 says holds when everything else can be forged. Two rules follow,
+and they are not negotiable:
+
+- **A miss is a recomputation, never a pass.** Unreadable, unparseable, keyed on
+  something that no longer matches: all of them mean ask git, and none of them
+  means assume the last answer.
+- **No cached state may produce an outcome the run did not earn.** §8 lists four
+  and they stay four. In particular `unchecked` -- signature present, no local
+  public key -- must not be cached into `verified`, and importing a key must be
+  able to change the answer. Keying on the keyring is not possible; what is
+  possible is that a stale `unchecked` is the safe direction, since it
+  under-claims. Say so where the key is built, and give the reader a way to
+  drop the cache.
+
+The test that matters is not the timing one. It is that a corpus whose
+`allowed_signers` changed, or whose ratification commit was replaced, reports
+the new verdict and not the old.


### PR DESCRIPTION
Corpus only. Two tasks, no ADR, no specification reopened, so nothing waits on a signature.

## The budget

Measured on this repository with `GIT_TRACE2_EVENT`, after PR #210 batched the calls:

| | |
|---|---|
| `ank check`, git | 24.7 s over 308 processes |
| `ank check`, ank's own | ~10 s |
| one git process start | 61 ms |
| `ank show` (one entity, 5 processes) | 1.0 s |
| `ank find` / `graph` / `scope` | ~10 s, 100 processes each |

**At 61 ms a start, one second allows sixteen processes in total.** So batching alone cannot get there, and two costs it does not touch have to be named.

## TASK-dbef284a166c — the signatures

Batching is already done: the whole corpus is verified in one `rev-list`, and that one process costs 4.5 s. It is not startup any more, it is gpg doing real work forty-three times inside git. Nothing in this repository makes that faster.

But it never needs doing twice. A ratification commit is immutable, so the verdict cannot change while the commit, `allowed_signers` and the keyring stay as they are. `.ank/index.db` is where it belongs: §6 calls the index derived, disposable and gitignored, which is exactly the standing a cache may have.

**Most of the task body is the danger**, and the task was deliberately left out of PR #210 for it. A cache that lies about a signature is worse than one that is slow, because the thing cached is the one anchor §8 says holds when everything else can be forged. Two rules the criterion carries: a miss recomputes and never passes, and no cached state may produce an outcome the run did not earn — `unchecked` must never cache into `verified`, and importing a key must be able to change the answer.

## TASK-097883a2c09f — the ten seconds that are not git

Untouched by every batching so far. `ank show` costs a second for one entity, of which roughly 0.7 s is paid before any corpus is read.

**The criterion asks for the measurement first**, and names a suspect without conceding it: `check_scope_alive` compiles a `ScopeSet` per glob, inside the loop over an entity's scope, and confronts it with every tracked file — 462 scope entries, ~1100 files, and `in_perimeter` compiles again for every entity the readers filter. If the profile says something else, the profile is right.

Identical output is half of both criteria, for the reason it was half of #210's: a faster reader that answers differently about which entity covers which file has broken the one mechanism attaching decisions to code.

## Ordering

None. The three fronts — the batching of TASK-5f05e0c22f7b on PR #210, and these two — are independent, and no `blocked_by` is written for a preference. Taking the batching first is the cheaper order; it is not a dependency.

`ank check` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014TALD31QGkPyVLi96LfAry