### PR TITLE
A watcher that keeps declared corpora warm and answers nothing

### DIFF
--- a/.ank/entities/LOG-4950aca8501f.md
+++ b/.ank/entities/LOG-4950aca8501f.md
@@ -1,0 +1,18 @@
+---
+id: LOG-4950aca8501f
+type: log
+title: Two things the criterion forced that the obvious implementation would have got wrong. Warming is a
+created: 2026-08-25T02:27:45Z
+author: claude-code/opus-5+daemon-watch
+scope:
+  - crates/ank-daemon/**
+  - Cargo.toml
+  - docs/integrating.md
+  - Cargo.lock
+about: TASK-f8802467b622
+seq: 4
+schema: 4
+version: 1
+---
+
+ spawn of ank find --repo <root>, never a link of index.rs: ank-cli has no library target, and a second refresh written against the same schema would drift silently because a stale cache answers rather than fails -- which is also what keeps the daemon from being a second dispatch path. And the undeclared-corpus test asserts on the absence of index.db in the neighbours, not on a log line: opening an index writes that file, so its absence is the read itself not having happened, planted above, beside and below the declared tree. Mutating the change detection to warm only on the first pass turns the follow test red, so it measures the loop and not the harness.

--- a/.ank/entities/LOG-7095fa92841e.md
+++ b/.ank/entities/LOG-7095fa92841e.md
@@ -1,0 +1,16 @@
+---
+id: LOG-7095fa92841e
+type: log
+title: done, proof commit:03a8e33144a60cd3407651279523cc2625f72e5d
+created: 2026-08-25T02:28:13Z
+author: claude-code/opus-5+daemon-watch
+scope:
+  - crates/ank-daemon/**
+  - Cargo.toml
+  - docs/integrating.md
+  - Cargo.lock
+about: TASK-f8802467b622
+seq: 5
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-c8bdc697d439.md
+++ b/.ank/entities/LOG-c8bdc697d439.md
@@ -1,0 +1,17 @@
+---
+id: LOG-c8bdc697d439
+type: log
+title: Shape settled before any code. The declaration is a watch.yml beside corpora.yml under the reader's
+created: 2026-08-25T02:09:18Z
+author: claude-code/opus-5+daemon-watch
+scope:
+  - crates/ank-daemon/**
+  - Cargo.toml
+  - docs/integrating.md
+about: TASK-f8802467b622
+seq: 1
+schema: 4
+version: 1
+---
+
+ config home, same rule as ADR-96174f1ac2b7, keyed on the 40-hex root commit, value one path or a list of them so two worktrees of one repository are two paths under one key and therefore one watched corpus. Warming goes through the CLI: ank find --repo <corpus> --status open --json --quiet opens the index, refreshes it against the file hashes, and writes nothing else, so the daemon is not a second implementation of index.rs and never links it -- which is also what keeps this task inside crates/ank-daemon/**, since ank-cli has no library target. No file-watching crate enters the tree: the poll is a stat walk of the declared .ank/ and only that.

--- a/.ank/entities/LOG-ca413120c333.md
+++ b/.ank/entities/LOG-ca413120c333.md
@@ -1,0 +1,17 @@
+---
+id: LOG-ca413120c333
+type: log
+title: Cargo.lock is outside the scope this task was written with, and a fourth crate in the workspace
+created: 2026-08-25T02:19:07Z
+author: claude-code/opus-5+daemon-watch
+scope:
+  - crates/ank-daemon/**
+  - Cargo.toml
+  - docs/integrating.md
+about: TASK-f8802467b622
+seq: 2
+schema: 4
+version: 1
+---
+
+ rewrites it: cargo resolves one lockfile for the whole tree, so a member cannot be added without the lock recording it. The lock is tracked here, so leaving it out would either fail the build for whoever checks the branch out or make the new member invisible to the lockfile CI resolves against. Adding it to the scope rather than writing it silently.

--- a/.ank/entities/LOG-d79360743055.md
+++ b/.ank/entities/LOG-d79360743055.md
@@ -1,0 +1,17 @@
+---
+id: LOG-d79360743055
+type: log
+title: +scope Cargo.lock (version 3 to 4, replaced ccdee0765562, produced c4c21ad87c64)
+created: 2026-08-25T02:19:10Z
+author: claude-code/opus-5+daemon-watch
+scope:
+  - crates/ank-daemon/**
+  - Cargo.toml
+  - docs/integrating.md
+  - Cargo.lock
+about: TASK-f8802467b622
+seq: 3
+records: edit
+schema: 4
+version: 1
+---

--- a/.ank/entities/TASK-f8802467b622.md
+++ b/.ank/entities/TASK-f8802467b622.md
@@ -5,17 +5,18 @@ slug: the-daemon-watches-the-corpora-it-was-handed-and
 title: The daemon watches the corpora it was handed, and every verb behaves as if it were absent
 created: 2026-08-24T22:02:58Z
 author: claude-code/opus-5+planning
-status: open
+status: in_progress
 scope:
   - crates/ank-daemon/**
   - Cargo.toml
   - docs/integrating.md
+  - Cargo.lock
 blocked_by: []
 done_criteria: |
   A sibling binary in this workspace takes a declaration of corpora to watch, keyed on the repository identity of ADR-621a7fd96ce1 and never on a path, held outside the repositories the way ADR-96174f1ac2b7 holds one, and refuses to start on a declaration naming a directory with no .ank rather than searching for one. It walks no filesystem looking for a corpus, and a test asserts that by pointing it at a tree holding an undeclared corpus and showing it is never read. It keeps each declared corpus's index current as files under .ank change, and a test shows a listing served from a warm index equals the listing the same verb gives with the daemon stopped, byte for byte. Two worktrees of one repository resolve to one watched corpus, asserted. Stopping the daemon changes no verb's output and no verb's exit code. cargo test is green and cargo fmt --check passes.
 criteria_by: creator
 schema: 4
-version: 2
+version: 4
 ---
 
 The floor ADR-a22cd3196529 rests on, and the two assertions in the criterion are

--- a/.ank/entities/TASK-f8802467b622.md
+++ b/.ank/entities/TASK-f8802467b622.md
@@ -5,7 +5,7 @@ slug: the-daemon-watches-the-corpora-it-was-handed-and
 title: The daemon watches the corpora it was handed, and every verb behaves as if it were absent
 created: 2026-08-24T22:02:58Z
 author: claude-code/opus-5+planning
-status: in_progress
+status: done
 scope:
   - crates/ank-daemon/**
   - Cargo.toml
@@ -15,8 +15,13 @@ blocked_by: []
 done_criteria: |
   A sibling binary in this workspace takes a declaration of corpora to watch, keyed on the repository identity of ADR-621a7fd96ce1 and never on a path, held outside the repositories the way ADR-96174f1ac2b7 holds one, and refuses to start on a declaration naming a directory with no .ank rather than searching for one. It walks no filesystem looking for a corpus, and a test asserts that by pointing it at a tree holding an undeclared corpus and showing it is never read. It keeps each declared corpus's index current as files under .ank change, and a test shows a listing served from a warm index equals the listing the same verb gives with the daemon stopped, byte for byte. Two worktrees of one repository resolve to one watched corpus, asserted. Stopping the daemon changes no verb's output and no verb's exit code. cargo test is green and cargo fmt --check passes.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 03a8e33144a60cd3407651279523cc2625f72e5d
+    criteria: e560893fbf21
+    via: submitted
 schema: 4
-version: 4
+version: 5
 ---
 
 The floor ADR-a22cd3196529 rests on, and the two assertions in the criterion are

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ank-daemon"
+version = "0.6.0"
+dependencies = [
+ "ank-contract",
+ "serde",
+ "serde_yaml",
+]
+
+[[package]]
 name = "ank-mcp"
 version = "0.6.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["crates/ank-core", "crates/ank-contract", "crates/ank-cli", "crates/ank-mcp"]
+members = ["crates/ank-core", "crates/ank-contract", "crates/ank-cli", "crates/ank-mcp", "crates/ank-daemon"]
 resolver = "2"

--- a/crates/ank-daemon/Cargo.toml
+++ b/crates/ank-daemon/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "ank-daemon"
+# ank-cli's version, for the reason ank-mcp's manifest gives: these binaries
+# come out of one build and describe one release, and a number of its own would
+# be a second answer to "which ank is this" with nothing to reconcile the two.
+version = "0.6.0"
+edition = "2021"
+# The workspace floor, for the reason ank-core's manifest gives: one lockfile,
+# one build.
+rust-version = "1.95"
+# Apache-2.0, like the whole tree (ADR-9f03438f5422).
+license = "Apache-2.0"
+description = "The Ank watcher: it keeps declared corpora warm, answers no verb, and nothing depends on it."
+
+[[bin]]
+name = "ank-daemon"
+path = "src/main.rs"
+
+[dependencies]
+# The exit codes, read out of the contract rather than typed as numbers
+# (ADR-6fd69efb629c). Nothing else is taken from it: this binary dispatches no
+# verb, so the verb table is not its business.
+ank-contract = { path = "../ank-contract" }
+# The declaration file, and nothing else. Both crates are already in this
+# workspace's lockfile -- `ank-core` and `ank-cli` read YAML with exactly this
+# pair -- so no third-party code enters the tree for the daemon (§13).
+serde = { version = "=1.0.210", features = ["derive"] }
+serde_yaml = "0.9"

--- a/crates/ank-daemon/src/declare.rs
+++ b/crates/ank-daemon/src/declare.rs
@@ -1,0 +1,319 @@
+//! The declaration: which corpora this reader wants kept warm
+//! (ADR-a22cd3196529).
+//!
+//! **Declared, never discovered.** ADR-621a7fd96ce1 says it and
+//! ADR-96174f1ac2b7 repeats it: nothing walks a filesystem looking for a
+//! corpus. A daemon that scanned a home directory for `.ank/` would be the
+//! single most natural implementation of this crate and the one the corpus
+//! refused in writing before it was proposed, so there is no scan here, no
+//! fallback to one, and no "if the declared path is wrong, try nearby". A
+//! declaration that names a directory carrying no corpus is a refusal.
+//!
+//! **Keyed on the repository identity, never on a path.** Two worktrees of one
+//! repository have two paths and one identity; two clones of two repositories
+//! can sit at one path on two machines. So the key is the root commit of
+//! ADR-621a7fd96ce1 and the value is where to look -- one place, or several
+//! when the reader keeps several checkouts. Several paths under one key are one
+//! watched corpus, which is the whole reason the key is not the path.
+//!
+//! **Held outside every repository**, in the reader's own configuration
+//! directory, on the rule ADR-96174f1ac2b7 fixed for `corpora.yml`: a pointer
+//! committed in a code repository is exactly the trace that decision exists to
+//! refuse, and a watcher's list of what somebody is working on is a worse trace
+//! than a corpus location.
+
+use crate::fail::{Fail, Result};
+use ank_contract::ExitCode;
+use serde::Deserialize;
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+/// The reader's watch list, under [`user_dir`].
+pub const WATCH_FILE: &str = "watch.yml";
+
+/// The only schema this build reads. A file declaring anything else is refused
+/// by number rather than read optimistically, for the reason `corpora.yml` is:
+/// a watcher that guessed at a format it does not know would be watching
+/// something nobody declared.
+const SUPPORTED_SCHEMA: u32 = 1;
+
+/// The corpus directory under a declared tree.
+///
+/// Spelled here rather than imported, because `ank-cli` has no library target:
+/// see the note in [`crate::warm`] about why this crate reaches the corpus
+/// through the binary and never through the code that reads it.
+pub const ANK_DIR: &str = ".ank";
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct WatchFileDoc {
+    schema: u32,
+    #[serde(default)]
+    watch: BTreeMap<String, Trees>,
+}
+
+/// One path, or several. A reader with one checkout writes a string; a reader
+/// with worktrees writes a list, and gets one watched corpus either way.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum Trees {
+    One(String),
+    Many(Vec<String>),
+}
+
+impl Trees {
+    fn paths(&self) -> Vec<&str> {
+        match self {
+            Trees::One(p) => vec![p.as_str()],
+            Trees::Many(ps) => ps.iter().map(String::as_str).collect(),
+        }
+    }
+}
+
+/// One corpus this daemon watches: an identity, and every checkout of it the
+/// reader declared.
+///
+/// **One entry per identity and never per path.** Two worktrees of one
+/// repository are two `roots` here, not two corpora -- each carries its own
+/// `.ank/index.db`, because each is its own checkout of the same committed
+/// files, and both are caches of the one corpus this names.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Watched {
+    pub identity: String,
+    pub roots: Vec<PathBuf>,
+}
+
+/// Where this reader's declarations live, or `None` where the environment names
+/// no home.
+///
+/// **The same rule `ank config --user` applies to `corpora.yml`**, deliberately
+/// and not by coincidence: a reader who declared a corpus in one file and a
+/// watch in another, under two different directories, would have two homes and
+/// no way to know it. `%APPDATA%\ank` on Windows; `$XDG_CONFIG_HOME/ank`
+/// elsewhere, falling back to `$HOME/.config/ank`. An empty value counts as
+/// unset, because a shell that exports a variable to nothing has said nothing
+/// and joining onto it would name a relative path under the current directory.
+///
+/// The rule is three lines of platform difference and the environment, so it is
+/// written here rather than depended on: `ank-cli` is a binary with no library
+/// target, and `the_watch_file_sits_beside_the_corpora_file` in this crate's
+/// suite drives both binaries to assert the two agree.
+pub fn user_dir() -> Option<PathBuf> {
+    let var = |key: &str| {
+        std::env::var_os(key)
+            .filter(|v| !v.is_empty())
+            .map(PathBuf::from)
+    };
+    if cfg!(windows) {
+        return var("APPDATA").map(|p| p.join("ank"));
+    }
+    if let Some(xdg) = var("XDG_CONFIG_HOME") {
+        return Some(xdg.join("ank"));
+    }
+    var("HOME").map(|p| p.join(".config").join("ank"))
+}
+
+/// The declaration file, wherever this reader's home is.
+pub fn watch_path() -> Result<PathBuf> {
+    user_dir().map(|d| d.join(WATCH_FILE)).ok_or_else(|| {
+        Fail::new(
+            ExitCode::Environment,
+            "no home directory in the environment, so there is nowhere to declare a corpus",
+        )
+        .with_hint(if cfg!(windows) {
+            "set APPDATA"
+        } else {
+            "set XDG_CONFIG_HOME or HOME"
+        })
+    })
+}
+
+/// A repository identity as ADR-621a7fd96ce1 defines it: the root commit, and
+/// therefore forty lowercase hex characters.
+fn is_identity(key: &str) -> bool {
+    key.len() == 40
+        && key
+            .bytes()
+            .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+}
+
+/// What the reader declared, resolved against the filesystem and against git.
+///
+/// Every refusal below is a refusal to *start*. A watcher that started on a
+/// declaration it could not honour would be warming nothing while reporting
+/// that it watches something, and the reader would find out when a listing was
+/// slow rather than when the file was wrong.
+pub fn resolve(
+    text: &str,
+    path: &Path,
+    identity_of: &dyn Fn(&Path) -> Option<String>,
+) -> Result<Vec<Watched>> {
+    let doc: WatchFileDoc = serde_yaml::from_str(text).map_err(|e| {
+        Fail::new(ExitCode::Environment, format!("{}: {e}", path.display())).with_hint(
+            "schema: 1 and a watch: map of repository identity to the path of a checkout, \
+             or to a list of them",
+        )
+    })?;
+    if doc.schema != SUPPORTED_SCHEMA {
+        return Err(Fail::new(
+            ExitCode::Environment,
+            format!(
+                "{}: schema {} is not {SUPPORTED_SCHEMA}",
+                path.display(),
+                doc.schema
+            ),
+        ));
+    }
+    if doc.watch.is_empty() {
+        return Err(Fail::new(
+            ExitCode::Environment,
+            format!(
+                "{}: nothing is declared, so there is nothing to watch",
+                path.display()
+            ),
+        )
+        .with_hint(
+            "a key is the root commit, which ank status --json prints under \"corpus\", \
+             and its value is the path of a checkout",
+        ));
+    }
+
+    let mut watched = Vec::new();
+    for (key, trees) in &doc.watch {
+        // **A key that is not an identity is refused by name.** The mistake
+        // this catches is the one ADR-96174f1ac2b7 names: a slug, a remote URL
+        // or a path typed where the root commit belongs. Each of those keys
+        // differently for one clone over ssh and one over https, for a fork and
+        // its upstream, and for a repository renamed on the forge -- and a
+        // wrong key that merely matched nothing would leave the corpus quietly
+        // unwatched, which is the one outcome worse than a refusal.
+        if !is_identity(key) {
+            return Err(Fail::new(
+                ExitCode::Environment,
+                format!("{}: '{key}' is not a repository identity", path.display()),
+            )
+            .with_hint(
+                "a key is the root commit, never a path, a remote or a slug: \
+                 ank status --json prints it under \"corpus\"",
+            ));
+        }
+        let declared = trees.paths();
+        if declared.is_empty() {
+            return Err(Fail::new(
+                ExitCode::Environment,
+                format!("{}: {key} declares no path", path.display()),
+            )
+            .with_hint("give it the path of a checkout, or remove the key"));
+        }
+        let mut roots: Vec<PathBuf> = Vec::new();
+        for raw in declared {
+            let root = PathBuf::from(raw);
+            // **No search, in either direction.** The walk up that `ank`
+            // performs from a working directory is a resolution the caller
+            // asked for; here the reader named a directory, and a directory
+            // that carries no corpus is a declaration to correct rather than a
+            // starting point for a hunt.
+            if !root.join(ANK_DIR).is_dir() {
+                return Err(Fail::new(
+                    ExitCode::Environment,
+                    format!("{raw} carries no {ANK_DIR}/, and nothing looks for one elsewhere"),
+                )
+                .with_hint(format!(
+                    "name the directory that contains {ANK_DIR}/, or ank init {raw}"
+                )));
+            }
+            // **The key is checked against the repository, not trusted.** This
+            // is what makes "keyed on the identity" a property rather than a
+            // label: without it, two checkouts of two different repositories
+            // filed under one key would be reported as one corpus, which is
+            // precisely the confusion a path key produces and this key exists
+            // to remove.
+            match identity_of(&root) {
+                Some(found) if found == *key => {}
+                Some(found) => {
+                    return Err(Fail::new(
+                        ExitCode::Environment,
+                        format!("{raw} is repository {found}, declared under {key}"),
+                    )
+                    .with_hint("file a checkout under its own root commit, or correct the key"));
+                }
+                None => {
+                    return Err(Fail::new(
+                        ExitCode::Environment,
+                        format!("{raw} has no root commit, so it has no identity to be keyed on"),
+                    )
+                    .with_hint(
+                        "a repository with no history cannot be keyed: commit, or drop the entry",
+                    ));
+                }
+            }
+            if !roots
+                .iter()
+                .any(|r: &PathBuf| same_dir(r.as_path(), root.as_path()))
+            {
+                roots.push(root);
+            }
+        }
+        watched.push(Watched {
+            identity: key.clone(),
+            roots,
+        });
+    }
+    Ok(watched)
+}
+
+/// Whether two paths name one directory, asked of the filesystem rather than of
+/// the strings.
+///
+/// One checkout declared twice -- once relative, once absolute, or once through
+/// a symlink -- is one root, and no textual comparison delivers that. A path
+/// that cannot be canonicalised does not exist, and by the time this is asked
+/// both have been shown to carry a `.ank/`.
+fn same_dir(a: &Path, b: &Path) -> bool {
+    match (std::fs::canonicalize(a), std::fs::canonicalize(b)) {
+        (Ok(a), Ok(b)) => a == b,
+        _ => a == b,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn none(_: &Path) -> Option<String> {
+        None
+    }
+
+    #[test]
+    fn a_key_that_is_not_a_root_commit_is_refused_by_name() {
+        let err = resolve(
+            "schema: 1\nwatch:\n  git@github.com:me/ank.git: /tmp\n",
+            Path::new("watch.yml"),
+            &none,
+        )
+        .unwrap_err();
+        assert_eq!(err.code, ExitCode::Environment);
+        assert!(
+            err.message.contains("is not a repository identity"),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn an_unknown_schema_is_refused_by_number() {
+        let err = resolve("schema: 7\nwatch: {}\n", Path::new("watch.yml"), &none).unwrap_err();
+        assert!(err.message.contains("schema 7 is not 1"), "{err:?}");
+    }
+
+    #[test]
+    fn an_empty_declaration_is_refused_rather_than_watched() {
+        let err = resolve("schema: 1\nwatch: {}\n", Path::new("watch.yml"), &none).unwrap_err();
+        assert!(err.message.contains("nothing is declared"), "{err:?}");
+    }
+
+    #[test]
+    fn an_unknown_field_is_refused() {
+        let err = resolve("schema: 1\nscan: true\n", Path::new("watch.yml"), &none).unwrap_err();
+        assert_eq!(err.code, ExitCode::Environment);
+    }
+}

--- a/crates/ank-daemon/src/fail.rs
+++ b/crates/ank-daemon/src/fail.rs
@@ -1,0 +1,45 @@
+//! A refusal, rendered the way the CLI renders one (§4).
+//!
+//! The daemon dispatches no verb and answers no question, so it has no output
+//! contract of its own. What it does have is a person reading its stderr when
+//! it will not start, and that person already knows one shape of refusal:
+//! `error[9]:` with the code §4 gives the cause, and an arrow naming the exact
+//! thing that resolves it. A second shape would be a second thing to learn for
+//! no gain, so this is the first one and nothing more.
+
+use ank_contract::ExitCode;
+use std::io::Write;
+
+pub type Result<T> = std::result::Result<T, Fail>;
+
+#[derive(Debug)]
+pub struct Fail {
+    pub code: ExitCode,
+    pub message: String,
+    pub hint: Option<String>,
+}
+
+impl Fail {
+    pub fn new(code: ExitCode, message: impl Into<String>) -> Fail {
+        Fail {
+            code,
+            message: message.into(),
+            hint: None,
+        }
+    }
+
+    /// The next command, or the exact correction. Every refusal in this crate
+    /// carries one, on the rule the CLI holds itself to: a refusal that names
+    /// no way forward is a refusal the reader has to guess past.
+    pub fn with_hint(mut self, hint: impl Into<String>) -> Fail {
+        self.hint = Some(hint.into());
+        self
+    }
+
+    pub fn report(&self, err: &mut dyn Write) {
+        let _ = writeln!(err, "error[{}]: {}", self.code, self.message);
+        if let Some(hint) = &self.hint {
+            let _ = writeln!(err, "  -> {hint}");
+        }
+    }
+}

--- a/crates/ank-daemon/src/main.rs
+++ b/crates/ank-daemon/src/main.rs
@@ -1,0 +1,338 @@
+//! `ank-daemon`: it keeps declared corpora warm, and that is the whole of it
+//! (ADR-a22cd3196529).
+//!
+//! **It answers no verb.** There is no query surface here, no socket, no
+//! protocol and no subset of the CLI wearing a different name. A caller that
+//! wants an answer runs `ank`, which finds a cache already warm. ADR-372b82af1ec7
+//! settled that a second surface is a generated full passthrough or it does not
+//! exist, and a daemon answering the three questions a board finds convenient
+//! would be the curated subset that decision refused, arrived at from the other
+//! direction.
+//!
+//! **Nothing depends on it.** Every verb behaves identically with this process
+//! absent; its absence is never an error and no route makes running it a
+//! condition of using ank. That is not modesty, it is what keeps one product
+//! from becoming two: the installation without a daemon is the one every CI
+//! runner, every container and every agent has, so it has to be the normal one,
+//! made slower rather than made lesser.
+//!
+//! **It watches what it was handed.** The declaration is
+//! [`declare::WATCH_FILE`], keyed on the repository identity of
+//! ADR-621a7fd96ce1, held outside every repository. Nothing here walks a
+//! filesystem looking for a corpus, in any direction, under any flag.
+//!
+//! What this build does not yet do, and where it is decided: it fetches
+//! nothing (TASK-a73bd7f1c8f0 carries ADR-a22cd3196529's `refs/ank/*` clause),
+//! and the change it notices reaches the reader as a line on stderr rather than
+//! as an event a program subscribes to (TASK-2f775b1cb32b). Both are additions
+//! to this floor and neither changes what a verb answers.
+
+mod declare;
+mod fail;
+mod warm;
+
+use ank_contract::ExitCode;
+use declare::Watched;
+use fail::{Fail, Result};
+use std::io::Write;
+use std::path::Path;
+use std::process::Command;
+use std::time::Duration;
+
+/// How often the declared corpora are looked at, when the caller names nothing.
+///
+/// A poll and not a subscription, because a subscription is a third-party crate
+/// and §13 spends one on necessity: what this buys over a stat of a directory
+/// holding a few hundred files is latency measured in milliseconds, on a
+/// process whose entire purpose is latency nobody is required to care about.
+///
+/// Half a second is under the time a person takes to move from one command to
+/// the next, and far above the cost of the walk, so the warm case is warm and
+/// the idle case is invisible.
+const DEFAULT_INTERVAL: Duration = Duration::from_millis(500);
+
+const USAGE: &str = "\
+ank-daemon                keeps the corpora you declared warm, so the ank you run answers sooner
+
+  --list                  print what would be watched, and watch nothing
+  --once                  warm every declared corpus once, then exit
+  --interval <ms>         how often to look (default 500)
+  --where                 print the declaration file this reader's environment names
+  --version               the build
+  --help                  this
+
+It declares nothing, answers no verb and holds no claim. Every verb behaves the
+same with it stopped, which is why stopping it is always safe.
+";
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let mut out = std::io::stdout();
+    let mut err = std::io::stderr();
+    match run(&args, &mut out, &mut err) {
+        Ok(code) => std::process::exit(code.code()),
+        Err(fail) => {
+            fail.report(&mut err);
+            std::process::exit(fail.code.code());
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct Options {
+    list: bool,
+    once: bool,
+    location: bool,
+    interval: Option<Duration>,
+}
+
+/// **An unknown argument is refused**, and refused with the environment code
+/// rather than passed along. A watcher that ignored a flag it did not know
+/// would be watching under a configuration its caller does not have.
+fn parse(args: &[String]) -> Result<Options> {
+    let mut opts = Options::default();
+    let mut it = args.iter();
+    while let Some(arg) = it.next() {
+        match arg.as_str() {
+            "--list" => opts.list = true,
+            "--once" => opts.once = true,
+            "--where" => opts.location = true,
+            "--interval" => {
+                let ms = it.next().ok_or_else(|| {
+                    Fail::new(
+                        ExitCode::Environment,
+                        "--interval expects a number of milliseconds",
+                    )
+                })?;
+                let ms: u64 = ms.parse().map_err(|_| {
+                    Fail::new(
+                        ExitCode::Environment,
+                        format!("--interval {ms} is not a number of milliseconds"),
+                    )
+                })?;
+                if ms == 0 {
+                    return Err(Fail::new(
+                        ExitCode::Environment,
+                        "--interval 0 would spin rather than watch",
+                    )
+                    .with_hint("give it a number of milliseconds, or take the default of 500"));
+                }
+                opts.interval = Some(Duration::from_millis(ms));
+            }
+            other => {
+                return Err(
+                    Fail::new(ExitCode::Environment, format!("unknown argument: {other}"))
+                        .with_hint("ank-daemon --help"),
+                )
+            }
+        }
+    }
+    Ok(opts)
+}
+
+fn run(args: &[String], out: &mut dyn Write, err: &mut dyn Write) -> Result<ExitCode> {
+    if args.iter().any(|a| a == "--help" || a == "-h") {
+        let _ = write!(out, "{USAGE}");
+        return Ok(ExitCode::Ok);
+    }
+    if args.iter().any(|a| a == "--version") {
+        // The shape `ank --version` uses, and the same number: the binaries come
+        // out of one build (ADR-e39a44f80e0e), so a caller holding both reads
+        // one answer rather than two it has to reconcile.
+        let _ = writeln!(out, "ank-daemon {}", env!("CARGO_PKG_VERSION"));
+        return Ok(ExitCode::Ok);
+    }
+    let opts = parse(args)?;
+    let path = declare::watch_path()?;
+    if opts.location {
+        let _ = writeln!(out, "{}", path.display());
+        return Ok(ExitCode::Ok);
+    }
+
+    let text = match std::fs::read_to_string(&path) {
+        Ok(text) => text,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Err(Fail::new(
+                ExitCode::Environment,
+                format!("{} does not exist, so nothing is declared", path.display()),
+            )
+            .with_hint(
+                "write schema: 1 and a watch: map of repository identity to the path of a \
+                 checkout; ank status --json prints the identity under \"corpus\"",
+            ))
+        }
+        Err(e) => {
+            return Err(Fail::new(
+                ExitCode::Environment,
+                format!("{}: {e}", path.display()),
+            ))
+        }
+    };
+    let watched = declare::resolve(&text, &path, &identity_of)?;
+
+    if opts.list {
+        report(&watched, out);
+        return Ok(ExitCode::Ok);
+    }
+
+    let ank = warm::locate_ank()?;
+    watch(
+        &watched,
+        &ank,
+        opts.once,
+        opts.interval.unwrap_or(DEFAULT_INTERVAL),
+        err,
+    );
+    Ok(ExitCode::Ok)
+}
+
+/// What is watched, as text and only as text.
+///
+/// No colour here at all, under ADR-0c8a12b4e0a1's split: the structure layer is
+/// emitted identically to every reader, and this process has no half that
+/// depends on who is reading -- its ordinary destination is a log file.
+fn report(watched: &[Watched], out: &mut dyn Write) {
+    let mut roots = 0;
+    for corpus in watched {
+        let _ = writeln!(out, "corpus {}", corpus.identity);
+        for root in &corpus.roots {
+            let _ = writeln!(out, "  {}", root.display());
+            roots += 1;
+        }
+    }
+    let _ = writeln!(
+        out,
+        "watching {} {}, {} {}",
+        watched.len(),
+        if watched.len() == 1 {
+            "corpus"
+        } else {
+            "corpora"
+        },
+        roots,
+        if roots == 1 { "checkout" } else { "checkouts" },
+    );
+}
+
+/// The identity a corpus is keyed on: the oldest root commit of `HEAD`
+/// (ADR-621a7fd96ce1).
+///
+/// The same question `ank status --json` answers under `"corpus"`, asked the
+/// same way -- `--reverse` so a history with several roots answers with the one
+/// the repository began at, and against `HEAD` rather than `--all` so fetching
+/// somebody's unrelated branch cannot rename this corpus.
+///
+/// **git is asked here and nowhere else in this crate.** A tree with no history
+/// has no identity and says so, which is a refusal at startup rather than a
+/// path silently standing in for a key.
+fn identity_of(root: &Path) -> Option<String> {
+    let out = Command::new("git")
+        .args(["rev-list", "--max-parents=0", "--reverse", "HEAD"])
+        .current_dir(root)
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .next()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// The loop: look, and read what moved.
+///
+/// The first pass warms every checkout unconditionally, because a daemon that
+/// waited for a change before doing anything would leave the reader cold for
+/// exactly as long as they were not editing -- which is most of the time, and
+/// all of the time that matters after a `git checkout`. That pass is a warming
+/// and not a change, so it says so: an event states what changed
+/// (ADR-a22cd3196529), and a first sighting is not one.
+fn watch(watched: &[Watched], ank: &Path, once: bool, interval: Duration, err: &mut dyn Write) {
+    // Flattened once, so the state and the checkout it belongs to are one
+    // value. The loop below indexes nothing.
+    let mut posts: Vec<Post> = Vec::new();
+    for corpus in watched {
+        let _ = writeln!(
+            err,
+            "watching {} ({} {})",
+            corpus.identity,
+            corpus.roots.len(),
+            if corpus.roots.len() == 1 {
+                "checkout"
+            } else {
+                "checkouts"
+            }
+        );
+        for root in &corpus.roots {
+            posts.push(Post {
+                identity: corpus.identity.clone(),
+                root: root.clone(),
+                seen: None,
+            });
+        }
+    }
+    loop {
+        for post in &mut posts {
+            let now = warm::fingerprint(&warm::ank_dir(&post.root));
+            let first = post.seen.is_none();
+            let moved = post.seen.as_ref() != Some(&now);
+            post.seen = Some(now);
+            if !moved {
+                continue;
+            }
+            if !first {
+                // What changed, and never what to do about it.
+                let _ = writeln!(err, "changed {} {}", post.identity, post.root.display());
+            }
+            // Degrades and never fails: nothing depends on this process, so one
+            // corpus the CLI refuses costs a line and the next poll.
+            if let Err(reason) = warm::warm(ank, &post.root) {
+                let _ = writeln!(err, "{} {}: {reason}", post.identity, post.root.display());
+            }
+        }
+        if once {
+            return;
+        }
+        std::thread::sleep(interval);
+    }
+}
+
+/// One checkout being watched, and what its `.ank/` looked like last time.
+struct Post {
+    identity: String,
+    root: std::path::PathBuf,
+    seen: Option<Vec<(String, u64, u128)>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn an_unknown_argument_is_refused_with_the_environment_code() {
+        let err = parse(&["--scan-everything".to_string()]).unwrap_err();
+        assert_eq!(err.code, ExitCode::Environment);
+        assert!(err.message.contains("--scan-everything"), "{err:?}");
+    }
+
+    #[test]
+    fn an_interval_of_zero_is_refused_rather_than_spun() {
+        let err = parse(&["--interval".to_string(), "0".to_string()]).unwrap_err();
+        assert!(err.message.contains("would spin"), "{err:?}");
+    }
+
+    #[test]
+    fn the_listing_counts_corpora_and_checkouts() {
+        let watched = vec![Watched {
+            identity: "a".repeat(40),
+            roots: vec![PathBuf::from("/one"), PathBuf::from("/two")],
+        }];
+        let mut out = Vec::new();
+        report(&watched, &mut out);
+        let text = String::from_utf8(out).unwrap();
+        assert!(text.contains("watching 1 corpus, 2 checkouts"), "{text}");
+    }
+}

--- a/crates/ank-daemon/src/warm.rs
+++ b/crates/ank-daemon/src/warm.rs
@@ -1,0 +1,179 @@
+//! Keeping a declared corpus's index current, and doing it through the CLI
+//! (ADR-a22cd3196529).
+//!
+//! **The daemon is not a second implementation of the index.** `index.rs` is a
+//! cache the CLI rebuilds from the files at read time, comparing a content hash
+//! per `.ank/` file against what it stored; warming it is running a read.
+//! Anything else here -- a second refresh written against the same schema, a
+//! second parser, a second set of hashes -- would be a second thing to keep in
+//! step with the format, and it would drift silently, because a stale cache
+//! answers rather than fails.
+//!
+//! So this spawns `ank` and asks it for a listing. That is also what keeps
+//! ADR-a22cd3196529's first clause true by construction: a process that has to
+//! run the CLI to learn anything is not a second dispatch path, because it has
+//! no dispatch of its own to be one. It is the rule ADR-8bd7ea0e8f2b already
+//! set for the terminal reader, applied to the one other thing that reads a
+//! corpus it did not write.
+//!
+//! **`--repo` and not a working directory.** The corpus is addressed by the
+//! flag §6 gives for exactly that, which short-circuits the walk. A daemon that
+//! set a current directory and let `ank` walk up from it would be discovering a
+//! corpus, one directory at a time.
+//!
+//! **The verb is a read and takes no claim.** `find` opens the index, refreshes
+//! what diverged, and writes nothing else; ADR-0bb7ea8991bc's rule that a claim
+//! is renewed by working and not by reporting is kept here by never touching a
+//! claim at all.
+//!
+//! **Nothing is believed over the files.** This is a cache warmer and its
+//! failure mode is a listing that costs what it always cost. So a poll that
+//! misses a change costs latency and never correctness -- the CLI hashes the
+//! files on the next read regardless -- which is why the fingerprint below is
+//! allowed to be as cheap as a stat.
+
+use crate::declare::ANK_DIR;
+use crate::fail::{Fail, Result};
+use ank_contract::ExitCode;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+/// Where the CLI is, told or found.
+///
+/// **Told first.** `ANK_BIN` is what a test uses and what anybody with the two
+/// binaries in unusual places uses; it is checked first so neither has to
+/// arrange a `PATH`.
+///
+/// **Then beside this binary**, which is the rule the release already follows
+/// for the pair it ships (ADR-e39a44f80e0e): where a route places `ank`, it
+/// places its siblings next to it. Then `PATH`, which is where a reader who
+/// installed one and built the other will have it.
+pub fn locate_ank() -> Result<PathBuf> {
+    if let Some(told) = std::env::var_os("ANK_BIN").filter(|v| !v.is_empty()) {
+        let path = PathBuf::from(told);
+        if path.is_file() {
+            return Ok(path);
+        }
+        return Err(Fail::new(
+            ExitCode::Environment,
+            format!("ANK_BIN names {}, which is not a file", path.display()),
+        )
+        .with_hint("unset ANK_BIN to look beside this binary and then on PATH"));
+    }
+    let exe = if cfg!(windows) { "ank.exe" } else { "ank" };
+    if let Some(sibling) = std::env::current_exe()
+        .ok()
+        .and_then(|p| p.parent().map(|d| d.join(exe)))
+        .filter(|p| p.is_file())
+    {
+        return Ok(sibling);
+    }
+    // `PATH`, resolved by the operating system when the name carries no
+    // separator. Whether it is there is answered by the first spawn rather than
+    // by a walk of `PATH` written here, which would be a third rule for finding
+    // an executable and would disagree with the shell on at least one platform.
+    Ok(PathBuf::from(exe))
+}
+
+/// What a `.ank/` looks like right now: every file under it, with its length
+/// and the instant it was last written.
+///
+/// **`index.db` is excluded, and that is load-bearing.** It is the file the
+/// warming writes, so counting it would make every refresh look like a change
+/// and the daemon would spin against its own output forever. Its journal and
+/// shared-memory siblings go with it for the same reason.
+///
+/// **A stat and not a hash.** The question this answers is "is it worth
+/// spawning a read", not "what is in these files": the CLI hashes them itself
+/// on the next read, so a fingerprint that misses a modification costs a
+/// listing that is cold, exactly as if no daemon were running, and never a
+/// wrong answer.
+pub fn fingerprint(ank: &Path) -> Vec<(String, u64, u128)> {
+    let mut out = Vec::new();
+    walk(ank, ank, &mut out);
+    out.sort();
+    out
+}
+
+fn walk(root: &Path, dir: &Path, out: &mut Vec<(String, u64, u128)>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Ok(meta) = entry.metadata() else { continue };
+        if meta.is_dir() {
+            walk(root, &path, out);
+            continue;
+        }
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if name.starts_with("index.db") {
+            continue;
+        }
+        let rel = path
+            .strip_prefix(root)
+            .unwrap_or(&path)
+            .to_string_lossy()
+            .replace('\\', "/");
+        let mtime = meta
+            .modified()
+            .ok()
+            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        out.push((rel, meta.len(), mtime));
+    }
+}
+
+/// One read of `root`'s corpus, which is what leaves its index current.
+///
+/// Degrades and never fails: a corpus the CLI refuses -- a schema this build
+/// does not read, a directory somebody removed under the daemon -- costs one
+/// line on stderr and the next poll. Nothing depends on this process, so
+/// nothing may be broken by it giving up on one corpus.
+pub fn warm(ank_bin: &Path, root: &Path) -> std::result::Result<(), String> {
+    let out = Command::new(ank_bin)
+        .arg("find")
+        .arg("--repo")
+        .arg(root)
+        .arg("--status")
+        .arg("open")
+        .arg("--json")
+        .arg("--quiet")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .output()
+        .map_err(|e| format!("{}: {e}", ank_bin.display()))?;
+    if out.status.success() {
+        return Ok(());
+    }
+    let said = String::from_utf8_lossy(&out.stderr);
+    Err(said.lines().next().unwrap_or("no reason given").to_string())
+}
+
+/// The corpus directory of a declared checkout.
+pub fn ank_dir(root: &Path) -> PathBuf {
+    root.join(ANK_DIR)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_fingerprint_ignores_the_file_the_warming_writes() {
+        let dir = std::env::temp_dir().join(format!("ank-daemon-fp-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("entities")).unwrap();
+        std::fs::write(dir.join("config.yml"), "schema: 4\n").unwrap();
+        let before = fingerprint(&dir);
+        std::fs::write(dir.join("index.db"), "not a database").unwrap();
+        std::fs::write(dir.join("index.db-wal"), "nor this").unwrap();
+        assert_eq!(before, fingerprint(&dir));
+        std::fs::write(dir.join("entities/TASK-0000.md"), "---\n").unwrap();
+        assert_ne!(before, fingerprint(&dir));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/crates/ank-daemon/tests/daemon.rs
+++ b/crates/ank-daemon/tests/daemon.rs
@@ -1,0 +1,703 @@
+//! The daemon, driven as a process.
+//!
+//! Driven rather than called, on the rule this repository learned twice: a
+//! criterion that talks about the binary is tested through the binary, because
+//! green unit tests have twice covered code that was right on a path the binary
+//! never reached. Every claim ADR-a22cd3196529 makes is a claim about a running
+//! process -- what it reads, what it leaves untouched, and what stopping it
+//! changes -- and none of them can be asserted from inside a function.
+//!
+//! Two of the assertions here are the two ways this is usually got wrong.
+//! `nothing_walks_a_filesystem_looking_for_a_corpus` plants corpora above,
+//! beside and below the declared one, and shows they stay unread: the friendly
+//! implementation that scans is the one the corpus refused in writing, and this
+//! is what makes it fail rather than ship. And
+//! `a_warm_listing_equals_a_cold_listing_byte_for_byte` is how the cache stops
+//! being trusted -- the moment a warm listing and a cold one differ, the daemon
+//! has become a source of truth nobody voted for.
+
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Output, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::OnceLock;
+use std::time::{Duration, Instant};
+
+// ---------------------------------------------------------------------------
+// The one door
+// ---------------------------------------------------------------------------
+
+/// git's global and system configuration, for every process this suite spawns.
+///
+/// The CLI's own suite learned this the expensive way: on a machine that signs
+/// by default, fixtures depended on a gpg agent staying unlocked and failed the
+/// moment pinentry timed out, while CI -- where nothing signs -- passed forever.
+/// A fixture may not inherit what it did not declare.
+fn isolated_git_config() -> &'static Path {
+    static PATH: OnceLock<PathBuf> = OnceLock::new();
+    PATH.get_or_init(|| {
+        let p =
+            std::env::temp_dir().join(format!("ank-daemon-it-gitconfig-{}", std::process::id()));
+        std::fs::write(&p, "[commit]\n\tgpgsign = false\n").unwrap();
+        p
+    })
+    .as_path()
+}
+
+/// The binaries, found the way the daemon itself finds `ank`: beside the one
+/// cargo built. In a test tree that is `target/<profile>/`, which is where
+/// cargo puts every binary of the workspace.
+fn bin(name: &str) -> PathBuf {
+    let daemon = PathBuf::from(env!("CARGO_BIN_EXE_ank-daemon"));
+    let dir = daemon.parent().expect("a built binary has a directory");
+    let exe = if cfg!(windows) {
+        format!("{name}.exe")
+    } else {
+        name.to_string()
+    };
+    dir.join(exe)
+}
+
+/// A temporary directory nothing else in this suite uses.
+fn scratch(what: &str) -> PathBuf {
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let root = std::env::temp_dir().join(format!(
+        "ank-daemon-it-{what}-{}-{}",
+        std::process::id(),
+        SEQ.fetch_add(1, Ordering::Relaxed)
+    ));
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(&root).unwrap();
+    root
+}
+
+/// A reader's configuration home, holding the watch file and nothing else.
+///
+/// Both platform rules are pointed at one directory, so the file this suite
+/// writes is the file the daemon reads on Windows and elsewhere alike:
+/// `%APPDATA%\ank` and `$XDG_CONFIG_HOME/ank` resolve to the same place here.
+struct Home(PathBuf);
+
+impl Home {
+    fn new() -> Home {
+        let dir = scratch("home");
+        std::fs::create_dir_all(dir.join("ank")).unwrap();
+        Home(dir)
+    }
+
+    fn declare(&self, body: &str) {
+        std::fs::write(self.0.join("ank").join("watch.yml"), body).unwrap();
+    }
+
+    fn watch_file(&self) -> PathBuf {
+        self.0.join("ank").join("watch.yml")
+    }
+
+    fn apply(&self, cmd: &mut Command) {
+        let config = isolated_git_config();
+        cmd.env("GIT_CONFIG_GLOBAL", config)
+            .env("GIT_CONFIG_SYSTEM", config)
+            .env("XDG_CONFIG_HOME", &self.0)
+            .env("APPDATA", &self.0)
+            .env("HOME", &self.0)
+            .env("ANK_AGENT", "test@ank.local");
+    }
+
+    fn daemon(&self, args: &[&str]) -> Command {
+        let mut c = Command::new(bin("ank-daemon"));
+        c.args(args);
+        self.apply(&mut c);
+        c
+    }
+}
+
+/// A git repository carrying a corpus, built through the CLI.
+struct Corpus {
+    root: PathBuf,
+}
+
+impl Corpus {
+    fn new(root: PathBuf, home: &Home) -> Corpus {
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(root.join("src/main.rs"), "fn main() {}\n").unwrap();
+        let corpus = Corpus { root };
+        corpus.git(home, &["init", "-q", "-b", "main"]);
+        corpus.git(home, &["config", "user.email", "test@ank.local"]);
+        corpus.git(home, &["config", "user.name", "Test"]);
+        corpus.git(home, &["config", "commit.gpgsign", "false"]);
+        corpus.ank(home, &["init"]);
+        corpus.ank(home, &["config", "default_branch", "main"]);
+        corpus.ank(
+            home,
+            &[
+                "new",
+                "task",
+                "--title",
+                "A watched task",
+                "--scope",
+                "src/**",
+            ],
+        );
+        corpus.git(home, &["add", "-A"]);
+        corpus.git(home, &["commit", "-qm", "the corpus"]);
+        corpus
+    }
+
+    fn git(&self, home: &Home, args: &[&str]) -> Output {
+        let mut c = Command::new("git");
+        c.args(args).current_dir(&self.root);
+        home.apply(&mut c);
+        let out = c
+            .output()
+            .expect("git is a hard dependency of this repository");
+        assert!(
+            out.status.success(),
+            "git {args:?} in {}: {}",
+            self.root.display(),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        out
+    }
+
+    fn ank_raw(&self, home: &Home, args: &[&OsStr], cwd: &Path) -> Output {
+        let mut c = Command::new(bin("ank"));
+        c.args(args).current_dir(cwd);
+        home.apply(&mut c);
+        c.output()
+            .expect("cargo builds every binary of the workspace before running a test")
+    }
+
+    fn ank(&self, home: &Home, args: &[&str]) -> Output {
+        let owned: Vec<&OsStr> = args.iter().map(OsStr::new).collect();
+        let out = self.ank_raw(home, &owned, &self.root);
+        assert!(
+            out.status.success(),
+            "ank {args:?} in {}: {}",
+            self.root.display(),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        out
+    }
+
+    fn ank_dir(&self) -> PathBuf {
+        self.root.join(".ank")
+    }
+
+    fn index(&self) -> PathBuf {
+        self.ank_dir().join("index.db")
+    }
+
+    fn identity(&self, home: &Home) -> String {
+        let out = self.git(home, &["rev-list", "--max-parents=0", "--reverse", "HEAD"]);
+        String::from_utf8_lossy(&out.stdout)
+            .lines()
+            .next()
+            .unwrap()
+            .trim()
+            .to_string()
+    }
+
+    fn task_id(&self, home: &Home) -> String {
+        let out = self.ank(home, &["find", "--status", "open", "--json"]);
+        let text = String::from_utf8_lossy(&out.stdout).to_string();
+        let at = text.find("\"id\":\"").expect("a corpus with one task");
+        text[at + 6..at + 6 + 17].to_string()
+    }
+
+    fn drop_index(&self) {
+        for suffix in ["", "-wal", "-shm"] {
+            let _ = std::fs::remove_file(self.ank_dir().join(format!("index.db{suffix}")));
+        }
+    }
+}
+
+/// Every file under a directory, with its bytes: the shape of "never touched".
+fn snapshot(dir: &Path) -> Vec<(String, Vec<u8>)> {
+    let mut out = Vec::new();
+    fn walk(root: &Path, dir: &Path, out: &mut Vec<(String, Vec<u8>)>) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                walk(root, &path, out);
+                continue;
+            }
+            let rel = path
+                .strip_prefix(root)
+                .unwrap_or(&path)
+                .to_string_lossy()
+                .replace('\\', "/");
+            out.push((rel, std::fs::read(&path).unwrap_or_default()));
+        }
+    }
+    walk(dir, dir, &mut out);
+    out.sort();
+    out
+}
+
+/// A running daemon, stopped when the test drops it.
+struct Running(Child);
+
+impl Drop for Running {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+impl Running {
+    fn stop(mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+fn start(home: &Home, args: &[&str]) -> Running {
+    let mut cmd = home.daemon(args);
+    cmd.stdout(Stdio::null()).stderr(Stdio::null());
+    Running(cmd.spawn().expect("the daemon must have been built"))
+}
+
+/// Waits for a condition the daemon is meant to produce.
+///
+/// Bounded, and generous: this is asserting that something happens at all, not
+/// how fast, so the wall is high enough that a loaded runner never reports the
+/// runner instead of the code.
+fn until(what: &str, mut done: impl FnMut() -> bool) {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    while Instant::now() < deadline {
+        if done() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    panic!("timed out waiting for {what}");
+}
+
+/// The bytes of a file the daemon has stopped writing.
+///
+/// Two identical, non-empty reads a poll apart. Without this, "the index
+/// changed" would be satisfied by the tail of the write that produced it, and
+/// the assertion would pass whether or not anything was ever reindexed.
+fn settled(path: &Path) -> Vec<u8> {
+    let mut last: Option<Vec<u8>> = None;
+    let deadline = Instant::now() + Duration::from_secs(30);
+    while Instant::now() < deadline {
+        let now = std::fs::read(path).unwrap_or_default();
+        if !now.is_empty() && last.as_deref() == Some(now.as_slice()) {
+            return now;
+        }
+        last = Some(now);
+        std::thread::sleep(Duration::from_millis(300));
+    }
+    panic!("timed out waiting for {} to settle", path.display());
+}
+
+// ---------------------------------------------------------------------------
+// Starting, and refusing to
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_declaration_naming_a_directory_with_no_ank_refuses_to_start() {
+    let home = Home::new();
+    let corpus = Corpus::new(scratch("declared").join("tree"), &home);
+    let bare = scratch("bare");
+    home.declare(&format!(
+        "schema: 1\nwatch:\n  {}: {}\n",
+        corpus.identity(&home),
+        bare.display()
+    ));
+    let out = home.daemon(&["--once"]).output().unwrap();
+    assert_eq!(out.status.code(), Some(9), "{out:?}");
+    let said = String::from_utf8_lossy(&out.stderr);
+    assert!(said.contains(&bare.display().to_string()), "{said}");
+    assert!(
+        said.contains("nothing looks for one elsewhere"),
+        "the refusal has to say it does not search: {said}"
+    );
+}
+
+#[test]
+fn a_checkout_filed_under_another_repositorys_identity_refuses_to_start() {
+    let home = Home::new();
+    let mine = Corpus::new(scratch("mine").join("tree"), &home);
+    let theirs = Corpus::new(scratch("theirs").join("tree"), &home);
+    home.declare(&format!(
+        "schema: 1\nwatch:\n  {}: {}\n",
+        mine.identity(&home),
+        theirs.root.display()
+    ));
+    let out = home.daemon(&["--once"]).output().unwrap();
+    assert_eq!(out.status.code(), Some(9), "{out:?}");
+    let said = String::from_utf8_lossy(&out.stderr);
+    assert!(said.contains(&theirs.identity(&home)), "{said}");
+    assert!(said.contains(&mine.identity(&home)), "{said}");
+}
+
+#[test]
+fn a_declaration_that_does_not_exist_refuses_to_start() {
+    let home = Home::new();
+    let out = home.daemon(&["--once"]).output().unwrap();
+    assert_eq!(out.status.code(), Some(9), "{out:?}");
+    let said = String::from_utf8_lossy(&out.stderr);
+    assert!(said.contains("watch.yml"), "{said}");
+}
+
+#[test]
+fn the_watch_file_sits_beside_the_corpora_file() {
+    let home = Home::new();
+    let corpus = Corpus::new(scratch("beside").join("tree"), &home);
+    // The CLI writes its own declarations wherever this reader's home is
+    // (ADR-96174f1ac2b7), and the daemon has to agree about where that is: a
+    // reader with two homes has none. Both binaries are asked, and the answers
+    // are compared rather than assumed.
+    corpus.ank(
+        &home,
+        &[
+            "config",
+            "--user",
+            &format!("corpora.{}", corpus.identity(&home)),
+            &corpus.root.display().to_string(),
+        ],
+    );
+    let out = home.daemon(&["--where"]).output().unwrap();
+    assert!(out.status.success(), "{out:?}");
+    let said = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    assert_eq!(Path::new(&said), home.watch_file());
+    assert!(
+        home.watch_file()
+            .parent()
+            .unwrap()
+            .join("corpora.yml")
+            .is_file(),
+        "the CLI wrote its declarations somewhere else"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Declared, never discovered
+// ---------------------------------------------------------------------------
+
+#[test]
+fn nothing_walks_a_filesystem_looking_for_a_corpus() {
+    let home = Home::new();
+    let root = scratch("neighbourhood");
+    // Three corpora nobody declared, planted in the three places a scan looks:
+    // above the declared one, beside it, and inside it.
+    let above = Corpus::new(root.join("above"), &home);
+    let declared = Corpus::new(root.join("above").join("declared"), &home);
+    let beside = Corpus::new(root.join("above").join("beside"), &home);
+    let below = Corpus::new(root.join("above").join("declared").join("below"), &home);
+    for undeclared in [&above, &beside, &below] {
+        undeclared.drop_index();
+    }
+    home.declare(&format!(
+        "schema: 1\nwatch:\n  {}: {}\n",
+        declared.identity(&home),
+        declared.root.display()
+    ));
+
+    let listed = home.daemon(&["--list"]).output().unwrap();
+    assert!(listed.status.success(), "{listed:?}");
+    let text = String::from_utf8_lossy(&listed.stdout);
+    assert!(text.contains("watching 1 corpus, 1 checkout"), "{text}");
+    assert!(
+        text.contains(&declared.root.display().to_string()),
+        "{text}"
+    );
+
+    let before: Vec<_> = [&above, &beside, &below]
+        .iter()
+        .map(|c| snapshot(&c.ank_dir()))
+        .collect();
+    let out = home.daemon(&["--once"]).output().unwrap();
+    assert!(out.status.success(), "{out:?}");
+    assert!(
+        declared.index().is_file(),
+        "the declared corpus is the one warmed"
+    );
+
+    for (undeclared, was) in [&above, &beside, &below].iter().zip(before) {
+        // **Opening an index writes it.** So the absence of `index.db` is not a
+        // proxy for "never read": it is the read itself, which cannot happen
+        // without leaving this file behind.
+        assert!(
+            !undeclared.index().exists(),
+            "{} was opened, and nothing declared it",
+            undeclared.root.display()
+        );
+        assert_eq!(
+            snapshot(&undeclared.ank_dir()),
+            was,
+            "{} changed under a daemon that was never told about it",
+            undeclared.root.display()
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// One repository, one corpus
+// ---------------------------------------------------------------------------
+
+#[test]
+fn two_worktrees_of_one_repository_resolve_to_one_watched_corpus() {
+    let home = Home::new();
+    let root = scratch("worktrees");
+    let first = Corpus::new(root.join("first"), &home);
+    let second_path = root.join("second");
+    first.git(
+        &home,
+        &["worktree", "add", "-q", &second_path.display().to_string()],
+    );
+    let second = Corpus { root: second_path };
+    assert!(
+        second.ank_dir().is_dir(),
+        "a worktree checks out the corpus files like any other tree"
+    );
+    // Two paths, one key. The key is the root commit, which both worktrees
+    // share and neither path carries (ADR-621a7fd96ce1).
+    home.declare(&format!(
+        "schema: 1\nwatch:\n  {}:\n    - {}\n    - {}\n",
+        first.identity(&home),
+        first.root.display(),
+        second.root.display()
+    ));
+    assert_eq!(first.identity(&home), second.identity(&home));
+
+    let listed = home.daemon(&["--list"]).output().unwrap();
+    assert!(listed.status.success(), "{listed:?}");
+    let text = String::from_utf8_lossy(&listed.stdout);
+    assert!(
+        text.contains("watching 1 corpus, 2 checkouts"),
+        "two worktrees are one corpus: {text}"
+    );
+    assert_eq!(
+        text.lines().filter(|l| l.starts_with("corpus ")).count(),
+        1,
+        "{text}"
+    );
+
+    first.drop_index();
+    second.drop_index();
+    let out = home.daemon(&["--once"]).output().unwrap();
+    assert!(out.status.success(), "{out:?}");
+    assert!(
+        first.index().is_file(),
+        "every checkout of the corpus is kept warm"
+    );
+    assert!(
+        second.index().is_file(),
+        "every checkout of the corpus is kept warm"
+    );
+}
+
+#[test]
+fn one_checkout_declared_twice_is_one_checkout() {
+    let home = Home::new();
+    let corpus = Corpus::new(scratch("twice").join("tree"), &home);
+    home.declare(&format!(
+        "schema: 1\nwatch:\n  {}:\n    - {}\n    - {}\n",
+        corpus.identity(&home),
+        corpus.root.display(),
+        corpus.root.join(".").display()
+    ));
+    let listed = home.daemon(&["--list"]).output().unwrap();
+    let text = String::from_utf8_lossy(&listed.stdout);
+    assert!(text.contains("watching 1 corpus, 1 checkout"), "{text}");
+}
+
+// ---------------------------------------------------------------------------
+// The cache is a cache
+// ---------------------------------------------------------------------------
+
+/// The verbs compared, and why these: a listing served straight out of the
+/// index, a search served out of its full-text table, an entity read whole, the
+/// graph, the scope resolution, and the one verb that writes.
+const VERBS: &[&[&str]] = &[
+    &["find", "--status", "open", "--json"],
+    &["find", "watched", "--json"],
+    &["graph"],
+    &["scope", "src/**"],
+    &["check"],
+];
+
+fn listings(corpus: &Corpus, home: &Home, task: &str) -> Vec<(String, Vec<u8>, Option<i32>)> {
+    let mut out = Vec::new();
+    for verb in VERBS {
+        let owned: Vec<&OsStr> = verb.iter().map(|a| OsStr::new(*a)).collect();
+        let got = corpus.ank_raw(home, &owned, &corpus.root);
+        out.push((format!("{verb:?}"), got.stdout, got.status.code()));
+    }
+    let show: Vec<&OsStr> = vec![OsStr::new("show"), OsStr::new(task)];
+    let got = corpus.ank_raw(home, &show, &corpus.root);
+    out.push(("show".to_string(), got.stdout, got.status.code()));
+    out
+}
+
+#[test]
+fn a_warm_listing_equals_a_cold_listing_byte_for_byte() {
+    let home = Home::new();
+    let corpus = Corpus::new(scratch("warm").join("tree"), &home);
+    let task = corpus.task_id(&home);
+    home.declare(&format!(
+        "schema: 1\nwatch:\n  {}: {}\n",
+        corpus.identity(&home),
+        corpus.root.display()
+    ));
+
+    corpus.drop_index();
+    let out = home.daemon(&["--once"]).output().unwrap();
+    assert!(out.status.success(), "{out:?}");
+    assert!(corpus.index().is_file(), "the daemon warmed nothing");
+    let warm = listings(&corpus, &home, &task);
+
+    // Cold: no daemon has run, and no index exists for one to have left behind.
+    corpus.drop_index();
+    let cold = listings(&corpus, &home, &task);
+
+    for ((verb, warm_bytes, warm_code), (_, cold_bytes, cold_code)) in warm.iter().zip(&cold) {
+        assert_eq!(
+            String::from_utf8_lossy(warm_bytes),
+            String::from_utf8_lossy(cold_bytes),
+            "{verb} answered differently off a warm index"
+        );
+        assert_eq!(warm_code, cold_code, "{verb}");
+    }
+}
+
+#[test]
+fn the_index_follows_the_files_under_ank() {
+    let home = Home::new();
+    let corpus = Corpus::new(scratch("follows").join("tree"), &home);
+    home.declare(&format!(
+        "schema: 1\nwatch:\n  {}: {}\n",
+        corpus.identity(&home),
+        corpus.root.display()
+    ));
+    // A second entity, committed on a branch, so that a `git checkout` moves
+    // files under `.ank/` without the CLI ever being asked to. That is the case
+    // this exists for: a corpus changes under an agent that did not change it.
+    corpus.git(&home, &["checkout", "-q", "-b", "more"]);
+    corpus.ank(
+        &home,
+        &[
+            "new",
+            "task",
+            "--title",
+            "A later task",
+            "--scope",
+            "src/**",
+        ],
+    );
+    corpus.git(&home, &["add", "-A"]);
+    corpus.git(&home, &["commit", "-qm", "a later task"]);
+    corpus.git(&home, &["checkout", "-q", "main"]);
+    corpus.drop_index();
+
+    let daemon = start(&home, &["--interval", "50"]);
+    // **Settled, not merely present.** A file that exists may be one the daemon
+    // is still writing, and recording those bytes would make the wait below
+    // succeed against a half-written page rather than against a reindex. The
+    // daemon rewrites only what moved, so an unchanging corpus goes quiet.
+    let warmed = settled(&corpus.index());
+
+    corpus.git(&home, &["checkout", "-q", "more"]);
+    until("the index to follow the checkout", || {
+        std::fs::read(corpus.index()).unwrap_or_default() != warmed
+    });
+    daemon.stop();
+
+    // And what it reindexed is what the files say, which is the only property
+    // that matters: the listing off this index is the listing off no index.
+    let task = corpus.task_id(&home);
+    let warm = listings(&corpus, &home, &task);
+    corpus.drop_index();
+    let cold = listings(&corpus, &home, &task);
+    for ((verb, warm_bytes, warm_code), (_, cold_bytes, cold_code)) in warm.iter().zip(&cold) {
+        assert_eq!(
+            String::from_utf8_lossy(warm_bytes),
+            String::from_utf8_lossy(cold_bytes),
+            "{verb} answered differently after the daemon followed a checkout"
+        );
+        assert_eq!(warm_code, cold_code, "{verb}");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Nothing depends on it
+// ---------------------------------------------------------------------------
+
+#[test]
+fn stopping_the_daemon_changes_no_verbs_output_and_no_verbs_exit_code() {
+    let home = Home::new();
+    let corpus = Corpus::new(scratch("stopping").join("tree"), &home);
+    let task = corpus.task_id(&home);
+    home.declare(&format!(
+        "schema: 1\nwatch:\n  {}: {}\n",
+        corpus.identity(&home),
+        corpus.root.display()
+    ));
+
+    corpus.drop_index();
+    let daemon = start(&home, &["--interval", "50"]);
+    until("the daemon to warm the corpus", || corpus.index().is_file());
+    let running = listings(&corpus, &home, &task);
+    daemon.stop();
+
+    let stopped = listings(&corpus, &home, &task);
+    for ((verb, up_bytes, up_code), (_, down_bytes, down_code)) in running.iter().zip(&stopped) {
+        assert_eq!(
+            String::from_utf8_lossy(up_bytes),
+            String::from_utf8_lossy(down_bytes),
+            "{verb} is not the same verb with the daemon stopped"
+        );
+        assert_eq!(up_code, down_code, "{verb} changed its exit code");
+    }
+}
+
+#[test]
+fn the_only_thing_it_writes_into_a_repository_is_the_index() {
+    let home = Home::new();
+    let corpus = Corpus::new(scratch("writes").join("tree"), &home);
+    home.declare(&format!(
+        "schema: 1\nwatch:\n  {}: {}\n",
+        corpus.identity(&home),
+        corpus.root.display()
+    ));
+    corpus.drop_index();
+
+    let refs_before = corpus.git(&home, &["for-each-ref"]).stdout;
+    let head_before = corpus.git(&home, &["rev-parse", "HEAD"]).stdout;
+    let tree_before = snapshot(&corpus.root.join("src"));
+    let corpus_before: Vec<_> = snapshot(&corpus.ank_dir())
+        .into_iter()
+        .filter(|(name, _)| !name.starts_with("index.db"))
+        .collect();
+
+    let out = home.daemon(&["--once"]).output().unwrap();
+    assert!(out.status.success(), "{out:?}");
+    assert!(corpus.index().is_file());
+
+    assert_eq!(corpus.git(&home, &["for-each-ref"]).stdout, refs_before);
+    assert_eq!(
+        corpus.git(&home, &["rev-parse", "HEAD"]).stdout,
+        head_before
+    );
+    assert_eq!(snapshot(&corpus.root.join("src")), tree_before);
+    assert_eq!(
+        snapshot(&corpus.ank_dir())
+            .into_iter()
+            .filter(|(name, _)| !name.starts_with("index.db"))
+            .collect::<Vec<_>>(),
+        corpus_before,
+        "the corpus itself is read and never written"
+    );
+    assert!(
+        String::from_utf8_lossy(&corpus.git(&home, &["status", "--porcelain"]).stdout)
+            .trim()
+            .is_empty(),
+        "the working tree is not the daemon's to touch"
+    );
+}

--- a/docs/integrating.md
+++ b/docs/integrating.md
@@ -295,6 +295,63 @@ names one, so a deployment that already names its agents keeps naming them.
 curates nothing out. Being reachable over a protocol changes nothing about it:
 it still refuses off the default branch, with no way around it.
 
+## The watcher keeps a cache warm, and answers nothing
+
+`ank-daemon` is a background process that keeps the derived index of the corpora
+you declare current, so the `ank` you run finds a cache it does not have to
+rebuild. It is built from this workspace and no installation route ships it,
+which is the same statement as the one below about nothing depending on it.
+Everything else worth knowing about it as an integrator is what it refuses to be
+(ADR-a22cd3196529).
+
+**It is not a surface.** No socket, no protocol, no query of its own, and no
+subset of the verbs. There is nothing here to bind to: a caller that wants an
+answer runs the CLI, or talks to `ank-mcp`. A daemon answering the three
+questions a dashboard finds convenient would be the curated subset
+ADR-372b82af1ec7 refused, reached from the other direction, and it would be a
+third dispatch path in a project that has spent its history reducing to one.
+
+**Nothing depends on it.** Every verb gives the same output and the same exit
+code with it stopped; its absence is never an error, and no installation route
+makes running it a condition of using ank. The installation without a watcher is
+the one every CI runner, every container and every agent has, so it is the
+normal one, made slower rather than made lesser. Stopping it is always safe, and
+`stopping_the_daemon_changes_no_verbs_output_and_no_verbs_exit_code` in its
+suite is what keeps that true.
+
+**Nothing it serves is believed over the files.** The index is a cache the CLI
+rebuilds from a content hash per `.ank/` file at read time, so a listing off a
+warm index and a listing off no index are the same bytes. The watcher does not
+compute that listing and holds no copy of it: it spawns `ank` and asks for a
+read, which is what leaves the index current. It is a cache warmer, so a poll it
+misses costs latency and never correctness.
+
+**It watches what you declared, and looks for nothing.** The declaration is
+`watch.yml`, beside the `corpora.yml` of ADR-96174f1ac2b7 and under the same
+directory rule -- `%APPDATA%\ank` on Windows, `$XDG_CONFIG_HOME/ank` elsewhere,
+falling back to `$HOME/.config/ank`. It lives outside every repository, and it
+is keyed on the repository identity of ADR-621a7fd96ce1 rather than on a path:
+
+    schema: 1
+    watch:
+      # The key is the root commit, which `ank status --json` prints under
+      # "corpus". One checkout, or a list of them.
+      4f0b8c2d1e6a39572c84ab0d6f31e75c9a2b48d0: /home/me/work/ank
+      9c31ea77b04d5f2681ac3e095b7d4f60a8213ce5: /home/me/work/other
+
+Two worktrees of one repository are two paths under one key, and therefore one
+watched corpus -- which is the whole reason the key is not the path. A key that
+is not a root commit is refused by name, a checkout filed under another
+repository's identity is refused with both identities, and a directory carrying
+no `.ank/` is refused rather than searched around: `ank-daemon --list` prints
+what would be watched without watching anything.
+
+**The only thing it writes into a repository is that repository's own
+`index.db`.** No branch, no working tree, no index of git's, and no
+`refs/ank/claims`. It takes no claim, holds none on anybody's behalf, and
+renews none -- a claim is renewed by working, not by reporting
+(ADR-0bb7ea8991bc).
+
 ## What binds and what does not
 
 - **Bind to `--json`**, never to the human output. One line, stdout only, never
@@ -310,3 +367,7 @@ it still refuses off the default branch, with no way around it.
 - **`--repo <path>` addresses a corpus**, so a tool holding several addresses
   each on its own. Claims are per repository: nothing merges the claim spaces of
   two clones, because `refs/ank/*` cannot carry such an arbitration.
+- **Do not bind to `ank-daemon`.** It answers nothing, and it is optional by
+  construction. Write your integration against the CLI or the protocol surface,
+  and let the watcher make those answers arrive sooner where somebody chose to
+  run one.


### PR DESCRIPTION
Closes TASK-f8802467b622. `ank done --proof commit:03a8e33144a6` recorded the proof; the `attest` job takes it from here once this lands on main.

`ank-daemon` is the floor ADR-a22cd3196529 rests on: a fourth binary in the workspace that keeps the derived index of declared corpora current, so the `ank` a reader runs finds a cache it does not have to rebuild.

## What it watches, and what it refuses to look for

The declaration is `watch.yml`, beside the `corpora.yml` of ADR-96174f1ac2b7 and under the same directory rule, held outside every repository. It is keyed on the repository identity of ADR-621a7fd96ce1, so two worktrees of one repository are two paths under one key and therefore **one** watched corpus -- which is the whole reason the key is not the path. The key is checked against the repository rather than trusted, so a checkout filed under somebody else's root commit is refused with both identities. A directory carrying no `.ank/` is refused rather than searched around, and nothing walks a filesystem in any direction.

## Warming goes through the CLI

`ank find --repo <root> --status open --json --quiet`, spawned. Never a link of `index.rs`: `ank-cli` has no library target, and a second refresh written against the same schema would be a second thing to keep in step with the format, drifting in silence because a stale cache answers rather than fails. It is also what keeps the first clause of ADR-a22cd3196529 true by construction -- a process that has to run the CLI to learn anything has no dispatch of its own to be a second one. No file-watching crate enters the tree: the poll is a stat walk of the declared `.ank/`, and a poll it misses costs latency and never correctness, because the CLI hashes the files itself on the next read.

## What the suite asserts, through the binary

- Corpora planted **above, beside and below** the declared tree stay unread, asserted on the absence of the `index.db` that opening one would have written, plus a byte snapshot of each neighbour's `.ank/`.
- A warm listing equals a cold listing **byte for byte**, across six verbs, before and after a `git checkout` moves files under `.ank/` with the CLI never asked to.
- Two worktrees resolve to one watched corpus, and both checkouts are kept warm.
- Stopping the daemon changes no verb's output and no verb's exit code.
- The only thing it writes into a repository is that repository's own `index.db`: refs, HEAD, the working tree and the corpus files are compared before and after.

Mutating the change detection so only the first pass warms turns `the_index_follows_the_files_under_ank` red, so it measures the loop rather than the harness.

## Not in this change

The `refs/ank/*` fetch is TASK-a73bd7f1c8f0, which this unblocks. The event a reader subscribes to is TASK-2f775b1cb32b; a change reaches stderr here as a line and nothing more. No installation route ships the binary yet, and `docs/integrating.md` says so.

`Cargo.lock` entered the scope by `ank amend`, with the log entry saying why: cargo resolves one lockfile for the whole tree, so a fourth member cannot be added without it.

`cargo test --workspace` green, `cargo fmt --check` clean, `ank check` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01325DqDcNT9vSHNhKbMMd2Z