### PR TITLE
A closed task is not asked to close down a chain it already closed

### DIFF
--- a/.ank/entities/LOG-aca0c03ee5d1.md
+++ b/.ank/entities/LOG-aca0c03ee5d1.md
@@ -1,0 +1,21 @@
+---
+id: LOG-aca0c03ee5d1
+type: log
+title: One condition, and the reason it is a condition rather than a rule change. The match read the
+created: 2026-08-24T18:03:44Z
+author: claude-code/opus-5-closed-chain
+scope:
+  - crates/ank-cli/src/human.rs
+about: TASK-a0ec19b32c39
+seq: 0
+schema: 4
+version: 1
+---
+
+ blocker's status alone and never the status of the task holding the blocked_by, so a closed task carrying a closed blocker was asked to close down a chain it had already closed. The rule the code states is untouched: a closed blocker still does not unblock, an open dependent stays blocked, and a human still decides.
+
+A done dependent keeps the finding, deliberately, and the criterion left the case open on purpose. A task recorded as finished whose prerequisite was abandoned is worth a reader's attention where a closed one carries no claim at all; what it gets is the wrong sentence for that state, and the right one is not this task's to invent. It does not occur in this corpus: the one instance of this signal was the closed-on-closed pair.
+
+Falsified before it was believed: with the guard forced true the test fails on the closed pair and names it. No test covered this signal at all before, in either direction.
+
+On this corpus the finding is gone, from one to none, and check stays green with no fault.

--- a/.ank/entities/LOG-c4f8d8001766.md
+++ b/.ank/entities/LOG-c4f8d8001766.md
@@ -1,0 +1,13 @@
+---
+id: LOG-c4f8d8001766
+type: log
+title: done, proof commit:05b42e5209b92f6b899d14a6c43854da04e332f3
+created: 2026-08-24T18:04:01Z
+author: claude-code/opus-5-closed-chain
+scope:
+  - crates/ank-cli/src/human.rs
+about: TASK-a0ec19b32c39
+seq: 1
+schema: 4
+version: 1
+---

--- a/.ank/entities/TASK-a0ec19b32c39.md
+++ b/.ank/entities/TASK-a0ec19b32c39.md
@@ -1,0 +1,44 @@
+---
+id: TASK-a0ec19b32c39
+type: task
+slug: a-closed-task-blocked-by-a-closed-task-is-asked
+title: A closed task blocked by a closed task is asked to close down a chain it already closed
+created: 2026-08-24T17:53:45Z
+author: claude-code/opus-5-closed-chain
+status: in_progress
+scope:
+  - crates/ank-cli/src/human.rs
+blocked_by: []
+done_criteria: |
+  check does not report 'blocked by <id>, which is closed' against a task that is itself closed, and still reports it against an open or in-progress one. The finding it does report is unchanged in wording for the cases that keep it. Verified through the binary on a corpus carrying both shapes. cargo test is green, cargo fmt --check passes, and ank check reports no fault.
+criteria_by: creator
+schema: 4
+version: 2
+---
+
+`check` reports a task blocked by a closed task, and the sentence it prints is
+`close down the chain or rewrite it`. On this corpus it prints it once, against
+TASK-1674d5b73761, which is itself **closed**: the chain was closed down, and the
+finding asks for it again.
+
+The rule the code states is right and is not in question. A closed blocker does
+not unblock, the work was not carried out, and a dependent that is still open
+stays blocked until a human decides. What the code never asks is whether the
+dependent is still waiting on anything. `check_task` matches on the blocker's
+status alone, and the finding is raised whatever the state of the task holding
+the `blocked_by`.
+
+**The corpus already draws this line twice, in the same file.** A dead scope on
+a closed task prints `nothing is owed` rather than the repair, on the reasoning
+that a closed task claimed nothing (TASK-4c031f7b44ed); eleven of this corpus's
+signals are that sentence. And the dead-scope severity rule exists precisely
+because a finding naming an act nobody can perform is, in `check_scope_alive`'s
+own words, a finding readers learn to skip. A closed task cannot be unblocked
+into anything: `amend` refuses a finished task, so the only repair the sentence
+names is one the reader is not allowed to make.
+
+**Not a rule about `blocked_by`, and nothing about the DAG moves.** `graph`
+still orders what it ordered, a closed blocker still blocks an open dependent,
+and the fault for a `blocked_by` naming an entity that does not exist is
+untouched. What changes is who is asked: a task that has itself been closed is
+not asked to close down a chain.

--- a/.ank/entities/TASK-a0ec19b32c39.md
+++ b/.ank/entities/TASK-a0ec19b32c39.md
@@ -5,15 +5,20 @@ slug: a-closed-task-blocked-by-a-closed-task-is-asked
 title: A closed task blocked by a closed task is asked to close down a chain it already closed
 created: 2026-08-24T17:53:45Z
 author: claude-code/opus-5-closed-chain
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/src/human.rs
 blocked_by: []
 done_criteria: |
   check does not report 'blocked by <id>, which is closed' against a task that is itself closed, and still reports it against an open or in-progress one. The finding it does report is unchanged in wording for the cases that keep it. Verified through the binary on a corpus carrying both shapes. cargo test is green, cargo fmt --check passes, and ank check reports no fault.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 05b42e5209b92f6b899d14a6c43854da04e332f3
+    criteria: ec3ae4cb431a
+    via: submitted
 schema: 4
-version: 2
+version: 3
 ---
 
 `check` reports a task blocked by a closed task, and the sentence it prints is

--- a/crates/ank-cli/src/human.rs
+++ b/crates/ank-cli/src/human.rs
@@ -1481,10 +1481,28 @@ fn check_task(
             )),
             // `closed` does not unblock: the work was not carried out, the
             // dependents stay blocked, and a human decides (§3).
-            Some(TaskStatus::Closed) => report.findings.push(Finding::signal(
-                &t.id,
-                format!("blocked by {b}, which is closed: close down the chain or rewrite it"),
-            )),
+            //
+            // **And a dependent that is itself closed is the chain closed
+            // down** (TASK-a0ec19b32c39). Asking again names an act nobody may
+            // perform: `amend` refuses a finished task, so the one repair the
+            // sentence offers is the one the reader is not allowed to make, and
+            // that is the shape `check_scope_alive` calls a finding readers
+            // learn to skip. The same line the dead-scope rule already draws for
+            // a closed task, where the finding says nothing is owed
+            // (TASK-4c031f7b44ed).
+            //
+            // A `done` dependent keeps the finding, and that is a choice rather
+            // than the condition being lazy: a task recorded as finished whose
+            // prerequisite was abandoned is worth a reader's attention, where a
+            // closed one carries no claim at all. The sentence it gets is the
+            // wrong one for that state, and the right one is not this task's to
+            // invent.
+            Some(TaskStatus::Closed) if t.status != TaskStatus::Closed => {
+                report.findings.push(Finding::signal(
+                    &t.id,
+                    format!("blocked by {b}, which is closed: close down the chain or rewrite it"),
+                ))
+            }
             _ => {}
         }
     }

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -19550,3 +19550,81 @@ fn a_ratification_that_orphans_nothing_says_nothing() {
         stderr(&out)
     );
 }
+
+/// A closed task is not asked to close down a chain it already closed
+/// (TASK-a0ec19b32c39).
+///
+/// **Both shapes, because only the pair says anything.** A rule that stopped
+/// asking altogether would pass the second assertion and fail the first, and
+/// the case the finding exists for is the first one: an open task waiting on a
+/// prerequisite somebody abandoned is a decision a human still owes.
+///
+/// What the closed one is offered is an act it may not perform. `amend` refuses
+/// a finished task, so `close down the chain or rewrite it` names a rewrite the
+/// reader is not allowed to make, which is the shape this corpus calls a
+/// finding readers learn to skip.
+///
+/// Through the binary, because the criterion is about what `check` prints.
+#[test]
+fn a_closed_task_is_not_asked_to_close_down_a_chain_it_already_closed() {
+    let r = Repo::new();
+    std::fs::create_dir_all(r.0.join("src")).unwrap();
+    std::fs::write(
+        r.0.join("src/lib.rs"),
+        "// x
+",
+    )
+    .unwrap();
+    r.git(&["add", "-A"]);
+    r.git(&["commit", "-qm", "seed"]);
+
+    let new_task = |title: &str, blocked: Option<&str>| -> String {
+        let mut argv = vec![
+            "new",
+            "task",
+            "--title",
+            title,
+            "--scope",
+            "src/**",
+            "--criteria",
+            "The prose says when.",
+        ];
+        if let Some(b) = blocked {
+            argv.push("--blocked-by");
+            argv.push(b);
+        }
+        let out = r.ank("claude-code@ank", &argv);
+        assert_eq!(code(&out), 0, "{}", stderr(&out));
+        stdout(&out)
+            .split_whitespace()
+            .nth(1)
+            .expect("created <id> <slug>")
+            .to_string()
+    };
+
+    let blocker = new_task("The prerequisite", None);
+    let waiting = new_task("Still waiting on it", Some(&blocker));
+    let finished = new_task("Closed down with it", Some(&blocker));
+    for (id, reason) in [
+        (&blocker, "not the road after all"),
+        (&finished, "the chain went with it"),
+    ] {
+        let out = r.ank("claude-code@ank", &["close", id, "--reason", reason]);
+        assert_eq!(code(&out), 0, "{}", stderr(&out));
+    }
+
+    let out = r.ank("claude-code@ank", &["check"]);
+    let said = format!("{}{}", stdout(&out), stderr(&out));
+    assert!(
+        said.contains(&format!(
+            "signal: {waiting}: blocked by {blocker}, which is closed"
+        )),
+        "an open task waiting on an abandoned prerequisite is still asked: {said}"
+    );
+    assert!(
+        !said
+            .lines()
+            .any(|l| l.contains(&format!("{finished}: blocked by"))),
+        "the chain is closed down, and asking again names an act amend refuses: {said}"
+    );
+}


### PR DESCRIPTION
Closes TASK-a0ec19b32c39.

`check` reported a task blocked by a closed task and offered `close down the chain or rewrite it`. On this corpus it printed it once, against TASK-1674d5b73761, which is **itself closed**: the chain was closed down, and the finding asked for it again. `amend` refuses a finished task, so the one repair the sentence names is the one the reader is not allowed to make, which is the shape `check_scope_alive` calls a finding readers learn to skip.

**The rule is untouched.** A closed blocker still does not unblock, an open dependent stays blocked until a human decides, and a `blocked_by` naming an entity that does not exist is still a fault. What changes is who is asked: the match read the blocker's status alone and never the status of the task holding the `blocked_by`.

It is the same line the dead-scope rule already draws in this file (TASK-4c031f7b44ed): a closed task claimed nothing, so a perimeter matching no file is its truth rather than its defect. Eleven of this corpus's signals are that sentence.

**A `done` dependent keeps the finding**, and the comment says why rather than leaving it to look like an oversight: a task recorded as finished whose prerequisite was abandoned is worth a reader's attention where a closed one carries no claim at all. The sentence it gets is the wrong one for that state, and the right one is not this task's to invent. The case does not occur here.

## Verification

- No test covered this signal in either direction. The one added drives the binary over both shapes: an open task waiting on a closed blocker still gets the finding, a closed one does not.
- Falsified: with the guard forced true, the test fails on the closed pair and names it.
- On this corpus the finding goes from one to none, and `ank check` stays exit 0 with no fault.
- `cargo test --workspace` green, `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01625RCmwhDTKUWv493BcJyp
