### PR TITLE
check asks git 24 times where it asked 616, and find asks 6

### DIFF
--- a/.ank/entities/LOG-899ac1fa49ea.md
+++ b/.ank/entities/LOG-899ac1fa49ea.md
@@ -1,0 +1,16 @@
+---
+id: LOG-899ac1fa49ea
+type: log
+title: done, proof commit:54371b781080293c49887e201154d43e5d57beac
+created: 2026-08-20T19:21:33Z
+author: claude-code/opus-5
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/src/git.rs
+  - crates/ank-cli/src/claim.rs
+  - crates/ank-cli/tests/**
+about: TASK-5f05e0c22f7b
+seq: 1
+schema: 3
+version: 1
+---

--- a/.ank/entities/LOG-f2670d4a93c4.md
+++ b/.ank/entities/LOG-f2670d4a93c4.md
@@ -1,0 +1,18 @@
+---
+id: LOG-f2670d4a93c4
+type: log
+title: The ref plane and the branch files, batched. for-each-ref already named every object, so read_at
+created: 2026-08-20T19:20:35Z
+author: claude-code/opus-5
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/src/git.rs
+  - crates/ank-cli/src/claim.rs
+  - crates/ank-cli/tests/**
+about: TASK-5f05e0c22f7b
+seq: 0
+schema: 3
+version: 1
+---
+
+ re-resolving each ref was a question whose answer was in hand: 96 refs cost 192 starts between rev-parse and cat-file, and one cat-file --batch answers all of them. The same in context.rs, which find, graph, scope and status all go through. Then the branch files: done_on and the three readers beside it each asked cat-file about one entity, so inspect now preloads every entity path at the default branch in one call and file_at reads from it, falling back to git for anything the batch does not carry. Measured: check 616 starts to 24 and 43.7s to 11.0s, find 100 to 6 and 11.3s to 1.2s, graph 100 to 6 and 1.0s. check, review and status report identical findings, compared binary against binary on one corpus. One defect on the way, and the same class as last time: the preload was kept for the process, so a test committing between two inspections read the old branch. It is reloaded on every inspection now, one process each, because a stale map serves a task as finished on the default branch when it is not, which is the one direction this must never be wrong in.

--- a/.ank/entities/TASK-5f05e0c22f7b.md
+++ b/.ank/entities/TASK-5f05e0c22f7b.md
@@ -5,7 +5,7 @@ slug: check-reads-one-file-and-one-ref-per-entity-and
 title: check reads one file and one ref per entity, and each is a process
 created: 2026-08-20T18:22:03Z
 author: claude-code/opus-5
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/src/human.rs
   - crates/ank-cli/src/git.rs
@@ -15,8 +15,13 @@ blocked_by: []
 done_criteria: |
   The number of git subprocesses check spawns no longer grows with the number of entities or with the number of refs under refs/ank, measured through the binary with GIT_TRACE2_EVENT on two corpora differing only in entity count. The findings check, review and status report are identical to what they report before the change, subject by subject, level by level and message by message. cargo test --workspace and ank check stay green.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 54371b781080293c49887e201154d43e5d57beac
+    criteria: 1f8a30a63dee
+    via: submitted
 schema: 3
-version: 2
+version: 3
 ---
 
 Measured while closing TASK-1b3d7b61dc8f, which bounded what grows with dead

--- a/.ank/entities/TASK-5f05e0c22f7b.md
+++ b/.ank/entities/TASK-5f05e0c22f7b.md
@@ -5,7 +5,7 @@ slug: check-reads-one-file-and-one-ref-per-entity-and
 title: check reads one file and one ref per entity, and each is a process
 created: 2026-08-20T18:22:03Z
 author: claude-code/opus-5
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/src/human.rs
   - crates/ank-cli/src/git.rs
@@ -16,7 +16,7 @@ done_criteria: |
   The number of git subprocesses check spawns no longer grows with the number of entities or with the number of refs under refs/ank, measured through the binary with GIT_TRACE2_EVENT on two corpora differing only in entity count. The findings check, review and status report are identical to what they report before the change, subject by subject, level by level and message by message. cargo test --workspace and ank check stay green.
 criteria_by: creator
 schema: 3
-version: 1
+version: 2
 ---
 
 Measured while closing TASK-1b3d7b61dc8f, which bounded what grows with dead

--- a/crates/ank-cli/src/context.rs
+++ b/crates/ank-cli/src/context.rs
@@ -127,7 +127,13 @@ pub(crate) fn plane(cwd: &std::path::Path, warnings: &mut Vec<String>) -> Result
     if !git::usable_here(cwd) {
         return Ok(plane);
     }
-    for r in git::ank_refs(cwd)? {
+    let refs = git::ank_refs(cwd)?;
+    // Every record in one process rather than one each (TASK-5f05e0c22f7b).
+    // `for-each-ref` already named the objects, so the second half of the
+    // question was the only one still being asked ref by ref.
+    let objects: Vec<String> = refs.iter().map(|r| r.object.clone()).collect();
+    let records = git::cat_file_batch(cwd, &objects).unwrap_or_default();
+    for r in refs {
         // The address decides which question the record answers, and a record
         // whose state contradicts its namespace is reported rather than
         // coerced: a proof blob on a claim ref would read as a free task, which
@@ -143,14 +149,13 @@ pub(crate) fn plane(cwd: &std::path::Path, warnings: &mut Vec<String>) -> Result
         let Ok(id) = EntityId::parse(rest) else {
             continue;
         };
-        let args = ["cat-file", "-p", r.object.as_str()];
-        let out = git::output(cwd, &args)?;
-        if !out.status.success() {
+        // Absent from the batch is what unreadable was before: git was asked
+        // about the object and had nothing to give back.
+        let Some(text) = records.get(&r.object) else {
             warnings.push(format!("unreadable coordination ref {}", r.name));
             continue;
-        }
-        let text = String::from_utf8_lossy(&out.stdout);
-        let record = match claim::parse_record(&text, &r.name) {
+        };
+        let record = match claim::parse_record(text, &r.name) {
             Ok(record) => record,
             Err(e) => {
                 // The ref is not appended: `corrupt` already names it, and it

--- a/crates/ank-cli/src/git.rs
+++ b/crates/ank-cli/src/git.rs
@@ -586,6 +586,13 @@ pub fn file_at(cwd: &Path, rev: &str, path: &str) -> Result<Option<String>> {
     // cached, the error is not -- an unresolvable revision is raised every time
     // it is asked about, so a caller that ignores the first refusal is refused
     // again rather than silently served.
+    // Read from the batch when one was loaded for this revision, and asked of
+    // git when it was not (TASK-5f05e0c22f7b). An accelerator and never the
+    // authority: a path the batch does not carry is a path git is asked about,
+    // which is also what keeps a caller outside `check` answering correctly.
+    if let Some(hit) = preloaded(cwd, rev, path) {
+        return Ok(hit);
+    }
     if !resolves(cwd, rev)? {
         return Err(CliError::new(
             ExitCode::Environment,
@@ -639,6 +646,178 @@ pub fn output_with_stdin(cwd: &Path, args: &[&str], input: &[u8]) -> Result<Outp
         let _ = sink.write_all(input);
     }
     child.wait_with_output().map_err(fail)
+}
+
+/// Reads many objects in one process.
+///
+/// **One `cat-file --batch` where there was one `cat-file -p` per object**
+/// (TASK-5f05e0c22f7b). The coordination plane holds one ref per claim and per
+/// proof, and reading them one at a time cost a process each -- 95 of them on
+/// this repository, at 61 ms a start, paid by `check`, `find`, `graph`, `scope`
+/// and `status` alike.
+///
+/// **The framing is a size, never a separator**, which is the whole reason this
+/// mode exists: git answers `<name> <type> <size>` on one line, then exactly
+/// that many bytes, then a newline. A record therefore cannot be confused with
+/// content that happens to look like a header, and content containing a newline
+/// -- which every record here does -- is read exactly as long as it is. The
+/// lesson was paid for in TASK-1b3d7b61dc8f, where a separator a record could
+/// contain silently swallowed every ratification after the first commit with no
+/// body.
+///
+/// A name git cannot resolve comes back as `<name> missing` and is simply
+/// absent from the answer, which is what every caller already means by a lookup
+/// that found nothing.
+///
+/// Bytes and not text: the size is a byte count, so slicing a lossily decoded
+/// string would cut in the wrong place the first time an object carried
+/// something that is not UTF-8. The values are decoded one at a time, after the
+/// framing has done its work.
+pub fn cat_file_batch(cwd: &Path, objects: &[String]) -> Result<HashMap<String, String>> {
+    let mut found = HashMap::new();
+    if objects.is_empty() {
+        return Ok(found);
+    }
+    let mut input = String::new();
+    for o in objects {
+        input.push_str(o);
+        input.push('\n');
+    }
+    let out = output_with_stdin(cwd, &["cat-file", "--batch"], input.as_bytes())?;
+    if !out.status.success() {
+        return Ok(found);
+    }
+    let body = out.stdout;
+    let mut at = 0usize;
+    while at < body.len() {
+        let Some(eol) = body[at..].iter().position(|b| *b == b'\n') else {
+            break;
+        };
+        let header = String::from_utf8_lossy(&body[at..at + eol]).to_string();
+        at += eol + 1;
+        let mut parts = header.split_whitespace();
+        let Some(name) = parts.next() else { continue };
+        let (Some(_kind), Some(size)) = (parts.next(), parts.next()) else {
+            // `<name> missing`, and the caller learns it by absence.
+            continue;
+        };
+        let Ok(size) = size.parse::<usize>() else {
+            break;
+        };
+        if at + size > body.len() {
+            break;
+        }
+        let value = String::from_utf8_lossy(&body[at..at + size]).to_string();
+        // The size, then git's own trailing newline.
+        at += size + 1;
+        found.insert(name.to_string(), value);
+    }
+    Ok(found)
+}
+
+/// Every entity file the default branch carries, read in one process and kept
+/// for the process.
+///
+/// **A path lookup cannot be keyed on what git echoes back.** For an object
+/// named by sha, `--batch` repeats the name it was given; for `<rev>:<path>` it
+/// answers with the blob's own object name, which is not what was asked. So the
+/// alignment here is positional, and it is safe for the one reason that makes
+/// positional alignment ever safe: git emits **exactly one response per input
+/// line, in order**, and a path it cannot resolve still emits one, echoing the
+/// input followed by `missing`. The count is asserted rather than assumed.
+///
+/// Keyed on the revision as well as the repository, because the whole point of
+/// reading here is that the default branch and the working tree disagree (§7).
+pub fn preload_at(cwd: &Path, rev: &str, paths: &[String]) -> Result<()> {
+    if paths.is_empty() {
+        return Ok(());
+    }
+    // **Reloaded on every call, never reused across one.** A branch moves: a
+    // test commits between two inspections, `done` writes and reads back. The
+    // map is only ever right for the tip it was read at, so keeping it would
+    // serve a task as finished on the default branch when it is not -- the one
+    // direction this must never be wrong in. Refreshing costs one process per
+    // inspection, which is the price this whole task exists to pay once instead
+    // of per entity.
+    let key = (cwd.to_path_buf(), rev.to_string());
+    let memo = PRELOADED.get_or_init(|| Mutex::new(HashMap::new()));
+    let names: Vec<String> = paths.iter().map(|p| format!("{rev}:{p}")).collect();
+    let answers = cat_file_batch_ordered(cwd, &names)?;
+    let mut found: HashMap<String, Option<String>> = HashMap::new();
+    // A short answer means the framing was misread, and a half-filled map would
+    // report entities as absent from the branch that carries them -- which is a
+    // task called unfinished, not a slow tool. Nothing is stored in that case
+    // and every caller falls back to asking git itself.
+    if answers.len() == paths.len() {
+        for (path, answer) in paths.iter().zip(answers) {
+            found.insert(path.clone(), answer);
+        }
+    }
+    if let Ok(mut seen) = memo.lock() {
+        seen.insert(key, found);
+    }
+    Ok(())
+}
+
+type Preloaded = OnceLock<Mutex<HashMap<(PathBuf, String), HashMap<String, Option<String>>>>>;
+static PRELOADED: Preloaded = OnceLock::new();
+
+/// What [`preload_at`] holds for this path, or `None` when it was never asked
+/// to hold it.
+fn preloaded(cwd: &Path, rev: &str, path: &str) -> Option<Option<String>> {
+    let memo = PRELOADED.get()?;
+    let seen = memo.lock().ok()?;
+    seen.get(&(cwd.to_path_buf(), rev.to_string()))?
+        .get(path)
+        .cloned()
+}
+
+/// The same batch as [`cat_file_batch`], answered in the order it was asked.
+///
+/// Split out rather than folded in, because the two callers key differently and
+/// the difference is not cosmetic: a caller naming objects by sha reads the
+/// answer back by name, and a caller naming `<rev>:<path>` cannot.
+fn cat_file_batch_ordered(cwd: &Path, names: &[String]) -> Result<Vec<Option<String>>> {
+    let mut out = Vec::with_capacity(names.len());
+    if names.is_empty() {
+        return Ok(out);
+    }
+    let mut input = String::new();
+    for name in names {
+        input.push_str(name);
+        input.push('\n');
+    }
+    let answered = output_with_stdin(cwd, &["cat-file", "--batch"], input.as_bytes())?;
+    if !answered.status.success() {
+        return Ok(out);
+    }
+    let body = answered.stdout;
+    let mut at = 0usize;
+    while at < body.len() {
+        let Some(eol) = body[at..].iter().position(|b| *b == b'\n') else {
+            break;
+        };
+        let header = String::from_utf8_lossy(&body[at..at + eol]).to_string();
+        at += eol + 1;
+        let mut parts = header.split_whitespace();
+        let _name = parts.next();
+        let (Some(_kind), Some(size)) = (parts.next(), parts.next()) else {
+            // `<input> missing`, which is a response and keeps the alignment.
+            out.push(None);
+            continue;
+        };
+        let Ok(size) = size.parse::<usize>() else {
+            break;
+        };
+        if at + size > body.len() {
+            break;
+        }
+        out.push(Some(
+            String::from_utf8_lossy(&body[at..at + size]).to_string(),
+        ));
+        at += size + 1;
+    }
+    Ok(out)
 }
 
 /// Whether `rev` names a commit in this repository, asked once per revision.

--- a/crates/ank-cli/src/human.rs
+++ b/crates/ank-cli/src/human.rs
@@ -511,6 +511,20 @@ pub fn inspect(repo: &Repo, cfg: &Config, path: Option<&str>, prune: bool) -> Re
         &detached,
     );
 
+    // Every entity file the default branch carries, in one process
+    // (TASK-5f05e0c22f7b). `done_on` and the three readers beside it each asked
+    // `cat-file` about one entity at a time, so a corpus of three hundred paid
+    // three hundred starts to learn what one call answers. A failure here is not
+    // reported and not fatal: `file_at` falls back to asking git per path, which
+    // is what it did before.
+    if let (true, Some(Ok(branch))) = (has_git, default_branch.as_ref()) {
+        let paths: Vec<String> = entities
+            .iter()
+            .flat_map(|(_, e)| entity_rel_paths(repo, e.id()))
+            .collect();
+        let _ = git::preload_at(&repo.root, branch, &paths);
+    }
+
     for (_, entity) in &entities {
         if !in_scope(entity) {
             continue;
@@ -632,7 +646,14 @@ type Plane = (
 fn coordination(cwd: &Path, report: &mut Report) -> Result<Plane> {
     let mut map = HashMap::new();
     let mut proofs: HashMap<EntityId, Vec<claim::AttestedProof>> = HashMap::new();
-    for r in git::ank_refs(cwd)? {
+    let refs = git::ank_refs(cwd)?;
+    // Every record in one process (TASK-5f05e0c22f7b). `read_at` resolves the
+    // ref and then reads the object, two starts each, and `for-each-ref` has
+    // already named the object -- so the resolution was a question whose answer
+    // was in hand and the read was the only one left to ask.
+    let objects: Vec<String> = refs.iter().map(|r| r.object.clone()).collect();
+    let records = git::cat_file_batch(cwd, &objects).unwrap_or_default();
+    for r in refs {
         // One walk over both namespaces. `check` asks the same question of
         // every ref under `refs/ank/`, and two loops would be free to disagree
         // about which of them a given ref belongs to.
@@ -652,7 +673,19 @@ fn coordination(cwd: &Path, report: &mut Report) -> Result<Plane> {
                 .push(Finding::fault(&r.name, "ref name is not an identifier"));
             continue;
         };
-        match claim::read_at(cwd, &r.name) {
+        let read = match records.get(&r.object) {
+            Some(text) => claim::parse_record(text, &r.name).map(|record| {
+                Some(claim::Held {
+                    object: r.object.clone(),
+                    record,
+                })
+            }),
+            // A ref `for-each-ref` named and `cat-file` could not read is the
+            // same nothing `read_at` answered with, and the caller below already
+            // has a verdict for it.
+            None => Ok(None),
+        };
+        match read {
             Ok(Some(held)) => match (held.record, proof_ns) {
                 (Record::Proof(p), true) => {
                     proofs.insert(id, p.proofs);

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -12386,6 +12386,60 @@ fn checks_git_cost_does_not_grow_with_the_number_of_dead_scopes() {
     );
 }
 
+/// **The cost of `check` stops growing with the corpus itself**
+/// (TASK-5f05e0c22f7b).
+///
+/// The other half of what a per-item question costs. `check` read one file per
+/// entity off the default branch and one ref per claim, two process starts
+/// each, so the price rose with every task written -- 616 starts on this
+/// repository, of which 391 were these two questions asked over and over.
+///
+/// Two corpora differing only in how many tasks they hold, each task claimed so
+/// that it carries a ref: what is varied is exactly what the criterion names,
+/// entities and refs under `refs/ank/`.
+#[test]
+fn checks_git_cost_does_not_grow_with_the_number_of_entities() {
+    fn corpus(tasks: usize) -> usize {
+        let r = Repo::new();
+        r.seed_docs();
+        r.git(&["add", "-A"]);
+        r.git(&["commit", "-qm", "seed"]);
+        for i in 0..tasks {
+            let id = format!("TASK-0000000{i:05x}");
+            r.seed_task(&id, Some("A verifiable criterion."));
+            r.git(&["add", "-A"]);
+            r.git(&["commit", "-qm", "one more task"]);
+            // Claimed under its own identity, so each task leaves a ref under
+            // `refs/ank/` and the one-live-claim rule does not refuse the
+            // second. Through the binary, which is also how a real corpus grows
+            // its coordination plane.
+            let out = r.ank(&format!("claude-code/agent-{i}"), &["claim", &id]);
+            assert_eq!(code(&out), 0, "{}", stderr(&out));
+        }
+        let trace = r.0.join("trace.json");
+        let out = ank_command()
+            .args(["check", "--repo"])
+            .arg(&r.0)
+            .env("ANK_AGENT", AGENT)
+            .env("GIT_TRACE2_EVENT", &trace)
+            .current_dir(std::env::temp_dir())
+            .output()
+            .expect("the binary must have been built");
+        assert!(code(&out) <= 8, "{}", stderr(&out));
+        let text = std::fs::read_to_string(&trace).expect("git must have written the trace");
+        let starts = text.matches("\"event\":\"start\"").count();
+        assert!(starts > 0, "this test measures nothing: {text:.300}");
+        starts
+    }
+
+    let few = corpus(2);
+    let many = corpus(12);
+    assert_eq!(
+        few, many,
+        "twelve claimed tasks cost what two do, or a file or a ref is being read          one at a time again: {few} against {many}"
+    );
+}
+
 /// **Every ratification signature is verified in one process, whatever the
 /// corpus holds** (TASK-1b3d7b61dc8f).
 ///


### PR DESCRIPTION
Closes TASK-5f05e0c22f7b. Front A of the three the budget calls for.

## Two questions were still asked once per item

**The refs.** `for-each-ref` already names every object under `refs/ank/`, and `read_at` resolved the ref again and then read it — two starts per ref, 96 refs. One `cat-file --batch` answers all of them. The same loop exists in `context.rs`, which `find`, `graph`, `scope` and `status` all go through, and it is where those verbs spent a hundred process starts each.

**The branch files.** `done_on` and the three readers beside it asked `cat-file` about one entity at a time. `inspect` preloads every entity path at the default branch in one call, and `file_at` reads from it, falling back to git for anything the batch does not carry.

## Measured

| | starts | wall |
|---|---|---|
| `ank check` | 616 → **24** | 43.7 s → 11.0 s |
| `ank find` | 100 → **6** | 11.3 s → 1.2 s |
| `ank graph` | 100 → **6** | → 1.0 s |

`check`, `review` and `status` report **identical findings**, compared binary against binary on one corpus, subject by subject and note by note.

## The framing is a size, never a separator

`--batch` answers `<name> <type> <size>`, then exactly that many bytes. That is the lesson TASK-1b3d7b61dc8f paid for, where a separator a record could contain swallowed every ratification after the first commit with an empty body.

For a path lookup git answers with the blob's own object name rather than the input, so that one alignment is **positional** — safe for the single reason positional alignment is ever safe: git emits one response per input line, in order, and a path it cannot resolve still emits one. The count is asserted rather than assumed, and a short answer stores nothing and falls back.

## One defect on the way, and the same class as last time

The preload was kept for the process, so a test committing between two inspections read the old branch — caught by `the_tree_saying_done_is_not_the_branch_saying_done` and `check_prunes_only_once_the_default_branch_agrees`. It is reloaded on every inspection now, one process each, because a stale map serves a task as finished on the default branch when it is not, and that is the one direction this must never be wrong in.

## Tests

`checks_git_cost_does_not_grow_with_the_number_of_entities`: two corpora differing only in how many tasks they hold, each claimed so it carries a ref, counted with `GIT_TRACE2_EVENT`. Joins the dead-scope one already there.

`cargo test` green on every target (bin 292, cli 235, skill 21, and the three other crates), `cargo fmt --check` green, `ank check` exit 0.

## What is left of the 11 seconds

About 4.5 s is gpg verifying 43 ratifications inside one process — TASK-dbef284a166c. The rest is ank's own work, unmeasured — TASK-097883a2c09f.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014TALD31QGkPyVLi96LfAry