### PR TITLE
A client is told how to reach the protocol surface, in a form it can paste

### DIFF
--- a/.ank/entities/LOG-53f71a886226.md
+++ b/.ank/entities/LOG-53f71a886226.md
@@ -1,0 +1,15 @@
+---
+id: LOG-53f71a886226
+type: log
+title: done, proof commit:6f5dadfda46bf26111d400c2db7303a0a4e11f05
+created: 2026-08-24T22:59:10Z
+author: claude-code/opus-5+docs-mcp
+scope:
+  - docs/getting-started.md
+  - docs/integrating.md
+  - README.md
+about: TASK-b3306bccf09d
+seq: 1
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-9e46d89d82c3.md
+++ b/.ank/entities/LOG-9e46d89d82c3.md
@@ -1,0 +1,17 @@
+---
+id: LOG-9e46d89d82c3
+type: log
+title: "The surface is measured before it is described: ank-mcp 0.3.0 answers tools/list with 23 tools"
+created: 2026-08-24T22:41:53Z
+author: claude-code/opus-5+docs-mcp
+scope:
+  - docs/getting-started.md
+  - docs/integrating.md
+  - README.md
+about: TASK-b3306bccf09d
+seq: 0
+schema: 4
+version: 1
+---
+
+ against the 23 verbs ank help --json carries, so 'every verb COMMANDS carries' is a count a reader can reproduce rather than a claim. Three refusals were captured from the process for the prose: a corpus with no .ank/ refuses at startup with error[9] before any client is listening, ank_show on a missing entity comes back isError with exitCode 2 and the CLI's own -> ank find hint verbatim, and a client passing repo is refused -32602 '--repo belongs to the server: one process, one corpus'. That last one is why --repo goes in every pasted configuration: it is the only place a client can set it.

--- a/.ank/entities/TASK-b3306bccf09d.md
+++ b/.ank/entities/TASK-b3306bccf09d.md
@@ -5,7 +5,7 @@ slug: a-client-is-told-how-to-reach-the-protocol-surfa
 title: A client is told how to reach the protocol surface, in a form it can paste
 created: 2026-08-24T21:58:27Z
 author: claude-code/opus-5+planning
-status: in_progress
+status: done
 scope:
   - docs/getting-started.md
   - docs/integrating.md
@@ -14,8 +14,13 @@ blocked_by: []
 done_criteria: |
   docs/getting-started.md states that installing ank installs the protocol surface with it, and carries a working MCP client configuration for Claude Code, Claude Desktop and Cursor, each naming --repo explicitly so the corpus a process speaks for is never implicit. docs/integrating.md states what the surface is: every verb COMMANDS carries, generated from that table, one process for one corpus, a refusal carrying the CLI exit code as its reason, and no claim taken that the CLI would not have taken in that clone. Every entity id cited in the new prose resolves under ank check, and check reports no finding on the three files. cargo test is green.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 6f5dadfda46bf26111d400c2db7303a0a4e11f05
+    criteria: 2f868a43d968
+    via: submitted
 schema: 4
-version: 2
+version: 3
 ---
 
 The third thing ADR-e39a44f80e0e requires, and the only one a reader ever sees.

--- a/.ank/entities/TASK-b3306bccf09d.md
+++ b/.ank/entities/TASK-b3306bccf09d.md
@@ -5,7 +5,7 @@ slug: a-client-is-told-how-to-reach-the-protocol-surfa
 title: A client is told how to reach the protocol surface, in a form it can paste
 created: 2026-08-24T21:58:27Z
 author: claude-code/opus-5+planning
-status: open
+status: in_progress
 scope:
   - docs/getting-started.md
   - docs/integrating.md
@@ -15,7 +15,7 @@ done_criteria: |
   docs/getting-started.md states that installing ank installs the protocol surface with it, and carries a working MCP client configuration for Claude Code, Claude Desktop and Cursor, each naming --repo explicitly so the corpus a process speaks for is never implicit. docs/integrating.md states what the surface is: every verb COMMANDS carries, generated from that table, one process for one corpus, a refusal carrying the CLI exit code as its reason, and no claim taken that the CLI would not have taken in that clone. Every entity id cited in the new prose resolves under ank check, and check reports no finding on the three files. cargo test is green.
 criteria_by: creator
 schema: 4
-version: 1
+version: 2
 ---
 
 The third thing ADR-e39a44f80e0e requires, and the only one a reader ever sees.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Tasks and architecture decisions in your repo, behind one CLI any coding agent c
 <a href="LICENSE"><img alt="Licence" src="https://img.shields.io/badge/licence-Apache--2.0-blue"></a></p>
 
 ```sh
-npm install -g @haksolot/ank     # the binary
+npm install -g @haksolot/ank     # the binary, and ank-mcp beside it
 npx skills add haksolot/ank      # the skill, into whichever agent you run
 ```
 
@@ -37,6 +37,10 @@ Four verbs carry the loop: `ank context` for what binds here and what is takeabl
 `ank claim` to take a task and freeze its criterion, `ank log` while you work, and
 `ank done` to finish with a proof that `ank check` can verify afterwards.
 [Getting started][start] walks all of it with real output, from `ank init` onward.
+
+A client with no shell reaches the same verbs over MCP. `ank-mcp` installs beside
+the binary by every route that installs it, and [getting started][start] carries
+the configuration to paste, for Claude Code, Claude Desktop and Cursor.
 
 ## What it is not
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -34,6 +34,93 @@ revision answers the same question about the other half: it is the value
 that file can compare two strings it already holds and see that its
 instructions predate its tool.
 
+### The protocol surface installs with it
+
+Every route places a second executable beside `ank`: **`ank-mcp`**, the same
+verbs over MCP, for a client that has no shell to run them in. It is freight of
+the three install routes rather than a fourth beside them (ADR-e39a44f80e0e),
+so there is nothing further to fetch:
+
+    $ ank-mcp --version
+    ank-mcp <version>
+
+The same version `ank` reports, because the two are freight of one release and
+come out of one build. They are not versionable apart on purpose: a server built
+from an older table would advertise verbs the installed CLI does not dispatch,
+and the refusal a caller got back would be one no exit code describes.
+
+It speaks JSON-RPC over stdio and the client spawns it, which means it is
+configured rather than started. Three configurations, and each of them is
+pasted rather than derived.
+
+**Claude Code**, one line, which writes the entry for you:
+
+    claude mcp add ank -- ank-mcp --repo /path/to/your/repo
+
+or `.mcp.json` at the root of the repository, which is the form that travels
+with the tree and reaches everyone who clones it:
+
+    {
+      "mcpServers": {
+        "ank": {
+          "command": "ank-mcp",
+          "args": ["--repo", "/path/to/your/repo"]
+        }
+      }
+    }
+
+**Claude Desktop**, in `claude_desktop_config.json` (`~/Library/Application
+Support/Claude/` on macOS, `%APPDATA%\Claude\` on Windows), which has no project
+directory of its own and so has nothing else to go on:
+
+    {
+      "mcpServers": {
+        "ank": {
+          "command": "ank-mcp",
+          "args": ["--repo", "/path/to/your/repo"]
+        }
+      }
+    }
+
+**Cursor**, in `.cursor/mcp.json` beside the repository, or `~/.cursor/mcp.json`
+for every project at once:
+
+    {
+      "mcpServers": {
+        "ank": {
+          "command": "ank-mcp",
+          "args": ["--repo", "/path/to/your/repo"]
+        }
+      }
+    }
+
+**`--repo` is written out in all three, and that is the point of showing them.**
+A client spawns the server in whatever directory it happens to be in, and with
+no `--repo` the server takes that directory. The failure mode is not an error:
+it is a process quietly speaking for a corpus nobody meant, or for none. The
+configuration is also the *only* place it can be named, because one process
+speaks for exactly one corpus, fixed at startup, and a call that tries to pass
+`--repo` itself is refused by name:
+
+    {"jsonrpc":"2.0","id":3,"error":{"code":-32602,"message":"--repo belongs to the server: one process, one corpus"}}
+
+So several repositories are several entries, one server each. That is the same
+answer the refs give everywhere else: claims live in `refs/ank/*`, which is per
+repository, and nothing merges the claim spaces of two clones.
+
+A path with no corpus under it is refused before any client is listening, rather
+than after, so it reaches a person rather than a log:
+
+    $ ank-mcp --repo /tmp
+    error[9]: no .ank/ under /tmp
+      -> ank-mcp --repo <path to a directory holding .ank/>
+
+Every verb the CLI dispatches is a tool on that surface, under the name
+`ank_<verb>`, and what a call gets back is the document `--json` returns with
+the exit code beside it. [integrating.md](integrating.md) says what the surface
+is, for somebody building against it. The rest of this page uses the shell,
+which is what an agent that has one should use.
+
 ### Where the binary you run comes from
 
 Worth stating once, because it costs time exactly where nobody expects it: **a

--- a/docs/integrating.md
+++ b/docs/integrating.md
@@ -234,6 +234,67 @@ Both are plain files in a public repository. Copy them into your own suite; a
 shape that changes here without its fixture changing is a failing test on our
 side, which is what makes them worth copying.
 
+## The protocol surface is the same verbs, over MCP
+
+A client with no shell reaches ank through `ank-mcp`, which installs beside the
+CLI by every route that installs the CLI (ADR-e39a44f80e0e). The configuration
+to paste is in [getting-started.md](getting-started.md); what it *is* belongs
+here, because four properties of it are load-bearing and none of them is
+visible from a tool list.
+
+**Every verb `COMMANDS` carries, generated from that table.** Not a curated
+subset, under any protocol (ADR-372b82af1ec7). It is the same table `ank help
+--json` is generated from, walked: the summary becomes the tool description, the
+refusals and their exit codes are written into it so a client can read what a
+call will refuse before making it, and the flags become the input schema. One
+tool per verb, whatever the table carries, named `ank_<verb>` because a bare
+`context` collides with every other server a client has loaded and `ank context`
+is not a legal tool name. Positionals arrive as `arguments`, an array of strings,
+exactly as they sit on the command line; flags arrive under their own names with
+the leading dashes stripped. Nothing in the server names a verb, so the two
+surfaces cannot disagree about what exists.
+
+**One process speaks for one corpus.** `--repo` is resolved once, at startup, and
+that value is what every call is given, so a server cannot drift between corpora
+while a client holds a claim in one. A call that passes `--repo`, `--json` or
+`--quiet` is refused by name rather than being allowed to contradict the process
+it is talking to:
+
+    {"jsonrpc":"2.0","id":3,"error":{"code":-32602,"message":"--repo belongs to the server: one process, one corpus"}}
+
+Nothing is hidden by that and nothing is curated: every verb takes exactly the
+arguments the table gives it, and what is withheld is three flags that are the
+server's own. A deployment over several repositories is several servers,
+addressed separately, presented together by whatever sits above them. It is the
+answer `refs/ank/*` forces, and the same one federation gets (ADR-a1de673043b4).
+
+**A refusal is the CLI's refusal, and it carries the CLI's exit code.** The
+surface spawns `ank`; it does not link it. So a refusal on state is not
+re-derived here, it is inherited, hint and all, and it comes back as a result
+rather than as a protocol error, because the request was well formed and the
+answer is no:
+
+    {"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"error[2]: entity not found: TASK-9999\n  -> ank find TASK-9999"}],"isError":true,"exitCode":2,"stderr":"error[2]: entity not found: TASK-9999\n  -> ank find TASK-9999"}}
+
+`exitCode` is present on every call including a successful one, so a client that
+branches on it never has to tell absence from zero; `stderr` is carried
+separately for the reason warnings live there in the first place. The two error
+channels stay apart: a JSON-RPC error means the *request* was wrong, a result
+with `isError` means the *corpus* said no. A client that conflates them reports
+its own bug as a state of your repository.
+
+**No claim is taken that the CLI would not have taken in that clone.** Every
+claim goes to `refs/ank/claims/<id>` in that repository, arbitrated by the same
+compare-and-swap against the same remote. The server holds no claim on a
+client's behalf, renews none for anybody, and pools no clients under one
+identity: one stdio server serves one client, so one process is one caller. It
+writes under a typed process identity, `ank-mcp/<version>`, unless `$ANK_AGENT`
+names one, so a deployment that already names its agents keeps naming them.
+
+`accept` is a tool here like every other verb, because a generated surface
+curates nothing out. Being reachable over a protocol changes nothing about it:
+it still refuses off the default branch, with no way around it.
+
 ## What binds and what does not
 
 - **Bind to `--json`**, never to the human output. One line, stdout only, never


### PR DESCRIPTION
Closes TASK-b3306bccf09d. Proof: `commit:6f5dadfda46bf26111d400c2db7303a0a4e11f05`.

ADR-e39a44f80e0e requires the documentation that teaches installing ank to
state, in the same place, how a client reaches `ank-mcp`, with a configuration a
reader can paste. No document in `docs/` mentioned the surface at all, so a
person who installed ank by all three official routes ended up with a protocol
surface and no way to learn one existed.

## docs/getting-started.md

A new subsection inside **Install**, which is where ADR-e39a44f80e0e says it has
to be. It states that every route places `ank-mcp` beside `ank` and that the two
are not versionable apart, then hands over three configurations:

- **Claude Code**, both the `claude mcp add` one-liner and the `.mcp.json` form
  that travels with the tree
- **Claude Desktop**, `claude_desktop_config.json`, with the path on macOS and
  on Windows
- **Cursor**, `.cursor/mcp.json` and the global `~/.cursor/mcp.json`

Every one of them writes `--repo` out. That is not verbosity. A client spawns
the server in whatever directory it happens to be in, and a server with no
`--repo` speaks for whatever corpus that turns out to be, with no error to read.
It is also the only place `--repo` can be named, since a call that passes it is
refused, and the refusal is shown as the process gives it.

## docs/integrating.md

What the surface *is*, for the reader building against it, in the four
properties that are load-bearing and invisible from a tool list:

- **Every verb `COMMANDS` carries, generated from that table**, the same one
  `ank help --json` comes from. Nothing in the server names a verb, so the two
  surfaces cannot disagree about what exists.
- **One process for one corpus**, addressed once at startup. A call passing
  `--repo`, `--json` or `--quiet` is refused by name.
- **A refusal is the CLI's own refusal, carrying the CLI's exit code**, returned
  as a result rather than a protocol error: the request was well formed and the
  answer is no. `exitCode` on every call including a successful one.
- **No claim taken that the CLI would not have taken in that clone**: same ref,
  same compare-and-swap, no claim held on a client's behalf, no clients pooled
  under one identity.

## README.md

Names `ank-mcp` where it names the binary, and points at the configuration.

## Verification

- `cargo test --workspace` green, `cargo fmt --check` clean.
- `ank check` reports 0 faults on each of the three files.
- Every entity id cited in the new prose resolves and is `accepted`:
  ADR-e39a44f80e0e, ADR-372b82af1ec7, ADR-a1de673043b4.
- Measured before described: `ank-mcp` answers `tools/list` with 23 tools
  against the 23 verbs `ank help --json` carries, and all three refusals quoted
  are captured from the process rather than composed.

The prose describes what ADR-e39a44f80e0e ratifies. The routes that make it true
are TASK-31500c1a7455 (the release) and TASK-682de76a2641 (the installers), both
of which this task was deliberately left unblocked by.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Ktopb59whJ4RifGGy8MAH