### PR TITLE
The superseded-citation guard walks the workspace and derives its dead set

### DIFF
--- a/.ank/entities/LOG-7c328867e7fe.md
+++ b/.ank/entities/LOG-7c328867e7fe.md
@@ -1,0 +1,21 @@
+---
+id: LOG-7c328867e7fe
+type: log
+title: done, proof commit:fd74dc1
+created: 2026-08-22T17:26:44Z
+author: claude-code/opus-5
+scope:
+  - crates/ank-cli/tests/cli.rs
+  - crates/ank-cli/src/**
+  - crates/ank-core/src/**
+  - crates/ank-contract/src/**
+  - crates/ank-mcp/src/**
+  - crates/ank-cli/Cargo.toml
+  - crates/ank-cli/build.rs
+  - crates/ank-core/tests/golden.rs
+  - crates/ank-cli/tests/skill.rs
+about: TASK-7a1c92961465
+seq: 2
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-85de6bf9a326.md
+++ b/.ank/entities/LOG-85de6bf9a326.md
@@ -1,0 +1,24 @@
+---
+id: LOG-85de6bf9a326
+type: log
+title: +scope crates/ank-cli/src/**, +scope crates/ank-core/src/**, +scope crates/ank-contract/src/**,
+created: 2026-08-22T17:26:05Z
+author: claude-code/opus-5
+scope:
+  - crates/ank-cli/tests/cli.rs
+  - crates/ank-cli/src/**
+  - crates/ank-core/src/**
+  - crates/ank-contract/src/**
+  - crates/ank-mcp/src/**
+  - crates/ank-cli/Cargo.toml
+  - crates/ank-cli/build.rs
+  - crates/ank-core/tests/golden.rs
+  - crates/ank-cli/tests/skill.rs
+about: TASK-7a1c92961465
+seq: 0
+records: edit
+schema: 4
+version: 1
+---
+
+ +scope crates/ank-mcp/src/**, +scope crates/ank-cli/Cargo.toml, +scope crates/ank-cli/build.rs, +scope crates/ank-core/tests/golden.rs, +scope crates/ank-cli/tests/skill.rs (version 2 to 3, replaced 808b25e78002)

--- a/.ank/entities/LOG-9814c37fed77.md
+++ b/.ank/entities/LOG-9814c37fed77.md
@@ -1,0 +1,23 @@
+---
+id: LOG-9814c37fed77
+type: log
+title: The three holes were three, and the repair behind them was a hundred and six. Widening the walk to
+created: 2026-08-22T17:26:19Z
+author: claude-code/opus-5
+scope:
+  - crates/ank-cli/tests/cli.rs
+  - crates/ank-cli/src/**
+  - crates/ank-core/src/**
+  - crates/ank-contract/src/**
+  - crates/ank-mcp/src/**
+  - crates/ank-cli/Cargo.toml
+  - crates/ank-cli/build.rs
+  - crates/ank-core/tests/golden.rs
+  - crates/ank-cli/tests/skill.rs
+about: TASK-7a1c92961465
+seq: 1
+schema: 4
+version: 1
+---
+
+ the workspace and deriving the dead set from the corpus turned up 106 citations of 35 superseded documents across 18 files and all four crates -- ank-contract, ank-core and ank-mcp had never been read by this guard, so nothing in them had ever been kept honest. Nine sites needed a judgement rather than a substitution, all of them sentences about the supersession itself: re-pointing ADR-f61e2d2c75e8, superseding ADR-c656cbcc33a9 would have produced one id superseding itself. Those name the live decision only, and the history stays in .ank/ where ank show carries supersedes. The set is asked of the binary with find --status superseded --json, and shown is compared against total so a listing the budget cut is not read as a shorter corpus. Falsified twice: once on a temp tree with a crate that is not ank-cli, and once on the real workspace by planting an id in ank-core and watching it go red.

--- a/.ank/entities/TASK-7a1c92961465.md
+++ b/.ank/entities/TASK-7a1c92961465.md
@@ -5,7 +5,7 @@ slug: the-superseded-citation-guard-walks-one-crate-of
 title: The superseded-citation guard walks one crate of four, and its dead list is remembered by hand
 created: 2026-08-21T20:53:46Z
 author: claude-code/opus-5
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/tests/cli.rs
   - crates/ank-cli/src/**
@@ -20,8 +20,13 @@ blocked_by: []
 done_criteria: |
   The walk covers every crate of the workspace and not only ank-cli, and a citation of a superseded id anywhere in the tree's sources fails it: a test asserts the guard fires on a citation planted in a crate other than ank-cli, which it does not do today. The set of dead ids is derived from the corpus rather than transcribed, so an entity superseded after this lands is covered without anyone editing a list, and both kinds are covered rather than adr alone. The count that guards against a walk finding nothing rises with the wider walk. cargo test is green, cargo fmt --check passes, and ank check reports no fault.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: fd74dc1
+    criteria: e5522332904d
+    via: submitted
 schema: 3
-version: 3
+version: 4
 ---
 
 Found while re-pointing the citations left by the two supersessions of

--- a/.ank/entities/TASK-7a1c92961465.md
+++ b/.ank/entities/TASK-7a1c92961465.md
@@ -5,15 +5,23 @@ slug: the-superseded-citation-guard-walks-one-crate-of
 title: The superseded-citation guard walks one crate of four, and its dead list is remembered by hand
 created: 2026-08-21T20:53:46Z
 author: claude-code/opus-5
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/tests/cli.rs
+  - crates/ank-cli/src/**
+  - crates/ank-core/src/**
+  - crates/ank-contract/src/**
+  - crates/ank-mcp/src/**
+  - crates/ank-cli/Cargo.toml
+  - crates/ank-cli/build.rs
+  - crates/ank-core/tests/golden.rs
+  - crates/ank-cli/tests/skill.rs
 blocked_by: []
 done_criteria: |
   The walk covers every crate of the workspace and not only ank-cli, and a citation of a superseded id anywhere in the tree's sources fails it: a test asserts the guard fires on a citation planted in a crate other than ank-cli, which it does not do today. The set of dead ids is derived from the corpus rather than transcribed, so an entity superseded after this lands is covered without anyone editing a list, and both kinds are covered rather than adr alone. The count that guards against a walk finding nothing rises with the wider walk. cargo test is green, cargo fmt --check passes, and ank check reports no fault.
 criteria_by: creator
 schema: 3
-version: 1
+version: 3
 ---
 
 Found while re-pointing the citations left by the two supersessions of

--- a/crates/ank-cli/Cargo.toml
+++ b/crates/ank-cli/Cargo.toml
@@ -11,9 +11,9 @@ edition = "2021"
 # claim turns something red the day it stops being true.
 rust-version = "1.95"
 # Apache-2.0, and this is the crate where that is a decision rather than a
-# default: the tool used to be GPL-3.0-only, and ADR-68018cda382c argued that the
-# tool was precisely the part worth defending with copyleft. ADR-9f03438f5422
-# supersedes it and says why the trade is judged differently -- and what it gives
+# default: the tool used to be GPL-3.0-only, on the argument that the tool was
+# precisely the part worth defending with copyleft. ADR-9f03438f5422 replaced
+# that argument and says why the trade is judged differently -- and what it gives
 # up, which is that a proprietary fork is now permitted. Prospective only: a
 # release already made under GPL-3.0 stays available under GPL-3.0 to whoever
 # received it.

--- a/crates/ank-cli/build.rs
+++ b/crates/ank-cli/build.rs
@@ -2,7 +2,7 @@
 //! `skill/SKILL.md` it was built alongside (§4).
 //!
 //! `rev-parse` and `symbolic-ref`, and nothing else: both are on the list of
-//! commands ADR-b8884edcebe3 allows, their output is a sha or a path and stable
+//! commands ADR-9307e5d214a7 allows, their output is a sha or a path and stable
 //! by contract, and no porcelain is parsed here any more than in the binary
 //! itself.
 //!

--- a/crates/ank-cli/src/claim.rs
+++ b/crates/ank-cli/src/claim.rs
@@ -455,7 +455,7 @@ fn live_claims_where(
 /// is a different question, answered by the transition check and by `acquire`,
 /// and this refusal has no business intercepting it.
 ///
-/// Refusing on state and never on identity (ADR-c656cbcc33a9): what is read is
+/// Refusing on state and never on identity (ADR-91b77f036884): what is read is
 /// the coordination plane — which refs exist and who holds them — and the
 /// answer is the same for every caller. A lapsed claim is not a live one, so
 /// pickup after expiry (§3) passes through untouched.
@@ -513,7 +513,7 @@ pub fn read_at(cwd: &Path, name: &str) -> Result<Option<Held>> {
 ///
 /// The one place that spawns git without going through [`git::output`], because
 /// the record is fed on stdin and that runner does not pipe one. `hash-object`
-/// is in the plumbing ADR-b8884edcebe3 allows; what is lost here is the debug
+/// is in the plumbing ADR-9307e5d214a7 allows; what is lost here is the debug
 /// assertion that guards the list, not the rule it enforces.
 fn write_blob(cwd: &Path, record: &Record) -> Result<String> {
     use std::io::Write as _;
@@ -1143,7 +1143,7 @@ fn renewed_by_working(
 /// freezes nothing, which is the reading `log` and `done` already apply.
 ///
 /// Any live claim, not this agent's: refusals are on state and never on identity
-/// (ADR-c656cbcc33a9).
+/// (ADR-91b77f036884).
 pub fn live(cwd: &Path, id: &EntityId) -> Result<Option<ClaimRecord>> {
     let Some(Record::Claim(c)) = read(cwd, id)?.map(|h| h.record) else {
         return Ok(None);
@@ -2101,8 +2101,9 @@ fn other_ready_task(cwd: &Path, store: &Store, task: &Task) -> Option<EntityId> 
 
 /// Anchors the ADRs whose constraint applies here, so that a reader of this
 /// module lands on them: claims in refs (ADR-4e7c25b1f639), the ref's second
-/// state (ADR-6d8736c04cfa), plumbing by criterion (ADR-b8884edcebe3), freeze
-/// by hash (ADR-6b3f19e08a24), one surface (ADR-c656cbcc33a9).
+/// state (ADR-6d8736c04cfa), git per verb and plumbing by criterion
+/// (ADR-9307e5d214a7), freeze by hash (ADR-6b3f19e08a24), one surface
+/// (ADR-91b77f036884).
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2142,7 +2143,7 @@ mod tests {
             t
         }
 
-        /// Porcelain is forbidden to the tool (ADR-b8884edcebe3), not to the
+        /// Porcelain is forbidden to the tool (ADR-9307e5d214a7), not to the
         /// harness that builds the fixture.
         fn porcelain(&self, args: &[&str]) {
             let st = Command::new("git")
@@ -2276,7 +2277,7 @@ mod tests {
     fn a_ref_can_point_at_a_blob_which_is_what_a_record_is() {
         // If this ever fails, nothing below is worth reading: the record would
         // have to become a tag object, and `mktag` is not in the plumbing list
-        // that ADR-b8884edcebe3 allows.
+        // that ADR-9307e5d214a7 allows.
         let t = Temp::new_repo();
         let id = EntityId::parse("TASK-000000000001").unwrap();
         let record = Record::Claim(ClaimRecord {

--- a/crates/ank-cli/src/cli.rs
+++ b/crates/ank-cli/src/cli.rs
@@ -15,11 +15,11 @@
 //! exactly the drift the `owner_task` field was added to prevent.
 //!
 //! **The listing is grouped by the moment a verb is reached for, and inside a
-//! group the order of [`COMMANDS`] survives untouched** (ADR-f61e2d2c75e8). It
+//! group the order of [`COMMANDS`] survives untouched** (ADR-91b77f036884). It
 //! once grouped verbs under headings named after callers, which was the
 //! two-surface model still speaking through the output an agent reads; a
 //! heading that sorts callers is a claim about who a verb is for, and there is
-//! no such claim left to make. ADR-c656cbcc33a9 removed those headings and left
+//! no such claim left to make. ADR-91b77f036884 removed those headings and left
 //! §4's order to carry the structure alone, which works for five verbs and not
 //! for twenty-one: the order only says something to a reader who already knows
 //! it is meaningful, which is precisely what a first reader does not know. So
@@ -505,7 +505,7 @@ fn globals_of(spec: &CommandSpec) -> Vec<&'static FlagSpec> {
 /// It states what the three globals of §4 are, once, for the surface — the
 /// exception belongs on the page of the verb that makes it, where a reader
 /// asking about `init` is looking. Qualifying it in the listing would put a
-/// second structure under headings that already carry one (ADR-f61e2d2c75e8),
+/// second structure under headings that already carry one (ADR-91b77f036884),
 /// on the three lines the whole surface shares.
 fn globals_line(globals: &[&'static FlagSpec], with_short: bool) -> String {
     globals
@@ -571,7 +571,7 @@ fn json_of(specs: &[&CommandSpec]) -> String {
             // same structure to everyone and lets only colour depend on the
             // reader, so giving a machine the grouping and withholding it from
             // the caller who scripts against it would be the split this ADR
-            // rejected, the other way round (ADR-f61e2d2c75e8).
+            // rejected, the other way round (ADR-91b77f036884).
             // What comes back, which is the half this document was missing
             // (ADR-6fd69efb629c). A caller can discover a flag by being refused
             // one; it cannot discover a field by being handed it, because it has
@@ -622,7 +622,7 @@ fn json_of(specs: &[&CommandSpec]) -> String {
 /// silently is worse than refusing the wrong one loudly.
 ///
 /// The listing is grouped by [`GROUPS`], and inside a group the order is
-/// [`COMMANDS`]', which is §4's (ADR-f61e2d2c75e8). No verb is hidden and there
+/// [`COMMANDS`]', which is §4's (ADR-91b77f036884). No verb is hidden and there
 /// is no second listing to ask for: git shows the common commands and sends the
 /// rest to `git help -a`, and hiding a verb from the one surface claiming to be
 /// complete is worse than never teaching it.
@@ -688,7 +688,7 @@ pub fn help(inv: &Invocation, out: &mut dyn Write) -> Result<ExitCode> {
     // says so rather than leaving the reader to discover it.
     //
     // **The width is computed across all of [`COMMANDS`] and never per group**
-    // (ADR-f61e2d2c75e8). Five widths would stop the columns lining up between
+    // (ADR-91b77f036884). Five widths would stop the columns lining up between
     // sections, and the listing would read as five tables rather than one thing
     // with five parts — which is the opposite of what the grouping is for.
     let width = COMMANDS.iter().map(|c| usage(c).len()).max().unwrap_or(0);
@@ -726,7 +726,7 @@ pub fn help(inv: &Invocation, out: &mut dyn Write) -> Result<ExitCode> {
     );
     // A trailing pointer, beside the one above it and in the same shape. The
     // three trailer lines are not a group and take no heading: they say where
-    // to look next rather than when a verb is used (ADR-f61e2d2c75e8). A flag
+    // to look next rather than when a verb is used (ADR-91b77f036884). A flag
     // nobody can discover answers nobody's question.
     let _ = writeln!(out, "ank --version for the build");
     Ok(ExitCode::Ok)
@@ -889,7 +889,7 @@ fn warn_if_schema_ahead(inv: &Invocation, repo: &crate::repo::Repo) {
 fn startup(inv: &Invocation, cwd: &std::path::Path) -> Result<Startup> {
     let repo = crate::repo::resolve(inv.repo(), inv.worktree(), cwd)?;
     // git is required by the verbs that coordinate, and never at startup
-    // (ADR-9307e5d214a7, superseding ADR-b8884edcebe3). The gate used to stand
+    // (ADR-9307e5d214a7). The gate used to stand
     // in front of the dispatch rather than in front of the operation, so `show`,
     // `find`, `graph`, `scope`, `new`, `amend` and the whole formal half of
     // `check` refused outside a repository although none of them touches a ref,
@@ -1346,7 +1346,7 @@ mod tests {
     #[test]
     fn the_listing_keeps_the_table_order_inside_every_group() {
         // The grouping is a second axis laid over COMMANDS, not a re-sort
-        // (ADR-f61e2d2c75e8) -- so it is asserted rather than assumed. The test
+        // (ADR-91b77f036884) -- so it is asserted rather than assumed. The test
         // above passes just as well on a renderer that sorts alphabetically,
         // which would bury the loop in the middle of its own group.
         let text = help_out(&["help"]);
@@ -1376,7 +1376,7 @@ mod tests {
     fn every_verb_has_a_group_and_every_group_has_verbs() {
         // The two halves of what stops a twenty-second verb from being added
         // with no home and disappearing off the end of a listing that renders
-        // by group (ADR-f61e2d2c75e8). The integration suite asserts the same
+        // by group (ADR-91b77f036884). The integration suite asserts the same
         // property through the binary, which is where a caller reads it; this
         // one fails at the table, which is where the mistake is made.
         for spec in COMMANDS {
@@ -1410,7 +1410,7 @@ mod tests {
         assert!(text.contains("--criteria <v>"), "{text}");
         assert!(
             !text.contains("audience"),
-            "the audience line is what ADR-c656cbcc33a9 removes:\n{text}"
+            "the audience line is what ADR-91b77f036884 removes:\n{text}"
         );
         // One verb means one verb: no other usage line rides along.
         assert!(!text.contains("ank accept"), "{text}");

--- a/crates/ank-cli/src/commands.rs
+++ b/crates/ank-cli/src/commands.rs
@@ -143,7 +143,7 @@ pub fn new(
                 // The identity that ran this, recorded at the only moment it is
                 // knowable. Nothing recovers it afterwards: git would say who
                 // committed the file, which is a different fact and a different
-                // person, and ADR-b8884edcebe3 forbids the porcelain anyway.
+                // person, and ADR-9307e5d214a7 forbids the porcelain anyway.
                 author: Some(identity.to_string()),
                 status: TaskStatus::Open,
                 scope,
@@ -931,7 +931,7 @@ fn supersedes_of(inv: &Invocation, store: &Store, kind: EntityKind) -> Result<Op
     Ok(Some(id))
 }
 
-/// Whether a specification may cite this kind (§3, ADR-5a690829388d).
+/// Whether a specification may cite this kind (§3, ADR-c88f99e1c16e).
 ///
 /// A spec and an ADR, and nothing else. A document resting on a binding decision
 /// is ordinary and worth declaring; a task is work that finishes and a log entry
@@ -961,7 +961,7 @@ pub(crate) fn not_citable(id: &EntityId) -> String {
 /// `check`, as a corpus fault nobody can attribute to the act that caused it.
 /// What `check` is left to report is the corpus moving underneath a citation
 /// that was good when it was written — a target deleted, promoted or superseded
-/// since — which is the drift ADR-5a690829388d exists to catch.
+/// since — which is the drift ADR-c88f99e1c16e exists to catch.
 fn references_of(inv: &Invocation, store: &Store) -> Result<Vec<EntityId>> {
     let mut out: Vec<EntityId> = Vec::new();
     for raw in inv.values("--reference") {
@@ -2414,7 +2414,7 @@ mod tests {
     /// The only moment the author is knowable is the one that writes the file.
     /// Nothing recovers it afterwards: git names whoever committed the entity,
     /// which is a different fact about a possibly different person, and
-    /// ADR-b8884edcebe3 forbids the porcelain that would ask.
+    /// ADR-9307e5d214a7 forbids the porcelain that would ask.
     ///
     /// Asserted on the bytes on disk and not on the returned model, because a
     /// field set on the struct and dropped by the serializer would pass every

--- a/crates/ank-cli/src/context.rs
+++ b/crates/ank-cli/src/context.rs
@@ -1053,7 +1053,7 @@ pub(crate) fn coordination_of<'a>(
 /// carries it. The relevance argument for putting it in `context` is real —
 /// this is what an agent reads every turn — and it loses to two others.
 ///
-/// `context` is loaded on every call and ADR-e17e1bbd93ff treats every word in
+/// `context` is loaded on every call and ADR-91b77f036884 treats every word in
 /// it as paid for, so a line covering a state that is rare, already announced
 /// at acquisition, and reported by a verb costing nothing would be paid on
 /// every turn of every session that never hits it. And the place the collision

--- a/crates/ank-cli/src/edit.rs
+++ b/crates/ank-cli/src/edit.rs
@@ -343,7 +343,7 @@ fn check_frozen(repo: &Repo, before: &Entity, after: &Entity) -> Result<()> {
                 return Ok(());
             }
             // Any live claim, not this agent's: refusals are on state and never
-            // on identity (ADR-c656cbcc33a9). An expired claim is not in force
+            // on identity (ADR-91b77f036884). An expired claim is not in force
             // and freezes nothing, which is the same reading `log` and `done`
             // already apply to it.
             let Some(anchor) = live_claim_anchor(&repo.corpus, id)? else {

--- a/crates/ank-cli/src/git.rs
+++ b/crates/ank-cli/src/git.rs
@@ -3,7 +3,7 @@
 //! Ank calls the git binary, never a library: `accept` and `check` rest on
 //! signing, and `git commit -S` / `git verify-commit` are three lines where a
 //! cryptographic reimplementation would be a project. The counterpart is the
-//! discipline imposed by ADR-b8884edcebe3: **plumbing only**, never porcelain,
+//! discipline imposed by ADR-9307e5d214a7: **plumbing only**, never porcelain,
 //! whose output offers no stability contract across versions.
 //!
 //! A broken git environment is not a failure of the agent's work: absence, too
@@ -23,7 +23,7 @@ pub const MIN_VERSION: (u32, u32) = (2, 34);
 const INSTALL_URL: &str = "https://git-scm.com/downloads";
 
 /// Allowed plumbing subcommands. The rule is the criterion carried by
-/// ADR-b8884edcebe3 — a command is usable only if its output is stable by
+/// ADR-9307e5d214a7 — a command is usable only if its output is stable by
 /// contract across git versions — and this list is its application, kept
 /// explicit so that reaching for porcelain is a visible act in review rather
 /// than an oversight. A closed list goes stale at every new need; the
@@ -98,7 +98,7 @@ pub fn output(cwd: &Path, args: &[&str]) -> Result<Output> {
         verb_of(args)
             .map(|a| PLUMBING.contains(&a))
             .unwrap_or(false),
-        "porcelain forbidden (ADR-b8884edcebe3): {args:?}"
+        "porcelain forbidden (ADR-9307e5d214a7): {args:?}"
     );
     Command::new("git")
         .current_dir(cwd)
@@ -195,7 +195,7 @@ pub enum Pushed {
 ///
 /// **A refused push is distinguished from an unreachable remote by asking, not
 /// by reading stderr.** Push says "rejected" in prose written for people, and
-/// parsing it would be the fragility ADR-b8884edcebe3 exists to prevent. So a
+/// parsing it would be the fragility ADR-9307e5d214a7 exists to prevent. So a
 /// failure is followed by one `ls-remote` of the same ref: an answer means the
 /// remote is there and the swap genuinely lost, and no answer at all means the
 /// remote is what failed. It costs a round trip on the failing path only.
@@ -230,7 +230,7 @@ pub fn push_ref(
 /// which kind of failure it just had.
 ///
 /// One line per ref, `<oid>\t<refname>`, which is what makes `ls-remote`
-/// admissible under ADR-b8884edcebe3.
+/// admissible under ADR-9307e5d214a7.
 pub fn ls_remote(cwd: &Path, refname: &str) -> Result<Option<String>> {
     let args = ["ls-remote", "origin", refname];
     let out = output(cwd, &args)?;
@@ -647,7 +647,7 @@ pub fn output_with_stdin(cwd: &Path, args: &[&str], input: &[u8]) -> Result<Outp
         verb_of(args)
             .map(|a| PLUMBING.contains(&a))
             .unwrap_or(false),
-        "porcelain forbidden (ADR-b8884edcebe3): {args:?}"
+        "porcelain forbidden (ADR-9307e5d214a7): {args:?}"
     );
     let fail = |e: std::io::Error| {
         if e.kind() == std::io::ErrorKind::NotFound {
@@ -1024,7 +1024,7 @@ impl History {
     }
 
     /// The rename that killed `path`, or `None` when git cannot name one
-    /// (ADR-97beaf55e73a).
+    /// (ADR-3094538d831e).
     ///
     /// `None` is the honest answer for everything this cannot explain: a
     /// deletion, a move under git's similarity threshold, a path renamed by a
@@ -1097,7 +1097,7 @@ fn joined(records: &[String]) -> String {
 }
 
 /// The rename that killed `path`, or `None` when git cannot name one
-/// (ADR-97beaf55e73a).
+/// (ADR-3094538d831e).
 ///
 /// Two plumbing calls and no porcelain. `rev-list -1 HEAD -- <path>` is the
 /// last commit that touched the path, and `diff-tree` on that commit is what
@@ -1475,7 +1475,7 @@ fn all_ratifications(cwd: &Path) -> Result<HashMap<String, Ratification>> {
     // contain one, and a body ending in a newline is left exactly as git wrote
     // it. `%x00` rather than a text marker, which a commit message could forge.
     // `rev-list` and not `log`: the walker is plumbing and the pretty format is
-    // the same machinery, where `log` is the porcelain ADR-b8884edcebe3 refuses
+    // the same machinery, where `log` is the porcelain ADR-9307e5d214a7 refuses
     // by name. `--format` makes `rev-list` print a `commit <sha>` line of its
     // own before each record, which is what the reader below steps past.
     let args = [
@@ -1830,7 +1830,7 @@ mod tests {
             t
         }
 
-        /// Porcelain is forbidden to the tool (ADR-b8884edcebe3), not to the
+        /// Porcelain is forbidden to the tool (ADR-9307e5d214a7), not to the
         /// harness that builds the fixture: `init` and `commit` have no
         /// plumbing equivalent worth rewriting here.
         fn porcelain(&self, args: &[&str]) {
@@ -2160,7 +2160,7 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // Rename detection (ADR-97beaf55e73a)
+    // Rename detection (ADR-3094538d831e)
     // -----------------------------------------------------------------------
 
     /// The shapes of `--name-status -z`, asserted on the bytes rather than

--- a/crates/ank-cli/src/human.rs
+++ b/crates/ank-cli/src/human.rs
@@ -1,7 +1,7 @@
 //! check, review, accept, close, attest, amend and show (§4, §8, §11).
 //!
 //! **This is a file, not a side.** The CLI exposes one surface
-//! (ADR-c656cbcc33a9): every verb here is available to every caller, and what
+//! (ADR-91b77f036884): every verb here is available to every caller, and what
 //! the module holds is what grew together rather than what a class of caller
 //! was allowed to run. Successive headers described this as the human half, the
 //! side that may grow freely, the half outside the loop — each true when
@@ -1125,7 +1125,7 @@ fn scope_verdicts(entities: &[(PathBuf, Entity)], files: &[String]) -> HashMap<S
 ///
 /// `git_root` is `Some` only where there is a repository to ask, and it is what
 /// turns "the scope matches nothing" into "the file moved here, and this is the
-/// command that follows it" (ADR-97beaf55e73a). Where it is `None` the walk is
+/// command that follows it" (ADR-3094538d831e). Where it is `None` the walk is
 /// skipped in silence: a corpus outside a repository already says so once, in
 /// the coordination line, and a second sentence about a question nobody could
 /// ask would be noise.
@@ -1199,14 +1199,14 @@ fn check_scope_alive(
         if cross.is_some() || *alive {
             continue;
         }
-        // The cost clause of ADR-97beaf55e73a, and the reason this sits here
+        // The cost clause of ADR-3094538d831e, and the reason this sits here
         // rather than above the loop: two git processes per glob, paid only by a
         // glob that already matches nothing. A healthy corpus reaches this line
         // no times.
         let mut note = match git_root {
             // Read once for the whole corpus and only where something is
             // already dead: a healthy corpus reaches this line no times and
-            // starts no process, which is the cost clause of ADR-97beaf55e73a
+            // starts no process, which is the cost clause of ADR-3094538d831e
             // kept intact while the per-glob price it allowed goes away
             // (TASK-1b3d7b61dc8f).
             Some(root) => {
@@ -1273,7 +1273,7 @@ fn check_scope_alive(
 }
 
 /// The note under a dead scope: what git says happened to the path, and what
-/// repairs the entity (ADR-97beaf55e73a).
+/// repairs the entity (ADR-3094538d831e).
 ///
 /// Two deaths git records, and it is asked about both: a rename, which names
 /// where the path went and what moves the scope after it, and a deletion, which
@@ -2014,7 +2014,7 @@ fn check_spec(
     );
 }
 
-/// What a spec's `references` owe (§4, ADR-5a690829388d).
+/// What a spec's `references` owe (§4, ADR-c88f99e1c16e).
 ///
 /// This is the mechanism that decision rests on: splitting a specification is
 /// safe because the drift it risks is **detected** rather than deprecated, and
@@ -2613,7 +2613,7 @@ fn check_authorship(
     // Skipped, and said so once. `None` means the entity predates the field and
     // never that nobody wrote it: the author of a file that already exists
     // cannot be recovered, since git would name whoever committed it — a
-    // different fact about a possibly different person — and ADR-b8884edcebe3
+    // different fact about a possibly different person — and ADR-9307e5d214a7
     // forbids the porcelain that would ask.
     let authorless = considered.iter().filter(|e| author_of(e).is_none()).count();
     if authorless > 0 {
@@ -4632,7 +4632,7 @@ pub fn ratification_anchor(text: &str, scope: &[String]) -> String {
 /// moment where both constraints bind.
 ///
 /// `add` and `commit` are porcelain, and this is the documented exception:
-/// neither has a plumbing equivalent worth rewriting, and ADR-b8884edcebe3's
+/// neither has a plumbing equivalent worth rewriting, and ADR-9307e5d214a7's
 /// rule is about parsing output — nothing here is parsed but the resulting sha,
 /// which `rev-parse` supplies.
 /// The two writes and the commit that makes them binding, as one fallible step.
@@ -5462,7 +5462,7 @@ pub fn amend(
             // fires on accepted documents, since revising one is a supersession
             // and a supersession is what leaves the citations behind. Refusing
             // the whole verb here would name a repair the verb turns down
-            // (ADR-5a690829388d).
+            // (ADR-c88f99e1c16e).
             let touches_anchor = !add_scope.is_empty() || !drop_scope.is_empty();
             if touches_anchor && spec.status != SpecStatus::Proposed {
                 return Err(CliError::new(
@@ -5560,7 +5560,7 @@ fn amend_references(
         }
         // The kind rule, at the point of the write and in the words `check`
         // uses for the same state. Both readings come from one function
-        // (ADR-5a690829388d).
+        // (ADR-c88f99e1c16e).
         if !crate::commands::citable(r.kind()) {
             return Err(
                 CliError::new(ExitCode::Generic, crate::commands::not_citable(r))
@@ -5944,7 +5944,7 @@ fn log_section(
         // The command that actually answers, and not a flag that does not
         // exist: `log` prints the same budget with no entity charged against
         // it, so it has strictly more room than this page had. Naming a
-        // command that would refuse is the failure ADR-97beaf55e73a and §5 both
+        // command that would refuse is the failure ADR-3094538d831e and §5 both
         // single out.
         let _ = writeln!(out, "+{cut} earlier entries, ank log {id}");
     } else if entries

--- a/crates/ank-cli/src/init.rs
+++ b/crates/ank-cli/src/init.rs
@@ -58,7 +58,7 @@ pub fn run(inv: &Invocation, cwd: &Path, out: &mut dyn Write) -> Result<ExitCode
         Some(p) => PathBuf::from(p),
         None => cwd.to_path_buf(),
     };
-    // git is a hard dependency (ADR-b8884edcebe3): we fail before writing
+    // git is a hard dependency (ADR-9307e5d214a7): we fail before writing
     // anything rather than leave a half-placed `.ank/` in a directory that is
     // not a repository.
     git::ensure_usable(&target)?;

--- a/crates/ank-cli/src/style.rs
+++ b/crates/ank-cli/src/style.rs
@@ -1,4 +1,4 @@
-//! ANSI styling, and the whole of it (§4, ADR-962c25797569).
+//! ANSI styling, and the whole of it (§4, ADR-0c8ab846d262).
 //!
 //! Every escape sequence this binary can emit is written here, in one table of
 //! eight codes. That is deliberate: color is presentation, and presentation

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -2282,7 +2282,7 @@ fn a_signature_git_cannot_read_is_reported_rather_than_passed_over() {
 /// A ratification git refused to commit leaves nothing behind
 /// (TASK-1dbb6e7843f1).
 ///
-/// Measured on this corpus on 2026-08-18, ratifying ADR-768374fe6076 on a
+/// Measured on this corpus on 2026-08-18, ratifying ADR-24e306277bd4 on a
 /// machine whose ratification key was protected by a passphrase nothing
 /// supplied. `git commit` failed, `accept` exited 9 carrying git's message, and
 /// the ADR came out `accepted` carrying the anchor of a commit that does not
@@ -2918,7 +2918,7 @@ fn inside_a_repository_the_coordination_half_still_runs() {
 }
 
 // ---------------------------------------------------------------------------
-// References between documents (TASK-50dd8f9b565c, ADR-5a690829388d)
+// References between documents (TASK-50dd8f9b565c, ADR-c88f99e1c16e)
 // ---------------------------------------------------------------------------
 
 const CITING: &str = "SPEC-00000000a001";
@@ -2950,7 +2950,7 @@ fn findings_about(said: &str, id: &str) -> Vec<String> {
 }
 
 /// **`check` resolves what a specification declares it rests on**
-/// (ADR-5a690829388d, TASK-50dd8f9b565c).
+/// (ADR-c88f99e1c16e, TASK-50dd8f9b565c).
 ///
 /// This is the mechanism that decision rests on. It argues that cutting a
 /// specification into documents is safe because the drift it risks is
@@ -3245,7 +3245,7 @@ fn retired_citer_fixture() -> Repo {
 /// (TASK-a6c643216f51).
 ///
 /// Measured the first time a spec was replaced: three live documents followed
-/// the chain, which is ADR-5a690829388d working as designed, and the fourth had
+/// the chain, which is ADR-c88f99e1c16e working as designed, and the fourth had
 /// been retired in the same operation. What the finding asked of it was that a
 /// document nobody reads any more be edited to cite one written after it was
 /// retired — and the repair it named would have worked, bumping the `version` of
@@ -3684,8 +3684,8 @@ default_branch: main
 /// files, a `closed` one claimed nothing.
 ///
 /// The perimeter names a directory no commit ever carried, so neither
-/// ADR-97beaf55e73a's rename walk nor ADR-3094538d831e's deletion clause has
-/// anything to lower a severity with. That is the case with no way out, and it is
+/// ADR-3094538d831e's rename walk nor its deletion clause has anything to lower
+/// a severity with. That is the case with no way out, and it is
 /// the one that used to redden a corpus for good: `amend` refuses a finished task,
 /// so the fault could never be cleared.
 #[test]
@@ -3911,7 +3911,7 @@ fn a_done_through_the_binary_leaves_a_completion_ref_naming_commit_and_branch() 
 }
 
 // ---------------------------------------------------------------------------
-// Short forms (TASK-f3e92656b5df, ADR-962c25797569)
+// Short forms (TASK-f3e92656b5df, ADR-0c8ab846d262)
 // ---------------------------------------------------------------------------
 
 /// The short form is the long form, and the output proves it byte for byte.
@@ -4017,7 +4017,7 @@ fn a_short_flag_the_verb_does_not_take_names_the_flag_it_stands_for() {
 ///
 /// The second half is the one worth a test. The listing carries one line per
 /// verb, and a second spelling of every flag is exactly the kind of addition
-/// that arrives looking like an improvement. Grouping it (ADR-f61e2d2c75e8)
+/// that arrives looking like an improvement. Grouping it (ADR-91b77f036884)
 /// changed what stands between the lines and nothing on them.
 #[test]
 fn help_shows_both_forms_for_one_verb_and_leaves_the_listing_lines_alone() {
@@ -4913,7 +4913,8 @@ fn status_names_every_live_claim_of_this_identity() {
 /// The ADR it supersedes created the completion ref so that a task finished on
 /// an unmerged branch would not look free everywhere else, and named this gap
 /// without settling it -- on the ground that `close` is "a human act and a rare
-/// one", which ADR-e17e1bbd93ff retired by dissolving the human side entirely.
+/// one", which the skill decision retired by dissolving the human side entirely
+/// (ADR-91b77f036884).
 /// That is history, and `.ank/` carries it (TASK-78326e2e3e89). The code has
 /// behaved this way throughout; what it lacked was a decision saying so and a
 /// test holding it.
@@ -7768,7 +7769,7 @@ fn help_from_nowhere(args: &[&str]) -> Output {
 ///
 /// The trailer is the block opening with `global:` at column 0, and it is what
 /// bounds the listing now that a blank line no longer does. The listing is
-/// grouped (ADR-f61e2d2c75e8), so an empty line is a boundary *between* groups
+/// grouped (ADR-91b77f036884), so an empty line is a boundary *between* groups
 /// -- a parser that stopped at the first one would read `run the loop`, find six
 /// verbs, and call that the whole surface. A folded description is indented and
 /// so can never be mistaken for the trailer.
@@ -7856,7 +7857,7 @@ fn help_answers_outside_a_repository_and_lists_every_verb() {
     }
 
     // Grouped by the moment a verb is used, and never by who uses it
-    // (ADR-f61e2d2c75e8). These four headings sorted callers -- agent loop,
+    // (ADR-91b77f036884). These four headings sorted callers -- agent loop,
     // agent off-loop, human -- which is the two-surface model speaking through
     // the output an agent reads, and a CLI that refuses on state and never on
     // identity has no such grouping to print. That refusal is untouched: what
@@ -7930,7 +7931,7 @@ fn help_for_one_verb_answers_and_an_unknown_one_is_a_two() {
     assert!(text.contains("--criteria"), "{text}");
     assert!(
         !text.contains("audience"),
-        "the audience line is what ADR-c656cbcc33a9 removes, and it is the \
+        "the audience line is what ADR-91b77f036884 removes, and it is the \
          line an agent reads about itself:\n{text}"
     );
     assert!(
@@ -8024,7 +8025,7 @@ fn help_json_reaches_the_process_intact() {
 }
 
 /// Every verb of the table appears exactly once in the grouped listing, under a
-/// heading, and in the table's order inside it (ADR-f61e2d2c75e8).
+/// heading, and in the table's order inside it (ADR-91b77f036884).
 ///
 /// Through the binary, against `ank help --json`: the same table read out of the
 /// same process, so the assertion is that the two renderings agree rather than
@@ -8099,7 +8100,7 @@ fn the_grouped_listing_prints_every_verb_exactly_once() {
 }
 
 /// Every verb carries a non-empty group, and every group is a heading the
-/// listing prints (ADR-f61e2d2c75e8).
+/// listing prints (ADR-91b77f036884).
 ///
 /// This is what stops a twenty-second verb from being added with no home and
 /// disappearing off the end unnoticed. The test above would pass on such a verb
@@ -8139,7 +8140,7 @@ fn every_verb_carries_a_group_and_no_group_goes_unprinted() {
              heading:\n{listing}"
         );
         // And a group says when a verb is used, never who may use it: the wall
-        // ADR-c656cbcc33a9 pulled down was built out of exactly these words.
+        // ADR-91b77f036884 pulled down was built out of exactly these words.
         for who in ["agent", "human", "caller", "you"] {
             assert!(
                 !group.split_whitespace().any(|w| w == who),
@@ -8160,67 +8161,211 @@ fn every_verb_carries_a_group_and_no_group_goes_unprinted() {
 }
 
 // ---------------------------------------------------------------------------
-// Dead constraints in the prose (ADR-c656cbcc33a9)
+// Dead constraints in the prose (ADR-91b77f036884)
 // ---------------------------------------------------------------------------
 
-/// A comment citing a superseded ADR as the reason for a design is worse than
-/// no comment: it hands the next reader a constraint that binds nobody, with
-/// the authority of a decision record. Two of them went on asserting a frozen
-/// agent surface -- at seven verbs in one, at eight in the other -- in module
-/// headers and doc comments, long after the split they protected had been
-/// dissolved and while the file around them had already stopped obeying it.
+/// The workspace root: two levels above this crate's manifest.
 ///
-/// The needles are assembled from fragments so this file does not defeat its
-/// own assertion by containing what it forbids. It reads as an affectation
-/// until you picture the test failing on itself.
-///
-/// The third arrived the same way and is the reason the list is worth keeping:
-/// thirteen comments, across six modules and this file, explained the
-/// completion ref by the ADR that created it, and a human ratified its
-/// successor on the default branch. The citations were right until that
-/// signature and wrong the instant after, which is why re-pointing them is a
-/// task of its own (TASK-d9d364bad929) and why the list holds the result rather
-/// than a reader's memory.
-///
-/// This is not a general ban on naming a superseded ADR: history is worth
-/// writing down, and `.ank/` is where it is written. It is a ban on these three,
-/// which have no live claim left to make anywhere in this crate.
-#[test]
-fn no_superseded_adr_is_cited_in_the_crate() {
-    const DEAD: [&str; 3] = [
-        concat!("ADR-", "2f8a61c04b7d"),
-        concat!("ADR-", "3859eb46bdc3"),
-        concat!("ADR-", "bcf222a31525"),
-    ];
+/// Derived rather than configured, so a crate added to the workspace is walked
+/// by the guard below without anybody wiring it in — which is the same property
+/// the dead set gains from being asked of the corpus.
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("crates/<name> sits two levels under the workspace root")
+        .to_path_buf()
+}
 
-    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let mut walked = 0usize;
-    for dir in ["src", "tests"] {
-        for entry in std::fs::read_dir(root.join(dir)).expect("the crate has this directory") {
-            let path = entry.expect("a readable entry").path();
-            if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+/// Every source file and manifest of every crate in the workspace.
+fn workspace_sources(root: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let mut stack = vec![root.join("crates")];
+    while let Some(dir) = stack.pop() {
+        for entry in std::fs::read_dir(&dir).into_iter().flatten().flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                // Build output is not source, and it is large.
+                if path.file_name().and_then(|n| n.to_str()) == Some("target") {
+                    continue;
+                }
+                stack.push(path);
                 continue;
             }
-            let text = std::fs::read_to_string(&path).expect("a readable source file");
-            for dead in DEAD {
-                assert!(
-                    !text.contains(dead),
-                    "{} cites {dead}, which is superseded: name the ADR that \
-                     binds today, or drop the citation",
-                    path.display()
-                );
+            if matches!(
+                path.extension().and_then(|e| e.to_str()),
+                Some("rs") | Some("toml")
+            ) {
+                out.push(path);
             }
-            walked += 1;
         }
     }
-    // A walk that quietly found nothing would pass forever, which is the one
-    // way a test like this fails at being a test.
-    assert!(walked >= 8, "only {walked} source files walked");
+    out.sort();
+    out
+}
 
-    let manifest = std::fs::read_to_string(root.join("Cargo.toml")).expect("a readable manifest");
-    for dead in DEAD {
-        assert!(!manifest.contains(dead), "Cargo.toml cites {dead}");
+/// The number a `--json` document carries under `name`.
+fn json_number(text: &str, name: &str) -> u64 {
+    let at = text
+        .find(name)
+        .unwrap_or_else(|| panic!("{name} is in the document: {text}"));
+    text[at + name.len()..]
+        .chars()
+        .take_while(char::is_ascii_digit)
+        .collect::<String>()
+        .parse()
+        .expect("a number")
+}
+
+/// The identifiers of every superseded document in a corpus, asked of the
+/// binary (ADR-01b6dd05f0db: `.ank/` is reached only through the CLI).
+///
+/// **Derived and never transcribed.** A list in this file protects the cases
+/// somebody remembered and no fourth: superseding an entity does not add to it,
+/// so the guard goes quiet on exactly the citation that has just gone stale.
+/// The corpus already knows what is superseded, and a test that asks it needs
+/// nobody to remember.
+fn superseded_ids(repo: &Path) -> Vec<String> {
+    let out = ank_command()
+        .args(["find", "--status", "superseded", "--json"])
+        .arg("--repo")
+        .arg(repo)
+        .current_dir(std::env::temp_dir())
+        .output()
+        .expect("the binary must have been built");
+    assert_eq!(code(&out), 0, "{}", both_streams(&out));
+    let said = stdout(&out);
+    // A listing the budget cut would be read as a shorter corpus, and the guard
+    // would go quiet on whatever it dropped. The document carries both numbers
+    // for exactly this.
+    assert_eq!(
+        json_number(&said, "\"shown\":"),
+        json_number(&said, "\"total\":"),
+        "the listing was cut, so the set is not the whole one: {said}"
+    );
+    let mut ids = Vec::new();
+    let mut rest = said.as_str();
+    while let Some(at) = rest.find("\"id\":\"") {
+        rest = &rest[at + "\"id\":\"".len()..];
+        let end = rest.find('"').expect("a closed string");
+        ids.push(rest[..end].to_string());
+        rest = &rest[end..];
     }
+    ids
+}
+
+/// Every citation of one of `dead` in `files`, as the line a reader would fix.
+fn stale_citations(files: &[PathBuf], dead: &[String]) -> Vec<String> {
+    let mut found = Vec::new();
+    for path in files {
+        let Ok(text) = std::fs::read_to_string(path) else {
+            continue;
+        };
+        for (n, line) in text.lines().enumerate() {
+            for id in dead {
+                if line.contains(id.as_str()) {
+                    found.push(format!("{}:{}: {id}", path.display(), n + 1));
+                }
+            }
+        }
+    }
+    found
+}
+
+/// A comment citing a superseded document as the reason for a design is worse
+/// than no comment: it hands the next reader a constraint that binds nobody,
+/// with the authority of a decision record. Two of them went on asserting a
+/// frozen agent surface -- at seven verbs in one, at eight in the other -- in
+/// module headers and doc comments, long after the split they protected had been
+/// dissolved and while the file around them had already stopped obeying it.
+///
+/// **This is not a ban on writing history down.** It is a ban on writing it in
+/// the source, because `.ank/` is where the corpus keeps it and `ank show
+/// <successor>` carries `supersedes:`. A comment says what binds today; the
+/// chain behind it is one command away and does not have to be pasted into a
+/// module header where nothing will ever notice it going stale.
+///
+/// **The set is asked of the corpus and the walk covers the workspace**
+/// (TASK-7a1c92961465). Both were holes and each on its own was enough. The
+/// list used to be three identifiers transcribed by whoever last remembered, so
+/// superseding an entity protected nothing new; and the walk used to be this
+/// crate's `src` and `tests`, so `ank-contract`, `ank-core` and `ank-mcp` were
+/// never read. The citation that prompted this was in one of the three, which is
+/// not a coincidence: the guard had never looked there, so nothing there had
+/// ever been kept honest. Re-pointing what the wider walk then found came to a
+/// hundred and six citations across eighteen files.
+#[test]
+fn no_superseded_document_is_cited_in_the_workspace() {
+    let root = workspace_root();
+    let dead = superseded_ids(&root);
+    // A corpus that answered with nothing would make this pass forever, which is
+    // the one way a test like this fails at being a test.
+    assert!(dead.len() >= 30, "only {} superseded documents", dead.len());
+
+    let files = workspace_sources(&root);
+    // The same guard for the walk, and the number rose with it: this crate's
+    // `src` and `tests` alone were eight.
+    assert!(
+        files.len() >= 40,
+        "only {} source files walked",
+        files.len()
+    );
+    assert!(
+        files
+            .iter()
+            .any(|p| p.components().any(|c| c.as_os_str() == "ank-core")),
+        "the walk never left ank-cli: {files:?}"
+    );
+
+    let stale = stale_citations(&files, &dead);
+    assert!(
+        stale.is_empty(),
+        "these cite a superseded document: name the one that binds today, or \
+         drop the citation and leave the history to `ank show`:\n{}",
+        stale.join("\n")
+    );
+}
+
+/// The falsification, and it is the hole the task was filed for: a citation
+/// planted in a crate that is not this one is found.
+///
+/// The identifier comes from the corpus rather than from a literal, because a
+/// literal written here would be a citation in this very file and the guard
+/// above would fail on it. That is the same reason the old list was assembled
+/// out of `concat!` fragments, arrived at from the other end.
+#[test]
+fn the_walk_reaches_a_crate_that_is_not_this_one() {
+    let root = workspace_root();
+    let dead = superseded_ids(&root);
+    let planted = dead.first().expect("the corpus has superseded documents");
+
+    let tree = std::env::temp_dir().join(format!("ank-guard-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&tree);
+    for crate_name in ["ank-cli", "ank-other"] {
+        std::fs::create_dir_all(tree.join("crates").join(crate_name).join("src")).unwrap();
+    }
+    std::fs::write(
+        tree.join("crates/ank-cli/src/lib.rs"),
+        "// nothing stale here\n",
+    )
+    .unwrap();
+    std::fs::write(
+        tree.join("crates/ank-other/src/lib.rs"),
+        format!("//! A design justified by {planted}.\n"),
+    )
+    .unwrap();
+
+    let files = workspace_sources(&tree);
+    assert_eq!(files.len(), 2, "{files:?}");
+    let stale = stale_citations(&files, &dead);
+    assert_eq!(stale.len(), 1, "{stale:?}");
+    assert!(
+        stale[0].contains("ank-other") && stale[0].contains(planted),
+        "the finding names the file and the identifier: {}",
+        stale[0]
+    );
+
+    let _ = std::fs::remove_dir_all(&tree);
 }
 
 // ---------------------------------------------------------------------------
@@ -9106,7 +9251,7 @@ fn a_blocker_that_does_not_exist_is_refused_at_creation() {
 }
 
 // ---------------------------------------------------------------------------
-// Color: the guarantee is negative (§4, ADR-962c25797569)
+// Color: the guarantee is negative (§4, ADR-0c8ab846d262)
 // ---------------------------------------------------------------------------
 
 /// Every verb worth styling, exercised against a corpus that actually has
@@ -9155,7 +9300,7 @@ fn color_fixture() -> Repo {
 ///
 /// A spawned process writes to a pipe, so this suite *is* the piped case — the
 /// same shape an agent shelling out to `ank` sees. An escape byte anywhere in
-/// either stream is the defect ADR-962c25797569 forbids, and `--json` is
+/// either stream is the defect ADR-0c8ab846d262 forbids, and `--json` is
 /// checked beside the plain form because it is the one surface that must stay
 /// clean even at a terminal.
 #[test]
@@ -10259,7 +10404,7 @@ fn surface() -> Vec<(String, String, Vec<String>)> {
     for line in listing_body(&text) {
         // The listing is `<usage>` padded, then the description. Its folded
         // continuation lines are indented and open no verb (TASK-fe130d2b732c),
-        // and a group heading opens none either (ADR-f61e2d2c75e8).
+        // and a group heading opens none either (ADR-91b77f036884).
         let Some(rest) = line.strip_prefix("ank ") else {
             continue;
         };
@@ -10315,7 +10460,7 @@ const GLOB_FLAGS: [(&str, &str); 3] = [
 /// a correction of.
 const NOT_A_PATH: [&str; 22] = [
     // Entity ids, both of them: what a document rests on is another entity of
-    // this corpus, never a file (ADR-5a690829388d). The scope is what names
+    // this corpus, never a file (ADR-c88f99e1c16e). The scope is what names
     // paths on a spec, and it is in GLOB_FLAGS.
     "--reference",
     "--drop-reference",
@@ -11543,7 +11688,7 @@ fn the_takeover_warnings_of_log_and_amend_are_on_standard_error() {
 }
 
 // ---------------------------------------------------------------------------
-// A dead scope, and where git says the file went (ADR-97beaf55e73a)
+// A dead scope, and where git says the file went (ADR-3094538d831e)
 // ---------------------------------------------------------------------------
 
 const DEAD_ADR: &str = "ADR-00000000aaaa";
@@ -11603,7 +11748,7 @@ fn proposal(text: &str) -> Option<Vec<String>> {
 /// agreeing with each other, and neither half proves the answer reached
 /// standard output carrying the other.
 ///
-/// **The proposed command is run, not merely matched.** ADR-97beaf55e73a
+/// **The proposed command is run, not merely matched.** ADR-3094538d831e
 /// requires a command that will not refuse on the spot, and the only way to
 /// assert that is to spend it: the text is split back into arguments and handed
 /// to the binary, which must exit 0 and leave the scope alive.
@@ -11648,7 +11793,7 @@ fn a_renamed_file_names_where_it_went_and_the_command_that_repairs_it() {
     );
 
     // Spent rather than read. A command that refuses here is the exact defect
-    // ADR-97beaf55e73a names, and no amount of matching on the string sees it.
+    // ADR-3094538d831e names, and no amount of matching on the string sees it.
     let args: Vec<String> = command
         .split_whitespace()
         .skip(1)
@@ -12109,7 +12254,7 @@ fn a_shallow_clone_cannot_explain_a_dead_scope_and_says_so_instead_of_faulting()
 
 /// No repository, no walk, and no line saying so.
 ///
-/// The cost clause of ADR-97beaf55e73a has a silence clause beside it, and the
+/// The cost clause of ADR-3094538d831e has a silence clause beside it, and the
 /// silence is the part a test has to hold: `check` already says once that the
 /// coordination half was skipped, and a second sentence about a question that
 /// could not be asked is noise in the one output an agent reads whole.

--- a/crates/ank-cli/tests/skill.rs
+++ b/crates/ank-cli/tests/skill.rs
@@ -2,7 +2,7 @@
 //!
 //! `skill/SKILL.md` is not documentation: it is loaded into an agent's context
 //! permanently, on every session, in every repository that installs it. That is
-//! what makes its content the thing actually frozen (ADR-e17e1bbd93ff) -- the
+//! what makes its content the thing actually frozen (ADR-91b77f036884) -- the
 //! dispatch table refuses nobody, and the two modes exist because this file
 //! teaches them and teaches nothing else. Four properties are therefore worth a
 //! test rather than a habit: that it carries the whole loop, that it carries
@@ -53,7 +53,7 @@ fn push_once(verbs: &mut Vec<String>, verb: String) {
 ///
 /// **Read through the binary, and that is the point rather than a detour.** The
 /// specification is no longer a file in `docs/` — it is ten entities of kind
-/// `spec` in `.ank/` (ADR-5a690829388d) — and `.ank/` is reached through the CLI
+/// `spec` in `.ank/` (ADR-c88f99e1c16e) — and `.ank/` is reached through the CLI
 /// and never by opening the files (ADR-01b6dd05f0db). A test that walked the
 /// directory would be the one reader in the repository exempt from the rule the
 /// repository enforces on every agent.
@@ -181,7 +181,7 @@ fn section_4_order() -> Vec<String> {
 }
 
 /// The listing, as the headings `ank help` prints and the verbs under each of
-/// them (ADR-f61e2d2c75e8).
+/// them (ADR-91b77f036884).
 ///
 /// Through the binary, because the ADR is a statement about what the process
 /// prints, not about the table it is derived from. The listing is everything
@@ -275,7 +275,7 @@ fn every_verb_section_4_lists_ships_or_is_declared_unimplemented() {
 }
 
 /// **Grouped by the moment a verb is used, and §4's order inside every group**
-/// (ADR-f61e2d2c75e8, superseding ADR-c656cbcc33a9 on this clause alone). Until
+/// (ADR-91b77f036884). Until
 /// this test the ADR described the output rather than constraining it, and the
 /// two orders agreed only while somebody remembered. Fixing the drift of
 /// TASK-5c868c20472f introduced a fresh one in the same edit -- `attest` placed
@@ -308,25 +308,25 @@ fn help_prints_section_4s_order_inside_every_group() {
     }
 }
 
-/// The loop and what is off it: how work gets done (ADR-e17e1bbd93ff).
+/// The loop and what is off it: how work gets done (ADR-91b77f036884).
 const LOOP_VERBS: [&str; 8] = [
     "context", "claim", "show", "log", "done", "new", "find", "release",
 ];
 
-/// Planning: how the work that gets done comes to exist (ADR-e17e1bbd93ff).
+/// Planning: how the work that gets done comes to exist (ADR-91b77f036884).
 ///
 /// `new adr` is spelled out rather than covered by `new`, because the whole
 /// point of the addition is the path from noticing an architectural problem to
 /// recording one — and `ank new task` alone does not carry it.
 const PLANNING_VERBS: [&str; 5] = ["review", "graph", "check", "amend", "new adr"];
 
-/// Investigation: how an agent arrives informed (ADR-5dd7b4a9c875).
+/// Investigation: how an agent arrives informed (ADR-91b77f036884).
 ///
 /// The two that carry the mode are `scope` and `status`: they answer *what
 /// governs this file* and *where am I*, they were shipped long before this, and
 /// an agent taught only the loop had the question and not the verb. `find
 /// --type spec` is the third, and it is what the corpus gained when the
-/// specification became entities of it (ADR-5a690829388d) — the normative
+/// specification became entities of it (ADR-c88f99e1c16e) — the normative
 /// answer reachable from inside the tool.
 ///
 /// `log` is deliberately absent from this list although the mode teaches its
@@ -347,7 +347,7 @@ fn the_skill_carries_the_whole_loop() {
     }
 }
 
-/// The half ADR-e17e1bbd93ff added. An agent taught only the loop can execute
+/// The half ADR-91b77f036884 added. An agent taught only the loop can execute
 /// work and cannot propose a decision, correct a graph, or notice the corpus
 /// has gone incoherent -- which is the gap that ADR names and this asserts is
 /// closed.
@@ -371,7 +371,7 @@ fn the_skill_carries_the_planning_mode() {
     }
 }
 
-/// The third mode ADR-5dd7b4a9c875 added, asserted on the same terms as the
+/// The third mode ADR-91b77f036884 added, asserted on the same terms as the
 /// other two: the verb is named, because an agent only knows the verbs this
 /// file names.
 #[test]
@@ -387,7 +387,7 @@ fn the_skill_carries_the_investigation_mode() {
 }
 
 /// **The read form of `log` is taught, and it is the half that is easy to lose**
-/// (ADR-5dd7b4a9c875).
+/// (ADR-91b77f036884).
 ///
 /// `ank log "<message>"` writes and renews the claim; `ank log <id>` reads, needs
 /// no claim, and is where the previous holder said why they handed the task
@@ -405,7 +405,7 @@ fn the_skill_teaches_the_read_form_of_log() {
     );
 }
 
-/// **The file says why before it says how** (ADR-5dd7b4a9c875).
+/// **The file says why before it says how** (ADR-91b77f036884).
 ///
 /// Asserted by the two things the argument has to establish rather than by any
 /// phrasing, on the standard the accept and styling tests already set: a test
@@ -419,12 +419,12 @@ fn the_skill_says_what_the_rules_protect() {
         assert!(
             text.contains(token),
             "SKILL.md does not say {token:?}: it teaches the verbs without the \
-             model behind them, which is the gap ADR-5dd7b4a9c875 closed"
+             model behind them, which is the gap ADR-91b77f036884 closed"
         );
     }
 }
 
-/// **`accept` is described and never invited** (ADR-e17e1bbd93ff).
+/// **`accept` is described and never invited** (ADR-91b77f036884).
 ///
 /// The two halves are one rule and neither works alone. The skill must say what
 /// `accept` is, so a planning agent knows where its own authority ends rather
@@ -455,8 +455,8 @@ fn the_skill_describes_accept_without_inviting_it() {
 /// loaded on demand. The number is a ceiling to notice drift, not a target to
 /// fill.
 ///
-/// It moved from 80/700 to 140/1200 with ADR-e17e1bbd93ff and to 180/1500 with
-/// ADR-5dd7b4a9c875, and each time because a decision said so — which is the
+/// It moved from 80/700 to 140/1200 with ADR-91b77f036884 and to 180/1500 with
+/// ADR-91b77f036884, and each time because a decision said so — which is the
 /// only way it is allowed to move. A ceiling raised to accommodate whatever was
 /// just written is not a ceiling.
 ///
@@ -479,16 +479,16 @@ fn the_skill_stays_within_one_page() {
 }
 
 /// These verbs run for whoever types them -- nothing here is refused to an
-/// agent (ADR-e17e1bbd93ff). What this asserts is narrower and is the whole of
+/// agent (ADR-91b77f036884). What this asserts is narrower and is the whole of
 /// the freeze: SKILL.md does not *teach* them. Naming one as a thing to run
 /// would grow what every session pays for, by habit rather than by decision,
 /// which is how a permanently loaded file actually grows.
 ///
 /// The list shrinks only by decision, and it has three times. `show` left it
 /// when it moved into the loop, back when the loop was still called a surface;
-/// `review`, `check` and `amend` left it with ADR-e17e1bbd93ff, which bought
+/// `review`, `check` and `amend` left it with ADR-91b77f036884, which bought
 /// planning with a raised ceiling and said so; `status` and `scope` left it
-/// with ADR-5dd7b4a9c875, which bought investigation the same way. `accept` is
+/// with ADR-91b77f036884, which bought investigation the same way. `accept` is
 /// the interesting survivor: the skill now *describes* it, and still must not
 /// show the command, so it stays here while
 /// `the_skill_describes_accept_without_inviting_it` holds the other half.
@@ -551,7 +551,7 @@ fn the_skill_states_that_what_an_agent_reads_is_never_styled() {
 /// (TASK-a548c95261a5).
 ///
 /// Not a superseding ADR, and the reason is measured rather than assumed. What
-/// ADR-e17e1bbd93ff freezes is which *verbs* the file teaches, which
+/// ADR-91b77f036884 freezes is which *verbs* the file teaches, which
 /// `the_skill_teaches_nothing_beyond_what_is_frozen` enforces, plus the ceiling
 /// below. This adds neither a verb nor a flag: it is a fact about the
 /// arrangement an agent is already working inside, the same register as "the
@@ -670,7 +670,7 @@ fn declared_revision(front: &str) -> Option<String> {
 /// It sits in `metadata`, which the Agent Skills standard defines as an
 /// arbitrary map for properties the standard does not itself define, so it is
 /// metadata about the file and not part of what the file teaches. That is the
-/// whole of the freeze (ADR-c656cbcc33a9), and the three assertions above are
+/// whole of the freeze (ADR-91b77f036884), and the three assertions above are
 /// the enforcement -- none of them moves because of a fingerprint.
 #[test]
 fn the_skill_says_which_revision_it_is() {

--- a/crates/ank-contract/src/verbs.rs
+++ b/crates/ank-contract/src/verbs.rs
@@ -328,7 +328,7 @@ const fn refuses(code: ExitCode, when: &'static str) -> Refusal {
 /// The refusal every path-taking verb performs, declared once and named six
 /// times.
 ///
-/// SPEC-f353359663d5 states it for all of them at once — a path naming nothing
+/// SPEC-c937ff8fa70a states it for all of them at once — a path naming nothing
 /// inside the repository, because it is absolute or because it climbs above the
 /// root, is refused with the command to run next and never answered — and the
 /// six verbs reach it through one helper, `context::normalised`. One sentence
@@ -354,7 +354,7 @@ pub const GLOBAL_FLAGS: &[FlagSpec] = &[
     flag("--worktree"),
 ];
 
-/// The short forms of §4 (ADR-962c25797569), and the whole of them.
+/// The short forms of §4 (ADR-0c8ab846d262), and the whole of them.
 ///
 /// One table rather than a letter beside each declaration: `--scope` and
 /// `--criteria` are declared in three [`CommandSpec`]s each, and three
@@ -402,7 +402,7 @@ pub fn long_of(c: char) -> Option<&'static str> {
 pub struct CommandSpec {
     pub name: &'static str,
     /// **When** the verb is reached for, which is the heading `ank help` prints
-    /// it under (ADR-f61e2d2c75e8). One of [`GROUPS`], and never a claim about
+    /// it under (ADR-91b77f036884). One of [`GROUPS`], and never a claim about
     /// who may run it: `check` sits under keeping the corpus honest whether a
     /// human or an agent types it, and the refusal machinery consults no caller.
     ///
@@ -482,10 +482,10 @@ pub struct CommandSpec {
 }
 
 /// The moments a verb is reached for, in the order `ank help` prints them
-/// (ADR-f61e2d2c75e8).
+/// (ADR-91b77f036884).
 ///
 /// A group says **when** a verb is used and never **who** may use it. The
-/// layering ADR-c656cbcc33a9 removed was the residue of an agent surface and a
+/// layering ADR-91b77f036884 removed was the residue of an agent surface and a
 /// human surface — headings that told a caller which verbs were theirs, behind
 /// a wall built from `$ANK_AGENT`, which the caller sets itself. Nothing here
 /// reopens that: the distinction is the one between a map and a gate.
@@ -506,7 +506,7 @@ pub const GROUPS: &[&str] = &[
 /// **The order is the specification's, and it is load-bearing**: §4 puts the
 /// loop first — `context claim show log done`, then `release new find` — and
 /// the rest after it. `help` groups this table by [`GROUPS`] and keeps this
-/// order inside each group (ADR-f61e2d2c75e8): the grouping is a second axis
+/// order inside each group (ADR-91b77f036884): the grouping is a second axis
 /// laid over §4's order, not a re-sort, so a verb never moves relative to its
 /// neighbours and sorting this list would still erase what §4 says.
 pub const COMMANDS: &[CommandSpec] = &[

--- a/crates/ank-core/src/model.rs
+++ b/crates/ank-core/src/model.rs
@@ -326,7 +326,7 @@ pub struct Task {
     /// `None` means the entity predates the field, never that nobody wrote it:
     /// schema 1 had no such thing, and the author of a file that already exists
     /// cannot be recovered — `git log` would say who committed it, and
-    /// ADR-b8884edcebe3 forbids porcelain. The signals that need it skip those
+    /// ADR-9307e5d214a7 forbids porcelain. The signals that need it skip those
     /// entities and `check` says so once for the corpus.
     pub author: Option<String>,
     pub status: TaskStatus,
@@ -416,7 +416,7 @@ pub struct Spec {
     pub author: Option<String>,
     pub status: SpecStatus,
     pub scope: Vec<String>,
-    /// The documents and decisions this one rests on (§3, ADR-5a690829388d).
+    /// The documents and decisions this one rests on (§3, ADR-c88f99e1c16e).
     ///
     /// A declared field and never a sentence: a specification cut into documents
     /// drifts unless the coherence between them is verified, and verifying it

--- a/crates/ank-core/tests/golden.rs
+++ b/crates/ank-core/tests/golden.rs
@@ -308,7 +308,7 @@ fn a_spec_carries_a_lifecycle_and_declares_no_constraint() {
 }
 
 /// A spec declares what it rests on in a field, and the format does no more
-/// than read it (§3, ADR-5a690829388d).
+/// than read it (§3, ADR-c88f99e1c16e).
 ///
 /// The two halves are one decision. A citation has to be a field or the
 /// coherence between documents cannot be verified at all; and it has to stay a

--- a/crates/ank-mcp/src/main.rs
+++ b/crates/ank-mcp/src/main.rs
@@ -1,9 +1,9 @@
 //! The Ank protocol surface: every verb, over MCP, generated from one table.
 //!
 //! ADR-372b82af1ec7 permits this and permits nothing else: a full-surface
-//! passthrough or no surface at all. It supersedes ADR-1713af205186, whose
-//! refusal is kept whole as the shape of what is now allowed. The proposal that
-//! ADR rejected exposed four verbs out of twenty-two, which rebuilt under a
+//! passthrough or no surface at all. It supersedes an earlier refusal, kept
+//! whole as the shape of what is now allowed. The proposal that refusal rejected
+//! exposed four verbs out of twenty-two, which rebuilt under a
 //! second protocol the agent-surface split that had been abolished once already,
 //! and rebuilt the worse half of it: a caller reached through the protocol could
 //! not amend, could not propose an ADR, could not check the corpus.

--- a/crates/ank-mcp/src/tools.rs
+++ b/crates/ank-mcp/src/tools.rs
@@ -3,8 +3,8 @@
 //! **Nothing here names a verb.** The list is [`COMMANDS`] walked, so a verb the
 //! table gains reaches this surface with no edit in this crate, and a verb it
 //! does not carry is a verb this surface does not have. That is the condition
-//! ADR-1713af205186 wrote for itself and ADR-372b82af1ec7 answered: not a
-//! curated subset, not parity kept by review, generated.
+//! ADR-372b82af1ec7 answered, on terms the refusal it replaced had written for
+//! itself: not a curated subset, not parity kept by review, generated.
 //!
 //! What a tool advertises is what the table already knows: the summary as the
 //! description, the positionals and flags as the input schema, the refusals with


### PR DESCRIPTION
Closes TASK-7a1c92961465.

Three holes, each enough on its own. The walk was `ank-cli`'s `src` and
`tests`, so `ank-contract`, `ank-core` and `ank-mcp` were never read.
The dead set was three identifiers transcribed by whoever last
remembered, so superseding an entity protected nothing new. And it said
`adr` and meant it, while specs supersede here too.

The set is now asked of the corpus through the binary — `find --status
superseded --json`, both kinds, with `shown` compared against `total` so
a listing the budget cut is not read as a shorter corpus. The walk
covers every crate, derived from the workspace root, so a crate added
later is covered without anyone editing anything.

## The repair behind the guard

Turning it on found **106 citations of 35 superseded documents across 18
files and all four crates**. They are re-pointed to the document at the
end of each chain.

Nine needed a judgement rather than a substitution, and all nine are
sentences about the supersession itself: `(ADR-f61e2d2c75e8, superseding
ADR-c656cbcc33a9)` re-pointed mechanically would have read as one
decision superseding itself. Those now name the live decision alone.

This is not a ban on writing history down. It is a ban on writing it in
the source, because `.ank/` is where the corpus keeps it and `ank show
<successor>` carries `supersedes:`.

## Falsified twice

Once on a temporary tree holding a crate that is not `ank-cli` — the
hole the task was filed for. Once on the real workspace, by planting an
identifier in `ank-core` and watching the guard go red on a crate it had
never opened before.

The planted identifier comes from the corpus and never from a literal: a
literal written into that file would be a citation in it, and the guard
would fail on itself.

Suite green, `cargo fmt --check` clean, `ank check` exit 0 with no
fault.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X5PCmpdS4j9itcqRKvrowX
