### PR TITLE
The installer offers the skills, and declining costs the install nothing

### DIFF
--- a/.ank/entities/LOG-0c638f134045.md
+++ b/.ank/entities/LOG-0c638f134045.md
@@ -1,0 +1,18 @@
+---
+id: LOG-0c638f134045
+type: log
+title: "The offer is gated on the same predicate the welcome is, minus the terminal width: the 24-column"
+created: 2026-08-25T03:09:12Z
+author: claude-code/opus-5+installer-skills
+scope:
+  - install.sh
+  - install.ps1
+about: TASK-5a2f1b47f204
+seq: 0
+schema: 4
+version: 1
+---
+
+ test is about the block of art and about nothing else, and a narrow terminal is still a terminal to ask at. So welcome_wanted splits into human_at_terminal plus the width, and both the logo and the offer read the first. On install.ps1 Test-WelcomeWanted already is that predicate -- the width lives inside Show-Logo -- so it is renamed rather than duplicated.
+
+Two traps found by reading rather than by running. First: npx must be handed /dev/tty as its standard input on POSIX. Under curl | sh standard input is the installer script, so an npx that prompts (a cold cache asks 'Ok to proceed?') would eat the rest of the file. Second: pwsh -File exits with $LASTEXITCODE, so a failing npx.cmd would become install.ps1's exit code with nothing in the script saying so. $global:LASTEXITCODE = 0 after the offer is what keeps the guarantee the criterion asks to falsify.

--- a/.ank/entities/LOG-6a740b40efb9.md
+++ b/.ank/entities/LOG-6a740b40efb9.md
@@ -1,0 +1,16 @@
+---
+id: LOG-6a740b40efb9
+type: log
+title: The criterion names install.yml as the place the exit-code claim is falsified, and install.yml is
+created: 2026-08-25T03:20:10Z
+author: claude-code/opus-5+installer-skills
+scope:
+  - install.sh
+  - install.ps1
+about: TASK-5a2f1b47f204
+seq: 1
+schema: 4
+version: 1
+---
+
+ not in the scope this task was written with. Amending it in rather than writing there quietly: the offer is two files of behaviour and one file of proof, and a perimeter that omits the proof is a perimeter that says the assertion belongs to nobody.

--- a/.ank/entities/LOG-98fb9ec08f13.md
+++ b/.ank/entities/LOG-98fb9ec08f13.md
@@ -1,0 +1,19 @@
+---
+id: LOG-98fb9ec08f13
+type: log
+title: "Rehearsed the unix step against a staged release on localhost, six pty runs: accept, Enter,"
+created: 2026-08-25T03:23:21Z
+author: claude-code/opus-5+installer-skills
+scope:
+  - install.sh
+  - install.ps1
+  - .github/workflows/install.yml
+about: TASK-5a2f1b47f204
+seq: 3
+schema: 4
+version: 1
+---
+
+ decline, EOT, --no-welcome, node absent. All six exit 0; the prompt appears exactly once except under --no-welcome where it appears not at all, and npx is reached only on accept and Enter.
+
+The negative control is the part worth recording. Dropping 'offer_skills || :' alone does not fail the step, because 'npx ... || offer_code=$?' already absorbs the failure -- the guard is a backstop for anything else in there, not for that. Writing the offer the naive way instead, with npx unguarded, makes accept and enter exit 1 and the step reports three FAILs. So what the step falsifies is the shape somebody would actually write.

--- a/.ank/entities/LOG-c007d94cc935.md
+++ b/.ank/entities/LOG-c007d94cc935.md
@@ -1,0 +1,15 @@
+---
+id: LOG-c007d94cc935
+type: log
+title: done, proof commit:f8b7116
+created: 2026-08-25T03:26:43Z
+author: claude-code/opus-5+installer-skills
+scope:
+  - install.sh
+  - install.ps1
+  - .github/workflows/install.yml
+about: TASK-5a2f1b47f204
+seq: 4
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-e3dbb71cb293.md
+++ b/.ank/entities/LOG-e3dbb71cb293.md
@@ -1,0 +1,16 @@
+---
+id: LOG-e3dbb71cb293
+type: log
+title: +scope .github/workflows/install.yml (version 2 to 3, replaced a0364eaf8d4d, produced eaab2f48ce95)
+created: 2026-08-25T03:20:13Z
+author: claude-code/opus-5+installer-skills
+scope:
+  - install.sh
+  - install.ps1
+  - .github/workflows/install.yml
+about: TASK-5a2f1b47f204
+seq: 2
+records: edit
+schema: 4
+version: 1
+---

--- a/.ank/entities/TASK-5a2f1b47f204.md
+++ b/.ank/entities/TASK-5a2f1b47f204.md
@@ -5,7 +5,7 @@ slug: the-installer-offers-the-skills-and-an-installed
 title: The installer offers the skills, and an installed ank is never the price of declining
 created: 2026-08-24T21:59:33Z
 author: claude-code/opus-5+planning
-status: in_progress
+status: done
 scope:
   - install.sh
   - install.ps1
@@ -14,8 +14,13 @@ blocked_by: [TASK-bbab313a4fea]
 done_criteria: |
   After the binary is installed and verified, and only with a terminal attached, both installers ask once whether to install the skills, defaulting to yes on Enter, reading the answer from /dev/tty on POSIX and from the console on Windows. On acceptance with node on PATH they run npx skills add haksolot/ank and report what it did. With node absent they print the command and one line saying why it was not run. Declining, answering nothing, having no terminal or passing the disabling flag leaves the machine in the state an installer without this step leaves it. No failure of the skill step changes the installer's exit code, and install.yml asserts that on all three platforms by making the step fail and showing the install still reports success.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: f8b7116
+    criteria: 02a26cd9ed4c
+    via: submitted
 schema: 4
-version: 3
+version: 4
 ---
 
 `npx skills add haksolot/ank` is what `skill/SKILL.md` already teaches, and it

--- a/.ank/entities/TASK-5a2f1b47f204.md
+++ b/.ank/entities/TASK-5a2f1b47f204.md
@@ -5,16 +5,17 @@ slug: the-installer-offers-the-skills-and-an-installed
 title: The installer offers the skills, and an installed ank is never the price of declining
 created: 2026-08-24T21:59:33Z
 author: claude-code/opus-5+planning
-status: open
+status: in_progress
 scope:
   - install.sh
   - install.ps1
+  - .github/workflows/install.yml
 blocked_by: [TASK-bbab313a4fea]
 done_criteria: |
   After the binary is installed and verified, and only with a terminal attached, both installers ask once whether to install the skills, defaulting to yes on Enter, reading the answer from /dev/tty on POSIX and from the console on Windows. On acceptance with node on PATH they run npx skills add haksolot/ank and report what it did. With node absent they print the command and one line saying why it was not run. Declining, answering nothing, having no terminal or passing the disabling flag leaves the machine in the state an installer without this step leaves it. No failure of the skill step changes the installer's exit code, and install.yml asserts that on all three platforms by making the step fail and showing the install still reports success.
 criteria_by: creator
 schema: 4
-version: 1
+version: 3
 ---
 
 `npx skills add haksolot/ank` is what `skill/SKILL.md` already teaches, and it

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1107,14 +1107,13 @@ jobs:
               [switch]$NoWelcome
           )
 
-          # A switch and not a list of extra arguments, which is what the first
-          # run of this step taught: `pwsh -File probe.ps1 -Extra -NoWelcome`
-          # hands the binder a value that begins with a dash, it reads it as a
-          # parameter name of its own, and the flag arrives nowhere. The
-          # argument install.ps1 is given is built here, where nothing has to
-          # survive a command line.
-          $extraArgs = @()
-          if ($NoWelcome) { $extraArgs += '-NoWelcome' }
+          # A switch, and the call written out twice rather than splatted, both
+          # for the same reason: a flag whose name begins with a dash does not
+          # survive being carried as a value. `-Extra -NoWelcome` on a
+          # `pwsh -File` command line is read as a parameter name of its own,
+          # and `@extraArgs` holding '-NoWelcome' is splatted positionally at a
+          # script that takes nothing positionally. Both arrived nowhere, and
+          # both left install.ps1 asking. Two literal call sites cannot.
 
           # A console of its own is the whole point of this file, so it is
           # asserted and not assumed: a probe that quietly lost its console
@@ -1150,11 +1149,20 @@ jobs:
           # one an exiting child sets is the one the engine keeps: seeded and
           # read here they would be two variables wearing one name, and a
           # refusal from install.ps1 would read back as a success.
+          $installer = Join-Path $PSScriptRoot 'install.ps1'
           $global:LASTEXITCODE = 0
-          $out = (& (Join-Path $PSScriptRoot 'install.ps1') `
-              -Version $env:STAGED_VERSION -Dir $Dir @extraArgs *>&1 | Out-String)
+          if ($NoWelcome) {
+              $out = (& $installer -Version $env:STAGED_VERSION -Dir $Dir -NoWelcome *>&1 | Out-String)
+          } else {
+              $out = (& $installer -Version $env:STAGED_VERSION -Dir $Dir *>&1 | Out-String)
+          }
           $code = $global:LASTEXITCODE
-          Set-Content -Path $OutFile -Value $out
+
+          # What the probe was told, recorded beside what the installer said.
+          # Without it, "-NoWelcome asked anyway" is the same message whether
+          # the installer ignored the switch or the harness never delivered it,
+          # and those are repairs in different files.
+          Set-Content -Path $OutFile -Value ("probe: NoWelcome=$([bool]$NoWelcome)`r`n" + $out)
           Set-Content -Path $CodeFile -Value "$code"
           exit 0
           '@
@@ -1265,6 +1273,10 @@ jobs:
           # since without a console there is nothing to differ from.
           $run = Invoke-Case -Label 'noflag' -Answer 'y' -NoWelcome
           Want $run ($run.Code -eq 0) "exit $($run.Code)"
+          # Asked first, because it separates the two repairs: a probe that was
+          # never handed the switch is a defect in this file, and one that was
+          # and still saw a question is a defect in install.ps1.
+          Want $run ($run.Out -match 'probe: NoWelcome=True') 'the probe was never handed the switch'
           Want $run ($run.Asked -eq 0) '-NoWelcome asked anyway'
           Want $run (-not $run.Ran) '-NoWelcome ran npx anyway'
           Want $run ($run.Out -notmatch '####') '-NoWelcome drew the logo at a console'

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1104,8 +1104,17 @@ jobs:
               [Parameter(Mandatory = $true)][string]$Dir,
               [Parameter(Mandatory = $true)][string]$OutFile,
               [Parameter(Mandatory = $true)][string]$CodeFile,
-              [string[]]$Extra = @()
+              [switch]$NoWelcome
           )
+
+          # A switch and not a list of extra arguments, which is what the first
+          # run of this step taught: `pwsh -File probe.ps1 -Extra -NoWelcome`
+          # hands the binder a value that begins with a dash, it reads it as a
+          # parameter name of its own, and the flag arrives nowhere. The
+          # argument install.ps1 is given is built here, where nothing has to
+          # survive a command line.
+          $extraArgs = @()
+          if ($NoWelcome) { $extraArgs += '-NoWelcome' }
 
           # A console of its own is the whole point of this file, so it is
           # asserted and not assumed: a probe that quietly lost its console
@@ -1143,7 +1152,7 @@ jobs:
           # refusal from install.ps1 would read back as a success.
           $global:LASTEXITCODE = 0
           $out = (& (Join-Path $PSScriptRoot 'install.ps1') `
-              -Version $env:STAGED_VERSION -Dir $Dir @Extra *>&1 | Out-String)
+              -Version $env:STAGED_VERSION -Dir $Dir @extraArgs *>&1 | Out-String)
           $code = $global:LASTEXITCODE
           Set-Content -Path $OutFile -Value $out
           Set-Content -Path $CodeFile -Value "$code"
@@ -1158,7 +1167,7 @@ jobs:
           $failures = New-Object System.Collections.ArrayList
 
           function Invoke-Case {
-              param([string]$Label, [string]$Answer, [string[]]$Extra = @(), [switch]$NoNode)
+              param([string]$Label, [string]$Answer, [switch]$NoWelcome, [switch]$NoNode)
 
               $marker = Join-Path $PWD "marker-$Label"
               $dir = Join-Path $PWD "bin-$Label"
@@ -1170,7 +1179,7 @@ jobs:
 
               $argv = @('-NoProfile', '-File', 'probe.ps1', '-Answer', $Answer,
                         '-Dir', $dir, '-OutFile', $outFile, '-CodeFile', $codeFile)
-              if ($Extra.Count) { $argv += '-Extra'; $argv += $Extra }
+              if ($NoWelcome) { $argv += '-NoWelcome' }
 
               # Hidden, and hidden is what forces the launch through
               # ShellExecute: that is the path which gives the child a console
@@ -1254,7 +1263,7 @@ jobs:
           # This is the only place ADR-5fbd99bf6fd5's "differs in no outcome
           # from an interactive run that declined everything" can be measured,
           # since without a console there is nothing to differ from.
-          $run = Invoke-Case -Label 'noflag' -Answer 'y' -Extra @('-NoWelcome')
+          $run = Invoke-Case -Label 'noflag' -Answer 'y' -NoWelcome
           Want $run ($run.Code -eq 0) "exit $($run.Code)"
           Want $run ($run.Asked -eq 0) '-NoWelcome asked anyway'
           Want $run (-not $run.Ran) '-NoWelcome ran npx anyway'

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -86,6 +86,14 @@ jobs:
               exit 1
             }
           done
+          # The offer is a thing this script does to the machine, so it is a
+          # thing --help says it does: a caller who reads this and is then
+          # asked a question they were not told about has been surprised by
+          # their installer.
+          printf '%s' "$out" | grep -q -- 'npx skills add haksolot/ank' || {
+            echo "--help does not name the command the offer runs"
+            exit 1
+          }
           # Two executables land, so --help says two land: a caller who reads it
           # and then finds one file has been told the wrong thing.
           printf '%s' "$out" | grep -q -- 'ank-mcp' || {
@@ -277,6 +285,16 @@ jobs:
           }
           echo "and it named ank-mcp in what it installed"
 
+          # And it asked nothing. ADR-5fbd99bf6fd5 read as an absence covers
+          # the offer as well as the animation: where no terminal is attached
+          # the installer converses not at all, so the word does not appear.
+          if grep -qi 'skills' staged.log; then
+            echo "the skills were raised with no terminal attached:"
+            grep -i 'skills' staged.log
+            exit 1
+          fi
+          echo "and it said nothing about the skills, with nobody there to answer"
+
           # The flag, on a run that already had no terminal: it has to be
           # accepted and to change nothing. The same directory, so the two logs
           # can differ in nothing but what the flag turns off.
@@ -368,6 +386,206 @@ jobs:
             exit 1
           }
           echo "installed ank, said on stderr what the archive is missing, exited 0"
+
+      # The offer ADR-5fbd99bf6fd5 describes, driven through a real pty, which
+      # is the only place it exists: it is gated on a terminal, and a workflow
+      # step is precisely a machine without one. `os.forkpty` gives the
+      # installer a controlling terminal, so `/dev/tty` opens, `-t 1` and
+      # `-t 2` answer yes, and what runs is the code path a person reaches
+      # rather than a flag standing in for them. The keys are written into the
+      # pty, which is the one thing simulated here and is what a keyboard does.
+      #
+      # The prompt appearing at all is the proof the terminal is real: it is
+      # printed on the far side of the same gate the logo is, so a harness that
+      # had quietly produced a pipe would assert its way to nothing.
+      #
+      # `npx` is replaced by one that fails on purpose, which is the last
+      # clause of the criterion asked as a falsification rather than as a
+      # review: an install that has already finished stays finished, so the
+      # exit code is 0, both executables are in place, and the failure is
+      # reported instead of swallowed.
+      - name: the offer is asked at a terminal, and no failure of it changes the exit code
+        env:
+          ANK_BASE_URL: http://127.0.0.1:${{ env.STAGED_PORT }}
+        run: |
+          set -e
+
+          # A node and an npx that exist, answer, and fail. The marker is how
+          # "it was not run" is asserted about a command rather than about a
+          # message: a file that is not there is not an absence of prose.
+          mkdir -p fakenode
+          cat > fakenode/node <<'EOF'
+          #!/bin/sh
+          echo "staged stand-in for node"
+          EOF
+          cat > fakenode/npx <<'EOF'
+          #!/bin/sh
+          printf 'npx ran: %s\n' "$*" >> "$NPX_MARKER"
+          echo "npx: this one fails on purpose" >&2
+          exit 1
+          EOF
+          chmod +x fakenode/node fakenode/npx
+
+          # A PATH with no node on it, built by naming what the installer uses
+          # rather than by removing entries from the real one: node lives in
+          # /usr/bin on the Linux image, and dropping that directory would take
+          # `sh` with it. A tool missing from this list shows up as the
+          # installer's own exit code and names itself.
+          mkdir -p nonode
+          for tool in sh uname curl wget sha256sum shasum openssl awk tr mktemp \
+            tar gzip gunzip chmod mv mkdir rm cat sed head tput sleep; do
+            if tool_path=$(command -v "$tool" 2>/dev/null); then
+              ln -sf "$tool_path" "nonode/$tool"
+            fi
+          done
+          test ! -e nonode/node || { echo "the node-free PATH has a node on it"; exit 1; }
+
+          cat > offer.py <<'PY'
+          import fcntl, os, select, signal, struct, sys, termios
+
+          INSTALL = os.path.join(os.getcwd(), "install.sh")
+          VERSION = os.environ["STAGED_VERSION"]
+          HERE = os.getcwd()
+          FAKE = os.path.join(HERE, "fakenode")
+          NONODE = os.path.join(HERE, "nonode")
+
+          def drive(args, keys, env_extra, timeout=180):
+              """Run args on a pty of its own and type keys at it."""
+              pid, fd = os.forkpty()
+              if pid == 0:
+                  env = dict(os.environ)
+                  # The runner sets it, and the installer reads it as "no human
+                  # here" -- which is true of the step and false of the pty.
+                  env.pop("CI", None)
+                  env["TERM"] = "xterm"
+                  env.update(env_extra)
+                  try:
+                      os.execvpe(args[0], args, env)
+                  finally:
+                      os._exit(127)
+              # A window the logo fits in, so the run resembles the one a person
+              # gets. Nothing below depends on it.
+              try:
+                  fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", 40, 100, 0, 0))
+              except OSError:
+                  pass
+              if keys:
+                  os.write(fd, keys)
+              out = b""
+              timed_out = False
+              while True:
+                  try:
+                      ready, _, _ = select.select([fd], [], [], timeout)
+                  except OSError:
+                      break
+                  if not ready:
+                      timed_out = True
+                      os.kill(pid, signal.SIGKILL)
+                      break
+                  try:
+                      chunk = os.read(fd, 65536)
+                  except OSError:
+                      break
+                  if not chunk:
+                      break
+                  out += chunk
+              _, status = os.waitpid(pid, 0)
+              os.close(fd)
+              code = os.WEXITSTATUS(status) if os.WIFEXITED(status) else 128 + os.WTERMSIG(status)
+              return code, out.decode("utf-8", "replace"), timed_out
+
+          failures = []
+
+          def case(label, keys, extra=(), node=True):
+              marker = os.path.join(HERE, "marker-" + label)
+              target = os.path.join(HERE, "bin-" + label)
+              env = {
+                  "NPX_MARKER": marker,
+                  "PATH": (FAKE + os.pathsep + os.environ["PATH"]) if node else NONODE,
+              }
+              args = ["sh", INSTALL, "--version", VERSION, "--dir", target] + list(extra)
+              code, out, timed_out = drive(args, keys, env)
+              print("=" * 70)
+              print(label, "-> exit", code, "| asked", out.count("[Y/n]"),
+                    "| npx ran", os.path.exists(marker), "| timed out", timed_out)
+              sys.stdout.write(out.replace("\r", ""))
+              sys.stdout.write("\n")
+              return {
+                  "label": label, "code": code, "out": out, "timed_out": timed_out,
+                  "asked": out.count("[Y/n]"), "ran": os.path.exists(marker),
+                  "dir": target,
+              }
+
+          def want(run, ok, why):
+              if not ok:
+                  failures.append(run["label"] + ": " + why)
+
+          def installed(run):
+              return (os.access(os.path.join(run["dir"], "ank"), os.X_OK)
+                      and os.access(os.path.join(run["dir"], "ank-mcp"), os.X_OK))
+
+          # Accepted, and the command it accepts fails. This is the assertion
+          # the criterion names: the install is already done, so it stays done.
+          run = case("accept", b"y\n")
+          want(run, not run["timed_out"], "it never finished")
+          want(run, run["code"] == 0, "a failing skill step changed the exit code to %d" % run["code"])
+          want(run, run["asked"] == 1, "it asked %d times, and once is the contract" % run["asked"])
+          want(run, run["ran"], "it accepted and never ran npx")
+          want(run, installed(run), "the binaries are not in place after the offer failed")
+          want(run, "npx skills add haksolot/ank" in run["out"], "it never named the command it ran")
+          want(run, "exited 1" in run["out"], "it swallowed the failure instead of reporting it")
+
+          # Enter is the default the criterion names, so it has to reach npx
+          # the way a typed yes does.
+          run = case("enter", b"\n")
+          want(run, run["code"] == 0, "exit %d" % run["code"])
+          want(run, run["asked"] == 1, "asked %d times" % run["asked"])
+          want(run, run["ran"], "Enter did not default to yes")
+
+          # Declined, end of input, and the flag: three ways to leave the
+          # machine in the state an installer without this step leaves it.
+          run = case("decline", b"n\n")
+          want(run, run["code"] == 0, "exit %d" % run["code"])
+          want(run, run["asked"] == 1, "asked %d times" % run["asked"])
+          want(run, not run["ran"], "it ran npx after being declined")
+          want(run, installed(run), "declining cost the install its binaries")
+
+          # ^D on an empty line, which is end of input rather than an answer.
+          run = case("eof", b"\x04")
+          want(run, run["code"] == 0, "exit %d" % run["code"])
+          want(run, run["asked"] == 1, "asked %d times" % run["asked"])
+          want(run, not run["ran"], "it ran npx having been told nothing")
+
+          # The flag, on a run that has a terminal and would have said yes.
+          # This is the only place ADR-5fbd99bf6fd5's "differs in no outcome
+          # from an interactive run that declined everything" can be measured,
+          # since without a terminal there is nothing to differ from.
+          run = case("noflag", b"y\n", extra=["--no-welcome"])
+          want(run, run["code"] == 0, "exit %d" % run["code"])
+          want(run, run["asked"] == 0, "--no-welcome asked anyway")
+          want(run, not run["ran"], "--no-welcome ran npx anyway")
+          want(run, "####" not in run["out"], "--no-welcome drew the logo at a terminal")
+          want(run, installed(run), "--no-welcome cost the install its binaries")
+
+          # node absent: the command, and one line saying why it was not run.
+          run = case("nonode", b"y\n", node=False)
+          want(run, run["code"] == 0, "exit %d" % run["code"])
+          want(run, run["asked"] == 1, "asked %d times" % run["asked"])
+          want(run, not run["ran"], "it ran npx with no node to run it")
+          want(run, "npx skills add haksolot/ank" in run["out"], "it did not print the command")
+          want(run, "node is not on PATH" in run["out"], "it did not say why it was not run")
+          want(run, installed(run), "the binaries are not in place")
+
+          print("=" * 70)
+          if failures:
+              for line in failures:
+                  print("FAIL", line)
+              sys.exit(1)
+          print("asked once at a terminal, defaulted to yes on Enter, and a skill step")
+          print("that failed left the install reporting success with both binaries in place")
+          PY
+
+          python3 offer.py
 
       # The second of the two failures that matter, and the reason the .sha256
       # is published at all. One byte appended to the archive, the checksum
@@ -538,14 +756,20 @@ jobs:
           # ank-mcp.exe is in the list for the reason the switch is: two
           # executables land, and a caller who reads -Help and then finds one
           # file has been told the wrong thing.
+          # The offer is a thing this script does to the machine, so it is a
+          # thing -Help says it does: a caller who reads this and is then asked
+          # a question they were not told about has been surprised by their
+          # installer.
           foreach ($needle in 'x86_64-pc-windows-msvc', 'ANK_BASE_URL', 'install.sh',
-                              '-NoWelcome', 'ANK_NO_WELCOME', 'ank-mcp.exe') {
+                              '-NoWelcome', 'ANK_NO_WELCOME', 'ank-mcp.exe',
+                              'npx skills add haksolot/ank') {
             if ($out -notmatch [regex]::Escape($needle)) {
               "-Help does not name $needle"
               exit 1
             }
           }
-          "-Help names the target, the environment, the other script, the switch and ank-mcp"
+          "-Help names the target, the environment, the other script, the switch,"
+          "ank-mcp and the command the offer runs"
 
       # The first of the two failures that matter. The architecture is read out
       # of the environment precisely so this is testable on a machine that is
@@ -718,6 +942,15 @@ jobs:
           }
           "and it named ank-mcp.exe in what it installed"
 
+          # And it asked nothing. ADR-5fbd99bf6fd5 read as an absence covers
+          # the offer as well as the animation: where no console is attached
+          # the installer converses not at all, so the word does not appear.
+          if ($out -match 'skills') {
+            "the skills were raised with no console attached"
+            exit 1
+          }
+          "and it said nothing about the skills, with nobody there to answer"
+
           # The switch, on a run that already had no console: it has to be
           # accepted and to change nothing. The same directory, so the two
           # transcripts can differ in nothing but what the switch turns off.
@@ -814,6 +1047,236 @@ jobs:
             exit 1
           }
           "installed ank, said what the archive is missing, exited 0"
+          exit 0
+
+      # The Windows half of the same claim, and the place the two files stop
+      # being translations of each other. install.sh opens /dev/tty; this one
+      # reads [Console]::ReadLine, because `irm | iex` never touches this
+      # process's standard input and the console is what a person types at.
+      #
+      # A workflow step has no console at all, so the probe is launched into
+      # one of its own: nothing is redirected, Windows hands a console-subsystem
+      # process a console when it has none to inherit, and the probe refuses to
+      # assert anything if it finds itself without one. Typing is the only
+      # thing simulated -- Console.SetIn swaps the reader ReadLine draws from,
+      # in that process alone, which leaves the gate reading a real console and
+      # the installer on the code path a person reaches.
+      #
+      # `npx` is replaced by one that fails on purpose, which is the last
+      # clause of the criterion asked as a falsification rather than as a
+      # review: an install that has already finished stays finished. On this
+      # platform that claim has a second half with no counterpart in sh --
+      # `pwsh -File` exits with $LASTEXITCODE, so an npx that failed would
+      # become the installer's exit code unless something says otherwise.
+      - name: the offer is asked at a console, and no failure of it changes the exit code
+        env:
+          ANK_BASE_URL: http://127.0.0.1:${{ env.STAGED_PORT }}
+        run: |
+          # A node and an npx that exist, answer, and fail. The marker is how
+          # "it was not run" is asserted about a command rather than about a
+          # message: a file that is not there is not an absence of prose.
+          New-Item -ItemType Directory -Path 'fakenode' -Force | Out-Null
+          Set-Content -Path 'fakenode/node.cmd' -Value @(
+            '@echo off',
+            'echo staged stand-in for node'
+          )
+          Set-Content -Path 'fakenode/npx.cmd' -Value @(
+            '@echo off',
+            '>>"%ANK_NPX_MARKER%" echo npx ran %*',
+            'echo npx: this one fails on purpose 1>&2',
+            'exit /b 1'
+          )
+
+          # A PATH with no node on it. Removing the entries that hold one is
+          # safe here in a way it is not on Linux: node lives in its own
+          # directory on this image, not in the one that carries the shell.
+          $noNodePath = (($env:Path -split ';') | Where-Object {
+            if (-not $_) { return $false }
+            try {
+              -not (Test-Path -LiteralPath (Join-Path $_ 'node.exe')) -and
+              -not (Test-Path -LiteralPath (Join-Path $_ 'npx.cmd'))
+            } catch { $true }
+          }) -join ';'
+
+          Set-Content -Path 'probe.ps1' -Value @'
+          param(
+              [Parameter(Mandatory = $true)][string]$Answer,
+              [Parameter(Mandatory = $true)][string]$Dir,
+              [Parameter(Mandatory = $true)][string]$OutFile,
+              [Parameter(Mandatory = $true)][string]$CodeFile,
+              [string[]]$Extra = @()
+          )
+
+          # A console of its own is the whole point of this file, so it is
+          # asserted and not assumed: a probe that quietly lost its console
+          # would take the no-terminal path through every case below and
+          # report six passes for a question never asked.
+          $console = $false
+          try {
+              $console = (-not [Console]::IsOutputRedirected) -and (-not [Console]::IsErrorRedirected)
+              $null = $Host.UI.RawUI.CursorPosition
+          } catch {
+              $console = $false
+          }
+          if (-not $console) {
+              Set-Content -Path $OutFile -Value 'the probe was given no console of its own'
+              Set-Content -Path $CodeFile -Value '199'
+              exit 0
+          }
+
+          # Typing, without a keyboard. Console.SetIn replaces the reader
+          # [Console]::ReadLine draws from, in this process and nowhere else:
+          # the console stays real, the gate reads it as real, and what runs is
+          # what runs for a person. An empty reader is at end of input from the
+          # first call, which is the answer nobody gives.
+          $text = switch ($Answer) {
+              'eof'   { '' }
+              'enter' { "`r`n" }
+              default { "$Answer`r`n" }
+          }
+          [Console]::SetIn([System.IO.StringReader]::new($text))
+
+          # Global, and named as global on both sides. An assignment without
+          # the prefix writes a variable in this script's own scope, and the
+          # one an exiting child sets is the one the engine keeps: seeded and
+          # read here they would be two variables wearing one name, and a
+          # refusal from install.ps1 would read back as a success.
+          $global:LASTEXITCODE = 0
+          $out = (& (Join-Path $PSScriptRoot 'install.ps1') `
+              -Version $env:STAGED_VERSION -Dir $Dir @Extra *>&1 | Out-String)
+          $code = $global:LASTEXITCODE
+          Set-Content -Path $OutFile -Value $out
+          Set-Content -Path $CodeFile -Value "$code"
+          exit 0
+          '@
+
+          $pwshPath = (Get-Command pwsh).Source
+          $savedPath = $env:Path
+          # The runner sets it, and the installer reads it as "no human here"
+          # -- which is true of this step and false of the console below.
+          $env:CI = ''
+          $failures = New-Object System.Collections.ArrayList
+
+          function Invoke-Case {
+              param([string]$Label, [string]$Answer, [string[]]$Extra = @(), [switch]$NoNode)
+
+              $marker = Join-Path $PWD "marker-$Label"
+              $dir = Join-Path $PWD "bin-$Label"
+              $outFile = Join-Path $PWD "out-$Label.txt"
+              $codeFile = Join-Path $PWD "code-$Label.txt"
+
+              $env:ANK_NPX_MARKER = $marker
+              $env:Path = if ($NoNode) { $script:noNodePath } else { (Join-Path $PWD 'fakenode') + ';' + $script:savedPath }
+
+              $argv = @('-NoProfile', '-File', 'probe.ps1', '-Answer', $Answer,
+                        '-Dir', $dir, '-OutFile', $outFile, '-CodeFile', $codeFile)
+              if ($Extra.Count) { $argv += '-Extra'; $argv += $Extra }
+
+              # Hidden, and hidden is what forces the launch through
+              # ShellExecute: that is the path which gives the child a console
+              # of its own rather than the pipes this step is holding.
+              Start-Process -FilePath $script:pwshPath -ArgumentList $argv `
+                  -WorkingDirectory "$PWD" -WindowStyle Hidden -Wait
+              $env:Path = $script:savedPath
+
+              $code = 999
+              if (Test-Path $codeFile) { $code = [int]((Get-Content $codeFile -Raw).Trim()) }
+              $out = ''
+              if (Test-Path $outFile) { $out = (Get-Content $outFile -Raw) }
+              if (-not $out) { $out = '' }
+
+              $asked = ([regex]::Matches($out, [regex]::Escape('[Y/n]'))).Count
+
+              # Write-Host and not a bare string, which is the difference
+              # between a log line and a return value: everything a function
+              # emits is its output, so three strings on the pipeline would
+              # reach the caller as an array with the object at the end of it
+              # and every assertion below would be read off a string.
+              Write-Host ('=' * 70)
+              Write-Host "$Label -> exit $code | asked $asked | npx ran $(Test-Path $marker)"
+              Write-Host $out
+
+              return [pscustomobject]@{
+                  Label = $Label; Code = $code; Out = $out
+                  Asked = $asked; Ran = (Test-Path $marker); Dir = $dir
+              }
+          }
+
+          function Want {
+              param($Run, [bool]$Ok, [string]$Why)
+              if ($Run.Out -match 'no console of its own') {
+                  # Said once for the run and not once per assertion: the
+                  # probe measured nothing, so there is one thing to report.
+                  $note = "$($Run.Label): the probe never got a console, so nothing about this run was measured"
+                  if (-not $script:failures.Contains($note)) { $null = $script:failures.Add($note) }
+                  return
+              }
+              if (-not $Ok) { $null = $script:failures.Add("$($Run.Label): $Why") }
+          }
+
+          function Installed {
+              param($Run)
+              return ((Test-Path (Join-Path $Run.Dir 'ank.exe')) -and
+                      (Test-Path (Join-Path $Run.Dir 'ank-mcp.exe')))
+          }
+
+          # Accepted, and the command it accepts fails. This is the assertion
+          # the criterion names: the install is already done, so it stays done.
+          $run = Invoke-Case -Label 'accept' -Answer 'y'
+          Want $run ($run.Code -eq 0) "a failing skill step changed the exit code to $($run.Code)"
+          Want $run ($run.Asked -eq 1) "it asked $($run.Asked) times, and once is the contract"
+          Want $run ($run.Ran) 'it accepted and never ran npx'
+          Want $run (Installed $run) 'the executables are not in place after the offer failed'
+          Want $run ($run.Out -match 'npx skills add haksolot/ank') 'it never named the command it ran'
+          Want $run ($run.Out -match 'exited 1') 'it swallowed the failure instead of reporting it'
+
+          # Enter is the default the criterion names, so it has to reach npx
+          # the way a typed yes does.
+          $run = Invoke-Case -Label 'enter' -Answer 'enter'
+          Want $run ($run.Code -eq 0) "exit $($run.Code)"
+          Want $run ($run.Asked -eq 1) "asked $($run.Asked) times"
+          Want $run ($run.Ran) 'Enter did not default to yes'
+
+          # Declined, end of input, and the switch: three ways to leave the
+          # machine in the state an installer without this step leaves it.
+          $run = Invoke-Case -Label 'decline' -Answer 'n'
+          Want $run ($run.Code -eq 0) "exit $($run.Code)"
+          Want $run ($run.Asked -eq 1) "asked $($run.Asked) times"
+          Want $run (-not $run.Ran) 'it ran npx after being declined'
+          Want $run (Installed $run) 'declining cost the install its executables'
+
+          $run = Invoke-Case -Label 'eof' -Answer 'eof'
+          Want $run ($run.Code -eq 0) "exit $($run.Code)"
+          Want $run ($run.Asked -eq 1) "asked $($run.Asked) times"
+          Want $run (-not $run.Ran) 'it ran npx having been told nothing'
+
+          # The switch, on a run that has a console and would have said yes.
+          # This is the only place ADR-5fbd99bf6fd5's "differs in no outcome
+          # from an interactive run that declined everything" can be measured,
+          # since without a console there is nothing to differ from.
+          $run = Invoke-Case -Label 'noflag' -Answer 'y' -Extra @('-NoWelcome')
+          Want $run ($run.Code -eq 0) "exit $($run.Code)"
+          Want $run ($run.Asked -eq 0) '-NoWelcome asked anyway'
+          Want $run (-not $run.Ran) '-NoWelcome ran npx anyway'
+          Want $run ($run.Out -notmatch '####') '-NoWelcome drew the logo at a console'
+          Want $run (Installed $run) '-NoWelcome cost the install its executables'
+
+          # node absent: the command, and one line saying why it was not run.
+          $run = Invoke-Case -Label 'nonode' -Answer 'y' -NoNode
+          Want $run ($run.Code -eq 0) "exit $($run.Code)"
+          Want $run ($run.Asked -eq 1) "asked $($run.Asked) times"
+          Want $run (-not $run.Ran) 'it ran npx with no node to run it'
+          Want $run ($run.Out -match 'npx skills add haksolot/ank') 'it did not print the command'
+          Want $run ($run.Out -match 'node is not on PATH') 'it did not say why it was not run'
+          Want $run (Installed $run) 'the executables are not in place'
+
+          '=' * 70
+          if ($failures.Count) {
+              foreach ($line in $failures) { "FAIL $line" }
+              exit 1
+          }
+          'asked once at a console, defaulted to yes on Enter, and a skill step that'
+          'failed left the install reporting success with both executables in place'
           exit 0
 
       # The second of the two failures that matter, and the reason the .sha256

--- a/install.ps1
+++ b/install.ps1
@@ -32,10 +32,12 @@ Exit codes, so a caller can branch on the failure rather than on the message:
   5  a runtime this script needs is missing
 
 -NoWelcome, or ANK_NO_WELCOME in the environment, turns off everything this
-script draws for a human and leaves only the lines a machine reads. It is
-absent from the list above on purpose: the welcome is drawn before the first
-request goes out, nothing in it can fail, and a flag able to change one of
-these five codes would be a flag that made the install depend on it.
+script draws for a human and everything it asks one, and leaves only the lines
+a machine reads. It is absent from the list above on purpose: the welcome is
+drawn before the first request goes out and the offer comes after the binary is
+on disk and verified, so neither is on the path to any of them -- a flag able
+to change one of these five codes would be a flag that made the install depend
+on it.
 
 They are the codes install.sh returns for the same failures, and they reach a
 caller who runs this as a file. The one-liner above runs it through `iex`, where
@@ -80,8 +82,8 @@ $RunningAsFile = -not [string]::IsNullOrEmpty($PSCommandPath)
 # stderr: under `iex` this runs in the caller's own session, and a diagnosis
 # written to the pipeline would land in whatever they were assembling.
 function Say {
-    param([string]$Line = '')
-    Write-Host $Line
+    param([string]$Line = '', [switch]$NoNewline)
+    if ($NoNewline) { Write-Host -NoNewline $Line } else { Write-Host $Line }
 }
 
 # `Fail <code> <lines>`: the code carries the kind of failure, the lines carry
@@ -119,8 +121,8 @@ function Show-Usage {
     Say '                      "v0.2.0" and "0.2.0" both work'
     Say '  -Dir <path>         install into <path> instead of'
     Say '                      $env:LOCALAPPDATA\Programs\ank'
-    Say '  -NoWelcome          draw nothing; install exactly what an install with'
-    Say '                      the animation installs, and say the same things about it'
+    Say '  -NoWelcome          draw nothing and ask nothing; install exactly what an'
+    Say '                      interactive run that declined every offer installs'
     Say '  -Help               print this and exit'
     Say ''
     Say 'environment:'
@@ -137,6 +139,14 @@ function Show-Usage {
     Say ''
     Say '  Linux and macOS are installed by install.sh:'
     Say "    curl -fsSL https://raw.githubusercontent.com/$Repo/main/install.sh | sh"
+    Say ''
+    Say 'the skills:'
+    Say '  With a console attached, once ank is installed and verified, this offers'
+    Say '  to run:'
+    Say "    npx skills add $Repo"
+    Say '  They teach an agent how to use ank. It is one question, Enter accepts it,'
+    Say '  declining installs nothing more, and nothing that command does can change'
+    Say '  any of the codes below.'
     Say ''
     Say 'exit codes:'
     Say '  1 usage   2 unsupported platform   3 download   4 checksum   5 missing runtime'
@@ -239,7 +249,7 @@ function Show-Logo {
 }
 
 # ADR-5fbd99bf6fd5 read as an absence: where no human is looking, this script
-# draws nothing at all.
+# draws nothing at all and asks nothing at all.
 #
 # Both streams are tested and not only one. `irm ... | iex` leaves stdout and
 # stderr on the console, which is the case that must animate; redirecting
@@ -248,7 +258,14 @@ function Show-Logo {
 # asked last, and by trying rather than by name: a host with no console answers
 # the two properties above happily and then throws on the first cursor it is
 # asked to place.
-function Test-WelcomeWanted {
+#
+# The logo and the offer read this same answer, which is what makes -NoWelcome
+# and an interactive run that declined everything leave the same machine
+# behind: one predicate, so there is no second gate to disagree with this one.
+# The width belongs to the block of art alone and is asked inside Show-Logo,
+# since a console too narrow to hold the logo is still a console with a person
+# in front of it.
+function Test-HumanAtTerminal {
     if ($NoWelcome) { return $false }
     if ($env:ANK_NO_WELCOME) { return $false }
     # A runner sets this, and a runner is a machine with no human at it.
@@ -261,6 +278,100 @@ function Test-WelcomeWanted {
         return $false
     }
     return $true
+}
+
+# ---------------------------------------------------------------------------
+# The skills
+# ---------------------------------------------------------------------------
+
+# ADR-5fbd99bf6fd5's offer, and the last thing this script does. Everything
+# else has already happened by then: the binary is on disk, verified, reported,
+# and the PATH advice given. That ordering is the decision rather than a layout
+# -- an installation that stops to ask something is an installation that can be
+# abandoned half-done, and half-done is the worst state for a tool whose next
+# action is `ank context`.
+#
+# `npx skills add <owner>/ank` is what skill/SKILL.md already teaches, and it
+# serves every agent the skills CLI knows about rather than one. An installer
+# that learned where each of them keeps its skills is an installer that goes
+# stale silently, so this one hands that work to the tool whose job it is.
+#
+# Nothing in here is allowed to reach the caller as a failure. The call site
+# wraps it, and the exit code is stamped after it returns.
+function Invoke-SkillOffer {
+    if (-not (Test-HumanAtTerminal)) { return }
+
+    Say ''
+    Say 'The skills teach an agent how to use ank: the contract, and one policy'
+    Say 'per activity. They install through the skills CLI, which puts them where'
+    Say 'each agent looks.'
+    Say ''
+    Say "  npx skills add $Repo"
+    Say ''
+
+    # [Console]::ReadLine and not Read-Host, which is where Windows differs
+    # from the /dev/tty install.sh opens and why the two files spell this step
+    # differently. `irm ... | iex` runs this text through a pipeline in the
+    # caller's own session: Console.In is the console and never that pipeline,
+    # so a question asked here cannot consume what they piped. $null is end of
+    # input -- nothing was typed, so nothing is assumed.
+    Say -NoNewline 'Install them now? [Y/n] '
+    $answer = $null
+    try { $answer = [Console]::ReadLine() } catch { $answer = $null }
+    if ($null -eq $answer) {
+        Say ''
+        return
+    }
+
+    # Enter is yes and everything unrecognised is no, in that order: a default
+    # the criterion names, and a decline for anything else because asking twice
+    # is asking twice.
+    $reply = $answer.Trim()
+    if ($reply -ne '' -and $reply -notmatch '^(y|yes)$') { return }
+
+    if (-not (Get-Command node -ErrorAction SilentlyContinue)) {
+        Say ''
+        Say "  npx skills add $Repo"
+        Say 'node is not on PATH, so that was not run.'
+        return
+    }
+
+    Say ''
+
+    # npm_config_yes is `npx --yes` spelled as the environment: on a cold cache
+    # npx asks its own question -- "Ok to proceed?" -- and this one was
+    # answered above, once. It is restored rather than left set, because under
+    # `iex` the environment of this process is the caller's own.
+    $savedYes = $env:npm_config_yes
+    $code = 0
+    try {
+        $env:npm_config_yes = '1'
+        $global:LASTEXITCODE = 0
+        # Through Say for the reason Say exists: under `iex` output written to
+        # the pipeline lands in whatever the caller was assembling. 2>&1 so
+        # npx's diagnosis arrives as text rather than as error records a
+        # caller's $ErrorActionPreference could turn into an exception.
+        & npx skills add $Repo 2>&1 | ForEach-Object { Say "$_" }
+        $code = $LASTEXITCODE
+    } catch {
+        Say "  $($_.Exception.Message)"
+        $code = 9
+    } finally {
+        $env:npm_config_yes = $savedYes
+    }
+
+    if ($code -eq 0) {
+        Say ''
+        Say 'the skills are installed'
+    } else {
+        Say ''
+        Say "npx skills add $Repo exited $code, so the skills are not installed."
+        Say 'ank is, and it is exactly the ank this script installs when nobody is'
+        Say 'asked anything at all.'
+        Say ''
+        Say 'Run that line again when you want them:'
+        Say "  npx skills add $Repo"
+    }
 }
 
 # ---------------------------------------------------------------------------
@@ -518,7 +629,7 @@ if ($BaseUrl) {
 # Wrapped, because a host that cannot place a cursor is not a reason to fail an
 # install: nothing has been downloaded yet and nothing below depends on a frame
 # having been drawn.
-if (Test-WelcomeWanted) {
+if (Test-HumanAtTerminal) {
     try { Show-Logo } catch { }
 }
 
@@ -818,6 +929,22 @@ try {
             Say 'after adding: a truncated PATH loses entries other tools put there.'
         }
     }
+
+    # Wrapped, and it is the whole guarantee in two lines rather than one.
+    #
+    # The try is the half install.sh spells `offer_skills || :`: a question
+    # asked after a successful install may not turn that install into a
+    # failure, so nothing thrown in there gets out of here.
+    #
+    # The stamp is the half that has no counterpart in install.sh, and it is
+    # the one that would have been missed by reading. `pwsh -File install.ps1`
+    # exits with $LASTEXITCODE, which every native command run above sets: with
+    # nothing here, an npx that failed would silently become this script's exit
+    # code and the caller would read a green install as red. Assigned in the
+    # global scope, because an assignment inside a script writes a script-local
+    # variable that shadows it and changes nothing the host reads.
+    try { Invoke-SkillOffer } catch { }
+    $global:LASTEXITCODE = 0
 } finally {
     if ($tmp -and (Test-Path -Path $tmp)) {
         Remove-Item -Path $tmp -Recurse -Force -ErrorAction SilentlyContinue

--- a/install.sh
+++ b/install.sh
@@ -28,10 +28,12 @@
 #   5  a tool this script needs is missing
 #
 # --no-welcome, or ANK_NO_WELCOME in the environment, turns off everything this
-# script draws for a human and leaves only the lines a machine reads. It is
-# absent from the list above on purpose: the welcome is drawn before the first
-# request goes out, nothing in it can fail, and a flag that could change one of
-# these five codes would be a flag that made the install depend on it.
+# script draws for a human and everything it asks one, and leaves only the
+# lines a machine reads. It is absent from the list above on purpose: the
+# welcome is drawn before the first request goes out and the offer comes after
+# the binary is on disk and verified, so neither is on the path to any of them
+# -- a flag able to change one of these five codes would be a flag that made
+# the install depend on it.
 #
 set -eu
 
@@ -151,7 +153,7 @@ draw_logo() {
 }
 
 # ADR-5fbd99bf6fd5 read as an absence: where no human is looking, this script
-# draws nothing at all.
+# draws nothing at all and asks nothing at all.
 #
 # Both streams are tested and not only one. Under `curl ... | sh` stdin is the
 # script and both of the others are the terminal, which is the case that must
@@ -160,7 +162,12 @@ draw_logo() {
 # produce. /dev/tty is the third test and the one the decision names: no
 # controlling terminal means a provisioning script, a Dockerfile or a runner,
 # whatever the streams happen to say.
-welcome_wanted() {
+#
+# The logo and the offer read this same answer, which is what makes
+# --no-welcome and an interactive run that declined everything leave the same
+# machine behind: one predicate, so there is no second gate to disagree with
+# this one.
+human_at_terminal() {
   [ "$no_welcome" = no ] || return 1
   [ -t 1 ] || return 1
   [ -t 2 ] || return 1
@@ -173,6 +180,13 @@ welcome_wanted() {
   # A subshell: a redirection that fails on a special builtin is fatal to the
   # shell itself, and this test exists to be answered no.
   ( : > /dev/tty ) 2>/dev/null || return 1
+}
+
+# The width is about the block of art and about nothing else, so it is here and
+# not above: a window too narrow to hold the logo is still a window with a
+# person in front of it, and a question fits in twenty columns.
+welcome_wanted() {
+  human_at_terminal || return 1
   # A window narrower than the art wraps every line, and a block that is taller
   # than twelve rows is a block the redraw moves back over the middle of. Asked
   # of tput, and only believed when it answers a number: a machine without it
@@ -218,8 +232,8 @@ options:
   --version <version>  install this release instead of the latest one;
                        "v0.2.0" and "0.2.0" both work
   --dir <path>         install into <path> instead of \$HOME/.local/bin
-  --no-welcome         draw nothing; install exactly what an install with the
-                       animation installs, and say the same things about it
+  --no-welcome         draw nothing and ask nothing; install exactly what an
+                       interactive run that declined every offer installs
   -h, --help           print this and exit
 
 environment:
@@ -236,6 +250,14 @@ $(supported_lines)
 
   Windows is published as a .zip and this script does not install it:
     ${releases_url}
+
+the skills:
+  With a terminal attached, once ank is installed and verified, this offers
+  to run:
+    npx skills add ${repo}
+  They teach an agent how to use ank. It is one question, Enter accepts it,
+  declining installs nothing more, and nothing that command does can change
+  any of the codes below.
 
 exit codes:
   1 usage   2 unsupported platform   3 download   4 checksum   5 missing tool
@@ -723,3 +745,100 @@ case ":${PATH}:" in
     say "then open a new shell, or run that line now in this one."
     ;;
 esac
+
+# --------------------------------------------------------------------------
+# The skills
+# --------------------------------------------------------------------------
+
+# ADR-5fbd99bf6fd5's offer, and the last thing this script does. Everything
+# above has already happened: the binary is on disk, verified, reported, and
+# the PATH advice given. That ordering is the decision rather than a layout --
+# an installation that stops to ask something is an installation that can be
+# abandoned half-done, and half-done is the worst state for a tool whose next
+# action is `ank context`.
+#
+# `npx skills add <owner>/ank` is what skill/SKILL.md already teaches, and it
+# serves every agent the skills CLI knows about rather than one. An installer
+# that learned where each of them keeps its skills is an installer that goes
+# stale silently, so this one hands that work to the tool whose job it is.
+offer_skills() {
+  human_at_terminal || return 0
+
+  say ""
+  say "The skills teach an agent how to use ank: the contract, and one policy"
+  say "per activity. They install through the skills CLI, which puts them where"
+  say "each agent looks."
+  say ""
+  say "  npx skills add ${repo}"
+  say ""
+
+  # /dev/tty and nowhere else, which is the trap ADR-5fbd99bf6fd5 exists to
+  # name. Under `curl ... | sh` standard input is this script: a plain `read`
+  # would consume the rest of the file and execute none of it, and it would do
+  # so only on the route people actually use, having worked in every local test
+  # where the script was run from a file.
+  printf 'Install them now? [Y/n] ' >&2
+  if ! IFS= read -r offer_answer < /dev/tty; then
+    # End of input rather than an answer. Nothing was typed, so nothing is
+    # assumed, and the newline is ours because no Enter was pressed to echo
+    # one.
+    say ""
+    return 0
+  fi
+
+  # Enter is yes and everything unrecognised is no, in that order: a default
+  # the criterion names, and a decline for anything else because asking twice
+  # is asking twice.
+  case "$offer_answer" in
+    "" | y | Y | yes | Yes | YES) : ;;
+    *) return 0 ;;
+  esac
+
+  if ! have node; then
+    say ""
+    say "  npx skills add ${repo}"
+    say "node is not on PATH, so that was not run."
+    return 0
+  fi
+
+  say ""
+
+  # Two redirections, each doing something this cannot work without.
+  #
+  # `< /dev/tty` for the reason the prompt above reads from there: standard
+  # input is still this script, and npx asks its own question on a cold cache
+  # -- "Ok to proceed?" -- which it would answer with the next lines of this
+  # file. npm_config_yes is `npx --yes` spelled as the environment, so that
+  # question is not asked at all: the person already answered it, once, above.
+  # It is set for the child and not exported, which is what keeps it out of
+  # every other command here.
+  #
+  # `>&2` for the reason `say` writes there: the interesting use of this script
+  # is `curl ... | sh`, and npx's output on stdout would land in whatever the
+  # caller was reading. A redirection and not a pipe, so nothing is buffered
+  # and the terminal shows npx working while it works.
+  offer_code=0
+  npm_config_yes=1 npx skills add "$repo" < /dev/tty >&2 || offer_code=$?
+
+  if [ "$offer_code" -eq 0 ]; then
+    say ""
+    say "the skills are installed"
+  else
+    say ""
+    say "npx skills add ${repo} exited ${offer_code}, so the skills are not"
+    say "installed. ank is, and it is exactly the ank this script installs when"
+    say "nobody is asked anything at all."
+    say ""
+    say "Run that line again when you want them:"
+    say "  npx skills add ${repo}"
+  fi
+}
+
+# `|| :` and not a bare call, and it is the whole guarantee in one line. This
+# is the last command in the file, so the script's status is its status: with
+# `set -e` in force a single failure anywhere inside would become the exit code
+# of an install that has already succeeded. Called this way, the failure is
+# tested rather than fatal, `set -e` is suspended for the duration, and the
+# status this script leaves with is the status it had before the question was
+# asked.
+offer_skills || :


### PR DESCRIPTION
Closes TASK-5a2f1b47f204. Proof: `commit:f8b7116`.

`install.sh` and `install.ps1` ask, once, after the binary is on disk and
verified, whether to run `npx skills add haksolot/ank`. Enter accepts, anything
else declines. With no terminal, or under the flag that turns the welcome off,
the question is not asked and the machine is left exactly as an installer
without this step leaves it (ADR-5fbd99bf6fd5).

## The gate

`welcome_wanted` splits into `human_at_terminal` plus the terminal width: the
24-column test is about the block of art alone, and a narrow terminal is still
a terminal to ask at. The logo and the offer read the one predicate, which is
what makes `--no-welcome` and a declined interactive run the same outcome
rather than two gates that could disagree. `Test-WelcomeWanted` already was
that predicate on the PowerShell side (its width test lives inside
`Show-Logo`), so it is renamed rather than duplicated.

## Two things reading would not have caught

`npx` is handed `/dev/tty` as its standard input on POSIX. Under `curl | sh`
standard input is the installer script, so an npx that asks its own question
would answer it with the rest of that file. `npm_config_yes` is set for that
child, since the person already answered once.

`pwsh -File` exits with `$LASTEXITCODE`, which every native command sets: a
failing `npx.cmd` would have become `install.ps1`'s exit code with nothing in
the script saying so. `$global:LASTEXITCODE = 0` after the offer is what keeps
the guarantee, and it has no counterpart in the sh file.

## How install.yml proves it

The offer only exists at a terminal and a workflow step has none, so the claim
is falsified rather than reviewed:

- Linux and macOS drive the installer through `os.forkpty` -- `/dev/tty` opens,
  both streams are ttys, keys are written into the pty.
- Windows launches a probe into a console of its own, where `Console.SetIn`
  stands in for a keyboard. The probe refuses to assert anything if it finds it
  has no console, so a harness that quietly lost one cannot report passes.

Six cases on each: accepted, Enter, declined, end of input, the flag, and node
absent. In the first two `npx` is one that fails on purpose, and the assertion
is that the install still exits 0 with both executables in place. Rehearsed
locally against a staged release: all six green, and written the naive way with
`npx` unguarded, the accepted and Enter cases exit 1 and the step reports it.

## Scope

`ank amend` added `.github/workflows/install.yml` to the task's scope: the
criterion names that file as where the claim is proved, and a perimeter that
carries the behaviour without the proof says the proof belongs to nobody.

`cargo test --workspace` 713 passed, `cargo fmt --check` clean, `ank check` ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YQcZecoqSWh7ntsbwnJLjf