### PR TITLE
A verb that changes content writes the entry that accounts for it

### DIFF
--- a/.ank/entities/LOG-4f65645228ab.md
+++ b/.ank/entities/LOG-4f65645228ab.md
@@ -1,0 +1,24 @@
+---
+id: LOG-4f65645228ab
+type: log
+title: +scope crates/ank-cli/src/human.rs, +scope crates/ank-cli/src/entries.rs, +scope
+created: 2026-08-22T16:03:12Z
+author: claude-code/opus-5
+scope:
+  - crates/ank-cli/src/edit.rs
+  - crates/ank-cli/src/commands.rs
+  - crates/ank-cli/src/claim.rs
+  - crates/ank-cli/tests/cli.rs
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/src/entries.rs
+  - crates/ank-cli/src/cli.rs
+  - crates/ank-core/src/model.rs
+  - crates/ank-core/src/lib.rs
+about: TASK-3c12e0ced2c0
+seq: 0
+records: edit
+schema: 4
+version: 1
+---
+
+ crates/ank-cli/src/cli.rs, +scope crates/ank-core/src/model.rs, +scope crates/ank-core/src/lib.rs (version 2 to 3, replaced 512bab79156a)

--- a/.ank/entities/LOG-cfe644d5469a.md
+++ b/.ank/entities/LOG-cfe644d5469a.md
@@ -1,0 +1,21 @@
+---
+id: LOG-cfe644d5469a
+type: log
+title: done, proof commit:9882b26
+created: 2026-08-22T16:10:46Z
+author: claude-code/opus-5
+scope:
+  - crates/ank-cli/src/edit.rs
+  - crates/ank-cli/src/commands.rs
+  - crates/ank-cli/src/claim.rs
+  - crates/ank-cli/tests/cli.rs
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/src/entries.rs
+  - crates/ank-cli/src/cli.rs
+  - crates/ank-core/src/model.rs
+  - crates/ank-core/src/lib.rs
+about: TASK-3c12e0ced2c0
+seq: 2
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-f18e5e57f4de.md
+++ b/.ank/entities/LOG-f18e5e57f4de.md
@@ -1,0 +1,23 @@
+---
+id: LOG-f18e5e57f4de
+type: log
+title: "Written and green. Three doors, one grammar: edit on both its paths, amend on all three kinds, and"
+created: 2026-08-22T16:09:55Z
+author: claude-code/opus-5
+scope:
+  - crates/ank-cli/src/edit.rs
+  - crates/ank-cli/src/commands.rs
+  - crates/ank-cli/src/claim.rs
+  - crates/ank-cli/tests/cli.rs
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/src/entries.rs
+  - crates/ank-cli/src/cli.rs
+  - crates/ank-core/src/model.rs
+  - crates/ank-core/src/lib.rs
+about: TASK-3c12e0ced2c0
+seq: 1
+schema: 4
+version: 1
+---
+
+ claim only when --criteria actually wrote a criterion. The message is <fields> (version N to M, replaced <hash12>), built in one place in entries.rs so TASK-dfe5a1bb0857 has one grammar to count against. The hash is over the canonical serialisation of the entity replaced, not over the file bytes: every other freeze here hashes parsed values, and a file is a rendering. Two existing assertions moved, because the amended: opening is gone from the work trace and the record is machinery now. Two holes closed on the way: changed_fields fell through for spec and log, so a spec edit named no field at all, and verified was missing from task and adr.

--- a/.ank/entities/TASK-3c12e0ced2c0.md
+++ b/.ank/entities/TASK-3c12e0ced2c0.md
@@ -5,7 +5,7 @@ slug: a-verb-that-changes-content-outside-a-transition
 title: A verb that changes content outside a transition writes the entry that accounts for it
 created: 2026-08-21T20:45:08Z
 author: claude-code/opus-5
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/src/edit.rs
   - crates/ank-cli/src/commands.rs
@@ -20,8 +20,13 @@ blocked_by: [TASK-027a429aad2e, TASK-353036d7972f]
 done_criteria: |
   ank edit on both its paths, ank amend, and ank claim --criteria each write one log entry marked as machinery, naming the fields that changed, the version moved from and to, and freeze_hash_short of the state replaced. A verb that changes nothing writes none. The entry is written once and never revisited, and no verb reads it to decide anything: a test asserts that deleting every such entry changes no exit code and no answer of any other verb, which is what makes it a trace and not an anchor. Driven through the binary end to end: an entity created and then edited twice answers ank log with the two entries in order, each naming its fields and its version transition, and the hash in the first entry matches what freeze_hash_short returns for the state the second entry replaced. A status transition writes none of this, and a test on done asserts it. cargo test is green, cargo fmt --check passes, and ank check reports no fault.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 9882b26
+    criteria: 26d23a4c182d
+    via: submitted
 schema: 3
-version: 3
+version: 4
 ---
 
 The writing half of ADR-16813b3bcf37, and it is deliberately the third task

--- a/.ank/entities/TASK-3c12e0ced2c0.md
+++ b/.ank/entities/TASK-3c12e0ced2c0.md
@@ -5,18 +5,23 @@ slug: a-verb-that-changes-content-outside-a-transition
 title: A verb that changes content outside a transition writes the entry that accounts for it
 created: 2026-08-21T20:45:08Z
 author: claude-code/opus-5
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/src/edit.rs
   - crates/ank-cli/src/commands.rs
   - crates/ank-cli/src/claim.rs
   - crates/ank-cli/tests/cli.rs
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/src/entries.rs
+  - crates/ank-cli/src/cli.rs
+  - crates/ank-core/src/model.rs
+  - crates/ank-core/src/lib.rs
 blocked_by: [TASK-027a429aad2e, TASK-353036d7972f]
 done_criteria: |
   ank edit on both its paths, ank amend, and ank claim --criteria each write one log entry marked as machinery, naming the fields that changed, the version moved from and to, and freeze_hash_short of the state replaced. A verb that changes nothing writes none. The entry is written once and never revisited, and no verb reads it to decide anything: a test asserts that deleting every such entry changes no exit code and no answer of any other verb, which is what makes it a trace and not an anchor. Driven through the binary end to end: an entity created and then edited twice answers ank log with the two entries in order, each naming its fields and its version transition, and the hash in the first entry matches what freeze_hash_short returns for the state the second entry replaced. A status transition writes none of this, and a test on done asserts it. cargo test is green, cargo fmt --check passes, and ank check reports no fault.
 criteria_by: creator
 schema: 3
-version: 1
+version: 3
 ---
 
 The writing half of ADR-16813b3bcf37, and it is deliberately the third task

--- a/crates/ank-cli/src/claim.rs
+++ b/crates/ank-cli/src/claim.rs
@@ -28,6 +28,7 @@ use crate::config::{self, Config};
 use crate::git;
 use crate::human::Freeze;
 use crate::identity::ENV_AGENT;
+use crate::index::Index;
 use crate::repo::Repo;
 use crate::store::Store;
 use ank_contract::ExitCode;
@@ -1760,6 +1761,9 @@ pub fn run(
     let store = Store::new(&repo.ank);
     let loaded = store.load_prefix(prefix)?;
     let base_version = crate::store::version_of(&loaded.entity);
+    // What a `--criteria` that writes one would replace, kept before the
+    // destructuring consumes it (ADR-16813b3bcf37).
+    let before = loaded.entity.clone();
     let Entity::Task(mut task) = loaded.entity else {
         return Err(
             CliError::new(ExitCode::Generic, format!("{prefix} is not a task"))
@@ -1849,7 +1853,36 @@ pub fn run(
     // Durable state last, and it carries the transition alone: no holder, no
     // expiry, no TTL ever reaches a task file (ADR-4e7c25b1f639).
     task.status = TaskStatus::InProgress;
-    store.write(&Entity::Task(task.clone()), base_version)?;
+    let claimed = Entity::Task(task.clone());
+    let version = store.write(&claimed, base_version)?;
+
+    // **The criterion this call wrote, accounted for** (ADR-16813b3bcf37).
+    // `claim` is on the list of three because `--criteria` writes a
+    // `done_criteria` the task did not have, which is content, and the whole
+    // authority model then rests on it. The status this same write moved is a
+    // transition, which the claim ref already records and which earns no entry:
+    // a plain `claim` writes none, and a test on `done` says the same of the
+    // other direction.
+    // Asked of the two states rather than remembered from the branch above:
+    // what earns an entry is content that moved, and the field is where that
+    // is legible.
+    let wrote_criteria =
+        matches!(&before, Entity::Task(t) if t.done_criteria != task.done_criteria);
+    if wrote_criteria {
+        crate::entries::record_edit(
+            &store,
+            &Index::open(&repo.ank)?,
+            &claimed,
+            identity,
+            &now_utc(),
+            &crate::entries::edit_message(
+                &["done_criteria".to_string(), "criteria_by".to_string()],
+                base_version,
+                version,
+                &crate::entries::replaced_hash(&before),
+            ),
+        )?;
+    }
 
     // Read a second time, after the ref is taken, and what it can still find is
     // the race `already_holding` cannot close: two sessions of one identity

--- a/crates/ank-cli/src/cli.rs
+++ b/crates/ank-cli/src/cli.rs
@@ -1014,7 +1014,7 @@ fn dispatch(
         "accept" => crate::human::accept(&inv, &s.repo, &s.config, &s.identity, out),
         "close" => crate::human::close(&inv, &s.repo, &s.identity, out),
         "attest" => crate::human::attest(&inv, &s.repo, &s.identity, out),
-        "edit" => crate::edit::run(&inv, &s.repo, out),
+        "edit" => crate::edit::run(&inv, &s.repo, &s.identity, out),
         "amend" => crate::human::amend(&inv, &s.repo, &s.identity, out),
         "show" => crate::human::show(&inv, &s.repo, &s.config, out),
         _ => Err(not_implemented(spec)),

--- a/crates/ank-cli/src/edit.rs
+++ b/crates/ank-cli/src/edit.rs
@@ -25,7 +25,9 @@
 use crate::claim;
 use crate::cli::{CliError, Invocation, Result};
 use crate::editor;
+use crate::entries;
 use crate::human::{self, Freeze};
+use crate::index::Index;
 use crate::json::Obj;
 use crate::repo::Repo;
 use crate::store::{version_of, Store};
@@ -34,7 +36,7 @@ use ank_core::{freeze, parse_entity, Entity, EntityId};
 use std::io::Write;
 use std::path::Path;
 
-pub fn run(inv: &Invocation, repo: &Repo, out: &mut dyn Write) -> Result<ExitCode> {
+pub fn run(inv: &Invocation, repo: &Repo, identity: &str, out: &mut dyn Write) -> Result<ExitCode> {
     let prefix = inv.positionals.first().ok_or_else(|| {
         CliError::new(ExitCode::Generic, "edit expects an id").with_hint("ank edit <id>")
     })?;
@@ -68,6 +70,7 @@ pub fn run(inv: &Invocation, repo: &Repo, out: &mut dyn Write) -> Result<ExitCod
             &loaded.entity,
             &edited,
             base_version,
+            identity,
             out,
         );
     }
@@ -109,6 +112,7 @@ pub fn run(inv: &Invocation, repo: &Repo, out: &mut dyn Write) -> Result<ExitCod
             &loaded.entity,
             &edited,
             base_version,
+            identity,
             out,
         )
     })();
@@ -196,6 +200,7 @@ fn no_such_field(before: &Entity, flag: &str) -> CliError {
 ///
 /// Split out so that the caller owns the scratch file's fate: every path
 /// through here that fails is a path on which the text has to survive.
+#[allow(clippy::too_many_arguments)]
 fn write_back(
     inv: &Invocation,
     repo: &Repo,
@@ -203,6 +208,7 @@ fn write_back(
     before: &Entity,
     edited: &str,
     base_version: u64,
+    identity: &str,
     out: &mut dyn Write,
 ) -> Result<ExitCode> {
     let id = before.id();
@@ -234,6 +240,30 @@ fn write_back(
     // is that a person spent that time typing. The scratch file is named by the
     // caller, on this path like every other.
     let version = store.write(&after, base_version)?;
+
+    // **The version this write just moved, accounted for** (ADR-16813b3bcf37).
+    // `edit` changes content and never a status, so it is one of the three
+    // verbs the decision names, and the entry is written after the write it
+    // records: a write that failed must leave no trace behind, and a write with
+    // no trace is merely incomplete.
+    //
+    // Written on every path through here, including the one where `changed` is
+    // empty: the store moved `version`, so an entity that accounted for nothing
+    // would read as edited by something other than the tool.
+    let fields: Vec<String> = changed.iter().map(|f| f.to_string()).collect();
+    entries::record_edit(
+        store,
+        &Index::open(&repo.ank)?,
+        &after,
+        identity,
+        &claim::now_utc(),
+        &entries::edit_message(
+            &fields,
+            base_version,
+            version,
+            &entries::replaced_hash(before),
+        ),
+    )?;
 
     if inv.json() {
         let doc = Obj::document()
@@ -426,6 +456,7 @@ fn changed_fields(before: &Entity, after: &Entity) -> Vec<&'static str> {
             note("criteria_by", a.criteria_by != b.criteria_by);
             note("verify", a.verify != b.verify);
             note("proof", a.proof != b.proof);
+            note("verified", a.verified != b.verified);
             note("schema", a.schema != b.schema);
             note("body", a.body != b.body);
         }
@@ -440,9 +471,44 @@ fn changed_fields(before: &Entity, after: &Entity) -> Vec<&'static str> {
             note("see", a.see != b.see);
             note("supersedes", a.supersedes != b.supersedes);
             note("ratified", a.ratified != b.ratified);
+            note("verified", a.verified != b.verified);
             note("schema", a.schema != b.schema);
             note("body", a.body != b.body);
         }
+        // The two kinds that used to fall through here, and the fall-through
+        // was a hole rather than a decision: a spec whose body an edit rewrote
+        // reported no field at all, so the line said `canonical form` and the
+        // machinery entry would have said it too (ADR-16813b3bcf37). Every kind
+        // the parser resolves is named, in the order §3 lists its fields.
+        (Entity::Spec(a), Entity::Spec(b)) => {
+            note("slug", a.slug != b.slug);
+            note("title", a.title != b.title);
+            note("created", a.created != b.created);
+            note("author", a.author != b.author);
+            note("status", a.status != b.status);
+            note("scope", a.scope != b.scope);
+            note("references", a.references != b.references);
+            note("supersedes", a.supersedes != b.supersedes);
+            note("ratified", a.ratified != b.ratified);
+            note("verified", a.verified != b.verified);
+            note("schema", a.schema != b.schema);
+            note("body", a.body != b.body);
+        }
+        (Entity::Log(a), Entity::Log(b)) => {
+            note("slug", a.slug != b.slug);
+            note("title", a.title != b.title);
+            note("created", a.created != b.created);
+            note("author", a.author != b.author);
+            note("scope", a.scope != b.scope);
+            note("about", a.about != b.about);
+            note("seq", a.seq != b.seq);
+            note("records", a.records != b.records);
+            note("verified", a.verified != b.verified);
+            note("schema", a.schema != b.schema);
+            note("body", a.body != b.body);
+        }
+        // Unreachable: the kind comes from the id, and [`check_id`] has already
+        // refused a result whose id moved. Stated rather than assumed.
         _ => {}
     }
     v

--- a/crates/ank-cli/src/entries.rs
+++ b/crates/ank-cli/src/entries.rs
@@ -38,7 +38,10 @@ use ank_contract::ExitCode;
 // log lives: `ank_core::log` is public and documented as the log's home, and a
 // re-export is a line in a file this work has no other reason to open.
 use ank_core::log::control_character;
-use ank_core::{message_fields, Entity, EntityId, EntityKind, Log, LogEntry};
+use ank_core::{
+    freeze_hash_short, message_fields, serialize_entity, Entity, EntityId, EntityKind, Log,
+    LogEntry, RECORDS_EDIT,
+};
 
 /// One entry as a reader receives it: the line, and the entity that carries it.
 ///
@@ -219,6 +222,49 @@ pub fn record(
     created: &str,
     message: &str,
 ) -> Result<EntityId> {
+    write_entry(store, index, subject, identity, created, message, None)
+}
+
+/// The same write, marked as machinery rather than as work
+/// (ADR-16813b3bcf37).
+///
+/// **The word is the only difference**, and that is deliberate: an entry an
+/// agent wrote and an entry a verb wrote are the same kind of entity, written
+/// once, addressable, ordered by the same key and carried by the same code.
+/// What separates them is `records`, which is what a reader splits on and what
+/// no verb consults.
+///
+/// The message is [`edit_message`]'s, and the two are never built apart: one
+/// grammar, one place that writes it.
+pub fn record_edit(
+    store: &Store,
+    index: &Index,
+    subject: &Entity,
+    identity: &str,
+    created: &str,
+    message: &str,
+) -> Result<EntityId> {
+    write_entry(
+        store,
+        index,
+        subject,
+        identity,
+        created,
+        message,
+        Some(RECORDS_EDIT),
+    )
+}
+
+/// The one door, whatever the entry records.
+fn write_entry(
+    store: &Store,
+    index: &Index,
+    subject: &Entity,
+    identity: &str,
+    created: &str,
+    message: &str,
+    records: Option<&str>,
+) -> Result<EntityId> {
     // **The one door, so every verb that writes an entry is covered**
     // (TASK-f3910718320a). `log`, `done`, `release --reason` and the human
     // verbs all record through this function and through nothing else, and a
@@ -241,8 +287,58 @@ pub fn record(
         &crate::commands::entropy(),
     );
     let seq = next_seq(store, index, subject)?;
-    store.create(&Entity::Log(from_line(id.clone(), subject, seq, &line)))?;
+    let mut entry = from_line(id.clone(), subject, seq, &line);
+    entry.records = records.map(str::to_string);
+    store.create(&Entity::Log(entry))?;
     Ok(id)
+}
+
+/// The hash a machinery entry carries: the state the write replaced
+/// (ADR-16813b3bcf37).
+///
+/// **The whole entity and never the field that moved.** What the entry hands a
+/// reader is a claim about how an entity *read* at a version, and a hash over
+/// one field could not settle it. The entity as the corpus serialises it is
+/// that state, and the value is reproducible by anybody holding the revision:
+/// check the commit out, run this over the file, read the same twelve
+/// characters.
+///
+/// **The normalisation every other freeze in this corpus uses**, so a trailing
+/// newline gained on the way through an editor does not read as a different
+/// past.
+///
+/// It anchors nothing, which is what ADR-ff294eff4d1a requires of the log: no
+/// verb consults it, no hash chains over it, and deleting the entry that
+/// carries it changes no answer the tool gives.
+pub fn replaced_hash(before: &Entity) -> String {
+    freeze_hash_short(&serialize_entity(before))
+}
+
+/// The message a machinery entry carries, in one grammar and in one place:
+///
+/// ```text
+/// <fields> (version <from> to <to>, replaced <hash>)
+/// ```
+///
+/// `<fields>` is what the verb reported as changed, comma separated, and
+/// `canonical form` where the write moved no parsed field. A normalisation is
+/// still a version, and an entity that could not account for it would read as
+/// edited behind the tool's back — so the entry is written and says what it
+/// was. It is also the word `edit` already prints for that case, so the line
+/// the caller saw and the entry the corpus keeps say the same thing.
+///
+/// **The version transition rides in the message and not in a field of its
+/// own.** An entry is an entity written once, and a field for this would put a
+/// column on every log entry in the corpus to serve one value of `records`.
+/// The grammar is what `check` will count against (TASK-dfe5a1bb0857), and
+/// that is the only reader it will ever have.
+pub fn edit_message(changed: &[String], from: u64, to: u64, replaced: &str) -> String {
+    let what = if changed.is_empty() {
+        "canonical form".to_string()
+    } else {
+        changed.join(", ")
+    };
+    format!("{what} (version {from} to {to}, replaced {replaced})")
 }
 
 /// One entry, built from a line the previous layout stored and the entity it
@@ -269,9 +365,10 @@ pub fn from_line(id: EntityId, subject: &Entity, seq: u64, line: &LogEntry) -> L
         scope: subject.scope().to_vec(),
         about: subject.id().clone(),
         seq,
-        // Both callers write work: `ank log` is a holder saying what they
-        // learned, and a migration carries a line a holder wrote. Machinery is
-        // written elsewhere and says so (ADR-16813b3bcf37).
+        // Work unless the caller says otherwise: `ank log` is a holder saying
+        // what they learned and a migration carries a line a holder wrote, and
+        // neither is machinery. [`record_edit`] is the one caller that sets the
+        // word, on the entry this function has just built (ADR-16813b3bcf37).
         records: None,
         verified: Vec::new(),
         schema: ank_core::SCHEMA_VERSION,

--- a/crates/ank-cli/src/human.rs
+++ b/crates/ank-cli/src/human.rs
@@ -1858,6 +1858,39 @@ fn record_entry(
     )
 }
 
+/// The machinery entry a write of content owes (ADR-16813b3bcf37).
+///
+/// **Beside [`record_entry`] and never inside it.** The two write the same kind
+/// of entity through the same door, and what separates them is one word and the
+/// grammar of the message — both of which live in `entries`, so a verb here
+/// chooses which record it is writing and never how it is spelled.
+///
+/// `before` is what the write replaced and `after` is what it wrote: the hash
+/// is of the first and the entry hangs off the second, because an entry copies
+/// the scope of what it is about and the scope that matters is the one the
+/// entity now carries.
+#[allow(clippy::too_many_arguments)]
+fn record_edit_entry(
+    store: &Store,
+    repo: &Repo,
+    before: &Entity,
+    after: &Entity,
+    identity: &str,
+    changed: &[String],
+    from: u64,
+    to: u64,
+) -> Result<EntityId> {
+    let index = Index::open(&repo.ank)?;
+    crate::entries::record_edit(
+        store,
+        &index,
+        after,
+        identity,
+        &claim::now_utc(),
+        &crate::entries::edit_message(changed, from, to, &crate::entries::replaced_hash(before)),
+    )
+}
+
 /// Why a task's log yielded nothing, and at what severity `check` says so.
 enum LogUnread {
     /// A merge left half done. The walk of the log directory has already
@@ -4989,6 +5022,10 @@ pub fn amend(
     let loaded = store.load_prefix(prefix)?;
     let base_version = version_of(&loaded.entity);
     let id = loaded.entity.id().clone();
+    // The state every arm below replaces, kept before the match consumes it:
+    // the machinery entry hashes it, and the hash is of what was there and not
+    // of what the amend produced (ADR-16813b3bcf37).
+    let before = loaded.entity.clone();
 
     // Both normalised, and both for the same reason `new --scope` is: one is
     // written into the entity, and the other is compared against what is
@@ -5150,13 +5187,22 @@ pub fn amend(
             };
 
             let amended = Entity::Task(task);
-            store.write(&amended, base_version)?;
-            record_entry(
+            let version = store.write(&amended, base_version)?;
+            // Machinery rather than work, since TASK-3c12e0ced2c0: an amend is a
+            // change of content outside a status transition, which is the case
+            // ADR-16813b3bcf37 names. The line it used to write into the work
+            // trace said the same thing in a place `ank log` reads for what a
+            // previous holder learned, and an entity amended eight times made
+            // that verb answer with eight of these.
+            record_edit_entry(
                 &store,
                 repo,
+                &before,
                 &amended,
                 identity,
-                format!("amended: {}", changes.join(", ")),
+                &changes,
+                base_version,
+                version,
             )?;
 
             report_amend(inv, &id, &changes, out);
@@ -5218,9 +5264,23 @@ pub fn amend(
                 )
                 .with_hint(format!("ank show {id}")));
             }
-            // An ADR has no log section, so the change is recorded by `version`
-            // and by the diff, which is what every other write to an ADR does.
-            store.write(&Entity::Adr(adr), base_version)?;
+            // Recorded by an entry of its own, on the same terms a task's
+            // amend is: any kind may carry entries (ADR-25f977377fa0), and
+            // ADR-16813b3bcf37 asks for one per write of content whatever the
+            // kind. It used to be `version` and the diff alone, which said
+            // nothing a reader could reach without git.
+            let amended = Entity::Adr(adr);
+            let version = store.write(&amended, base_version)?;
+            record_edit_entry(
+                &store,
+                repo,
+                &before,
+                &amended,
+                identity,
+                &changes,
+                base_version,
+                version,
+            )?;
             report_amend(inv, &id, &changes, out);
         }
         Entity::Spec(mut spec) => {
@@ -5284,8 +5344,19 @@ pub fn amend(
                 )
                 .with_hint(format!("ank show {id}")));
             }
-            // Recorded by `version` and by the diff, as an ADR's amend is.
-            store.write(&Entity::Spec(spec), base_version)?;
+            // An entry of its own, as an ADR's amend now writes.
+            let amended = Entity::Spec(spec);
+            let version = store.write(&amended, base_version)?;
+            record_edit_entry(
+                &store,
+                repo,
+                &before,
+                &amended,
+                identity,
+                &changes,
+                base_version,
+                version,
+            )?;
             report_amend(inv, &id, &changes, out);
         }
         // Declared in the registry, and not reachable from this verb. A refusal

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -464,6 +464,32 @@ impl Repo {
         ids
     }
 
+    /// The machinery entries about an entity, oldest first, as the messages
+    /// they carry (ADR-16813b3bcf37).
+    ///
+    /// Read off the files rather than through the binary, on the same reasoning
+    /// `log_text` is: what has to be true is the state of the corpus, and a
+    /// helper that asked the tool would be asking the writer whether it wrote.
+    fn machinery_of(&self, id: &str) -> Vec<String> {
+        let mut rows: Vec<(u64, String)> = Vec::new();
+        for entry in std::fs::read_dir(self.0.join(".ank/entities"))
+            .into_iter()
+            .flatten()
+            .flatten()
+        {
+            let Ok(text) = std::fs::read_to_string(entry.path()) else {
+                continue;
+            };
+            if let Ok(ank_core::Entity::Log(l)) = ank_core::parse_entity(&text) {
+                if l.about.to_string() == id && l.records.is_some() {
+                    rows.push((l.seq, l.message()));
+                }
+            }
+        }
+        rows.sort();
+        rows.into_iter().map(|(_, m)| m).collect()
+    }
+
     fn task_text(&self, id: &str) -> String {
         std::fs::read_to_string(self.0.join(".ank/entities").join(format!("{id}.md"))).unwrap()
     }
@@ -7264,9 +7290,12 @@ fn amend_adds_and_removes_without_disturbing_the_rest() {
     );
     assert!(text.contains("  - src/**\n  - docs/**"), "{text}");
     assert!(text.contains("version: 2"), "the write increments: {text}");
+    // The record of an amend is machinery since TASK-3c12e0ced2c0, so it names
+    // the fields alone and the `amended:` opening is gone. What it gained is
+    // the version transition and the hash of the state replaced, which is what
+    // makes the entry account for the write (ADR-16813b3bcf37).
     assert!(
-        r.log_text(ID)
-            .contains("amended: +blocked_by TASK-000000000002"),
+        r.log_text(ID).contains("+blocked_by TASK-000000000002"),
         "the log says what changed: {}",
         r.log_text(ID)
     );
@@ -7365,7 +7394,8 @@ fn a_criterion_under_no_claim_is_amended_and_stays_the_creators() {
         "the correction was recorded as somebody else's: {text}"
     );
     assert!(
-        r.log_text(ID).contains("amended: done_criteria"),
+        r.log_text(ID)
+            .contains("done_criteria (version 1 to 2, replaced "),
         "the log is what records the amend: {}",
         r.log_text(ID)
     );
@@ -16328,6 +16358,429 @@ fn an_entity_with_no_machinery_grows_no_section() {
         stdout(&shown).contains("LOG (1 of 1)"),
         "{}",
         stdout(&shown)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// A write of content accounts for the version it moved
+// (ADR-16813b3bcf37, TASK-3c12e0ced2c0)
+// ---------------------------------------------------------------------------
+//
+// Through the binary throughout, and the criterion says so for a reason that
+// outlives it: what these tests are about is a file written beside another
+// file, by a verb, in the order the two writes happen.
+
+/// The hash a machinery entry must carry for a state, computed the way any
+/// reader holding that revision would.
+///
+/// Over the entity and not over the bytes, which is the doctrine every other
+/// freeze in this corpus follows: a ratification anchors `constraint` and
+/// `scope`, a claim anchors `done_criteria`, and none of them hashes a file.
+fn replaced_hash_of(text: &str) -> String {
+    ank_core::freeze_hash_short(&ank_core::serialize_entity(
+        &ank_core::parse_entity(text).expect("the fixture parses"),
+    ))
+}
+
+/// The three verbs ADR-16813b3bcf37 names, and the two doors `edit` has.
+///
+/// One test over the four because the property is one property: whichever door
+/// the write came through, the entity ends up accounting for the version it
+/// moved, in one grammar. Split four ways it would be four chances to write the
+/// message four ways.
+#[test]
+fn every_door_that_changes_content_writes_one_entry_that_accounts_for_it() {
+    // --- edit, on the path that names its field -----------------------------
+    let r = Repo::new();
+    r.seed_task(ID, Some("A verifiable criterion."));
+    let was = r.task_text(ID);
+
+    let out = r.ank_edit(
+        "claude-code@ank",
+        &["edit", ID, "--title", "A better title"],
+        None,
+    );
+    assert_eq!(code(&out), 0, "{}", both_streams(&out));
+    let entries = r.machinery_of(ID);
+    assert_eq!(entries.len(), 1, "one write, one entry: {entries:?}");
+    assert_eq!(
+        entries[0],
+        format!(
+            "title (version 1 to 2, replaced {})",
+            replaced_hash_of(&was)
+        ),
+        "the fields, the transition and the state replaced"
+    );
+
+    // --- edit, on the path that opens $EDITOR -------------------------------
+    let r = Repo::new();
+    r.seed_task(ID, Some("A verifiable criterion."));
+    let was = r.task_text(ID);
+    let editor = r.editor_saving(EDITED_TASK);
+
+    let out = r.ank_edit("claude-code@ank", &["edit", ID], Some(&editor));
+    assert_eq!(code(&out), 0, "{}", both_streams(&out));
+    let entries = r.machinery_of(ID);
+    assert_eq!(entries.len(), 1, "{entries:?}");
+    assert_eq!(
+        entries[0],
+        format!(
+            "title, body (version 1 to 2, replaced {})",
+            replaced_hash_of(&was)
+        ),
+        "the two paths write one grammar, not two"
+    );
+
+    // --- amend --------------------------------------------------------------
+    let r = Repo::new();
+    r.seed_task(ID, Some("A verifiable criterion."));
+    let was = r.task_text(ID);
+
+    let out = r.ank("claude-code@ank", &["amend", ID, "--scope", "docs/**"]);
+    assert_eq!(code(&out), 0, "{}", both_streams(&out));
+    let entries = r.machinery_of(ID);
+    assert_eq!(entries.len(), 1, "{entries:?}");
+    assert_eq!(
+        entries[0],
+        format!(
+            "+scope docs/** (version 1 to 2, replaced {})",
+            replaced_hash_of(&was)
+        )
+    );
+    // And the work trace never sees it, which is the half TASK-027a429aad2e
+    // bought: `ank log` is what an agent reads before repeating what a previous
+    // holder tried, and an amend is not something a previous holder learned.
+    let logged = r.ank("claude-code@ank", &["log", ID]);
+    let said = stdout(&logged);
+    let (trace, edits) = said.split_once("EDITS").expect("a section of its own");
+    assert!(!trace.contains("+scope docs/**"), "{trace}");
+    assert!(edits.contains("+scope docs/**"), "{edits}");
+
+    // --- claim --criteria ---------------------------------------------------
+    let r = Repo::new();
+    r.seed_task(ID, None);
+    let was = r.task_text(ID);
+
+    let out = r.ank(
+        "claude-code@ank",
+        &["claim", ID, "--criteria", "A verifiable criterion."],
+    );
+    assert_eq!(code(&out), 0, "{}", both_streams(&out));
+    let entries = r.machinery_of(ID);
+    assert_eq!(entries.len(), 1, "{entries:?}");
+    assert_eq!(
+        entries[0],
+        format!(
+            "done_criteria, criteria_by (version 1 to 2, replaced {})",
+            replaced_hash_of(&was)
+        ),
+        "the criterion the whole authority model then rests on"
+    );
+}
+
+/// A claim that writes no criterion moves `status` and nothing else, and a
+/// status transition has records of its own.
+#[test]
+fn a_status_transition_writes_none_of_this() {
+    let r = Repo::new().with_verifiers("verifiers:\n  ok:\n    run: echo fine\n");
+    r.seed_task(ID, Some("A verifiable criterion."));
+
+    // The claim: a transition, and the claim ref is what records it.
+    assert_eq!(code(&r.ank("claude-code@ank", &["claim", ID])), 0);
+    assert!(
+        r.machinery_of(ID).is_empty(),
+        "a plain claim is a transition: {:?}",
+        r.machinery_of(ID)
+    );
+
+    // And the other direction, which the criterion names: `done` writes a proof
+    // and a completion ref, and tracing it again would say nothing the corpus
+    // does not already say.
+    let head = r.head();
+    let out = r.ank(
+        "claude-code@ank",
+        &["done", "--proof", &format!("commit:{head}")],
+    );
+    assert_eq!(code(&out), 0, "{}", both_streams(&out));
+    assert!(
+        r.task_text(ID).contains("status: done"),
+        "{}",
+        r.task_text(ID)
+    );
+    assert!(
+        r.machinery_of(ID).is_empty(),
+        "done writes a proof, never machinery: {:?}",
+        r.machinery_of(ID)
+    );
+    // And the work trace is untouched by any of it: `done` still logs what it
+    // did, where a holder reads it.
+    assert!(
+        r.log_text(ID).contains("done, proof commit:"),
+        "{}",
+        r.log_text(ID)
+    );
+}
+
+/// Nothing moved, nothing written. A version is what an entry accounts for, so
+/// a call that moved none owes none.
+#[test]
+fn a_verb_that_changes_nothing_writes_no_entry() {
+    let r = Repo::new();
+    r.seed_task(ID, Some("A verifiable criterion."));
+    let before = r.task_text(ID);
+
+    // The editor saved the file back exactly as it opened it.
+    let editor = r.editor_saving(&before);
+    let out = r.ank_edit("claude-code@ank", &["edit", ID], Some(&editor));
+    assert_eq!(code(&out), 0, "{}", both_streams(&out));
+    assert!(stdout(&out).starts_with("unchanged"), "{}", stdout(&out));
+
+    // The named path, handed the title the entity already carries.
+    let out = r.ank_edit(
+        "claude-code@ank",
+        &["edit", ID, "--title", "Example task"],
+        None,
+    );
+    assert_eq!(code(&out), 0, "{}", both_streams(&out));
+    assert!(stdout(&out).starts_with("unchanged"), "{}", stdout(&out));
+
+    // And an amend asking for what is already there is refused outright.
+    let out = r.ank("claude-code@ank", &["amend", ID, "--scope", "src/**"]);
+    assert_ne!(code(&out), 0, "{}", both_streams(&out));
+
+    assert_eq!(r.task_text(ID), before, "no write, so no version moved");
+    assert!(
+        r.machinery_of(ID).is_empty(),
+        "and nothing to account for: {:?}",
+        r.machinery_of(ID)
+    );
+}
+
+/// The end-to-end clause: created through the binary, edited twice through it,
+/// read back through it.
+#[test]
+fn an_entity_edited_twice_answers_log_with_both_entries_in_order() {
+    let r = Repo::new();
+    let out = r.ank(
+        "claude-code@ank",
+        &[
+            "new",
+            "task",
+            "--title",
+            "Rotate secrets",
+            "--scope",
+            "src/**",
+            "--criteria",
+            "The rotation runs.",
+        ],
+    );
+    assert_eq!(code(&out), 0, "{}", both_streams(&out));
+    let id = stdout(&out)
+        .split_whitespace()
+        .nth(1)
+        .expect("created <id> <title>")
+        .to_string();
+
+    // The state each edit replaces, captured before it happens: the entry has
+    // to be checkable by somebody holding that revision, and this is that
+    // somebody.
+    let at_one = r.task_text(&id);
+    let out = r.ank_edit(
+        "claude-code@ank",
+        &["edit", &id, "--title", "Rotate the secrets"],
+        None,
+    );
+    assert_eq!(code(&out), 0, "{}", both_streams(&out));
+
+    let at_two = r.task_text(&id);
+    let out = r.ank_edit(
+        "claude-code@ank",
+        &["edit", &id, "--body", "A body written second."],
+        None,
+    );
+    assert_eq!(code(&out), 0, "{}", both_streams(&out));
+
+    assert!(
+        r.task_text(&id).contains("version: 3"),
+        "two writes on top of the creation: {}",
+        r.task_text(&id)
+    );
+
+    let entries = r.machinery_of(&id);
+    assert_eq!(entries.len(), 2, "one per write: {entries:?}");
+    assert_eq!(
+        entries[0],
+        format!(
+            "title (version 1 to 2, replaced {})",
+            replaced_hash_of(&at_one)
+        )
+    );
+    assert_eq!(
+        entries[1],
+        format!(
+            "body (version 2 to 3, replaced {})",
+            replaced_hash_of(&at_two)
+        ),
+        "the hash is of the state that write replaced, and of no other"
+    );
+
+    // Read back through the verb, which is where a reader meets them: a section
+    // of their own, in order, each naming its fields and its transition.
+    let logged = r.ank("claude-code@ank", &["log", &id]);
+    assert_eq!(code(&logged), 0, "{}", both_streams(&logged));
+    let said = stdout(&logged);
+    let (_, edits) = said.split_once("EDITS").expect("a section of its own");
+    let printed: Vec<&str> = edits.lines().filter(|l| l.contains("version ")).collect();
+    assert_eq!(printed.len(), 2, "{edits}");
+    assert!(printed[0].contains("title (version 1 to 2"), "{edits}");
+    assert!(
+        printed[1].contains(&format!(
+            "body (version 2 to 3, replaced {})",
+            replaced_hash_of(&at_two)
+        )),
+        "{edits}"
+    );
+}
+
+/// The same page with the machinery section taken out of it.
+///
+/// The section is what `show` and `log` grew for these entries, so its going is
+/// the display doing what it is for. Everything else on the page is the answer,
+/// and the answer is what must not have moved.
+fn without_edits(text: &str) -> String {
+    let mut kept: Vec<&str> = Vec::new();
+    let mut inside = false;
+    for line in text.lines() {
+        if line.starts_with("EDITS (") {
+            // And the blank line that opened the section with it, so what is
+            // left reads as a page that never had one.
+            kept.pop();
+            inside = true;
+            continue;
+        }
+        if inside {
+            if !line.is_empty() {
+                continue;
+            }
+            inside = false;
+        }
+        kept.push(line);
+    }
+    kept.join("\n").trim_end().to_string()
+}
+
+/// A trace and not an anchor: deleting every machinery entry changes no exit
+/// code and no answer.
+///
+/// **Asserted by deletion rather than by a comment**, which is what the
+/// criterion asks and what ADR-ff294eff4d1a requires of the log: nothing
+/// authoritative is anchored in it. A verb that had quietly started consulting
+/// one of these entries would answer differently here, whatever its author
+/// believed.
+///
+/// The two verbs that *print* the entries are compared on what they answer
+/// about the entity rather than on the section that holds them: `show` and
+/// `log` have one for exactly this, which is the whole of TASK-027a429aad2e.
+///
+/// **The identity is typed, and that is the one arrangement in the fixture.**
+/// An entry is an entity (ADR-25f977377fa0), so `check`'s census of authors
+/// counts it like anything else and removing three files moves that number,
+/// which is a count of the corpus and not a judgement about the entity the
+/// entries are about. Typing the identity takes the census out of the
+/// comparison and leaves the judgements in it, which is what the clause is
+/// about.
+#[test]
+fn deleting_every_machinery_entry_changes_no_answer() {
+    let r = Repo::new();
+    r.seed_task(ID, Some("A verifiable criterion."));
+    r.seed_adr("ADR-00000000aa01", "Do not do X.", "src/**");
+    // A work entry beside them, so that what `ank log` answers is a trace in
+    // both readings. Without one the verb would go from printing a section to
+    // saying there is no entry at all, which is the display moving and not the
+    // answer, and it would drown the assertion this test is making.
+    seed_entry(
+        &r,
+        "LOG-00000000ac01",
+        ID,
+        0,
+        "what the last holder learned",
+        None,
+    );
+    assert_eq!(
+        code(&r.ank_edit(
+            "claude-code/1.0",
+            &["edit", ID, "--title", "A better title"],
+            None
+        )),
+        0
+    );
+    assert_eq!(
+        code(&r.ank("claude-code/1.0", &["amend", ID, "--scope", "docs/**"])),
+        0
+    );
+    assert_eq!(
+        code(&r.ank(
+            "claude-code/1.0",
+            &["amend", "ADR-00000000aa01", "--scope", "docs/**"]
+        )),
+        0
+    );
+    assert_eq!(r.machinery_of(ID).len(), 2, "{:?}", r.machinery_of(ID));
+    assert_eq!(r.machinery_of("ADR-00000000aa01").len(), 1);
+
+    let asked: [&[&str]; 6] = [
+        &["check"],
+        &["status"],
+        &["context", "src"],
+        &["scope", "src"],
+        &["graph"],
+        &["show", ID],
+    ];
+    let before: Vec<(i32, String)> = asked
+        .iter()
+        .map(|a| {
+            let o = r.ank("claude-code/1.0", a);
+            (code(&o), stdout(&o))
+        })
+        .collect();
+    let logged_before = r.ank("claude-code/1.0", &["log", ID]);
+
+    // Every one of them, by hand: the corpus is writable by anything, and what
+    // is under test is what the tool answers about a corpus that lost them.
+    let mut deleted = 0;
+    for entry in std::fs::read_dir(r.0.join(".ank/entities"))
+        .unwrap()
+        .flatten()
+    {
+        let path = entry.path();
+        let Ok(text) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        if let Ok(ank_core::Entity::Log(l)) = ank_core::parse_entity(&text) {
+            if l.records.is_some() {
+                std::fs::remove_file(&path).unwrap();
+                deleted += 1;
+            }
+        }
+    }
+    assert_eq!(deleted, 3, "every such entry, and only those");
+
+    for (a, was) in asked.iter().zip(before) {
+        let now = r.ank("claude-code/1.0", a);
+        assert_eq!(code(&now), was.0, "ank {a:?} moved its exit code");
+        assert_eq!(
+            without_edits(&stdout(&now)),
+            without_edits(&was.1),
+            "ank {a:?} moved its answer"
+        );
+    }
+
+    let logged_now = r.ank("claude-code/1.0", &["log", ID]);
+    assert_eq!(code(&logged_now), code(&logged_before));
+    assert_eq!(
+        without_edits(&stdout(&logged_now)),
+        without_edits(&stdout(&logged_before)),
+        "the work trace never held them and does not miss them"
     );
 }
 

--- a/crates/ank-core/src/lib.rs
+++ b/crates/ank-core/src/lib.rs
@@ -35,7 +35,7 @@ pub use log::{
 };
 pub use model::{
     Adr, AdrStatus, CriteriaBy, Entity, Log, Proof, ProofType, ProofVia, Spec, SpecStatus, Task,
-    TaskStatus, Verified, MIN_SCHEMA, RECORDS_KINDS, SCHEMA_VERSION,
+    TaskStatus, Verified, MIN_SCHEMA, RECORDS_EDIT, RECORDS_KINDS, SCHEMA_VERSION,
 };
 pub use parse::{
     has_crlf, normalise_line_endings, parse_adr, parse_entity, parse_log_entity, parse_spec,

--- a/crates/ank-core/src/model.rs
+++ b/crates/ank-core/src/model.rs
@@ -8,7 +8,14 @@ use serde::{Deserialize, Serialize};
 /// string so that an entry written by a newer build is read rather than
 /// refused, and this list is what `check` compares against to say that a word
 /// is unknown to *this* build (ADR-3877fef1d662).
-pub const RECORDS_KINDS: &[&str] = &["edit"];
+pub const RECORDS_KINDS: &[&str] = &[RECORDS_EDIT];
+
+/// The word an entry carries when it records a change of content made outside
+/// a status transition (ADR-16813b3bcf37).
+///
+/// Named once and written from one place, so the vocabulary above and the verb
+/// that writes into it cannot drift apart by a typo.
+pub const RECORDS_EDIT: &str = "edit";
 
 /// Format version this crate **writes**, and the newest it reads.
 ///


### PR DESCRIPTION
Closes TASK-3c12e0ced2c0, the writing half of ADR-16813b3bcf37.

Three verbs change an entity's content outside a status transition, and
each now writes one log entry marked as machinery: `edit` on both its
paths, `amend` on all three kinds it reaches, and `claim` only where
`--criteria` actually wrote a criterion the task did not carry.

One grammar, built in one place (`entries::edit_message`):

    <fields> (version <from> to <to>, replaced <hash>)

so TASK-dfe5a1bb0857, which counts against it, has one grammar to read
rather than three `format!` calls to agree with. The hash is over the
canonical serialisation of the entity replaced and not over the file
bytes: every other freeze in this corpus hashes parsed values.

The entry anchors nothing, and the test says so by deletion rather than
by comment: every machinery entry removed from the corpus by hand, and
`check`, `status`, `context`, `scope`, `graph`, `show` and the work
trace of `log` answer byte for byte what they answered before.

`amend` used to write `amended: <changes>` into the work trace. It is
the same record, in the place TASK-027a429aad2e made for it.

Two holes closed on the way, both in `changed_fields`: `spec` and `log`
fell through, so an edit rewriting a spec's body named no field at all;
and `verified` was missing from the task and ADR arms.

Suite green on all three, `cargo fmt --check` clean, `ank check` exit 0
with no fault.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X5PCmpdS4j9itcqRKvrowX
