### PR TITLE
Profile the per-entity phase of check, and file what it names

### DIFF
--- a/.ank/entities/LOG-01264018b4bd.md
+++ b/.ank/entities/LOG-01264018b4bd.md
@@ -1,0 +1,15 @@
+---
+id: LOG-01264018b4bd
+type: log
+title: What the profile named is filed as TASK-0515cfe21421, git::history walks all 917 commits to explain
+created: 2026-08-23T22:22:33Z
+author: claude-code/opus-5-measure
+scope:
+  - crates/ank-cli/src/human.rs
+about: TASK-756a870eb0ab
+seq: 6
+schema: 4
+version: 1
+---
+
+ a dead scope. It carries the mechanism and not the intention: the two processes, the 917 commits, the 177 KB, the 46 ms and the 183 to 240 ms, and the fact that the walk scales with the repository's commit count while the confrontation it serves costs 7.5 ms. It also carries the two things that must not be built, a cache and a search per glob, both already closed. The other three one-shots are left unfiled on purpose: the ratifications walk and the signature sqlite were each added by a task that measured them and replaced something worse, and gpg_config is a single git config spawn, so proposing to remove any of them would be the guess this task exists to avoid.

--- a/.ank/entities/LOG-3df7823a9cae.md
+++ b/.ank/entities/LOG-3df7823a9cae.md
@@ -1,0 +1,15 @@
+---
+id: LOG-3df7823a9cae
+type: log
+title: The per-entity phase is not per-entity. Timing each probe's slowest single call apart from the rest
+created: 2026-08-23T22:20:37Z
+author: claude-code/opus-5-measure
+scope:
+  - crates/ank-cli/src/human.rs
+about: TASK-756a870eb0ab
+seq: 2
+schema: 4
+version: 1
+---
+
+ splits the loop cleanly: 400 of the 544 ms, 74 percent, is four one-shot lazy initialisations that happen to be reached from inside the loop, on the first entity that needs them. git::history 251 ms (one call, 46 percent of the whole loop). The all_ratifications git log walk 56 ms, visible as the first freeze_state. Index::open on the signature sqlite 59 ms, and gpg_config's git config spawn 34 ms, both inside the first signature_cache lookup. That is why one ADR costs 142 to 164 ms and the other 61 cost 12 ms between them, and why one task costs 30 ms and the other 265 cost 76 ms between them.

--- a/.ank/entities/LOG-5bc16cbeb44f.md
+++ b/.ank/entities/LOG-5bc16cbeb44f.md
@@ -1,0 +1,15 @@
+---
+id: LOG-5bc16cbeb44f
+type: log
+title: The four sub-phases the criterion names, with the one-shot share taken out. Dead-scope
+created: 2026-08-23T22:20:55Z
+author: claude-code/opus-5-measure
+scope:
+  - crates/ank-cli/src/human.rs
+about: TASK-756a870eb0ab
+seq: 3
+schema: 4
+version: 1
+---
+
+ confrontation: 258 ms gross, but 251 of that is the single git::history call and the confrontation itself is 7.4 to 8.0 ms over 355 entities, of which scope_moved is 7.1 to 7.8 ms over the 114 dead globs this corpus carries. Freeze state: 54 to 69 ms gross on 89 anchored entities, of which 52 to 67 is the first call's git log walk, leaving 1.5 to 2.4 ms for the other 88; plus 28 to 31 ms in check_task, where 14 to 17 is the one claimed task's applicable_constraints and 13 to 15 is 265 coord lookups that find nothing. Signature reading: 106 to 113 ms gross on 89, of which 90 to 98 is the first call, sqlite open plus one git config; the other 88 cost 14 to 16 ms, and the cache query itself is 4.3 to 5.0 ms over 50. git::signature_of and commit_carries_signature were never reached, n=0, so no gpg ran. Proof reading: 3.0 to 3.8 ms over 266 tasks, and log_entries 0.9 to 1.0 ms. Succession 0.13 to 0.23, references 0.10 to 0.23, is_shallow 0.01.

--- a/.ank/entities/LOG-899ddcc52288.md
+++ b/.ank/entities/LOG-899ddcc52288.md
@@ -1,0 +1,13 @@
+---
+id: LOG-899ddcc52288
+type: log
+title: done, proof commit:20d8249640a5ccffc67368d115e17d0d08120781
+created: 2026-08-23T22:33:24Z
+author: claude-code/opus-5-measure
+scope:
+  - crates/ank-cli/src/human.rs
+about: TASK-756a870eb0ab
+seq: 7
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-89b126a5141d.md
+++ b/.ank/entities/LOG-89b126a5141d.md
@@ -1,0 +1,15 @@
+---
+id: LOG-89b126a5141d
+type: log
+title: The mechanism behind the 251 ms, measured outside ank so it rests on nothing this profile did.
+created: 2026-08-23T22:21:26Z
+author: claude-code/opus-5-measure
+scope:
+  - crates/ank-cli/src/human.rs
+about: TASK-756a870eb0ab
+seq: 5
+schema: 4
+version: 1
+---
+
+ git::history is two processes: git rev-list HEAD, 46 ms for 917 shas, piped into git diff-tree --stdin -r -M -z --name-status over all 917 commits, 183 to 240 ms for 177 KB of records, then parsed into one string per commit. It reads the rename and deletion history of the entire repository, and it scales with the repository's commit count rather than with the corpus. It is lazy, so a corpus with no dead scope pays nothing; this one has 114 dead globs and pays it whole on the first. That is what the follow-up task carries.

--- a/.ank/entities/LOG-a0207064921e.md
+++ b/.ank/entities/LOG-a0207064921e.md
@@ -1,0 +1,15 @@
+---
+id: LOG-a0207064921e
+type: log
+title: "Survey before instrumenting. The per-entity phase is the loop at human.rs:604: check_scope_alive"
+created: 2026-08-23T22:07:37Z
+author: claude-code/opus-5-measure
+scope:
+  - crates/ank-cli/src/human.rs
+about: TASK-756a870eb0ab
+seq: 0
+schema: 4
+version: 1
+---
+
+ for every non-log entity, then check_task / check_adr / check_spec. check_task reaches for verify_frozen and claim::applicable_constraints under a claim record, log_entries (a file read per task where the corpus entries are empty), the weak/dead/verifier proof block, and store.load in the heaviest-constraint note. check_adr and check_spec both go through check_anchor, which is freeze_state (ratification_of -> git::ratification_at, memoised) then signature_state (declared_signers reads allowed_signers from disk per entity, signers_for_git reads and maybe writes a temp file per entity, signature_cache hashes allowed_signers and gpg_config per lookup). Probes go on all of those; nothing concluded until the numbers are in.

--- a/.ank/entities/LOG-a0777d543009.md
+++ b/.ank/entities/LOG-a0777d543009.md
@@ -1,0 +1,15 @@
+---
+id: LOG-a0777d543009
+type: log
+title: "Profiled, release build, warm, this corpus (355 non-log entities: 266 tasks, 62 ADRs, 27 specs)."
+created: 2026-08-23T22:20:21Z
+author: claude-code/opus-5-measure
+scope:
+  - crates/ank-cli/src/human.rs
+about: TASK-756a870eb0ab
+seq: 1
+schema: 4
+version: 1
+---
+
+ Six runs on an idle machine, per-entity loop 488 495 547 541 554 557 ms, median 544. By kind: scope confrontation 226 230 257 260 285 286 (median 258, 47 percent), check_task 101 101 107 111 106 105 (median 105, 19 percent), check_adr 155 159 178 165 159 162 (median 161, 30 percent), check_spec 4.5 to 5.4 (1 percent). The four sum exactly to the loop total, so nothing is unattributed at that level.

--- a/.ank/entities/LOG-d0de7cfa2fa6.md
+++ b/.ank/entities/LOG-d0de7cfa2fa6.md
@@ -1,0 +1,15 @@
+---
+id: LOG-d0de7cfa2fa6
+type: log
+title: Which figures are stable. Repeated six times idle and five times while the other agent ran cargo
+created: 2026-08-23T22:21:11Z
+author: claude-code/opus-5-measure
+scope:
+  - crates/ank-cli/src/human.rs
+about: TASK-756a870eb0ab
+seq: 4
+schema: 4
+version: 1
+---
+
+ test --workspace. Idle, every figure holds inside 15 percent and the ordering never moves. Under load the absolute milliseconds double, loop total 508 to 1059, and no absolute figure survives; what survives unchanged is the decomposition, git::history stays 96 to 98 percent of the scope phase, the first ADR stays 91 to 93 percent of check_adr, and the per-entity residues stay where they are. So the shares are the stable measurement and the milliseconds are only stable on an idle machine. Recorded the idle series as the figures.

--- a/.ank/entities/TASK-0515cfe21421.md
+++ b/.ank/entities/TASK-0515cfe21421.md
@@ -1,0 +1,30 @@
+---
+id: TASK-0515cfe21421
+type: task
+slug: git-history-walks-all-917-commits-to-explain-a-d
+title: git::history walks all 917 commits to explain a dead scope, and it is 46 percent of check's per-entity phase
+created: 2026-08-23T22:22:13Z
+author: claude-code/opus-5-measure
+status: open
+scope:
+  - crates/ank-cli/src/git.rs
+  - crates/ank-cli/src/human.rs
+blocked_by: []
+done_criteria: |
+  The whole-history walk git::history performs is either narrowed to what a dead-scope explanation actually needs, or shown by measurement to be irreducible and recorded as such. Either way the answer is measured on this repository's corpus, release build, warm, on an idle machine, against the baseline TASK-756a870eb0ab recorded: 251 ms for the walk, 544 ms for the per-entity loop, 917 commits, 114 dead globs. Two constraints on whatever is built. It must not reintroduce a search per glob, which TASK-1b3d7b61dc8f removed deliberately after measuring 58 rev-list and 113 cat-file process starts on this repository; and no cache is added, which is what closed TASK-da7738572825. The explanation check prints for each of the 114 dead globs is identical before and after, glob by glob, and the findings check reports are identical subject by subject. cargo test is green, cargo fmt --check passes, ank check reports no fault.
+criteria_by: creator
+schema: 4
+version: 1
+---
+
+TASK-756a870eb0ab profiled the per-entity phase and this is the one thing it named.
+
+The phase is 544 ms on an idle machine, and 400 ms of that is four one-shot lazy initialisations reached from inside the loop rather than per-entity work. The largest by far is git::history, one call, 251 ms, 46 percent of the whole phase.
+
+**The mechanism, measured outside ank.** git::history is two processes: `git rev-list HEAD`, 46 ms for 917 shas, piped into `git diff-tree --stdin -r -M -z --name-status` over all 917 commits, 183 to 240 ms producing 177 KB of records, parsed into one string per commit. It reads the rename and deletion history of the entire repository so that scope_moved can say where a dead path went.
+
+**It scales with the repository's commit count, not with the corpus.** 114 dead globs cost the same walk as one would, and a repository with no dead scope pays nothing at all: the call is behind a OnceCell reached only by the first glob that matches no file. So the cost is conditional, and this corpus meets the condition permanently, because a document renamed once left 58 entities scoping the path it used to have.
+
+**What the confrontation itself costs, for contrast.** scope_moved over all 114 dead globs is 7.1 to 7.8 ms, and the whole per-entity scope check over all 355 entities is 7.4 to 8.0 ms. The searching is free; the walk it searches is not.
+
+**What must not be built here.** Not a cache, and not a search per glob. Both have been tried and both were closed. ADR-3094538d831e's cost clause is what the current shape was built to honour, and any narrower walk still has to report the rename or the deletion that killed a scope, for every one of the 114.

--- a/.ank/entities/TASK-756a870eb0ab.md
+++ b/.ank/entities/TASK-756a870eb0ab.md
@@ -5,15 +5,20 @@ slug: the-per-entity-half-of-check-is-374-ms-and-nothi
 title: The per-entity half of check is 374 ms and nothing has looked inside it
 created: 2026-08-22T20:52:22Z
 author: claude-code/opus-5
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/src/human.rs
 blocked_by: []
 done_criteria: |
   The per-entity phase of check is profiled by sub-phase on this repository's own corpus, release build, warm, and the numbers are recorded on this task: what check_task, check_adr and check_spec each cost, and inside them what the dead-scope confrontation, the freeze state, the signature reading and the proof reading each cost. The measurement is taken with the probes removed afterwards and the tree left as it was, and it is repeated once to say which figures are stable. Whatever the profile names is filed as a task carrying the mechanism, not the intention, and this task names it. No cache is added and no behaviour changes here: cargo test is green, cargo fmt --check passes, ank check reports no fault, and the findings check reports are identical to what it reported before, subject by subject.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 20d8249640a5ccffc67368d115e17d0d08120781
+    criteria: b204b8d56b48
+    via: submitted
 schema: 4
-version: 2
+version: 3
 ---
 
 What TASK-2e2bac895056 left, and it is deliberately a measurement rather than a

--- a/.ank/entities/TASK-756a870eb0ab.md
+++ b/.ank/entities/TASK-756a870eb0ab.md
@@ -5,7 +5,7 @@ slug: the-per-entity-half-of-check-is-374-ms-and-nothi
 title: The per-entity half of check is 374 ms and nothing has looked inside it
 created: 2026-08-22T20:52:22Z
 author: claude-code/opus-5
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/src/human.rs
 blocked_by: []
@@ -13,7 +13,7 @@ done_criteria: |
   The per-entity phase of check is profiled by sub-phase on this repository's own corpus, release build, warm, and the numbers are recorded on this task: what check_task, check_adr and check_spec each cost, and inside them what the dead-scope confrontation, the freeze state, the signature reading and the proof reading each cost. The measurement is taken with the probes removed afterwards and the tree left as it was, and it is repeated once to say which figures are stable. Whatever the profile names is filed as a task carrying the mechanism, not the intention, and this task names it. No cache is added and no behaviour changes here: cargo test is green, cargo fmt --check passes, ank check reports no fault, and the findings check reports are identical to what it reported before, subject by subject.
 criteria_by: creator
 schema: 4
-version: 1
+version: 2
 ---
 
 What TASK-2e2bac895056 left, and it is deliberately a measurement rather than a


### PR DESCRIPTION
TASK-756a870eb0ab was a measurement, not a repair. Two earlier tasks on this
cost were filed on intuition and one was closed because the intuition was wrong
by a factor of forty, so the criterion asked for numbers first.

Temporary probes were added to `crates/ank-cli/src/human.rs`, the phase was
profiled by sub-phase on this repository's corpus in a release build, warm, and
the probes were removed. **This PR changes no source at all**: the diff is
`.ank/` only, and `human.rs` is byte-identical to `main`.

## What the phase costs

Six runs on an idle machine, 355 non-log entities (266 tasks, 62 ADRs, 27
specs). Per-entity loop 488 495 547 541 554 557 ms, median 544.

| sub-phase | median | share |
|---|---|---|
| dead-scope confrontation | 258 ms | 47% |
| `check_adr` | 161 ms | 30% |
| `check_task` | 105 ms | 19% |
| `check_spec` | 4.8 ms | 1% |

The four sum exactly to the loop total.

## The phase is not per-entity

Timing each probe's slowest single call apart from the rest splits it cleanly.
**400 of the 544 ms, 74%, is four one-shot lazy initialisations** that happen to
be reached from inside the loop, on the first entity that needs them:

- `git::history` — **251 ms**, one call, 46% of the whole phase
- the `all_ratifications` git log walk — 56 ms, the first `freeze_state`
- `Index::open` on the signature sqlite — 59 ms
- `gpg_config`'s `git config` spawn — 34 ms

That is why one ADR costs 142-164 ms and the other 61 cost 12 ms between them,
and why one task costs 30 ms and the other 265 cost 76 ms between them.

The genuine per-entity work is small and was never the problem: the scope
confrontation is 7.4-8.0 ms over all 355 entities, `scope_moved` is 7.1-7.8 ms
over all 114 dead globs, proof reading is 3.0-3.8 ms over 266 tasks, log reading
1 ms, succession 0.2 ms, references 0.2 ms. `git::signature_of` and
`commit_carries_signature` were never reached (n=0), so no gpg ran.

## Which figures are stable

Repeated idle and again while another agent ran `cargo test --workspace`. Idle,
every figure holds inside 15% and the ordering never moves. Under load the
absolute milliseconds double (loop total 508-1059) and no absolute figure
survives, but the decomposition does not move: `git::history` stays 96-98% of
the scope phase, the first ADR stays 91-93% of `check_adr`. **The shares are the
stable measurement; the milliseconds are stable only on an idle machine.** The
idle series is what is recorded.

## What is filed

TASK-0515cfe21421, carrying the mechanism rather than the intention:
`git::history` is `git rev-list HEAD` (46 ms, 917 shas) piped into
`git diff-tree --stdin -r -M -z --name-status` over all 917 commits (183-240 ms,
177 KB), measured outside ank so it rests on nothing this profile did. It scales
with the repository's commit count rather than with the corpus, and it is paid
in full by any corpus holding one dead scope. It names the two things that must
not be built: a cache (closed TASK-da7738572825) and a search per glob (removed
by TASK-1b3d7b61dc8f).

The other three one-shots are left unfiled on purpose: two were each added by a
task that measured them and replaced something worse, and the third is a single
`git config` spawn.

## Verification

- `cargo test --workspace` green, 666 tests, 0 failures
- `cargo fmt --check` passes
- `ank check` exit 0, no fault
- findings identical subject by subject against the pre-change baseline, save
  the task the criterion required be filed
- proof `commit:20d8249`

🤖 Generated with [Claude Code](https://claude.com/claude-code)