### PR TITLE
File the TTL renewal flake as a task

### DIFF
--- a/.ank/entities/TASK-53ed7978621b.md
+++ b/.ank/entities/TASK-53ed7978621b.md
@@ -1,0 +1,43 @@
+---
+id: TASK-53ed7978621b
+type: task
+slug: the-ttl-renewal-test-decides-on-a-wall-clock-and
+title: The TTL renewal test decides on a wall clock, and a loaded runner loses
+created: 2026-08-22T17:37:14Z
+author: claude-code/opus-5
+status: open
+scope:
+  - crates/ank-cli/src/commands.rs
+  - crates/ank-cli/src/claim.rs
+blocked_by: []
+done_criteria: |
+  The assertion that a renewal recomputes from the granted lease no longer depends on how long the process took: it compares recorded values, so the test gives the same verdict on an idle laptop and on a runner under load, and no tolerance is widened to buy that. The property under test is unchanged and a falsification says so: a renewal made to fall back to the default lease fails the test. cargo test is green on all three operating systems, cargo fmt --check passes, and ank check reports no fault.
+criteria_by: creator
+schema: 4
+version: 1
+---
+
+Measured on 2026-08-22, on the Windows runner of the pull request that closed
+TASK-7a1c92961465. The job went red on a test whose subject the change never
+touched, a rerun of the same commit went green, and nothing else in the suite
+moved.
+
+The assertion reads the expiry the renewal wrote, subtracts the clock as it
+stands at the moment of reading, and requires the difference to sit within two
+seconds of the granted lease. Everything between the write and the read is
+inside that budget: the rest of the verb, the process, and whatever else the
+runner is doing. Two seconds is a wide margin on an idle laptop and a narrow one
+on a loaded runner building four crates.
+
+**The doc comment on the test already names the defect it is repeating.** It
+records that the previous assertion, `after > before`, passed for the wrong
+reason and would have been deciding on clock granularity. The replacement
+decides on it too; it only moved the threshold.
+
+**What must not be built here is a wider window.** A tolerance raised until the
+runner stops losing is a test that has stopped asserting the thing and started
+asserting that the machine is fast enough. What the test is about is that the
+renewal recomputes from the lease the claim was granted rather than from the
+default, and that is a property of two recorded values, not of the wall clock:
+the claim record carries the granted TTL, and the expiry the renewal writes is
+derivable from it and from the instant of the write.


### PR DESCRIPTION
A record, not a fix. TASK-53ed7978621b.

Measured on the Windows runner of #230: the job went red on
`log_renews_the_ttl_because_working_is_what_keeps_the_lock`, whose
subject that change never touched — the only edits to `commands.rs` in
it were comments. A rerun of the same commit went green and nothing else
in the suite moved.

The assertion reads the expiry the renewal wrote, subtracts the clock as
it stands at the moment of reading, and requires the difference to sit
within two seconds of the granted lease. Everything between the write
and the read is inside that budget: the rest of the verb, the process,
and whatever else the runner is doing.

The test's own doc comment records that the assertion it replaced,
`after > before`, passed for the wrong reason and would have been
deciding on clock granularity. The replacement decides on it too; it
only moved the threshold. The task says outright that widening the
window again is not the repair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X5PCmpdS4j9itcqRKvrowX
