### PR TITLE
Release 0.6.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ank",
   "description": "Tasks and architecture decisions in your repo, behind one CLI any coding agent can call.",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "author": {
     "name": "haksolot",
     "url": "https://github.com/haksolot"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "ank-cli"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "ank-contract",
  "ank-core",
@@ -30,7 +30,7 @@ version = "0.3.0"
 
 [[package]]
 name = "ank-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "globset",
  "hex",

--- a/crates/ank-cli/Cargo.toml
+++ b/crates/ank-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ank-cli"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 # Measured on 2026-08-01 by walking toolchains upward against this tree, which
 # is the only way this number means anything: 1.78, 1.91, 1.92, 1.93 and 1.94

--- a/crates/ank-core/Cargo.toml
+++ b/crates/ank-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ank-core"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 # Measured, not assumed: see the note in ank-cli's manifest. This crate's own
 # code needs far less, but the workspace resolves one lockfile and builds as a

--- a/npm/ank-darwin-arm64/package.json
+++ b/npm/ank-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haksolot/ank-darwin-arm64",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "The ank binary for macOS on Apple silicon.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/haksolot/ank",

--- a/npm/ank-linux-x64-musl/package.json
+++ b/npm/ank-linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haksolot/ank-linux-x64-musl",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "The ank binary for Linux x86_64, statically linked against musl.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/haksolot/ank",

--- a/npm/ank-win32-x64/package.json
+++ b/npm/ank-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haksolot/ank-win32-x64",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "The ank binary for Windows x86_64.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/haksolot/ank",

--- a/npm/ank/package.json
+++ b/npm/ank/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haksolot/ank",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "The stupid coordination tool: tasks and architecture decisions in your repo, behind one CLI any coding agent can call.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/haksolot/ank",
@@ -39,8 +39,8 @@
     "node": ">=18"
   },
   "optionalDependencies": {
-    "@haksolot/ank-darwin-arm64": "0.5.0",
-    "@haksolot/ank-linux-x64-musl": "0.5.0",
-    "@haksolot/ank-win32-x64": "0.5.0"
+    "@haksolot/ank-darwin-arm64": "0.6.0",
+    "@haksolot/ank-linux-x64-musl": "0.6.0",
+    "@haksolot/ank-win32-x64": "0.6.0"
   }
 }


### PR DESCRIPTION
The version bump only. Everything this release carries is already on `main`.

## Why a minor

**The format moved to schema 4**, and that is a compatibility break in one direction: a corpus this build writes into carries entities `0.5.0` cannot read. `schema_ahead` warns once and leaves them out of every listing. Nobody upgrading loses anything; everybody who does not upgrade stops seeing what the upgraded write.

## Why it is not optional for anyone sharing a corpus

`0.5.0` meeting a schema 4 corpus reported **nineteen faults, of which nine were honest**. The other ten were drawn after the schema gate, and eight prescribed `--drop-reference` against citations that were correct. TASK-5c7aae69a4c0 fixed the conclusion; shipping it is what makes the fix reach anyone.

## What else, all additive to the contract (still version 1)

- `ank edit` accepts `--title`, `--body`, `--constraint`, and needs no editor when a field is named (ADR-5bd8257dfeac)
- `show` and `log` gained a `machinery` array and a `records` field per entry, declared before emitted
- `--worktree` names the tree a corpus is anchored to (ADR-9e56318631f3)
- a log entry says what it records, and the work trace stops carrying machinery (ADR-16813b3bcf37)

## Verification

`check-version.sh 0.6.0` agrees with all ten literals across the seven files. `cargo test --workspace` green, `cargo fmt --check` clean.

Same eight files the 0.5.0 bump touched, no more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
