### PR TITLE
Accept names the source citations it just orphaned

### DIFF
--- a/.ank/entities/LOG-3552bc11bfed.md
+++ b/.ank/entities/LOG-3552bc11bfed.md
@@ -1,0 +1,13 @@
+---
+id: LOG-3552bc11bfed
+type: log
+title: done, proof commit:880ec41bb2cd141ecea60d0aa340efa16bcad627
+created: 2026-08-24T16:54:56Z
+author: claude-code/opus-5-orphaned-citations
+scope:
+  - crates/ank-cli/**
+about: TASK-3f47e6fd3598
+seq: 1
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-f2c3f554159a.md
+++ b/.ank/entities/LOG-f2c3f554159a.md
@@ -1,0 +1,23 @@
+---
+id: LOG-f2c3f554159a
+type: log
+title: Built as one walk and one message inside accept, after the commit. The commit is the act, so a
+created: 2026-08-24T16:54:04Z
+author: claude-code/opus-5-orphaned-citations
+scope:
+  - crates/ank-cli/**
+about: TASK-3f47e6fd3598
+seq: 0
+schema: 4
+version: 1
+---
+
+ ratification that failed to commit superseded nothing and owes no repair; warning before it would send a reader at citations that are still alive.
+
+Two things the criterion did not have to settle and the code did. The walk is the working tree's, rooted on repo.worktree where a scope glob is confronted, and not git's index: ADR-9307e5d214a7 names the git commands this binary may use and ls-files is not among them, so asking git for the tracked set would have been a constraint change to buy a smaller answer. What that costs is a file git does not track yet being named too, which is the honest side of the trade, since a stale citation costs the next reader the same either way. The existing tracked_files walk is reused, so .git, target and node_modules are skipped exactly where the scope verdicts skip them.
+
+And .ank/ is excluded, which is the whole of what separates this from the rule ADR-1e6bcbf62e61 states: a superseded identifier is legitimate in the prose of the corpus, where ank show carries the chain, and stale in the source, where nothing carries anything.
+
+Falsified before it was believed: with the call disabled the citation test fails on the empty stderr, and it passes with the call restored. Both silences are pinned in a test of their own, since a warning that fires on every ratification that is not a succession is one people learn to scroll past.
+
+Nothing is truncated, because the list is the repair. The largest real case in this repository was a hundred and six citations across eighteen files.

--- a/.ank/entities/TASK-3f47e6fd3598.md
+++ b/.ank/entities/TASK-3f47e6fd3598.md
@@ -5,15 +5,20 @@ slug: ratifying-a-successor-names-the-source-citations
 title: Ratifying a successor names the source citations it just orphaned
 created: 2026-08-23T21:44:28Z
 author: claude-code/opus-5
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/**
 blocked_by: []
 done_criteria: |
   ank accept, on a document carrying supersedes, having written the transition, names on standard error every tracked file and line outside .ank/ that mentions the superseded identifier, and names the successor as what to write instead. It warns and never refuses: the exit code is the one accept already returns, and a ratification whose predecessor no file mentions, or which supersedes nothing, prints nothing at all. Verified through the binary, on a repository whose source mentions the predecessor.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 880ec41bb2cd141ecea60d0aa340efa16bcad627
+    criteria: 5b1b03a5fcae
+    via: submitted
 schema: 4
-version: 2
+version: 3
 ---
 
 Ratifying a successor is the act that kills every citation of its

--- a/.ank/entities/TASK-3f47e6fd3598.md
+++ b/.ank/entities/TASK-3f47e6fd3598.md
@@ -5,7 +5,7 @@ slug: ratifying-a-successor-names-the-source-citations
 title: Ratifying a successor names the source citations it just orphaned
 created: 2026-08-23T21:44:28Z
 author: claude-code/opus-5
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/**
 blocked_by: []
@@ -13,7 +13,7 @@ done_criteria: |
   ank accept, on a document carrying supersedes, having written the transition, names on standard error every tracked file and line outside .ank/ that mentions the superseded identifier, and names the successor as what to write instead. It warns and never refuses: the exit code is the one accept already returns, and a ratification whose predecessor no file mentions, or which supersedes nothing, prints nothing at all. Verified through the binary, on a repository whose source mentions the predecessor.
 criteria_by: creator
 schema: 4
-version: 1
+version: 2
 ---
 
 Ratifying a successor is the act that kills every citation of its

--- a/crates/ank-cli/src/human.rs
+++ b/crates/ank-cli/src/human.rs
@@ -4271,7 +4271,121 @@ pub fn accept(
             );
         }
     }
+    // The citations this ratification just orphaned, named where the knowledge
+    // exists (TASK-3f47e6fd3598). Ratifying a successor is the act that makes
+    // every mention of its predecessor in the source stale, and it was the one
+    // act in the corpus whose damage was invisible to the person performing it:
+    // two ratifications on 2026-08-22 left thirty-three citations behind in nine
+    // files across three crates, both correct, both signed, and neither saying
+    // anything. The default branch went red at the next push on a test that had
+    // been green minutes before.
+    //
+    // **After the commit, because the commit is the act.** A ratification that
+    // failed to commit superseded nothing, and a warning about it would send a
+    // reader to repair citations that are still perfectly alive.
+    if let Some(target) = replaced.target() {
+        warn_orphaned_citations(inv, repo, target.id(), &id);
+    }
+
     Ok(ExitCode::Ok)
+}
+
+/// Every line outside `.ank/` that mentions `superseded`, on standard error,
+/// with the successor named as what to write instead.
+///
+/// **It warns and never refuses**, and the exit code does not move. A citation
+/// left behind is stale source; the decision is sound the moment it is signed.
+/// Refusing on the state of the working tree would make a correct human act
+/// fail on somebody else's comment, and would give the person holding the
+/// signing key a reason to look for a way around a ratification.
+///
+/// **It says where the repair is owed and never performs it.**
+/// ADR-c88f99e1c16e refused the re-pointing itself inside this verb, because
+/// writing to nine entities in one act would deposit nine machinery entries and
+/// pollute the trace the corpus keeps to watch itself. A message writes
+/// nothing: no amend, no version, no entry, no commit. What was refused there
+/// was the repair performing itself, not the tool saying where it is due.
+///
+/// **`.ank/` is excluded, and that is not an omission.** ADR-1e6bcbf62e61 holds
+/// a superseded identifier legitimate in the prose of the corpus, where history
+/// is written and `ank show` carries the chain. The source has no chain to
+/// follow: a comment in a module header hands the next reader a constraint with
+/// the authority of a decision record and no command attached. Same identifier,
+/// opposite verdict, and the place is what separates them.
+///
+/// **Here and not in `check`, and the reason is cost.** `check` runs on every
+/// edit to the corpus, and reading every file in the tree on each of those runs
+/// would spend that budget on a question that has a new answer only at a
+/// ratification. `accept` is rare, human, signed, on the default branch, and
+/// already slow.
+///
+/// The walk is the workspace's, rooted where a scope glob is confronted
+/// (ADR-9e56318631f3), and it reads the working tree rather than the index: a
+/// file git does not track yet is named too, which is the honest answer, since
+/// a stale citation costs the next reader the same whether or not it has been
+/// added. Nothing is truncated, because the list is the repair.
+fn warn_orphaned_citations(
+    inv: &Invocation,
+    repo: &Repo,
+    superseded: &EntityId,
+    successor: &EntityId,
+) {
+    if inv.quiet() {
+        return;
+    }
+    let needle = superseded.to_string();
+    let mut sites: Vec<String> = Vec::new();
+    let mut files: BTreeSet<String> = BTreeSet::new();
+    for rel in tracked_files(&repo.worktree) {
+        if rel == ".ank" || rel.starts_with(".ank/") {
+            continue;
+        }
+        // A file that is not text answers `Err` and is skipped, which is the
+        // whole of what this walk owes a binary.
+        let Ok(text) = std::fs::read_to_string(repo.worktree.join(&rel)) else {
+            continue;
+        };
+        if !text.contains(&needle) {
+            continue;
+        }
+        for (n, line) in text.lines().enumerate() {
+            if line.contains(&needle) {
+                sites.push(format!("{rel}:{}", n + 1));
+                files.insert(rel.clone());
+            }
+        }
+    }
+    // A ratification that supersedes nothing never reaches here, and one whose
+    // predecessor no file mentions says nothing at all: a verb that announced
+    // its own silence would be noise on the ordinary case.
+    if sites.is_empty() {
+        return;
+    }
+    sites.sort();
+    let style = inv.style().on_stderr();
+    eprintln!(
+        "{} {} {} of {superseded}, superseded by this ratification, {} in {} {}",
+        style.yellow("warning:"),
+        sites.len(),
+        if sites.len() == 1 {
+            "citation"
+        } else {
+            "citations"
+        },
+        if sites.len() == 1 {
+            "remains"
+        } else {
+            "remain"
+        },
+        files.len(),
+        if files.len() == 1 { "file" } else { "files" },
+    );
+    for site in &sites {
+        eprintln!("  {site}");
+    }
+    eprintln!(
+        "  -> write {successor} instead, or drop the citation and leave the history to `ank show`"
+    );
 }
 
 /// The command that changes a ratified decision, in the kind's own words.

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -19401,3 +19401,152 @@ fn the_json_document_of_context_is_served_under_the_same_budget() {
         "the counters follow the page instead of the perimeter:\n{doc}"
     );
 }
+
+/// Ratifying a successor names the citations it just orphaned
+/// (TASK-3f47e6fd3598).
+///
+/// **The act and the damage are the same instant, and only one of them used to
+/// be visible.** `accept` holds the predecessor's identifier, it has just
+/// written the transition that made it superseded, and the working tree is
+/// right there. Two ratifications on this project's own corpus left
+/// thirty-three citations behind in nine files and said nothing, and the
+/// default branch went red at the next push on a test that had been green
+/// minutes before.
+///
+/// Driven through the binary, on a repository whose source mentions the
+/// predecessor, because the walk is of a working tree and no unit test over
+/// `accept` has one.
+#[test]
+fn ratifying_a_successor_names_the_citations_it_orphaned() {
+    let r = ready_to_ratify();
+    let first = new_adr(&r, "human:marie", "Do not do X.");
+    r.git(&["add", "-A"]);
+    r.git(&["commit", "-qm", "seed"]);
+    let out = r.ank("human:marie", &["accept", &first]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+
+    // The citation a module header carries: a constraint handed to the next
+    // reader with the authority of a decision record and no command attached.
+    std::fs::write(
+        r.0.join("src/main.rs"),
+        format!(
+            "//! The shape below is what {first} asks for.
+fn main() {{}}
+"
+        ),
+    )
+    .unwrap();
+
+    let out = r.ank(
+        "human:marie",
+        &[
+            "new",
+            "adr",
+            "--title",
+            "The replacement",
+            "--scope",
+            "src/**",
+            "--constraint",
+            "Do not do Y.",
+            "--supersedes",
+            &first,
+        ],
+    );
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    let second = stdout(&out)
+        .split_whitespace()
+        .nth(1)
+        .expect("created <id> <slug>")
+        .to_string();
+    r.git(&["add", "-A"]);
+    r.git(&[
+        "commit",
+        "-qm",
+        "the successor, and the citation it will orphan",
+    ]);
+
+    let out = r.ank("human:marie", &["accept", &second]);
+    // The exit code does not move: the ratification is not what is wrong.
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    let err = stderr(&out);
+    assert!(
+        err.contains("src/main.rs:1"),
+        "the file and the line a reader would fix: {err}"
+    );
+    assert!(
+        err.contains(&first),
+        "the identifier that just went stale: {err}"
+    );
+    assert!(err.contains(&second), "and the one to write instead: {err}");
+    // `.ank/` is where a superseded identifier belongs (ADR-1e6bcbf62e61), and
+    // the successor's own file carries it in `supersedes:`. Naming that would
+    // send a reader to repair the corpus for recording its own history.
+    assert!(
+        !err.contains(".ank"),
+        "the corpus is not the source, and its prose is not stale: {err}"
+    );
+}
+
+/// The two silences, which are what keeps the warning readable: a ratification
+/// that supersedes nothing, and one whose predecessor no file mentions, print
+/// nothing at all (TASK-3f47e6fd3598).
+///
+/// A verb announcing that it found nothing would put a line on the ordinary
+/// case, which is every ratification that is not a succession, and a warning
+/// that fires on ordinary work is one people learn to scroll past.
+#[test]
+fn a_ratification_that_orphans_nothing_says_nothing() {
+    const MARKER: &str = "superseded by this ratification";
+    let r = ready_to_ratify();
+    let first = new_adr(&r, "human:marie", "Do not do X.");
+    r.git(&["add", "-A"]);
+    r.git(&["commit", "-qm", "seed"]);
+
+    // Supersedes nothing.
+    let out = r.ank("human:marie", &["accept", &first]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    assert!(
+        !stderr(&out).contains(MARKER),
+        "a ratification replacing nothing orphans nothing: {}",
+        stderr(&out)
+    );
+
+    // Supersedes a predecessor no file outside the corpus mentions: `src`
+    // stands as `ready_to_ratify` left it.
+    let out = r.ank(
+        "human:marie",
+        &[
+            "new",
+            "adr",
+            "--title",
+            "The replacement",
+            "--scope",
+            "src/**",
+            "--constraint",
+            "Do not do Y.",
+            "--supersedes",
+            &first,
+        ],
+    );
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    let second = stdout(&out)
+        .split_whitespace()
+        .nth(1)
+        .expect("created <id> <slug>")
+        .to_string();
+    r.git(&["add", "-A"]);
+    r.git(&["commit", "-qm", "the successor"]);
+
+    let out = r.ank("human:marie", &["accept", &second]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    assert!(
+        stdout(&out).contains("superseded"),
+        "the succession did happen: {}",
+        stdout(&out)
+    );
+    assert!(
+        !stderr(&out).contains(MARKER),
+        "no file cites it, so there is nothing to say: {}",
+        stderr(&out)
+    );
+}


### PR DESCRIPTION
Closes TASK-3f47e6fd3598.

Ratifying a successor is the act that makes every mention of its predecessor in the source stale, and it was the one act in this corpus whose damage was invisible to the person performing it. Accepting ADR-f7dc76886db2 and SPEC-d3adbd77dca9 on 2026-08-22 left thirty-three citations in nine files across three crates; both ratifications were correct, both were signed, and neither said anything. The default branch went red on all three platforms at the next push, on a test that had been green minutes before. It happened a fourth time today, on the same line of `verbs.rs`.

`accept` holds the predecessor's identifier, it has just written the transition that made it superseded, and the working tree is right there. What was missing is one walk and one message.

**It warns and never refuses.** The exit code does not move. A citation left behind is stale source, and the decision is sound the moment it is signed; refusing on the state of the working tree would make a correct human act fail on somebody else's comment.

**It says where the repair is owed and never performs it.** ADR-c88f99e1c16e refused the re-pointing itself inside this verb, because writing to nine entities in one act would deposit nine machinery entries. A message writes nothing: no amend, no version, no entry, no commit.

**The walk is the working tree's, not git's index.** ADR-9307e5d214a7 names the git commands this binary may use and `ls-files` is not among them, so asking git for the tracked set would be a constraint change bought for a smaller answer. The existing `tracked_files` walk is reused, skipping `.git`, `target` and `node_modules` where the scope verdicts already skip them. A file git does not track yet is named too, which is the honest side of that trade and is stated in the doc comment.

**`.ank/` is excluded**, which is what separates this from ADR-1e6bcbf62e61: a superseded identifier is legitimate in the prose of the corpus, where `ank show` carries the chain, and stale in the source, where nothing carries anything.

Nothing is truncated, because the list is the repair. The largest real case in this repository was a hundred and six citations across eighteen files.

## Verification

- `ratifying_a_successor_names_the_citations_it_orphaned` drives the binary on a repository whose source cites the predecessor, and asserts the file and line, both identifiers, exit code 0, and that no path under `.ank/` is named. Falsified: with the call disabled it fails on an empty stderr.
- `a_ratification_that_orphans_nothing_says_nothing` pins both silences, a ratification that supersedes nothing and one whose predecessor no file mentions.
- `cargo test --workspace` green, `cargo fmt --check` clean, `ank check` exit 0 with no fault.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01625RCmwhDTKUWv493BcJyp
