### PR TITLE
The stale-binary hint names a road that resolves the state it describes

### DIFF
--- a/.ank/entities/LOG-2d0e6d83b09c.md
+++ b/.ank/entities/LOG-2d0e6d83b09c.md
@@ -1,0 +1,17 @@
+---
+id: LOG-2d0e6d83b09c
+type: log
+title: done, proof commit:4bc38aa
+created: 2026-08-22T18:13:15Z
+author: claude-code/opus-5
+scope:
+  - crates/ank-cli/src/repo.rs
+  - crates/ank-cli/tests/cli.rs
+  - crates/ank-cli/build.rs
+  - crates/ank-cli/src/cli.rs
+  - docs/getting-started.md
+about: TASK-7a2c9d1b13a0
+seq: 2
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-5361a4bdc140.md
+++ b/.ank/entities/LOG-5361a4bdc140.md
@@ -1,0 +1,19 @@
+---
+id: LOG-5361a4bdc140
+type: log
+title: "The knowable fact is the schema the newest tag carries, and build.rs derives it: for-each-ref for"
+created: 2026-08-22T18:12:49Z
+author: claude-code/opus-5
+scope:
+  - crates/ank-cli/src/repo.rs
+  - crates/ank-cli/tests/cli.rs
+  - crates/ank-cli/build.rs
+  - crates/ank-cli/src/cli.rs
+  - docs/getting-started.md
+about: TASK-7a2c9d1b13a0
+seq: 1
+schema: 4
+version: 1
+---
+
+ the tag, cat-file blob for that tag's model.rs, parse SCHEMA_VERSION. Never a constant in the source, because a number bumped by hand at the tag is exactly the defect this repairs, one level down. Empty degrades to the safe road rather than to a claim: a tarball, a clone fetched without tags, a spelling the parser does not know, all answer nothing known, and the wording says no release is known rather than no release exists. One clause of the criterion needed a reading. Driving the binary through both cases in one test is not reachable: the discriminator is compiled in, and a binary built from this tree can never have a release ahead of it. So both wordings are pinned where they live, in repo.rs, and the binary-driven test asserts exactly one road is named, the right sentence for whichever it is, and ank --version in both -- which is case-agnostic rather than pinned to today. Verified end to end anyway by forcing the stamp to 5 and watching the install road appear, then restoring.

--- a/.ank/entities/LOG-abbc20245c62.md
+++ b/.ank/entities/LOG-abbc20245c62.md
@@ -1,0 +1,20 @@
+---
+id: LOG-abbc20245c62
+type: log
+title: +scope crates/ank-cli/build.rs, +scope crates/ank-cli/src/cli.rs, +scope docs/getting-started.md
+created: 2026-08-22T18:12:46Z
+author: claude-code/opus-5
+scope:
+  - crates/ank-cli/src/repo.rs
+  - crates/ank-cli/tests/cli.rs
+  - crates/ank-cli/build.rs
+  - crates/ank-cli/src/cli.rs
+  - docs/getting-started.md
+about: TASK-7a2c9d1b13a0
+seq: 0
+records: edit
+schema: 4
+version: 1
+---
+
+ (version 2 to 3, replaced f3e1afc6d1f3)

--- a/.ank/entities/TASK-7a2c9d1b13a0.md
+++ b/.ank/entities/TASK-7a2c9d1b13a0.md
@@ -5,7 +5,7 @@ slug: the-stale-binary-hint-names-an-install-that-rein
 title: The stale-binary hint names an install that reinstalls the same build
 created: 2026-08-21T23:59:29Z
 author: claude-code/opus-5
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/src/repo.rs
   - crates/ank-cli/tests/cli.rs
@@ -16,8 +16,13 @@ blocked_by: []
 done_criteria: |
   The next step a corpus-ahead-of-binary warning names is one that resolves the state it describes, and where no released version carries the schema found, it does not send the reader to reinstall the version they already have. The message distinguishes the two cases it can be in and says which: a release exists that reads the corpus, and the install command is the answer; or none does, and the answer is to build from the tree or wait for a release, said in those words. A test drives the binary on a corpus one schema ahead and asserts the sentence against both cases rather than against whichever holds today. cargo test is green, cargo fmt --check passes, and ank check reports no fault.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 4bc38aa
+    criteria: 694ac130937d
+    via: submitted
 schema: 4
-version: 3
+version: 4
 ---
 
 Found in use, not by reading. `ank show` on this corpus printed:

--- a/.ank/entities/TASK-7a2c9d1b13a0.md
+++ b/.ank/entities/TASK-7a2c9d1b13a0.md
@@ -5,16 +5,19 @@ slug: the-stale-binary-hint-names-an-install-that-rein
 title: The stale-binary hint names an install that reinstalls the same build
 created: 2026-08-21T23:59:29Z
 author: claude-code/opus-5
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/src/repo.rs
   - crates/ank-cli/tests/cli.rs
+  - crates/ank-cli/build.rs
+  - crates/ank-cli/src/cli.rs
+  - docs/getting-started.md
 blocked_by: []
 done_criteria: |
   The next step a corpus-ahead-of-binary warning names is one that resolves the state it describes, and where no released version carries the schema found, it does not send the reader to reinstall the version they already have. The message distinguishes the two cases it can be in and says which: a release exists that reads the corpus, and the install command is the answer; or none does, and the answer is to build from the tree or wait for a release, said in those words. A test drives the binary on a corpus one schema ahead and asserts the sentence against both cases rather than against whichever holds today. cargo test is green, cargo fmt --check passes, and ank check reports no fault.
 criteria_by: creator
 schema: 4
-version: 1
+version: 3
 ---
 
 Found in use, not by reading. `ank show` on this corpus printed:

--- a/crates/ank-cli/build.rs
+++ b/crates/ank-cli/build.rs
@@ -37,10 +37,18 @@ use std::process::Command;
 /// The skill whose revision is stamped in, relative to this package.
 const SKILL: &str = "../../skill/SKILL.md";
 
+/// Where `SCHEMA_VERSION` is declared, as git addresses it: repository-relative,
+/// which is what `cat-file` takes whatever directory the build runs in.
+const MODEL: &str = "crates/ank-core/src/model.rs";
+
 fn main() {
     let dir = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".into());
     println!("cargo:rustc-env=ANK_COMMIT={}", commit(&dir));
     println!("cargo:rustc-env=ANK_SKILL={}", skill_revision(&dir));
+    println!(
+        "cargo:rustc-env=ANK_RELEASED_SCHEMA={}",
+        released_schema(&dir)
+    );
     if PathBuf::from(&dir).join(SKILL).is_file() {
         println!("cargo:rerun-if-changed={SKILL}");
     }
@@ -103,6 +111,49 @@ fn skill_revision(dir: &str) -> String {
         .find("\n---\n")
         .unwrap_or_else(|| panic!("{}: frontmatter must be closed", path.display()));
     ank_core::freeze_hash_short(&rest[end + "\n---\n".len()..])
+}
+
+/// The entity schema the newest release reads, or empty where there is nothing
+/// to ask (TASK-7a2c9d1b13a0).
+///
+/// **Derived and never typed**, which is the whole of why it is here rather
+/// than a constant in the source. A number kept by hand is true only while
+/// somebody remembers to bump it at the tag, and the message it feeds would
+/// then be confident and wrong — which is the defect this value exists to
+/// repair, reproduced one level down.
+///
+/// The newest tag by version order, and `SCHEMA_VERSION` as that tag's tree
+/// declares it. Both reads are plumbing: `for-each-ref` takes the format it
+/// prints, and `cat-file blob` hands back a file.
+///
+/// **Empty degrades to the safe road.** A tarball, a clone fetched without
+/// tags, a spelling of the constant this parser does not know: each answers
+/// empty, and the reader is then told to build from the tree rather than told
+/// something unverified about a release. Silence about a release is a worse
+/// answer than none only when it sends somebody in a circle, and this one does
+/// not.
+fn released_schema(dir: &str) -> String {
+    let Some(tag) = git(
+        dir,
+        &[
+            "for-each-ref",
+            "--sort=-v:refname",
+            "--count=1",
+            "--format=%(refname:short)",
+            "refs/tags/v*",
+        ],
+    ) else {
+        return String::new();
+    };
+    let Some(source) = git(dir, &["cat-file", "blob", &format!("{tag}:{MODEL}")]) else {
+        return String::new();
+    };
+    source
+        .lines()
+        .find_map(|line| line.trim().strip_prefix("pub const SCHEMA_VERSION: u32 = "))
+        .and_then(|value| value.trim().trim_end_matches(';').parse::<u32>().ok())
+        .map(|schema| schema.to_string())
+        .unwrap_or_default()
 }
 
 /// The files whose change can change the answer, and no others.

--- a/crates/ank-cli/src/cli.rs
+++ b/crates/ank-cli/src/cli.rs
@@ -881,7 +881,7 @@ fn warn_if_schema_ahead(inv: &Invocation, repo: &crate::repo::Repo) {
         return;
     };
     let style = inv.style().on_stderr();
-    let (what, next) = ahead.lines();
+    let (what, next) = ahead.lines(crate::repo::released_schema());
     eprintln!("{} {what}", style.yellow("warning:"));
     eprintln!("  -> {next}");
 }

--- a/crates/ank-cli/src/repo.rs
+++ b/crates/ank-cli/src/repo.rs
@@ -342,26 +342,70 @@ pub struct SchemaAhead {
     pub entities: usize,
 }
 
+/// The entity schema a published release reads, as it stood when this build was
+/// made, or `None` where the build had no tag to ask (TASK-7a2c9d1b13a0).
+///
+/// Stamped by the build script from the newest tag's own source, so nothing here
+/// is remembered and nothing is guessed. `None` is *not known*, never *does not
+/// exist*, and the wording below keeps that difference.
+pub fn released_schema() -> Option<u32> {
+    option_env!("ANK_RELEASED_SCHEMA")
+        .filter(|value| !value.is_empty())
+        .and_then(|value| value.parse().ok())
+}
+
 impl SchemaAhead {
     /// The two lines the caller prints, warning first, next step second.
     ///
     /// Built here rather than at the printing site so that the wording is
     /// asserted where the numbers are, and so that a second caller cannot
     /// phrase the same fact differently.
-    pub fn lines(&self) -> (String, String) {
+    ///
+    /// **The next step has to resolve the state the first line describes**, and
+    /// the one it used to name did not. Measured in use: a corpus at schema 4
+    /// against a binary reading 3, and the install it named would have fetched
+    /// the very build that had just refused — schema 4 had landed on the default
+    /// branch after the tag, so no published version read that corpus at all,
+    /// and the two copies even printed the same version string. §4 asks for the
+    /// command to run next; naming one that returns the caller where they were
+    /// is worse than naming none, because the remedy visibly does nothing and
+    /// the reader concludes the tool is broken rather than that their copy is
+    /// old (TASK-7a2c9d1b13a0).
+    ///
+    /// So there are two roads and the build knows which one it can name.
+    /// `released` is what a published version reads, derived at build time from
+    /// the newest tag: at or above what the corpus declares, reinstalling is the
+    /// answer; anything else — including not knowing — and the answer is the
+    /// tree or a wait, which is always true and never circular.
+    ///
+    /// What both keep is `ank --version`. Naming the build with its commit is
+    /// what let two copies claiming the same version be told apart at all, and
+    /// the count of entities left out is what makes the warning actionable
+    /// rather than vague.
+    pub fn lines(&self, released: Option<u32>) -> (String, String) {
         let entities = if self.entities == 1 {
             "1 entity".to_string()
         } else {
             format!("{} entities", self.entities)
+        };
+        let next = match released {
+            Some(released) if released >= self.found => {
+                "the binary is older than the corpus: ank --version names the build, \
+                 npm install -g @haksolot/ank replaces it"
+                    .to_string()
+            }
+            _ => format!(
+                "no release is known to read schema {}: ank --version names the build, \
+                 build from the tree or wait for a release",
+                self.found
+            ),
         };
         (
             format!(
                 "corpus at schema {}, this binary reads {}: {entities} left out of every listing",
                 self.found, self.supported
             ),
-            "the binary is older than the corpus: ank --version names the build, \
-             npm install -g @haksolot/ank replaces it"
-                .to_string(),
+            next,
         )
     }
 }
@@ -628,14 +672,20 @@ mod tests {
         assert_eq!(schema_ahead(&Repo::at(t.0.clone())), None);
     }
 
-    #[test]
-    fn the_message_counts_in_words_the_reader_can_check() {
-        let one = SchemaAhead {
+    /// One `SchemaAhead` for the wording tests: a corpus at 4 against a build
+    /// that reads 3, which is the state measured in use.
+    fn ahead() -> SchemaAhead {
+        SchemaAhead {
             found: 4,
             supported: 3,
             entities: 1,
-        };
-        let (what, next) = one.lines();
+        }
+    }
+
+    #[test]
+    fn the_message_counts_in_words_the_reader_can_check() {
+        let one = ahead();
+        let (what, next) = one.lines(None);
         assert!(
             what.contains("schema 4") && what.contains("reads 3"),
             "{what}"
@@ -645,9 +695,59 @@ mod tests {
 
         let many = SchemaAhead { entities: 2, ..one };
         assert!(
-            many.lines().0.contains("2 entities left"),
+            many.lines(None).0.contains("2 entities left"),
             "{}",
-            many.lines().0
+            many.lines(None).0
         );
+    }
+
+    /// A release reads the corpus, so reinstalling is the answer and the message
+    /// says so (TASK-7a2c9d1b13a0).
+    #[test]
+    fn a_release_that_reads_the_corpus_is_the_install_command() {
+        let (_, next) = ahead().lines(Some(4));
+        assert!(
+            next.contains("npm install -g @haksolot/ank"),
+            "the road that resolves it is named: {next}"
+        );
+        assert!(!next.contains("build from the tree"), "{next}");
+
+        // Above the corpus is the same case: a release that reads 5 reads 4.
+        let (_, next) = ahead().lines(Some(5));
+        assert!(next.contains("npm install -g @haksolot/ank"), "{next}");
+    }
+
+    /// No release reads it, so the install is the one command that must not be
+    /// named: it fetches the build that has just refused, and a reader who
+    /// follows it concludes the tool is broken rather than that their copy is
+    /// old.
+    #[test]
+    fn no_release_that_reads_the_corpus_names_the_tree_and_never_the_install() {
+        for released in [None, Some(0), Some(3)] {
+            let (_, next) = ahead().lines(released);
+            assert!(
+                !next.contains("npm install"),
+                "{released:?} sent the reader to reinstall the build that refused: {next}"
+            );
+            assert!(
+                next.contains("build from the tree or wait for a release"),
+                "{released:?}: {next}"
+            );
+            assert!(
+                next.contains("no release is known to read schema 4"),
+                "{next}"
+            );
+            assert!(next.contains("ank --version"), "{next}");
+        }
+    }
+
+    /// **Not known is not the same as does not exist**, and the wording carries
+    /// the difference: a build with no tag to ask says what it knows and names
+    /// the road that works either way.
+    #[test]
+    fn an_unknown_release_schema_claims_nothing_about_a_release() {
+        let (_, next) = ahead().lines(None);
+        assert!(next.contains("no release is known"), "{next}");
+        assert!(!next.contains("no release exists"), "{next}");
     }
 }

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -11255,10 +11255,31 @@ fn a_corpus_one_schema_ahead_is_named_by_every_verb_that_reads_it() {
         );
         // And what to do, which is not a migration: the corpus is fine and the
         // binary is old.
+        //
+        // **Asserted against whichever case holds, never against today's**
+        // (TASK-7a2c9d1b13a0). There are two roads and the build knows which one
+        // it can name: a release that reads the corpus makes the install the
+        // answer, and anything else makes it the tree or a wait. Pinning one of
+        // them here would pin the tag history of whoever runs the suite, and
+        // pinning neither is what let the wrong one ship. So: exactly one road,
+        // the right sentence for it, and the half that works in both.
         assert!(
-            err.contains("ank --version") && err.contains("npm install -g @haksolot/ank"),
-            "{args:?} left the reader with no next step: {err}"
+            err.contains("ank --version"),
+            "{args:?} stopped naming the build, which is what tells two copies \
+             claiming one version apart: {err}"
         );
+        let install = err.contains("npm install -g @haksolot/ank");
+        let tree = err.contains("build from the tree or wait for a release");
+        assert!(
+            install ^ tree,
+            "{args:?} named both roads or neither: {err}"
+        );
+        if tree {
+            assert!(
+                err.contains(&format!("no release is known to read schema {ahead}")),
+                "{args:?} sent the reader to the tree without saying why: {err}"
+            );
+        }
     }
 
     // The half that makes the warning necessary. `find` answers, exits zero,
@@ -11345,7 +11366,11 @@ fn the_guide_carries_the_warning_the_binary_prints_about_a_newer_corpus() {
     let err = erred(&r.ank("claude-code@ank", &["find"]));
     let warned: Vec<&str> = err
         .lines()
-        .filter(|l| l.contains("warning:") || l.trim_start().starts_with("-> the binary"))
+        // The next step is one of two sentences since TASK-7a2c9d1b13a0, and
+        // which one a build names depends on its tags. Matching the arrow rather
+        // than either opening is what keeps this test asserting that the guide
+        // carries what the binary said, whichever that was.
+        .filter(|l| l.contains("warning:") || l.trim_start().starts_with("->"))
         .collect();
     assert_eq!(warned.len(), 2, "the warning is two lines: {err}");
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -69,6 +69,21 @@ first:
 
 It warns and still answers, because the entities this build does understand are worth
 having, and a corpus mid-migration is a real state rather than a broken one.
+
+**The second line is one of two, and which one depends on whether a release can
+help.** The schema a published version reads is stamped into the binary at build
+time, from the newest tag's own source, so the message names the road that
+actually resolves the state rather than the one that sounds like it does. Where
+no release reads the corpus -- a schema that landed on the default branch after
+the last tag, which is the ordinary case for a contributor -- it says so and
+sends you to the tree instead:
+
+      -> no release is known to read schema 4: ank --version names the build, build from the tree or wait for a release
+
+Naming the install there would fetch the build that had just refused, and a
+reader who follows advice that visibly does nothing concludes the tool is broken
+rather than that their copy is old.
+
 The other half, an old binary reading an old corpus, is not detectable: nothing
 in the files says a newer format exists. That one is `--version` and the
 paragraphs above.


### PR DESCRIPTION
Closes TASK-7a2c9d1b13a0.

Measured in use: a corpus at schema 4 against a binary reading 3, and
the install the message named would have fetched the very build that had
just refused. Schema 4 landed on the default branch after the tag, so no
published version read that corpus at all — and the two copies even
printed the same version string, `0.5.0 (7bc34f8)` against `0.5.0
(52c59da)`.

§4 asks for the command to run next. Naming one that returns the caller
where they were is worse than naming none: the remedy visibly does
nothing, so the reader concludes the tool is broken rather than that
their copy is old.

## What it knows now

Two roads, and the build knows which one it can name. The schema a
published version reads is derived at build time from the newest tag's
own source — `for-each-ref` for the tag, `cat-file blob` for that tag's
`model.rs`, `SCHEMA_VERSION` parsed out of it.

    corpus at schema 5, this binary reads 4: 1 entity left out of every listing
      -> no release is known to read schema 5: ank --version names the build, build from the tree or wait for a release

**Derived and never typed.** A constant bumped by hand at the tag is the
same defect one level down: confident, and wrong the first time somebody
forgets.

**Empty degrades to the safe road, not to a claim.** A tarball, a clone
fetched without tags, a spelling this parser does not know: each answers
nothing known, and the wording keeps the difference — `no release is
known to read schema N`, never `no release exists`.

Both roads keep `ank --version`, which is what let two copies claiming
one version be told apart at all.

## On testing both cases

The discriminator is compiled in, and a binary built from this tree can
never have a release ahead of it — so one test driving the binary
through both cases is not reachable. Both wordings are pinned where they
live, in `repo.rs`; the binary-driven test asserts exactly one road is
named, the right sentence for whichever it is, and `ank --version` in
both. That is case-agnostic rather than pinned to today, which is what
the criterion asks for.

Verified end to end anyway: forcing the stamp to 5 makes the install
road appear, and restoring it brings the tree road back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X5PCmpdS4j9itcqRKvrowX
