### PR TITLE
amend refuses a scope opening on a list marker, and names the way back

### DIFF
--- a/.ank/entities/LOG-1ae79a429754.md
+++ b/.ank/entities/LOG-1ae79a429754.md
@@ -1,0 +1,14 @@
+---
+id: LOG-1ae79a429754
+type: log
+title: done, proof commit:2ebb949d6e3b50cf04d0d4659eb0e7215d2a0f00
+created: 2026-08-25T04:20:54Z
+author: claude-code/opus-5+amend-plus
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/tests/cli.rs
+about: TASK-86babab0eb1b
+seq: 6
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-2c68a8b2367c.md
+++ b/.ank/entities/LOG-2c68a8b2367c.md
@@ -1,0 +1,15 @@
+---
+id: LOG-2c68a8b2367c
+type: log
+title: +scope crates/ank-cli/tests/cli.rs (version 4 to 5, replaced c32ae6e78f5e, produced f7f0469e77ee)
+created: 2026-08-25T04:02:52Z
+author: claude-code/opus-5+amend-plus
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/tests/cli.rs
+about: TASK-86babab0eb1b
+seq: 4
+records: edit
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-2de25d8af5fb.md
+++ b/.ank/entities/LOG-2de25d8af5fb.md
@@ -1,0 +1,14 @@
+---
+id: LOG-2de25d8af5fb
+type: log
+title: done_criteria, criteria_by (version 3 to 4, replaced fec428f40b3a, produced d13de330e32f)
+created: 2026-08-25T04:02:32Z
+author: claude-code/opus-5+amend-plus
+scope:
+  - crates/ank-cli/src/human.rs
+about: TASK-86babab0eb1b
+seq: 2
+records: edit
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-b488de4f97a6.md
+++ b/.ank/entities/LOG-b488de4f97a6.md
@@ -1,0 +1,16 @@
+---
+id: LOG-b488de4f97a6
+type: log
+title: Scope widened to crates/ank-cli/tests/cli.rs. CLAUDE.md requires that a criterion about the binary
+created: 2026-08-25T04:02:58Z
+author: claude-code/opus-5+amend-plus
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/tests/cli.rs
+about: TASK-86babab0eb1b
+seq: 5
+schema: 4
+version: 1
+---
+
+ be tested through the binary, and that file is where amend is driven end to end; human.rs alone would let the refusal be proved on a function the binary never reaches.

--- a/.ank/entities/LOG-df9aa28a3f8b.md
+++ b/.ank/entities/LOG-df9aa28a3f8b.md
@@ -1,0 +1,15 @@
+---
+id: LOG-df9aa28a3f8b
+type: log
+title: Chose the refusal over strip-and-say. Stripping would write a glob the caller did not type, and a
+created: 2026-08-25T04:02:49Z
+author: claude-code/opus-5+amend-plus
+scope:
+  - crates/ank-cli/src/human.rs
+about: TASK-86babab0eb1b
+seq: 3
+schema: 4
+version: 1
+---
+
+ leading + is a real filename in the wild (SvelteKit's +page.svelte), so the strip makes a legitimate path unwritable while claiming it worked. The refusal has an escape the normaliser already provides: normalize_path drops a leading ./ segment, so --scope "./+page.svelte" stores +page.svelte, and the hint can name it. The precedent is one screen above in amend itself, on --reference against a non-spec: a flag silently ignored teaches the caller it worked.

--- a/.ank/entities/TASK-86babab0eb1b.md
+++ b/.ank/entities/TASK-86babab0eb1b.md
@@ -5,7 +5,7 @@ slug: amend-takes-a-scope-with-a-leading-and-check-fin
 title: amend takes a scope with a leading + and check finds it four commands later
 created: 2026-08-25T03:26:36Z
 author: claude-code/opus-5+daemon-refs
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/src/human.rs
   - crates/ank-cli/tests/cli.rs
@@ -13,8 +13,13 @@ blocked_by: []
 done_criteria: |
   ank amend <id> --scope "+p" and ank amend <id> --drop-scope "-p" both exit non-zero and write nothing to the entity: the refusal names the leading marker as a marker, names --drop-scope as the way to remove a glob, and names a leading ./ as the way to write a path whose own name begins with that character, so ank amend <id> --scope "./+p" succeeds and stores +p. A test in crates/ank-cli/tests/cli.rs drives the binary for each of those cases.
 criteria_by: claimer
+proof:
+  - type: commit
+    ref: 2ebb949d6e3b50cf04d0d4659eb0e7215d2a0f00
+    criteria: 71999546f5f8
+    via: submitted
 schema: 4
-version: 5
+version: 6
 ---
 
 `ank amend <id> --scope "+crates/ank-cli/src/context.rs"` stores the `+` as part

--- a/.ank/entities/TASK-86babab0eb1b.md
+++ b/.ank/entities/TASK-86babab0eb1b.md
@@ -5,12 +5,16 @@ slug: amend-takes-a-scope-with-a-leading-and-check-fin
 title: amend takes a scope with a leading + and check finds it four commands later
 created: 2026-08-25T03:26:36Z
 author: claude-code/opus-5+daemon-refs
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/src/human.rs
+  - crates/ank-cli/tests/cli.rs
 blocked_by: []
+done_criteria: |
+  ank amend <id> --scope "+p" and ank amend <id> --drop-scope "-p" both exit non-zero and write nothing to the entity: the refusal names the leading marker as a marker, names --drop-scope as the way to remove a glob, and names a leading ./ as the way to write a path whose own name begins with that character, so ank amend <id> --scope "./+p" succeeds and stores +p. A test in crates/ank-cli/tests/cli.rs drives the binary for each of those cases.
+criteria_by: claimer
 schema: 4
-version: 3
+version: 5
 ---
 
 `ank amend <id> --scope "+crates/ank-cli/src/context.rs"` stores the `+` as part

--- a/crates/ank-cli/src/human.rs
+++ b/crates/ank-cli/src/human.rs
@@ -5654,6 +5654,16 @@ pub fn amend(
     // of what the amend produced (ADR-f7dc76886db2).
     let before = loaded.entity.clone();
 
+    // Refused on what was typed, before the normaliser sees it: `+src/**` is a
+    // glob that compiles and matches nothing, so nothing downstream has a
+    // reason to object until `check` reports the dead scope (TASK-86babab0eb1b).
+    // Here rather than in `normalised_globs`, because the marker's whole
+    // plausibility comes from this verb's `--scope`/`--drop-scope` pairing, and
+    // `new --scope` and `find --scope` offer the caller no such pairing to
+    // confuse.
+    refuse_scope_marker(inv.values("--scope"), "--scope", &id)?;
+    refuse_scope_marker(inv.values("--drop-scope"), "--drop-scope", &id)?;
+
     // Both normalised, and both for the same reason `new --scope` is: one is
     // written into the entity, and the other is compared against what is
     // already stored there, which is now always a normal form. A raw
@@ -6055,6 +6065,56 @@ fn amend_references(
     }
     for r in drop {
         changes.push(format!("-references {r}"));
+    }
+    Ok(())
+}
+
+/// A `--scope` or `--drop-scope` value opening on `+` or `-`, which is a list
+/// marker and not a glob.
+///
+/// The mistake is this verb's own doing. `--scope` adds and `--drop-scope`
+/// removes, which is exactly the pairing that `+`/`-` list syntax expresses
+/// elsewhere as one flag with two markers, so a caller who has met that syntax
+/// writes `--scope "+src/**"` and is told it worked. What was stored was the
+/// glob `+src/**`, which matches no file: `check` then reported a dead scope
+/// with no rename and no deletion behind it, four commands and often a `done`
+/// later, at which point `amend` refuses because the plan is settled.
+///
+/// **Refused rather than stripped**, and the choice is TASK-86babab0eb1b's
+/// work. Stripping would store a glob the caller did not type, and a leading
+/// `+` is a real filename in the wild -- SvelteKit's `+page.svelte` -- so the
+/// strip would make a legitimate path unwritable while reporting success. That
+/// is the defect this exists to remove, one character further along. The
+/// reasoning is the one the `--reference` refusal above already follows: a flag
+/// quietly reinterpreted teaches the caller it worked.
+///
+/// The escape is the normaliser's, not a second rule: `normalize_path` drops a
+/// leading `./` segment, so `--scope "./+page.svelte"` stores `+page.svelte`.
+/// The hint names it, because a refusal that leaves a legitimate value
+/// unwritable is a wall rather than a correction.
+fn refuse_scope_marker(raw: &[String], flag: &str, id: &EntityId) -> Result<()> {
+    for g in raw {
+        let g = g.trim();
+        let Some(marker) = g.chars().next().filter(|c| *c == '+' || *c == '-') else {
+            continue;
+        };
+        // What the caller meant, on either reading, with the marker gone. A
+        // value that is nothing but the marker leaves nothing to propose, so
+        // the hint falls back to the placeholder every other scope refusal
+        // here uses.
+        let bare = g[marker.len_utf8()..].trim();
+        let bare = if bare.is_empty() { "<glob>" } else { bare };
+        return Err(CliError::new(
+            ExitCode::Prerequisite,
+            format!(
+                "'{g}' opens on '{marker}', which is a list marker and not part of a glob: \
+                 {flag} takes the glob alone"
+            ),
+        )
+        .with_hint(format!(
+            "ank amend {id} --scope \"{bare}\" adds and --drop-scope \"{bare}\" removes, \
+             or {flag} \"./{g}\" for a path whose name really begins with '{marker}'"
+        )));
     }
     Ok(())
 }

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -8088,6 +8088,67 @@ fn amend_adds_and_removes_without_disturbing_the_rest() {
     );
 }
 
+/// A scope opening on `+` or `-` is a list marker, and this verb refuses it
+/// rather than storing it as part of the glob.
+///
+/// The mistake is `amend`'s own to make: `--scope` adds and `--drop-scope`
+/// removes, which is the pairing `+`/`-` list syntax expresses as one flag with
+/// two markers. Stored, `+docs/**` matches no file, and the first thing to say
+/// so is `check`, with a dead scope carrying no rename and no deletion to
+/// explain it -- four commands later, and often after a `done` past which
+/// `amend` refuses to repair anything.
+///
+/// Through the binary, and reading the file, because what is asserted is that
+/// the refusal reaches the caller and that nothing was written on the way.
+#[test]
+fn a_scope_opening_on_a_list_marker_is_refused_and_the_literal_path_keeps_a_way_in() {
+    let r = Repo::new();
+    r.seed_task(ID, Some("A verifiable criterion."));
+    let before = r.task_text(ID);
+
+    let out = r.ank("marie@laptop", &["amend", ID, "--scope", "+docs/**"]);
+    assert_eq!(code(&out), 7, "{}", stderr(&out));
+    assert_eq!(r.task_text(ID), before, "a refusal writes nothing");
+    let said = stderr(&out);
+    // The marker named as a marker, the verb that actually removes, and the
+    // way to write a path whose own name begins with the character.
+    assert!(said.contains("list marker"), "{said}");
+    assert!(said.contains("'+'"), "{said}");
+    assert!(said.contains("--drop-scope \"docs/**\""), "{said}");
+    assert!(said.contains("--scope \"./+docs/**\""), "{said}");
+
+    // The same on the removing flag, where the marker a caller reaches for is
+    // the minus.
+    let out = r.ank("marie@laptop", &["amend", ID, "--drop-scope", "-src/**"]);
+    assert_eq!(code(&out), 7, "{}", stderr(&out));
+    assert_eq!(r.task_text(ID), before, "a refusal writes nothing");
+    assert!(stderr(&out).contains("list marker"), "{}", stderr(&out));
+    assert!(
+        stderr(&out).contains("--drop-scope \"src/**\""),
+        "{}",
+        stderr(&out)
+    );
+    // The escape names the flag the caller typed, and not the other one.
+    assert!(
+        stderr(&out).contains("--drop-scope \"./-src/**\""),
+        "{}",
+        stderr(&out)
+    );
+
+    // And the escape the refusal names is real, rather than a sentence: a
+    // repository may hold a file whose name begins with a plus, and `./` is
+    // the leading segment the normaliser already drops.
+    let out = r.ank("marie@laptop", &["amend", ID, "--scope", "./+page.svelte"]);
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    let text = r.task_text(ID);
+    assert!(text.contains("  - src/**\n  - +page.svelte"), "{text}");
+    assert!(
+        r.log_text(ID).contains("+scope +page.svelte"),
+        "{}",
+        r.log_text(ID)
+    );
+}
+
 /// A criterion that turns out unmeasurable is corrected, by a caller holding no
 /// claim, without the correction being recorded as the claimer's.
 ///


### PR DESCRIPTION
Closes TASK-86babab0eb1b.

`ank amend <id> --scope "+crates/ank-cli/src/context.rs"` stored the `+` as
part of the glob. Nothing refused it and nothing warned: `--scope` adds and
`--drop-scope` removes, which is exactly the pairing that `+`/`-` list syntax
expresses elsewhere as one flag with two markers, so a caller who has met that
syntax writes the marker and is told it worked.

The stored glob compiles and matches no file. The first thing to say so was
`check`, reporting a dead scope with no rename and no deletion behind it to
explain it -- four commands later, and often past a `done` beyond which `amend`
refuses to touch a settled plan, leaving `edit` as the only route to a
correction.

## The choice

The task named two candidate answers and said that choosing between them was
the work: refuse the marker, or accept it, strip it and say so.

This refuses. Stripping would store a glob the caller did not type, and a
leading `+` is a real filename in the wild -- SvelteKit's `+page.svelte` -- so
the strip would make a legitimate path unwritable while reporting success,
which is the same defect one character further along. The precedent is one
screen above in `amend` itself, on `--reference` against a non-spec: a flag
quietly reinterpreted teaches the caller it worked.

A refusal that leaves a legitimate value unwritable would be a wall rather than
a correction, so the escape is named in the hint, and it is the normaliser's
own rather than a second rule: `normalize_path` already drops a leading `./`
segment, so `--scope "./+page.svelte"` stores `+page.svelte`.

    error[7]: '+crates/ank-cli/src/context.rs' opens on '+', which is a list marker and not part of a glob: --scope takes the glob alone
      -> ank amend TASK-86babab0eb1b --scope "crates/ank-cli/src/context.rs" adds and --drop-scope "crates/ank-cli/src/context.rs" removes, or --scope "./+crates/ank-cli/src/context.rs" for a path whose name really begins with '+'

The check lives in `amend` rather than in `normalised_globs`, because the
marker's whole plausibility comes from this verb's two flags: `new --scope` and
`find --scope` offer the caller no such pairing to confuse.

## Verification

Driven through the binary, per CLAUDE.md, in
`crates/ank-cli/tests/cli.rs`: `--scope "+docs/**"` and `--drop-scope "-src/**"`
both exit 7 and leave the entity file byte-identical, the refusal names the
marker as a marker, names `--drop-scope`, and names the flag the caller typed
in the `./` escape; and `--scope "./+page.svelte"` succeeds and stores
`+page.svelte`.

`cargo test --workspace` green (313 + 304 + 21 + ...), `cargo fmt --check`
green, `ank check` exit 0 with no faults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GGXihyY8mRie5JaGTRrPh