### PR TITLE
check hashes the working copy in one git call instead of seven

### DIFF
--- a/.ank/entities/LOG-291f61981143.md
+++ b/.ank/entities/LOG-291f61981143.md
@@ -1,0 +1,17 @@
+---
+id: LOG-291f61981143
+type: log
+title: "correction: the closure entry on TASK-da7738572825 points at TASK-eb2c8b0bee45, which does not"
+created: 2026-08-22T19:02:12Z
+author: claude-code/opus-5
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/src/git.rs
+  - crates/ank-cli/tests/cli.rs
+about: TASK-2e2bac895056
+seq: 0
+schema: 4
+version: 1
+---
+
+ exist. I wrote the identifier before creating the task, and no verb resolves an id inside a message, so nothing refused it. The replacement it means is this task. Recorded here rather than there because log refuses a closed task: a closure is settled and its entries cannot be added to, so a mistake in a closure reason has no route back through the CLI.

--- a/.ank/entities/LOG-7bd5bc891e0a.md
+++ b/.ank/entities/LOG-7bd5bc891e0a.md
@@ -1,0 +1,17 @@
+---
+id: LOG-7bd5bc891e0a
+type: log
+title: The phase profile the previous holder asked for, measured on 2026-08-22 on this corpus, release
+created: 2026-08-22T19:00:37Z
+author: claude-code/opus-5
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/src/index.rs
+  - crates/ank-cli/tests/**
+about: TASK-da7738572825
+seq: 2
+schema: 4
+version: 1
+---
+
+ build, warm. Total 1216 ms. By phase: walk read+parse+serialize 133, log files and maps and unread 1, tracked_files 28, scope_verdicts 2, usable_here 38, coordination refs 111, resolve_default_branch 22, check_signers 0, detached_commit_proofs 44, branch preload 454, per-entity checks 374, corpus-wide checks 9. Counted at the one door in git.rs: 20 spawns costing 483 ms, which is 40 percent of the run, and every spawn costs 17 to 37 ms whatever it asks -- process creation on Windows, not git's work. Seven of the twenty are hash-object, 190 ms, and they are one loop: blobs_here_uncached batches paths under a 6000 character budget, so 1064 entity paths become seven command lines. git hash-object --stdin-paths takes the paths on stdin and has no argument limit at all, which collapses seven spawns into one and saves about 165 ms, 13 percent of the whole run. The subject of this task's criterion, serialize_entity over 1064 entities, is 25 ms of the 133 ms walk: 2 percent. That confirms the release of 2026-08-20 rather than overturning it.

--- a/.ank/entities/LOG-93e3a2782cfa.md
+++ b/.ank/entities/LOG-93e3a2782cfa.md
@@ -1,0 +1,17 @@
+---
+id: LOG-93e3a2782cfa
+type: log
+title: "closed: The premise is false and it has now been measured twice. serialize_entity over 1064"
+created: 2026-08-22T19:00:57Z
+author: claude-code/opus-5
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/src/index.rs
+  - crates/ank-cli/tests/**
+about: TASK-da7738572825
+seq: 3
+schema: 4
+version: 1
+---
+
+ entities is 25 ms of a 1216 ms check, 2 percent, and parsing cannot be skipped at all since every later phase works on the parsed entity. Meeting the criterion costs a third cache, a column on the index and a schema bump that wipes and rebuilds every index, for a fortieth of a second. Released on 2026-08-20 for that reason and left open, which is how it was claimed a second time and cost a second session; closing is what stops a third. The phase profile is on this task and TASK-eb2c8b0bee45 carries what it found.

--- a/.ank/entities/LOG-e59fa7d919da.md
+++ b/.ank/entities/LOG-e59fa7d919da.md
@@ -1,0 +1,15 @@
+---
+id: LOG-e59fa7d919da
+type: log
+title: done, proof commit:4301950
+created: 2026-08-22T19:09:54Z
+author: claude-code/opus-5
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/src/git.rs
+  - crates/ank-cli/tests/cli.rs
+about: TASK-2e2bac895056
+seq: 2
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-f9c943e97212.md
+++ b/.ank/entities/LOG-f9c943e97212.md
@@ -1,0 +1,17 @@
+---
+id: LOG-f9c943e97212
+type: log
+title: Measured rather than asserted, which the criterion asks for. Two release binaries built from the
+created: 2026-08-22T19:09:26Z
+author: claude-code/opus-5
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/src/git.rs
+  - crates/ank-cli/tests/cli.rs
+about: TASK-2e2bac895056
+seq: 1
+schema: 4
+version: 1
+---
+
+ same tree either side of the change and alternated six times each on this corpus: 1385 ms before, mean of 1377 1416 1377 1389 1370 1382, and 1297 ms after, mean of 1295 1298 1284 1299 1301 1310. No overlap between the two series. 88 ms, 6.4 percent. Less than the 165 ms the task body predicted, and the arithmetic says why: I costed seven spawns at 27 ms each, but the one that replaces them still costs its 27 ms and still hashes the same 1064 files. What was actually removed is six process creations, about 15 ms of pure overhead each. The prediction was wrong in the honest direction and the recorded number is the measured one. The test is slow on purpose, 9.5 s: a thousand entities is what it takes to outrun a Windows command line, and falsified by pairing each hash with the next path, where it goes red on every file at once.

--- a/.ank/entities/TASK-2e2bac895056.md
+++ b/.ank/entities/TASK-2e2bac895056.md
@@ -5,7 +5,7 @@ slug: check-pays-for-seven-git-spawns-to-hash-what-one
 title: check pays for seven git spawns to hash what one could
 created: 2026-08-22T19:01:24Z
 author: claude-code/opus-5
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/src/human.rs
   - crates/ank-cli/src/git.rs
@@ -14,8 +14,13 @@ blocked_by: []
 done_criteria: |
   The working copy of every entity is hashed in one git invocation rather than in one per command-line batch, and the character budget that produced the batches is gone with the loop that used it. A corpus larger than any single command line accepts is hashed correctly, and a test asserts it on a corpus seeded past that width. check reports the same findings it reported before, subject by subject and note by note, and its exit code is unchanged. The saving is measured and recorded on the task rather than asserted. cargo test --workspace is green on all three operating systems, cargo fmt --check passes, and ank check reports no fault.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: "4301950"
+    criteria: a17037524deb
+    via: submitted
 schema: 4
-version: 2
+version: 3
 ---
 
 Measured on 2026-08-22, release build, warm, on this repository's own corpus of

--- a/.ank/entities/TASK-2e2bac895056.md
+++ b/.ank/entities/TASK-2e2bac895056.md
@@ -1,0 +1,49 @@
+---
+id: TASK-2e2bac895056
+type: task
+slug: check-pays-for-seven-git-spawns-to-hash-what-one
+title: check pays for seven git spawns to hash what one could
+created: 2026-08-22T19:01:24Z
+author: claude-code/opus-5
+status: in_progress
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/src/git.rs
+  - crates/ank-cli/tests/cli.rs
+blocked_by: []
+done_criteria: |
+  The working copy of every entity is hashed in one git invocation rather than in one per command-line batch, and the character budget that produced the batches is gone with the loop that used it. A corpus larger than any single command line accepts is hashed correctly, and a test asserts it on a corpus seeded past that width. check reports the same findings it reported before, subject by subject and note by note, and its exit code is unchanged. The saving is measured and recorded on the task rather than asserted. cargo test --workspace is green on all three operating systems, cargo fmt --check passes, and ank check reports no fault.
+criteria_by: creator
+schema: 4
+version: 2
+---
+
+Measured on 2026-08-22, release build, warm, on this repository's own corpus of
+1064 entities. `ank check` costs 1216 ms, and 483 ms of it is twenty git
+spawns -- 40 percent of the run. Every spawn costs between 17 and 37 ms whatever
+it asks: `config` costs the same as `rev-list`, so what is being paid is process
+creation and not git's work.
+
+Seven of those twenty are one loop. `blobs_here_uncached` hashes every entity
+file to compare the working copy against the branch, and it batches the paths
+onto command lines under a 6000-character budget, so 1064 paths become seven
+invocations of `git hash-object`. They cost 190 ms between them.
+
+**The budget exists to dodge a platform limit, and the limit does not have to be
+dodged.** `git hash-object --stdin-paths` reads the paths from standard input,
+where no argument limit applies at all, and `output_with_stdin` is already the
+door for handing git a stream. Seven spawns become one and the batching loop
+goes with them, along with the constant that had to be chosen conservatively
+enough for the shortest of three platforms.
+
+**The phase profile, so that whoever takes this knows what is left afterwards.**
+Walk (read, parse, serialise) 133 ms, of which `serialize_entity` is 25;
+`tracked_files` 28; `usable_here` 38; coordination refs 111;
+`resolve_default_branch` 22; `detached_commit_proofs` 44; branch preload 454;
+per-entity checks 374; corpus-wide checks 9. After this task the branch preload
+loses about 165 ms and the next thing worth looking at is the per-entity checks,
+which are 374 ms of in-process work over three git calls.
+
+**What must not be built here is a cache.** TASK-da7738572825 was closed because
+it proposed one for a 25 ms saving; this is the opposite trade, a spawn removed
+rather than a verdict remembered, and it adds no state to invalidate.

--- a/.ank/entities/TASK-da7738572825.md
+++ b/.ank/entities/TASK-da7738572825.md
@@ -5,7 +5,7 @@ slug: check-re-reads-and-re-serialises-1018-entities-t
 title: check re-reads and re-serialises 1018 entities that have not changed
 created: 2026-08-20T22:14:40Z
 author: claude-code/opus-5
-status: open
+status: closed
 scope:
   - crates/ank-cli/src/human.rs
   - crates/ank-cli/src/index.rs
@@ -15,7 +15,7 @@ done_criteria: |
   An entity whose file has not changed since it was last inspected is not parsed and re-serialised again to decide its canonical form: the verdict is kept and keyed on the file's content hash, which the index already records. A file that changed, is absent from the cache, or whose stored verdict cannot be read is inspected as it is today. The findings check, review and status report are identical to what they report before the change, subject by subject and note by note, and remain identical after a file is edited, reverted, and edited again. cargo test --workspace and ank check stay green.
 criteria_by: creator
 schema: 3
-version: 3
+version: 5
 ---
 
 Measured on 2026-08-20: of the 7.0 s `ank check` costs, 2.09 s is ank's own

--- a/crates/ank-cli/src/human.rs
+++ b/crates/ank-cli/src/human.rs
@@ -3267,10 +3267,6 @@ fn blobs_here_uncached(
     repo: &Repo,
     here: &BTreeMap<String, PathBuf>,
 ) -> Result<BTreeMap<String, String>> {
-    /// Well under the shortest limit of the three platforms, and far above what
-    /// a corpus of a few hundred entities needs.
-    const BUDGET: usize = 6000;
-
     let ids: Vec<&String> = here.keys().collect();
     let paths: Vec<String> = here
         .values()
@@ -3281,38 +3277,64 @@ fn blobs_here_uncached(
                 .replace('\\', "/")
         })
         .collect();
-    let mut out = BTreeMap::new();
-    let mut i = 0;
-    while i < paths.len() {
-        let start = i;
-        let mut args: Vec<&str> = vec!["hash-object", "--"];
-        let mut budget = 0usize;
-        while i < paths.len() && (i == start || budget + paths[i].len() < BUDGET) {
-            budget += paths[i].len() + 1;
-            args.push(&paths[i]);
-            i += 1;
-        }
-        let text = git::run(&repo.corpus, &args)?;
-        let objects: Vec<&str> = text
-            .lines()
-            .map(str::trim)
-            .filter(|l| !l.is_empty())
-            .collect();
-        if objects.len() != i - start {
-            return Err(CliError::new(
-                ExitCode::Environment,
-                format!(
-                    "git hash-object answered {} object(s) for {} file(s)",
-                    objects.len(),
-                    i - start
-                ),
-            ));
-        }
-        for (n, object) in objects.into_iter().enumerate() {
-            out.insert(ids[start + n].to_string(), object.to_string());
-        }
+    // No paths, no process. `hash-object --stdin-paths` handed an empty stream
+    // answers nothing and costs a spawn to do it.
+    if paths.is_empty() {
+        return Ok(BTreeMap::new());
     }
-    Ok(out)
+
+    // **One process, whatever the corpus weighs** (TASK-2e2bac895056). This
+    // used to pack the paths onto command lines under a 6000-character budget,
+    // which is a number chosen conservatively enough for the shortest limit of
+    // the three platforms — and 1064 entity paths became seven invocations
+    // costing 190 ms, on a run where twenty git spawns were 40 percent of the
+    // whole. `--stdin-paths` takes them on standard input, where no argument
+    // limit applies at all, so the budget goes along with the loop it existed
+    // for and the corpus can be any size.
+    //
+    // One path per line, which is what `--stdin-paths` reads without `-z`. An
+    // entity path is an identifier under a directory this tool names, so it
+    // holds no newline to confuse the framing; a corpus that carried one would
+    // have a file name no verb here can address either.
+    let input = paths.join("\n") + "\n";
+    let out = git::output_with_stdin(
+        &repo.corpus,
+        &["hash-object", "--stdin-paths"],
+        input.as_bytes(),
+    )?;
+    if !out.status.success() {
+        return Err(CliError::new(
+            ExitCode::Environment,
+            format!(
+                "git hash-object --stdin-paths: {}",
+                String::from_utf8_lossy(&out.stderr).trim()
+            ),
+        ));
+    }
+    let text = String::from_utf8_lossy(&out.stdout);
+    let objects: Vec<&str> = text
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .collect();
+    // One object per path, in the order they were written. git guarantees the
+    // order and the count; a disagreement means the stream was framed wrong,
+    // and pairing on it anyway would attribute one file's hash to another.
+    if objects.len() != paths.len() {
+        return Err(CliError::new(
+            ExitCode::Environment,
+            format!(
+                "git hash-object answered {} object(s) for {} file(s)",
+                objects.len(),
+                paths.len()
+            ),
+        ));
+    }
+    Ok(objects
+        .into_iter()
+        .enumerate()
+        .map(|(n, object)| (ids[n].to_string(), object.to_string()))
+        .collect())
 }
 
 /// Whether this repository carries any commit at all.

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -8164,6 +8164,63 @@ fn every_verb_carries_a_group_and_no_group_goes_unprinted() {
 // Dead constraints in the prose (ADR-91b77f036884)
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Hashing the working copy (TASK-2e2bac895056)
+// ---------------------------------------------------------------------------
+
+/// A corpus wider than any single command line, hashed in one process.
+///
+/// **The width is the assertion.** The paths used to be packed onto command
+/// lines under a 6000-character budget, a number chosen conservatively enough
+/// for the shortest limit of the three platforms; `--stdin-paths` has no limit
+/// to be conservative about, and this seeds a corpus past the shortest one to
+/// say so. Windows takes 32767 characters on a command line, which is the bar
+/// here because it is the low one — the same corpus is far inside what Linux
+/// and macOS accept, and the test is about the door that no longer has a limit
+/// rather than about any platform's.
+///
+/// **What it observes is the hashing, through the one finding that rests on
+/// it.** Every entity is committed, so the working copy and the branch agree
+/// file for file and `check` must report no drift. A hash mispaired with a path
+/// — the framing read wrong, the order not the order git wrote — would make
+/// every one of them look different at once, which is the loudest possible
+/// failure and the reason this is worth a slow test.
+#[test]
+fn a_corpus_wider_than_a_command_line_is_hashed_correctly() {
+    /// Chosen so the paths outrun the shortest command line of the three
+    /// platforms, and no further: every entity here is a file written and read.
+    const ENTITIES: usize = 1000;
+    const PATH_WIDTH: usize = ".ank/entities/TASK-000000000000.md".len() + 1;
+
+    let r = Repo::new();
+    for n in 0..ENTITIES {
+        r.seed_task(&format!("TASK-{n:012x}"), Some("A verifiable criterion."));
+    }
+    assert!(
+        ENTITIES * PATH_WIDTH > 32_767,
+        "the fixture is inside a Windows command line, so it asserts nothing: {}",
+        ENTITIES * PATH_WIDTH
+    );
+
+    // Committed, so the working copy and the branch carry the same bytes: the
+    // drift count is then a statement about the hashing and about nothing else.
+    r.git(&["add", "-A"]);
+    r.git(&["commit", "-qm", "seed"]);
+
+    let out = r.ank("claude-code/1.0", &["check"]);
+    let said = both_streams(&out);
+    assert!(
+        !said.contains("differ from main"),
+        "the working copy hashed to something the branch does not carry: {said}"
+    );
+    // And the corpus was actually read, rather than skipped by a failure that
+    // left the comparison with nothing to disagree about.
+    assert!(
+        said.contains(&format!("{ENTITIES} tasks")),
+        "the walk did not reach the corpus: {said}"
+    );
+}
+
 /// The workspace root: two levels above this crate's manifest.
 ///
 /// Derived rather than configured, so a crate added to the workspace is walked


### PR DESCRIPTION
Closes TASK-2e2bac895056, and closes TASK-da7738572825 without building
what it asked for.

## What the profile found

`ank check` costs 1216 ms on this corpus, release build, warm. Twenty
git spawns are 483 ms of it — 40 percent. Every spawn costs between 17
and 37 ms whatever it asks (`config` costs the same as `rev-list`), so
what is being paid is process creation.

    walk read+parse+serialize   133 ms   (serialize_entity: 25)
    tracked_files                28
    usable_here                  38
    coordination refs           111
    resolve_default_branch       22
    detached_commit_proofs       44
    branch preload              454
    per-entity checks           374
    corpus-wide checks            9

Seven of the twenty spawns were one loop: `blobs_here_uncached` packed
entity paths onto command lines under a 6000-character budget, so 1064
paths became seven `git hash-object` invocations costing 190 ms.
`--stdin-paths` takes them on standard input, where no argument limit
applies, so the budget goes with the loop.

## Measured, not asserted

Two release binaries from the same tree either side of the change,
alternated six times each: **1385 ms → 1297 ms**, no overlap between the
series. 88 ms, 6.4 percent.

Less than predicted, and the arithmetic says why: seven spawns were
costed at 27 ms each, but the one that replaces them still costs its 27
ms and still hashes the same files. Six process creations were removed,
not seven spawns' worth of work.

## Why TASK-da7738572825 is closed

Its criterion asked for a cache of the canonical-form verdict.
`serialize_entity` over 1064 entities is 25 ms of that 1216 — 2 percent
— and parsing cannot be skipped at all, since every later phase works on
the parsed entity. It was released for that reason on 2026-08-20 and
left open, which is how it was claimed a second time and cost a second
session. Closing is what stops a third.

The phase profile is recorded on it, and this task carries what the
profile found.

## The test is slow on purpose

A thousand entities is what it takes to outrun a Windows command line —
the low bar of the three, and therefore the one worth clearing. Every
entity is committed, so a hash mispaired with a path makes all thousand
look different at once. Falsified by pairing each hash with the next
path, where it goes red exactly that way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X5PCmpdS4j9itcqRKvrowX
