### PR TITLE
A ratification is verified once, and three tests decided what that may mean

### DIFF
--- a/.ank/entities/LOG-9d5f7cc6b379.md
+++ b/.ank/entities/LOG-9d5f7cc6b379.md
@@ -1,0 +1,16 @@
+---
+id: LOG-9d5f7cc6b379
+type: log
+title: done, proof commit:8466ba2c35034c9f1c06512dc3c5a0f353e002e2
+created: 2026-08-20T20:58:10Z
+author: claude-code/opus-5
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/src/git.rs
+  - crates/ank-cli/src/index.rs
+  - crates/ank-cli/tests/**
+about: TASK-dbef284a166c
+seq: 1
+schema: 3
+version: 1
+---

--- a/.ank/entities/LOG-b3c98d8ba70e.md
+++ b/.ank/entities/LOG-b3c98d8ba70e.md
@@ -1,0 +1,28 @@
+---
+id: LOG-b3c98d8ba70e
+type: log
+title: The cache is in, and two existing tests are what made it honest.
+created: 2026-08-20T20:56:41Z
+author: claude-code/opus-5
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/src/git.rs
+  - crates/ank-cli/src/index.rs
+  - crates/ank-cli/tests/**
+about: TASK-dbef284a166c
+seq: 0
+schema: 3
+version: 1
+---
+
+
+
+First draft opened the index inside the loop, once per ratification, and made check slower than the gpg calls it replaced: a sqlite open is not free and forty-three of them cost more than they saved. The connection is held per repository now.
+
+Second draft held the allowlist hash beside the connection, so declaring a key changed nothing and the verdict cached under the old list went on being served. The test I wrote for exactly that caught it. The connection is kept and the key is recomputed every lookup, which is a small file hashed per call and nothing beside a signature.
+
+Third, and this is the one I did not see coming: a_signature_git_cannot_read_is_reported_rather_than_passed_over failed. The verdict depends on the local signing configuration too, not only on the commit and the allowlist. Setting gpg.format to something git cannot use turns a readable signature into one it refuses to answer about, and the cache reported the old verdict on a machine that could no longer reach it. That is precisely the cache lying about the one anchor section 8 says holds when everything else can be forged, and it was caught by a test written for another reason entirely. Every gpg.* key now goes into the cache key, taken whole rather than named one by one, because which of them matters depends on the format in use.
+
+E is never written, which is the other half: no local public key is a fact about the keyring rather than about the commit, so importing a key changes the answer on the next run instead of leaving a reader wondering.
+
+Measured: check 7.1s to 4.8s warm on this corpus, and zero gpg processes on any run after the first. Cold and warm report identical findings.

--- a/.ank/entities/TASK-dbef284a166c.md
+++ b/.ank/entities/TASK-dbef284a166c.md
@@ -5,7 +5,7 @@ slug: every-ratification-is-verified-by-gpg-on-every-r
 title: Every ratification is verified by gpg on every run, and the verdict cannot change
 created: 2026-08-20T18:31:47Z
 author: claude-code/opus-5
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/src/human.rs
   - crates/ank-cli/src/git.rs
@@ -15,8 +15,13 @@ blocked_by: []
 done_criteria: |
   A signature verdict already computed for a commit is not computed again: check run twice on an unchanged corpus starts gpg on the second run for no ratification it verified on the first, measured through the binary. The verdict is keyed on the commit and on the content of .ank/allowed_signers, so declaring a key changes every key that depends on it. A cache that cannot be read or that does not match its key is recomputed and never trusted, and no cached state can turn a signature check into a pass it did not earn: the four outcomes SPEC-199de7ac4730 lists are reported from a cache exactly as they are from git. cargo test --workspace and ank check stay green.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 8466ba2c35034c9f1c06512dc3c5a0f353e002e2
+    criteria: bf70f021aee1
+    via: submitted
 schema: 3
-version: 2
+version: 3
 ---
 
 Measured on 2026-08-20, after TASK-1b3d7b61dc8f batched the calls: the whole

--- a/.ank/entities/TASK-dbef284a166c.md
+++ b/.ank/entities/TASK-dbef284a166c.md
@@ -5,7 +5,7 @@ slug: every-ratification-is-verified-by-gpg-on-every-r
 title: Every ratification is verified by gpg on every run, and the verdict cannot change
 created: 2026-08-20T18:31:47Z
 author: claude-code/opus-5
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/src/human.rs
   - crates/ank-cli/src/git.rs
@@ -16,7 +16,7 @@ done_criteria: |
   A signature verdict already computed for a commit is not computed again: check run twice on an unchanged corpus starts gpg on the second run for no ratification it verified on the first, measured through the binary. The verdict is keyed on the commit and on the content of .ank/allowed_signers, so declaring a key changes every key that depends on it. A cache that cannot be read or that does not match its key is recomputed and never trusted, and no cached state can turn a signature check into a pass it did not earn: the four outcomes SPEC-199de7ac4730 lists are reported from a cache exactly as they are from git. cargo test --workspace and ank check stay green.
 criteria_by: creator
 schema: 3
-version: 1
+version: 2
 ---
 
 Measured on 2026-08-20, after TASK-1b3d7b61dc8f batched the calls: the whole

--- a/crates/ank-cli/src/human.rs
+++ b/crates/ank-cli/src/human.rs
@@ -4018,8 +4018,33 @@ pub fn signature_state<'a>(repo: &Repo, of: impl Into<Anchored<'a>>) -> Option<S
     // entries only ank reads. Falling back to the source on a failure to write
     // keeps the behaviour this had before the filter existed.
     let for_git = signers_for_git(&signers).unwrap_or_else(|| signers.clone());
+
+    // **The verdict already reached for this commit, under this allowlist**
+    // (TASK-dbef284a166c). gpg is 4.0 of the 7.1 seconds `check` costs on this
+    // repository, one verification per ratification inside a single `rev-list`,
+    // and batching cannot make a signature cheaper. It never needs doing twice:
+    // a ratification commit is immutable, and the allowlist is hashed into the
+    // key, so declaring a key invalidates every verdict that rested on the old
+    // one.
+    //
+    // A miss recomputes and never passes. Every failure below -- no index, no
+    // row, a status that will not read -- lands in the same place as a corpus
+    // seen for the first time, which is git being asked.
+    let cached = signature_cache(repo, |index, key| index.signature(&sha, key)).flatten();
+    if let Some((status, fingerprint)) = cached {
+        let facts = git::SignatureFacts {
+            status,
+            fingerprint,
+        };
+        let carries = facts.status == 'N' && commit_carries_signature(&repo.root, &sha);
+        return Some(classify_signature(&facts, &declared, carries));
+    }
+
     match git::signature_of(&repo.root, &sha, Some(&for_git)) {
         Ok(facts) => {
+            signature_cache(repo, |index, key| {
+                index.remember_signature(&sha, key, facts.status, &facts.fingerprint);
+            });
             // Asked only where the answer can change the verdict: every other
             // status already says whether a signature was there.
             let carries = facts.status == 'N' && commit_carries_signature(&repo.root, &sha);
@@ -4029,6 +4054,81 @@ pub fn signature_state<'a>(repo: &Repo, of: impl Into<Anchored<'a>>) -> Option<S
             reason: e.to_string(),
         }),
     }
+}
+
+/// The signing configuration git would use, as one string, read once per
+/// process.
+///
+/// Empty when git cannot be asked, which is a miss like any other: an empty key
+/// is still a key, and it changes the moment git can answer again.
+fn gpg_config(root: &Path) -> String {
+    thread_local! {
+        static SEEN: std::cell::RefCell<HashMap<PathBuf, String>> =
+            std::cell::RefCell::new(HashMap::new());
+    }
+    SEEN.with(|cell| {
+        if let Some(hit) = cell.borrow().get(root) {
+            return hit.clone();
+        }
+        let read = git::output(root, &["config", "--get-regexp", r"^gpg\."])
+            .ok()
+            .map(|o| String::from_utf8_lossy(&o.stdout).to_string())
+            .unwrap_or_default();
+        cell.borrow_mut().insert(root.to_path_buf(), read.clone());
+        read
+    })
+}
+
+/// The index this repository's verdicts live in, and the key the allowlist
+/// contributes to them.
+///
+/// `None` whenever the cache cannot be reached, which every caller reads as a
+/// miss: §6 calls the index derived and disposable, and that is exactly the
+/// standing a signature cache may have -- losing it costs a recomputation and
+/// never a wrong answer.
+///
+/// The key is a hash of the file's **bytes** and not of the parsed entries: a
+/// comment is not a signer, but a file that changed is a file worth re-reading,
+/// and hashing the bytes cannot be wrong in the direction that matters.
+fn signature_cache<T>(repo: &Repo, with: impl FnOnce(&Index, &str) -> T) -> Option<T> {
+    thread_local! {
+        // **The connection is kept and the key never is.** Opening sqlite once
+        // per ratification made `check` slower than the gpg calls it was
+        // replacing, so the connection is held; but the first draft held the
+        // allowlist hash beside it, and then declaring a key changed nothing --
+        // the verdict cached under the old list went on being served. A test
+        // caught it, and it is the exact failure this cache must not have.
+        // Hashing a small file per lookup is the price of that, and it is
+        // nothing beside a signature.
+        //
+        // Keyed on the path because one process serves many corpora in the
+        // tests.
+        static OPEN: std::cell::RefCell<HashMap<PathBuf, Index>> =
+            std::cell::RefCell::new(HashMap::new());
+    }
+    let text = std::fs::read(repo.ank.join("allowed_signers")).ok()?;
+    let mut hasher = <sha2::Sha256 as sha2::Digest>::new();
+    sha2::Digest::update(&mut hasher, &text);
+    // **The signing configuration is in the key too**, and a test that already
+    // existed is what said it had to be: `gpg.format` set to something git
+    // cannot use turns a readable signature into one it refuses to answer
+    // about, and a cache keyed on the commit and the allowlist alone went on
+    // reporting the old verdict on a machine that could no longer reach it
+    // (`a_signature_git_cannot_read_is_reported_rather_than_passed_over`).
+    //
+    // Every `gpg.*` key, taken whole rather than named one by one: which of
+    // them matters depends on the format in use, and a list written here would
+    // be a fourth surface to keep true.
+    sha2::Digest::update(&mut hasher, gpg_config(&repo.root).as_bytes());
+    let key = format!("{:x}", sha2::Digest::finalize(hasher));
+    OPEN.with(|cell| {
+        let mut open = cell.borrow_mut();
+        if !open.contains_key(&repo.ank) {
+            open.insert(repo.ank.clone(), Index::open(&repo.ank).ok()?);
+        }
+        let index = open.get(&repo.ank)?;
+        Some(with(index, &key))
+    })
 }
 
 /// Whether the commit object holds a signature header at all, whatever git was
@@ -7334,6 +7434,61 @@ mod tests {
     /// ordinary unsigned commit whose subject reads `ratify <id>` used to be
     /// accepted as a ratification: `rev-list` found it, the subject matched,
     /// the hashes agreed, and the freeze was reported intact.
+    #[test]
+    /// **A verdict cached under one allowlist does not survive another**
+    /// (TASK-dbef284a166c).
+    ///
+    /// The commit does not move, so a cache keyed on the commit alone would go
+    /// on answering `Trusted` about a signature nobody declares any more. The
+    /// allowlist is hashed into the key for exactly this, and the third act --
+    /// declaring the original key again -- is what says the key is the file's
+    /// content rather than the bare fact that it changed once.
+    #[test]
+    fn declaring_another_key_changes_the_verdict_a_cache_already_holds() {
+        let t = Temp::new();
+        t.enable_signing();
+        declare(&t, &signing_principal(&t));
+
+        t.write(&adr("00000000aaaa", AdrStatus::Proposed, &["src/**"]));
+        t.commit("seed");
+        t.call(&["accept", "ADR-00000000aaaa"], "marie@laptop")
+            .unwrap();
+
+        // The first reading is what fills the cache, and it must be the right
+        // one or the rest of this proves nothing.
+        let repo = t.repo();
+        assert_eq!(
+            signature_state(&repo, &t.adr_at("00000000aaaa")),
+            Some(Signature::Trusted),
+            "the key that signed it is the key declared"
+        );
+
+        // Now the allowlist names somebody else. The commit has not moved, so a
+        // cache keyed on the commit alone would go on answering `Trusted` about
+        // a signature nobody declares any more -- which is the cache lying about
+        // the one anchor §8 says holds when everything else can be forged.
+        declare(
+            &t,
+            "someone@else ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINotTheKey",
+        );
+        assert!(
+            matches!(
+                signature_state(&repo, &t.adr_at("00000000aaaa")),
+                Some(Signature::Undeclared { .. })
+            ),
+            "a verdict cached under the old allowlist must not survive it"
+        );
+
+        // And declaring the real key again brings the first answer back, which
+        // says the key is the allowlist's content and not the mere fact that it
+        // changed once.
+        declare(&t, &signing_principal(&t));
+        assert_eq!(
+            signature_state(&repo, &t.adr_at("00000000aaaa")),
+            Some(Signature::Trusted)
+        );
+    }
+
     #[test]
     fn an_unsigned_ratification_commit_is_refused_as_a_ratification() {
         let t = Temp::new();

--- a/crates/ank-cli/src/index.rs
+++ b/crates/ank-cli/src/index.rs
@@ -35,9 +35,9 @@ use std::path::{Path, PathBuf};
 /// Bumped whenever the schema changes. An index carrying anything else is
 /// wiped and rebuilt, which is why a schema change costs nothing.
 ///
-/// Moved to 2 by the FTS5 table, to 3 by `about` and to 4 by `seq`: nothing
-/// migrated any of those times, and nothing had to.
-pub const SCHEMA_VERSION: u32 = 4;
+/// Moved to 2 by the FTS5 table, to 3 by `about` and to 4 by `seq`, and to 5 by
+/// `signatures`: nothing migrated any of those times, and nothing had to.
+pub const SCHEMA_VERSION: u32 = 5;
 
 pub const DB_FILE: &str = "index.db";
 
@@ -120,6 +120,13 @@ CREATE VIRTUAL TABLE entities_fts USING fts5(
     criteria,
     tokenize = 'unicode61'
 );
+CREATE TABLE signatures (
+    commit_sha  TEXT NOT NULL,
+    signers     TEXT NOT NULL,
+    status      TEXT NOT NULL,
+    fingerprint TEXT NOT NULL,
+    PRIMARY KEY (commit_sha, signers)
+);
 ";
 
 /// The searchable columns, in the order the FTS table declares them, because
@@ -167,11 +174,11 @@ fn db_error(e: rusqlite::Error, ank: &Path) -> CliError {
 fn tables_present_in(conn: &Connection) -> rusqlite::Result<bool> {
     let found: i64 = conn.query_row(
         "SELECT count(*) FROM sqlite_master \
-         WHERE type = 'table' AND name IN ('meta', 'files', 'entities')",
+         WHERE type = 'table' AND name IN ('meta', 'files', 'entities', 'signatures')",
         [],
         |r| r.get(0),
     )?;
-    Ok(found == 3)
+    Ok(found == 4)
 }
 
 fn schema_version_of(conn: &Connection) -> rusqlite::Result<Option<u32>> {
@@ -647,6 +654,57 @@ impl Index {
 
     /// Every entity, ordered by id so that two reads of an unchanged corpus
     /// never differ — the property the disposability test rests on.
+    /// The verdict already reached for this commit under this allowed-signers
+    /// file, if one was.
+    ///
+    /// **A ratification commit is immutable**, so the answer to "is this object
+    /// signed by a declared key" cannot change while the commit and the
+    /// allowlist stay as they are. Both are in the key: the sha, and a hash of
+    /// the file's bytes, so declaring a key invalidates every verdict that
+    /// depended on the old list rather than leaving stale ones behind
+    /// (TASK-dbef284a166c).
+    ///
+    /// **Every failure here is a miss.** Unreadable row, absent table, a
+    /// database that will not open: all of them mean ask git, and none of them
+    /// means assume the last answer. The thing being cached is the one anchor §8
+    /// says holds when everything else can be forged, so a cache that guesses is
+    /// worse than no cache at all.
+    pub fn signature(&self, commit: &str, signers: &str) -> Option<(char, String)> {
+        let row = self
+            .conn
+            .query_row(
+                "SELECT status, fingerprint FROM signatures                  WHERE commit_sha = ?1 AND signers = ?2",
+                params![commit, signers],
+                |r| Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?)),
+            )
+            .optional()
+            .ok()??;
+        let status = row.0.chars().next()?;
+        Some((status, row.1))
+    }
+
+    /// Records a verdict git reached, so the next run does not start gpg for it.
+    ///
+    /// **`E` is never written, and that is what keeps the cache honest about the
+    /// one outcome that depends on this machine.** §8's four outcomes include
+    /// "signature present, no local public key", which is a fact about the
+    /// keyring rather than about the commit -- and the keyring is the one input
+    /// not in the key. Refusing to store it means importing the key changes the
+    /// answer on the very next run, instead of leaving a reader to wonder why a
+    /// signature they can now verify still reads as unchecked.
+    ///
+    /// A write that fails is not an error: the cache is an accelerator, and the
+    /// next run recomputes.
+    pub fn remember_signature(&self, commit: &str, signers: &str, status: char, fp: &str) {
+        if status == 'E' {
+            return;
+        }
+        let _ = self.conn.execute(
+            "INSERT OR REPLACE INTO signatures (commit_sha, signers, status, fingerprint)              VALUES (?1, ?2, ?3, ?4)",
+            params![commit, signers, status.to_string(), fp],
+        );
+    }
+
     pub fn all(&self) -> Result<Vec<Row>> {
         self.query(&format!("{SELECT_ROW} ORDER BY id"), params![])
     }


### PR DESCRIPTION
Closes TASK-dbef284a166c. The last of the three fronts.

gpg was 4.0 of the 7.1 seconds `check` cost — one verification per ratification inside a single `rev-list`, and batching cannot make a signature cheaper. It never needs doing twice: a ratification commit is immutable. The verdict lives in `.ank/index.db`, which §6 already calls derived, disposable and gitignored — exactly the standing a cache may have.

## What may be cached was decided by tests, not by me

**The first draft** opened the index once per ratification and made `check` *slower* than the gpg calls it replaced. A sqlite open is not free and forty-three of them cost more than they saved. The connection is held per repository now.

**The second** held the allowlist hash beside the connection, so declaring a key changed nothing and the verdict cached under the old list went on being served. `declaring_another_key_changes_the_verdict_a_cache_already_holds` was written for exactly that and caught it. The connection is kept; the key is recomputed on every lookup.

**The third I did not see coming.** `a_signature_git_cannot_read_is_reported_rather_than_passed_over` — written for another reason entirely — failed. The verdict depends on the local **signing configuration** as well as on the commit and the allowlist: `gpg.format` set to something git cannot use turns a readable signature into one git refuses to answer about, and the cache reported the old verdict on a machine that could no longer reach it.

That is the cache lying about the one anchor §8 says holds when everything else can be forged. Every `gpg.*` key is in the cache key now, taken whole rather than named one by one, because which of them matters depends on the format in use.

## The two rules the criterion carries

**A miss recomputes and never passes.** No index, no row, an unreadable status — all land where a corpus seen for the first time lands, which is git being asked.

**`E` is never written.** "Signature present, no local public key" is a fact about the keyring rather than about the commit, and the keyring is the one input not in the key. Refusing to store it means importing a key changes the answer on the very next run, instead of leaving a reader to wonder why a signature they can now verify still reads as unchecked.

## Measured

| | |
|---|---|
| `ank check`, warm | 7.1 s → **4.8 s** |
| gpg processes after the first run | **0** |
| cold and warm findings | identical |

`SCHEMA_VERSION` moves to 5, which wipes and rebuilds the index — the first run after this lands pays for that once, and nothing migrates.

`cargo test` green on every target (bin 294, cli 235, skill 21, and the rest), `cargo fmt --check` green, `ank check` exit 0.

## Where that leaves the second

`check` is ~4.8 s warm on this corpus. What remains is batched git I/O and about 1.5 s of linear per-entity work, over a fixed floor of 81 ms. `find` and `graph` are already at ~1 s. One second for `check` on a corpus this size would need a further round, and no task is open for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014TALD31QGkPyVLi96LfAry