### PR TITLE
A corpus outside the tree is found by a declaration keyed on its identity

### DIFF
--- a/.ank/entities/LOG-08206c3c232b.md
+++ b/.ank/entities/LOG-08206c3c232b.md
@@ -1,0 +1,17 @@
+---
+id: LOG-08206c3c232b
+type: log
+title: +scope crates/ank-cli/src/cli.rs (version 2 to 3, replaced de0707d882a3)
+created: 2026-08-22T19:35:07Z
+author: claude-code/opus-5
+scope:
+  - crates/ank-cli/src/repo.rs
+  - crates/ank-cli/src/config.rs
+  - crates/ank-cli/tests/cli.rs
+  - crates/ank-cli/src/cli.rs
+about: TASK-88bff140d416
+seq: 0
+records: edit
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-22d0cdc9eaf3.md
+++ b/.ank/entities/LOG-22d0cdc9eaf3.md
@@ -1,0 +1,18 @@
+---
+id: LOG-22d0cdc9eaf3
+type: log
+title: "The reading half, and four cases in one order: --repo, a declaration keyed on the identity, the"
+created: 2026-08-22T19:35:10Z
+author: claude-code/opus-5
+scope:
+  - crates/ank-cli/src/repo.rs
+  - crates/ank-cli/src/config.rs
+  - crates/ank-cli/tests/cli.rs
+  - crates/ank-cli/src/cli.rs
+about: TASK-88bff140d416
+seq: 1
+schema: 4
+version: 1
+---
+
+ walk, the refusal. Two things the criterion named needed a reading. The spec clause says SPEC-201041998d90 states the resolution order; that document is superseded twice over and its chain ends on SPEC-55162f52d40e, which is what I superseded -- the rule TASK-e2da6b0cc817 implemented, applied to the criterion that names it. And the git question: resolving a corpus now asks for the repository identity, which is a git process at startup, where ADR-9307e5d214a7 says git is required per verb and never at startup. It is compatible and the guard is the order: an empty map costs a file that is not there and asks git nothing, so only a reader who has declared something pays a spawn, and a directory that is no repository has no identity, matches nothing and falls through to the walk. No verb is refused for want of git. Measured by hand before the tests: the declared corpus answers from the tree root and from a subdirectory two deep, with the scope glob confronted against the tree and not against the corpus.

--- a/.ank/entities/LOG-8a7bce7e59da.md
+++ b/.ank/entities/LOG-8a7bce7e59da.md
@@ -1,0 +1,16 @@
+---
+id: LOG-8a7bce7e59da
+type: log
+title: done, proof commit:67d1aae
+created: 2026-08-22T19:35:38Z
+author: claude-code/opus-5
+scope:
+  - crates/ank-cli/src/repo.rs
+  - crates/ank-cli/src/config.rs
+  - crates/ank-cli/tests/cli.rs
+  - crates/ank-cli/src/cli.rs
+about: TASK-88bff140d416
+seq: 2
+schema: 4
+version: 1
+---

--- a/.ank/entities/SPEC-aa4b4f119929.md
+++ b/.ank/entities/SPEC-aa4b4f119929.md
@@ -1,0 +1,152 @@
+---
+id: SPEC-aa4b4f119929
+type: spec
+slug: storage-and-search
+title: Storage and search
+created: 2026-08-22T19:34:45Z
+author: claude-code/opus-5
+status: proposed
+scope:
+  - crates/ank-cli/src/store.rs
+  - crates/ank-cli/src/index.rs
+  - crates/ank-cli/src/repo.rs
+  - crates/ank-cli/src/config.rs
+references: [SPEC-a89ba4f755e9, SPEC-c937ff8fa70a]
+supersedes: SPEC-55162f52d40e
+schema: 4
+version: 1
+---
+
+One of the ten documents that carry the Ank specification (ADR-5a690829388d).
+This one carries **§6 entire**: the layout of `.ank/`, the two previous shapes
+read for one window, atomic writes and the index, how an invocation resolves
+which corpus it is in, and the three levels of search.
+
+## Why this stands alone, and why it is not merged with synchronisation
+
+It is a section this decomposition leaves exactly as it found it, and the reason
+is that it passes the test in both directions against the document it is closest
+to.
+
+Storage answers **where a byte lives and how it is found**: one flat directory,
+the file name is the id, the walk up for the first `.ank/`, the index that is
+derived and disposable. Synchronisation answers **who may write it and when it
+becomes everybody's**: refs, leases, pushes, the default branch. A reader
+repairing a claim ref needs none of the index lifecycle; a reader implementing
+the walk needs nothing about levels 0 and 1.
+
+The one place they touch is a path — the pruning predicate reads a task file as
+it appears on the default branch, at the path this document fixes — and a path
+named across a boundary is a reference, which is what the field is for. That is
+the difference between two documents that cite each other and one document
+pretending to be two.
+
+**What keeps this whole is the layout rule itself.** The layout is fixed and not
+configured, so that a third-party reader can find a file without parsing
+anything first; the entries of an entity are a query rather than an address; and
+both previous shapes are read for one window and never written. Those three are
+one argument about addressing, and no boundary inside them would leave either
+side readable.
+
+## What it rests on
+
+- **The data model** — ids, the kind registry, and the entities this layout
+  stores.
+- **The CLI surface** — `migrate`, the one verb this document names as the
+  command a finding points to.
+
+---
+
+## 6. Storage and search
+
+```
+.ank/
+  config.yml
+  allowed_signers      # public keys allowed to ratify (§8), versioned
+  entities/TASK-<id>.md
+  entities/ADR-<id>.md
+  entities/SPEC-<id>.md
+  entities/LOG-<id>.md # one entry of the work trace, written once (§3)
+  log/<id>.md          # the previous shape of the trace, read for one window (§3)
+  index.db             # derived, disposable, gitignored by init (§9)
+```
+
+**Flat tree.** Attachment happens through `scope`, not through location. One entity can constrain several modules; a tree mirroring the code would force a single parent and break at the first refactor.
+
+**One directory, and no per-kind subdirectory** (ADR-c9f9d0d6f05d). The kind is in the id prefix, which is in the file name, which the store already cross-checks against the id inside the file; a directory would be a third statement of the same fact, and the only thing a third copy can do is disagree with the first two. Every entity therefore lives at `.ank/entities/<ID>.md`, whatever its kind, and the file name is the id. Since the directory no longer states the kind, the file-name / id cross-check is the only thing left doing it, and it stays exactly as strict: a file whose name does not match the id inside it is refused.
+
+**An entity's entries are a query, not a path.** They are the entities of kind `log` whose `about` names it, ordered by `created`, then `seq`, then the identifier (§3), which is the one place this layout gives up an address computed from an id: the previous shape put a whole log at `.ank/log/<ID>.md`, arithmetic on the entity's own id and no lookup. What the index answers cheaply, a reader without one answers by reading the directory, which is what it does for every other question about a set of entities.
+
+**The previous shape is read for one window**, on the same terms and for the same reason as the previous layout below: a reader accepts a `.ank/log/` a former release wrote, a writer never produces one, and an entity's entries are the union of the two sources with none counted twice. A corpus still holding one is a `check` finding naming the command that moves it, a signal and not a fault.
+
+**The command it names is `ank migrate`, and that is the one place a verb is warranted where the entity layout needed none.** The layout below moves with `git mv`: the same file, a different directory, and the reader accepting both does the rest. A line becoming an entity is a rewrite — an id allocated per entry, a message split across `title` and the body, a scope copied from the subject — and no shell command performs it. The verb is bounded by that: it reads `.ank/log/<ID>.md`, writes one entity per line, removes the file it read, and asserts the entry count equal before and after with every message compared byte for byte to the line it came from. A log file the grammar refuses **stops the migration naming it** rather than being skipped, because the parser refuses a whole file on its first malformed line and a file quietly dropped would take every sound entry beside it. It writes files and never commits (§12), so what it leaves is a working tree the caller reviews in one go.
+
+**The layout is fixed, not configured.** A layout read from `config.yml` was asked for and is the one thing to refuse: every third-party reader would have to parse the configuration before it could find a file, which is the exact coupling the format exists to avoid, and the conformance suite would stop being something anybody can run against a directory. Flat and fixed, or the format is not a format.
+
+**The previous layout is read for one window.** Corpora exist at `.ank/tasks/TASK-<id>.md` and `.ank/adr/ADR-<id>.md`. **A reader accepts them; a writer never produces them.** A corpus holding both is read as one corpus, with no entity counted twice. A corpus still in the previous layout is a `check` finding naming the command that moves it — a **signal and not a fault**, because such a corpus still parses, still round-trips and still answers every verb, and reddening a pipeline over a file location is the kind of finding that teaches a reader to stop reading `check`.
+
+The dual read is a **window, not a feature**: it exists for the one release across which an existing corpus moves. A migration verb was rejected for the opposite reason — a permanent surface for a temporary problem, where the reader accepting both layouts does the same work with no surface at all.
+
+`index.db` is derived and carries the path already, so it rebuilds from either layout and nothing about it migrates.
+
+**Atomic writes** (write-then-rename), under a file lock for the duration of the read-compare-write cycle — that is what makes the `version` compare-and-swap effective, since write-then-rename alone compares nothing.
+
+**Derived SQLite index**, fully rebuildable from the files. It is never the source of truth.
+
+**Index lifecycle, fixed** (formerly open point 1): the index stores a content hash per `.ank/` file. Every command compares the files in the perimeter it touches against those hashes and incrementally reindexes what diverged — the index is therefore always up to date *at read time*, with no daemon and no watcher. `check` reindexes fully. An index that is absent or of an unknown schema is rebuilt silently: deleting it is always a safe operation.
+
+### Resolving the repository
+
+Every invocation begins by answering which corpus it is in, and the answer is derived from the working directory rather than configured.
+
+**The walk.** With no `--repo`, resolution starts at the working directory and walks up, parent by parent, to the **first** directory containing a `.ank/`. That directory is the root and the corpus is `<root>/.ank/`. It is git's rule for `.git`, for git's reason: an agent is launched in whatever subdirectory the work happens to be in, and a corpus that had to be named would be a flag on every command.
+
+**What stops it** is the first `.ank/` and nothing else — not a `.git/`, not a workspace manifest, not a mount point. The walk ends at the filesystem root, and ending there is a generic error (code 1) naming `ank init`. Nothing is created implicitly: a corpus that appears because a command ran in the wrong directory is worse than a refusal.
+
+**`--repo <path>` short-circuits the walk** without ever contradicting it. The path given must itself contain a `.ank/`, and resolution stops there with no walk at all. The `.ank/` directory is accepted in place of its parent, since being off by one level is the likely mistake and refusing it would gain nothing. A path holding no corpus is the same code 1 naming the same command.
+
+**A corpus may live outside the tree it anchors, and where it lives is declared** (ADR-96174f1ac2b7). The declaration is a map held outside the repository -- `%APPDATA%\\ank\\corpora.yml` on Windows, `$XDG_CONFIG_HOME/ank/corpora.yml` or `$HOME/.config/ank/corpora.yml` elsewhere -- with one entry per repository, keyed on the repository identity of §7 and never on a path, a remote URL or a slug derived from one. That the file is outside the repository is the whole promise it keeps: a pointer committed in the code repository would be the more useful design for a team wanting shared context, and it is precisely the trace the request refuses.
+
+**So resolution has four cases, in this order.** `--repo` given, which short-circuits everything as it always did. A declaration whose key is this repository's identity, which short-circuits the walk the same way and answers with the corpus it names, anchored to the work tree the caller is standing in. No declaration, which is the walk above, unchanged. Neither, which is the refusal above, unchanged.
+
+**A key that is not an identity is refused by name**, with the command that prints the right one. A remote URL fails every test a path fails and fails it in more ways -- one clone over ssh and one over https key differently, a fork keys differently from its upstream, a rename on the forge silently orphans the declaration, a repository with no remote has no key at all -- and a tree with no history has no identity rather than a fallback that every historyless tree on a machine would share. A wrong key that merely matched nothing would leave the corpus quietly not found, which is the one outcome worse than a refusal.
+
+**A declaration naming a path that holds no corpus is a refusal naming that path**, and never a fallback to the walk: falling back would make a typo in the map indistinguishable from having no map at all.
+
+**Where a corpus also exists in the tree, the declaration answers and both roots are named** on standard error. No verb fails, `--quiet` silences the line like every other note, and what stdout and `--json` carry is byte for byte what the same corpus answers reached any other way -- the note says where the answer came from and never what it is.
+
+**Nothing is asked of git until a declaration exists to match**, which is what keeps "git per verb, never at startup" (ADR-9307e5d214a7) true here. A reader who has declared nothing pays a file that is not there; past that, the identity is a git process, and its absence is not a refusal but a directory that matches no declaration and falls through to the walk.
+
+**A corpus outside the working directory's repository is warned about, not refused.** Because the walk stops at the first `.ank/` and at nothing else, a checkout nested inside another repository silently resolves the outer corpus. That is not merely reading the wrong files: claims are refs (§7), so they land in the resolved root's repository and never in the one holding the code being changed, and the inner repository ends with no ank ref at all. So the walk compares the two and, when they differ, prints a warning naming the resolved root and the two ways out — `ank init` here, or `--repo` to confirm the corpus was meant. Four properties, each load-bearing:
+
+- **Only on the walk.** `--repo` is the caller saying which corpus they mean, and warning about an answer asked for by name would fire forever in the one layout this behaviour makes usable: a single `.ank/` above several checkouts, with scopes written `repoA/src/**`. That layout was never designed for and is not forbidden either; naming `--repo` once is what separates it from the accident.
+- **Compared on the git common directory, not the toplevel.** A linked worktree has a toplevel of its own and shares `refs/` with the checkout that made it, so comparing toplevels would report two worktrees of one repository as two repositories. The question being asked is where a claim ref lands (§7), and that is the common directory. A working directory in no repository at all is a legible answer too, and says so in its own words.
+- **On standard error.** It is no part of any verb's answer, and §4 requires `--json` to stay byte-for-byte what a caller's parser already reads; a line on stdout would break every one of them to say something no parser asked for. `--quiet` silences it.
+- **It degrades and never fails** (§2). The walk succeeded, and the caller may well have meant it.
+
+### The corpus, and the tree it is anchored to
+
+**A corpus has a location and an anchor, and they are two facts** (ADR-9e56318631f3). The location is the directory holding `.ank/`, which the walk above resolves. The anchor is the tree the corpus constrains. Until a corpus could be put anywhere but beside its code the two were the same directory, and nothing had to say which one a question meant.
+
+Four things are confronted with a filesystem, and all four resolve against the **work tree**:
+
+- **A scope glob.** §3 makes scope the only attachment because a glob is confronted with the filesystem where a label is confronted with somebody remembering it, and the files it has to meet are the code's. Held against a corpus directory instead, every scope in it matches nothing, which §11 reports as a dead scope: a fault on a constraint, and one nothing could repair.
+- **The path argument of a path-taking verb**, and with it the hint that names an absolute path back relative to the tree it was absolute in.
+- **The working directory of a verifier.** A test command run in a directory of entity files is not a failing test, it is a category error.
+- **The commit a `commit:` proof names.** §8 makes `commit:` the one proof type confronted with git, and the commit it names is one of the code. Looked up anywhere else it is not a weak proof but an unfindable one.
+
+Three resolve against the **corpus directory**:
+
+- **`refs/ank/*`.** Claims and proofs live in refs and stay per repository (§7), so that nothing is arbitrated across a boundary the refs cannot reach. That boundary is the corpus: whoever shares it is whoever arbitrates over its tasks.
+- **The corpus's own drift from its default branch**, which is the question the paragraphs above answer, read of the corpus's checkout and not of the code's.
+- **Every entity path handed to git**, which comes from the store rather than from a literal, and the store is rooted in the corpus.
+
+**The divergence is named, never derived.** `--worktree <path>` (§4) says which tree, and absent it the work tree is the corpus's own directory. That default is what leaves every corpus written before the flag existed resolving exactly as it did, and it is what keeps the layout described above usable: one `.ank/` standing over several checkouts, with scopes written `repoA/src/**`, is a corpus whose work tree is its own directory, and a work tree read off the caller's current directory would have killed that layout without anybody deciding to. `--repo` and `--worktree` therefore imply each other in neither direction.
+
+**Git is asked of the work tree by the verb that needs it there, and never at startup** (ADR-9307e5d214a7). `done` and `attest` are those verbs, and no others: both look up a `commit:` proof, and `done` takes the scope hash there as well. A work tree that is no repository is refused by them, **named as the work tree**, because "not inside a git repository" said of a corpus that plainly is one sends a reader to look in the wrong place. Everything else answers unchanged, a scope included: confronting one is a walk of the filesystem, and only the *explanation* of a dead scope needs a history to read.
+
+### Three levels of search
+
+1. **Scope resolution** — glob matching, deterministic, zero ambiguity. Covers the bulk of cases; this is what `context` does.
+2. **Lexical search** (FTS5) for `find`. Fast, local, explainable.
+3. **Semantic** — explicitly out of scope. It would impose an embedding model (loss of agnosticism) and non-deterministic ranking, which reintroduces exactly the uncertainty the tool is trying to eliminate.

--- a/.ank/entities/TASK-88bff140d416.md
+++ b/.ank/entities/TASK-88bff140d416.md
@@ -5,7 +5,7 @@ slug: a-corpus-outside-the-tree-is-found-by-a-declarat
 title: A corpus outside the tree is found by a declaration keyed on the repository's identity
 created: 2026-08-21T17:57:22Z
 author: claude-code/opus-5
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/src/repo.rs
   - crates/ank-cli/src/config.rs
@@ -15,8 +15,13 @@ blocked_by: [TASK-a12553192afa]
 done_criteria: |
   With no .ank/ in the tree and a declaration held outside the repository naming a corpus for this repository's identity, every verb resolves that corpus and anchors it to the working directory's work tree, with no flag on the invocation. The key is the identity TASK-d55cef0b0ef1 already publishes in ank status --json; a key that is a path, a remote URL or a slug derived from one is refused by name and never resolved. Where a .ank/ also exists in the tree the declaration wins, both roots are named on standard error, --quiet silences it and a test asserts stdout and --json are byte for byte what they were without the declaration. With no declaration the walk is unchanged, and a tree with neither still refuses with code 1 naming ank init. No third-party crate is added: the home directory is resolved from the environment and the standard library, and a test drives the binary on all three platforms with that environment set. SPEC-201041998d90 states the resolution order. cargo test is green, cargo fmt --check passes, and ank check reports no fault.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 67d1aae
+    criteria: 1a737158b002
+    via: submitted
 schema: 3
-version: 3
+version: 4
 ---
 
 ADR-96174f1ac2b7 is the decision; this is the reading half of it. The corpus is

--- a/.ank/entities/TASK-88bff140d416.md
+++ b/.ank/entities/TASK-88bff140d416.md
@@ -5,17 +5,18 @@ slug: a-corpus-outside-the-tree-is-found-by-a-declarat
 title: A corpus outside the tree is found by a declaration keyed on the repository's identity
 created: 2026-08-21T17:57:22Z
 author: claude-code/opus-5
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/src/repo.rs
   - crates/ank-cli/src/config.rs
   - crates/ank-cli/tests/cli.rs
+  - crates/ank-cli/src/cli.rs
 blocked_by: [TASK-a12553192afa]
 done_criteria: |
   With no .ank/ in the tree and a declaration held outside the repository naming a corpus for this repository's identity, every verb resolves that corpus and anchors it to the working directory's work tree, with no flag on the invocation. The key is the identity TASK-d55cef0b0ef1 already publishes in ank status --json; a key that is a path, a remote URL or a slug derived from one is refused by name and never resolved. Where a .ank/ also exists in the tree the declaration wins, both roots are named on standard error, --quiet silences it and a test asserts stdout and --json are byte for byte what they were without the declaration. With no declaration the walk is unchanged, and a tree with neither still refuses with code 1 naming ank init. No third-party crate is added: the home directory is resolved from the environment and the standard library, and a test drives the binary on all three platforms with that environment set. SPEC-201041998d90 states the resolution order. cargo test is green, cargo fmt --check passes, and ank check reports no fault.
 criteria_by: creator
 schema: 3
-version: 1
+version: 3
 ---
 
 ADR-96174f1ac2b7 is the decision; this is the reading half of it. The corpus is

--- a/crates/ank-cli/src/cli.rs
+++ b/crates/ank-cli/src/cli.rs
@@ -886,8 +886,27 @@ fn warn_if_schema_ahead(inv: &Invocation, repo: &crate::repo::Repo) {
     eprintln!("  -> {next}");
 }
 
+/// The corpus, and whatever resolving it had to say.
+///
+/// **The note is printed here and never inside the resolution**, on the split
+/// ADR-0c8ab846d262 draws: what a reader is told is presentation, and a
+/// resolver that printed would be a second place deciding what `--quiet` means.
+/// Standard error, because stdout is a parser's input (§4) and a declaration
+/// answering instead of the tree changes no answer, only where it came from.
+fn resolved(inv: &Invocation, cwd: &std::path::Path) -> Result<crate::repo::Repo> {
+    let mut notes = Vec::new();
+    let repo = crate::repo::resolve(inv.repo(), inv.worktree(), cwd, &mut notes)?;
+    if !inv.quiet() {
+        let style = inv.style().on_stderr();
+        for note in notes {
+            eprintln!("{} {note}", style.yellow("warning:"));
+        }
+    }
+    Ok(repo)
+}
+
 fn startup(inv: &Invocation, cwd: &std::path::Path) -> Result<Startup> {
-    let repo = crate::repo::resolve(inv.repo(), inv.worktree(), cwd)?;
+    let repo = resolved(inv, cwd)?;
     // git is required by the verbs that coordinate, and never at startup
     // (ADR-9307e5d214a7). The gate used to stand
     // in front of the dispatch rather than in front of the operation, so `show`,
@@ -980,7 +999,7 @@ fn dispatch(
         return help(&inv, out);
     }
     if inv.command == "config" {
-        let repo = crate::repo::resolve(inv.repo(), inv.worktree(), cwd)?;
+        let repo = resolved(&inv, cwd)?;
         // The same hazard, and it reaches this verb too: a `config` run from a
         // nested checkout edits the outer repository's configuration. `git` is
         // unchecked here, which costs nothing — `common_dir` answers `None`

--- a/crates/ank-cli/src/config.rs
+++ b/crates/ank-cli/src/config.rs
@@ -258,6 +258,131 @@ identities: {}
 }
 
 // ---------------------------------------------------------------------------
+// The reader's declarations, outside every repository (ADR-96174f1ac2b7)
+// ---------------------------------------------------------------------------
+//
+// **Outside the repository is the whole promise.** A pointer committed in the
+// code repository would be the more useful design for a team wanting shared
+// context, and it is precisely the trace the request refuses. So this file is
+// the reader's, one entry per repository identity, and the code repository
+// keeps not one byte it did not already have.
+//
+// **Declared, never discovered.** Nothing here walks a filesystem looking for a
+// corpus and nothing reads a git remote, for the reason ADR-a1de673043b4 gives
+// about peers: inference is how a corpus starts depending on where somebody
+// happened to check something out.
+
+/// The reader's map of repository identity to corpus, under [`user_dir`].
+pub const CORPORA_FILE: &str = "corpora.yml";
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CorporaFile {
+    schema: u32,
+    #[serde(default)]
+    corpora: BTreeMap<String, String>,
+}
+
+/// Where this reader's declarations live, or `None` where the environment names
+/// no home.
+///
+/// **The environment and the standard library, and no third-party crate.** The
+/// rule is three lines of platform difference and a dependency for it would be
+/// a supply chain for a `getenv`.
+///
+/// `%APPDATA%\ank` on Windows; `$XDG_CONFIG_HOME/ank` elsewhere, falling back to
+/// `$HOME/.config/ank`, which is the same order every other tool on those two
+/// platforms applies. An empty value counts as unset: a shell that exports a
+/// variable to nothing has said nothing, and joining onto it would name a
+/// relative path under the current directory.
+pub fn user_dir() -> Option<std::path::PathBuf> {
+    let var = |key: &str| {
+        std::env::var_os(key)
+            .filter(|v| !v.is_empty())
+            .map(std::path::PathBuf::from)
+    };
+    if cfg!(windows) {
+        return var("APPDATA").map(|p| p.join("ank"));
+    }
+    if let Some(xdg) = var("XDG_CONFIG_HOME") {
+        return Some(xdg.join("ank"));
+    }
+    var("HOME").map(|p| p.join(".config").join("ank"))
+}
+
+/// The declarations file, wherever this reader's home is.
+pub fn corpora_path() -> Option<std::path::PathBuf> {
+    user_dir().map(|d| d.join(CORPORA_FILE))
+}
+
+/// A repository identity as ADR-621a7fd96ce1 defines it: the root commit, and
+/// therefore forty lowercase hex characters.
+fn is_identity(key: &str) -> bool {
+    key.len() == 40
+        && key
+            .bytes()
+            .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+}
+
+/// Every corpus this reader has declared, keyed on repository identity.
+///
+/// **An empty map for a file that is not there**, which is the ordinary case
+/// and not a failure: a reader who has declared nothing gets the walk, and the
+/// walk is what every corpus written before this existed resolves through.
+///
+/// **A key that is not an identity is refused by name**, and that is behaviour
+/// rather than commentary. The request this comes from proposed a directory
+/// named by the slugified remote URL, so this map will be handed slugs, paths
+/// and URLs by people who read that thread. Each of them fails the test
+/// ADR-96174f1ac2b7 states -- one clone over ssh and one over https key
+/// differently, a fork keys differently from its upstream, a rename on the
+/// forge silently orphans the declaration -- and a wrong key that merely
+/// matched nothing would leave the corpus quietly not found, which is the one
+/// outcome worse than a refusal.
+pub fn declarations() -> Result<BTreeMap<String, String>> {
+    let Some(path) = corpora_path() else {
+        return Ok(BTreeMap::new());
+    };
+    let text = match std::fs::read_to_string(&path) {
+        Ok(text) => text,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(BTreeMap::new()),
+        Err(e) => {
+            return Err(CliError::new(
+                ExitCode::Environment,
+                format!("{}: {e}", path.display()),
+            ))
+        }
+    };
+    let file: CorporaFile = serde_yaml::from_str(&text).map_err(|e| {
+        CliError::new(ExitCode::Environment, format!("{}: {e}", path.display()))
+            .with_hint("schema: 1 and a corpora: map of repository identity to path")
+    })?;
+    if file.schema != SUPPORTED_SCHEMA {
+        return Err(CliError::new(
+            ExitCode::Environment,
+            format!(
+                "{}: schema {} is not {SUPPORTED_SCHEMA}",
+                path.display(),
+                file.schema
+            ),
+        ));
+    }
+    for key in file.corpora.keys() {
+        if !is_identity(key) {
+            return Err(CliError::new(
+                ExitCode::Environment,
+                format!("{}: '{key}' is not a repository identity", path.display()),
+            )
+            .with_hint(
+                "a key is the root commit, never a path, a remote or a slug: \
+                 ank status --json prints it under \"corpus\"",
+            ));
+        }
+    }
+    Ok(file.corpora)
+}
+
+// ---------------------------------------------------------------------------
 // `ank config` (§4, ADR-e64dfaafd578)
 // ---------------------------------------------------------------------------
 //

--- a/crates/ank-cli/src/repo.rs
+++ b/crates/ank-cli/src/repo.rs
@@ -111,15 +111,98 @@ pub fn at(path: &Path) -> Result<Repo> {
 /// that corpus is anchored to. Absent the second, the anchor is the corpus's
 /// own directory, which is what every corpus written before this flag existed
 /// resolves to and why no existing invocation moves.
-pub fn resolve(repo_flag: Option<&str>, worktree_flag: Option<&str>, cwd: &Path) -> Result<Repo> {
+pub fn resolve(
+    repo_flag: Option<&str>,
+    worktree_flag: Option<&str>,
+    cwd: &Path,
+    notes: &mut Vec<String>,
+) -> Result<Repo> {
     let repo = match repo_flag {
         Some(p) => at(Path::new(p))?,
-        None => discover(cwd)?,
+        // **Four cases and this is the order** (ADR-96174f1ac2b7): the flag,
+        // which short-circuits everything as it always did; a declaration
+        // matching this repository's identity, which wins over the tree and
+        // says so; the walk, unchanged; and the refusal that already existed.
+        None => match declared(cwd, notes)? {
+            Some(repo) => repo,
+            None => discover(cwd)?,
+        },
     };
     match worktree_flag {
         None => Ok(repo),
         Some(p) => Ok(repo.anchored(anchor(Path::new(p))?)),
     }
+}
+
+/// The corpus this reader has declared for the repository `cwd` sits in, if
+/// there is one (ADR-96174f1ac2b7).
+///
+/// **Nothing is asked of git until a declaration exists to match.** An empty
+/// map is the answer for every reader who has declared nothing, and it costs a
+/// file that is not there. Only past that does this ask for the identity, which
+/// is a git process — and its absence is not a refusal: a directory that is no
+/// repository has no identity, matches no declaration, and falls through to the
+/// walk. That is what keeps ADR-9307e5d214a7 true here, where a startup that
+/// required git would turn away every verb that does not need it.
+///
+/// **A declaration that names no corpus is a refusal, never a fallback.**
+/// Falling back to the walk would make a typo in the map indistinguishable from
+/// having no map at all, which is the failure the whole design is arranged
+/// against.
+fn declared(cwd: &Path, notes: &mut Vec<String>) -> Result<Option<Repo>> {
+    let map = crate::config::declarations()?;
+    if map.is_empty() {
+        return Ok(None);
+    }
+    let Some(id) = identity(cwd) else {
+        return Ok(None);
+    };
+    let Some(declared) = map.get(&id) else {
+        return Ok(None);
+    };
+    let root = Path::new(declared);
+    let repo = at(root).map_err(|_| {
+        CliError::new(
+            ExitCode::Generic,
+            format!("the corpus declared for {id} is not at {declared}"),
+        )
+        .with_hint(format!(
+            "ank init --at {declared}, or correct the entry in {}",
+            crate::config::corpora_path()
+                .map(|p| p.display().to_string())
+                .unwrap_or_else(|| crate::config::CORPORA_FILE.to_string())
+        ))
+    })?;
+
+    // **Both roots named, and no verb fails.** A corpus in the tree under a
+    // declaration is a reader who has one of each, and which one answered is
+    // the single fact they need. It goes to standard error because stdout is a
+    // parser's input (§4), and `--quiet` silences it like every other note.
+    if let Ok(in_tree) = discover(cwd) {
+        notes.push(format!(
+            "corpus declared at {declared}, and {} also carries one: the \
+             declaration answers",
+            in_tree.corpus.display()
+        ));
+    }
+    // Anchored to the tree the caller is standing in, which is what the corpus
+    // is a corpus *of* (ADR-9e56318631f3). `--worktree` still overrides it, on
+    // the same terms it overrides the nominal layout.
+    Ok(Some(repo.anchored(worktree_of(cwd))))
+}
+
+/// The top of the work tree `cwd` sits in, or `cwd` itself where git cannot
+/// say.
+///
+/// A scope glob is confronted from the root of the tree and not from wherever
+/// the agent happened to run, so resolving it to `cwd` would make `src/**` mean
+/// something different in every subdirectory.
+fn worktree_of(cwd: &Path) -> PathBuf {
+    crate::git::run(cwd, &["rev-parse", "--show-toplevel"])
+        .ok()
+        .map(PathBuf::from)
+        .filter(|p| p.is_dir())
+        .unwrap_or_else(|| cwd.to_path_buf())
 }
 
 /// The work tree `--worktree` names, checked for the one property resolution
@@ -530,7 +613,13 @@ mod tests {
     fn the_repo_flag_short_circuits_the_walk_up() {
         let t = Temp::new();
         let elsewhere = std::env::temp_dir();
-        let via_flag = resolve(Some(t.0.to_str().unwrap()), None, &elsewhere).unwrap();
+        let via_flag = resolve(
+            Some(t.0.to_str().unwrap()),
+            None,
+            &elsewhere,
+            &mut Vec::new(),
+        )
+        .unwrap();
         assert_eq!(via_flag.corpus, t.0);
     }
 

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -8221,6 +8221,319 @@ fn a_corpus_wider_than_a_command_line_is_hashed_correctly() {
     );
 }
 
+// ---------------------------------------------------------------------------
+// A corpus declared outside the tree (ADR-96174f1ac2b7, TASK-88bff140d416)
+// ---------------------------------------------------------------------------
+//
+// Driven with the environment set rather than by calling the function that
+// reads it, because the home directory is `%APPDATA%` on one platform and
+// `$XDG_CONFIG_HOME` or `$HOME` on the other two, and CLAUDE.md is explicit
+// that OS-dependent behaviour is not verified until it has run on all three.
+// All three variables are set to one directory, so the file lands at
+// `<home>/ank/corpora.yml` whichever rule the binary applied.
+
+/// A tree with history and no corpus of its own, a corpus outside it, and a
+/// home this test owns.
+struct Declared {
+    home: PathBuf,
+    tree: PathBuf,
+    corpus: PathBuf,
+    identity: String,
+}
+
+impl Declared {
+    fn new() -> Declared {
+        static SEQ: AtomicU64 = AtomicU64::new(0);
+        let root = std::env::temp_dir().join(format!(
+            "ank-declared-{}-{}",
+            std::process::id(),
+            SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+        let (home, tree, corpus) = (root.join("home"), root.join("tree"), root.join("corpus"));
+        std::fs::create_dir_all(home.join("ank")).unwrap();
+        std::fs::create_dir_all(&tree).unwrap();
+
+        let d = Declared {
+            home,
+            tree,
+            corpus,
+            identity: String::new(),
+        };
+        d.git(&["init", "-q", "-b", "main"]);
+        d.git(&["config", "user.email", "test@ank.local"]);
+        d.git(&["config", "user.name", "Test"]);
+        d.git(&["config", "commit.gpgsign", "false"]);
+        std::fs::write(d.tree.join("a.txt"), "hi\n").unwrap();
+        d.git(&["add", "-A"]);
+        d.git(&["commit", "-qm", "seed"]);
+        // The identity a reader keys on, read the way `status --json` prints
+        // it: the oldest root of HEAD.
+        let identity = d.git(&["rev-list", "--max-parents=0", "--reverse", "HEAD"]);
+        let identity = identity.lines().next().expect("a root commit").to_string();
+
+        // The corpus, written by hand: `ank init` refuses outside a git
+        // repository, and creating a detached one is the *writing* half
+        // (TASK-49fc7e1e0e0e). This task is the reading half and seeds what it
+        // reads.
+        Declared { identity, ..d }.with_corpus()
+    }
+
+    fn with_corpus(self) -> Declared {
+        std::fs::create_dir_all(self.corpus.join(".ank/entities")).unwrap();
+        std::fs::write(
+            self.corpus.join(".ank/config.yml"),
+            "schema: 1\nclaim_ttl_max: 2h\ndefault_branch: main\n",
+        )
+        .unwrap();
+        std::fs::write(
+            self.corpus.join(".ank/entities/TASK-000000000001.md"),
+            "---\nid: TASK-000000000001\ntype: task\nslug: example\n\
+             title: Declared corpus task\ncreated: 2026-07-28T00:00:00Z\nstatus: open\n\
+             scope:\n  - a.txt\nblocked_by: []\ndone_criteria: |\n  A verifiable criterion.\n\
+             criteria_by: creator\nschema: 1\nversion: 1\n---\n\nFree body.\n",
+        )
+        .unwrap();
+        self
+    }
+
+    fn git(&self, args: &[&str]) -> String {
+        let out = git_command(&self.tree)
+            .args(args)
+            .output()
+            .expect("git must be installed");
+        assert!(
+            out.status.success(),
+            "git {args:?}: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        String::from_utf8_lossy(&out.stdout).trim().to_string()
+    }
+
+    /// Writes the map this reader declares. `keys` is what goes in it verbatim,
+    /// so a test can hand it something that is not an identity.
+    fn declare(&self, keys: &[(&str, &str)]) {
+        let mut text = String::from("schema: 1\ncorpora:\n");
+        for (key, path) in keys {
+            text.push_str(&format!("  \"{key}\": \"{}\"\n", path.replace('\\', "/")));
+        }
+        std::fs::write(self.home.join("ank").join("corpora.yml"), text).unwrap();
+    }
+
+    /// A corpus in the tree as well, so that both roots exist.
+    fn corpus_in_tree(&self) {
+        std::fs::create_dir_all(self.tree.join(".ank/entities")).unwrap();
+        std::fs::write(
+            self.tree.join(".ank/config.yml"),
+            "schema: 1\nclaim_ttl_max: 2h\ndefault_branch: main\n",
+        )
+        .unwrap();
+        std::fs::write(
+            self.tree.join(".ank/entities/TASK-00000000000f.md"),
+            "---\nid: TASK-00000000000f\ntype: task\nslug: in-tree\n\
+             title: In-tree task\ncreated: 2026-07-28T00:00:00Z\nstatus: open\n\
+             scope:\n  - a.txt\nblocked_by: []\ndone_criteria: |\n  A verifiable criterion.\n\
+             criteria_by: creator\nschema: 1\nversion: 1\n---\n\nFree body.\n",
+        )
+        .unwrap();
+    }
+
+    /// The binary, run inside `at` with this test's home in the environment.
+    fn ank_at(&self, at: &Path, args: &[&str]) -> Output {
+        ank_command()
+            .args(args)
+            .env("ANK_AGENT", "claude-code/1.0")
+            // All three, so one fixture serves the three platforms: the binary
+            // reads whichever its own rule names and the file is at the same
+            // place either way.
+            .env("APPDATA", &self.home)
+            .env("XDG_CONFIG_HOME", &self.home)
+            .env("HOME", &self.home)
+            .current_dir(at)
+            .output()
+            .expect("the binary must have been built")
+    }
+
+    fn ank(&self, args: &[&str]) -> Output {
+        self.ank_at(&self.tree.clone(), args)
+    }
+}
+
+/// The whole of the surface: no flag, and the corpus the reader declared
+/// answers, anchored to the tree they are standing in.
+#[test]
+fn a_declared_corpus_answers_with_no_flag_and_anchors_to_the_tree() {
+    let d = Declared::new();
+    d.declare(&[(&d.identity, &d.corpus.to_string_lossy())]);
+
+    let out = d.ank(&["find"]);
+    assert_eq!(code(&out), 0, "{}", both_streams(&out));
+    assert!(
+        stdout(&out).contains("Declared corpus task"),
+        "the declared corpus did not answer: {}",
+        both_streams(&out)
+    );
+
+    // **Anchored to the tree, not to the corpus** (ADR-9e56318631f3), and from a
+    // subdirectory, which is where an agent is actually launched. `a.txt` lives
+    // in the tree and nowhere near the corpus, so a scope that matches it can
+    // only have been confronted against the tree.
+    let deep = d.tree.join("deep").join("er");
+    std::fs::create_dir_all(&deep).unwrap();
+    let out = d.ank_at(&deep, &["scope", "a.txt"]);
+    assert_eq!(code(&out), 0, "{}", both_streams(&out));
+    assert!(
+        stdout(&out).contains("Declared corpus task"),
+        "the glob was confronted somewhere other than the tree: {}",
+        both_streams(&out)
+    );
+}
+
+/// Both roots exist: the declaration answers, both are named, and what a parser
+/// reads does not move.
+#[test]
+fn a_declaration_wins_over_a_corpus_in_the_tree_and_names_both() {
+    let d = Declared::new();
+    d.declare(&[(&d.identity, &d.corpus.to_string_lossy())]);
+
+    // What the same corpus answers reached the way that was always available.
+    let by_flag = d.ank_at(&d.tree, &["find", "--repo", &d.corpus.to_string_lossy()]);
+    assert_eq!(code(&by_flag), 0, "{}", both_streams(&by_flag));
+
+    d.corpus_in_tree();
+    let out = d.ank(&["find"]);
+    assert_eq!(code(&out), 0, "{}", both_streams(&out));
+
+    // The declaration answered, and the tree's corpus did not.
+    assert!(
+        stdout(&out).contains("Declared corpus task"),
+        "{}",
+        stdout(&out)
+    );
+    assert!(!stdout(&out).contains("In-tree task"), "{}", stdout(&out));
+
+    // Both roots named, on standard error, because stdout is a parser's input.
+    let said = stderr(&out);
+    assert!(said.contains("warning:"), "{said}");
+    assert!(
+        said.contains(&d.corpus.to_string_lossy().replace('\\', "/")),
+        "the declaration is named: {said}"
+    );
+    assert!(
+        said.contains("also carries one"),
+        "the tree's corpus is named too: {said}"
+    );
+
+    // Byte for byte what the same corpus answers without any declaration at
+    // all, which is the half that says the note is a note and not an answer.
+    assert_eq!(stdout(&out), stdout(&by_flag), "the answer moved");
+
+    // `--quiet` silences it like every other note, and `--json` never carries
+    // it: a parser handed a warning on stdout would be a parser handed a
+    // syntax error.
+    let quiet = d.ank(&["find", "--quiet"]);
+    assert!(!stderr(&quiet).contains("warning:"), "{}", stderr(&quiet));
+    let json = d.ank(&["find", "--json"]);
+    let by_flag_json = d.ank_at(
+        &d.tree,
+        &["find", "--json", "--repo", &d.corpus.to_string_lossy()],
+    );
+    assert!(
+        stdout(&json).trim_start().starts_with('{'),
+        "{}",
+        stdout(&json)
+    );
+    assert_eq!(stdout(&json), stdout(&by_flag_json), "the document moved");
+}
+
+/// A key that is not an identity is refused by name, and the refusal names the
+/// command that prints the right one.
+///
+/// Behaviour and not commentary: the request this comes from proposed a
+/// directory named by the slugified remote URL, so this map will be handed
+/// slugs, paths and URLs. A wrong key that merely matched nothing would leave
+/// the corpus quietly not found, which is the one outcome worse than a refusal.
+#[test]
+fn a_key_that_is_not_an_identity_is_refused_by_name() {
+    let d = Declared::new();
+    for key in [
+        "git@github.com:acme/thing.git",
+        "https://github.com/acme/thing",
+        "acme-thing",
+        "/home/someone/code/thing",
+        // The identity with one character too few: a near miss is still a miss,
+        // and it is the shape a hand-typed key actually takes.
+        &d.identity[..39],
+    ] {
+        d.declare(&[(key, &d.corpus.to_string_lossy())]);
+        let out = d.ank(&["find"]);
+        assert_ne!(code(&out), 0, "{key} was accepted: {}", both_streams(&out));
+        let said = both_streams(&out);
+        assert!(said.contains(key), "the refusal names the key: {said}");
+        assert!(
+            said.contains("is not a repository identity"),
+            "and says what is wrong with it: {said}"
+        );
+        assert!(
+            said.contains("ank status --json"),
+            "and names the command that prints the right one: {said}"
+        );
+    }
+}
+
+/// A declaration naming a path that holds no corpus is a refusal naming the
+/// path, and never a fallback to the walk.
+///
+/// The tree carries a corpus here on purpose: falling back would find it, and
+/// a typo in the map would then be indistinguishable from having no map at all.
+#[test]
+fn a_declaration_naming_no_corpus_is_a_refusal_and_never_the_walk() {
+    let d = Declared::new();
+    d.corpus_in_tree();
+    let absent = d.corpus.with_extension("nowhere");
+    d.declare(&[(&d.identity, &absent.to_string_lossy())]);
+
+    let out = d.ank(&["find"]);
+    assert_ne!(code(&out), 0, "{}", both_streams(&out));
+    let said = both_streams(&out);
+    assert!(
+        said.contains(&absent.to_string_lossy().replace('\\', "/")),
+        "the refusal names the path it was sent to: {said}"
+    );
+    assert!(
+        !said.contains("In-tree task"),
+        "it fell back to the walk, so a typo reads as no map at all: {said}"
+    );
+}
+
+/// With no declaration the walk is what it always was, and a tree with neither
+/// is the refusal it always was.
+#[test]
+fn with_no_declaration_the_walk_is_unchanged() {
+    let d = Declared::new();
+
+    // Neither: the refusal that already existed, naming `ank init`.
+    let out = d.ank(&["find"]);
+    assert_eq!(code(&out), 1, "{}", both_streams(&out));
+    let said = both_streams(&out);
+    assert!(said.contains("no .ank/ found"), "{said}");
+    assert!(said.contains("ank init"), "{said}");
+
+    // A corpus in the tree and still no declaration: the walk finds it, and
+    // nothing is said about a declaration nobody made.
+    d.corpus_in_tree();
+    let out = d.ank(&["find"]);
+    assert_eq!(code(&out), 0, "{}", both_streams(&out));
+    assert!(stdout(&out).contains("In-tree task"), "{}", stdout(&out));
+    assert!(!stderr(&out).contains("warning:"), "{}", stderr(&out));
+
+    // And an empty map is the same as no map: a reader who has declared nothing
+    // is a reader who walks.
+    d.declare(&[]);
+    let out = d.ank(&["find"]);
+    assert_eq!(code(&out), 0, "{}", both_streams(&out));
+    assert!(stdout(&out).contains("In-tree task"), "{}", stdout(&out));
+}
+
 /// The workspace root: two levels above this crate's manifest.
 ///
 /// Derived rather than configured, so a crate added to the workspace is walked


### PR DESCRIPTION
Closes TASK-88bff140d416, the reading half of ADR-96174f1ac2b7. The
corpus is found and anchored; nothing is created or written.

## Four cases, one order

`--repo`, which short-circuits everything as it always did. A
declaration whose key is this repository's identity, which
short-circuits the walk the same way and answers with the corpus it
names, anchored to the work tree the caller is standing in. No
declaration, which is the walk unchanged. Neither, which is the refusal
that already existed, naming `ank init`.

The map is the reader's and lives outside every repository —
`%APPDATA%\ank\corpora.yml` on Windows, `$XDG_CONFIG_HOME/ank` or
`$HOME/.config/ank` elsewhere, resolved from the environment and the
standard library with no crate added for a `getenv`.

## The two refusals are the design

**A key that is not an identity is refused by name**, with the command
that prints the right one. The request this comes from proposed a
directory named by the slugified remote URL, so the map will be handed
slugs, paths and URLs; a wrong key that merely matched nothing would
leave the corpus quietly not found. The test covers a near miss too —
the identity one character short — because that is the shape a
hand-typed key actually takes.

**A declaration naming no corpus is a refusal naming the path**, never a
fallback. The test puts a corpus in the tree so falling back would find
one, which is exactly what would make a typo indistinguishable from
having no map.

## On git at startup

Resolving now asks for the repository identity, which is a git process,
where ADR-9307e5d214a7 says git is per verb and never at startup. The
order is the guard: an empty map costs a file that is not there and asks
git nothing, so only a reader who has declared something pays a spawn —
and a directory with no identity matches nothing and falls through to
the walk rather than being refused. No verb is turned away for want of
git.

## Waiting on a human

SPEC-aa4b4f119929 states the resolution order. It supersedes
SPEC-55162f52d40e rather than SPEC-201041998d90 as the criterion names,
because that document's chain ends there — the rule TASK-e2da6b0cc817
implemented, applied to the criterion that names it. `ank accept
SPEC-aa4b` is not mine to run.

Tests drive the binary with all three home variables set, so one fixture
serves the three platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X5PCmpdS4j9itcqRKvrowX
