### PR TITLE
Re-point the citations two ratifications left superseded

### DIFF
--- a/crates/ank-cli/src/claim.rs
+++ b/crates/ank-cli/src/claim.rs
@@ -1762,7 +1762,7 @@ pub fn run(
     let loaded = store.load_prefix(prefix)?;
     let base_version = crate::store::version_of(&loaded.entity);
     // What a `--criteria` that writes one would replace, kept before the
-    // destructuring consumes it (ADR-16813b3bcf37).
+    // destructuring consumes it (ADR-f7dc76886db2).
     let before = loaded.entity.clone();
     let Entity::Task(mut task) = loaded.entity else {
         return Err(
@@ -1856,7 +1856,7 @@ pub fn run(
     let claimed = Entity::Task(task.clone());
     let version = store.write(&claimed, base_version)?;
 
-    // **The criterion this call wrote, accounted for** (ADR-16813b3bcf37).
+    // **The criterion this call wrote, accounted for** (ADR-f7dc76886db2).
     // `claim` is on the list of three because `--criteria` writes a
     // `done_criteria` the task did not have, which is content, and the whole
     // authority model then rests on it. The status this same write moved is a

--- a/crates/ank-cli/src/commands.rs
+++ b/crates/ank-cli/src/commands.rs
@@ -1779,7 +1779,7 @@ fn log_read(
     // corpus has not been migrated yet (§3).
     let all = entries::about(store, &Index::open(&repo.ank)?, &loaded.entity)?;
     // This verb *is* the work trace: it is what an agent reads before repeating
-    // what a previous holder already tried (ADR-16813b3bcf37). The machinery is
+    // what a previous holder already tried (ADR-f7dc76886db2). The machinery is
     // listed under it, addressable like every other row, and it is charged no
     // budget against the trace.
     let (all, machinery) = entries::split(all);

--- a/crates/ank-cli/src/context.rs
+++ b/crates/ank-cli/src/context.rs
@@ -884,7 +884,7 @@ fn build_execution(
     // The work trace alone. This view is served under a budget to an agent
     // about to work, and what it is for is what previous holders learned; a
     // mechanical line here would spend that budget on saying that a field
-    // moved (ADR-16813b3bcf37). The machinery is reachable through `ank log`
+    // moved (ADR-f7dc76886db2). The machinery is reachable through `ank log`
     // and `ank show`, which are the verbs a reader asks that question with.
     let (log_entries, _machinery) =
         crate::entries::split(crate::entries::about(store, index, &loaded.entity)?);

--- a/crates/ank-cli/src/edit.rs
+++ b/crates/ank-cli/src/edit.rs
@@ -241,7 +241,7 @@ fn write_back(
     // caller, on this path like every other.
     let version = store.write(&after, base_version)?;
 
-    // **The version this write just moved, accounted for** (ADR-16813b3bcf37).
+    // **The version this write just moved, accounted for** (ADR-f7dc76886db2).
     // `edit` changes content and never a status, so it is one of the three
     // verbs the decision names, and the entry is written after the write it
     // records: a write that failed must leave no trace behind, and a write with
@@ -479,7 +479,7 @@ fn changed_fields(before: &Entity, after: &Entity) -> Vec<&'static str> {
         // The two kinds that used to fall through here, and the fall-through
         // was a hole rather than a decision: a spec whose body an edit rewrote
         // reported no field at all, so the line said `canonical form` and the
-        // machinery entry would have said it too (ADR-16813b3bcf37). Every kind
+        // machinery entry would have said it too (ADR-f7dc76886db2). Every kind
         // the parser resolves is named, in the order §3 lists its fields.
         (Entity::Spec(a), Entity::Spec(b)) => {
             note("slug", a.slug != b.slug);

--- a/crates/ank-cli/src/entries.rs
+++ b/crates/ank-cli/src/entries.rs
@@ -54,7 +54,7 @@ use ank_core::{
 pub struct Entry {
     pub id: Option<EntityId>,
     /// What the entry records, when it records something other than work
-    /// (ADR-16813b3bcf37). `None` is the work trace, which is what a reader
+    /// (ADR-f7dc76886db2). `None` is the work trace, which is what a reader
     /// means by the log and what every line of the previous layout is.
     pub records: Option<String>,
     /// The rank of §3: the entry's own `seq`, and the line's index in the file
@@ -91,7 +91,7 @@ impl Entry {
 /// changes is the presentation: `ank log` is what an agent reads before
 /// repeating what a previous holder already tried, and an entity edited eight
 /// times would answer that question with eight mechanical lines
-/// (ADR-16813b3bcf37).
+/// (ADR-f7dc76886db2).
 pub fn split(entries: Vec<Entry>) -> (Vec<Entry>, Vec<Entry>) {
     entries.into_iter().partition(|e| !e.is_machinery())
 }
@@ -226,7 +226,7 @@ pub fn record(
 }
 
 /// The same write, marked as machinery rather than as work
-/// (ADR-16813b3bcf37).
+/// (ADR-f7dc76886db2).
 ///
 /// **The word is the only difference**, and that is deliberate: an entry an
 /// agent wrote and an entry a verb wrote are the same kind of entity, written
@@ -294,7 +294,7 @@ fn write_entry(
 }
 
 /// The hash a machinery entry carries: the state the write replaced
-/// (ADR-16813b3bcf37).
+/// (ADR-f7dc76886db2).
 ///
 /// **The whole entity and never the field that moved.** What the entry hands a
 /// reader is a claim about how an entity *read* at a version, and a hash over
@@ -402,7 +402,7 @@ pub fn edit_message(
 }
 
 /// The version transition a machinery entry states, read back out of its
-/// message (ADR-16813b3bcf37).
+/// message (ADR-f7dc76886db2).
 ///
 /// The other direction of [`edit_message`], and the pair is why the grammar is
 /// written in one place: the writer and the only reader sit beside each other,
@@ -482,7 +482,7 @@ pub fn from_line(id: EntityId, subject: &Entity, seq: u64, line: &LogEntry) -> L
         // Work unless the caller says otherwise: `ank log` is a holder saying
         // what they learned and a migration carries a line a holder wrote, and
         // neither is machinery. [`record_edit`] is the one caller that sets the
-        // word, on the entry this function has just built (ADR-16813b3bcf37).
+        // word, on the entry this function has just built (ADR-f7dc76886db2).
         records: None,
         verified: Vec::new(),
         schema: ank_core::SCHEMA_VERSION,

--- a/crates/ank-cli/src/human.rs
+++ b/crates/ank-cli/src/human.rs
@@ -1859,7 +1859,7 @@ fn record_entry(
     )
 }
 
-/// The machinery entry a write of content owes (ADR-16813b3bcf37).
+/// The machinery entry a write of content owes (ADR-f7dc76886db2).
 ///
 /// **Beside [`record_entry`] and never inside it.** The two write the same kind
 /// of entity through the same door, and what separates them is one word and the
@@ -2129,7 +2129,7 @@ fn check_references(
         //
         // Nothing is written to make this resolve. The file keeps the
         // identifier its author wrote, the version does not move, and no
-        // machinery entry is deposited by a read (ADR-16813b3bcf37).
+        // machinery entry is deposited by a read (ADR-f7dc76886db2).
         let mut named = target.clone();
         if view.status == AdrStatus::Superseded {
             if let Some(head) = chain_head(target, entities) {
@@ -5231,7 +5231,7 @@ pub fn amend(
     let id = loaded.entity.id().clone();
     // The state every arm below replaces, kept before the match consumes it:
     // the machinery entry hashes it, and the hash is of what was there and not
-    // of what the amend produced (ADR-16813b3bcf37).
+    // of what the amend produced (ADR-f7dc76886db2).
     let before = loaded.entity.clone();
 
     // Both normalised, and both for the same reason `new --scope` is: one is
@@ -5397,7 +5397,7 @@ pub fn amend(
             let version = store.write(&amended, base_version)?;
             // Machinery rather than work, since TASK-3c12e0ced2c0: an amend is a
             // change of content outside a status transition, which is the case
-            // ADR-16813b3bcf37 names. The line it used to write into the work
+            // ADR-f7dc76886db2 names. The line it used to write into the work
             // trace said the same thing in a place `ank log` reads for what a
             // previous holder learned, and an entity amended eight times made
             // that verb answer with eight of these.
@@ -5473,7 +5473,7 @@ pub fn amend(
             }
             // Recorded by an entry of its own, on the same terms a task's
             // amend is: any kind may carry entries (ADR-25f977377fa0), and
-            // ADR-16813b3bcf37 asks for one per write of content whatever the
+            // ADR-f7dc76886db2 asks for one per write of content whatever the
             // kind. It used to be `version` and the diff alone, which said
             // nothing a reader could reach without git.
             let amended = Entity::Adr(adr);
@@ -5804,7 +5804,7 @@ pub fn show(inv: &Invocation, repo: &Repo, cfg: &Config, out: &mut dyn Write) ->
     if body_carries_its_own_log(&loaded.entity) {
         log.retain(|e| e.id.is_some());
     }
-    // The work trace and the machinery part here (ADR-16813b3bcf37). What the
+    // The work trace and the machinery part here (ADR-f7dc76886db2). What the
     // budget below is spent on is the trace, because that is what a reader came
     // for; the machinery is listed under it, out of what is left, and an entity
     // edited eight times therefore does not answer "what did the last holder
@@ -5914,7 +5914,7 @@ fn log_json(entries: &[crate::entries::Entry]) -> String {
 
 /// The machinery, printed under the work trace and never mixed into it.
 ///
-/// **A section of its own, and not a filter.** ADR-16813b3bcf37 asks that an
+/// **A section of its own, and not a filter.** ADR-f7dc76886db2 asks that an
 /// edit leave a record a reader can find, which a record nobody prints does not
 /// satisfy; and TASK-027a429aad2e asks that the work trace stop carrying it,
 /// which mixing the two does not satisfy either. Two sections answer both, and

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -465,7 +465,7 @@ impl Repo {
     }
 
     /// The machinery entries about an entity, oldest first, as the messages
-    /// they carry (ADR-16813b3bcf37).
+    /// they carry (ADR-f7dc76886db2).
     ///
     /// Read off the files rather than through the binary, on the same reasoning
     /// `log_text` is: what has to be true is the state of the corpus, and a
@@ -660,7 +660,7 @@ impl Repo {
     }
 
     /// An entry that records machinery rather than work, which is what
-    /// `show.machinery` and `log-read.machinery` are (ADR-16813b3bcf37).
+    /// `show.machinery` and `log-read.machinery` are (ADR-f7dc76886db2).
     ///
     /// Written by hand and at schema 4, because no verb writes one yet: the
     /// verbs that will are TASK-3c12e0ced2c0, and a declaration no fixture
@@ -3113,7 +3113,7 @@ fn a_citation_two_hops_behind_resolves_and_the_file_is_not_touched() {
 
     // **Nothing is written to make a reference resolve.** The whole argument
     // against repairing citations in place was that one `accept` would write to
-    // nine entities and, under ADR-16813b3bcf37, leave nine machinery entries
+    // nine entities and, under ADR-f7dc76886db2, leave nine machinery entries
     // behind. A read that writes is the same defect one verb further along.
     let after = std::fs::read(r.0.join(".ank/entities").join(format!("{BEHIND}.md"))).unwrap();
     assert_eq!(before, after, "check wrote to the citing document");
@@ -7435,7 +7435,7 @@ fn amend_adds_and_removes_without_disturbing_the_rest() {
     // The record of an amend is machinery since TASK-3c12e0ced2c0, so it names
     // the fields alone and the `amended:` opening is gone. What it gained is
     // the version transition and the hash of the state replaced, which is what
-    // makes the entry account for the write (ADR-16813b3bcf37).
+    // makes the entry account for the write (ADR-f7dc76886db2).
     assert!(
         r.log_text(ID).contains("+blocked_by TASK-000000000002"),
         "the log says what changed: {}",
@@ -17195,7 +17195,7 @@ fn the_corpus_named_as_its_own_work_tree_answers_identically() {
 }
 
 // ---------------------------------------------------------------------------
-// The work trace and the machinery (ADR-16813b3bcf37, TASK-027a429aad2e)
+// The work trace and the machinery (ADR-f7dc76886db2, TASK-027a429aad2e)
 // ---------------------------------------------------------------------------
 
 /// One entry about `about`, written by hand because no verb writes machinery
@@ -17348,7 +17348,7 @@ fn an_entity_with_no_machinery_grows_no_section() {
 
 // ---------------------------------------------------------------------------
 // A write of content accounts for the version it moved
-// (ADR-16813b3bcf37, TASK-3c12e0ced2c0)
+// (ADR-f7dc76886db2, TASK-3c12e0ced2c0)
 // ---------------------------------------------------------------------------
 //
 // Through the binary throughout, and the criterion says so for a reason that
@@ -17479,7 +17479,7 @@ fn content_edited_by_hand_is_reported_with_both_hashes() {
 /// An entry written before the clause existed says nothing about content, and
 /// an entity carrying none says nothing at all.
 ///
-/// The bootstrap, and it is the same one ADR-16813b3bcf37 already rested on: no
+/// The bootstrap ADR-f7dc76886db2 states in the same breath as the clause: no
 /// corpus is migrated by a rule it predates.
 #[test]
 fn an_entry_without_a_produced_hash_leaves_the_entity_silent() {
@@ -17552,7 +17552,7 @@ fn replaced_hash_of(text: &str) -> String {
     ))
 }
 
-/// The three verbs ADR-16813b3bcf37 names, and the two doors `edit` has.
+/// The three verbs ADR-f7dc76886db2 names, and the two doors `edit` has.
 ///
 /// One test over the four because the property is one property: whichever door
 /// the write came through, the entity ends up accounting for the version it
@@ -17821,8 +17821,8 @@ fn an_entity_edited_twice_answers_log_with_both_entries_in_order() {
 }
 
 // ---------------------------------------------------------------------------
-// An entity accounts for the versions it carries (ADR-16813b3bcf37,
-// TASK-dfe5a1bb0857)
+// The version count is kept where a transition's own fields evidence it
+// (ADR-f7dc76886db2, TASK-dfe5a1bb0857)
 // ---------------------------------------------------------------------------
 //
 // The falsification is a direct file write, performed rather than described:

--- a/crates/ank-contract/src/verbs.rs
+++ b/crates/ank-contract/src/verbs.rs
@@ -57,7 +57,7 @@ const LOG_ENTRY: &[Field] = &[
     f("who", Type::Str),
     f("message", Type::Str),
     // Absent on the work trace, which is what an entry is unless it says
-    // otherwise (ADR-16813b3bcf37). Present, it names what the entry records.
+    // otherwise (ADR-f7dc76886db2). Present, it names what the entry records.
     opt("records", Type::Str),
 ];
 
@@ -328,7 +328,7 @@ const fn refuses(code: ExitCode, when: &'static str) -> Refusal {
 /// The refusal every path-taking verb performs, declared once and named six
 /// times.
 ///
-/// SPEC-c937ff8fa70a states it for all of them at once — a path naming nothing
+/// SPEC-d3adbd77dca9 states it for all of them at once — a path naming nothing
 /// inside the repository, because it is absolute or because it climbs above the
 /// root, is refused with the command to run next and never answered — and the
 /// six verbs reach it through one helper, `context::normalised`. One sentence

--- a/crates/ank-core/src/model.rs
+++ b/crates/ank-core/src/model.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 pub const RECORDS_KINDS: &[&str] = &[RECORDS_EDIT];
 
 /// The word an entry carries when it records a change of content made outside
-/// a status transition (ADR-16813b3bcf37).
+/// a status transition (ADR-f7dc76886db2).
 ///
 /// Named once and written from one place, so the vocabulary above and the verb
 /// that writes into it cannot drift apart by a typo.
@@ -30,7 +30,7 @@ pub const RECORDS_EDIT: &str = "edit";
 ///
 /// 4 carries one change, [`Log::records`], and it is the same case again. An
 /// entry marked as machinery is kept out of the work trace a reader reads
-/// (ADR-16813b3bcf37); a reader that does not know the field drops it on the
+/// (ADR-f7dc76886db2); a reader that does not know the field drops it on the
 /// next rewrite, and the entry silently rejoins the trace it was written to
 /// stay out of. Silently is the word that decides it, here as at 3.
 ///
@@ -488,7 +488,7 @@ pub struct Log {
     /// **Absent means a work entry**, which is what `ank log` means to a reader
     /// and what every entry written before this field existed is. A value names
     /// machinery: `edit`, written by the verbs that change an entity's content
-    /// outside a status transition (ADR-16813b3bcf37).
+    /// outside a status transition (ADR-f7dc76886db2).
     ///
     /// **A free string at parse time, a vocabulary at `check` time**, on the
     /// terms ADR-3877fef1d662 sets for a typed actor: a value the tool does not


### PR DESCRIPTION
`main` has been red since the push of 20:40 on 2026-08-22, on all three
platforms, on one test: `no_superseded_document_is_cited_in_the_workspace`.

The merge of #237 was green. What turned it red is the pair of ratifications
that followed, in a single push whose run GitHub named after its second commit:
`2e5fdca` marked ADR-16813b3bcf37 superseded, `f6fcb06` marked
SPEC-c937ff8fa70a superseded, and thirty-three citations of the two stayed in
the source. The guard asks the corpus for that set rather than a transcribed
list, so a ratification is what kills a citation while a test is what finds it.

Thirty-one sites take the identifier alone; the two ids are the same length as
their successors, so no line rewrapped. Two sites said more than the name and
were reworded: the bootstrap clause at `cli.rs:17482` would have read as
resting on its own successor, and the section header at `cli.rs:17824` carried
the predecessor's title over the successor's identifier, which is the drift the
guard exists to catch, with a live identifier.

No behaviour changes. The code already carried `replaced` and `produced` from
 #237, so every re-pointed sentence still holds under the new constraint; each
was read in context before the identifier moved.

    cargo fmt --check        exit 0
    cargo test --workspace   all green, cli at 284 passed
    ank check                ok, 0 fault, 354 signal(s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
