### PR TITLE
The release carries the protocol surface, in every archive and every package

### DIFF
--- a/.ank/entities/LOG-0b758f19b3c7.md
+++ b/.ank/entities/LOG-0b758f19b3c7.md
@@ -1,0 +1,20 @@
+---
+id: LOG-0b758f19b3c7
+type: log
+title: +scope Cargo.lock (version 3 to 4, replaced 9cb2f509e1f7, produced 8240af00948b)
+created: 2026-08-24T22:53:45Z
+author: claude-code/opus-5+release-mcp
+scope:
+  - .github/workflows/release.yml
+  - .github/scripts/npm-assemble.sh
+  - npm/**
+  - crates/ank-mcp/Cargo.toml
+  - .github/scripts/check-version.sh
+  - .github/scripts/check-version-fixtures.sh
+  - Cargo.lock
+about: TASK-31500c1a7455
+seq: 3
+records: edit
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-0fadf8141848.md
+++ b/.ank/entities/LOG-0fadf8141848.md
@@ -1,0 +1,20 @@
+---
+id: LOG-0fadf8141848
+type: log
+title: Cargo.lock records ank-mcp 0.3.0 and cargo rewrote it the moment the manifest moved to 0.6.0. Not a
+created: 2026-08-24T22:53:42Z
+author: claude-code/opus-5+release-mcp
+scope:
+  - .github/workflows/release.yml
+  - .github/scripts/npm-assemble.sh
+  - npm/**
+  - crates/ank-mcp/Cargo.toml
+  - .github/scripts/check-version.sh
+  - .github/scripts/check-version-fixtures.sh
+about: TASK-31500c1a7455
+seq: 2
+schema: 4
+version: 1
+---
+
+ decision of its own, a mechanical consequence of an in-scope edit -- but leaving it out of the commit ships a lockfile that disagrees with the manifest, which is a red --locked build for everyone. Amending scope with Cargo.lock rather than committing a file the task does not name.

--- a/.ank/entities/LOG-1d82d78c8d83.md
+++ b/.ank/entities/LOG-1d82d78c8d83.md
@@ -1,0 +1,21 @@
+---
+id: LOG-1d82d78c8d83
+type: log
+title: Rehearsed the whole npm half locally before writing the CI steps, on a dist/ built from a real
+created: 2026-08-24T23:03:01Z
+author: claude-code/opus-5+release-mcp
+scope:
+  - .github/workflows/release.yml
+  - .github/scripts/npm-assemble.sh
+  - npm/**
+  - crates/ank-mcp/Cargo.toml
+  - .github/scripts/check-version.sh
+  - .github/scripts/check-version-fixtures.sh
+  - Cargo.lock
+about: TASK-31500c1a7455
+seq: 4
+schema: 4
+version: 1
+---
+
+ cargo build --release --bin ank --bin ank-mcp: assemble, npm pack, install from the two tarballs, then every assertion. ank prints 'ank 0.6.0 (14551eb, skill c5bae2a5f350)' and ank-mcp prints 'ank-mcp 0.6.0', so the comparison is field two of each line and not the line. npx resolves both bins. An initialize request piped into npx ank-mcp comes back with serverInfo name ank-mcp -- that one is the step that matters, because --version never reads a byte of stdin and a wrapper that captured the pipe would pass everything else. npx ank-mcp --nosuchflag exits 9 and says 'unknown argument', which is asserted alongside the code because 9 is also what the wrapper emits for its own failures. The archive step was exercised both ways on a real tarball: it names both executables, and it refuses one built without ank-mcp.

--- a/.ank/entities/LOG-47394d59dbf5.md
+++ b/.ank/entities/LOG-47394d59dbf5.md
@@ -1,0 +1,21 @@
+---
+id: LOG-47394d59dbf5
+type: log
+title: One wrapper, two shims. bin/wrapper.js holds the resolution, the diagnostics and the exit-code
+created: 2026-08-24T23:03:03Z
+author: claude-code/opus-5+release-mcp
+scope:
+  - .github/workflows/release.yml
+  - .github/scripts/npm-assemble.sh
+  - npm/**
+  - crates/ank-mcp/Cargo.toml
+  - .github/scripts/check-version.sh
+  - .github/scripts/check-version-fixtures.sh
+  - Cargo.lock
+about: TASK-31500c1a7455
+seq: 5
+schema: 4
+version: 1
+---
+
+ passthrough; bin/ank and bin/ank-mcp are three lines each and pass their own name in. Two copies of the resolver is the arrangement where the protocol surface quietly stops resolving the way the CLI does with nothing turning red -- which is the same reason npm-assemble.sh copies both binaries in one loop over a name list rather than twice by hand. Rehearsing dirties the committed npm manifests, since npm-assemble.sh runs npm pkg set on them: check-version.sh caught the 0.0.0-smoke I left behind, which is the job it exists for. Restored to 0.6.0 and the fixtures are green again. ank check reports one fault, on TASK-8108e3771ba0, a criterion diverging from a claim another agent holds in another worktree over the shared refs; nothing in this task writes that entity.

--- a/.ank/entities/LOG-5965c5b72530.md
+++ b/.ank/entities/LOG-5965c5b72530.md
@@ -1,0 +1,19 @@
+---
+id: LOG-5965c5b72530
+type: log
+title: done, proof commit:e253a00bd370145e3b7d99a5f1ce2d2f108e67b1
+created: 2026-08-24T23:03:33Z
+author: claude-code/opus-5+release-mcp
+scope:
+  - .github/workflows/release.yml
+  - .github/scripts/npm-assemble.sh
+  - npm/**
+  - crates/ank-mcp/Cargo.toml
+  - .github/scripts/check-version.sh
+  - .github/scripts/check-version-fixtures.sh
+  - Cargo.lock
+about: TASK-31500c1a7455
+seq: 6
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-9a000c2e823e.md
+++ b/.ank/entities/LOG-9a000c2e823e.md
@@ -1,0 +1,17 @@
+---
+id: LOG-9a000c2e823e
+type: log
+title: The criterion asks a CI assertion to show ank-mcp reporting the version ank reports. Today ank
+created: 2026-08-24T22:40:20Z
+author: claude-code/opus-5+release-mcp
+scope:
+  - .github/workflows/release.yml
+  - .github/scripts/npm-assemble.sh
+  - npm/**
+about: TASK-31500c1a7455
+seq: 0
+schema: 4
+version: 1
+---
+
+ reports 0.6.0 (ank-cli's CARGO_PKG_VERSION) and ank-mcp reports 0.3.0 (its own). The assertion cannot be green without the two crate versions being equal, so crates/ank-mcp/Cargo.toml has to move to 0.6.0 -- one file outside the declared scope, and the only edit under crates/ that this task needs. Once it moves, ank-mcp's version literal is a released artefact's version like ank-cli's, and check-version.sh -- the gate whose whole job is that every version literal agrees with the tag -- does not know about it. Leaving it out would let the next tag pass the version gate with ank-mcp stale, and the failure would surface in npm-smoke on the tag itself, which is exactly the 'discover it on a tag you then have to delete' failure that job exists to prevent. So .github/scripts/check-version.sh and its positive control .github/scripts/check-version-fixtures.sh come in too. Amending scope with these three rather than overflowing.

--- a/.ank/entities/LOG-d690aeb95611.md
+++ b/.ank/entities/LOG-d690aeb95611.md
@@ -1,0 +1,21 @@
+---
+id: LOG-d690aeb95611
+type: log
+title: +scope crates/ank-mcp/Cargo.toml, +scope .github/scripts/check-version.sh, +scope
+created: 2026-08-24T22:40:28Z
+author: claude-code/opus-5+release-mcp
+scope:
+  - .github/workflows/release.yml
+  - .github/scripts/npm-assemble.sh
+  - npm/**
+  - crates/ank-mcp/Cargo.toml
+  - .github/scripts/check-version.sh
+  - .github/scripts/check-version-fixtures.sh
+about: TASK-31500c1a7455
+seq: 1
+records: edit
+schema: 4
+version: 1
+---
+
+ .github/scripts/check-version-fixtures.sh (version 2 to 3, replaced a42f3b061caa, produced ddf101f980b9)

--- a/.ank/entities/TASK-31500c1a7455.md
+++ b/.ank/entities/TASK-31500c1a7455.md
@@ -5,17 +5,21 @@ slug: the-release-carries-the-protocol-surface-in-ever
 title: The release carries the protocol surface, in every archive and every package
 created: 2026-08-24T21:58:04Z
 author: claude-code/opus-5+planning
-status: open
+status: in_progress
 scope:
   - .github/workflows/release.yml
   - .github/scripts/npm-assemble.sh
   - npm/**
+  - crates/ank-mcp/Cargo.toml
+  - .github/scripts/check-version.sh
+  - .github/scripts/check-version-fixtures.sh
+  - Cargo.lock
 blocked_by: []
 done_criteria: |
   release.yml builds ank-mcp for the same three targets as ank -- x86_64-unknown-linux-musl, aarch64-apple-darwin, x86_64-pc-windows-msvc -- in the same job and from the same checkout, and every archive and loose artefact it uploads for a target carries both executables. npm-assemble.sh places ank-mcp beside ank in each platform package and stamps it at the same version. npm/ank declares a second bin entry ank-mcp, resolved through the same platform package as ank by the same wrapper. A CI assertion runs the assembled package on all three platforms and shows ank-mcp reporting the version ank reports. cargo test is green and cargo fmt --check passes.
 criteria_by: creator
 schema: 4
-version: 1
+version: 4
 ---
 
 The first of the three things ADR-e39a44f80e0e requires, and the one the other

--- a/.ank/entities/TASK-31500c1a7455.md
+++ b/.ank/entities/TASK-31500c1a7455.md
@@ -5,7 +5,7 @@ slug: the-release-carries-the-protocol-surface-in-ever
 title: The release carries the protocol surface, in every archive and every package
 created: 2026-08-24T21:58:04Z
 author: claude-code/opus-5+planning
-status: in_progress
+status: done
 scope:
   - .github/workflows/release.yml
   - .github/scripts/npm-assemble.sh
@@ -18,8 +18,13 @@ blocked_by: []
 done_criteria: |
   release.yml builds ank-mcp for the same three targets as ank -- x86_64-unknown-linux-musl, aarch64-apple-darwin, x86_64-pc-windows-msvc -- in the same job and from the same checkout, and every archive and loose artefact it uploads for a target carries both executables. npm-assemble.sh places ank-mcp beside ank in each platform package and stamps it at the same version. npm/ank declares a second bin entry ank-mcp, resolved through the same platform package as ank by the same wrapper. A CI assertion runs the assembled package on all three platforms and shows ank-mcp reporting the version ank reports. cargo test is green and cargo fmt --check passes.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: e253a00bd370145e3b7d99a5f1ce2d2f108e67b1
+    criteria: 1861799079fb
+    via: submitted
 schema: 4
-version: 4
+version: 5
 ---
 
 The first of the three things ADR-e39a44f80e0e requires, and the one the other

--- a/.github/scripts/check-version-fixtures.sh
+++ b/.github/scripts/check-version-fixtures.sh
@@ -21,6 +21,7 @@ check="$root/.github/scripts/check-version.sh"
 manifests=(
   crates/ank-cli/Cargo.toml
   crates/ank-core/Cargo.toml
+  crates/ank-mcp/Cargo.toml
   npm/ank/package.json
   npm/ank-linux-x64-musl/package.json
   npm/ank-darwin-arm64/package.json
@@ -40,7 +41,7 @@ fi
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 
-# plant <dir> -- the seven manifests, at their real paths, byte for byte.
+# plant <dir> -- the eight manifests, at their real paths, byte for byte.
 plant() {
   local dir="$1" m
   for m in "${manifests[@]}"; do

--- a/.github/scripts/check-version.sh
+++ b/.github/scripts/check-version.sh
@@ -12,7 +12,7 @@
 # with itself, which is a correct test of the wrapper and no test at all of the
 # version.
 #
-# Ten literals across seven files carry the version today, which is nine more
+# Eleven literals across eight files carry the version today, which is ten more
 # chances to be careful than anyone gets right forever. This makes the
 # disagreement fail instead.
 #
@@ -21,7 +21,7 @@
 # here costs a tag.
 #
 # The parsing is sed and awk. jq is on the runner but not on every machine a
-# maintainer would run this from, and the shapes read here are seven files this
+# maintainer would run this from, and the shapes read here are eight files this
 # repository writes itself. A literal the parser cannot find is a failure and
 # never a pass -- a shape that moved must turn this red, or the check quietly
 # stops checking.
@@ -91,7 +91,12 @@ compare() {
   bad_fix+=("$fix")
 }
 
-for crate in ank-cli ank-core; do
+# ank-mcp is here for the same reason ank-cli is: the release ships it, in every
+# archive and every npm package, and the smoke job asserts it answers --version
+# with the number ank answers with (ADR-e39a44f80e0e). A tag that bumped ank-cli
+# and left ank-mcp behind would pass this gate and then break on the tag itself,
+# which is the loop this whole job exists to spare.
+for crate in ank-cli ank-core ank-mcp; do
   f="crates/$crate/Cargo.toml"
   compare "$f" "$f" "$(cargo_version "$f" 2>/dev/null)" \
     "$f: version = \"$version\""

--- a/.github/scripts/npm-assemble.sh
+++ b/.github/scripts/npm-assemble.sh
@@ -8,6 +8,10 @@
 # first. Nothing here downloads anything, which is the property the whole
 # channel exists for (npm/README.md).
 #
+# Two executables per platform package, never one: ADR-e39a44f80e0e makes
+# ank-mcp freight of every route that carries ank, so the pair travels in one
+# package under one version and an install cannot end up holding half of it.
+#
 #   npm-assemble.sh <version> [package ...]
 #
 # With no package named, all three are assembled -- which is what the publish
@@ -38,34 +42,46 @@ target_of() {
   esac
 }
 
-exe_of() {
+# The extension, applied to both names rather than each name written out twice
+# per platform. Windows is the only row that has one.
+suffix_of() {
   case "$1" in
-    ank-win32-x64) echo ank.exe ;;
-    *) echo ank ;;
+    ank-win32-x64) echo .exe ;;
+    *) echo "" ;;
   esac
 }
 
+# The two executables a platform package carries, in the order the wrapper
+# declares them. A name added here is a name the release must have built, and a
+# missing one below stops the assembly rather than shipping a package that is
+# short a binary.
+executables=(ank ank-mcp)
+
 for p in "${packages[@]}"; do
   target="$(target_of "$p")"
-  exe="$(exe_of "$p")"
-  # The loose binary the build job uploads beside the archives. Reaching for it
-  # rather than unpacking a .zip keeps this script free of unzip, which the
-  # Windows runner's bash does not have.
-  src="$(find dist -type f -path "*${target}*" -name "$exe" | head -n 1)"
-  if [ -z "$src" ]; then
-    echo "no $exe built for $target under dist/" >&2
-    exit 1
-  fi
+  suffix="$(suffix_of "$p")"
   mkdir -p "npm/$p/bin"
-  cp "$src" "npm/$p/bin/$exe"
-  chmod +x "npm/$p/bin/$exe"
+  for name in "${executables[@]}"; do
+    exe="${name}${suffix}"
+    # The loose binaries the build job uploads beside the archives. Reaching for
+    # them rather than unpacking a .zip keeps this script free of unzip, which
+    # the Windows runner's bash does not have.
+    src="$(find dist -type f -path "*${target}*" -name "$exe" | head -n 1)"
+    if [ -z "$src" ]; then
+      echo "no $exe built for $target under dist/" >&2
+      exit 1
+    fi
+    cp "$src" "npm/$p/bin/$exe"
+    chmod +x "npm/$p/bin/$exe"
+    echo "  npm/$p/bin/$exe from $src"
+  done
   cp LICENSE "npm/$p/LICENSE"
   (
     cd "npm/$p"
     npm pkg set version="$version"
     npm pack --silent > /dev/null
   )
-  echo "assembled npm/$p from $src"
+  echo "assembled npm/$p at $version"
 done
 
 # The wrapper pins the platform packages exactly. A range would let an install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ name: release
 # produced from a branch would make "the binary for v0.1.0" a question rather
 # than an answer.
 #
-# `workflow_dispatch` builds the same four binaries and publishes nothing. The
+# `workflow_dispatch` builds the same four targets and publishes nothing. The
 # alternative is discovering that the release pipeline is broken at the moment
 # you use it, on a tag you then have to delete -- and a tag is the one thing
 # here that is awkward to take back.
@@ -127,8 +127,15 @@ jobs:
       - name: test
         run: cargo test --workspace --target ${{ matrix.target }}
 
+      # Both executables, one invocation, one checkout (ADR-e39a44f80e0e). Two
+      # `cargo build` lines would compile the same table twice and could be
+      # made to disagree; one line cannot. `ank-mcp` is a generated passthrough
+      # over `ank_contract::COMMANDS`, so a surface built from an older table
+      # than the CLI beside it advertises verbs that CLI does not dispatch --
+      # a refusal section 4 gives no code for, because it should not be
+      # reachable.
       - name: build
-        run: cargo build --release --bin ank --target ${{ matrix.target }}
+        run: cargo build --release --bin ank --bin ank-mcp --target ${{ matrix.target }}
 
       # Named for what it runs on, because that is the question someone
       # downloading it is asking.
@@ -143,10 +150,15 @@ jobs:
           esac
           name="ank-${version}-${{ matrix.target }}"
           mkdir -p "dist/${name}"
+          # Both, into every archive. ADR-e39a44f80e0e: where a route places
+          # ank, it places ank-mcp next to it, and the archive is the route
+          # install.sh and install.ps1 unpack.
           if [ "${{ matrix.archive }}" = "zip" ]; then
             cp "target/${{ matrix.target }}/release/ank.exe" "dist/${name}/"
+            cp "target/${{ matrix.target }}/release/ank-mcp.exe" "dist/${name}/"
           else
             cp "target/${{ matrix.target }}/release/ank" "dist/${name}/"
+            cp "target/${{ matrix.target }}/release/ank-mcp" "dist/${name}/"
           fi
           cp README.md LICENSE "dist/${name}/"
           # The contract alone, and not the three activity policies beside
@@ -188,10 +200,45 @@ jobs:
             sha256sum "${name}.tar.gz" > "${name}.tar.gz.sha256"
           fi
 
-      # The loose binary travels beside the archives, for the npm packages
+      # Read back out of the archive, not off the disk. The archive is what the
+      # release page serves and what install.sh and install.ps1 unpack, and a
+      # `cp` that silently did not happen leaves the executable in `target/`
+      # and out of the tarball -- where nothing else in this file would notice.
+      # ADR-e39a44f80e0e says no route carries one without the other; this is
+      # that condition, asserted on the artefact rather than assumed from the
+      # step above it.
+      - name: the archive carries both executables
+        shell: bash
+        run: |
+          set -e
+          cd dist
+          archive=$(find . -maxdepth 1 -type f \( -name '*.tar.gz' -o -name '*.zip' \) | head -n 1)
+          echo "reading $archive"
+          case "$archive" in
+            # `7z l -ba -slt` prints one `Path = ` line per entry, which is the
+            # only listing shape that survives a name with a space in it. `tr`
+            # because 7z is a native Windows program and ends its lines CRLF,
+            # and a trailing carriage return would make every name below miss.
+            *.zip) listing=$(7z l -ba -slt "$archive" | tr -d '\r' | sed -n 's/^Path = //p'); exes="ank.exe ank-mcp.exe" ;;
+            *)     listing=$(tar tzf "$archive"); exes="ank ank-mcp" ;;
+          esac
+          # Basenames, because 7z on Windows separates with a backslash and tar
+          # with a slash, and the question here is which files are inside.
+          names=$(printf '%s\n' "$listing" | sed 's|.*[/\\]||')
+          printf '%s\n' "$listing" | sed 's/^/  /'
+          for exe in $exes; do
+            printf '%s\n' "$names" | grep -qx "$exe"
+            echo "  carries $exe"
+          done
+
+      # The loose binaries travel beside the archives, for the npm packages
       # below: extracting a .zip would need `unzip`, which the Windows runner's
       # bash does not have, and building a second time to avoid that would be
       # two binaries where the point is one.
+      #
+      # Both of them, named one per line rather than as `ank*`: a glob would
+      # also sweep up whatever the packaging step leaves in that directory
+      # next, and what the npm packages are entitled to take is exactly these.
       - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.target }}
@@ -201,6 +248,8 @@ jobs:
             dist/*.sha256
             dist/*/ank
             dist/*/ank.exe
+            dist/*/ank-mcp
+            dist/*/ank-mcp.exe
           if-no-files-found: error
 
   # The npm channel exists for the workstation whose firewall blocks downloading
@@ -374,11 +423,65 @@ jobs:
           echo "npx:    $actual"
           test "$expected" = "$actual"
 
+      # The criterion of ADR-e39a44f80e0e, on the machine that will run it. The
+      # two executables come out of one `cargo build`, and the observable form
+      # of that is answering `--version` with one number.
+      #
+      # Read out of the installed package and not off `dist/`: what a user holds
+      # is what npm resolved through optionalDependencies, and a platform
+      # package assembled without ank-mcp would pass every assertion above this
+      # one. Compared against each other rather than against a literal, so the
+      # check cannot drift from the version it ships.
+      #
+      # The number, not the line: `ank` prints the commit and the skill revision
+      # beside it (section 4) and `ank-mcp` prints neither, so it is field two
+      # of each. Field two is asserted non-empty first, because two versions
+      # that are both empty are equal and that is not the news.
+      - name: ank-mcp reports the version ank reports
+        shell: bash
+        run: |
+          set -e
+          cd smoke
+          ank_line=$(npx ank --version)
+          mcp_line=$(npx ank-mcp --version)
+          echo "ank:     $ank_line"
+          echo "ank-mcp: $mcp_line"
+          ank_version=$(printf '%s\n' "$ank_line" | awk '{print $2}')
+          mcp_version=$(printf '%s\n' "$mcp_line" | awk '{print $2}')
+          test -n "$ank_version"
+          test "$ank_version" = "$mcp_version"
+
+      # A version is printed on stdout; a protocol surface is a conversation on
+      # stdin. The wrapper spawns with `stdio: inherit` precisely so that a
+      # client's request reaches the server, and nothing above this line would
+      # notice if it stopped: `--version` never reads a byte. One `initialize`
+      # is the smallest exchange that does.
+      #
+      # `--repo` is given the checkout, which is the one directory on this
+      # runner holding a `.ank/`, in the runner's own path shape rather than
+      # `pwd` -- Git Bash on Windows answers `/d/a/...`, which is not a path
+      # anything outside it can open.
+      - name: the protocol surface answers through the wrapper
+        shell: bash
+        run: |
+          set -e
+          cd smoke
+          reply=$(echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' \
+            | npx ank-mcp --repo "$GITHUB_WORKSPACE")
+          echo "$reply"
+          printf '%s\n' "$reply" | grep -q '"name":"ank-mcp"'
+
       # The exit codes carry meaning (section 4) and a wrapper is where they go
       # to die. An unknown verb is a 2, and 2 rather than 1 is the point: a
       # wrapper collapsing every failure into "it failed" would still pass a
       # test that only asked for non-zero. It also needs no repository, so what
       # is under test is the wrapper and not the fixture.
+      #
+      # Both bins, because both now go through one wrapper.js and a shim of
+      # their own: `ank-mcp` refuses an unknown argument with the environment
+      # code, and 9 is the one code this wrapper also produces by itself, so a
+      # 9 that came from the wrapper instead of the server would read the same.
+      # The line on stderr is what tells them apart, and it is asserted.
       - name: the exit code survives the wrapper
         shell: bash
         run: |
@@ -390,6 +493,15 @@ jobs:
           set -e
           echo "an unknown verb exited $code"
           test "$code" -eq 2
+
+          set +e
+          err=$(npx ank-mcp --nosuchflag 2>&1)
+          code=$?
+          set -e
+          echo "$err"
+          echo "an unknown argument to ank-mcp exited $code"
+          test "$code" -eq 9
+          printf '%s\n' "$err" | grep -q "unknown argument"
 
   publish-npm:
     # Only on a tag, and only once all three smoke tests agree. Publishing is

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "ank-mcp"
-version = "0.3.0"
+version = "0.6.0"
 dependencies = [
  "ank-contract",
  "serde_yaml",

--- a/crates/ank-mcp/Cargo.toml
+++ b/crates/ank-mcp/Cargo.toml
@@ -1,6 +1,11 @@
 [package]
 name = "ank-mcp"
-version = "0.3.0"
+# ank-cli's version, and not a version of its own. The two binaries ship out of
+# one build and one archive (ADR-e39a44f80e0e), so a caller holding both has no
+# way to ask which of two numbers describes the pair -- and the release asserts
+# they answer `--version` alike, on all three platforms, before it publishes
+# anything. check-version.sh holds this literal to the tag with the others.
+version = "0.6.0"
 edition = "2021"
 # The workspace floor, for the reason ank-core's manifest gives: one lockfile,
 # one build.

--- a/npm/README.md
+++ b/npm/README.md
@@ -2,8 +2,8 @@
 
 Four packages, and the shape is the one esbuild uses.
 
-    @haksolot/ank                    the wrapper, and the only name anyone types
-    @haksolot/ank-linux-x64-musl     the binary, one package per target
+    @haksolot/ank                    the wrapper, and the only name anyone installs
+    @haksolot/ank-linux-x64-musl     the binaries, one package per target
     @haksolot/ank-darwin-arm64
     @haksolot/ank-win32-x64
 
@@ -16,8 +16,18 @@ That is the whole point of this channel rather than a detail of it. The driving
 case is the corporate workstation whose firewall blocks downloading a bare
 executable but lets the npm registry through; a `postinstall` script that
 fetched the binary would die behind exactly the firewall this package exists to
-cross. `bin/ank` is therefore a resolver, never a downloader: it finds the
-platform package with `require.resolve` and executes what it finds.
+cross. `bin/wrapper.js` is therefore a resolver, never a downloader: it finds
+the platform package with `require.resolve` and executes what it finds.
+
+**Two executables, one package, one version.** Each platform package carries
+`ank` and `ank-mcp`, the protocol surface, out of the same build
+(ADR-e39a44f80e0e): no route carries one without the other, so there is no
+install holding a CLI and a passthrough generated from a different table. The
+wrapper declares both as `bin` and resolves them by one route -- `bin/ank` and
+`bin/ank-mcp` are two lines each, and `bin/wrapper.js` is the resolution, the
+diagnostics and the exit code for both. Two copies of that file is the
+arrangement where the protocol surface quietly stops resolving the way the CLI
+does and nothing turns red.
 
 **The Linux package declares no `libc`.** The build is `x86_64-unknown-linux-musl`
 and statically linked, so it runs on a glibc distribution just as well; declaring
@@ -28,12 +38,14 @@ not because it restricts where it runs.
 **The wrapper forwards the exit code unchanged.** Section 4 of the specification
 gives 4, 6, 8 and 9 distinct meanings that an agent branches on. A wrapper that
 collapsed them into 0 and 1 would break every caller reading them, which is why
-`bin/ank` exits with the child's status and reserves 9, the environment code,
-for its own failures.
+`bin/wrapper.js` exits with the child's status and reserves 9, the environment
+code, for its own failures. `ank-mcp` reaches its client the same way, and `stdio` is
+inherited rather than captured, because a surface that speaks JSON-RPC on stdin
+has nothing to say to a wrapper holding the pipe.
 
 ## What is not in git
 
-`npm/ank-*/bin/` is empty here and ignored. The binaries land in it during the
+`npm/ank-*/bin/` is empty here and ignored. Both binaries land in it during the
 release run, from the same artefacts the GitHub release publishes: one build,
 two channels, no second compilation that could disagree with the first.
 
@@ -48,6 +60,7 @@ only ever the last released one.
 `release.yml` does it on a `v*` tag, with `NPM_TOKEN` from the repository
 secrets and `--access public`, which a scoped package needs on its first
 publish. On `workflow_dispatch` the same job assembles the packages, installs
-them from the tarballs on all three platforms and runs `ank --version`, so the
-pipeline is proved before a tag depends on it, and a tag is the one thing here
-that is awkward to take back.
+them from the tarballs on all three platforms, and shows `ank-mcp` answering
+`--version` with the number `ank` answers with, so the pipeline is proved before
+a tag depends on it, and a tag is the one thing here that is awkward to take
+back.

--- a/npm/ank-darwin-arm64/package.json
+++ b/npm/ank-darwin-arm64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@haksolot/ank-darwin-arm64",
   "version": "0.6.0",
-  "description": "The ank binary for macOS on Apple silicon.",
+  "description": "The ank and ank-mcp binaries for macOS on Apple silicon.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/haksolot/ank",
   "repository": {
@@ -16,6 +16,7 @@
   ],
   "files": [
     "bin/ank",
+    "bin/ank-mcp",
     "LICENSE"
   ]
 }

--- a/npm/ank-linux-x64-musl/package.json
+++ b/npm/ank-linux-x64-musl/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@haksolot/ank-linux-x64-musl",
   "version": "0.6.0",
-  "description": "The ank binary for Linux x86_64, statically linked against musl.",
+  "description": "The ank and ank-mcp binaries for Linux x86_64, statically linked against musl.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/haksolot/ank",
   "repository": {
@@ -16,6 +16,7 @@
   ],
   "files": [
     "bin/ank",
+    "bin/ank-mcp",
     "LICENSE"
   ]
 }

--- a/npm/ank-win32-x64/package.json
+++ b/npm/ank-win32-x64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@haksolot/ank-win32-x64",
   "version": "0.6.0",
-  "description": "The ank binary for Windows x86_64.",
+  "description": "The ank and ank-mcp binaries for Windows x86_64.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/haksolot/ank",
   "repository": {
@@ -16,6 +16,7 @@
   ],
   "files": [
     "bin/ank.exe",
+    "bin/ank-mcp.exe",
     "LICENSE"
   ]
 }

--- a/npm/ank/README.md
+++ b/npm/ank/README.md
@@ -6,12 +6,16 @@ behind one CLI any coding agent can call.
     npx @haksolot/ank --version
     npm install -g @haksolot/ank
 
-The binary travels inside the package: nothing is downloaded at install time, so
+The binaries travel inside the package: nothing is downloaded at install time, so
 this channel works where fetching a bare executable does not. It covers
 `linux x64`, `darwin arm64` and `win32 x64`; on any other platform the wrapper
 exits 9 and names `cargo install`. ank needs **git 2.34 or newer**.
 
-This package carries the CLI. The skill an agent loads is a separate install, and
+Two commands are installed, out of one build and under one version: `ank`, the
+CLI, and `ank-mcp`, the protocol surface a client with no shell reaches instead.
+Every verb the CLI dispatches is a tool there, generated from the same table.
+
+This package carries both. The skill an agent loads is a separate install, and
 [the documentation](https://github.com/haksolot/ank) covers both, along with the
 specification and the source.
 

--- a/npm/ank/bin/ank
+++ b/npm/ank/bin/ank
@@ -1,62 +1,6 @@
 #!/usr/bin/env node
 "use strict";
 
-// This wrapper resolves a binary. It never downloads one.
-//
-// The driving case is the corporate workstation: a firewall that blocks
-// downloading a bare executable usually lets the npm registry through. A
-// postinstall script that fetched the binary would therefore die behind the
-// very firewall this package exists to cross. The binaries travel inside the
-// platform packages instead, and npm installs exactly one of them by matching
-// `os` and `cpu` through optionalDependencies.
-
-const { spawnSync } = require("child_process");
-
-const PACKAGES = {
-  "linux x64": "@haksolot/ank-linux-x64-musl",
-  "darwin arm64": "@haksolot/ank-darwin-arm64",
-  "win32 x64": "@haksolot/ank-win32-x64",
-};
-
-const platform = process.platform + " " + process.arch;
-const pkg = PACKAGES[platform];
-const exe = process.platform === "win32" ? "ank.exe" : "ank";
-
-// Code 9 is the environment, and it is the right one for every failure in this
-// file: none of them is a failure of the caller's work, which is exactly what
-// section 4 reserves 9 for. Each one names the command that fixes it.
-function fail(lines) {
-  for (const line of lines) {
-    console.error(line);
-  }
-  process.exit(9);
-}
-
-if (!pkg) {
-  fail([
-    "ank: no prebuilt binary for " + platform,
-    "  -> cargo install --git https://github.com/haksolot/ank ank-cli",
-  ]);
-}
-
-let binary;
-try {
-  binary = require.resolve(pkg + "/bin/" + exe);
-} catch (e) {
-  fail([
-    "ank: " + pkg + " is not installed",
-    "  -> npm install @haksolot/ank",
-    "  -> optional dependencies carry the binary, so --no-optional removes it",
-  ]);
-}
-
-// The exit code is the interface. Section 4 gives 4, 6, 8 and 9 distinct
-// meanings that an agent branches on, so a wrapper collapsing them into 0 and 1
-// would break every caller that reads them.
-const run = spawnSync(binary, process.argv.slice(2), { stdio: "inherit" });
-if (run.error) {
-  fail(["ank: " + run.error.message, "  -> " + binary]);
-}
-// A process killed by a signal carries no code of its own; 9 says environment,
-// which is what a signal from outside is.
-process.exit(run.status === null ? 9 : run.status);
+// The CLI. Every word about how this resolves is in wrapper.js, which ank-mcp
+// beside it uses unchanged.
+require("./wrapper.js").run("ank");

--- a/npm/ank/bin/ank-mcp
+++ b/npm/ank/bin/ank-mcp
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+"use strict";
+
+// The protocol surface, resolved through the same platform package as `ank` by
+// the same wrapper (ADR-e39a44f80e0e). A client points its MCP configuration at
+// this name; the reasoning is in wrapper.js.
+require("./wrapper.js").run("ank-mcp");

--- a/npm/ank/bin/wrapper.js
+++ b/npm/ank/bin/wrapper.js
@@ -1,0 +1,83 @@
+"use strict";
+
+// One wrapper, two names.
+//
+// This wrapper resolves a binary. It never downloads one.
+//
+// The driving case is the corporate workstation: a firewall that blocks
+// downloading a bare executable usually lets the npm registry through. A
+// postinstall script that fetched the binary would therefore die behind the
+// very firewall this package exists to cross. The binaries travel inside the
+// platform packages instead, and npm installs exactly one of them by matching
+// `os` and `cpu` through optionalDependencies.
+//
+// `ank` and `ank-mcp` come out of one build and travel in one platform package
+// (ADR-e39a44f80e0e), so they resolve by one route. Two copies of this file,
+// one per bin, is the arrangement where the protocol surface quietly stops
+// resolving the way the CLI does and nothing turns red: the resolution, the
+// diagnostics and the exit-code passthrough are written once and `run` is
+// given the name to look for.
+
+const { spawnSync } = require("child_process");
+
+const PACKAGES = {
+  "linux x64": "@haksolot/ank-linux-x64-musl",
+  "darwin arm64": "@haksolot/ank-darwin-arm64",
+  "win32 x64": "@haksolot/ank-win32-x64",
+};
+
+// Code 9 is the environment, and it is the right one for every failure in this
+// file: none of them is a failure of the caller's work, which is exactly what
+// section 4 reserves 9 for. Each one names the command that fixes it.
+function fail(lines) {
+  for (const line of lines) {
+    console.error(line);
+  }
+  process.exit(9);
+}
+
+// run(name) -- spawn `name` out of the platform package, and be its exit code.
+//
+// `name` is the bin npm wrote a shim for, and it is also the file inside the
+// platform package: the assembly script copies both executables under the
+// names they were built with, so there is nothing here to map.
+function run(name) {
+  const platform = process.platform + " " + process.arch;
+  const pkg = PACKAGES[platform];
+  const exe = process.platform === "win32" ? name + ".exe" : name;
+
+  if (!pkg) {
+    fail([
+      name + ": no prebuilt binary for " + platform,
+      "  -> cargo install --git https://github.com/haksolot/ank ank-cli",
+    ]);
+  }
+
+  let binary;
+  try {
+    binary = require.resolve(pkg + "/bin/" + exe);
+  } catch (e) {
+    fail([
+      name + ": " + pkg + " is not installed",
+      "  -> npm install @haksolot/ank",
+      "  -> optional dependencies carry the binary, so --no-optional removes it",
+    ]);
+  }
+
+  // The exit code is the interface. Section 4 gives 4, 6, 8 and 9 distinct
+  // meanings that an agent branches on, so a wrapper collapsing them into 0 and
+  // 1 would break every caller that reads them.
+  //
+  // `stdio: inherit` is also what makes the protocol surface work at all:
+  // ank-mcp speaks JSON-RPC over stdin and stdout, so a wrapper that captured
+  // either would leave the client waiting forever.
+  const child = spawnSync(binary, process.argv.slice(2), { stdio: "inherit" });
+  if (child.error) {
+    fail([name + ": " + child.error.message, "  -> " + binary]);
+  }
+  // A process killed by a signal carries no code of its own; 9 says
+  // environment, which is what a signal from outside is.
+  process.exit(child.status === null ? 9 : child.status);
+}
+
+module.exports = { run };

--- a/npm/ank/package.json
+++ b/npm/ank/package.json
@@ -18,10 +18,12 @@
     "architecture-decision-record",
     "tasks",
     "coordination",
+    "mcp",
     "pi-package"
   ],
   "bin": {
-    "ank": "bin/ank"
+    "ank": "bin/ank",
+    "ank-mcp": "bin/ank-mcp"
   },
   "pi": {
     "skills": [
@@ -31,6 +33,8 @@
   },
   "files": [
     "bin/ank",
+    "bin/ank-mcp",
+    "bin/wrapper.js",
     "skills/",
     "README.md",
     "LICENSE"


### PR DESCRIPTION
`TASK-31500c1a7455`, the first of the three things ADR-e39a44f80e0e requires and
the one the other two rest on: an installer cannot place a binary the release
never built.

## What changed

**One job, one checkout, one version.** `release.yml` builds both executables
from a single `cargo build --release --bin ank --bin ank-mcp` per target. Two
build lines would compile the same table twice and could be made to disagree,
and a generated passthrough built from an older table than the CLI beside it
advertises verbs that CLI does not dispatch.

**Every archive carries both.** The packaging step copies `ank-mcp` beside
`ank`, and a new step reads the pair back out of the tarball or the zip rather
than trusting the `cp` above it -- the archive is what the release page serves
and what `install.sh` and `install.ps1` unpack. Both loose binaries are uploaded
for the npm packages.

**Two executables per npm platform package.** `npm-assemble.sh` copies the pair
in one loop over a name list, so a package short a binary stops the assembly
instead of shipping. `npm/ank` declares `ank-mcp` as a second bin: `bin/ank` and
`bin/ank-mcp` are shims that pass their own name into `bin/wrapper.js`, which
holds the resolution, the diagnostics and the exit-code passthrough. Two copies
of that resolver is the arrangement where the protocol surface quietly stops
resolving the way the CLI does and nothing turns red.

**The assertions.** On all three platforms, the smoke job shows `ank-mcp`
answering `--version` with the number `ank` answers with, read out of the
installed package rather than off `dist/` -- a package assembled without
`ank-mcp` passes every assertion above it. Beside it, one `initialize` piped
through the wrapper, because `--version` never reads stdin and a wrapper holding
the pipe would pass everything else; and `ank-mcp`'s own exit 9 asserted with
the stderr line that tells it apart from the wrapper's own 9.

## Scope, amended twice and logged

- `crates/ank-mcp/Cargo.toml` -> 0.6.0. The assertion cannot be green while the
  two crates carry different numbers.
- `.github/scripts/check-version.sh` and its positive control. Once `ank-mcp`'s
  version literal is a released artefact's, that gate is where it is held to the
  tag; leaving it out would let a tag pass the gate and break on itself.
- `Cargo.lock`, which cargo rewrote when the manifest moved.

## Verification

- `cargo test --workspace`: 694 passed, 0 failed.
- `cargo fmt --check`: clean.
- `check-version.sh 0.6.0`: agrees with all 11 version literals.
- `check-version-fixtures.sh`: green on all five fixtures.
- `ank check`: the one fault is `TASK-8108e3771ba0`, a criterion diverging from
  a claim another agent holds in another worktree over the shared refs. Nothing
  here writes that entity.
- The npm half was rehearsed locally end to end on a real `dist/`: assemble,
  pack, install from the tarballs, and every assertion the CI steps run. The
  archive step was exercised both ways, including on a tarball built without
  `ank-mcp`, which it refuses.

`ank done --proof commit:e253a00b` recorded and the task is `done`. The `attest`
job records `test:<run-id>` on `refs/ank/proof/` once this lands on main.

## Noted, not touched

`.claude-plugin/plugin.json` declares `"license": "GPL-3.0-only"`, which
disagrees with ADR-9f03438f5422. Outside this task's scope and not part of its
criterion, so it is left for whoever owns that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019khv391w1e4UxZjdjo3dpd