### PR TITLE
Measure what consolidating identically-scoped decisions would return

### DIFF
--- a/.ank/entities/LOG-05afb741b013.md
+++ b/.ank/entities/LOG-05afb741b013.md
@@ -1,0 +1,29 @@
+---
+id: LOG-05afb741b013
+type: log
+title: FIGURE 3, what the same perimeter would receive if every identical-scope group were stated once at
+created: 2026-08-24T00:41:45Z
+author: claude-code/opus-5-consolidation
+scope:
+  - crates/ank-cli/src/claim.rs
+about: TASK-3da9d69d899f
+seq: 2
+schema: 4
+version: 1
+---
+
+ the length of its longest member.
+
+Arithmetic, entirely from the numbers in the two entries above, so it is reproducible without running anything further:
+  consolidated = (total of the 9 unshared constraints) + (longest member of each of the 4 groups)
+               = 4207 + 1374 + 1140 + 668 + 1155
+               = 8544 characters, served as 13 constraints instead of 26.
+
+  reduction = 16787 - 8544 = 8243 characters, 49.1 percent.
+  limit = 4000. 8544 is still 2.1 times the limit. The perimeter stays over-constrained.
+
+The same computation on the other one-file perimeter, TASK-e2f501ad1bbb (crates/ank-cli/src/context.rs): 23 constraints and 15602 characters become 10 constraints and 7359 characters. Absolute reduction 8243, identical to the claim.rs figure because the same four groups apply; relative reduction 52.8 percent; still 1.8 times the limit.
+
+Command for the second perimeter: the FIGURE 1 and FIGURE 2 commands with TASK-e2f501ad1bbb substituted for TASK-3da9d69d899f throughout.
+
+Measured on this corpus at commit 69b2fcc, ank 0.6.0, 2026-08-23. No source file was changed to produce any of this; every figure comes from ank check --json and ank show --json.

--- a/.ank/entities/LOG-07e4415f10b0.md
+++ b/.ank/entities/LOG-07e4415f10b0.md
@@ -1,0 +1,25 @@
+---
+id: LOG-07e4415f10b0
+type: log
+title: READING. The measurement, and only what it supports.
+created: 2026-08-24T00:42:08Z
+author: claude-code/opus-5-consolidation
+scope:
+  - crates/ank-cli/src/claim.rs
+about: TASK-3da9d69d899f
+seq: 3
+schema: 4
+version: 1
+---
+
+
+
+The upper bound is not small. 49.1 percent of the charge on a one-file perimeter sits in constraints that share their scope with another constraint, and 66 percent of it (12580 of 16787) sits in the four identical-scope groups. On the intuition test this task was filed under, the answer is not the one the earlier check tasks got: the tendency is not a rounding error.
+
+But the bound does not clear the limit, and that is the finding that matters. Consolidated to the ceiling the perimeter still serves 8544 characters against a limit of 4000, 2.1 times over. The other one-file perimeter lands at 1.8 times over. Every open task in this corpus carries the over-constrained signal today, and it would still carry it after a perfect consolidation. So consolidation is not the exit from over-constraint. It would make the charge smaller; it would not make it legal.
+
+The bound is also optimistic in a way the number hides. "Stated once at the length of its longest member" assumes nine distinct decisions can be restated inside 1374 characters, the length of the longest of them. They say nine different things: identity typing, reference following, the attention budget, log entries as entities, entity paths through the store, and so on. Nothing in the measurement says they compress. The 8243 characters is a ceiling on what the move could ever return, and the realistic return is some unknown fraction of it. The task asked for an honest upper bound and this is one; it is not a forecast.
+
+One thing the grouping shows that was not asked for. The largest group by far, 9 of the 26 constraints and 6568 characters, has the scope crates/ank-cli/**, the whole crate. These constraints are not on a one-file perimeter because they are about claim.rs. They are there because their perimeter is the crate. The charge on a narrow perimeter is driven at least as much by how coarsely decisions are scoped as by how many decisions there are. That is an observation about the corpus and not about the model, and it is recorded here rather than acted on.
+
+What this task does not do. It does not propose an ADR, it does not touch supersedes, and it does not recommend a model change. The measurement is the deliverable. Whether 49.1 percent of a charge that stays over the limit either way is worth changing Option<EntityId> is a decision for the plan and for a human, not for this task.

--- a/.ank/entities/LOG-614829180d89.md
+++ b/.ank/entities/LOG-614829180d89.md
@@ -1,0 +1,51 @@
+---
+id: LOG-614829180d89
+type: log
+title: FIGURE 2, how many of those constraints share an identical scope with at least one other, and what
+created: 2026-08-24T00:41:29Z
+author: claude-code/opus-5-consolidation
+scope:
+  - crates/ank-cli/src/claim.rs
+about: TASK-3da9d69d899f
+seq: 1
+schema: 4
+version: 1
+---
+
+ each group totals. On the claim.rs perimeter: 17 of the 26 fall into 4 groups of identical scope. 9 constraints have a scope shared with no other applicable constraint.
+
+Command. Take the charge ids from FIGURE 1, read each entity scope from its own front matter, group on the scope list sorted and joined:
+  $chk = ank check --json | ConvertFrom-Json
+  $f = $chk.findings | ? { $_.subject -eq "TASK-3da9d69d899f" -and $_.message -match "over-constrained" }
+  $charge = @{}; $f.charge | % { $charge[$_.id] = $_.characters }
+  $scopes = @{}
+  foreach ($id in $charge.Keys) {
+    $c = (ank show $id --json | ConvertFrom-Json).content
+    $in = $false; $g = @()
+    foreach ($l in ($c -split "\n")) {
+      if ($l -match "^scope:\s*$") { $in = $true; continue }
+      if ($in) { if ($l -match "^\s+-\s+(.+?)\s*$") { $g += $Matches[1] } else { break } }
+    }
+    $scopes[$id] = (($g | Sort-Object) -join " | ")
+  }
+  $scopes.GetEnumerator() | Group-Object Value | ? Count -gt 1
+
+Identical scope means the same set of globs, compared as strings after sorting the list, so a reordered scope is not counted as a different one. This is the mechanical proxy the task asked for, not a judgement about whether two rules could actually be written as one.
+
+The four groups, with the character count of each member from the charge array:
+
+  scope crates/ank-cli/** , 9 members, group total 6568, longest member 1374
+    ADR-1e6bcbf62e61=688 ADR-3e6ce108edcd=599 ADR-4e7c25b1f639=181 ADR-5bd8257dfeac=519
+    ADR-6fd69efb629c=762 ADR-9e56318631f3=929 ADR-c88f99e1c16e=879 ADR-f7dc76886db2=1374
+    ADR-f8a6cf65160e=637
+
+  scope crates/ank-cli/** | crates/ank-core/** | docs/** , 3 members, group total 2180, longest member 1140
+    ADR-25f977377fa0=426 ADR-3877fef1d662=1140 ADR-ff294eff4d1a=614
+
+  scope crates/ank-cli/** | docs/** , 3 members, group total 1723, longest member 668
+    ADR-894defc26f3d=668 ADR-96174f1ac2b7=623 ADR-a1de673043b4=432
+
+  scope crates/ank-cli/** | docs/ank-spec-v1.1.md , 2 members, group total 2109, longest member 1155
+    ADR-493471d64ba0=954 ADR-9307e5d214a7=1155
+
+The four groups total 12580 characters. The 9 unshared constraints total 4207. 12580 + 4207 = 16787, which reconciles with FIGURE 1.

--- a/.ank/entities/LOG-6c4069523071.md
+++ b/.ank/entities/LOG-6c4069523071.md
@@ -1,0 +1,39 @@
+---
+id: LOG-6c4069523071
+type: log
+title: RETRACTION of the final paragraph of LOG-a1c5a33dfc81, written as a new entry because an entry is
+created: 2026-08-24T01:15:20Z
+author: claude-code/opus-5-consolidation
+scope:
+  - crates/ank-cli/src/claim.rs
+about: TASK-3da9d69d899f
+seq: 5
+schema: 4
+version: 1
+---
+
+ written once (ADR-25f977377fa0).
+
+That paragraph claimed the task body's "28 constraints and 19599 characters" was not a one-file figure, on the grounds that the number appears on TASK-0515cfe21421 and TASK-0d6fa3a7ea47, which name two files each. The claim is wrong and is withdrawn. The task body was right, and so is the same figure in ADR-6e09f8a67540.
+
+crates/ank-cli/src/human.rs alone receives 28 constraints and 19599 characters.
+
+Command, per-file constraint counts:
+  ank context crates/ank-cli/src/human.rs   -> CONSTRAINTS (28 active)
+  ank context crates/ank-cli/src/claim.rs   -> CONSTRAINTS (26 active)
+  ank context crates/ank-cli/src/git.rs     -> CONSTRAINTS (24 active)
+  ank context crates/ank-cli/tests/cli.rs   -> CONSTRAINTS (21 active)
+
+Command, that the 19599 is human.rs alone and not the pair:
+  $ctx = ank context crates/ank-cli/src/human.rs --json | ConvertFrom-Json
+  $ctxIds = @($ctx.constraints | % { $_.id }) | Sort-Object
+  $f = (ank check --json | ConvertFrom-Json).findings | ? { $_.subject -eq "TASK-0515cfe21421" -and $_.message -match "over-constrained" }
+  $chIds = @($f.charge | % { $_.id }) | Sort-Object
+  Compare-Object $ctxIds $chIds                      # returns nothing: identical sets
+  ($f.charge | Measure-Object characters -Sum).Sum   # 19599
+
+The 28 ids context serves for human.rs are exactly the 28 ids charged 19599 characters on the two-file task. The second file contributes no constraint of its own.
+
+Why the inference failed, which is the reusable part. Constraints are matched by glob, not counted per file, so a union of two scopes charges more than one of them only when the second file matches a constraint the first does not. Here git.rs (24) and tests/cli.rs (21) are both strict subsets of human.rs (28), so both pairs charge exactly what human.rs charges alone. Two scopes can differ by a file and charge identically. I treated scope arity as a proxy for charge and did not run the one command that measures it, which is the same substitution of a plausible reading for a measurement that this task exists to avoid.
+
+Nothing else in this log depends on the retracted claim. FIGURE 1, FIGURE 2, FIGURE 3 and the READING were all measured on this task's own scope, crates/ank-cli/src/claim.rs, and stand unchanged: 26 constraints, 16787 characters, 17 of 26 in 4 identical-scope groups, a 49.1 percent ceiling, and a consolidated perimeter still 2.1 times over the limit. The correct human.rs figure sharpens rather than softens the reading: the worst one-file perimeter in this corpus is larger than the one measured, so the gap a consolidation would have to close is wider, not narrower.

--- a/.ank/entities/LOG-a1c5a33dfc81.md
+++ b/.ank/entities/LOG-a1c5a33dfc81.md
@@ -1,0 +1,26 @@
+---
+id: LOG-a1c5a33dfc81
+type: log
+title: FIGURE 1, the charge on an execution-mode perimeter of one file. Scope of this task is
+created: 2026-08-24T00:41:09Z
+author: claude-code/opus-5-consolidation
+scope:
+  - crates/ank-cli/src/claim.rs
+about: TASK-3da9d69d899f
+seq: 0
+schema: 4
+version: 1
+---
+
+ crates/ank-cli/src/claim.rs, one file. It receives 26 live constraints totalling 16787 characters, against a limit of 4000 (half of context_budget).
+
+Command, run from the repository root with the corpus at .ank/:
+  ank check --json | ConvertFrom-Json | % findings | ? { $_.subject -eq "TASK-3da9d69d899f" -and $_.message -match "over-constrained" } | % { $_.message; $_.charge.Count }
+
+It prints: "over-constrained scope: 16787 characters of constraint against a limit of 4000, half of context_budget" and 26. The per-constraint breakdown is the charge array of that same finding, one entry per applicable ADR with its character count. The definition of the figure is not mine: check computes it as the sum of chars().count() over the constraint field of every ADR applicable_constraints returns for the task, which is exactly what context serves in execution mode without truncation.
+
+Second one-file perimeter for comparison, same command with TASK-e2f501ad1bbb (scope crates/ank-cli/src/context.rs): 23 constraints, 15602 characters.
+
+Correction to this task body. The body cites "a task whose scope names one file receives 28 constraints and 19599 characters". On this corpus today that figure belongs to TASK-0515cfe21421 and TASK-0d6fa3a7ea47, both of which name two files, not one. Verified with:
+  ank show TASK-0515cfe21421 --json | ConvertFrom-Json | % content
+which lists crates/ank-cli/src/git.rs and crates/ank-cli/src/human.rs. The premise figure was a two-file perimeter. It does not change the direction of the argument, but the number quoted in the body is not a one-file number.

--- a/.ank/entities/LOG-f80e4b0c1f02.md
+++ b/.ank/entities/LOG-f80e4b0c1f02.md
@@ -1,0 +1,13 @@
+---
+id: LOG-f80e4b0c1f02
+type: log
+title: done, proof commit:6deb9f3e9dbb199ce6005f8004d13240764ef515
+created: 2026-08-24T01:09:35Z
+author: claude-code/opus-5-consolidation
+scope:
+  - crates/ank-cli/src/claim.rs
+about: TASK-3da9d69d899f
+seq: 4
+schema: 4
+version: 1
+---

--- a/.ank/entities/TASK-3da9d69d899f.md
+++ b/.ank/entities/TASK-3da9d69d899f.md
@@ -5,7 +5,7 @@ slug: nothing-has-measured-what-consolidating-decision
 title: Nothing has measured what consolidating decisions would return
 created: 2026-08-24T00:19:33Z
 author: claude-code/opus-5
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/src/claim.rs
 blocked_by: []
@@ -13,7 +13,7 @@ done_criteria: |
   The task log records, each figure with the command that produces it: how many live constraints an execution-mode perimeter of one file receives on this corpus and what they total in characters; how many of those constraints share an identical scope with at least one other and what each such group totals; and what the same perimeter would receive if every group were stated once at the length of its longest member. The figures are taken on this corpus and are reproducible from the log alone. No source file changes: a probe that ships is a different task.
 criteria_by: creator
 schema: 4
-version: 1
+version: 2
 ---
 
 The charge a perimeter carries has never gone down, and nothing in the model

--- a/.ank/entities/TASK-3da9d69d899f.md
+++ b/.ank/entities/TASK-3da9d69d899f.md
@@ -5,15 +5,20 @@ slug: nothing-has-measured-what-consolidating-decision
 title: Nothing has measured what consolidating decisions would return
 created: 2026-08-24T00:19:33Z
 author: claude-code/opus-5
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/src/claim.rs
 blocked_by: []
 done_criteria: |
   The task log records, each figure with the command that produces it: how many live constraints an execution-mode perimeter of one file receives on this corpus and what they total in characters; how many of those constraints share an identical scope with at least one other and what each such group totals; and what the same perimeter would receive if every group were stated once at the length of its longest member. The figures are taken on this corpus and are reproducible from the log alone. No source file changes: a probe that ships is a different task.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 6deb9f3e9dbb199ce6005f8004d13240764ef515
+    criteria: 45947bd86038
+    via: submitted
 schema: 4
-version: 2
+version: 3
 ---
 
 The charge a perimeter carries has never gone down, and nothing in the model


### PR DESCRIPTION
Measures whether consolidating identically-scoped decisions is worth a model change, and does not make the change. No source file is touched: `git diff origin/main -- crates/` is empty. Closes TASK-3da9d69d899f, proof `commit:6deb9f3e9dbb199ce6005f8004d13240764ef515`.

## The figures

Perimeter is the task's own scope, `crates/ank-cli/src/claim.rs`, one file. Every number comes from `ank check --json` and `ank show --json`; the commands are in the task log so the figures are reproducible from the log alone.

| | constraints | characters |
|---|---|---|
| served today | 26 | 16787 |
| in 4 identical-scope groups | 17 | 12580 |
| unshared | 9 | 4207 |
| each group stated once at its longest member | 13 | 8544 |

Reduction 8243 characters, 49.1 percent. The limit is 4000, half of `context_budget`.

The four groups: `crates/ank-cli/**` (9 members, 6568, longest 1374), `ank-cli/** + ank-core/** + docs/**` (3, 2180, longest 1140), `ank-cli/** + docs/**` (3, 1723, longest 668), `ank-cli/** + docs/ank-spec-v1.1.md` (2, 2109, longest 1155).

Second one-file perimeter, `crates/ank-cli/src/context.rs`: 23 constraints and 15602 characters become 10 and 7359, the same 8243 absolute saving, 52.8 percent.

## The reading

The tendency is not a rounding error, unlike the two earlier `check` tasks filed on intuition. But **the bound does not clear the limit**: 8544 is still 2.1 times 4000, and every open task in the corpus would carry the over-constrained signal after a perfect consolidation. Consolidation would make the charge smaller without making it legal.

The 49.1 percent is also a ceiling and not a forecast. It assumes nine decisions saying nine different things restate inside the 1374 characters of the longest of them. Nothing measured says they compress.

One thing the grouping shows that was not asked for: the largest group is 9 of the 26 constraints and 6568 characters, scoped `crates/ank-cli/**`, the whole crate. Those constraints reach a one-file perimeter because their own perimeter is coarse, not because they concern that file. Scope granularity drives the charge at least as much as decision count. Recorded, not acted on.

No ADR is proposed and `supersedes` is untouched. Whether the move is worth the model change is the plan's call and a human's.

## Reviewer note: one log entry carries a claim that a later entry retracts

`LOG-a1c5a33dfc81` ends with a "correction" that is itself wrong. **Do not read that paragraph as fact.** It is withdrawn by `LOG-6c4069523071`, which is in this PR; the note is repeated here as belt and braces.

The bad paragraph claims the task body's "28 constraints and 19599 characters" is not a one-file figure, reasoning that the number appears on TASK-0515cfe21421 and TASK-0d6fa3a7ea47, which name two files each. That inference is invalid. Measured directly:

```
ank context crates/ank-cli/src/human.rs   -> CONSTRAINTS (28 active)
ank context crates/ank-cli/src/claim.rs   -> CONSTRAINTS (26 active)
ank context crates/ank-cli/src/git.rs     -> CONSTRAINTS (24 active)
ank context crates/ank-cli/tests/cli.rs   -> CONSTRAINTS (21 active)
```

and the 28 ids `context` serves for `human.rs` are exactly the 28 ids charged 19599 characters on TASK-0515cfe21421 (`Compare-Object` on the two sorted id sets returns nothing). So `human.rs` alone is 28 constraints and 19599 characters. **The task body was right, and so is the same figure in ADR-6e09f8a67540.**

Why the inference failed: constraints are matched by glob, not counted per file, so a two-file scope charges more than one of its files only when the second matches a constraint the first does not. Here `git.rs` (24) and `tests/cli.rs` (21) are both strict subsets of `human.rs` (28), so both pairs charge exactly what `human.rs` charges alone. Two scopes can differ by a file and charge identically; scope arity is not a proxy for charge.

The retraction reached the corpus because TASK-c34392707a7b widened exactly this door: `claim_arbitrates` is `Open | InProgress` and nothing else, so a settled task accepts an entry when it is named explicitly (`ank log <id> "<msg>"`). Writing one settles nothing and the task file does not move: `status` stays `done`, `version` stays 3, the proof is intact, and `ank check` stays at exit 0.

Nothing else depends on the retracted claim. FIGURE 1, FIGURE 2, FIGURE 3 and the READING were all measured on `claim.rs` and stand unchanged. If anything the correct `human.rs` figure sharpens the reading: the worst one-file perimeter in this corpus is larger than the one measured, so the gap consolidation would have to close is wider, not narrower.

## Verification

- `cargo test --workspace` green, twice independently: 667 tests, 0 failed. `cli.rs` 285 passed in 382s (slow under three concurrent agents, not flaky).
- `cargo fmt --check` clean.
- `ank check` exit 0, 0 faults.
- `git diff origin/main -- crates/` empty.
- All three commits GPG-signed.

Pre-existing on `origin/main`, untouched and outside this task's scope: a `duplicated attribute` warning at `crates/ank-cli/src/human.rs:8067`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
