### PR TITLE
Release 0.5.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ank",
   "description": "Tasks and architecture decisions in your repo, behind one CLI any coding agent can call.",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "author": {
     "name": "haksolot",
     "url": "https://github.com/haksolot"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "ank-cli"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "ank-contract",
  "ank-core",
@@ -30,7 +30,7 @@ version = "0.3.0"
 
 [[package]]
 name = "ank-core"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "globset",
  "hex",

--- a/crates/ank-cli/Cargo.toml
+++ b/crates/ank-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ank-cli"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 # Measured on 2026-08-01 by walking toolchains upward against this tree, which
 # is the only way this number means anything: 1.78, 1.91, 1.92, 1.93 and 1.94

--- a/crates/ank-core/Cargo.toml
+++ b/crates/ank-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ank-core"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 # Measured, not assumed: see the note in ank-cli's manifest. This crate's own
 # code needs far less, but the workspace resolves one lockfile and builds as a

--- a/npm/ank-darwin-arm64/package.json
+++ b/npm/ank-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haksolot/ank-darwin-arm64",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "The ank binary for macOS on Apple silicon.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/haksolot/ank",

--- a/npm/ank-linux-x64-musl/package.json
+++ b/npm/ank-linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haksolot/ank-linux-x64-musl",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "The ank binary for Linux x86_64, statically linked against musl.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/haksolot/ank",

--- a/npm/ank-win32-x64/package.json
+++ b/npm/ank-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haksolot/ank-win32-x64",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "The ank binary for Windows x86_64.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/haksolot/ank",

--- a/npm/ank/package.json
+++ b/npm/ank/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haksolot/ank",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "The stupid coordination tool: tasks and architecture decisions in your repo, behind one CLI any coding agent can call.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/haksolot/ank",
@@ -39,8 +39,8 @@
     "node": ">=18"
   },
   "optionalDependencies": {
-    "@haksolot/ank-darwin-arm64": "0.4.1",
-    "@haksolot/ank-linux-x64-musl": "0.4.1",
-    "@haksolot/ank-win32-x64": "0.4.1"
+    "@haksolot/ank-darwin-arm64": "0.5.0",
+    "@haksolot/ank-linux-x64-musl": "0.5.0",
+    "@haksolot/ank-win32-x64": "0.5.0"
   }
 }


### PR DESCRIPTION
Version bump only. **A minor and not a patch**, because `accept` behaves differently and not merely faster: it no longer refuses to ratify for want of a signing key. Somebody upgrading meets a tool that answers where it used to exit 9, and that is not a fix to slip into a patch number.

## What 0.5.0 carries over 0.4.1

**The authority model changed, and a ratified specification says so.** `accept` signs where the repository can sign and produces an unsigned commit where it cannot (ADR-964be4d940b2, SPEC-88e1ba60a95d, both ratified). `check` had an advisory mode `accept` refused to work in — no key declared, no signature judged — so a corpus running the mode the specification defines could not produce a ratification at all. What may never degrade is the corpus saying which regime it is in.

**`review` names who may ratify** (#209). `.ank/allowed_signers` was the one file the format requires a human to hand-edit and no verb could show, while ADR-01b6dd05f0db forbids opening anything under `.ank/` directly. Printing it also found the parser reading an entry from the end, so an SSH key pasted with its comment had its type read as base64 and its key read as an email address.

**`check` is twelve times faster**, and every step was verified by comparing findings binary against binary on the same corpus:

| | 0.4.1 | 0.5.0 |
|---|---|---|
| `ank check` | 43.7 s / 616 git processes | **~3.4 s / 24** |
| `ank status` | 8.0 s | **1.8 s** |
| `ank find` | 11.3 s | **0.44 s** |
| `ank graph` | ~10 s | **0.49 s** |

Dead scopes go through one history walk instead of two calls each; ratifications through one; signature verdicts are cached on the commit and the allowlist, and gpg does not run twice for the same object; the coordination refs and the branch's entity files are read in one `cat-file --batch`; and an entity the branch and the tree agree on is read from the tree, since matching object names mean matching bytes.

**The scope matching is one pass.** Every glob was confronted with every tracked file through a set compiled per glob — a product of two things that grow together. It buys almost no seconds today and stops the cost growing faster than the corpus.

## The bump

Ten literals across seven files: the two published crates, the four npm manifests with their pinned `optionalDependencies`, and the plugin manifest. `Cargo.lock` follows.

```
$ bash .github/scripts/check-version.sh 0.5.0
version 0.5.0 agrees with all 10 version literals
```

`cargo test` green on every target (bin 294, cli 237, skill 21, and the rest), `cargo fmt --check` green, `ank check` exit 0.

The tag goes on after this merges: the `version` job gates the build by comparing the tag with these manifests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014TALD31QGkPyVLi96LfAry