### PR TITLE
accept signs where it can and never refuses, and the specification follows

### DIFF
--- a/.ank/entities/LOG-86a8a3b08775.md
+++ b/.ank/entities/LOG-86a8a3b08775.md
@@ -1,0 +1,16 @@
+---
+id: LOG-86a8a3b08775
+type: log
+title: done, proof commit:045490e66ece74d6ecd2a77d8b9ac8a940886964
+created: 2026-08-20T23:59:28Z
+author: claude-code/opus-5
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/tests/**
+  - skill/**
+  - docs/**
+about: TASK-507660c3ebc4
+seq: 1
+schema: 3
+version: 1
+---

--- a/.ank/entities/LOG-9e9e8522bbb5.md
+++ b/.ank/entities/LOG-9e9e8522bbb5.md
@@ -1,0 +1,17 @@
+---
+id: LOG-9e9e8522bbb5
+type: log
+title: "released: The criterion is achievable and worth 25 ms. Measured before building: parse_entity is"
+created: 2026-08-20T23:43:31Z
+author: claude-code/opus-5
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/src/index.rs
+  - crates/ank-cli/tests/**
+about: TASK-da7738572825
+seq: 1
+schema: 3
+version: 1
+---
+
+ 0.215s over 1024 entities and serialize_entity is 0.025s, where the task body attributes almost all of ank's 2.09s to the canonical round trip. Parsing cannot be skipped in any case, every later phase needs the parsed entity. A third cache, a schema bump that wipes every index, and a permanent invalidation, for a fortieth of a second, is a trade I will not make on my own judgement. The measurement is in LOG on this task; what is needed next is a phase profile of the two thirds of ank's own time this task never looked at.

--- a/.ank/entities/LOG-c6aa3625cd3d.md
+++ b/.ank/entities/LOG-c6aa3625cd3d.md
@@ -1,0 +1,30 @@
+---
+id: LOG-c6aa3625cd3d
+type: log
+title: Measured before building anything, and the premise of this task is false.
+created: 2026-08-20T23:43:27Z
+author: claude-code/opus-5
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/src/index.rs
+  - crates/ank-cli/tests/**
+about: TASK-da7738572825
+seq: 0
+schema: 3
+version: 1
+---
+
+
+
+The body says of the 7.0s check cost, 2.09s is ank's own work and almost all of it is the canonical-form round trip. Timed directly, with a probe around each call on the current tree:
+
+  parse_entity      0.215 s
+  serialize_entity  0.025 s
+
+Twenty-five milliseconds. The whole canonical decision is a fortieth of what the task attributes to it, and parsing - which the criterion also names - cannot be skipped at all, since every later phase of inspect works on the parsed entity.
+
+Current shape of check on this corpus, after TASK-2ba2619b90e2 landed: 3.19s wall, 1.58s of git measured from inside git over 24 processes, 1.61s left to ank. But trace2 begins after process creation, so roughly 0.7s of that remainder is the 24 spawns the parent pays for and cannot see, leaving about 0.9s of real ank compute. Of that 0.9s, parse is 0.22s and serialize is 0.03s. The other two thirds are somewhere this task never looked.
+
+So a cache keyed on the content hash would be correct, would be the least dangerous of the three caches in this corpus, and would save twenty-five milliseconds. That is not worth a third cache, a schema bump that wipes and rebuilds every index, and an invalidation to keep right forever.
+
+Releasing rather than delivering a criterion that buys nothing. What a replacement task should ask is where the remaining two thirds of ank's own time go, measured by phase before anything is proposed - the same discipline that found this, and the third premise of mine that measuring has overturned today.

--- a/.ank/entities/LOG-fdf6157d5843.md
+++ b/.ank/entities/LOG-fdf6157d5843.md
@@ -1,0 +1,26 @@
+---
+id: LOG-fdf6157d5843
+type: log
+title: accept signs where it can and never refuses, and the specification follows.
+created: 2026-08-20T23:59:25Z
+author: claude-code/opus-5
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/tests/**
+  - skill/**
+  - docs/**
+about: TASK-507660c3ebc4
+seq: 0
+schema: 3
+version: 1
+---
+
+
+
+The change to accept is small and the reasoning is where it happens: -S is passed when this repository can sign, meaning a user.signingkey is set or commit.gpgsign is true, and a plain commit otherwise. Signing when it is possible rather than only when commit.gpgsign asks for it, because a maintainer who signs selectively still means a ratification to be signed, and taking their key away because a default says otherwise would be the tool overriding them in the direction that loses the anchor.
+
+The stale hint went with it. accept used to answer a failed commit with git config user.signingkey, which after this change would send a maintainer to configure the one thing that was not the problem: a repository with no key is no longer asked to sign at all, so reaching that error means git refused for some other reason.
+
+The specification is superseded rather than amended, which the task said and which the format enforces: the body of an accepted spec is hashed into its ratification commit. SPEC-88e1ba60a95d carries the whole of SPEC-199de7ac4730 with two passages changed, extracted through ank show and edited rather than retyped, because transcribing 24 KB by hand is a way to introduce a difference nobody intended. It lands proposed and binds nobody until a human signs it.
+
+The test asserts both halves, since the repair is only honest with the second: a repository with no key ratifies, and the corpus states the regime. The advisory sentence is taken from check and matched in review, so the two surfaces are compared against each other rather than against a string written in the test - the same shape as the test written when review learned to name the signers.

--- a/.ank/entities/SPEC-88e1ba60a95d.md
+++ b/.ank/entities/SPEC-88e1ba60a95d.md
@@ -1,0 +1,208 @@
+---
+id: SPEC-88e1ba60a95d
+type: spec
+slug: proof-anchoring-and-authority
+title: Proof, anchoring and authority
+created: 2026-08-20T23:53:05Z
+author: claude-code/opus-5
+status: proposed
+scope:
+  - crates/ank-cli/src/done.rs
+  - crates/ank-cli/src/verify.rs
+  - .ank/allowed_signers
+references: [SPEC-acee5d9cb21b, SPEC-183d297253ac, SPEC-93531977642f]
+supersedes: SPEC-199de7ac4730
+schema: 3
+version: 1
+---
+
+One of the ten documents that carry the Ank specification (ADR-5a690829388d).
+This one carries the **proof half of §4** — proofs, named verifiers, the trust
+hierarchy — together with **§8 entire**: the three places policy lives, roles and
+what they are worth, and the anchoring of human identity.
+
+## Why two sections four apart are one document
+
+This is the longest merge the decomposition makes, and it is the one the monolith
+argued for without performing. Both halves answer a single question: **what is a
+claim about the world worth, and who validated it.**
+
+The trust hierarchy answers it about a run. A reference is worth what its route
+is worth — a `test:` reference is the strongest row in the table when a pipeline
+wrote it and the weakest when somebody typed it, and the type alone cannot tell
+them apart. §8 answers it about a person. An identity is declared and never
+proved, roles are advisory because a wall whose bricks are self-declared identity
+is a sign and not a wall, and the only hard line in the system is a signature
+verifiable against a versioned key file.
+
+Those are the same sentence about two subjects, and the corpus already treats
+them as one: the CLI refuses on state and never on identity **because** roles are
+advisory, and the ratification anchor is a proof requirement in exactly the shape
+every other anchor in this document has. The monolith put four sections between
+them, so a reader arriving at the trust hierarchy met the run half of the
+argument and had to reach §8 to learn why the person half is weaker — which is
+the entanglement the test names, in the form that costs most: two halves of one
+argument, each readable and each incomplete.
+
+**What this document does not carry** is the freeze machinery itself. `ratified`,
+the hash it holds and the walk that reaches the commit are the data model's,
+because they are fields of an entity; what is here is what that anchor is worth
+and what verifies the signature on it.
+
+## What it rests on
+
+- **The data model** — the `proof` list, `verify`, and the freezes this anchors.
+- **Synchronisation** — detached proofs on `refs/ank/proof/*`, the third
+  category of state, and the push that arbitrates them.
+- **Implementation, and the decisions that bound it** — the git plumbing that
+  produces and verifies a signature, and the rule that Ank never commits except
+  `accept`.
+
+---
+
+### Proofs
+
+**Ank runs the verification itself.** This is the central point: if the agent runs the tests and then reports the result through `--proof`, nothing is anchored — it can simply claim it passes. The task declares its verifiers, `ank done` runs them, captures the exit codes and a hash of the outputs. The agent never self-reports.
+
+```
+$ ank done
+verifying done_criteria hash ... ok
+running: auth-tests ... ok (2.4s)
+running: no-jwt ... ok (0.1s)
+proof recorded: auth-tests -> local/9c1f4a@a3f9c21
+proof recorded: no-jwt -> local/e51b22@a3f9c21  (tree:scope/4be2d10c)
+```
+
+**Two modes, never ambiguous.** If the task declares a `verify`, `ank done` runs **all** the verifiers in the list — a composite `done_criteria` ("the tests pass *and* no more jwt.verify") is mechanised by several verifiers, not by one that covers only part of it — and `--proof` is refused: the agent cannot short-circuit. Every verifier that runs produces **its own proof entry**, with its output hash and its definition anchored. Without `verify` — field absent or empty list, the two forms are equivalent and the canonical form omits the empty field — `--proof` is mandatory and Ank validates what it can: `commit:` is checked with git, `human-review:` and `assertion:` are recorded as they are and marked unverified. Every entry recorded on that path carries `via: submitted`, whatever its type, because that is what happened — the entries produced by a verifier above carry `via: verifier`, and an attestation reaching the task on a ref carries `via: attested` (§3).
+
+If a verifier fails or times out, the transition is refused. No dependency on any service: this is usable **inside** the loop, not only at the end.
+
+### Named verifiers
+
+A task's `verify` field references verifiers declared in `config.yml`, never an inline shell command.
+
+```yaml
+verifiers:
+  auth-tests:
+    run: pytest tests/auth/ -q
+    timeout: 10m              # default: 10m, a timeout failure is code 5
+  no-jwt:
+    run: "! grep -rq jwt.verify src/auth/"
+```
+
+The reason: a task may arrive through a PR from a fork. An inline command would be arbitrary code execution triggered by `ank done`. Git has exactly this problem with hooks and solved it by never running them on clone. Here, verifiers live in a file controlled by the repository, so modifying one goes through code review like any other change.
+
+**Execution: always `sh -c`, on all three operating systems.** Linux, macOS and Windows are supported natively in v1. On Windows, `sh` is resolved from Git for Windows, which ships it — Ank already requires git, so the dependency is free and verifiers are written once, in POSIX syntax, for the whole team. An `sh` that cannot be found is an explicit error with the installation link, never a silent fallback to `cmd`. **A broken environment is not a task failure**: `sh` not found, command absent (shell code 126/127), inability to spawn the process all exit with code 9 and the exact command that failed — the agent should report or repair the environment, not conclude that its code is wrong. Code 5 stays reserved for a verifier that ran and said no. The **timeout is fixed** (formerly open point 4): 10 minutes by default, overridable per verifier, exceeding it is a code 5 failure with the elapsed time in the message.
+
+`config.yml` remains editable by an agent — replacing a verifier with `true` is the obvious workaround. Two complementary defences, neither resting on good faith. First, **the proof records the hash of the definition that ran** (`verifier: auth-tests@<hash>`, a normalised hash of the `run` + `timeout` entry): what actually ran is anchored in the proof, not in the current state of `config.yml`, so a verifier weakened before or after the `done` — in the same commit or another — is detectable by comparing the proof's hash with the definition at the corresponding commit. Second, `check` reports the patterns: **verifier modified inside the task's activity window** (between the first log entry and the `done`), and **proof hash diverging from the definition in force at the `done` commit**. Splitting the workaround across several commits no longer hides it; it stays a diff in review — faithful to the principle that faking must cost more than doing.
+
+### Trust hierarchy
+
+| Type | `via` | What is guaranteed | What validated it |
+|---|---|---|---|
+| `assertion:"..."` | `submitted` | Nothing. The agent asserts. **Marked weak** in `check`. | Nobody. Recorded as given. |
+| `test:<ref>` | `submitted` | Nothing. A reference typed at a keyboard, in the shape of the strongest proof this table has. | Nobody. Recorded as given. |
+| `human-review:<ref>` | `submitted` | A person says they read it. **Marked weak** in `check`. | Nobody. Recorded as given. |
+| `test:local/<hash>@<sha>` | `verifier` | Ank executed it, in an environment the agent controls | Ank, running a verifier `config.yml` declares, its definition hashed into the entry |
+| `commit:<sha>` | `submitted` | Verifiable by anyone with `git` | Ank, against `git rev-parse` at the moment it was recorded |
+| `test:ci://<ref>` | `attested` | Third-party environment, out of the agent's reach | The pipeline that wrote it to `refs/ank/proof/<id>`, under its own identity (§7) |
+
+The dividing line is not local versus hosted, it is **who controls the environment**. Locally, an agent can weaken a test to make it pass — the same class of problem as an ADR edited to unblock oneself.
+
+**The type says what the reference points at; `via` says who put it there, and the second is what the trust rests on** (ADR-b6b69053a47b). The two rows for `test:` are the whole reason the column exists. A run reference is the strongest thing in this table when a pipeline wrote it and the weakest when somebody typed it, and until `via` existed the file said the same thing in both cases — so `--proof test:<anything>` was recorded as strong, unchecked, and silenced the one finding designed to catch a completion nothing external anchors. The fix is not to demote `test:`, which would punish the anchor `attest --detached` and §7 exist to build. It is to record the route and let the signal read it.
+
+**So the `done with no test proof` signal below is derived from the route and never from the type alone.** A `test` entry whose `via` is `verifier` or `attested` silences it; one whose `via` is `submitted` does not, and the finding names the reference it declined to count. **An entry carrying no `via` at all silences it, exactly as it always did**: the field is optional, its absence means the entry predates the distinction, and a rule that reinterpreted the corpus it postdates would redden every completion recorded before it landed. That is the same reading §3 gives to pre-convention actors and to entities predating `author` — the entities mean what they meant.
+
+**This changes what is reported and never what is refused.** A typed reference is still accepted by `done` and by `attest`, still recorded, still part of the proof list. The CLI is not a gatekeeper (§2), and a proof somebody typed in good faith is worth having in the record — it is worth having as what it is.
+
+**A `commit:` reference is validated once, and a rebase detaches it.** The table says what `git rev-parse` answered *at the moment the entry was recorded*, and nothing asked again afterwards — so the strongest proof this tool checks itself comes undone in silence under the routine this project prescribes: a branch rebased onto a newer default branch has its commits replaced, the recorded sha then resolves only on the stale branch, and nowhere at all once that branch is force-pushed. `check` therefore asks the question a second time, of the clone rather than of the entry: a `commit:` proof naming no commit this clone can reach is reported as a **signal naming the task and the reference**, never as a fault and never re-anchored. Never a fault, because an unreachable commit here is a shallow clone, a branch never fetched, or a rebase on somebody else's machine — a check that reddens over the shape of a clone is a check people learn to ignore, which is the reading this section already gives to a dead scope a truncated history cannot explain. Never re-anchored, because choosing which commit now carries the work is a judgement the tool cannot make — the rebase may have split it, or dropped it — and appending a proof is the only legal post-`done` write (§3): the repair is `ank attest <id> --proof commit:<sha>`, and it is the reader's to make. The dead entry stays where it is; a proof list is append-only, and removing an entry is the rewrite that append-only exists to prevent.
+
+**A clone that cannot see is not asked, and the question costs one git process.** A shallow clone reaches almost no history, so the question is skipped there outright rather than allowed to accuse every commit proof in the corpus at once — the volume failure this section legislates against everywhere else — and so is a clone with no reachable commit at all. It is asked only of `commit:` entries, and only of references in the shape of an object name: a reference git could not read as one is not a question this can ask, and silence is never evidence. The whole corpus is answered by **one git process per invocation and never one per proof**: the set of proofs is tested against a single listing of what this clone can reach.
+
+**What local proof anchors.** An agent's nominal case is an uncommitted working tree: anchoring proof on the HEAD SHA alone would almost always point at a stale state. The proof therefore records three things: the HEAD SHA, a dirty-tree indicator, and **a hash of the scope files' content at execution time** (`tree:scope/<hash>`, git hash-object style). That last one is what actually captures what was tested. `check` additionally reports the case where the task itself modified the test files it invokes.
+
+The levels stack: local proof at `done` time, a CI reference **appended** later to the `proof` list — appending proof is the only legal post-`done` write (§3).
+
+**`ank attest` is in v1, and this settles it.** Earlier revisions deferred it with its shape frozen, on the reasoning that the data structure was ready and the command would come *when a CI called it*. The command was implemented before that happened, and has been used: this repository's own corpus carries `attest`ed CI references. A deferral whose condition has been overtaken is not a plan, it is a document disagreeing with its binary — the state ADR-63b59c5c26f7 orders the work to prevent, and the one a reader could not resolve from §4 and §10 alone (TASK-5c868c20472f).
+
+What that deferral was actually protecting is worth keeping, because it is still deferred and it is not a command: **nothing calls `attest` automatically**. A CI provider appending its own run reference at the end of a pipeline is an integration, not a verb, and it is listed below as such. The verb exists and anyone — an agent, a human, a CI script — can call it today.
+
+**What `check` does instead is notice the omission**, which is the same choice read from the other side. A pipeline that attests itself would assert "a green run existed on a tree containing this task"; the entry carries the frozen criteria hash, so that statement is mechanically true, and it is still not the statement a `test` proof makes. CI proves the tree passes its tests, not that *this* criterion was met — the link between the two exists only because somebody wrote a test encoding the criterion, and no pipeline can know whether they did. Collapsing the two is the rollup hole of §3 one level out. So the assertion stays human, and forgetting to make it is what gets reported (§4).
+
+The `assertion` type exists because "refactor for readability" has no hash to attach. It is allowed but visible as weak, which avoids a `--force` becoming the default path within two weeks.
+
+
+## 8. Permissions
+
+There is one surface (§4) and the CLI refuses on state. What is left here is **policy applied over that surface**, and policy has to live somewhere it can actually hold. Three places, in decreasing order of how much they hold:
+
+- **SKILL.md**, whose content is frozen (§4, §9). It is what an agent is taught, it is the only description of Ank most agents will ever read, and a verb it does not name is a verb that does not come up. This is the strongest of the three precisely because it does not pretend to be a check.
+- **Harness hooks**, which is where enforcement is real. A `PreToolUse` hook that refuses a tool call cannot be talked out of it by an environment variable, because the process it guards does not get to set it. This repository's own hook, refusing direct reads of `.ank/` per ADR-01b6dd05f0db, is the working example.
+- **Roles in `config.yml`**, which are **advisory** and are named as such. They catch honest drift and nothing else.
+
+### Roles, and what they are worth
+
+A declarative model in `.ank/config.yml`, identity through `$ANK_AGENT`.
+
+```yaml
+roles:
+  agent:
+    can: [context, find, claim, log, done, new:task, new:adr:proposed]
+    cannot: [adr:accept, adr:edit-constraint, task:close, delete]
+  human:
+    can: ["*"]
+identities:
+  "marie@laptop": human      # any identifier absent from the table gets the agent role
+```
+
+**The default role is `agent`.** An unknown identity — including `$ANK_AGENT` being absent, in which case the fallback identity is `<user>@<hostname>` — gets least privilege. Declaring yourself human in the config confers no real authority anyway: the signature is what carries it.
+
+They are kept, three lines and advisory, rather than dropped. They express intent where a reader can see it, an unknown identity defaulting to least privilege is a sane default, and `check` can say when the record and the behaviour disagree. What they never do is make the CLI refuse: a refusal derived from `$ANK_AGENT` would be a refusal the caller can lift by exporting a different string, and shipping that as a guarantee is worse than shipping no guarantee at all. Dropping them entirely was considered and rejected on the same grounds — the cost is three lines, and honest drift is worth catching.
+
+**One identity per concurrent session, and the fallback cannot tell them apart.** With `$ANK_AGENT` unset, two terminals on one machine both resolve to `<user>@<hostname>`: they are one agent as far as the refs can see, so they share and renew each other's claims in silence. Binding the identity to the session instead — a PID, a TTY — is rejected for the reason above: identity is declared, never proved, and a session-bound identity would also lose a claim to a restarted terminal, which is the one case the 30-minute TTL exists to survive. What the CLI owes the user is therefore the observation, not a stricter identity: `claim` **warns** when the claiming identity already holds a live claim on another task, naming that task and its expiry, and names `$ANK_AGENT` as the way to tell two sessions apart. It warns and never refuses — parallel agents, each with its own identity, are the design, and one claim at a time is a convention rather than a lock (§3).
+
+The main guardrail is not the permission but **the status**: an agent writes freely, in `proposed`. It captures information immediately without being able to constrain anyone. Human ratification is the only path to authority.
+
+### Anchoring human identity
+
+`$ANK_AGENT` is set by the agent itself: an agent going off the rails can declare itself `human`. No file-level check can prevent that, since it has filesystem access.
+
+The anchor that holds is therefore external: **a ratification is a commit, and a signature is what makes it answerable to somebody**. `accept` produces the ratification commit itself (§12), recording the SHA and the hash of what was made binding — the accepted ADR's `constraint` + `scope`, or the accepted spec's body + `scope`, under the key that names which (§3, [format.md](format.md)) — and `check` verifies that signature against the keys in `.ank/allowed_signers`. The key file is versioned: adding a key to it is a diff in review.
+
+**Signing is a regime the corpus is in, not a precondition of ratifying** (ADR-964be4d940b2). `accept` signs where the repository is configured to sign and produces an unsigned commit where it is not; it never refuses for want of a key. The two halves of this section used to disagree about that: `check` had the advisory mode described below, in which no key is declared and no signature is judged, while `accept` passed `-S` unconditionally and exited 9 — so a corpus running the very mode this document defines could not produce a ratification at all. Nobody chose that asymmetry; it was two halves written at different times.
+
+What permits the repair is stated a few lines down and is not withdrawn: we protect against drift, not against an adversary. A signature nobody is obliged to produce still anchors every ratification made by someone who does produce one, and git has taken this shape for twenty years without anybody calling its history unauthenticated.
+
+**What may never degrade is the corpus saying which regime it is in.** An optional signature is honest; a corpus that reads as ratified-and-verified when nothing verified it is not. That is the rule this section already applies to its fourth outcome below — a verification that degrades to success is not a verification — and it now governs the unsigned regime on the same terms: every surface reporting on ratification states it, and none lets an unsigned corpus read as a signed one.
+
+**The file uses git's allowed-signers layout**, `principal [options] keytype key`, with the key type naming the format:
+
+```
+sean.lamet@dekrow.com gpg 739A603FB05F9F2F7D3C8D50624FCFCC1482554A
+marie@laptop          ssh-ed25519 AAAAC3NzaC1lZDI1NTE5...
+```
+
+**Who enforces the allowlist depends on the signature format, and the difference is not cosmetic.** Under `gpg.format = ssh`, git reads the file itself and answers with the match: a signature whose principal the file covers verifies, one it does not comes back as good-but-unmatched. Under OpenPGP, **git never reads the file at all** — it resolves the signature through the keyring — so `check` parses the file and compares the signing key's fingerprint itself. A `gpg` entry may name the full fingerprint or the long key id, since the second is the tail of the first. Without this, the file would go on declaring something nothing enforced.
+
+**Four outcomes, and collapsing any two of them loses the check.**
+
+| Outcome | Reported as |
+|---|---|
+| signed by a declared key | nothing |
+| no signature, or one git refuses | fault: the anchor proves nothing |
+| good signature, key not declared | fault: not a ratification |
+| signature present, no local public key | signal: **not verified, and not refused** |
+
+The last row is the one that needs saying out loud. A clone without the public key is a correct repository on an incomplete machine: calling it a fault turns CI red on a sound corpus, and calling it verified is worse, because **a verification that degrades to success is not a verification**. It is reported once for the corpus rather than once per ADR, for the reason §4 gives about entities predating `author` — a line per file is the volume that teaches a reader to stop reading `check`.
+
+With **no key declared at all**, `check` does not judge signatures. There is no allowlist to judge against, the advisory notice below already covers it, and the abstention is also what keeps the tool honest: under `gpg.format = ssh` with no allowed-signers file configured, git reports a perfectly signed commit as unsigned, so a corpus without the file would otherwise have every ratification called a forgery.
+
+**What the signature proves — and does not.** It proves access to an authorised key, not human intent. An agent running on a developer's machine whose git signing is configured and unlocked can produce a valid signed commit. The defence against that case is operational, not cryptographic: a ratification key protected by passphrase or hardware (touch-to-sign), distinct from the everyday commit key if needed. This is consistent with the threat model (§1): we protect against drift, not against an adversary.
+
+**So the entity records who ran the ratification, and the signature is not asked to carry it.** `accept` writes the actor into `verified` (§3), typed like every other actor field, beside the anchor it writes into `ratified`. Three statements, and each is the answer to a question the other two do not ask: the anchor says *what* was made binding, the signature says *a key authorised it*, and the reading says *who ran the command*. Without the third, a ratification an agent performed under a cached passphrase and one a human typed at a keyboard are the same bytes in the file. That is not a hypothesis — ADR-782a3556cf2d, SPEC-93531977642f and SPEC-dbbd533cbc78 were ratified on 2026-08-16 by an agent, at the maintainer's explicit instruction from a phone, and every mechanism in this section reported exactly what it was built to report while none of them could say it.
+
+**It is a record and not a defence, and that is this document's bargain rather than an exception to it.** `$ANK_AGENT` is declared and never proved, so an agent can write `human:` in front of its own name exactly as it can write anything else there. What the reading buys is that an honest ratification leaves a trace and that a reader can tell the two cases apart — not that a dishonest one becomes impossible. It is a sign in the sense this section already gives to roles, the signature remains the only hard line, and nothing about the reading is verified by anything.
+
+**`check` reports self-ratification, as a signal and never as a fault**: an entity whose ratifying actor is its own `author`. It is the case the human act exists to prevent, and it is also what a solo maintainer legitimately does every time they write a decision and ratify it — a rule that reddened over it would redden a one-person corpus wholesale and be silenced within a week, which is the volume failure §4 legislates against everywhere else. Reported, and the reader judges.
+
+With no signing configured, **the hard line is gone and nothing replaces it**: roles were already advisory, and the ratification anchor becomes a hash in a commit message that anyone can write. Ank protects against accidental drift there, not against an agent actively trying to get around it. That is an accepted limitation, and `check` displays it rather than hiding it — a corpus whose ratifications cannot be verified says so, since a verification that degrades to success is not a verification.

--- a/.ank/entities/TASK-507660c3ebc4.md
+++ b/.ank/entities/TASK-507660c3ebc4.md
@@ -5,7 +5,7 @@ slug: accept-refuses-to-ratify-without-a-signing-key-a
 title: accept refuses to ratify without a signing key, and check does not
 created: 2026-08-20T22:15:33Z
 author: claude-code/opus-5
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/src/human.rs
   - crates/ank-cli/tests/**
@@ -15,8 +15,13 @@ blocked_by: []
 done_criteria: |
   accept produces a signed ratification commit where the repository is configured to sign and an unsigned one where it is not, and never refuses for want of a signing key. A corpus ratified without signatures says so on every surface that reports on ratification, and no rendering lets it read as one whose ratifications were verified. Where a key is declared, the four outcomes of section 8 are unchanged. The specification is superseded to match, written against the behaviour rather than before it, and left proposed for a human to ratify. cargo test --workspace and ank check stay green.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 045490e66ece74d6ecd2a77d8b9ac8a940886964
+    criteria: a22eb547dd75
+    via: submitted
 schema: 3
-version: 2
+version: 3
 ---
 
 Rests on ADR-964be4d940b2, which is proposed and binds nobody until it is

--- a/.ank/entities/TASK-507660c3ebc4.md
+++ b/.ank/entities/TASK-507660c3ebc4.md
@@ -5,7 +5,7 @@ slug: accept-refuses-to-ratify-without-a-signing-key-a
 title: accept refuses to ratify without a signing key, and check does not
 created: 2026-08-20T22:15:33Z
 author: claude-code/opus-5
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/src/human.rs
   - crates/ank-cli/tests/**
@@ -16,7 +16,7 @@ done_criteria: |
   accept produces a signed ratification commit where the repository is configured to sign and an unsigned one where it is not, and never refuses for want of a signing key. A corpus ratified without signatures says so on every surface that reports on ratification, and no rendering lets it read as one whose ratifications were verified. Where a key is declared, the four outcomes of section 8 are unchanged. The specification is superseded to match, written against the behaviour rather than before it, and left proposed for a human to ratify. cargo test --workspace and ank check stay green.
 criteria_by: creator
 schema: 3
-version: 1
+version: 2
 ---
 
 Rests on ADR-964be4d940b2, which is proposed and binds nobody until it is

--- a/.ank/entities/TASK-da7738572825.md
+++ b/.ank/entities/TASK-da7738572825.md
@@ -15,7 +15,7 @@ done_criteria: |
   An entity whose file has not changed since it was last inspected is not parsed and re-serialised again to decide its canonical form: the verdict is kept and keyed on the file's content hash, which the index already records. A file that changed, is absent from the cache, or whose stored verdict cannot be read is inspected as it is today. The findings check, review and status report are identical to what they report before the change, subject by subject and note by note, and remain identical after a file is edited, reverted, and edited again. cargo test --workspace and ank check stay green.
 criteria_by: creator
 schema: 3
-version: 1
+version: 3
 ---
 
 Measured on 2026-08-20: of the 7.0 s `ank check` costs, 2.09 s is ank's own

--- a/crates/ank-cli/src/human.rs
+++ b/crates/ank-cli/src/human.rs
@@ -4231,6 +4231,37 @@ fn signature_cache<T>(repo: &Repo, with: impl FnOnce(&Index, &str) -> T) -> Opti
     })
 }
 
+/// Whether this repository is configured to produce a signature at all.
+///
+/// A key to sign with, or `commit.gpgsign` asking for one: either is enough,
+/// and neither is required. §8's advisory mode is a regime a corpus may run in,
+/// and a corpus in it ratifies without a signature rather than not at all
+/// (ADR-964be4d940b2).
+///
+/// Read once per repository. Git is asked rather than guessed at, and a git
+/// that cannot answer means no signature -- which is the safe direction: an
+/// unsigned ratification is reported as one, where a `-S` that fails is a
+/// ratification that never happens.
+fn can_sign(cwd: &Path) -> bool {
+    thread_local! {
+        static SEEN: std::cell::RefCell<HashMap<PathBuf, bool>> =
+            std::cell::RefCell::new(HashMap::new());
+    }
+    if let Some(hit) = SEEN.with(|c| c.borrow().get(cwd).copied()) {
+        return hit;
+    }
+    let value = |key: &str| {
+        git::output(cwd, &["config", "--get", key])
+            .ok()
+            .filter(|o| o.status.success())
+            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_lowercase())
+            .unwrap_or_default()
+    };
+    let signs = !value("user.signingkey").is_empty() || value("commit.gpgsign") == "true";
+    SEEN.with(|c| c.borrow_mut().insert(cwd.to_path_buf(), signs));
+    signs
+}
+
 /// Whether the commit object holds a signature header at all, whatever git was
 /// able to make of it.
 ///
@@ -4401,7 +4432,12 @@ fn commit_signed(cwd: &Path, paths: &[String], message: &str) -> Result<String> 
                 ExitCode::Environment,
                 format!("git {} failed: {stderr}", args.join(" ")),
             )
-            .with_hint("git config user.signingkey <key> && git config commit.gpgsign true"));
+            // The hint no longer prescribes signing: `accept` reaches this only
+            // when git refused the commit for some other reason, since a
+            // repository with no key is not asked to sign at all
+            // (ADR-964be4d940b2). Naming a signing key here would send a
+            // maintainer to configure the one thing that was not the problem.
+            .with_hint("git status --short"));
         }
         Ok(())
     };
@@ -4416,7 +4452,20 @@ fn commit_signed(cwd: &Path, paths: &[String], message: &str) -> Result<String> 
     add.extend_from_slice(&refs);
     run(&add)?;
 
-    let mut commit = vec!["commit", "-S", "-q", "-m", message, "--"];
+    // **`-S` where this repository can sign, and a plain commit where it
+    // cannot** (ADR-964be4d940b2). This passed `-S` unconditionally and exited
+    // 9 naming `git config user.signingkey`, so a corpus running the advisory
+    // mode §8 defines could not produce a ratification at all -- `check` had a
+    // regime `accept` refused to work in, and nobody chose that asymmetry.
+    //
+    // Signing when it is possible rather than only when `commit.gpgsign` asks
+    // for it: a maintainer who signs selectively still means a ratification to
+    // be signed, and taking their key away because a default says otherwise
+    // would be the tool overriding them in the direction that loses the anchor.
+    let mut commit = vec!["commit", "-q", "-m", message, "--"];
+    if can_sign(cwd) {
+        commit.insert(1, "-S");
+    }
     commit.extend_from_slice(&refs);
     run(&commit)?;
 

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -12543,6 +12543,79 @@ fn every_ratification_signature_is_verified_in_one_call() {
     let _ = std::fs::remove_file(&trace);
 }
 
+/// **A repository with no signing key ratifies, and the corpus says it did so
+/// unsigned** (TASK-507660c3ebc4, ADR-964be4d940b2).
+///
+/// `accept` passed `-S` unconditionally and exited 9 naming
+/// `git config user.signingkey`, so a corpus running the advisory mode §8
+/// defines -- no key declared, no signature judged -- could not produce a
+/// ratification at all. `check` had a regime `accept` refused to work in.
+///
+/// Both halves are asserted, because the repair is only honest with the second:
+/// the ratification lands, **and** the corpus states the regime rather than
+/// letting an unsigned decision read as a verified one.
+#[test]
+fn a_repository_with_no_signing_key_ratifies_and_says_it_was_unsigned() {
+    const ADR: &str = "ADR-00000000c0c0";
+    let r = Repo::new();
+    r.seed_docs();
+    r.seed_adr(ADR, "Do not do X.", "src/**");
+    std::fs::create_dir_all(r.0.join("src")).unwrap();
+    std::fs::write(
+        r.0.join("src/main.rs"),
+        "fn main() {}
+",
+    )
+    .unwrap();
+    r.git(&["add", "-A"]);
+    r.git(&["commit", "-qm", "seed"]);
+
+    // No `enable_signing`, no `declare_signing_key`: this repository cannot
+    // sign and declares nobody, which is the state that used to be a dead end.
+    let out = r.ank(AGENT, &["accept", ADR]);
+    assert_eq!(
+        code(&out),
+        0,
+        "a corpus with no key must still be able to ratify: {}",
+        stderr(&out)
+    );
+
+    // The decision is binding, which is what ratifying is for.
+    let shown = stdout(&r.ank(AGENT, &["show", ADR]));
+    assert!(shown.contains("accepted"), "{shown}");
+
+    // And the regime is stated rather than implied by silence. The sentence is
+    // taken from `check` and matched in `review`, so the two surfaces are
+    // compared against each other and never against a string written here.
+    let checked = stdout(&r.ank(AGENT, &["check"]));
+    let said = checked
+        .lines()
+        .find(|l| l.contains("no ratification key declared"))
+        .unwrap_or_else(|| {
+            panic!(
+                "check must state the advisory regime:
+{checked}"
+            )
+        })
+        .trim()
+        .trim_start_matches("signal: allowed_signers:")
+        .trim()
+        .to_string();
+    let reviewed = stdout(&r.ank(AGENT, &["review"]));
+    assert!(
+        reviewed.contains(&said),
+        "review must say what check says:
+check: {said}
+review:
+{reviewed}"
+    );
+    assert!(
+        !checked.contains("ratified by") || !checked.contains("verified"),
+        "nothing may read as a verified ratification here: {checked}"
+    );
+    assert!(code(&out) == 0, "{}", stderr(&out));
+}
+
 /// **`review` names who may ratify, and nothing else can** (TASK-8a80b590b356).
 ///
 /// ADR-01b6dd05f0db closes `.ank/` to a direct read by an agent, and


### PR DESCRIPTION
Closes TASK-507660c3ebc4, resting on ADR-964be4d940b2, which is ratified.

**A specification succession is proposed here and waits for a signature.**

## The asymmetry

`accept` passed `-S` unconditionally and exited 9 naming `git config user.signingkey`, so a corpus running the advisory mode §8 defines — no key declared, no signature judged — could not produce a ratification at all. `check` had a regime `accept` refused to work in, and nobody chose that.

`-S` is now passed where the repository **can** sign (a `user.signingkey` is set, or `commit.gpgsign` is true) and a plain commit otherwise.

Signing when it is *possible* rather than only when `commit.gpgsign` asks for it: a maintainer who signs selectively still means a ratification to be signed, and taking their key away because a default says otherwise would be the tool overriding them in the direction that loses the anchor.

The stale hint goes with it — answering a failed commit with `git config user.signingkey` would now send a maintainer to configure the one thing that was not the problem.

## The specification is superseded, not amended

The body of an accepted spec is hashed into its ratification commit, so there is no edit to make. **SPEC-88e1ba60a95d** carries the whole of SPEC-199de7ac4730 with two passages changed:

- "ratification requires a signed commit" becomes "a ratification is a commit, and a signature is what makes it answerable to somebody"
- a new paragraph states that signing is a regime the corpus is in, why the threat model permits it (*"we protect against drift, not against an adversary"* — the document's own words, unchanged), and that **what may never degrade is the corpus saying which regime it is in**

It was extracted through `ank show` and edited rather than retyped: transcribing 24 KB by hand is a way to introduce a difference nobody intended.

It lands `proposed` and binds nobody until you sign it:

```
ank accept SPEC-88e1ba60a95d
```

## The test asserts both halves

The repair is only honest with the second: a repository with no key **ratifies**, and the corpus **states the regime**. The advisory sentence is taken from `check` and matched in `review`, so the two surfaces are compared against each other rather than against a string written in the test.

`cargo test` green on every target (bin 294, cli 237, skill 21, and the rest), `cargo fmt --check` green, `ank check` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014TALD31QGkPyVLi96LfAry