### PR TITLE
Narrow the history walk to the paths a dead scope asks about

### DIFF
--- a/.ank/entities/LOG-040b1b6686f6.md
+++ b/.ank/entities/LOG-040b1b6686f6.md
@@ -1,0 +1,14 @@
+---
+id: LOG-040b1b6686f6
+type: log
+title: done, proof commit:1cab74886eabd39e221f81fac1b31c9c1d353fe1
+created: 2026-08-24T17:35:23Z
+author: claude-code/opus-5-history-walk
+scope:
+  - crates/ank-cli/src/git.rs
+  - crates/ank-cli/src/human.rs
+about: TASK-0515cfe21421
+seq: 3
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-17612ecc0f16.md
+++ b/.ank/entities/LOG-17612ecc0f16.md
@@ -1,0 +1,22 @@
+---
+id: LOG-17612ecc0f16
+type: log
+title: Narrowed, and the answer is a quarter rather than the four fifths the commit count promises.
+created: 2026-08-24T17:34:29Z
+author: claude-code/opus-5-history-walk
+scope:
+  - crates/ank-cli/src/git.rs
+  - crates/ank-cli/src/human.rs
+about: TASK-0515cfe21421
+seq: 1
+schema: 4
+version: 1
+---
+
+ rev-list HEAD -- <17 literal pathspecs> selects 140 commits of 957, and the walk goes from 264-339 ms, median 286, to 175-264 ms, median 227, seven alternating runs each, same machine, same build.
+
+The saving is not proportional because the selection is not free: rev-list now diffs every commit against the pathspec where it used to print names, 79-86 ms becoming 111-179 ms, and it takes back most of what diff-tree stops paying, 220-353 ms becoming 86-221. That is the irreducible half, and it is worth stating plainly: what remains cannot be narrowed by asking git for less, because asking is itself the cost.
+
+Three things measured and rejected. Deferring rename detection, walking wide with --no-renames to find each path's newest commit and then running one -M pass over the 17 commits it named, is correct but slower: the third process costs 66 to 131 ms here, which is the whole of what --no-renames saves. --full-history selects 217 commits instead of 140 for 296 ms against 249, and buys nothing: a merge it adds is a commit diff-tree prints no records for, so both walks step over it. And rev-list cannot produce the records itself, which would have removed a process: git 2.54 answers "fatal: -z option used with unsupported option", and -z is what makes the parse safe against a path that looks like a sha.
+
+End to end nothing is visible, and that is the honest half of the result: ank check is 1865 ms median before and 1764 after, ranges overlapping, because the walk is a sixth of a run that is not otherwise this task's subject.

--- a/.ank/entities/LOG-296d3efd0a3a.md
+++ b/.ank/entities/LOG-296d3efd0a3a.md
@@ -1,0 +1,20 @@
+---
+id: LOG-296d3efd0a3a
+type: log
+title: Measured before building, and the premise holds with one correction. The walk is 264 to 339 ms,
+created: 2026-08-24T17:34:26Z
+author: claude-code/opus-5-history-walk
+scope:
+  - crates/ank-cli/src/git.rs
+  - crates/ank-cli/src/human.rs
+about: TASK-0515cfe21421
+seq: 0
+schema: 4
+version: 1
+---
+
+ median 286, in process, release build, warm, idle machine, over the 957 commits this repository now carries: the baseline TASK-756a870eb0ab recorded was 251 ms over 917, and the difference is the forty commits since.
+
+The correction is the count. That profile says 114 dead globs, and 114 is the number of entity-and-glob pairs scope_moved is called on, 106 of them today. The walk is not asked 106 questions: the distinct dead patterns are 21, and 17 after an ancestor swallows its descendants. That is the whole reason a narrowing exists to be built, and reading 114 as 114 different paths would have hidden it.
+
+What git actually spends. Two processes: rev-list HEAD is 79 to 86 ms for 957 shas, and diff-tree --stdin -r -M -z --name-status over all of them is 220 to 353 ms for 182 KB. Rename detection is 80 to 100 ms of the diff-tree half, measured by running the same list with --no-renames: 145 to 151 ms against 220 to 353.

--- a/.ank/entities/LOG-c0a7e7297dbb.md
+++ b/.ank/entities/LOG-c0a7e7297dbb.md
@@ -1,0 +1,20 @@
+---
+id: LOG-c0a7e7297dbb
+type: log
+title: Verification, since the criterion asks for identity rather than for a green suite. ank check on
+created: 2026-08-24T17:34:32Z
+author: claude-code/opus-5-history-walk
+scope:
+  - crates/ank-cli/src/git.rs
+  - crates/ank-cli/src/human.rs
+about: TASK-0515cfe21421
+seq: 2
+schema: 4
+version: 1
+---
+
+ this corpus prints byte for byte the same 106 dead-scope findings and the same 130 explanation lines before and after, compared with cmp on the release build of each. The only line that ever differed was a claim ref the first run pruned, which the second run no longer had to prune.
+
+Under the answer, the four readers agree path by path. A probe held wide and narrow histories side by side and asserted rename_of, deletion_of, directory_rename_of and deletions_under equal for all 21 asked paths, seven times. It is a probe and not a test: it takes 4 seconds and pins this repository's history rather than a rule, and the rule it would have pinned is already carried by a_scope_deleted_by_a_commit_is_a_signal_and_a_scope_git_never_knew_is_a_fault, which drives the binary over three dead scopes in three directories, one of them a path git never knew.
+
+What is pinned in tests is the reduction itself: the ancestor swallowing its descendants without swallowing a-b, which sorts between a and a/c and would otherwise be dropped; the literal pathspec magic, since a scope that never reduced to a directory names a path git never had; and the command-line budget, past which the walk is wide again rather than refused by the operating system at 32767 characters.

--- a/.ank/entities/TASK-0515cfe21421.md
+++ b/.ank/entities/TASK-0515cfe21421.md
@@ -5,7 +5,7 @@ slug: git-history-walks-all-917-commits-to-explain-a-d
 title: git::history walks all 917 commits to explain a dead scope, and it is 46 percent of check's per-entity phase
 created: 2026-08-23T22:22:13Z
 author: claude-code/opus-5-measure
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/src/git.rs
   - crates/ank-cli/src/human.rs
@@ -13,8 +13,13 @@ blocked_by: []
 done_criteria: |
   The whole-history walk git::history performs is either narrowed to what a dead-scope explanation actually needs, or shown by measurement to be irreducible and recorded as such. Either way the answer is measured on this repository's corpus, release build, warm, on an idle machine, against the baseline TASK-756a870eb0ab recorded: 251 ms for the walk, 544 ms for the per-entity loop, 917 commits, 114 dead globs. Two constraints on whatever is built. It must not reintroduce a search per glob, which TASK-1b3d7b61dc8f removed deliberately after measuring 58 rev-list and 113 cat-file process starts on this repository; and no cache is added, which is what closed TASK-da7738572825. The explanation check prints for each of the 114 dead globs is identical before and after, glob by glob, and the findings check reports are identical subject by subject. cargo test is green, cargo fmt --check passes, ank check reports no fault.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 1cab74886eabd39e221f81fac1b31c9c1d353fe1
+    criteria: d2503e852765
+    via: submitted
 schema: 4
-version: 2
+version: 3
 ---
 
 TASK-756a870eb0ab profiled the per-entity phase and this is the one thing it named.

--- a/.ank/entities/TASK-0515cfe21421.md
+++ b/.ank/entities/TASK-0515cfe21421.md
@@ -5,7 +5,7 @@ slug: git-history-walks-all-917-commits-to-explain-a-d
 title: git::history walks all 917 commits to explain a dead scope, and it is 46 percent of check's per-entity phase
 created: 2026-08-23T22:22:13Z
 author: claude-code/opus-5-measure
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/src/git.rs
   - crates/ank-cli/src/human.rs
@@ -14,7 +14,7 @@ done_criteria: |
   The whole-history walk git::history performs is either narrowed to what a dead-scope explanation actually needs, or shown by measurement to be irreducible and recorded as such. Either way the answer is measured on this repository's corpus, release build, warm, on an idle machine, against the baseline TASK-756a870eb0ab recorded: 251 ms for the walk, 544 ms for the per-entity loop, 917 commits, 114 dead globs. Two constraints on whatever is built. It must not reintroduce a search per glob, which TASK-1b3d7b61dc8f removed deliberately after measuring 58 rev-list and 113 cat-file process starts on this repository; and no cache is added, which is what closed TASK-da7738572825. The explanation check prints for each of the 114 dead globs is identical before and after, glob by glob, and the findings check reports are identical subject by subject. cargo test is green, cargo fmt --check passes, ank check reports no fault.
 criteria_by: creator
 schema: 4
-version: 1
+version: 2
 ---
 
 TASK-756a870eb0ab profiled the per-entity phase and this is the one thing it named.

--- a/crates/ank-cli/src/git.rs
+++ b/crates/ank-cli/src/git.rs
@@ -930,6 +930,66 @@ pub struct History {
     commits: Vec<(String, String)>,
 }
 
+/// The pathspecs that narrow the walk to the commits a dead-scope explanation
+/// can be answered from, or `None` to walk everything.
+///
+/// **Measured on this repository** (957 commits, 21 distinct dead globs, 17
+/// pathspecs after the reduction below, release build, warm, idle machine): the
+/// walk selects 140 commits instead of 957 and costs 249 ms against 346 ms,
+/// medians of seven alternating runs. A quarter, and not the four fifths the
+/// commit count suggests, because the selection is not free: `rev-list` now
+/// diffs every commit against the pathspec where it used to print names, and it
+/// takes back most of what `diff-tree` stops paying (TASK-0515cfe21421).
+///
+/// **Ancestors subsume descendants.** A pathspec matches the path and
+/// everything beneath it, which is the rule [`History::last_change`] applies
+/// too, so asking for `docs/spec.md` beside `docs` selects not one commit more
+/// and lengthens the command line.
+///
+/// **`:(literal)` rather than git's default globbing**, because the question
+/// the caller will ask is literal: `last_change` compares with `==` and a
+/// prefix test, so a scope that never reduced to a directory names a path git
+/// simply never had, and it must select nothing here exactly as it matches
+/// nothing there.
+///
+/// **A bound on the command line, and the whole walk beyond it.** A corpus
+/// carrying hundreds of dead scopes in unrelated directories would build an
+/// argument list Windows refuses at 32767 characters, and a walk that fails to
+/// start explains nothing at all where the wide one merely costs more. The
+/// bound is on the bytes rather than on the count, since it is bytes the
+/// operating system refuses.
+fn narrowing(asked: &[String]) -> Option<Vec<String>> {
+    const MAGIC: &str = ":(literal)";
+    /// Well under the 32767 characters Windows allows, since the pathspecs are
+    /// not the whole command line and the margin costs nothing: past it the
+    /// walk is wide, which is what it always was.
+    const BUDGET: usize = 8192;
+    if asked.is_empty() {
+        return None;
+    }
+    let mut sorted: Vec<&str> = asked.iter().map(String::as_str).collect();
+    sorted.sort_unstable();
+    sorted.dedup();
+    let mut kept: Vec<&str> = Vec::new();
+    for path in sorted {
+        // Sorted, so an ancestor is always already kept when its descendant
+        // arrives, and one comparison against the last kept prefix would still
+        // miss `a`, `a-b`, `a/c` -- where `a-b` sorts between the two.
+        if kept
+            .iter()
+            .any(|k| path == *k || path.starts_with(&format!("{k}/")))
+        {
+            continue;
+        }
+        kept.push(path);
+    }
+    let bytes: usize = kept.iter().map(|p| p.len() + MAGIC.len() + 1).sum();
+    if bytes > BUDGET {
+        return None;
+    }
+    Some(kept.into_iter().map(|p| format!("{MAGIC}{p}")).collect())
+}
+
 /// Reads the whole history in one call.
 ///
 /// `--format=%x00%H` frames it: `-z` terminates the format with a NUL of its
@@ -937,12 +997,35 @@ pub struct History {
 /// empty field is a frame no path can forge. A path is never empty, where a path
 /// of forty hexadecimal characters is perfectly possible.
 ///
-/// **No pathspec and no `--full-history`**, which is what keeps this the same
-/// question the per-path calls asked: default simplification walks to the commit
-/// that made a change rather than to the merges that carried it, and a merge is
-/// a commit `--name-status` prints nothing for.
-pub fn history(cwd: &Path) -> Result<History> {
-    let listed = output(cwd, &["rev-list", "HEAD"])?;
+/// **No `--full-history`**, which is what keeps this the same question the
+/// per-path calls asked: default simplification walks to the commit that made a
+/// change rather than to the merges that carried it, and a merge is a commit
+/// `--name-status` prints nothing for.
+///
+/// **A pathspec, and only where the caller supplied one** (TASK-0515cfe21421).
+/// `asked` is every path a dead-scope explanation will be asked about, known
+/// before the walk because the verdicts already are; empty, or too long to hand
+/// an operating system, and the walk is the whole history exactly as it was. It
+/// narrows which commits are listed and never what `diff-tree` is shown of
+/// them: rename detection needs the other side of a rename, and the other side
+/// is by definition a path no dead scope names, so limiting the diff would turn
+/// a rename this exists to report into a bare deletion.
+///
+/// The commit [`History::last_change`] finds is the same under both, and the
+/// reason is the sentence above: default simplification follows a parent the
+/// change is actually on, and a merge it does show carries no records for
+/// `diff-tree` to print, so both walks step over it to the same commit
+/// underneath. Measured rather than only argued: on this repository the four
+/// readers below answer identically for all twenty-one asked paths, wide walk
+/// against narrow, over seven runs.
+pub fn history(cwd: &Path, asked: &[String]) -> Result<History> {
+    let mut argv: Vec<String> = vec!["rev-list".to_string(), "HEAD".to_string()];
+    if let Some(specs) = narrowing(asked) {
+        argv.push("--".to_string());
+        argv.extend(specs);
+    }
+    let args: Vec<&str> = argv.iter().map(String::as_str).collect();
+    let listed = output(cwd, &args)?;
     if !listed.status.success() {
         return Ok(History::default());
     }
@@ -2351,5 +2434,54 @@ mod tests {
             none.is_empty(),
             "a commit that added a file under the prefix deleted nothing: {none:?}"
         );
+    }
+
+    /// Nothing to narrow by is the whole history, which is the walk this verb
+    /// always performed.
+    #[test]
+    fn nothing_asked_narrows_nothing() {
+        assert_eq!(narrowing(&[]), None);
+    }
+
+    /// An ancestor subsumes what is beneath it, and a name that merely shares
+    /// its letters is not beneath it.
+    ///
+    /// `a-b` is the case a single comparison against the last kept path gets
+    /// wrong: sorted, it arrives between `a` and `a/c`, and dropping it would
+    /// lose a dead scope its explanation for the sake of a shorter command
+    /// line.
+    #[test]
+    fn an_ancestor_subsumes_its_descendants_and_nothing_else() {
+        let asked: Vec<String> = ["a/c", "a-b", "a", "a/c/d", "ab"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        assert_eq!(
+            narrowing(&asked),
+            Some(vec![
+                ":(literal)a".to_string(),
+                ":(literal)a-b".to_string(),
+                ":(literal)ab".to_string(),
+            ])
+        );
+    }
+
+    /// The magic is literal, because the question the caller will ask is: a
+    /// scope that never reduced to a directory names a path git never had, and
+    /// git's default globbing would answer about files it does have.
+    #[test]
+    fn a_pathspec_is_literal() {
+        let asked = vec!["*.rs".to_string()];
+        assert_eq!(narrowing(&asked), Some(vec![":(literal)*.rs".to_string()]));
+    }
+
+    /// Past the budget the walk is wide again. A corpus with hundreds of dead
+    /// scopes in unrelated directories is where the narrowing pays least and
+    /// where the argument list grows long enough to be refused, so the answer
+    /// is the walk that always worked rather than one that will not start.
+    #[test]
+    fn a_command_line_too_long_walks_everything() {
+        let asked: Vec<String> = (0..1000).map(|n| format!("crates/pkg{n}/src")).collect();
+        assert_eq!(narrowing(&asked), None);
     }
 }

--- a/crates/ank-cli/src/human.rs
+++ b/crates/ank-cli/src/human.rs
@@ -519,6 +519,27 @@ pub fn inspect(repo: &Repo, cfg: &Config, path: Option<&str>, prune: bool) -> Re
     // One history walk for every dead scope this pass finds, read the first
     // time one is found and never before (TASK-1b3d7b61dc8f).
     let walked: OnceCell<git::History> = OnceCell::new();
+    // And narrowed to the paths that walk will be asked about
+    // (TASK-0515cfe21421). The verdicts already say which patterns match no
+    // file, and `scope_moved` below turns each of them into exactly one
+    // question for git, so the questions are known before the walk rather than
+    // discovered one entity at a time. Derived here and not inside the loop
+    // because a pathspec list assembled per entity would be a different walk
+    // per entity, which is the shape TASK-1b3d7b61dc8f removed.
+    //
+    // Every dead pattern is included, including the ones the loop will skip
+    // for a reason of its own -- a cross-corpus entry, a scope ahead of the
+    // code. A pathspec more selects a few commits more and answers the same
+    // question; deriving the skips a second time here would put the rule in
+    // two places, and the two would disagree.
+    let asked: Vec<String> = verdicts
+        .iter()
+        .filter(|(_, alive)| !**alive)
+        .map(|(pattern, _)| match literal_prefix(pattern) {
+            Some((prefix, _)) => prefix,
+            None => pattern.clone(),
+        })
+        .collect();
 
     // From here the inspection has two halves, and one of them can be absent
     // (ADR-9307e5d214a7). Everything above is the corpus — parse, canonical
@@ -616,6 +637,7 @@ pub fn inspect(repo: &Repo, cfg: &Config, path: Option<&str>, prune: bool) -> Re
                 &verdicts,
                 has_worktree_git.then_some(repo.worktree.as_path()),
                 &walked,
+                &asked,
                 &mut report,
             );
         }
@@ -1135,6 +1157,7 @@ fn check_scope_alive(
     verdicts: &HashMap<String, bool>,
     git_root: Option<&Path>,
     walked: &OnceCell<git::History>,
+    asked: &[String],
     report: &mut Report,
 ) {
     let globs = entity.scope();
@@ -1211,7 +1234,7 @@ fn check_scope_alive(
             // kept intact while the per-glob price it allowed goes away
             // (TASK-1b3d7b61dc8f).
             Some(root) => {
-                let history = walked.get_or_init(|| git::history(root).unwrap_or_default());
+                let history = walked.get_or_init(|| git::history(root, asked).unwrap_or_default());
                 scope_moved(entity, glob, history)
             }
             None => Vec::new(),


### PR DESCRIPTION
Closes TASK-0515cfe21421.

`git::history` read the rename and deletion history of the whole repository so that `scope_moved` could say where a dead path went: 957 commits, 182 KB of records, and 46 percent of `check`'s per-entity phase in the profile TASK-756a870eb0ab recorded. It scales with the repository's commit count and not with the corpus, and this corpus meets the condition permanently, because a document renamed once left dozens of entities scoping the path it used to have.

**The questions are known before the walk.** The verdicts already say which patterns match no file, and `scope_moved` turns each of them into exactly one question for git, so `rev-list` is now given them as pathspecs. The 106 dead-scope findings this corpus carries are 21 distinct patterns, and 17 once an ancestor swallows its descendants, which selects 140 commits of 957.

## Measured

In process, release build, warm, idle machine, seven alternating runs each:

| | commits | walk |
|---|---|---|
| before | 957 | 264-339 ms, median 286 |
| after | 140 | 175-264 ms, median 227 |

A quarter, and not the four fifths the commit count promises, because the selection is not free: `rev-list` now diffs each commit against the pathspec where it used to print names, 79-86 ms becoming 111-179, and takes back most of what `diff-tree` stops paying. **That is the irreducible half**, and it is worth stating plainly: what remains cannot be narrowed by asking git for less, because asking is itself the cost.

End to end nothing is visible, which is the honest other half: `ank check` is 1865 ms median before and 1764 after, ranges overlapping, because the walk is a sixth of a run that is not otherwise this task's subject.

## What was measured and rejected

- **Deferring rename detection** (a wide `--no-renames` pass to find each path's newest commit, then one `-M` pass over the 17 it named) is correct but slower: the third process costs 66-131 ms here, the whole of what `--no-renames` saves.
- **`--full-history`** selects 217 commits instead of 140, 296 ms against 249, and buys nothing: a merge it adds is a commit `diff-tree` prints no records for, so both walks step over it.
- **`rev-list` emitting the records itself**, which would have removed a process: git 2.54 answers `fatal: -z option used with unsupported option`, and `-z` is what makes the parse safe against a path that looks like a sha.

## The two constraints the task set

No cache is added (TASK-da7738572825), and no search per glob returns (TASK-1b3d7b61dc8f): it is still one `rev-list` and one `diff-tree`, whatever the number of dead scopes. The narrowing limits which commits are listed and never what `diff-tree` is shown of them, because rename detection needs the other side of a rename and the other side is by definition a path no dead scope names.

## Verification

- `ank check` prints **byte for byte** the same 106 dead-scope findings and the same 130 explanation lines before and after, compared with `cmp` on the release build of each.
- A probe held the wide and narrow histories side by side and asserted `rename_of`, `deletion_of`, `directory_rename_of` and `deletions_under` equal for all 21 asked paths, seven times. It is not committed: it pins this repository's history rather than a rule, and the rule is already carried by `a_scope_deleted_by_a_commit_is_a_signal_and_a_scope_git_never_knew_is_a_fault`, which drives the binary over three dead scopes in three directories, one of them a path git never knew.
- Four unit tests pin the reduction: the ancestor that swallows its descendants without swallowing `a-b`, which sorts between `a` and `a/c`; the literal pathspec magic; the empty case; and the command-line budget, past which the walk is wide again rather than refused by the operating system at 32767 characters.
- `cargo test --workspace` green, `cargo fmt --check` clean, `ank check` exit 0 with no fault.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01625RCmwhDTKUWv493BcJyp
