### PR TITLE
Serve context --json under the attention budget

### DIFF
--- a/.ank/entities/LOG-019ec5328737.md
+++ b/.ank/entities/LOG-019ec5328737.md
@@ -1,0 +1,17 @@
+---
+id: LOG-019ec5328737
+type: log
+title: +scope crates/ank-cli/tests/cli.rs, -scope crates/ank-cli/tests/golden-json/context.json (version 3
+created: 2026-08-24T04:47:07Z
+author: claude-code/opus-5-context-budget
+scope:
+  - crates/ank-cli/src/context.rs
+  - crates/ank-cli/tests/cli.rs
+about: TASK-ecf0f37f68c9
+seq: 8
+records: edit
+schema: 4
+version: 1
+---
+
+ to 4, replaced 5442b56a1294, produced c4a200058168)

--- a/.ank/entities/LOG-38afc68b479e.md
+++ b/.ank/entities/LOG-38afc68b479e.md
@@ -1,0 +1,16 @@
+---
+id: LOG-38afc68b479e
+type: log
+title: What moved and what did not. The counters in the_budget_still_governs_the_page_context_serves did
+created: 2026-08-24T04:46:34Z
+author: claude-code/opus-5-context-budget
+scope:
+  - crates/ank-cli/src/context.rs
+  - crates/ank-cli/tests/golden-json/context.json
+about: TASK-ecf0f37f68c9
+seq: 7
+schema: 4
+version: 1
+---
+
+ not move: +12 not shown and +8 more tasks still hold, because that corpus is genuinely over budget and those numbers were pinning correct behaviour rather than the defect. tests/golden-json/context.json returned to its original bytes, so the bless is a no-op and is out of the diff; the conformance walker is green again and context.proposed and context.specs are exercised as before. The prose-identifier signal is unchanged by me: it reports 33 for the corpus, and every identifier my log entries and the new task body name resolves, so I add none. Worked under the existing claim because without the fix my own criterion cannot be green.

--- a/.ank/entities/LOG-64bee8250ad8.md
+++ b/.ank/entities/LOG-64bee8250ad8.md
@@ -1,0 +1,16 @@
+---
+id: LOG-64bee8250ad8
+type: log
+title: Fixed the over-cutting, and only half of what I filed was a defect. The share loop priced the full
+created: 2026-08-24T04:46:14Z
+author: claude-code/opus-5-context-budget
+scope:
+  - crates/ank-cli/src/context.rs
+  - crates/ank-cli/tests/golden-json/context.json
+about: TASK-ecf0f37f68c9
+seq: 6
+schema: 4
+version: 1
+---
+
+ list together with a cut notice for a row it had not removed, so a section costing 98 against a share of 133 read as 149 and was cut: that is real, and pricing the section as it stands fixes it. The second mechanism is not a defect. A cut notice does cost more than the row it replaces, but it is paid once per section and every later row is pure saving, so a guard requiring each cut to shrink the page left twelve proposals and twelve tasks entirely uncut at a budget of 400. I tried it, measured it, and took it back out.

--- a/.ank/entities/LOG-8612991735dc.md
+++ b/.ank/entities/LOG-8612991735dc.md
@@ -1,0 +1,15 @@
+---
+id: LOG-8612991735dc
+type: log
+title: Blocked on two files outside the declared scope, reported rather than widened. First,
+created: 2026-08-24T03:59:00Z
+author: claude-code/opus-5-context-budget
+scope:
+  - crates/ank-cli/src/context.rs
+about: TASK-ecf0f37f68c9
+seq: 2
+schema: 4
+version: 1
+---
+
+ tests/golden-json/context.json reddens by construction: golden_repo pins context_budget 400 so the ADR could produce an over-constrained finding, and the document there now cuts to one constraint, no proposal, no spec and one task, which is precisely what the human page at 400 shows. Second, the criterion asks for a test driving the binary, and CARGO_BIN_EXE_ank exists only for an integration target, so it belongs in tests/cli.rs beside the past_the_budget fixture that already carries the gap. Everything else is green: 306 unit, 291 of 292 cli, 21 skill, 20 core, 28 core golden, 3 mcp, 7 contract; fmt clean; check exit 0, no fault.

--- a/.ank/entities/LOG-92245a9332e5.md
+++ b/.ank/entities/LOG-92245a9332e5.md
@@ -1,0 +1,14 @@
+---
+id: LOG-92245a9332e5
+type: log
+title: done, proof commit:07540892eafe6e8a927a70bd10e9946a9e74226d
+created: 2026-08-24T04:48:34Z
+author: claude-code/opus-5-context-budget
+scope:
+  - crates/ank-cli/src/context.rs
+  - crates/ank-cli/tests/cli.rs
+about: TASK-ecf0f37f68c9
+seq: 9
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-bfbe7d6663af.md
+++ b/.ank/entities/LOG-bfbe7d6663af.md
@@ -1,0 +1,17 @@
+---
+id: LOG-bfbe7d6663af
+type: log
+title: +scope crates/ank-cli/tests/golden-json/context.json (version 2 to 3, replaced bdb922c59449,
+created: 2026-08-24T04:01:18Z
+author: claude-code/opus-5-context-budget
+scope:
+  - crates/ank-cli/src/context.rs
+  - crates/ank-cli/tests/golden-json/context.json
+about: TASK-ecf0f37f68c9
+seq: 3
+records: edit
+schema: 4
+version: 1
+---
+
+ produced 24aef80c4702)

--- a/.ank/entities/LOG-d43fecb6a48e.md
+++ b/.ank/entities/LOG-d43fecb6a48e.md
@@ -1,0 +1,16 @@
+---
+id: LOG-d43fecb6a48e
+type: log
+title: "Root cause found, and it is not mine. The orientation fitting over-cuts: the first-half loop prices"
+created: 2026-08-24T04:20:55Z
+author: claude-code/opus-5-context-budget
+scope:
+  - crates/ank-cli/src/context.rs
+  - crates/ank-cli/tests/golden-json/context.json
+about: TASK-ecf0f37f68c9
+seq: 5
+schema: 4
+version: 1
+---
+
+ the full spec list together with a cut notice for a row it has not removed, a state that never exists, so a section costing 98 against a share of 133 is cut anyway; and every cut notice costs more than the row it replaces, so the second-half loop cascades to the floor. On the golden corpus the uncut page is 381 characters against a budget of 400 and the fitted page is 373 with five rows gone. It has been the human render's behaviour all along and nothing pinned it; giving --json the same decision put it in a fixture. Filed as TASK-345c35a8beba. Fixing it there returns context.json to its one-of-everything document with no fixture change at all.

--- a/.ank/entities/LOG-dfc80fe7b43d.md
+++ b/.ank/entities/LOG-dfc80fe7b43d.md
@@ -1,0 +1,16 @@
+---
+id: LOG-dfc80fe7b43d
+type: log
+title: "Blessed the golden as instructed and verified it against the human page: at budget 400 the page"
+created: 2026-08-24T04:19:25Z
+author: claude-code/opus-5-context-budget
+scope:
+  - crates/ank-cli/src/context.rs
+  - crates/ank-cli/tests/golden-json/context.json
+about: TASK-ecf0f37f68c9
+seq: 4
+schema: 4
+version: 1
+---
+
+ shows one constraint, 'PROPOSED +1 not shown', 'SPECIFICATIONS +1 not shown', one task and '+3 more tasks', which is exactly the blessed document. The bless is faithful. But it starved a second test: every_golden_conforms_to_the_shape_its_verb_declares now reports context.proposed and context.specs as declarations no fixture reaches. That list is deliberately empty and took two tasks to empty.

--- a/.ank/entities/LOG-e805d60dbe75.md
+++ b/.ank/entities/LOG-e805d60dbe75.md
@@ -1,0 +1,15 @@
+---
+id: LOG-e805d60dbe75
+type: log
+title: The ADR is right and the criterion matches it, so the code learns the ADR. A listing is asked what
+created: 2026-08-24T03:43:37Z
+author: claude-code/opus-5-context-budget
+scope:
+  - crates/ank-cli/src/context.rs
+about: TASK-ecf0f37f68c9
+seq: 1
+schema: 4
+version: 1
+---
+
+ exists and an answer omitting rows is wrong about the corpus; context is asked what to read first, where the selection is the answer. Lifted the fitting out of render into fit(), priced in plain style since chars() already ignores SGR, and gave render_json the budget. The three counters stay the perimeter's, as the human PROPOSED and SPECIFICATIONS headers already are.

--- a/.ank/entities/LOG-eba4a7ae7a91.md
+++ b/.ank/entities/LOG-eba4a7ae7a91.md
@@ -1,0 +1,15 @@
+---
+id: LOG-eba4a7ae7a91
+type: log
+title: Verified the filed measurement before changing anything. On a fixture of twelve open tasks and
+created: 2026-08-24T03:43:17Z
+author: claude-code/opus-5-context-budget
+scope:
+  - crates/ank-cli/src/context.rs
+about: TASK-ecf0f37f68c9
+seq: 0
+schema: 4
+version: 1
+---
+
+ twelve proposed decisions at context_budget 400, the human page carried four task rows and no proposal while render_json carried all twenty-four; in execution mode with twenty log entries at 800, the page kept a handful and the document kept all twenty. render_json took no budget argument.

--- a/.ank/entities/TASK-345c35a8beba.md
+++ b/.ank/entities/TASK-345c35a8beba.md
@@ -1,0 +1,72 @@
+---
+id: TASK-345c35a8beba
+type: task
+slug: the-orientation-budget-cuts-a-page-that-already
+title: The orientation budget cuts a page that already fitted
+created: 2026-08-24T04:20:36Z
+author: claude-code/opus-5-context-budget
+status: open
+scope:
+  - crates/ank-cli/src/context.rs
+blocked_by: []
+done_criteria: |
+  On a perimeter whose orientation page fits within context_budget, context cuts nothing on either surface, and a test pins it on the golden corpus at the budget golden_repo declares. A cut that does not reduce the rendered page is not taken. The floor of SPEC-a1234da5449a is unchanged: one constraint and one task always survive, and a page genuinely over budget is still cut. cargo test is green, cargo fmt --check passes, and ank check reports no fault.
+criteria_by: creator
+schema: 4
+version: 1
+---
+
+Measured on the golden corpus of `tests/cli.rs` (one accepted constraint, one
+proposed decision, one spec, four open tasks over `src/**`) at the
+`context_budget: 400` that `golden_repo()` pins:
+
+    uncut page   381 characters, one of everything, nothing cut
+    at budget 400  373 characters, and five rows gone
+
+The page **already fitted**. The budget cut a spec, a proposal and three tasks
+off a page eighteen characters under the limit, and the result is *shorter by
+eight characters than the cut it paid for*.
+
+**Two defects compose.** The first is in the first-half loop:
+
+    while !specs.is_empty()
+        && priced(&constraints, &specs, cut_constraints, cut_specs + 1) > share
+
+`priced` is handed the **full** spec list *and* `cut_specs + 1`, so it renders a
+state that never exists: every row still present, plus a `+1 not shown` notice
+for a row that was not removed. On this corpus the real section costs 98 against
+a share of 133 and the hybrid costs 149, so a section that fitted with 35
+characters to spare is cut. The post-cut state is `priced(specs_after_pop,
+cut_specs + 1)`; the pre-cut state is `priced(specs, cut_specs)`. The condition
+asks for neither.
+
+The second is that **a cut notice costs more than the row it replaces**, so
+cutting inflates the page and the second-half loop cascades:
+
+    spec row      24 characters  ->  `+1 not shown, ank find --type spec ...`      51
+    proposal row  30 characters  ->  `+1 not shown, ank find --type adr ...`       69
+    task row      45 characters  ->  `+3 more tasks, ank find --type task ...`     49
+
+Each cut makes the page larger, the loop sees it still over budget, and it
+descends to the floor of one constraint and one task. The loop has no guard for
+"this cut did not reduce the page", so it cannot stop.
+
+**Why it surfaced now.** It has been the human page's behaviour since the budget
+was written, and nothing pinned the human page of `context` on a corpus close to
+the limit. TASK-ecf0f37f68c9 gave `--json` the same fitting decision
+(ADR-3e6ce108edcd), which put the cut rows in a golden fixture where the
+conformance test walks them: `every_golden_conforms_to_the_shape_its_verb_declares`
+now reports `context.proposed` and `context.specs` as declarations no fixture
+reaches, because the budget emptied both arrays.
+
+That failure is the symptom. Raising the fixture's budget hides it; fixing the
+arithmetic removes it, and `tests/golden-json/context.json` then returns to the
+one-of-everything document it held before, with no fixture change at all.
+
+**What must not be lost.** §5 keeps its floor — one constraint and one task
+always survive — and keeps cutting where a page genuinely does not fit. What
+changes is that a page which fits is not cut, and that a cut which does not
+shrink the page is not taken. `the_budget_still_governs_the_page_context_serves`
+in `tests/cli.rs` pins the genuinely-over case at twelve tasks and twelve
+proposals; its counters will move if the arithmetic changes, and the diff is to
+be read rather than blessed.

--- a/.ank/entities/TASK-ecf0f37f68c9.md
+++ b/.ank/entities/TASK-ecf0f37f68c9.md
@@ -5,15 +5,16 @@ slug: context-json-is-not-budgeted-and-adr-3e6ce108edc
 title: context --json is not budgeted, and ADR-3e6ce108edcd says it is
 created: 2026-08-24T02:21:00Z
 author: claude-code/opus-5-json-budget
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/src/context.rs
+  - crates/ank-cli/tests/cli.rs
 blocked_by: []
 done_criteria: |
   context --json is served under context_budget, the same page the human render already spends, and a test drives the binary on a corpus past the budget and asserts that the --json document carries what the human page carried and no more. The four listing verbs stay whole under --json. cargo test is green, cargo fmt --check passes, and ank check reports no fault.
 criteria_by: creator
 schema: 4
-version: 1
+version: 4
 ---
 
 ADR-3e6ce108edcd exempts `context` from the rule it lays on the four listing

--- a/.ank/entities/TASK-ecf0f37f68c9.md
+++ b/.ank/entities/TASK-ecf0f37f68c9.md
@@ -5,7 +5,7 @@ slug: context-json-is-not-budgeted-and-adr-3e6ce108edc
 title: context --json is not budgeted, and ADR-3e6ce108edcd says it is
 created: 2026-08-24T02:21:00Z
 author: claude-code/opus-5-json-budget
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/src/context.rs
   - crates/ank-cli/tests/cli.rs
@@ -13,8 +13,13 @@ blocked_by: []
 done_criteria: |
   context --json is served under context_budget, the same page the human render already spends, and a test drives the binary on a corpus past the budget and asserts that the --json document carries what the human page carried and no more. The four listing verbs stay whole under --json. cargo test is green, cargo fmt --check passes, and ank check reports no fault.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 07540892eafe6e8a927a70bd10e9946a9e74226d
+    criteria: f9c7b3c81869
+    via: submitted
 schema: 4
-version: 4
+version: 5
 ---
 
 ADR-3e6ce108edcd exempts `context` from the rule it lays on the four listing

--- a/crates/ank-cli/src/context.rs
+++ b/crates/ank-cli/src/context.rs
@@ -1152,76 +1152,193 @@ fn visible_len(s: &str) -> usize {
     n
 }
 
-pub fn render(view: &View, budget: usize, style: Style) -> String {
-    let mut out: Vec<String> = Vec::new();
-    for w in &view.warnings {
-        out.push(format!("{} {w}", style.yellow("warning:")));
+// ---------------------------------------------------------------------------
+// The budget
+// ---------------------------------------------------------------------------
+
+/// What the budget leaves of a view, decided once and spent by both surfaces.
+///
+/// ADR-3e6ce108edcd draws its line at the verb rather than at the flag. A
+/// listing answers a program whole, because a parser reads no page and spends
+/// no budget; `context` keeps the budget under `--json`, because deciding what
+/// a reader is handed first *is* that verb's answer rather than a limit on it.
+/// That asymmetry only means something if there is **one** fitting decision
+/// rather than two, so it lives here, above both renderers, and neither of them
+/// cuts anything of its own. A second copy would be free to disagree with the
+/// first about which rule survives, and the same perimeter would then be
+/// described differently depending on which surface a reader typed.
+///
+/// **Priced in plain style, always.** [`chars`] already ignores SGR sequences,
+/// so a painted page costs a reader exactly what a piped one does. Fitting once
+/// and in plain turns that from a property two renderers happen to share into
+/// one they cannot disagree about, and it is what lets `--json` — which carries
+/// no style at all (ADR-0c8ab846d262) — be served the very rows the terminal
+/// was.
+#[derive(Clone)]
+pub(crate) struct Fitted {
+    pub constraints: Vec<ConstraintLine>,
+    pub proposals: Vec<ConstraintLine>,
+    pub specs: Vec<SpecLine>,
+    pub tasks: Vec<TaskLine>,
+    /// The entries that survived, oldest first and without the page's indent.
+    pub log: Vec<String>,
+    pub cut_constraints: usize,
+    pub cut_proposals: usize,
+    pub cut_specs: usize,
+    pub cut_tasks: usize,
+}
+
+/// The four sections orientation can cut, named so that the cutting loops speak
+/// in §5's order instead of repeating four near-identical branches.
+#[derive(Clone, Copy)]
+enum Section {
+    Proposals,
+    Specs,
+    Tasks,
+    Constraints,
+}
+
+impl Fitted {
+    /// The same page one row lighter in `section`, or `None` where there is no
+    /// row to take: an empty section, or the floor of §5 — **one constraint and
+    /// one task always survive, whatever the budget** — which is a rule about
+    /// what a page must still say and not an arithmetic stopping condition.
+    ///
+    /// Returning the state rather than mutating is what lets a caller ask what a
+    /// cut would cost before taking it, which is the whole of the fix in the two
+    /// loops below.
+    fn without(&self, section: Section) -> Option<Fitted> {
+        let mut next = self.clone();
+        match section {
+            Section::Proposals => {
+                next.proposals.pop()?;
+                next.cut_proposals += 1;
+            }
+            Section::Specs => {
+                next.specs.pop()?;
+                next.cut_specs += 1;
+            }
+            Section::Tasks => {
+                if next.tasks.len() <= 1 {
+                    return None;
+                }
+                next.tasks.pop();
+                next.cut_tasks += 1;
+            }
+            Section::Constraints => {
+                if next.constraints.len() <= 1 {
+                    return None;
+                }
+                next.constraints.pop();
+                next.cut_constraints += 1;
+            }
+        }
+        Some(next)
     }
+}
+
+/// The warnings, which both modes carry and the budget charges before anything
+/// else: a page that is degraded says so in a line, and a shorter page cannot
+/// say it at all.
+fn warning_lines(view: &View, style: Style) -> Vec<String> {
+    view.warnings
+        .iter()
+        .map(|w| format!("{} {w}", style.yellow("warning:")))
+        .collect()
+}
+
+/// Execution mode, everything above the log: the task, the criterion whole, the
+/// constraints never truncated, the specifications named.
+///
+/// Split out because the log is the one section that yields, and the budget has
+/// to price what sits above it before it can decide how much of it survives.
+fn execution_head(view: &View, style: Style) -> Vec<String> {
+    let Mode::Execution {
+        short,
+        title,
+        criteria,
+        ..
+    } = &view.mode
+    else {
+        return Vec::new();
+    };
+    let mut out = vec![String::new(), format!("{}  {title}", style.id(short))];
+    if let Some(c) = criteria {
+        out.push(String::new());
+        out.push(style.header("DONE_CRITERIA"));
+        for line in c.lines() {
+            out.push(format!("  {}", line.trim_end()));
+        }
+    }
+    if !view.constraints.is_empty() {
+        out.push(String::new());
+        out.push(style.header(&format!("CONSTRAINTS ({} active)", view.constraints.len())));
+        // Never truncated here, budget or no budget: an agent that violates a
+        // rule it was never shown is the failure this whole design exists to
+        // prevent.
+        for c in &view.constraints {
+            out.extend(constraint_block(c, style));
+        }
+    }
+    // Named here as in orientation, and never quoted: there is no mode that
+    // serves a spec body, because there is no `constraint` to serve and the
+    // body is the document (§3, §5). Charged before the log, which is what
+    // yields, so a spec line never costs an entry.
+    out.extend(spec_section(&view.specs, 0, ".", style));
+    out
+}
+
+/// The log section of execution mode, over the entries the budget kept.
+///
+/// The header counts the survivors against the total, which is the one place a
+/// truncated section names its own truncation without a `+N` line.
+fn log_section(kept: &[String], total: usize, style: Style) -> Vec<String> {
+    let mut out = vec![
+        String::new(),
+        style.header(&format!("LOG ({} of {total})", kept.len())),
+    ];
+    out.extend(kept.iter().map(|e| format!("  {e}")));
+    out
+}
+
+/// The truncation of §5, made once, for whichever surface is about to print.
+pub(crate) fn fit(view: &View, budget: usize) -> Fitted {
+    let style = crate::style::PLAIN;
+    let mut fitted = Fitted {
+        constraints: view.constraints.clone(),
+        proposals: view.proposals.clone(),
+        specs: view.specs.clone(),
+        tasks: view.tasks.clone(),
+        log: Vec::new(),
+        cut_constraints: 0,
+        cut_proposals: 0,
+        cut_specs: 0,
+        cut_tasks: 0,
+    };
+    let head = chars(&warning_lines(view, style));
 
     match &view.mode {
-        Mode::Execution {
-            short,
-            title,
-            criteria,
-            log,
-            ..
-        } => {
-            out.push(String::new());
-            out.push(format!("{}  {title}", style.id(short)));
-            if let Some(c) = criteria {
-                out.push(String::new());
-                out.push(style.header("DONE_CRITERIA"));
-                for line in c.lines() {
-                    out.push(format!("  {}", line.trim_end()));
-                }
-            }
-            if !view.constraints.is_empty() {
-                out.push(String::new());
-                out.push(style.header(&format!("CONSTRAINTS ({} active)", view.constraints.len())));
-                // Never truncated here, budget or no budget: an agent that
-                // violates a rule it was never shown is the failure this whole
-                // design exists to prevent.
-                for c in &view.constraints {
-                    out.extend(constraint_block(c, style));
-                }
-            }
-            // Named here as in orientation, and never quoted: there is no mode
-            // that serves a spec body, because there is no `constraint` to
-            // serve and the body is the document (§3, §5). Charged before the
-            // log, which is what yields, so a spec line never costs an entry.
-            out.extend(spec_section(&view.specs, 0, ".", style));
+        Mode::Execution { log, .. } => {
+            // The log is what yields: it is the one section whose older half
+            // costs more than it informs. Everything above it is either the
+            // criterion, which is why the mode exists, or a binding rule.
             if !log.is_empty() {
-                // The log is what yields: it is the one section whose older
-                // half costs more than it informs.
-                let used = chars(&out);
-                let mut kept: Vec<String> = Vec::new();
+                let used = head + chars(&execution_head(view, style));
                 let mut room = budget.saturating_sub(used + 16);
                 for entry in log.iter().rev() {
                     let cost = entry.chars().count() + 3;
-                    if cost > room && !kept.is_empty() {
+                    if cost > room && !fitted.log.is_empty() {
                         break;
                     }
                     room = room.saturating_sub(cost);
-                    kept.push(format!("  {entry}"));
+                    fitted.log.push(entry.clone());
                 }
-                kept.reverse();
-                out.push(String::new());
-                out.push(style.header(&format!("LOG ({} of {})", kept.len(), log.len())));
-                out.extend(kept);
+                fitted.log.reverse();
             }
         }
 
         Mode::Orientation { path } => {
             let scope_arg = path.clone().unwrap_or_else(|| ".".to_string());
-            let mut constraints = view.constraints.clone();
-            let mut proposals = view.proposals.clone();
-            let mut specs = view.specs.clone();
-            let mut tasks = view.tasks.clone();
-
-            let mut cut_tasks = 0usize;
-            let mut cut_constraints = 0usize;
-            let mut cut_proposals = 0usize;
-            let mut cut_specs = 0usize;
 
             // §5, first half: constraints take at most a third, and what they
             // do not use goes to the tasks. Charged before anything else is
@@ -1241,77 +1358,117 @@ pub fn render(view: &View, budget: usize, style: Style) -> String {
             // page reduced to one line has to keep the rule rather than the
             // description.
             let share = budget / 3;
-            let priced = |constraints: &[ConstraintLine],
-                          specs: &[SpecLine],
-                          cut_constraints: usize,
-                          cut_specs: usize| {
+            let share_cost = |f: &Fitted| {
                 chars(&constraint_section(
-                    constraints,
-                    cut_constraints,
+                    &f.constraints,
+                    f.cut_constraints,
                     &scope_arg,
                     style,
-                )) + chars(&spec_section(specs, cut_specs, &scope_arg, style))
+                )) + chars(&spec_section(&f.specs, f.cut_specs, &scope_arg, style))
             };
-            while !specs.is_empty()
-                && priced(&constraints, &specs, cut_constraints, cut_specs + 1) > share
-            {
-                specs.pop();
-                cut_specs += 1;
-            }
-            while constraints.len() > 1
-                && priced(&constraints, &specs, cut_constraints + 1, cut_specs) > share
-            {
-                constraints.pop();
-                cut_constraints += 1;
+            // Specs first, then constraints, which is what "specs yield first
+            // inside the share" means.
+            //
+            // **The section is priced as it stands.** This loop used to price
+            // the full list *together with* a `+1 not shown` notice for a row it
+            // had not removed — a state that never exists — and compare that
+            // against the share. On the corpus `golden_repo` builds, the section
+            // as it stood cost 98 against a share of 133 while the hybrid came
+            // to 149, so a section that fitted with thirty-five characters to
+            // spare was cut. Replacing a 24-character row with a 51-character
+            // notice then put the whole page over budget and sent the loop below
+            // down to the floor: 381 characters became 373, with five rows gone
+            // (TASK-345c35a8beba).
+            for section in [Section::Specs, Section::Constraints] {
+                while share_cost(&fitted) > share {
+                    let Some(trial) = fitted.without(section) else {
+                        break;
+                    };
+                    fitted = trial;
+                }
             }
 
             // Second half: the whole page against the whole budget. Tasks are
             // cut last and only once their own share is full, which is the
             // order §5 now states.
-            loop {
-                let size = chars(&orientation_lines(
-                    &constraints,
-                    &proposals,
-                    &specs,
-                    &tasks,
-                    cut_tasks,
-                    cut_proposals,
-                    cut_constraints,
-                    cut_specs,
+            let page = |f: &Fitted| {
+                chars(&orientation_lines(
+                    &f.constraints,
+                    &f.proposals,
+                    &f.specs,
+                    &f.tasks,
+                    f.cut_tasks,
+                    f.cut_proposals,
+                    f.cut_constraints,
+                    f.cut_specs,
                     &scope_arg,
                     view,
                     style,
-                )) + chars(&out);
-                if size <= budget {
+                )) + head
+            };
+            // Cut in §5's order until the page fits, and stop only where
+            // there is no row left to take. **A cut is not required to shrink
+            // the page on its own**, and an earlier revision of this loop got
+            // that backwards: a `+n not shown` notice is longer than the row it
+            // replaces, so the first cut of a section always costs more than it
+            // saves, and refusing it left a page of twelve proposals and twelve
+            // tasks entirely uncut at a budget of 400. The notice is paid once
+            // and every later row of that section is pure saving, so the
+            // arithmetic only works out over the section rather than over one
+            // row.
+            //
+            // What made the page grow was never this loop. It was the share
+            // above handing it a page already inflated by a cut that should not
+            // have happened (TASK-345c35a8beba); priced correctly, this loop is
+            // reached only by a page that genuinely does not fit.
+            loop {
+                if page(&fitted) <= budget {
                     break;
                 }
-                if !proposals.is_empty() {
-                    proposals.pop();
-                    cut_proposals += 1;
-                } else if !specs.is_empty() {
-                    specs.pop();
-                    cut_specs += 1;
-                } else if tasks.len() > 1 {
-                    tasks.pop();
-                    cut_tasks += 1;
-                } else if constraints.len() > 1 {
-                    constraints.pop();
-                    cut_constraints += 1;
-                } else {
-                    // One task and one constraint left. Cutting further would
-                    // buy nothing an agent can use.
-                    break;
+                let taken = [
+                    Section::Proposals,
+                    Section::Specs,
+                    Section::Tasks,
+                    Section::Constraints,
+                ]
+                .into_iter()
+                .find_map(|section| fitted.without(section));
+                match taken {
+                    Some(trial) => fitted = trial,
+                    // The floor of §5: one constraint and one task survive
+                    // whatever the budget, and cutting further would buy
+                    // nothing an agent can use.
+                    None => break,
                 }
             }
+        }
+    }
+    fitted
+}
+
+pub fn render(view: &View, budget: usize, style: Style) -> String {
+    let fitted = fit(view, budget);
+    let mut out = warning_lines(view, style);
+
+    match &view.mode {
+        Mode::Execution { log, .. } => {
+            out.extend(execution_head(view, style));
+            if !log.is_empty() {
+                out.extend(log_section(&fitted.log, log.len(), style));
+            }
+        }
+
+        Mode::Orientation { path } => {
+            let scope_arg = path.clone().unwrap_or_else(|| ".".to_string());
             out.extend(orientation_lines(
-                &constraints,
-                &proposals,
-                &specs,
-                &tasks,
-                cut_tasks,
-                cut_proposals,
-                cut_constraints,
-                cut_specs,
+                &fitted.constraints,
+                &fitted.proposals,
+                &fitted.specs,
+                &fitted.tasks,
+                fitted.cut_tasks,
+                fitted.cut_proposals,
+                fitted.cut_constraints,
+                fitted.cut_specs,
                 &scope_arg,
                 view,
                 style,
@@ -1477,11 +1634,33 @@ fn orientation_lines(
 // JSON
 // ---------------------------------------------------------------------------
 
-pub fn render_json(view: &View) -> String {
+/// **Budgeted, and it is the only `--json` document that is** (ADR-3e6ce108edcd).
+///
+/// The four listing verbs answer a program whole under `--json`, because the
+/// budget is the human reader's and a parser reads no page. `context` is the
+/// exception the same decision names, and the asymmetry is not a lapse in it:
+/// a listing is asked *what exists*, and an answer that silently omits rows is
+/// simply wrong about the corpus, while `context` is asked *what to read
+/// first*, and there the selection is the answer rather than a limit on it. A
+/// `context --json` that returned everything would not be a fuller answer to
+/// the question the verb was asked; it would be a refusal to answer it, handing
+/// the fitting back to a caller that has no budget, no ordering and no §5.
+///
+/// So the rows here are [`fit`]'s, the same ones the terminal was handed at the
+/// same `context_budget`, and nothing is cut a second time.
+///
+/// The three counters are the exception, and they are the perimeter's rather
+/// than the page's: `ready`, `blocked` and `finished_elsewhere` say what the
+/// scope holds, exactly as the human page's `SPECIFICATIONS (n)` and
+/// `PROPOSED (n)` headers count what the perimeter holds and not what survived.
+/// A counter that shrank with the page would leave a caller unable to tell a
+/// perimeter with two ready tasks from a budget that had room for two.
+pub fn render_json(view: &View, budget: usize) -> String {
+    let fitted = fit(view, budget);
     // The peer a constraint came from, `null` for a rule at home. The human
     // surface carries the same fact in the identifier it prints; `--json` has
     // nowhere to put a suffix, so it gets a field of its own.
-    let constraints: Vec<String> = view
+    let constraints: Vec<String> = fitted
         .constraints
         .iter()
         .map(|c| {
@@ -1494,7 +1673,7 @@ pub fn render_json(view: &View) -> String {
                 .finish()
         })
         .collect();
-    let proposals: Vec<String> = view
+    let proposals: Vec<String> = fitted
         .proposals
         .iter()
         .map(|c| {
@@ -1510,7 +1689,7 @@ pub fn render_json(view: &View) -> String {
     // the same rule as the human one — there is no mode that serves a spec
     // body — and a `--json` caller is exactly the one that would pipe two
     // hundred thousand bytes into an agent's context without noticing.
-    let specs: Vec<String> = view
+    let specs: Vec<String> = fitted
         .specs
         .iter()
         .map(|s| {
@@ -1521,7 +1700,7 @@ pub fn render_json(view: &View) -> String {
                 .finish()
         })
         .collect();
-    let tasks: Vec<String> = view
+    let tasks: Vec<String> = fitted
         .tasks
         .iter()
         .map(|t| {
@@ -1552,10 +1731,11 @@ pub fn render_json(view: &View) -> String {
         } => Some(c.clone()),
         _ => None,
     };
-    let log: &[String] = match &view.mode {
-        Mode::Execution { log, .. } => log,
-        Mode::Orientation { .. } => &[],
-    };
+    // The entries the budget kept, which in execution mode is the one section
+    // that yields: the criterion above it is why the mode exists and a
+    // constraint is never cut, so the log is where a `--json` caller and a
+    // terminal see the same page shorten.
+    let log: &[String] = &fitted.log;
 
     Obj::document()
         .str("mode", mode)
@@ -1607,7 +1787,7 @@ pub fn run(
     }
 
     if inv.json() {
-        let _ = writeln!(out, "{}", render_json(&view));
+        let _ = writeln!(out, "{}", render_json(&view, cfg.context_budget));
     } else if !inv.quiet() {
         let _ = write!(out, "{}", render(&view, cfg.context_budget, inv.style()));
     }
@@ -1814,6 +1994,28 @@ After a blank one."
             schema: 1,
             version: 1,
             body: "\nWhy.\n".into(),
+        })
+    }
+
+    fn spec(hex: &str, title: &str, scope: &[&str]) -> Entity {
+        Entity::Spec(ank_core::Spec {
+            id: EntityId::parse(&format!("SPEC-{hex}")).unwrap(),
+            slug: Some("example".into()),
+            title: title.into(),
+            created: "2026-07-20T00:00:00Z".into(),
+            author: None,
+            status: ank_core::SpecStatus::Accepted,
+            scope: scope.iter().map(|s| s.to_string()).collect(),
+            references: vec![],
+            supersedes: None,
+            ratified: None,
+            verified: Vec::new(),
+            schema: 1,
+            version: 1,
+            body: "
+The document.
+"
+            .into(),
         })
     }
 
@@ -2369,7 +2571,7 @@ After a blank one."
             AdrStatus::Accepted,
         ));
         let view = t.view("claude-code@ank", None);
-        let json = render_json(&view);
+        let json = render_json(&view, 8000);
 
         // serde_yaml parses JSON, YAML being a superset: a cheap way to assert
         // the output is well formed without adding a JSON dependency.
@@ -2386,5 +2588,270 @@ After a blank one."
             parsed["constraints"][0]["constraint"].as_str(),
             Some("Line one.\nLine two.")
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // The budget, on both surfaces
+    // -----------------------------------------------------------------------
+
+    /// A perimeter past the budget: twelve open tasks and twelve proposed
+    /// decisions on one scope, which is the corpus the measurement recorded in
+    /// TASK-ecf0f37f68c9 was taken on.
+    fn past_the_budget() -> Temp {
+        let t = Temp::new();
+        t.write(&adr(
+            "00000000aaaa",
+            "The one accepted rule",
+            &["src/**"],
+            "Nothing under src/ reaches the network at import time.\n",
+            AdrStatus::Accepted,
+        ));
+        for i in 1..=12u32 {
+            t.write(&task(
+                &format!("0000000000{i:02}"),
+                &format!("Open task number {i}"),
+                &["src/**"],
+                &[],
+                TaskStatus::Open,
+            ));
+            t.write(&adr(
+                &format!("0000000000{i:02}"),
+                &format!("A proposal number {i}"),
+                &["src/**"],
+                "Prefer the idempotent form.\n",
+                AdrStatus::Proposed,
+            ));
+        }
+        t
+    }
+
+    fn parse(json: &str) -> serde_yaml::Value {
+        serde_yaml::from_str(json).unwrap_or_else(|e| panic!("invalid JSON: {e}\n{json}"))
+    }
+
+    /// The `short` of every row of one array, in order.
+    fn shorts_of(doc: &serde_yaml::Value, key: &str) -> Vec<String> {
+        doc[key]
+            .as_sequence()
+            .unwrap_or_else(|| panic!("{key} is not an array"))
+            .iter()
+            .map(|row| row["short"].as_str().expect("a row without a short").into())
+            .collect()
+    }
+
+    /// The `--json` document carries what the page carried, and no more (§5,
+    /// ADR-3e6ce108edcd).
+    ///
+    /// Asserted against the page rather than against a recorded number, in both
+    /// directions: every row the document carries is on the page, and every row
+    /// the page shows is in the document. A count alone would pass on a
+    /// document that cut the right *number* of the wrong rows, which is exactly
+    /// what a second fitting decision would produce.
+    #[test]
+    fn the_json_document_is_served_under_the_page_s_budget() {
+        let t = past_the_budget();
+        let view = t.view("claude-code@ank", None);
+        assert_eq!(view.tasks.len(), 12, "the fixture is past the budget");
+        assert_eq!(view.proposals.len(), 12);
+
+        // The measurement the task was filed on: at 400 the page carried four
+        // task rows and no proposal, and the document carried all twenty-four.
+        let page = render(&view, 400, crate::style::PLAIN);
+        let doc = parse(&render_json(&view, 400));
+
+        let tasks = shorts_of(&doc, "tasks");
+        let proposed = shorts_of(&doc, "proposed");
+        assert!(
+            tasks.len() < view.tasks.len(),
+            "the budget did no work on the tasks: {tasks:?}"
+        );
+        assert!(
+            proposed.len() < view.proposals.len(),
+            "the budget did no work on the proposals: {proposed:?}"
+        );
+
+        for short in tasks.iter().chain(&proposed) {
+            assert!(
+                page.contains(short.as_str()),
+                "the document carries {short}, which the page cut:\n{page}"
+            );
+        }
+        for line in view.tasks.iter().map(|t| &t.short) {
+            assert_eq!(
+                page.contains(line.as_str()),
+                tasks.contains(line),
+                "{line}: the page and the document disagree:\n{page}"
+            );
+        }
+        for line in view.proposals.iter().map(|c| &c.short) {
+            assert_eq!(
+                page.contains(line.as_str()),
+                proposed.contains(line),
+                "{line}: the page and the document disagree:\n{page}"
+            );
+        }
+
+        // The counters are the perimeter's and never the page's, exactly as the
+        // human headers count what the perimeter holds. A caller reading four
+        // rows and `ready: 12` knows the page was fitted; one reading
+        // `ready: 4` could not tell that from a corpus of four tasks.
+        assert_eq!(doc["ready"].as_u64(), Some(12), "{doc:?}");
+    }
+
+    /// **A page that fits is not cut**, even at a budget it barely fits under.
+    ///
+    /// This is the corpus `golden_repo` builds in `tests/cli.rs`, at the
+    /// `context_budget: 400` it declares: one accepted constraint, one proposal,
+    /// one spec and four open tasks over `src/**`. Uncut it renders 381
+    /// characters, eighteen under the budget, so §5 has nothing to do.
+    ///
+    /// It used to cut five rows and hand back 373 characters — shorter by eight
+    /// than the cut it bought. The share loop priced the full spec list
+    /// *together with* a `+1 not shown` notice for a row it had not removed, a
+    /// state that never exists: 149 against a share of 133, where the section as
+    /// it stood cost 98. Cutting the spec then replaced a 24-character row with
+    /// a 51-character notice, which put the page over budget and sent the second
+    /// loop down to the floor (TASK-345c35a8beba).
+    #[test]
+    fn a_page_that_fits_is_not_cut_at_the_budget_it_fits_under() {
+        let t = Temp::new();
+        t.write(&adr(
+            "0000000000ab",
+            "A decision",
+            &["src/**"],
+            "Nothing under src/ reaches the network at import time. A module that
+             opens a socket, reads an environment variable naming a host, or resolves
+             a name while it is being loaded makes the import order a fact about the
+             machine rather than about the program, and the failure it produces names
+             the importer instead of the line that reached out.
+",
+            AdrStatus::Accepted,
+        ));
+        t.write(&adr(
+            "0000000000ba",
+            "A decision",
+            &["src/**"],
+            "A proposal.
+",
+            AdrStatus::Proposed,
+        ));
+        t.write(&spec("0000000000cd", "A document", &["src/**"]));
+        for (hex, title, blocked) in [
+            ("000000000001", "Example task", &["TASK-000000000002"][..]),
+            ("000000000002", "A task that blocks", &[]),
+            ("000000000003", "A task that waits", &["TASK-000000000004"]),
+            ("000000000004", "A task apart", &[]),
+        ] {
+            t.write(&task(hex, title, &["src/**"], blocked, TaskStatus::Open));
+        }
+
+        let view = t.view("claude-code@ank", Some("src/**"));
+        let page = render(&view, 400, crate::style::PLAIN);
+        assert!(
+            page.chars().count() <= 400,
+            "the page does not fit, so this corpus proves nothing: {}",
+            page.chars().count()
+        );
+        assert!(
+            !page.contains("not shown"),
+            "a section was cut:
+{page}"
+        );
+        assert!(
+            !page.contains("more tasks"),
+            "a task was cut:
+{page}"
+        );
+        assert!(page.contains("SPECIFICATIONS (1)"), "{page}");
+        assert!(page.contains("PROPOSED (1, non-binding)"), "{page}");
+        assert!(page.contains("TASKS (4)"), "{page}");
+
+        // And the document says the same, which is what makes this a fact about
+        // the budget rather than about one renderer.
+        let doc = parse(&render_json(&view, 400));
+        assert_eq!(shorts_of(&doc, "tasks").len(), 4);
+        assert_eq!(shorts_of(&doc, "proposed").len(), 1);
+        assert_eq!(shorts_of(&doc, "specs").len(), 1);
+        assert_eq!(shorts_of(&doc, "constraints").len(), 1);
+    }
+
+    /// A budget large enough to hold the perimeter cuts nothing on either
+    /// surface: the fitting is a consequence of the number, not a habit.
+    #[test]
+    fn a_budget_that_fits_cuts_neither_surface() {
+        let t = past_the_budget();
+        let view = t.view("claude-code@ank", None);
+        let doc = parse(&render_json(&view, 100_000));
+        assert_eq!(shorts_of(&doc, "tasks").len(), 12);
+        assert_eq!(shorts_of(&doc, "proposed").len(), 12);
+        assert_eq!(shorts_of(&doc, "constraints").len(), 1);
+    }
+
+    /// Execution mode has one section that yields, and `--json` yields with it.
+    ///
+    /// The criterion is never cut and a constraint is never cut, so the log is
+    /// the only place the two surfaces can be seen shortening together.
+    #[test]
+    fn the_json_log_is_cut_where_the_page_cuts_it() {
+        let t = Temp::new();
+        let mut body = String::from("\nBody.\n\n## Log\n");
+        for i in 1..=20 {
+            body.push_str(&format!(
+                "- 2026-07-28T10:{i:02}Z a@h — entry number {i}, long enough to cost \
+                 something against a small budget\n"
+            ));
+        }
+        let Entity::Task(mut task_entity) = task(
+            "000000000001",
+            "The task",
+            &["src/**"],
+            &[],
+            TaskStatus::Open,
+        ) else {
+            panic!("not a task")
+        };
+        task_entity.body = body;
+        t.write(&Entity::Task(task_entity));
+        t.write(&adr(
+            "00000000aaaa",
+            "A rule",
+            &["src/**"],
+            "Every session goes through the store.\n",
+            AdrStatus::Accepted,
+        ));
+        let id = EntityId::parse("TASK-000000000001").unwrap();
+        t.claim_as(&id, "claude-code@ank");
+
+        let view = t.view("claude-code@ank", None);
+        let Mode::Execution { log, .. } = &view.mode else {
+            panic!("expected execution mode")
+        };
+        assert_eq!(log.len(), 20);
+
+        let page = render(&view, 800, crate::style::PLAIN);
+        let doc = parse(&render_json(&view, 800));
+        let kept: Vec<String> = doc["log"]
+            .as_sequence()
+            .expect("log is not an array")
+            .iter()
+            .map(|e| e.as_str().expect("an entry that is not a string").into())
+            .collect();
+
+        assert!(kept.len() < 20, "the budget did no work: {kept:?}");
+        assert!(!kept.is_empty(), "the floor keeps one entry");
+        assert!(
+            page.contains(&format!("LOG ({} of 20)", kept.len())),
+            "the page kept a different number of entries:\n{page}"
+        );
+        for entry in &kept {
+            assert!(
+                page.contains(entry.as_str()),
+                "{entry} was cut from the page"
+            );
+        }
+        // The oldest are what yields, so the newest entry is on both surfaces
+        // and the first is on neither.
+        assert_eq!(kept.last(), log.last());
+        assert!(!kept.contains(&log[0]), "the oldest survived the cut");
     }
 }

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -19304,16 +19304,13 @@ fn the_human_page_of_all_four_listings_is_unchanged() {
 /// output cuts, counts what it cut, and names the query that would show the
 /// rest.
 ///
-/// **The `--json` half of that clause does not hold, and this test does not
-/// pretend otherwise.** Measured on this fixture: `context --json` emits all
-/// twenty-four rows while the page above shows four. `context.rs` reads
+/// **The `--json` half of that clause holds now**, and the test below is where
+/// it is asserted. When this one was written it did not: `context.rs` read
 /// `cfg.context_budget` at exactly one line, the human `render`, and
-/// `render_json` has never taken a budget argument since it was introduced in
-/// 6ec4f70 -- so `context --json` was never budgeted and this change did not
-/// make it so. Nothing is asserted here about the `--json` document in either
-/// direction, deliberately: pinning today's behaviour would cement what the
-/// decision forbids, and pinning the decision's behaviour would fail. The gap is
-/// carried by TASK-ecf0f37f68c9.
+/// `render_json` had never taken a budget argument since it was introduced in
+/// 6ec4f70, so `context --json` emitted all twenty-four rows while the page here
+/// showed four. Nothing was asserted about the document in either direction,
+/// deliberately, and the gap was carried by TASK-ecf0f37f68c9, which closed it.
 #[test]
 fn the_budget_still_governs_the_page_context_serves() {
     let (r, _tasks, _adrs) = past_the_budget();
@@ -19335,5 +19332,72 @@ fn the_budget_still_governs_the_page_context_serves() {
     assert!(
         said.contains("TASK-000000000003") && !said.contains("TASK-000000000004"),
         "the page ends where the budget does: {said}"
+    );
+}
+
+/// `context --json` is served under the budget, and carries what the page
+/// carried and no more (ADR-3e6ce108edcd, TASK-ecf0f37f68c9).
+///
+/// **The asymmetry with the four listings above is the decision's, not an
+/// oversight in it.** A listing is asked *what exists*, and a document that
+/// silently omits rows is wrong about the corpus; `context` is asked *what to
+/// read first*, and there the selection is the answer rather than a limit on it.
+/// A whole `context --json` would not be a fuller answer to that question, it
+/// would hand the fitting back to a caller with no budget, no ordering and no
+/// section 5.
+///
+/// Driven through the binary and compared against the page the binary just
+/// printed, in **both** directions: every row the document carries is on the
+/// page, and every row the page shows is in the document. A count alone would
+/// pass on a document that cut the right number of the wrong rows, which is
+/// exactly what a second fitting decision would produce -- and the fitting is
+/// made once, above both renderers, so that there cannot be one.
+#[test]
+fn the_json_document_of_context_is_served_under_the_same_budget() {
+    let (r, tasks, adrs) = past_the_budget();
+
+    let out = r.ank("claude-code@ank", &["context"]);
+    assert_eq!(code(&out), 0, "{}", both_streams(&out));
+    let page = stdout(&out);
+
+    let out = r.ank("claude-code@ank", &["context", "--json"]);
+    assert_eq!(code(&out), 0, "{}", both_streams(&out));
+    let doc = stdout(&out);
+
+    // The budget did real work on the page, or this fixture proves nothing.
+    assert!(page.contains("+12 not shown"), "{page}");
+    assert!(page.contains("+8 more tasks"), "{page}");
+
+    let quoted = |id: &String| format!("\"{id}\"");
+    for id in tasks.iter().chain(&adrs) {
+        assert_eq!(
+            page.contains(id.as_str()),
+            doc.contains(&quoted(id)),
+            "{id}: the page and the document disagree.\npage:\n{page}\ndocument:\n{doc}"
+        );
+    }
+
+    // Named rather than merely counted, so a failure says which row moved.
+    let in_doc: Vec<&String> = tasks
+        .iter()
+        .filter(|id| doc.contains(&quoted(id)))
+        .collect();
+    assert_eq!(
+        in_doc.len(),
+        4,
+        "four of twelve tasks, as the page shows: {in_doc:?}\n{doc}"
+    );
+    assert!(
+        !adrs.iter().any(|id| doc.contains(&quoted(id))),
+        "the proposals were cut from the page and belong nowhere in the document:\n{doc}"
+    );
+
+    // The counters stay the perimeter's, exactly as the human headers count what
+    // the perimeter holds and not what survived. A caller reading four rows and
+    // `"ready":12` knows the page was fitted; `"ready":4` would be
+    // indistinguishable from a corpus of four tasks.
+    assert!(
+        doc.contains("\"ready\":12"),
+        "the counters follow the page instead of the perimeter:\n{doc}"
     );
 }


### PR DESCRIPTION
Closes TASK-ecf0f37f68c9.

## What was wrong

ADR-3e6ce108edcd says the attention budget cuts what a human is shown and never what a program receives, with one exception: `context` keeps the budget under `--json`, "because deciding what a reader is handed first is that verb's answer rather than a limit on it".

The exception described code that did not exist. `context.rs` read `cfg.context_budget` at exactly one line, the human `render`, and `render_json` had never taken a budget argument since it was introduced in 6ec4f70. Measured at `context_budget: 400` on twelve open tasks and twelve proposed decisions:

| | rows |
|---|---|
| `ank context` | 4 tasks, 0 proposals, `+12 not shown`, `+8 more tasks` |
| `ank context --json` | all 24 |

## The asymmetry, and why it is right

A listing verb is asked *what exists*, and a document that silently omits rows is simply wrong about the corpus. `context` is asked *what to read first*, and there the selection **is** the answer rather than a limit on it. A whole `context --json` would not be a fuller answer to that question; it would hand the fitting back to a caller with no budget, no ordering and no §5. The four listings stay whole under `--json` and are unaffected.

## What changed

The fitting decision moved out of the human `render` into `fit`, above both renderers, so both spend the same page. A second copy would be free to disagree with the first about which rule survives, and the same perimeter would then be described differently depending on which surface a reader typed.

`fit` prices in plain style. `chars` already ignores SGR sequences, so this turns colour-neutrality from a property two renderers happen to share into one they cannot disagree about, and it is what lets `--json` — which carries no style at all (ADR-0c8ab846d262) — be handed the very rows the terminal was.

The three counters stay the perimeter's rather than the page's. `ready`, `blocked` and `finished_elsewhere` say what the scope holds, exactly as the human `PROPOSED (n)` and `SPECIFICATIONS (n)` headers count what the perimeter holds and not what survived. A caller reading four rows and `ready: 12` can tell the page was fitted; `ready: 4` would be indistinguishable from a corpus of four tasks. **No field is added, removed or retyped, so the contract version does not move** (ADR-6fd69efb629c).

## A defect this exposed

Budgeting the document put the fitting's output into a golden fixture, and the fixture went red. Chasing that found a defect the human page had carried unnoticed, because nothing pinned `context`'s page on a corpus close to its budget.

The first-half loop priced the full list **together with** a `+1 not shown` notice for a row it had not removed — a state that never exists. On the corpus `golden_repo` builds, the section as it stood cost 98 against a share of 133 while the hybrid came to 149, so a section that fitted with thirty-five characters to spare was cut. Replacing a 24-character row with a 51-character notice then put the whole page over budget and sent the second loop down to the floor:

```
uncut page      381 characters, one of everything
at budget 400   373 characters, and five rows gone
```

The page already fitted, and the result was shorter by eight characters than the cut it bought. Pricing each section as it stands is the fix. `tests/golden-json/context.json` is **unchanged** as a result — the fixture is not in this diff.

A second mechanism I suspected turned out **not** to be a defect, and is recorded as such rather than quietly dropped. A `+n not shown` notice really is longer than the row it replaces, but it is paid once per section and every later row is pure saving. Requiring each individual cut to shrink the page left twelve proposals and twelve tasks entirely uncut at a budget of 400. I implemented it, measured it, and took it back out. The counters `+12 not shown` and `+8 more tasks` in `the_budget_still_governs_the_page_context_serves` were pinning correct behaviour and do not move.

## Tests

Three unit tests in `context.rs` and one integration test in `tests/cli.rs`, which drives the binary on a corpus past the budget and compares the document against the page the binary just printed, **in both directions**: every row the document carries is on the page, and every row the page shows is in the document. A count alone would pass on a document that cut the right number of the wrong rows, which is exactly what a second fitting decision would produce.

Every test was falsified before being trusted:

- reverting `render_json` to an unbudgeted `fit` turns the budget tests red, reproducing the filed numbers exactly (all 12 tasks, all 20 log entries);
- restoring the hybrid pricing turns `a_page_that_fits_is_not_cut_at_the_budget_it_fits_under` red with the spec and the proposal cut off a page that fits.

`cargo test --workspace` green, `cargo fmt --check` clean, `ank check` exit 0 with 0 faults. The prose-identifier signal is unchanged: every identifier the new prose names resolves.

## Left over

`TASK-345c35a8beba` was filed while chasing the above and is **absorbed whole by this PR** — its criterion is met here and its body's second mechanism is corrected by the log. It wants closing with a reason rather than working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
