### PR TITLE
The watcher mirrors refs/ank/* and moves nothing else

### DIFF
--- a/.ank/entities/LOG-1280bbc14efd.md
+++ b/.ank/entities/LOG-1280bbc14efd.md
@@ -1,0 +1,17 @@
+---
+id: LOG-1280bbc14efd
+type: log
+title: done, proof commit:046b8fd
+created: 2026-08-25T03:23:28Z
+author: claude-code/opus-5+daemon-refs
+scope:
+  - crates/ank-daemon/**
+  - +crates/ank-cli/src/context.rs
+  - +crates/ank-cli/src/status.rs
+  - +crates/ank-cli/tests/cli.rs
+  - +docs/integrating.md
+about: TASK-a73b41660413
+seq: 3
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-2f4f319ce45f.md
+++ b/.ank/entities/LOG-2f4f319ce45f.md
@@ -1,0 +1,20 @@
+---
+id: LOG-2f4f319ce45f
+type: log
+title: +scope +crates/ank-cli/src/context.rs, +scope +crates/ank-cli/src/status.rs, +scope
+created: 2026-08-25T03:04:40Z
+author: claude-code/opus-5+daemon-refs
+scope:
+  - crates/ank-daemon/**
+  - +crates/ank-cli/src/context.rs
+  - +crates/ank-cli/src/status.rs
+  - +crates/ank-cli/tests/cli.rs
+  - +docs/integrating.md
+about: TASK-a73b41660413
+seq: 1
+records: edit
+schema: 4
+version: 1
+---
+
+ +crates/ank-cli/tests/cli.rs, +scope +docs/integrating.md (version 2 to 3, replaced 75c5d7a0577d, produced 6a4eab2f8f56)

--- a/.ank/entities/LOG-3c6abafaae36.md
+++ b/.ank/entities/LOG-3c6abafaae36.md
@@ -1,0 +1,15 @@
+---
+id: LOG-3c6abafaae36
+type: log
+title: The criterion binds two crates, not one. The daemon can fetch refs/ank/* into a tracking namespace
+created: 2026-08-25T03:04:29Z
+author: claude-code/opus-5+daemon-refs
+scope:
+  - crates/ank-daemon/**
+about: TASK-a73b41660413
+seq: 0
+schema: 4
+version: 1
+---
+
+ of its own inside crates/ank-daemon/**, but the second half -- what ank status reports about claims held elsewhere becomes current -- is unreachable from there: status builds its elsewhere list from context::plane(), which enumerates refs/ank/* and drops every ref that is not under refs/ank/claims/ or refs/ank/proof/. A tracking namespace is by construction neither, so with no CLI change the daemon would fetch and status would report exactly what it reported before. Reading the mirror is the CLI's own act and cannot be delegated to the watcher without making it answer a verb, which ADR-a22cd3196529 refuses. Scope has to grow to the reader side.

--- a/.ank/entities/LOG-45308da9081d.md
+++ b/.ank/entities/LOG-45308da9081d.md
@@ -1,0 +1,18 @@
+---
+id: LOG-45308da9081d
+type: log
+title: scope (version 4 to 5, replaced 143327bd930e, produced c9bb3114e159)
+created: 2026-08-25T03:26:10Z
+author: claude-code/opus-5+daemon-refs
+scope:
+  - crates/ank-daemon/**
+  - crates/ank-cli/src/context.rs
+  - crates/ank-cli/src/status.rs
+  - crates/ank-cli/tests/cli.rs
+  - docs/integrating.md
+about: TASK-a73b41660413
+seq: 4
+records: edit
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-538c859ac6f7.md
+++ b/.ank/entities/LOG-538c859ac6f7.md
@@ -1,0 +1,16 @@
+---
+id: LOG-538c859ac6f7
+type: log
+title: +scope crates/ank-cli/src/human.rs, -scope crates/ank-cli/src/amend.rs (version 2 to 3, replaced
+created: 2026-08-25T03:27:03Z
+author: claude-code/opus-5+daemon-refs
+scope:
+  - crates/ank-cli/src/human.rs
+about: TASK-86babab0eb1b
+seq: 1
+records: edit
+schema: 4
+version: 1
+---
+
+ 4a1482b4bc8a, produced 9d407cbc3eb1)

--- a/.ank/entities/LOG-5f4d45060ea2.md
+++ b/.ank/entities/LOG-5f4d45060ea2.md
@@ -1,0 +1,19 @@
+---
+id: LOG-5f4d45060ea2
+type: log
+title: The mirror lands in refs/ank/watch/origin/*, inside the namespace ADR-85e6ff5b8b7c gives the
+created: 2026-08-25T03:14:25Z
+author: claude-code/opus-5+daemon-refs
+scope:
+  - crates/ank-daemon/**
+  - +crates/ank-cli/src/context.rs
+  - +crates/ank-cli/src/status.rs
+  - +crates/ank-cli/tests/cli.rs
+  - +docs/integrating.md
+about: TASK-a73b41660413
+seq: 2
+schema: 4
+version: 1
+---
+
+ project rather than beside it, and it is inert by construction: every existing reader of the plane strips refs/ank/claims/ or refs/ank/proof/ and skips what matches neither, and maint prunes off those same two maps. So a build that knows nothing about the mirror behaves exactly as it did before one existed, which is what makes the watcher's absence the normal mode rather than a degraded one. Three git flags are load-bearing and were found by asking what a fetch does when nobody looks: --no-tags, because a tag arriving unasked is the surprise the decision refuses; --no-write-fetch-head, because FETCH_HEAD is a file the person's next merge reads; --prune, because a claim released on the remote has to disappear here and a mirror that only grows reports holders who let go an hour ago.

--- a/.ank/entities/LOG-667df1849d97.md
+++ b/.ank/entities/LOG-667df1849d97.md
@@ -1,0 +1,19 @@
+---
+id: LOG-667df1849d97
+type: log
+title: The scope amendment was written as --scope +crates/... and the + was stored as part of the glob, so
+created: 2026-08-25T03:26:32Z
+author: claude-code/opus-5+daemon-refs
+scope:
+  - crates/ank-daemon/**
+  - crates/ank-cli/src/context.rs
+  - crates/ank-cli/src/status.rs
+  - crates/ank-cli/tests/cli.rs
+  - docs/integrating.md
+about: TASK-a73b41660413
+seq: 5
+schema: 4
+version: 1
+---
+
+ four scopes matched nothing and check turned four faults. amend refuses a done task -- its plan is settled -- while edit accepts one, so the correction went through edit, which recorded it as version 5. The completion ref was already on origin, so rewinding the corpus was not available and fixing forward was the only honest route.

--- a/.ank/entities/LOG-fa480d60da77.md
+++ b/.ank/entities/LOG-fa480d60da77.md
@@ -1,0 +1,14 @@
+---
+id: LOG-fa480d60da77
+type: log
+title: body (version 1 to 2, replaced 1a7c1ab10d10, produced 40071eb9e9ab)
+created: 2026-08-25T03:26:49Z
+author: claude-code/opus-5+daemon-refs
+scope:
+  - crates/ank-cli/src/amend.rs
+about: TASK-86babab0eb1b
+seq: 0
+records: edit
+schema: 4
+version: 1
+---

--- a/.ank/entities/TASK-86babab0eb1b.md
+++ b/.ank/entities/TASK-86babab0eb1b.md
@@ -1,0 +1,35 @@
+---
+id: TASK-86babab0eb1b
+type: task
+slug: amend-takes-a-scope-with-a-leading-and-check-fin
+title: amend takes a scope with a leading + and check finds it four commands later
+created: 2026-08-25T03:26:36Z
+author: claude-code/opus-5+daemon-refs
+status: open
+scope:
+  - crates/ank-cli/src/human.rs
+blocked_by: []
+schema: 4
+version: 3
+---
+
+`ank amend <id> --scope "+crates/ank-cli/src/context.rs"` stores the `+` as part
+of the glob. Nothing refuses it, nothing warns, and `--list`-style feedback says
+`+scope +crates/...`, which reads as the tool acknowledging an add-marker rather
+than as a glob that begins with a plus sign. The mistake is easy to make
+precisely because this CLI's own idiom is `--scope` to add and `--drop-scope` to
+remove: a caller who has met `+`/`-` list syntax elsewhere writes the marker and
+is told it worked.
+
+The cost arrives four commands later. The scope matches no file, so `check`
+reports a dead scope with no rename and no deletion to explain it, which is a
+fault; and by then the task can be `done`, where `amend` refuses because the
+plan is settled. That leaves `edit` as the only route to a correction, and
+`edit` does not declare the refusal `amend` does -- two verbs disagreeing about
+whether a done task's plan may move, which is a disagreement to settle rather
+than a door to use.
+
+Two candidate answers, and choosing between them is the work: refuse a scope
+whose first character is `+` or `-` at `amend` time, naming `--drop-scope` as
+the way to remove; or accept it, strip it, and say so. What must not stay is a
+silent acceptance whose only report is a fault four commands downstream.

--- a/.ank/entities/TASK-a73b41660413.md
+++ b/.ank/entities/TASK-a73b41660413.md
@@ -5,19 +5,24 @@ slug: the-daemon-fetches-refs-ank-and-demonstrably-not
 title: The daemon fetches refs/ank/* and demonstrably nothing else
 created: 2026-08-24T22:03:11Z
 author: claude-code/opus-5+planning
-status: in_progress
+status: done
 scope:
   - crates/ank-daemon/**
-  - +crates/ank-cli/src/context.rs
-  - +crates/ank-cli/src/status.rs
-  - +crates/ank-cli/tests/cli.rs
-  - +docs/integrating.md
+  - crates/ank-cli/src/context.rs
+  - crates/ank-cli/src/status.rs
+  - crates/ank-cli/tests/cli.rs
+  - docs/integrating.md
 blocked_by: [TASK-f8802467b622]
 done_criteria: |
   The daemon fetches refs/ank/* for each declared corpus into a tracking namespace of its own, on an interval the declaration states, and what ank status reports about claims held elsewhere becomes current without anyone running a fetch by hand. A test drives the daemon against two clones of one repository and shows a claim taken in the first is reported by status in the second without a manual fetch. A second test asserts the negative on a repository with local commits, an unpushed branch and a dirty working tree: after a watching cycle, HEAD, every branch, every tag, the working tree, git's index and local refs/ank/claims are unchanged, and only the daemon's tracking namespace moved. A network failure is reported and never fatal, and the daemon keeps watching. cargo test is green and cargo fmt --check passes.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 046b8fd
+    criteria: 718a87ab99ed
+    via: submitted
 schema: 4
-version: 3
+version: 5
 ---
 
 The half of ADR-a22cd3196529 that touches somebody else's repository, which is

--- a/.ank/entities/TASK-a73b41660413.md
+++ b/.ank/entities/TASK-a73b41660413.md
@@ -5,15 +5,19 @@ slug: the-daemon-fetches-refs-ank-and-demonstrably-not
 title: The daemon fetches refs/ank/* and demonstrably nothing else
 created: 2026-08-24T22:03:11Z
 author: claude-code/opus-5+planning
-status: open
+status: in_progress
 scope:
   - crates/ank-daemon/**
+  - +crates/ank-cli/src/context.rs
+  - +crates/ank-cli/src/status.rs
+  - +crates/ank-cli/tests/cli.rs
+  - +docs/integrating.md
 blocked_by: [TASK-f8802467b622]
 done_criteria: |
   The daemon fetches refs/ank/* for each declared corpus into a tracking namespace of its own, on an interval the declaration states, and what ank status reports about claims held elsewhere becomes current without anyone running a fetch by hand. A test drives the daemon against two clones of one repository and shows a claim taken in the first is reported by status in the second without a manual fetch. A second test asserts the negative on a repository with local commits, an unpushed branch and a dirty working tree: after a watching cycle, HEAD, every branch, every tag, the working tree, git's index and local refs/ank/claims are unchanged, and only the daemon's tracking namespace moved. A network failure is reported and never fatal, and the daemon keeps watching. cargo test is green and cargo fmt --check passes.
 criteria_by: creator
 schema: 4
-version: 1
+version: 3
 ---
 
 The half of ADR-a22cd3196529 that touches somebody else's repository, which is

--- a/crates/ank-cli/src/context.rs
+++ b/crates/ank-cli/src/context.rs
@@ -92,17 +92,60 @@ impl Coordination {
 /// A listing has no channel for a warning and passes an empty vector — `check`
 /// is what reports a damaged ref, and a reader must not fail for having nothing
 /// to say about one.
+/// Where the watcher mirrors the remote's `refs/ank/*`, when somebody is
+/// running one (ADR-a22cd3196529).
+///
+/// **A mirror, and never the plane itself.** `refs/ank/claims/<id>` is where a
+/// claim of this clone lives, so a background process writing there would be
+/// rewriting the coordination plane under whoever is working in the tree. The
+/// watcher writes here instead, and this is the only place in the CLI that
+/// reads it: nothing claims against it, nothing prunes it, and a corpus no
+/// watcher has ever touched carries none of it -- which is what makes the
+/// watcher's absence the normal mode rather than a degraded one.
+///
+/// `refs/ank/watch/<remote>/claims/<id>`, so the tail is reached by stripping
+/// the prefix and then the one segment naming the remote.
+const WATCH_PREFIX: &str = "refs/ank/watch/";
+
+/// The task a mirrored claim ref is about, or `None` for any other ref.
+///
+/// The mirror carries whatever the remote's `refs/ank/*` carries, proofs
+/// included; only the claims half is read, because the question it answers --
+/// who holds what, right now, in another clone -- is the one a stale local plane
+/// gets wrong. A mirrored proof is an attestation this clone will receive with
+/// the branch that carries it.
+fn mirrored_claim(name: &str) -> Option<&str> {
+    let rest = name.strip_prefix(WATCH_PREFIX)?;
+    let (_remote, rest) = rest.split_once('/')?;
+    rest.strip_prefix("claims/")
+}
+
 /// Everything `refs/ank/*` says about the corpus, read in one walk.
 ///
-/// Two namespaces answering two questions — who holds a task, and what has been
-/// attested against it outside its file (ADR-493471d64ba0) — and one
-/// enumeration, because a second walk would be free to disagree with the first
-/// about a ref they both read.
+/// Three namespaces answering three questions -- who holds a task, what has been
+/// attested against it outside its file (ADR-493471d64ba0), and who the remote
+/// last said was holding it -- and one enumeration, because a second walk would
+/// be free to disagree with the first about a ref they both read.
 #[derive(Debug, Default)]
 pub(crate) struct Plane {
     pub claims: HashMap<EntityId, Coordination>,
     /// Empty for a task with no attestation, which is nearly all of them.
     pub proofs: HashMap<EntityId, Vec<claim::AttestedProof>>,
+    /// The remote's claims as a watcher last mirrored them, and **empty
+    /// wherever no watcher runs** -- which is every CI runner, every container
+    /// and most checkouts. Read by `status` alone: it is news about other
+    /// clones, and a verb that decided anything on it would make a background
+    /// process a thing to depend on.
+    pub mirrored: HashMap<EntityId, Coordination>,
+}
+
+/// Which of the three namespaces a ref was found in, and therefore which
+/// question its record answers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Ns {
+    Claims,
+    Proof,
+    Mirror,
 }
 
 /// The claim half alone, for the callers that only ask who holds what.
@@ -138,12 +181,14 @@ pub(crate) fn plane(cwd: &std::path::Path, warnings: &mut Vec<String>) -> Result
         // whose state contradicts its namespace is reported rather than
         // coerced: a proof blob on a claim ref would read as a free task, which
         // is the silent fallback this module refuses everywhere else.
-        let (rest, proof_ns) = match (
+        let (rest, ns) = match (
             r.name.strip_prefix(claim::CLAIMS_PREFIX),
             r.name.strip_prefix(claim::PROOF_PREFIX),
+            mirrored_claim(&r.name),
         ) {
-            (Some(rest), _) => (rest, false),
-            (_, Some(rest)) => (rest, true),
+            (Some(rest), _, _) => (rest, Ns::Claims),
+            (_, Some(rest), _) => (rest, Ns::Proof),
+            (_, _, Some(rest)) => (rest, Ns::Mirror),
             _ => continue,
         };
         let Ok(id) = EntityId::parse(rest) else {
@@ -164,40 +209,52 @@ pub(crate) fn plane(cwd: &std::path::Path, warnings: &mut Vec<String>) -> Result
                 continue;
             }
         };
-        match (record, proof_ns) {
-            (Record::Proof(p), true) => {
-                plane.proofs.insert(id, p.proofs);
+        // Read once and filed by address. The mirror carries the same records
+        // as the namespace it mirrors, so the reading is the same reading; what
+        // differs is which map it lands in, and therefore who is allowed to act
+        // on it.
+        let state = match record {
+            Record::Proof(p) => {
+                if ns == Ns::Proof {
+                    plane.proofs.insert(id, p.proofs);
+                } else {
+                    warnings.push(format!(
+                        "{} carries a record of the wrong kind for its namespace",
+                        r.name
+                    ));
+                }
+                continue;
             }
-            (Record::Completed(c), false) => {
-                plane.claims.insert(
-                    id,
-                    Coordination::Finished {
-                        commit: c.commit,
-                        branch: c.branch,
-                    },
-                );
+            _ if ns == Ns::Proof => {
+                warnings.push(format!(
+                    "{} carries a record of the wrong kind for its namespace",
+                    r.name
+                ));
+                continue;
             }
-            (Record::Claim(c), false) => {
-                let state = match claim::is_expired(&c, claim::now_secs(), &id) {
-                    Ok(true) => Coordination::Lapsed { holder: c.holder },
-                    Ok(false) => Coordination::Claimed {
-                        holder: c.holder,
-                        expires: c.expires,
-                    },
-                    Err(e) => {
-                        // The ref is not appended: `corrupt` already names it, and it
-                        // is the one thing the reader acts on.
-                        warnings.push(e.message);
-                        continue;
-                    }
-                };
-                plane.claims.insert(id, state);
-            }
-            (_, _) => warnings.push(format!(
-                "{} carries a record of the wrong kind for its namespace",
-                r.name
-            )),
-        }
+            Record::Completed(c) => Coordination::Finished {
+                commit: c.commit,
+                branch: c.branch,
+            },
+            Record::Claim(c) => match claim::is_expired(&c, claim::now_secs(), &id) {
+                Ok(true) => Coordination::Lapsed { holder: c.holder },
+                Ok(false) => Coordination::Claimed {
+                    holder: c.holder,
+                    expires: c.expires,
+                },
+                Err(e) => {
+                    // The ref is not appended: `corrupt` already names it, and it
+                    // is the one thing the reader acts on.
+                    warnings.push(e.message);
+                    continue;
+                }
+            },
+        };
+        match ns {
+            Ns::Claims => plane.claims.insert(id, state),
+            Ns::Mirror => plane.mirrored.insert(id, state),
+            Ns::Proof => unreachable!("a proof namespace never reaches a coordination state"),
+        };
     }
     Ok(plane)
 }

--- a/crates/ank-cli/src/status.rs
+++ b/crates/ank-cli/src/status.rs
@@ -118,11 +118,12 @@ pub fn run(
     // is the verb an agent runs to learn where things stand rather than what to
     // do next.
     //
-    // Read through the same `coordination` map every listing verb uses, not a
-    // second enumeration of the refs: one plane, one reading, and a second one
-    // would be free to disagree with the first.
-    let plane = context::coordination(&repo.corpus, &mut Vec::new())?;
+    // Read through the same plane every listing verb uses, not a second
+    // enumeration of the refs: one plane, one reading, and a second one would
+    // be free to disagree with the first.
+    let plane = context::plane(&repo.corpus, &mut Vec::new())?;
     let mut elsewhere: Vec<Held> = plane
+        .claims
         .iter()
         .filter_map(|(id, state)| match state {
             // **The title, joined here and not looked up later.** The rows are
@@ -141,6 +142,40 @@ pub fn run(
             _ => None,
         })
         .collect();
+
+    // **What a watcher mirrored, which is the same fact arriving without the
+    // round trip** (ADR-a22cd3196529). `refs/ank/claims/*` in this clone is
+    // whatever somebody last fetched by hand, so on a parc of clones the
+    // section above reports holders as of an hour ago and has no way to say so.
+    // A watcher mirrors the remote's namespace on the interval its declaration
+    // states, and reading that mirror is what makes this line current.
+    //
+    // **Added, never substituted.** A local record wins where both carry the
+    // same task: the mirror is news about other clones and the local plane is
+    // this one's own arbitration, and a background process may not overrule it.
+    // Where no watcher runs the map is empty and every line below is exactly
+    // what it was -- which is the whole of "nothing depends on it", asserted
+    // rather than promised.
+    //
+    // `seen` stays untouched: it answers whether `--remote` found the ref on
+    // origin, which is a different question from where this clone read the
+    // record. A mirrored claim carries a holder and an expiry like any other,
+    // because the record itself is here to be read.
+    for (id, state) in &plane.mirrored {
+        let context::Coordination::Claimed { holder, expires } = state else {
+            continue;
+        };
+        if holder == identity || plane.claims.contains_key(id) {
+            continue;
+        }
+        elsewhere.push(Held {
+            id: id.clone(),
+            title: title_of(&rows, id),
+            holder: Some(holder.clone()),
+            expires: Some(expires.clone()),
+            seen: None,
+        });
+    }
 
     // **The remote plane, only when it is asked for** (§7, ADR-47e2ac102f58).
     // The default stays what §7 says it is: `claim` is the one verb that pays
@@ -172,7 +207,10 @@ pub fn run(
         // never that it is a claim rather than the completion record that
         // shares the namespace.
         for id in ids {
-            if plane.contains_key(id) {
+            // Both sources, because a claim already listed is a claim already
+            // listed however it got here: from this clone's own plane, or from
+            // a mirror a watcher filled.
+            if plane.claims.contains_key(id) || elsewhere.iter().any(|h| &h.id == id) {
                 continue;
             }
             elsewhere.push(Held {

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -5769,6 +5769,146 @@ fn status_remote_names_the_claims_origin_holds_and_which_are_only_there() {
     );
 }
 
+/// What a watcher mirrors into `refs/ank/watch/*` reaches `status`, and reaches
+/// nothing else (ADR-a22cd3196529).
+///
+/// The reader's half of the watcher. `refs/ank/claims/*` in this clone is
+/// whatever somebody last fetched by hand, so on a parc of clones `status`
+/// reports holders as of an hour ago; a watcher mirrors the remote's namespace
+/// on an interval and this is what reading that mirror buys.
+///
+/// **The mirror is written here by git and not by the daemon**, deliberately:
+/// what this file is about is the CLI, and the refspec below is the one the
+/// watcher runs. That the watcher runs it, on the interval its declaration
+/// states, is asserted where it belongs -- against the binary, in
+/// `crates/ank-daemon/tests/daemon.rs`.
+///
+/// **Nothing depends on it**, asserted as an equality rather than promised: the
+/// listing verbs, the graph, `check` and `context` answer the same bytes with
+/// the mirror present and absent, because the day one of them starts deciding
+/// on it, an installation with a watcher and one without have become two
+/// products.
+#[test]
+fn a_claim_a_watcher_mirrored_is_reported_by_status_and_by_nothing_else() {
+    const MINE: &str = "TASK-000000000f41";
+    const THEIRS: &str = "TASK-000000000f42";
+    let r = Repo::new();
+    r.seed_task_titled(MINE, "Held in this clone");
+    r.seed_task_titled(THEIRS, "Held in the other clone");
+    let (_origin, other) = r.cloned();
+
+    let out = r.ank_at("codex@host-9", &["claim", THEIRS], &other);
+    assert_eq!(code(&out), 0, "{}{}", stdout(&out), stderr(&out));
+
+    // Every verb, before any mirror exists. This is the installation without a
+    // watcher, which is the one every CI runner and every container has.
+    let verbs: &[&[&str]] = &[
+        &["find", "--status", "open", "--json"],
+        &["find", "--json"],
+        &["graph"],
+        &["scope", "src/**"],
+        &["check"],
+        &["context"],
+        &["show", THEIRS],
+    ];
+    let cold: Vec<(Vec<u8>, Option<i32>)> = verbs
+        .iter()
+        .map(|v| {
+            let out = r.ank("claude-code@ank", v);
+            (out.stdout.clone(), out.status.code())
+        })
+        .collect();
+    let said = stdout(&r.ank("claude-code@ank", &["status"]));
+    assert!(
+        said.contains("elsewhere no claim by another agent"),
+        "the claim reached this clone by a route nobody ran:\n{said}"
+    );
+
+    // The refspec the watcher runs, and nothing else it runs: the destination
+    // is its own namespace, so `refs/ank/claims/*` here is untouched.
+    r.git(&[
+        "fetch",
+        "--quiet",
+        "--prune",
+        "--no-tags",
+        "--no-write-fetch-head",
+        "origin",
+        "+refs/ank/*:refs/ank/watch/origin/*",
+    ]);
+    assert!(
+        r.claim_ref(THEIRS).is_none(),
+        "the mirror landed on the plane it is supposed to stay off"
+    );
+
+    let out = r.ank("claude-code@ank", &["status"]);
+    assert_eq!(code(&out), 0, "{}{}", stdout(&out), stderr(&out));
+    let said = stdout(&out);
+    let line = said
+        .lines()
+        .find(|l| l.contains(THEIRS))
+        .unwrap_or_else(|| panic!("the mirrored claim went unreported:\n{said}"));
+    // The record itself is here, unlike a ref seen with `ls-remote`: the mirror
+    // carries the object, so the holder is read rather than guessed at.
+    assert!(
+        line.contains("codex@host-9") && line.contains("Held in the other clone"),
+        "a mirrored claim lost what the record says: {line}"
+    );
+    assert!(
+        !line.contains("on origin only"),
+        "a record this clone can read is reported as one it cannot: {line}"
+    );
+    // No network was paid for: `seen` answers whether `--remote` found the ref
+    // on origin, and nothing asked it to.
+    let json = stdout(&r.ank("claude-code@ank", &["status", "--json"]));
+    assert!(
+        json.contains(&format!(
+            "{{\"id\":\"{THEIRS}\",\"title\":\"Held in the other clone\",\
+             \"holder\":\"codex@host-9\""
+        )),
+        "{json}"
+    );
+    assert!(
+        json.contains("\"remote\":false"),
+        "the mirror was reported as a remote read: {json}"
+    );
+
+    // And every other verb answers exactly what it answered with no mirror at
+    // all, byte for byte and code for code.
+    for (verb, (bytes, exit)) in verbs.iter().zip(&cold) {
+        let out = r.ank("claude-code@ank", verb);
+        assert_eq!(
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(bytes),
+            "{verb:?} answered differently because a watcher had run"
+        );
+        assert_eq!(out.status.code(), *exit, "{verb:?}");
+    }
+
+    // A local record wins where both planes carry the task: the mirror is news
+    // about other clones, and a background process may not overrule this one's
+    // own arbitration.
+    assert_eq!(code(&r.ank("claude-code@ank", &["claim", MINE])), 0);
+    r.git(&[
+        "fetch",
+        "--quiet",
+        "--prune",
+        "--no-tags",
+        "--no-write-fetch-head",
+        "origin",
+        "+refs/ank/*:refs/ank/watch/origin/*",
+    ]);
+    let said = stdout(&r.ank("someone-else@host-2", &["status"]));
+    assert_eq!(
+        said.lines().filter(|l| l.contains(MINE)).count(),
+        1,
+        "the task is listed twice, once per plane:\n{said}"
+    );
+    assert!(
+        said.contains("elsewhere 2 claim(s) by other agents"),
+        "the two planes did not sort into one list:\n{said}"
+    );
+}
+
 /// The flag degrades where there is no remote to read, and never fails
 /// (TASK-028bcee93801, §2).
 ///

--- a/crates/ank-daemon/src/declare.rs
+++ b/crates/ank-daemon/src/declare.rs
@@ -27,9 +27,20 @@ use ank_contract::ExitCode;
 use serde::Deserialize;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 /// The reader's watch list, under [`user_dir`].
 pub const WATCH_FILE: &str = "watch.yml";
+
+/// How often `refs/ank/*` is mirrored when the declaration states nothing.
+///
+/// A minute, and deliberately three orders of magnitude above the warm poll.
+/// The poll is a stat of a local directory and costs nothing; this is a network
+/// round trip against somebody's forge, once per watched checkout, forever. A
+/// claim is a thirty-minute lease (§3), so a minute is already an order of
+/// magnitude finer than the thing it reports on, and anybody who wants it
+/// finer, or who is watching a remote that charges for it, states a number.
+pub const DEFAULT_FETCH: Duration = Duration::from_secs(60);
 
 /// The only schema this build reads. A file declaring anything else is refused
 /// by number rather than read optimistically, for the reason `corpora.yml` is:
@@ -48,6 +59,15 @@ pub const ANK_DIR: &str = ".ank";
 #[serde(deny_unknown_fields)]
 struct WatchFileDoc {
     schema: u32,
+    /// Seconds between two mirrors of `refs/ank/*`, stated by the reader who
+    /// pays for them.
+    ///
+    /// **Optional, and still schema 1.** A field that may be omitted is
+    /// readable by a build that predates it, so the number does not move; a
+    /// file that *states* it is refused by an older daemon, which is the
+    /// honest outcome of asking for something that build cannot do.
+    #[serde(default)]
+    fetch: Option<u64>,
     #[serde(default)]
     watch: BTreeMap<String, Trees>,
 }
@@ -81,6 +101,18 @@ impl Trees {
 pub struct Watched {
     pub identity: String,
     pub roots: Vec<PathBuf>,
+}
+
+/// A declaration resolved: what to watch, and how often to pay the network for
+/// news about it.
+///
+/// The interval travels with the list rather than beside it, because it is
+/// stated in the same file by the same reader and a second source for it would
+/// be a second answer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Declaration {
+    pub fetch: Duration,
+    pub watch: Vec<Watched>,
 }
 
 /// Where this reader's declarations live, or `None` where the environment names
@@ -147,7 +179,7 @@ pub fn resolve(
     text: &str,
     path: &Path,
     identity_of: &dyn Fn(&Path) -> Option<String>,
-) -> Result<Vec<Watched>> {
+) -> Result<Declaration> {
     let doc: WatchFileDoc = serde_yaml::from_str(text).map_err(|e| {
         Fail::new(ExitCode::Environment, format!("{}: {e}", path.display())).with_hint(
             "schema: 1 and a watch: map of repository identity to the path of a checkout, \
@@ -164,6 +196,30 @@ pub fn resolve(
             ),
         ));
     }
+    // **A stated zero is refused rather than rounded up.** `fetch: 0` reads as
+    // "as often as possible", and as often as possible is a network round trip
+    // per poll -- twice a second by default, against somebody's forge. A reader
+    // who wants that has mistyped, and a watcher that silently substituted its
+    // own number would be watching under a configuration its caller does not
+    // have.
+    let fetch = match doc.fetch {
+        Some(0) => {
+            return Err(Fail::new(
+                ExitCode::Environment,
+                format!(
+                    "{}: fetch: 0 would fetch on every look rather than on an interval",
+                    path.display()
+                ),
+            )
+            .with_hint(format!(
+                "give it a number of seconds, or omit fetch to take the default of {}",
+                DEFAULT_FETCH.as_secs()
+            )))
+        }
+        Some(secs) => Duration::from_secs(secs),
+        None => DEFAULT_FETCH,
+    };
+
     if doc.watch.is_empty() {
         return Err(Fail::new(
             ExitCode::Environment,
@@ -259,7 +315,10 @@ pub fn resolve(
             roots,
         });
     }
-    Ok(watched)
+    Ok(Declaration {
+        fetch,
+        watch: watched,
+    })
 }
 
 /// Whether two paths name one directory, asked of the filesystem rather than of
@@ -315,5 +374,47 @@ mod tests {
     fn an_unknown_field_is_refused() {
         let err = resolve("schema: 1\nscan: true\n", Path::new("watch.yml"), &none).unwrap_err();
         assert_eq!(err.code, ExitCode::Environment);
+    }
+
+    #[test]
+    fn a_fetch_interval_of_zero_is_refused_rather_than_run_every_poll() {
+        let err = resolve(
+            "schema: 1\nfetch: 0\nwatch: {}\n",
+            Path::new("watch.yml"),
+            &none,
+        )
+        .unwrap_err();
+        assert_eq!(err.code, ExitCode::Environment);
+        assert!(err.message.contains("fetch: 0"), "{err:?}");
+        // Refused before the emptiness of `watch:` is: a number that cannot be
+        // honoured is wrong whatever it is applied to, and reporting the second
+        // fault first would send the reader to correct the wrong line.
+        assert!(
+            !err.message.contains("nothing is declared"),
+            "the interval is judged on its own terms: {err:?}"
+        );
+    }
+
+    #[test]
+    fn a_declaration_that_states_no_interval_takes_the_default() {
+        // Read through a declaration that resolves, because the interval is a
+        // field of the answer rather than a constant a caller reaches for.
+        let dir = std::env::temp_dir().join(format!(
+            "ank-daemon-declare-{}-{}",
+            std::process::id(),
+            "default"
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join(ANK_DIR)).unwrap();
+        let key = "a".repeat(40);
+        let found = |_: &Path| Some("a".repeat(40));
+        let text = format!("schema: 1\nwatch:\n  {key}: {}\n", dir.display());
+        let declared = resolve(&text, Path::new("watch.yml"), &found).unwrap();
+        assert_eq!(declared.fetch, DEFAULT_FETCH);
+
+        let stated = format!("schema: 1\nfetch: 5\nwatch:\n  {key}: {}\n", dir.display());
+        let declared = resolve(&stated, Path::new("watch.yml"), &found).unwrap();
+        assert_eq!(declared.fetch, Duration::from_secs(5));
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/ank-daemon/src/fetch.rs
+++ b/crates/ank-daemon/src/fetch.rs
@@ -1,0 +1,132 @@
+//! The one thing this process writes into somebody else's repository
+//! (ADR-a22cd3196529).
+//!
+//! **A tracking namespace, and never the corpus's own.** `init` wires
+//! `+refs/ank/*:refs/ank/*`, so the fetch a person runs by hand lands the
+//! remote's refs on top of this clone's. That is a person choosing to
+//! synchronise. A background process doing the same thing would be rewriting
+//! the coordination plane underneath whoever is working in the tree, and
+//! `refs/ank/claims/<id>` is the ref a live claim of theirs sits on. So the
+//! destination is [`TRACKING`]: a mirror the CLI reads and nobody claims
+//! against, in a namespace no verb writes.
+//!
+//! **Narrow on purpose.** `refs/ank/*` is the namespace this project owns and
+//! nobody rebases onto it. A full fetch would keep drift from the default
+//! branch accurate too, which is tempting and is refused: a background process
+//! that updates branches in a repository where somebody is working is a source
+//! of surprises a coordination tool has no business being.
+//!
+//! **Everything git would otherwise do on the side is turned off.** `--no-tags`
+//! because tag auto-following would bring tags in as a side effect of
+//! downloading objects, and a tag that appeared while nobody asked is exactly
+//! the surprise above. `--no-write-fetch-head` because `FETCH_HEAD` is a file
+//! the person's next `git merge FETCH_HEAD` reads. `--prune` because a claim
+//! released on the remote has to *disappear* here, and a mirror that only ever
+//! grows reports holders who let go an hour ago.
+//!
+//! **A failure is a line and never an exit.** The daemon is optional by
+//! construction, so a dead network downgrades what it offers and never stops
+//! it, and never reaches the exit code of anything the person is running.
+
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+/// Where the remote's `refs/ank/*` land in a repository this daemon watches.
+///
+/// Under `refs/ank/` rather than beside it, because ADR-85e6ff5b8b7c gives this
+/// project one ref namespace and a second one would be a second answer to
+/// "which refs are ank's". Inert to every verb: each reader of the plane strips
+/// `refs/ank/claims/` or `refs/ank/proof/` and skips what matches neither, so a
+/// build of the CLI that knows nothing about this mirror behaves exactly as it
+/// did before one existed.
+///
+/// The remote is named in the path even though `origin` is the only one ank
+/// arbitrates through, for the reason the CLI names it rather than discovering
+/// it: a mirror whose refs do not say where they came from is a mirror that
+/// cannot gain a second source without renaming the first.
+pub const TRACKING: &str = "refs/ank/watch/origin/";
+
+/// Whether this repository has the remote ank arbitrates through.
+///
+/// **Absence is not a failure**, exactly as it is for the CLI: a repository
+/// with no remote is the mode every solo checkout is in, and a watcher that
+/// complained once a minute about it would be reporting a configuration nobody
+/// got wrong.
+fn has_origin(root: &Path) -> bool {
+    Command::new("git")
+        .args(["config", "--get", "remote.origin.url"])
+        .current_dir(root)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// What one fetch cycle did.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Fetched {
+    /// The remote answered and the mirror is current.
+    Ok,
+    /// There is no remote to mirror, which is the nominal state of a solo
+    /// checkout and not a fault.
+    NoRemote,
+}
+
+/// Mirrors `refs/ank/*` of `origin` into [`TRACKING`], and touches nothing
+/// else.
+///
+/// `Err` carries the first line of git's own complaint, which is what a person
+/// reading the log needs and is never parsed by anything here: the exit code is
+/// what decided, as ADR-9307e5d214a7 requires.
+pub fn mirror(root: &Path) -> Result<Fetched, String> {
+    if !has_origin(root) {
+        return Ok(Fetched::NoRemote);
+    }
+    let spec = format!("+refs/ank/*:{TRACKING}*");
+    let out = Command::new("git")
+        .args([
+            "fetch",
+            "--quiet",
+            "--prune",
+            "--no-tags",
+            "--no-write-fetch-head",
+            "--no-recurse-submodules",
+            "origin",
+            spec.as_str(),
+        ])
+        .current_dir(root)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .output()
+        .map_err(|e| format!("git fetch: {e}"))?;
+    if out.status.success() {
+        return Ok(Fetched::Ok);
+    }
+    let said = String::from_utf8_lossy(&out.stderr);
+    Err(said
+        .lines()
+        .map(str::trim)
+        .find(|l| !l.is_empty())
+        .unwrap_or("no reason given")
+        .to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_tracking_namespace_is_neither_of_the_two_the_cli_reads() {
+        // The property that makes this mirror inert to every existing verb:
+        // `context::plane` strips these two prefixes and skips whatever matches
+        // neither. If this ever started with one of them, a mirrored claim
+        // would read as a claim taken in this clone.
+        assert!(!TRACKING.starts_with("refs/ank/claims/"));
+        assert!(!TRACKING.starts_with("refs/ank/proof/"));
+        assert!(TRACKING.starts_with("refs/ank/"));
+        assert!(TRACKING.ends_with('/'));
+    }
+}

--- a/crates/ank-daemon/src/main.rs
+++ b/crates/ank-daemon/src/main.rs
@@ -21,23 +21,32 @@
 //! ADR-621a7fd96ce1, held outside every repository. Nothing here walks a
 //! filesystem looking for a corpus, in any direction, under any flag.
 //!
-//! What this build does not yet do, and where it is decided: it fetches
-//! nothing (TASK-a73bd7f1c8f0 carries ADR-a22cd3196529's `refs/ank/*` clause),
-//! and the change it notices reaches the reader as a line on stderr rather than
-//! as an event a program subscribes to (TASK-2f775b1cb32b). Both are additions
-//! to this floor and neither changes what a verb answers.
+//! **It mirrors `refs/ank/*` and nothing else.** The one thing it writes into
+//! somebody else's repository is a fetch into [`fetch::TRACKING`], a namespace
+//! no verb writes and every reader of the plane skips. No branch, no tag, no
+//! working tree, no index of git's, and no local `refs/ank/claims`: a
+//! background process that moved any of those in a repository where somebody is
+//! working would be the source of surprises a coordination tool has no business
+//! being. What it buys is that `ank status` stops reporting who holds what out
+//! of somebody's last manual fetch.
+//!
+//! What this build does not yet do, and where it is decided: the change it
+//! notices reaches the reader as a line on stderr rather than as an event a
+//! program subscribes to (TASK-2f775b1cb32b). That is an addition to this floor
+//! and it changes nothing about what a verb answers.
 
 mod declare;
 mod fail;
+mod fetch;
 mod warm;
 
 use ank_contract::ExitCode;
-use declare::Watched;
+use declare::Declaration;
 use fail::{Fail, Result};
 use std::io::Write;
 use std::path::Path;
 use std::process::Command;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 /// How often the declared corpora are looked at, when the caller names nothing.
 ///
@@ -61,8 +70,11 @@ ank-daemon                keeps the corpora you declared warm, so the ank you ru
   --version               the build
   --help                  this
 
-It declares nothing, answers no verb and holds no claim. Every verb behaves the
-same with it stopped, which is why stopping it is always safe.
+It declares nothing, answers no verb and holds no claim. The only thing it
+writes into a repository is that repository's own index and a mirror of
+refs/ank/* under refs/ank/watch/, on the interval watch.yml states; it moves no
+branch, no tag and no claim of yours. Every verb behaves the same with it
+stopped, which is why stopping it is always safe.
 ";
 
 fn main() {
@@ -168,16 +180,16 @@ fn run(args: &[String], out: &mut dyn Write, err: &mut dyn Write) -> Result<Exit
             ))
         }
     };
-    let watched = declare::resolve(&text, &path, &identity_of)?;
+    let declared = declare::resolve(&text, &path, &identity_of)?;
 
     if opts.list {
-        report(&watched, out);
+        report(&declared, out);
         return Ok(ExitCode::Ok);
     }
 
     let ank = warm::locate_ank()?;
     watch(
-        &watched,
+        &declared,
         &ank,
         opts.once,
         opts.interval.unwrap_or(DEFAULT_INTERVAL),
@@ -191,7 +203,8 @@ fn run(args: &[String], out: &mut dyn Write, err: &mut dyn Write) -> Result<Exit
 /// No colour here at all, under ADR-0c8a12b4e0a1's split: the structure layer is
 /// emitted identically to every reader, and this process has no half that
 /// depends on who is reading -- its ordinary destination is a log file.
-fn report(watched: &[Watched], out: &mut dyn Write) {
+fn report(declared: &Declaration, out: &mut dyn Write) {
+    let watched = &declared.watch;
     let mut roots = 0;
     for corpus in watched {
         let _ = writeln!(out, "corpus {}", corpus.identity);
@@ -211,6 +224,15 @@ fn report(watched: &[Watched], out: &mut dyn Write) {
         },
         roots,
         if roots == 1 { "checkout" } else { "checkouts" },
+    );
+    // The number the reader stated, or the one they took by not stating it,
+    // printed either way: an interval a listing leaves out is one a reader
+    // discovers from their forge's rate limit.
+    let _ = writeln!(
+        out,
+        "mirroring {}* every {}s",
+        fetch::TRACKING,
+        declared.fetch.as_secs()
     );
 }
 
@@ -249,11 +271,11 @@ fn identity_of(root: &Path) -> Option<String> {
 /// all of the time that matters after a `git checkout`. That pass is a warming
 /// and not a change, so it says so: an event states what changed
 /// (ADR-a22cd3196529), and a first sighting is not one.
-fn watch(watched: &[Watched], ank: &Path, once: bool, interval: Duration, err: &mut dyn Write) {
+fn watch(declared: &Declaration, ank: &Path, once: bool, interval: Duration, err: &mut dyn Write) {
     // Flattened once, so the state and the checkout it belongs to are one
     // value. The loop below indexes nothing.
     let mut posts: Vec<Post> = Vec::new();
-    for corpus in watched {
+    for corpus in &declared.watch {
         let _ = writeln!(
             err,
             "watching {} ({} {})",
@@ -270,11 +292,41 @@ fn watch(watched: &[Watched], ank: &Path, once: bool, interval: Duration, err: &
                 identity: corpus.identity.clone(),
                 root: root.clone(),
                 seen: None,
+                mirrored: None,
             });
         }
     }
     loop {
         for post in &mut posts {
+            // **The mirror first, and on its own clock.** The warm poll is a
+            // stat of a local directory twice a second; this is a round trip
+            // against somebody's forge, so it runs on the interval the
+            // declaration states and not on the one the poll uses.
+            //
+            // Per checkout rather than per corpus, because two roots under one
+            // identity are two *clones* as readily as two worktrees, and two
+            // clones are two repositories each holding its own mirror. Two
+            // worktrees share a repository and so pay for one redundant fetch a
+            // minute, which is the cheaper of the two ways to be wrong.
+            if post
+                .mirrored
+                .is_none_or(|at| at.elapsed() >= declared.fetch)
+            {
+                if let Err(reason) = fetch::mirror(&post.root) {
+                    // Reported and never fatal: a dead network is a normal
+                    // Tuesday, and nothing depends on this process.
+                    let _ = writeln!(
+                        err,
+                        "{} {}: fetch: {reason}",
+                        post.identity,
+                        post.root.display()
+                    );
+                }
+                // Stamped whichever way it went. A remote that is down stays
+                // down for a while, and retrying it every poll would turn one
+                // failure into a spin against a network that is not answering.
+                post.mirrored = Some(Instant::now());
+            }
             let now = warm::fingerprint(&warm::ank_dir(&post.root));
             let first = post.seen.is_none();
             let moved = post.seen.as_ref() != Some(&now);
@@ -304,11 +356,16 @@ struct Post {
     identity: String,
     root: std::path::PathBuf,
     seen: Option<Vec<(String, u64, u128)>>,
+    /// When `refs/ank/*` was last mirrored, or `None` for a checkout this
+    /// process has not yet reached. `None` is due immediately, so `--once`
+    /// mirrors once and a fresh start does not leave the reader a minute behind.
+    mirrored: Option<Instant>,
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use declare::Watched;
     use std::path::PathBuf;
 
     #[test]
@@ -326,13 +383,20 @@ mod tests {
 
     #[test]
     fn the_listing_counts_corpora_and_checkouts() {
-        let watched = vec![Watched {
-            identity: "a".repeat(40),
-            roots: vec![PathBuf::from("/one"), PathBuf::from("/two")],
-        }];
+        let declared = Declaration {
+            fetch: Duration::from_secs(60),
+            watch: vec![Watched {
+                identity: "a".repeat(40),
+                roots: vec![PathBuf::from("/one"), PathBuf::from("/two")],
+            }],
+        };
         let mut out = Vec::new();
-        report(&watched, &mut out);
+        report(&declared, &mut out);
         let text = String::from_utf8(out).unwrap();
         assert!(text.contains("watching 1 corpus, 2 checkouts"), "{text}");
+        assert!(
+            text.contains("mirroring refs/ank/watch/origin/* every 60s"),
+            "{text}"
+        );
     }
 }

--- a/crates/ank-daemon/tests/daemon.rs
+++ b/crates/ank-daemon/tests/daemon.rs
@@ -179,6 +179,41 @@ impl Corpus {
         out
     }
 
+    /// The CLI under a named identity.
+    ///
+    /// Two clones with one `ANK_AGENT` are one agent as far as `refs/ank/*` can
+    /// tell, and `status` filters its own identity out of what other agents
+    /// hold -- so a fixture that let both sides share the default would assert
+    /// the mirror by never reading it.
+    fn ank_as(&self, home: &Home, agent: &str, args: &[&str]) -> Output {
+        let mut c = Command::new(bin("ank"));
+        c.args(args).current_dir(&self.root);
+        home.apply(&mut c);
+        c.env("ANK_AGENT", agent);
+        let out = c
+            .output()
+            .expect("cargo builds every binary of the workspace");
+        assert!(
+            out.status.success(),
+            "ank {args:?} as {agent} in {}: {}",
+            self.root.display(),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        out
+    }
+
+    /// Every `refs/ank/*` this repository carries, as `<name> <object>` lines.
+    ///
+    /// The plane and the mirror both, because the assertions that matter are
+    /// about which of the two moved.
+    fn ank_refs(&self, home: &Home, pattern: &str) -> String {
+        let out = self.git(
+            home,
+            &["for-each-ref", "--format=%(refname) %(objectname)", pattern],
+        );
+        String::from_utf8_lossy(&out.stdout).to_string()
+    }
+
     fn ank_dir(&self) -> PathBuf {
         self.root.join(".ank")
     }
@@ -209,6 +244,50 @@ impl Corpus {
             let _ = std::fs::remove_file(self.ank_dir().join(format!("index.db{suffix}")));
         }
     }
+}
+
+/// A bare repository two clones arbitrate through.
+///
+/// Bare and not a third checkout: `origin` here is what a forge is, a place
+/// refs are pushed to and fetched from, and giving it a working tree would let
+/// a test pass by writing into a file nobody would have in production.
+fn bare(home: &Home, path: &Path) {
+    let mut c = Command::new("git");
+    c.args(["init", "-q", "--bare", "-b", "main"])
+        .arg(path)
+        .current_dir(std::env::temp_dir());
+    home.apply(&mut c);
+    let out = c.output().expect("git is a hard dependency");
+    assert!(out.status.success(), "{out:?}");
+}
+
+/// A clone of `origin`, wired the way `git clone` wires one and no further.
+///
+/// **No `ank init` and therefore no `+refs/ank/*:refs/ank/*` refspec.** That is
+/// the whole point: a clone made by hand fetches branches and tags, so
+/// `refs/ank/claims/*` reaches it only when somebody runs the fetch by hand --
+/// which is the staleness the watcher exists to remove, and it cannot be
+/// demonstrated in a clone that was already synchronising itself.
+fn clone(home: &Home, origin: &Path, into: &Path) -> Corpus {
+    let mut c = Command::new("git");
+    c.args(["clone", "-q"])
+        .arg(origin)
+        .arg(into)
+        .current_dir(std::env::temp_dir());
+    home.apply(&mut c);
+    let out = c.output().expect("git is a hard dependency");
+    assert!(
+        out.status.success(),
+        "git clone: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let corpus = Corpus {
+        root: into.to_path_buf(),
+    };
+    corpus.git(home, &["config", "user.email", "test@ank.local"]);
+    corpus.git(home, &["config", "user.name", "Test"]);
+    corpus.git(home, &["config", "commit.gpgsign", "false"]);
+    corpus
 }
 
 /// Every file under a directory, with its bytes: the shape of "never touched".
@@ -257,6 +336,15 @@ impl Running {
 fn start(home: &Home, args: &[&str]) -> Running {
     let mut cmd = home.daemon(args);
     cmd.stdout(Stdio::null()).stderr(Stdio::null());
+    Running(cmd.spawn().expect("the daemon must have been built"))
+}
+
+/// The same, with stderr kept: what the watcher reports is an assertion in its
+/// own right, and a failure it swallowed reads exactly like one it never had.
+fn start_logging(home: &Home, args: &[&str], log: &Path) -> Running {
+    let mut cmd = home.daemon(args);
+    let file = std::fs::File::create(log).unwrap();
+    cmd.stdout(Stdio::null()).stderr(Stdio::from(file));
     Running(cmd.spawn().expect("the daemon must have been built"))
 }
 
@@ -657,6 +745,12 @@ fn stopping_the_daemon_changes_no_verbs_output_and_no_verbs_exit_code() {
     }
 }
 
+/// A checkout with no remote gains its own index and nothing whatsoever else.
+///
+/// The other half of the negative, and the case every solo repository is in:
+/// with nothing to mirror there is no fetch, so `for-each-ref` is unchanged
+/// entirely rather than unchanged outside one namespace. A watcher that
+/// complained about the absent remote, or invented one, would show up here.
 #[test]
 fn the_only_thing_it_writes_into_a_repository_is_the_index() {
     let home = Home::new();
@@ -699,5 +793,322 @@ fn the_only_thing_it_writes_into_a_repository_is_the_index() {
             .trim()
             .is_empty(),
         "the working tree is not the daemon's to touch"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The mirror: refs/ank/*, and demonstrably nothing else
+// ---------------------------------------------------------------------------
+
+/// The fact this whole namespace exists for: `status` in one clone reports what
+/// another clone holds, and nobody ran a fetch.
+///
+/// **Two clones is the only honest fixture.** The thing being fixed is that
+/// `status` reports who holds what out of a stale local copy of the refs. One
+/// clone cannot show that, because there is no second plane for the first to be
+/// stale about, and a test that tried would be measuring nothing.
+///
+/// The second clone is made by `git clone` and never by `ank init`, so it
+/// carries no `+refs/ank/*:refs/ank/*` refspec: without the watcher there is no
+/// route by which a claim taken elsewhere reaches it at all.
+#[test]
+fn a_claim_taken_in_one_clone_is_reported_by_status_in_the_other() {
+    let home = Home::new();
+    let root = scratch("clones");
+    let origin = root.join("origin.git");
+    bare(&home, &origin);
+
+    let first = Corpus::new(root.join("first"), &home);
+    // `ank init` has already written `remote.origin.fetch`, so the section
+    // exists and only the url is missing: `git remote add` would refuse.
+    first.git(
+        &home,
+        &["config", "remote.origin.url", &origin.display().to_string()],
+    );
+    first.git(&home, &["push", "-q", "-u", "origin", "main"]);
+    let second = clone(&home, &origin, &root.join("second"));
+    assert_eq!(first.identity(&home), second.identity(&home));
+    let task = first.task_id(&home);
+
+    // Before anything: the second clone has no coordination plane at all, so
+    // the claim below is unreachable from it by every route but the mirror.
+    assert!(
+        second.ank_refs(&home, "refs/ank").is_empty(),
+        "a plain clone carries no refs/ank/*"
+    );
+
+    // One key, two roots: two clones of one repository are one watched corpus,
+    // and each holds its own mirror because each is its own git repository.
+    home.declare(&format!(
+        "schema: 1\nfetch: 1\nwatch:\n  {}:\n    - {}\n    - {}\n",
+        first.identity(&home),
+        first.root.display(),
+        second.root.display()
+    ));
+
+    first.ank_as(
+        &home,
+        "first@ank.local",
+        &["claim", &task, "--criteria", "the mirror carries it"],
+    );
+    assert!(
+        first
+            .ank_refs(&home, "refs/ank/claims")
+            .contains(&format!("refs/ank/claims/{task}")),
+        "the claim is a ref in the clone that took it"
+    );
+
+    let elsewhere = |c: &Corpus| -> String {
+        let out = c.ank_raw(
+            &home,
+            &[OsStr::new("status"), OsStr::new("--json")],
+            &c.root,
+        );
+        String::from_utf8_lossy(&out.stdout).to_string()
+    };
+    assert!(
+        !elsewhere(&second).contains("first@ank.local"),
+        "nothing has fetched yet, so the second clone cannot know"
+    );
+
+    let daemon = start(&home, &["--interval", "50"]);
+    until("status in the second clone to report the claim", || {
+        elsewhere(&second).contains("first@ank.local")
+    });
+    let said = elsewhere(&second);
+    daemon.stop();
+
+    assert!(said.contains(&task), "the task the claim is about: {said}");
+    assert!(
+        said.contains("A watched task"),
+        "the title the corpus already carries: {said}"
+    );
+    // And it is reported as a claim held by somebody else, with the record read
+    // rather than guessed at: the mirror carries the object, not merely the
+    // name of a ref.
+    assert!(
+        said.contains("\"holder\":\"first@ank.local\""),
+        "the holder comes out of the record: {said}"
+    );
+    // The local plane is where a claim of this clone's own would live, and the
+    // watcher never wrote there.
+    assert!(
+        second.ank_refs(&home, "refs/ank/claims").is_empty(),
+        "the mirror is not the plane"
+    );
+}
+
+/// The negative, which is the point of this namespace.
+///
+/// "We only fetch `refs/ank/*`" is a sentence that stays true right up until a
+/// refspec is written slightly wrong, so what must be identical afterwards is
+/// listed and asserted against a repository that has something to lose: a
+/// commit nobody pushed, a branch nobody pushed, a tag, a dirty working tree
+/// and a claim of its own.
+#[test]
+fn a_watching_cycle_moves_the_tracking_namespace_and_nothing_else() {
+    let home = Home::new();
+    let root = scratch("negative");
+    let origin = root.join("origin.git");
+    bare(&home, &origin);
+
+    let seed = Corpus::new(root.join("seed"), &home);
+    seed.git(
+        &home,
+        &["config", "remote.origin.url", &origin.display().to_string()],
+    );
+    seed.git(&home, &["push", "-q", "-u", "origin", "main"]);
+
+    let mine = clone(&home, &origin, &root.join("mine"));
+    let task = mine.task_id(&home);
+
+    // A tag pushed to the remote *after* the clone, so it is a ref the working
+    // clone has never had. If the fetch followed tags, this is what would
+    // appear in somebody's repository without anybody asking for it.
+    seed.git(&home, &["tag", "on-the-remote"]);
+    seed.git(&home, &["push", "-q", "origin", "on-the-remote"]);
+
+    // A repository with something to lose.
+    mine.git(&home, &["checkout", "-q", "-b", "unpushed"]);
+    std::fs::write(mine.root.join("src/local.rs"), "// mine\n").unwrap();
+    mine.git(&home, &["add", "-A"]);
+    mine.git(&home, &["commit", "-qm", "a commit nobody has seen"]);
+    mine.git(&home, &["tag", "mine-only"]);
+    std::fs::write(mine.root.join("src/main.rs"), "fn main() { /* dirty */ }\n").unwrap();
+    std::fs::write(mine.root.join("src/untracked.rs"), "// not added\n").unwrap();
+    // A claim of this clone's own, which is the one ref a watcher must never
+    // move: it is a live lease, and rewriting it from the remote would hand
+    // somebody's task away underneath them.
+    mine.ank_as(
+        &home,
+        "mine@ank.local",
+        &["claim", &task, "--criteria", "the mirror never touches it"],
+    );
+
+    home.declare(&format!(
+        "schema: 1\nfetch: 1\nwatch:\n  {}: {}\n",
+        mine.identity(&home),
+        mine.root.display()
+    ));
+
+    let head = mine.git(&home, &["rev-parse", "HEAD"]).stdout;
+    let branches = mine.ank_refs(&home, "refs/heads");
+    let tags = mine.ank_refs(&home, "refs/tags");
+    let index = mine.git(&home, &["ls-files", "--stage"]).stdout;
+    let porcelain = mine.git(&home, &["status", "--porcelain"]).stdout;
+    let tree = snapshot(&mine.root.join("src"));
+    let claims = mine.ank_refs(&home, "refs/ank/claims");
+    let remotes = mine.ank_refs(&home, "refs/remotes");
+    // Every ref this repository carries, whatever its namespace. The named
+    // assertions below say what must not move and are worth reading; this one
+    // says nothing else moved either, which no list of names can.
+    let every_ref = mine.ank_refs(&home, "refs/");
+    assert!(!claims.is_empty(), "the fixture holds a claim of its own");
+    assert!(
+        mine.ank_refs(&home, "refs/ank/watch").is_empty(),
+        "nothing has mirrored yet"
+    );
+
+    let out = home.daemon(&["--once"]).output().unwrap();
+    assert!(out.status.success(), "{out:?}");
+
+    // Whatever moved, moved inside the tracking namespace: the whole ref space
+    // is diffed, and the mirror is the only difference allowed to appear.
+    let after = mine.ank_refs(&home, "refs/");
+    let moved: Vec<&str> = after
+        .lines()
+        .filter(|l| !every_ref.lines().any(|was| was == *l))
+        .collect();
+    assert!(!moved.is_empty(), "nothing was mirrored at all");
+    assert!(
+        moved
+            .iter()
+            .all(|l| l.starts_with("refs/ank/watch/origin/")),
+        "a ref outside the tracking namespace moved: {moved:?}"
+    );
+    let gone: Vec<&str> = every_ref
+        .lines()
+        .filter(|l| !after.lines().any(|now| now == *l))
+        .collect();
+    assert!(gone.is_empty(), "a ref was removed: {gone:?}");
+
+    // Only the mirror moved.
+    assert!(
+        mine.ank_refs(&home, "refs/ank/watch")
+            .contains(&format!("refs/ank/watch/origin/claims/{task}")),
+        "the mirror is what the cycle was for: {}",
+        mine.ank_refs(&home, "refs/ank")
+    );
+    assert_eq!(
+        mine.git(&home, &["rev-parse", "HEAD"]).stdout,
+        head,
+        "HEAD moved"
+    );
+    assert_eq!(
+        mine.ank_refs(&home, "refs/heads"),
+        branches,
+        "a branch moved"
+    );
+    assert_eq!(
+        mine.ank_refs(&home, "refs/tags"),
+        tags,
+        "a tag arrived, or one moved"
+    );
+    assert!(
+        !mine.ank_refs(&home, "refs/tags").contains("on-the-remote"),
+        "the remote's tag followed the fetch in"
+    );
+    assert_eq!(
+        mine.git(&home, &["ls-files", "--stage"]).stdout,
+        index,
+        "git's index moved"
+    );
+    assert_eq!(
+        mine.git(&home, &["status", "--porcelain"]).stdout,
+        porcelain,
+        "the working tree moved"
+    );
+    assert_eq!(snapshot(&mine.root.join("src")), tree, "a file changed");
+    assert_eq!(
+        mine.ank_refs(&home, "refs/ank/claims"),
+        claims,
+        "a claim of this clone's own was rewritten from the remote"
+    );
+    // And git's own mirror is untouched: a remote-tracking branch that moved
+    // is how a background fetch usually announces itself, and the refspec here
+    // is narrow precisely so none of them can.
+    assert_eq!(
+        mine.ank_refs(&home, "refs/remotes"),
+        remotes,
+        "a remote-tracking branch moved, so the fetch reached beyond refs/ank/*"
+    );
+}
+
+/// A dead network is a normal Tuesday.
+///
+/// The watcher is optional by construction, so a failed mirror downgrades what
+/// it offers, says so, and never stops it -- and never reaches the exit code of
+/// anything the person is running.
+#[test]
+fn an_unreachable_remote_is_reported_and_the_watcher_keeps_watching() {
+    let home = Home::new();
+    let root = scratch("unreachable");
+    let corpus = Corpus::new(root.join("tree"), &home);
+    // A remote that is configured and cannot be reached, which is the case that
+    // has to degrade: no remote at all is the other one, and it is silent.
+    corpus.git(
+        &home,
+        &[
+            "config",
+            "remote.origin.url",
+            &root.join("nowhere.git").display().to_string(),
+        ],
+    );
+    home.declare(&format!(
+        "schema: 1\nfetch: 1\nwatch:\n  {}: {}\n",
+        corpus.identity(&home),
+        corpus.root.display()
+    ));
+
+    // One cycle: it reports, and it still exits zero. Nothing depends on this
+    // process, so a network it could not reach is not the caller's failure.
+    let out = home.daemon(&["--once"]).output().unwrap();
+    assert!(
+        out.status.success(),
+        "a dead remote is not an exit code: {out:?}"
+    );
+    let said = String::from_utf8_lossy(&out.stderr);
+    assert!(said.contains("fetch:"), "the failure is reported: {said}");
+    assert!(
+        corpus.index().is_file(),
+        "a corpus is warmed whether or not its remote answered"
+    );
+
+    // And it keeps watching: the failure repeats every cycle and the loop
+    // survives all of them, which is the property a single pass cannot show.
+    corpus.drop_index();
+    let log = root.join("watcher.log");
+    let daemon = start_logging(&home, &["--interval", "50"], &log);
+    let warmed = settled(&corpus.index());
+    corpus.ank(
+        &home,
+        &[
+            "new",
+            "task",
+            "--title",
+            "A later task",
+            "--scope",
+            "src/**",
+        ],
+    );
+    until(
+        "the watcher to follow the corpus past a dead remote",
+        || std::fs::read(corpus.index()).unwrap_or_default() != warmed,
+    );
+    daemon.stop();
+    let logged = std::fs::read_to_string(&log).unwrap_or_default();
+    assert!(
+        logged.matches("fetch:").count() >= 1,
+        "the watcher went quiet about a remote it never reached: {logged}"
     );
 }

--- a/docs/integrating.md
+++ b/docs/integrating.md
@@ -333,6 +333,8 @@ falling back to `$HOME/.config/ank`. It lives outside every repository, and it
 is keyed on the repository identity of ADR-621a7fd96ce1 rather than on a path:
 
     schema: 1
+    # Seconds between two mirrors of refs/ank/*. Optional; 60 when omitted.
+    fetch: 60
     watch:
       # The key is the root commit, which `ank status --json` prints under
       # "corpus". One checkout, or a list of them.
@@ -346,11 +348,24 @@ repository's identity is refused with both identities, and a directory carrying
 no `.ank/` is refused rather than searched around: `ank-daemon --list` prints
 what would be watched without watching anything.
 
-**The only thing it writes into a repository is that repository's own
-`index.db`.** No branch, no working tree, no index of git's, and no
-`refs/ank/claims`. It takes no claim, holds none on anybody's behalf, and
-renews none -- a claim is renewed by working, not by reporting
-(ADR-0bb7ea8991bc).
+**The only things it writes into a repository are that repository's own
+`index.db` and a mirror of `refs/ank/*`.** The mirror lands in
+`refs/ank/watch/origin/*`, a tracking namespace of the watcher's own: no branch,
+no tag, no working tree, no index of git's, and no `refs/ank/claims`. It takes
+no claim, holds none on anybody's behalf, and renews none -- a claim is renewed
+by working, not by reporting (ADR-0bb7ea8991bc). A fetch that fails is a line on
+stderr and never an exit code: the watcher keeps watching, and a dead network
+downgrades what it offers rather than stopping it.
+
+**What the mirror buys is one line of `ank status`.** `refs/ank/claims/*` in a
+clone is whatever somebody last fetched by hand, so on a parc of clones the
+`elsewhere` section reports who held what an hour ago and has no way to say so.
+`status` reads the mirror beside its own plane and reports both as one list,
+with the local record winning wherever they carry the same task. No other verb
+reads it, and none may: an installation with a watcher and one without have to
+be one product. That is asserted rather than promised, in
+`a_claim_a_watcher_mirrored_is_reported_by_status_and_by_nothing_else`, which
+compares every listing verb byte for byte with the mirror present and absent.
 
 ## What binds and what does not
 


### PR DESCRIPTION
Closes the remaining clause of ADR-a22cd3196529 (TASK-a73b41660413): the one
thing the daemon writes into somebody else's repository is a fetch of
`refs/ank/*` into a tracking namespace of its own, on the interval `watch.yml`
states.

## The mirror

Lands in `refs/ank/watch/origin/*`, inside the namespace ADR-85e6ff5b8b7c gives
the project rather than beside it, and it is inert by construction: every
existing reader of the plane strips `refs/ank/claims/` or `refs/ank/proof/` and
skips what matches neither, and `maint` prunes off those same two maps. A build
that knows nothing about the mirror answers exactly what it answered before one
existed.

Three git flags carry the negative. `--no-tags`, because a tag arriving unasked
is the surprise the decision refuses; `--no-write-fetch-head`, because
`FETCH_HEAD` is a file the person's next merge reads; `--prune`, because a claim
released on the remote has to disappear here, and a mirror that only grows
reports holders who let go an hour ago.

## The interval

`watch.yml` gains an optional `fetch:` in seconds, 60 when omitted, refused at
0. Still schema 1: an optional field is readable by a build that predates it.

## The reader

`status` alone. `context::plane` files a mirrored record in a third map in the
same walk, and `status` merges it into the `elsewhere` section with the local
record winning wherever both carry one task -- the mirror is news about other
clones, and a background process may not overrule this one's own arbitration.
No other verb reads it, and none may.

## Driven through the binaries

- `a_claim_taken_in_one_clone_is_reported_by_status_in_the_other`: two clones,
  the second made by `git clone` and so carrying no `refs/ank/*` refspec, and a
  claim that crosses without a manual fetch.
- `a_watching_cycle_moves_the_tracking_namespace_and_nothing_else`: a
  repository with a local commit, an unpushed branch, a tag pushed to origin
  after the clone, a dirty tree and a claim of its own. The whole ref space is
  diffed after a cycle and the mirror is the only difference allowed to appear.
- `an_unreachable_remote_is_reported_and_the_watcher_keeps_watching`: reported
  every cycle, fatal to nothing, and the loop survives all of them.
- `a_claim_a_watcher_mirrored_is_reported_by_status_and_by_nothing_else`: the
  reader's half, comparing every listing verb byte for byte with the mirror
  present and absent.

## Scope

Amended, with the reason logged: the criterion binds both crates. The mirror is
reachable from `crates/ank-daemon/**`, but "what `ank status` reports becomes
current" is not -- reading the mirror is the CLI's own act and cannot be
delegated to the watcher without making it answer a verb, which the ADR refuses.

## One defect found and recorded

`ank amend --scope "+glob"` stores the plus as part of the glob, in silence, and
`check` reports it as a dead scope four commands later -- by which time `amend`
refuses a done task while `edit` accepts one. TASK-86babab0eb1b carries it. The
four scopes on this task were corrected through `edit`, recorded as version 5.

`cargo test --workspace` green, `cargo fmt --check` clean, `ank check` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY4F13e58Xi6pYXiGa1Jzg