### PR TITLE
The ank logo is drawn to a terminal, and to nothing else

### DIFF
--- a/.ank/entities/LOG-21fef5c81096.md
+++ b/.ank/entities/LOG-21fef5c81096.md
@@ -1,0 +1,17 @@
+---
+id: LOG-21fef5c81096
+type: log
+title: "The terminal test is three questions, not one. Both stdout and stderr must be terminals: under curl"
+created: 2026-08-24T23:02:21Z
+author: claude-code/opus-5+install-logo
+scope:
+  - install.sh
+  - install.ps1
+  - .github/workflows/install.yml
+about: TASK-bbab313a4fea
+seq: 3
+schema: 4
+version: 1
+---
+
+ | sh stdin is the script and the other two are the terminal, which must animate, while sh install.sh > install.log leaves stderr a terminal and must not. Then /dev/tty, which is what ADR-5fbd99bf6fd5 names, and CI, since some runner images hand their steps a pty. A fourth was added after the fact: tput cols under 24 wraps every line and turns the twelve-row block into something the redraw walks back into the middle of.

--- a/.ank/entities/LOG-8eab9b72a06a.md
+++ b/.ank/entities/LOG-8eab9b72a06a.md
@@ -1,0 +1,17 @@
+---
+id: LOG-8eab9b72a06a
+type: log
+title: The Windows staged stand-in had to become a real executable. The criterion asks install.yml to
+created: 2026-08-24T23:02:26Z
+author: claude-code/opus-5+install-logo
+scope:
+  - install.sh
+  - install.ps1
+  - .github/workflows/install.yml
+about: TASK-bbab313a4fea
+seq: 5
+schema: 4
+version: 1
+---
+
+ assert that the installed binary answers --version on all three platforms, and Windows will not run a .exe that is a text file. Built with csc.exe from the .NET Framework that is part of the OS; Add-Type -OutputAssembly reads better and is not available, PowerShell 7 dropped that parameter and these steps run under pwsh.

--- a/.ank/entities/LOG-9dd904bc7543.md
+++ b/.ank/entities/LOG-9dd904bc7543.md
@@ -1,0 +1,15 @@
+---
+id: LOG-9dd904bc7543
+type: log
+title: done, proof commit:9af607a49e7151ba6c6828860b2a3f8dbb9bf4a9
+created: 2026-08-24T23:03:35Z
+author: claude-code/opus-5+install-logo
+scope:
+  - install.sh
+  - install.ps1
+  - .github/workflows/install.yml
+about: TASK-bbab313a4fea
+seq: 6
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-bd099b629f6e.md
+++ b/.ank/entities/LOG-bd099b629f6e.md
@@ -1,0 +1,17 @@
+---
+id: LOG-bd099b629f6e
+type: log
+title: The two scripts cannot move a cursor the same way. install.sh uses ESC[12A and ESC[K; install.ps1
+created: 2026-08-24T23:02:19Z
+author: claude-code/opus-5+install-logo
+scope:
+  - install.sh
+  - install.ps1
+  - .github/workflows/install.yml
+about: TASK-bbab313a4fea
+seq: 2
+schema: 4
+version: 1
+---
+
+ uses $Host.UI.RawUI.CursorPosition, because Windows PowerShell 5.1 in conhost does not enable virtual terminal processing for its own output and would print ESC[12A as glyphs -- on precisely the shell that file claims as its floor. The consequence for the proof: install.ps1 emits no escape sequence on any run, so the escape assertion is a floor on Windows and the frame itself has to be asserted absent beside it.

--- a/.ank/entities/LOG-d2ac2dd1a228.md
+++ b/.ank/entities/LOG-d2ac2dd1a228.md
@@ -1,0 +1,16 @@
+---
+id: LOG-d2ac2dd1a228
+type: log
+title: +scope .github/workflows/install.yml (version 2 to 3, replaced 6ba11a32a132, produced e1c43d2ca824)
+created: 2026-08-24T22:46:23Z
+author: claude-code/opus-5+install-logo
+scope:
+  - install.sh
+  - install.ps1
+  - .github/workflows/install.yml
+about: TASK-bbab313a4fea
+seq: 1
+records: edit
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-e0e9ff280e99.md
+++ b/.ank/entities/LOG-e0e9ff280e99.md
@@ -1,0 +1,16 @@
+---
+id: LOG-e0e9ff280e99
+type: log
+title: The criterion names install.yml as the place the absence is proved on all three platforms, and
+created: 2026-08-24T22:46:21Z
+author: claude-code/opus-5+install-logo
+scope:
+  - install.sh
+  - install.ps1
+about: TASK-bbab313a4fea
+seq: 0
+schema: 4
+version: 1
+---
+
+ install.yml is not in the frozen scope. Amending the scope to add .github/workflows/install.yml rather than editing it silently: the assertion is half the criterion, so the perimeter has to say so.

--- a/.ank/entities/LOG-e503637cfaf9.md
+++ b/.ank/entities/LOG-e503637cfaf9.md
@@ -1,0 +1,17 @@
+---
+id: LOG-e503637cfaf9
+type: log
+title: POSIX sleep takes an integer. Fractional seconds are what coreutils, BSD and a fancy-built busybox
+created: 2026-08-24T23:02:24Z
+author: claude-code/opus-5+install-logo
+scope:
+  - install.sh
+  - install.ps1
+  - .github/workflows/install.yml
+about: TASK-bbab313a4fea
+seq: 4
+schema: 4
+version: 1
+---
+
+ all accept, and the ones that do not are told apart by asking once -- sleep 0.01 -- rather than by guessing. Without a delay the frames still draw in order, as fast as the terminal takes them, so the fallback costs the animation its pacing and nothing else.

--- a/.ank/entities/TASK-bbab313a4fea.md
+++ b/.ank/entities/TASK-bbab313a4fea.md
@@ -5,16 +5,17 @@ slug: the-ank-logo-is-drawn-to-a-terminal-and-to-nothi
 title: The ank logo is drawn to a terminal, and to nothing else
 created: 2026-08-24T21:59:19Z
 author: claude-code/opus-5+planning
-status: open
+status: in_progress
 scope:
   - install.sh
   - install.ps1
+  - .github/workflows/install.yml
 blocked_by: []
 done_criteria: |
   Both installers draw the ank logo as animated ASCII art before the download starts, and only when a terminal is attached. Piped, redirected, run under a CI runner or run with the disabling flag, they emit no frame and no escape sequence at all. The frames are held in the scripts themselves, so neither installer gains a network request it does not already make, and install.sh stays POSIX sh with no bashisms. install.yml asserts on all three platforms that a non-interactive run emits no escape sequence and that the installed binary answers --version. The disabling flag appears in the usage text and in the comment block that lists the exit codes. cargo test is green.
 criteria_by: creator
 schema: 4
-version: 1
+version: 3
 ---
 
 The visible half of ADR-5fbd99bf6fd5, and the half that carries its whole risk:

--- a/.ank/entities/TASK-bbab313a4fea.md
+++ b/.ank/entities/TASK-bbab313a4fea.md
@@ -5,7 +5,7 @@ slug: the-ank-logo-is-drawn-to-a-terminal-and-to-nothi
 title: The ank logo is drawn to a terminal, and to nothing else
 created: 2026-08-24T21:59:19Z
 author: claude-code/opus-5+planning
-status: in_progress
+status: done
 scope:
   - install.sh
   - install.ps1
@@ -14,8 +14,13 @@ blocked_by: []
 done_criteria: |
   Both installers draw the ank logo as animated ASCII art before the download starts, and only when a terminal is attached. Piped, redirected, run under a CI runner or run with the disabling flag, they emit no frame and no escape sequence at all. The frames are held in the scripts themselves, so neither installer gains a network request it does not already make, and install.sh stays POSIX sh with no bashisms. install.yml asserts on all three platforms that a non-interactive run emits no escape sequence and that the installed binary answers --version. The disabling flag appears in the usage text and in the comment block that lists the exit codes. cargo test is green.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 9af607a49e7151ba6c6828860b2a3f8dbb9bf4a9
+    criteria: 38e45e5f61ed
+    via: submitted
 schema: 4
-version: 3
+version: 4
 ---
 
 The visible half of ADR-5fbd99bf6fd5, and the half that carries its whole risk:

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -73,7 +73,15 @@ jobs:
               exit 1
             }
           done
-          echo "--help names all three targets"
+          # The flag that turns the welcome off is documented only if it is
+          # here: one a caller cannot find is one they cannot use.
+          for f in --no-welcome ANK_NO_WELCOME; do
+            printf '%s' "$out" | grep -q -- "$f" || {
+              echo "--help does not name $f"
+              exit 1
+            }
+          done
+          echo "--help names all three targets, and the flag that draws nothing"
 
       # The first of the two failures that matter. A fake `uname` on PATH is
       # what makes this testable on a machine that is one of the supported
@@ -175,18 +183,53 @@ jobs:
           echo "the staged release never came up"
           exit 1
 
-      - name: the staged release installs and answers with its version
+      # The install itself, and with it the absence ADR-5fbd99bf6fd5 is written
+      # as. A runner is precisely a machine with no terminal, so the welcome has
+      # to produce nothing at all here -- asserted on the bytes rather than on
+      # the rendering, because an escape sequence is invisible in exactly the
+      # log somebody would open to check for it.
+      - name: a non-interactive run draws nothing, and answers with its version
         env:
           ANK_BASE_URL: http://127.0.0.1:${{ env.STAGED_PORT }}
         run: |
           set -e
-          sh install.sh --version "$STAGED_VERSION" --dir "$PWD/staged-bin"
+          esc=$(printf '\033')
+
+          # Both streams into a file, which is what
+          # `curl ... | sh > install.log 2>&1` leaves behind.
+          sh install.sh --version "$STAGED_VERSION" --dir "$PWD/staged-bin" > staged.log 2>&1
+          cat staged.log
+
+          if LC_ALL=C grep -q "$esc" staged.log; then
+            echo "an escape sequence reached the log with no terminal attached:"
+            LC_ALL=C cat -v staged.log
+            exit 1
+          fi
+          # The art is ASCII, so the frame is asserted absent as well as the
+          # escapes that animate it: a logo drawn without moving a cursor would
+          # pass the test above and still be noise in the log.
+          if grep -q '####' staged.log; then
+            echo "the logo was drawn with no terminal attached"
+            exit 1
+          fi
+
           got=$("$PWD/staged-bin/ank" --version)
           echo "ank --version: $got"
           test "$got" = "ank ${STAGED_VERSION} (staged)" || {
             echo "expected: ank ${STAGED_VERSION} (staged)"
             exit 1
           }
+          echo "no escape sequence, no frame, and the binary answers --version"
+
+          # The flag, on a run that already had no terminal: it has to be
+          # accepted and to change nothing. The same directory, so the two logs
+          # can differ in nothing but what the flag turns off.
+          sh install.sh --no-welcome --version "$STAGED_VERSION" --dir "$PWD/staged-bin" > flag.log 2>&1
+          diff staged.log flag.log || {
+            echo "--no-welcome changed what the install said"
+            exit 1
+          }
+          echo "--no-welcome is accepted, and changes nothing"
 
       # The second of the two failures that matter, and the reason the .sha256
       # is published at all. One byte appended to the archive, the checksum
@@ -331,13 +374,16 @@ jobs:
         run: |
           & ./install.ps1 -Help
           $out = (& ./install.ps1 -Help *>&1 | Out-String)
-          foreach ($needle in 'x86_64-pc-windows-msvc', 'ANK_BASE_URL', 'install.sh') {
+          # -NoWelcome is in the list for the reason the others are: a switch
+          # a caller cannot find is a switch they cannot use.
+          foreach ($needle in 'x86_64-pc-windows-msvc', 'ANK_BASE_URL', 'install.sh',
+                              '-NoWelcome', 'ANK_NO_WELCOME') {
             if ($out -notmatch [regex]::Escape($needle)) {
               "-Help does not name $needle"
               exit 1
             }
           }
-          "-Help names the target, the environment and the other script"
+          "-Help names the target, the environment, the other script and the switch"
 
       # The first of the two failures that matter. The architecture is read out
       # of the environment precisely so this is testable on a machine that is
@@ -377,7 +423,37 @@ jobs:
         run: |
           $name = "ank-$env:STAGED_VERSION-x86_64-pc-windows-msvc"
           New-Item -ItemType Directory -Path "stage/pack/$name" -Force | Out-Null
-          Set-Content -Path "stage/pack/$name/ank.exe" -Value 'staged stand-in for ank' -NoNewline
+
+          # A real executable and not a text file wearing the name, because the
+          # claim under test is that the installed binary answers --version and
+          # Windows will not run a .exe that is not one. csc.exe comes with the
+          # .NET Framework that is part of the OS, so this asks the image for
+          # nothing it does not already carry.
+          #
+          # Add-Type -OutputAssembly would read better and is not used:
+          # PowerShell 7 dropped that parameter, and these steps run under pwsh.
+          $src = @(
+            'public class StandIn {',
+            '    public static int Main(string[] args) {',
+            '        if (args.Length > 0 && args[0] == "--version") {',
+            "            System.Console.WriteLine(`"ank $env:STAGED_VERSION (staged)`");",
+            '            return 0;',
+            '        }',
+            '        System.Console.Error.WriteLine("staged stand-in for ank");',
+            '        return 2;',
+            '    }',
+            '}'
+          )
+          Set-Content -Path 'stage/standin.cs' -Value $src
+
+          $csc = Get-ChildItem "$env:WINDIR\Microsoft.NET\Framework64\v4.0.*\csc.exe" `
+            -ErrorAction SilentlyContinue | Select-Object -Last 1
+          if (-not $csc) { "no csc.exe on this image, so no runnable stand-in can be built"; exit 1 }
+          & $csc.FullName /nologo /target:exe /out:"stage\pack\$name\ank.exe" 'stage\standin.cs'
+          if ($LASTEXITCODE -ne 0) { "the stand-in did not compile"; exit 1 }
+
+          # The source stays outside stage/pack, so the archive carries the
+          # binary and the README and nothing this step needed to build them.
           Set-Content -Path "stage/pack/$name/README.md" -Value 'staged'
 
           Add-Type -AssemblyName System.IO.Compression.FileSystem
@@ -410,20 +486,54 @@ jobs:
           "the staged release never came up"
           exit 1
 
-      - name: the staged release installs what the archive carried
+      # The install itself, and with it the absence ADR-5fbd99bf6fd5 is written
+      # as. A runner is precisely a machine with no console, so the welcome has
+      # to produce nothing at all here.
+      #
+      # install.ps1 moves the cursor through $Host.UI.RawUI rather than with an
+      # escape sequence -- Windows PowerShell 5.1 in conhost prints ESC[12A
+      # instead of obeying it -- so the escape assertion below is a floor rather
+      # than the whole of the claim. The frame is asserted absent too, and that
+      # is the one that would catch a guard which stopped holding.
+      - name: a non-interactive run draws nothing, and answers with its version
         env:
           ANK_BASE_URL: http://127.0.0.1:${{ env.STAGED_PORT }}
         run: |
+          $esc = [char]27
           $LASTEXITCODE = 0
-          & ./install.ps1 -Version $env:STAGED_VERSION -Dir "$PWD/staged-bin"
+          $out = (& ./install.ps1 -Version $env:STAGED_VERSION -Dir "$PWD/staged-bin" *>&1 | Out-String)
+          $out
           if ($LASTEXITCODE -ne 0) { "the staged install failed"; exit 1 }
-          $got = Get-Content "$PWD/staged-bin/ank.exe" -Raw
-          "installed content: $got"
-          if ($got -ne 'staged stand-in for ank') {
-            "the installed file is not what the archive carried"
+
+          if ($out.Contains($esc)) {
+            "an escape sequence reached the transcript with no console attached"
             exit 1
           }
-          "installed exactly what the staged archive carried"
+          if ($out -match '####') {
+            "the logo was drawn with no console attached"
+            exit 1
+          }
+
+          $got = & "$PWD/staged-bin/ank.exe" --version
+          "ank --version: $got"
+          if ($got -ne "ank $env:STAGED_VERSION (staged)") {
+            "expected: ank $env:STAGED_VERSION (staged)"
+            exit 1
+          }
+          "no escape sequence, no frame, and the binary answers --version"
+
+          # The switch, on a run that already had no console: it has to be
+          # accepted and to change nothing. The same directory, so the two
+          # transcripts can differ in nothing but what the switch turns off.
+          $LASTEXITCODE = 0
+          $flag = (& ./install.ps1 -NoWelcome -Version $env:STAGED_VERSION -Dir "$PWD/staged-bin" *>&1 | Out-String)
+          if ($LASTEXITCODE -ne 0) { "-NoWelcome failed the install"; exit 1 }
+          if ($flag -ne $out) {
+            "-NoWelcome changed what the install said"
+            $flag
+            exit 1
+          }
+          "-NoWelcome is accepted, and changes nothing"
           exit 0
 
       # The second of the two failures that matter, and the reason the .sha256

--- a/install.ps1
+++ b/install.ps1
@@ -24,6 +24,12 @@ Exit codes, so a caller can branch on the failure rather than on the message:
   4  the checksum did not match the one the release published
   5  a runtime this script needs is missing
 
+-NoWelcome, or ANK_NO_WELCOME in the environment, turns off everything this
+script draws for a human and leaves only the lines a machine reads. It is
+absent from the list above on purpose: the welcome is drawn before the first
+request goes out, nothing in it can fail, and a flag able to change one of
+these five codes would be a flag that made the install depend on it.
+
 They are the codes install.sh returns for the same failures, and they reach a
 caller who runs this as a file. The one-liner above runs it through `iex`, where
 `exit` would close the window the caller is typing in -- so under `iex` a
@@ -35,6 +41,7 @@ not being run as a file.
 param(
     [string]$Version,
     [string]$Dir,
+    [switch]$NoWelcome,
     [switch]$Help
 )
 
@@ -100,11 +107,15 @@ function Show-Usage {
     Say '                      "v0.2.0" and "0.2.0" both work'
     Say '  -Dir <path>         install into <path> instead of'
     Say '                      $env:LOCALAPPDATA\Programs\ank'
+    Say '  -NoWelcome          draw nothing; install exactly what an install with'
+    Say '                      the animation installs, and say the same things about it'
     Say '  -Help               print this and exit'
     Say ''
     Say 'environment:'
     Say '  ANK_VERSION         same as -Version'
     Say '  ANK_INSTALL_DIR     same as -Dir'
+    Say '  ANK_NO_WELCOME      same as -NoWelcome, for a caller that pipes this script'
+    Say '                      into iex and cannot pass a switch to it'
     Say '  ANK_BASE_URL        where the archives are fetched from, for a mirror or a'
     Say '                      staged release; requires -Version, since only GitHub'
     Say '                      can be asked which release is the latest'
@@ -117,6 +128,127 @@ function Show-Usage {
     Say ''
     Say 'exit codes:'
     Say '  1 usage   2 unsupported platform   3 download   4 checksum   5 missing runtime'
+}
+
+# ---------------------------------------------------------------------------
+# Welcome
+# ---------------------------------------------------------------------------
+
+# The logo, at half the resolution of assets/ank.svg and drawn in ASCII: the
+# same twelve lines install.sh holds, because it is the same logo and two
+# spellings of it would drift. That file is the reference for the shape and
+# nothing here reads it -- an installer that fetches a logo before it fetches
+# the binary is an installer with a second way to fail before doing anything
+# useful, so the frames are bytes in this file.
+#
+# ASCII and not U+2588, because the console this lands in is not always UTF-8:
+# a Windows PowerShell 5.1 in conhost under codepage 437 renders a block
+# character as a question mark, and a logo that arrives as question marks is
+# worse than no logo at all.
+$LogoArt = @(
+    '          ####',
+    '        ##    ##',
+    '        ##    ##',
+    '          ####',
+    '          ####',
+    '  ######  ####  ######',
+    '  ####    ####    ####',
+    '  ####    ####    ####',
+    '  ####    ####    ####',
+    '    ################',
+    '',
+    '          ank'
+)
+$LogoWidth = 24
+
+# The cursor is moved through $Host.UI.RawUI and not with an escape sequence,
+# and that is the Windows half of this decision rather than a preference.
+# Windows PowerShell 5.1 in conhost does not turn on virtual terminal
+# processing for its own output, so an ESC[12A written there is printed as
+# glyphs instead of obeyed: the animation would become exactly the mess it
+# exists to avoid, on precisely the shell this file claims as its floor. RawUI
+# is the interface both hosts implement, and it emits no escape sequence at
+# all, on any run.
+function Show-Logo {
+    $ui = $Host.UI.RawUI
+
+    # A window narrower than the art wraps every line, and a block that is
+    # taller than twelve rows is a block the redraw moves back over the middle
+    # of. Nothing is written before this is known.
+    if ($ui.WindowSize.Width -lt $LogoWidth) { return }
+
+    # The blank lines are written before the position is read, so that a window
+    # with the prompt at its bottom does its scrolling now: a coordinate saved
+    # while the buffer is still moving points at the wrong row for every frame
+    # after it.
+    for ($i = 0; $i -lt $LogoArt.Count; $i++) { Say '' }
+
+    $top = $ui.CursorPosition.Y - $LogoArt.Count
+    if ($top -lt 0) { return }
+    $origin = New-Object System.Management.Automation.Host.Coordinates 0, $top
+
+    $savedCursor = $true
+    try {
+        $savedCursor = [Console]::CursorVisible
+        [Console]::CursorVisible = $false
+    } catch {
+        # A host that will not say whether its cursor is visible still draws.
+    }
+
+    try {
+        # Bottom up: the base, then the stem, then the loop, which is the order
+        # the shape is built in and the order that leaves the whole of it
+        # standing at the end. Frame 11 adds the name, and that is the beat the
+        # animation exists for: it costs the time it takes to read the name of
+        # the tool and not a second more.
+        for ($frame = 1; $frame -le 11; $frame++) {
+            $ui.CursorPosition = $origin
+            for ($line = 1; $line -le $LogoArt.Count; $line++) {
+                $text = ''
+                if ($line -le 10 -and $line -ge (11 - $frame)) {
+                    $text = $LogoArt[$line - 1]
+                } elseif ($line -eq 12 -and $frame -eq 11) {
+                    $text = $LogoArt[11]
+                }
+                # Padded rather than erased: there is no clear-to-end-of-line
+                # without an escape sequence, and writing the spaces says the
+                # same thing in the alphabet this function is restricted to.
+                Say $text.PadRight($LogoWidth)
+            }
+            if ($frame -lt 11) { Start-Sleep -Milliseconds 60 }
+        }
+    } finally {
+        try { [Console]::CursorVisible = $savedCursor } catch { }
+    }
+
+    # One blank line under the block, so what the install says next does not
+    # start on the line the name ends on.
+    Say ''
+}
+
+# ADR-5fbd99bf6fd5 read as an absence: where no human is looking, this script
+# draws nothing at all.
+#
+# Both streams are tested and not only one. `irm ... | iex` leaves stdout and
+# stderr on the console, which is the case that must animate; redirecting
+# either of them into a file is the case that must not, since a transcript full
+# of padding and repositioning is the noise this exists to avoid. The host is
+# asked last, and by trying rather than by name: a host with no console answers
+# the two properties above happily and then throws on the first cursor it is
+# asked to place.
+function Test-WelcomeWanted {
+    if ($NoWelcome) { return $false }
+    if ($env:ANK_NO_WELCOME) { return $false }
+    # A runner sets this, and a runner is a machine with no human at it.
+    if ($env:CI) { return $false }
+    try {
+        if ([Console]::IsOutputRedirected) { return $false }
+        if ([Console]::IsErrorRedirected) { return $false }
+        $null = $Host.UI.RawUI.CursorPosition
+    } catch {
+        return $false
+    }
+    return $true
 }
 
 # ---------------------------------------------------------------------------
@@ -326,8 +458,19 @@ if ($BaseUrl) {
 }
 
 # ---------------------------------------------------------------------------
-# Install
+# Welcome, then install
 # ---------------------------------------------------------------------------
+
+# Before anything is asked of the network, which is what "before the download
+# starts" has to mean here: the first request this script makes is the HEAD
+# that resolves the latest tag, and it is below.
+#
+# Wrapped, because a host that cannot place a cursor is not a reason to fail an
+# install: nothing has been downloaded yet and nothing below depends on a frame
+# having been drawn.
+if (Test-WelcomeWanted) {
+    try { Show-Logo } catch { }
+}
 
 # Both of these are session state, and under `iex` the session belongs to the
 # caller: they are restored in the finally below rather than left changed by an

--- a/install.sh
+++ b/install.sh
@@ -19,6 +19,12 @@
 #   4  the checksum did not match the one the release published
 #   5  a tool this script needs is missing
 #
+# --no-welcome, or ANK_NO_WELCOME in the environment, turns off everything this
+# script draws for a human and leaves only the lines a machine reads. It is
+# absent from the list above on purpose: the welcome is drawn before the first
+# request goes out, nothing in it can fail, and a flag that could change one of
+# these five codes would be a flag that made the install depend on it.
+#
 set -eu
 
 repo="haksolot/ank"
@@ -52,6 +58,125 @@ die() {
 }
 
 # --------------------------------------------------------------------------
+# Welcome
+# --------------------------------------------------------------------------
+
+# The logo, at half the resolution of assets/ank.svg and drawn in ASCII. That
+# file is the reference for the shape and nothing here reads it: an installer
+# that fetches a logo before it fetches the binary is an installer with a
+# second way to fail before doing anything useful, so the frames are bytes in
+# this file. ASCII and not U+2588 for the reason the shebang is /bin/sh -- this
+# runs on busybox, under a locale nobody chose, and a logo that arrives as
+# question marks is worse than no logo at all.
+#
+# Twelve lines, always, including the empty ones. The animation redraws the
+# same block in place, so a frame that were shorter would leave the tail of the
+# one before it on the screen.
+#
+# \033 and not \e: the octal escape is the one POSIX printf guarantees, and \e
+# is a bashism in a file that has none. \033[K clears what the previous frame
+# left to the right of this line.
+logo_line() {
+  case $1 in
+    1) logo_art='          ####' ;;
+    2) logo_art='        ##    ##' ;;
+    3) logo_art='        ##    ##' ;;
+    4) logo_art='          ####' ;;
+    5) logo_art='          ####' ;;
+    6) logo_art='  ######  ####  ######' ;;
+    7) logo_art='  ####    ####    ####' ;;
+    8) logo_art='  ####    ####    ####' ;;
+    9) logo_art='  ####    ####    ####' ;;
+    10) logo_art='    ################' ;;
+    12) logo_art='          ank' ;;
+    *) logo_art='' ;;
+  esac
+  printf '%s\033[K\n' "$logo_art" >&2
+}
+
+# Bottom up: the base, then the stem, then the loop, which is the order the
+# shape is built in and the order that leaves the whole of it standing at the
+# end. Frame 11 adds the name, and that is the beat the animation exists for:
+# it costs the time it takes to read the name of the tool and not a second
+# more.
+draw_logo() {
+  # POSIX sleep takes an integer, and every sleep this script is likely to meet
+  # -- coreutils, BSD, busybox built with the fancy option -- takes a fraction.
+  # The ones that do not are told apart by asking rather than by guessing:
+  # without a delay the frames still draw, in the order they draw, as fast as
+  # the terminal will take them.
+  frame_delay=0.06
+  sleep 0.01 2>/dev/null || frame_delay=""
+
+  # The cursor would otherwise blink in the middle of the drawing. Restored on
+  # the way out and on the two signals a human sends, because a terminal left
+  # with an invisible cursor is a terminal somebody has to repair with `reset`.
+  trap 'printf "\033[?25h" >&2; exit 130' INT
+  trap 'printf "\033[?25h" >&2; exit 143' TERM
+  printf '\033[?25l' >&2
+
+  frame=1
+  while [ "$frame" -le 11 ]; do
+    line=1
+    while [ "$line" -le 12 ]; do
+      if [ "$line" -le 10 ] && [ "$line" -ge $((11 - frame)) ]; then
+        logo_line "$line"
+      elif [ "$line" -eq 12 ] && [ "$frame" -eq 11 ]; then
+        logo_line 12
+      else
+        logo_line 0
+      fi
+      line=$((line + 1))
+    done
+    if [ "$frame" -lt 11 ]; then
+      [ -z "$frame_delay" ] || sleep "$frame_delay"
+      printf '\033[12A' >&2
+    fi
+    frame=$((frame + 1))
+  done
+
+  # The cursor comes back first and the blank line after it, so the last byte
+  # this function writes is a newline: whatever the install says next starts on
+  # a line of its own rather than behind an escape sequence.
+  printf '\033[?25h\n' >&2
+  trap - INT TERM
+}
+
+# ADR-5fbd99bf6fd5 read as an absence: where no human is looking, this script
+# draws nothing at all.
+#
+# Both streams are tested and not only one. Under `curl ... | sh` stdin is the
+# script and both of the others are the terminal, which is the case that must
+# animate; under `sh install.sh > install.log` stderr is still a terminal, and
+# a log file full of cursor movements is exactly the noise this must never
+# produce. /dev/tty is the third test and the one the decision names: no
+# controlling terminal means a provisioning script, a Dockerfile or a runner,
+# whatever the streams happen to say.
+welcome_wanted() {
+  [ "$no_welcome" = no ] || return 1
+  [ -t 1 ] || return 1
+  [ -t 2 ] || return 1
+  # A runner sets this, and some runner images hand their steps a pty.
+  [ -z "${CI:-}" ] || return 1
+  # A terminal that says it cannot move a cursor is taken at its word.
+  case "${TERM:-}" in
+    "" | dumb) return 1 ;;
+  esac
+  # A subshell: a redirection that fails on a special builtin is fatal to the
+  # shell itself, and this test exists to be answered no.
+  ( : > /dev/tty ) 2>/dev/null || return 1
+  # A window narrower than the art wraps every line, and a block that is taller
+  # than twelve rows is a block the redraw moves back over the middle of. Asked
+  # of tput, and only believed when it answers a number: a machine without it
+  # is a machine this refuses to guess about in the direction of drawing.
+  logo_cols=$(tput cols 2>/dev/null) || logo_cols=""
+  case "$logo_cols" in
+    "" | *[!0-9]*) : ;;
+    *) [ "$logo_cols" -ge 24 ] || return 1 ;;
+  esac
+}
+
+# --------------------------------------------------------------------------
 # Platforms
 # --------------------------------------------------------------------------
 
@@ -81,11 +206,15 @@ options:
   --version <version>  install this release instead of the latest one;
                        "v0.2.0" and "0.2.0" both work
   --dir <path>         install into <path> instead of \$HOME/.local/bin
+  --no-welcome         draw nothing; install exactly what an install with the
+                       animation installs, and say the same things about it
   -h, --help           print this and exit
 
 environment:
   ANK_VERSION          same as --version
   ANK_INSTALL_DIR      same as --dir
+  ANK_NO_WELCOME       same as --no-welcome, for a caller that pipes this
+                       script into sh and cannot pass an argument to it
   ANK_BASE_URL         where the archives are fetched from, for a mirror or a
                        staged release; requires --version, since only GitHub
                        can be asked which release is the latest
@@ -267,6 +396,8 @@ resolve_latest() {
 version=${ANK_VERSION:-}
 install_dir=${ANK_INSTALL_DIR:-}
 base_url=${ANK_BASE_URL:-}
+no_welcome=no
+[ -z "${ANK_NO_WELCOME:-}" ] || no_welcome=yes
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -288,6 +419,10 @@ while [ $# -gt 0 ]; do
       ;;
     --dir=*)
       install_dir=${1#--dir=}
+      shift
+      ;;
+    --no-welcome)
+      no_welcome=yes
       shift
       ;;
     -h | --help)
@@ -324,6 +459,13 @@ fi
 # --------------------------------------------------------------------------
 # Install
 # --------------------------------------------------------------------------
+
+# Before anything is asked of the network, which is what "before the download
+# starts" has to mean here: the first request this script makes is the redirect
+# that resolves the latest tag, and it is below.
+if welcome_wanted; then
+  draw_logo
+fi
 
 pick_downloader
 pick_sha_tool


### PR DESCRIPTION
Closes TASK-bbab313a4fea, the visible half of ADR-5fbd99bf6fd5.

Both installers animate the ankh from `assets/ank.svg` before the first request
goes out, and only when a human is at a terminal. The criterion is written as an
absence and that is the half that carries the risk: an animation is escape
sequences, and escape sequences in `install.log` or a CI transcript are noise
somebody has to clean up.

## What the frames are

Bytes in the scripts. Neither installer gains a network request it did not
already make -- an installer that reaches for a logo before it reaches for the
binary has a second way to fail before doing anything useful. `assets/ank.svg`
is the reference for the shape and nothing reads it at run time.

ASCII and not `U+2588`, for the reason `install.sh` has a `/bin/sh` shebang: this
lands on busybox under a locale nobody chose, and in a conhost under codepage
437. A logo that arrives as question marks is worse than no logo.

The ankh grows from its base, then the stem, then the loop, and the last frame
adds the name -- eleven frames, about seven hundred milliseconds, the time it
takes to read the name of the tool.

## Two ways to move a cursor, and why

`install.sh` writes `ESC[12A` and `ESC[K`. `install.ps1` goes through
`$Host.UI.RawUI.CursorPosition` instead, because Windows PowerShell 5.1 in
conhost does not enable virtual terminal processing for its own output and would
print `ESC[12A` as glyphs -- on precisely the shell that file claims as its
floor. The consequence for the proof: `install.ps1` emits no escape sequence on
any run, so the workflow asserts the frame absent beside the escape, and that is
the assertion that would catch a guard which stopped holding.

## When it draws

Four questions, all of which must answer yes:

- **stdout and stderr are both terminals.** Under `curl ... | sh` stdin is the
  script and the other two are the terminal, which must animate. Under
  `sh install.sh > install.log` stderr is still a terminal, and must not.
- **`/dev/tty` opens**, which is what ADR-5fbd99bf6fd5 names: no controlling
  terminal means a provisioning script, a Dockerfile or a runner.
- **`CI` is unset**, since some runner images hand their steps a pty.
- **the window is at least as wide as the art**, which would otherwise wrap and
  leave the redraw walking back into the middle of a taller block.

`--no-welcome` / `-NoWelcome`, and `ANK_NO_WELCOME` for the caller who pipes the
script into a shell and cannot pass an argument, turn the whole welcome off. Both
are in the usage text and in the comment block that lists the exit codes, and
both are absent from that list on purpose: nothing the welcome does can change
one of those five codes.

## What install.yml proves

On all three platforms, a non-interactive run emits no escape sequence, draws no
frame, and leaves a binary that answers `--version`; and the flag is accepted and
changes nothing, asserted by diffing the two transcripts.

The Windows staged stand-in is compiled with `csc.exe` for that last claim.
Windows will not run a `.exe` that is a text file, so the assertion the criterion
asks for could not be made against the stand-in as it was.

## Verification

- `cargo test --workspace`: 694 passed, 0 failed
- `cargo fmt --check`: clean
- `sh -n` and `dash -n` on `install.sh`
- staged release served from localhost, run piped and under a pty: the pty run
  animates, the piped run emits no `ESC` byte and no frame, and the two outcomes
  are identical

`ank check` reports one fault, `TASK-8108e3771ba0: done_criteria diverges from
the claim`. It belongs to another agent working in another tree -- claims live in
`refs/ank/*`, which worktrees share -- and nothing here touches it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ssTzq7p5FBm9jbEV1oP2y