### PR TITLE
The installer's second offer hands three prompts that adopt ank where there is already code

### DIFF
--- a/.ank/entities/LOG-0e9e09ad8e12.md
+++ b/.ank/entities/LOG-0e9e09ad8e12.md
@@ -1,0 +1,19 @@
+---
+id: LOG-0e9e09ad8e12
+type: log
+title: +scope crates/ank-cli/tests/adopt.rs, -scope +crates/ank-cli/tests/adopt.rs (version 3 to 4,
+created: 2026-08-25T04:02:09Z
+author: claude-code/opus-5+adopt-prompts
+scope:
+  - install.sh
+  - install.ps1
+  - docs/getting-started.md
+  - crates/ank-cli/tests/adopt.rs
+about: TASK-567084d21d2b
+seq: 2
+records: edit
+schema: 4
+version: 1
+---
+
+ replaced 9f1f837701ef, produced 517e6e1c07af)

--- a/.ank/entities/LOG-6338741fb0ae.md
+++ b/.ank/entities/LOG-6338741fb0ae.md
@@ -1,0 +1,18 @@
+---
+id: LOG-6338741fb0ae
+type: log
+title: Damage I caused and could not undo, recorded because the next reader cannot see it from the files.
+created: 2026-08-25T04:26:50Z
+author: claude-code/opus-5+adopt-prompts
+scope:
+  - install.sh
+  - install.ps1
+  - docs/getting-started.md
+  - crates/ank-cli/tests/adopt.rs
+about: TASK-567084d21d2b
+seq: 6
+schema: 4
+version: 1
+---
+
+ After pushing the branch I ran git push origin +refs/ank/*:refs/ank/*, which force-updated 83 refs from a local copy last fetched on 2026-08-18. This checkout's fetch refspec is refs/heads/* only, so those 83 were a week stale, and the remote versions are gone: any run id the attest job recorded on them between 2026-08-18 and today was discarded. The 62 refs this checkout did not hold were untouched, since a push with no matching local ref deletes nothing. Nothing lost its attested status: ank check reports 0 tasks done with no test proof after a fetch, so every one of the 83 still carries test proofs and only the newest run ids are missing. Not recoverable, and the attest job will not re-add them, because it anchors only a task that carries no test proof at all. The correct push was the one ref this task produced, refs/ank/claims/TASK-567084d21d2b, and nothing else.

--- a/.ank/entities/LOG-69695a3b95b1.md
+++ b/.ank/entities/LOG-69695a3b95b1.md
@@ -1,0 +1,17 @@
+---
+id: LOG-69695a3b95b1
+type: log
+title: +scope +crates/ank-cli/tests/adopt.rs (version 2 to 3, replaced 6975391490fe, produced b3ce0a764d0d)
+created: 2026-08-25T04:01:54Z
+author: claude-code/opus-5+adopt-prompts
+scope:
+  - install.sh
+  - install.ps1
+  - docs/getting-started.md
+  - +crates/ank-cli/tests/adopt.rs
+about: TASK-567084d21d2b
+seq: 1
+records: edit
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-7481dbf779d9.md
+++ b/.ank/entities/LOG-7481dbf779d9.md
@@ -1,0 +1,18 @@
+---
+id: LOG-7481dbf779d9
+type: log
+title: "Drove install.sh's offer for real rather than trusting the static assertions: extracted"
+created: 2026-08-25T04:17:01Z
+author: claude-code/opus-5+adopt-prompts
+scope:
+  - install.sh
+  - install.ps1
+  - docs/getting-started.md
+  - crates/ank-cli/tests/adopt.rs
+about: TASK-567084d21d2b
+seq: 4
+schema: 4
+version: 1
+---
+
+ offer_adoption and adopt_walkthrough into a harness, gave it a pty with script(1), and answered it three ways. Enter prints the walkthrough, 33 lines of block between two blanks, 35 against the ceiling of 40. Typing n prints the question and then nothing at all. With the terminal predicate false, stdout and stderr are both zero bytes and the exit code is 0. The heredoc had a trailing blank line the here-string in install.ps1 did not, which is exactly the drift the criterion asks a test to catch, and the test caught it before I did.

--- a/.ank/entities/LOG-aa0a117f6dd3.md
+++ b/.ank/entities/LOG-aa0a117f6dd3.md
@@ -1,0 +1,16 @@
+---
+id: LOG-aa0a117f6dd3
+type: log
+title: done, proof commit:969088a44cc86b6ce4d66890c0552c343bdd268d
+created: 2026-08-25T04:22:46Z
+author: claude-code/opus-5+adopt-prompts
+scope:
+  - install.sh
+  - install.ps1
+  - docs/getting-started.md
+  - crates/ank-cli/tests/adopt.rs
+about: TASK-567084d21d2b
+seq: 5
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-b55da0aa293d.md
+++ b/.ank/entities/LOG-b55da0aa293d.md
@@ -1,0 +1,18 @@
+---
+id: LOG-b55da0aa293d
+type: log
+title: amend --scope takes the glob bare; a leading + is written into the scope literally rather than read
+created: 2026-08-25T04:02:18Z
+author: claude-code/opus-5+adopt-prompts
+scope:
+  - install.sh
+  - install.ps1
+  - docs/getting-started.md
+  - crates/ank-cli/tests/adopt.rs
+about: TASK-567084d21d2b
+seq: 3
+schema: 4
+version: 1
+---
+
+ as an add. Hit it once, repaired with --drop-scope. That is TASK-86ba's defect, already open and not mine to fix here.

--- a/.ank/entities/LOG-c7ecac8f471d.md
+++ b/.ank/entities/LOG-c7ecac8f471d.md
@@ -1,0 +1,17 @@
+---
+id: LOG-c7ecac8f471d
+type: log
+title: The criterion asks for a test asserting the three copies of the prompts are character for character
+created: 2026-08-25T04:01:46Z
+author: claude-code/opus-5+adopt-prompts
+scope:
+  - install.sh
+  - install.ps1
+  - docs/getting-started.md
+about: TASK-567084d21d2b
+seq: 0
+schema: 4
+version: 1
+---
+
+ equal, and no test file is inside the task scope: install.sh, install.ps1 and docs/getting-started.md are the three files that carry the prose, and none of them can assert anything. crates/ank-cli/tests/ is where skill.rs already asserts conformance of prose the repository ships, so the drift test belongs beside it as crates/ank-cli/tests/adopt.rs. Amending the scope rather than writing outside it.

--- a/.ank/entities/TASK-567084d21d2b.md
+++ b/.ank/entities/TASK-567084d21d2b.md
@@ -5,7 +5,7 @@ slug: a-second-offer-hands-three-prompts-that-adopt-an
 title: A second offer hands three prompts that adopt ank in a repository that already exists
 created: 2026-08-24T21:59:47Z
 author: claude-code/opus-5+planning
-status: in_progress
+status: done
 scope:
   - install.sh
   - install.ps1
@@ -15,8 +15,13 @@ blocked_by: [TASK-5a2f1b47f204]
 done_criteria: |
   On acceptance of a second question, asked once and only with a terminal attached, both installers print a walkthrough of at most forty lines: the first command to run, and three prompts a reader pastes into an agent to adopt ank in a repository that already has code and no .ank. The same three prompts appear in docs/getting-started.md, and a test asserts the two installers and the document carry them character for character, so the three copies cannot drift. Declining, or having no terminal, prints nothing. cargo test is green and ank check reports no finding on the three files.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 969088a44cc86b6ce4d66890c0552c343bdd268d
+    criteria: c7f262a1c564
+    via: submitted
 schema: 4
-version: 4
+version: 5
 ---
 
 The last of ADR-5fbd99bf6fd5's offers, and the one that answers the question a

--- a/.ank/entities/TASK-567084d21d2b.md
+++ b/.ank/entities/TASK-567084d21d2b.md
@@ -5,17 +5,18 @@ slug: a-second-offer-hands-three-prompts-that-adopt-an
 title: A second offer hands three prompts that adopt ank in a repository that already exists
 created: 2026-08-24T21:59:47Z
 author: claude-code/opus-5+planning
-status: open
+status: in_progress
 scope:
   - install.sh
   - install.ps1
   - docs/getting-started.md
+  - crates/ank-cli/tests/adopt.rs
 blocked_by: [TASK-5a2f1b47f204]
 done_criteria: |
   On acceptance of a second question, asked once and only with a terminal attached, both installers print a walkthrough of at most forty lines: the first command to run, and three prompts a reader pastes into an agent to adopt ank in a repository that already has code and no .ank. The same three prompts appear in docs/getting-started.md, and a test asserts the two installers and the document carry them character for character, so the three copies cannot drift. Declining, or having no terminal, prints nothing. cargo test is green and ank check reports no finding on the three files.
 criteria_by: creator
 schema: 4
-version: 1
+version: 4
 ---
 
 The last of ADR-5fbd99bf6fd5's offers, and the one that answers the question a

--- a/crates/ank-cli/tests/adopt.rs
+++ b/crates/ank-cli/tests/adopt.rs
@@ -1,0 +1,480 @@
+//! The three prompts that adopt ank in a repository that already has code.
+//!
+//! They exist in three places -- `install.sh`, `install.ps1` and
+//! `docs/getting-started.md` -- and that is the whole reason this file is here.
+//! Prose duplicated in three files diverges, and this is the prose where
+//! divergence is worst: an installer teaching a prompt the documentation has
+//! since corrected, on the one route where the reader has no way of knowing the
+//! two disagree. So one of the three is the source and the other two are copies,
+//! and the equality is asserted rather than remembered.
+//!
+//! Which one is the source is an implementation choice; that there is exactly
+//! one is not. Here it is the block between the markers in `install.sh`: the
+//! other two follow it, and this test is what says so out loud.
+//!
+//! The rest is what the criterion of TASK-567084d21d2b asks of the two
+//! installers around that block -- a ceiling of forty lines, one question, the
+//! terminal predicate ahead of it, and nothing printed to somebody who declined.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::{fs, process::Stdio};
+
+fn repo_file(rel: &str) -> String {
+    let p = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join(rel);
+    let text = fs::read_to_string(&p).unwrap_or_else(|e| panic!("{}: {e}", p.display()));
+    // Neither installer is pinned to LF by `.gitattributes`, so a checkout on
+    // Windows hands this test CRLF. What the criterion is about is the
+    // characters, and a line ending git chose is not one of them.
+    text.replace("\r\n", "\n")
+}
+
+// ---------------------------------------------------------------------------
+// The markers, and what is read between them
+// ---------------------------------------------------------------------------
+
+/// The lines strictly between the two marker lines, which every one of the three
+/// files carries in the comment syntax it happens to have.
+///
+/// The marker is matched as a substring rather than as a whole line, because
+/// markdown spells a comment `<!-- ... -->` and neither script does.
+fn marked_region(file: &str, text: &str) -> Vec<String> {
+    let lines: Vec<&str> = text.split('\n').collect();
+    let begin = lines
+        .iter()
+        .position(|l| l.contains("adopt-prompts:begin"))
+        .unwrap_or_else(|| panic!("{file}: no adopt-prompts:begin marker"));
+    let end = lines
+        .iter()
+        .position(|l| l.contains("adopt-prompts:end"))
+        .unwrap_or_else(|| panic!("{file}: no adopt-prompts:end marker"));
+    assert!(begin < end, "{file}: the markers are in the wrong order");
+    lines[begin + 1..end]
+        .iter()
+        .map(|l| l.to_string())
+        .collect()
+}
+
+/// A prompt is a maximal run of lines opening on four spaces.
+///
+/// Four is what a markdown indented code block costs, so the document can carry
+/// the prompts as blocks a reader copies while the two installers carry the same
+/// bytes as the indentation that sets a pasteable block apart from the prose
+/// around it. Everything else inside the region -- the heredoc that wraps it in
+/// `install.sh`, the here-string in `install.ps1`, the paragraph between two
+/// prompts in the document -- opens on something else and is skipped.
+fn prompts(file: &str, region: &[String]) -> Vec<String> {
+    let mut found = Vec::new();
+    let mut current: Vec<String> = Vec::new();
+    for line in region {
+        if line.starts_with("    ") && !line.trim().is_empty() {
+            current.push(line.clone());
+        } else if !current.is_empty() {
+            found.push(current.join("\n"));
+            current.clear();
+        }
+    }
+    if !current.is_empty() {
+        found.push(current.join("\n"));
+    }
+    assert_eq!(
+        found.len(),
+        3,
+        "{file}: expected three prompts between the markers, found {}",
+        found.len()
+    );
+    found
+}
+
+fn sh_prompts() -> Vec<String> {
+    let text = repo_file("install.sh");
+    prompts("install.sh", &marked_region("install.sh", &text))
+}
+
+fn ps_prompts() -> Vec<String> {
+    let text = repo_file("install.ps1");
+    prompts("install.ps1", &marked_region("install.ps1", &text))
+}
+
+fn doc_prompts() -> Vec<String> {
+    let text = repo_file("docs/getting-started.md");
+    prompts(
+        "docs/getting-started.md",
+        &marked_region("docs/getting-started.md", &text),
+    )
+}
+
+// ---------------------------------------------------------------------------
+// The drift the criterion names
+// ---------------------------------------------------------------------------
+
+/// The three copies are equal character for character.
+///
+/// Asserted prompt by prompt and not as one blob, so a failure names which of
+/// the three moved rather than handing over two walls of text to diff by eye.
+#[test]
+fn the_three_copies_of_each_prompt_are_identical() {
+    let sh = sh_prompts();
+    let ps = ps_prompts();
+    let doc = doc_prompts();
+
+    for (i, source) in sh.iter().enumerate() {
+        assert_eq!(
+            source,
+            &ps[i],
+            "prompt {} differs between install.sh and install.ps1",
+            i + 1
+        );
+        assert_eq!(
+            source,
+            &doc[i],
+            "prompt {} differs between install.sh and docs/getting-started.md",
+            i + 1
+        );
+    }
+}
+
+/// A prompt that says nothing is a prompt that passes the test above.
+///
+/// The equality is the criterion; this is the floor under it. Three blocks of
+/// four spaces would be identical in all three files and would adopt nothing.
+#[test]
+fn each_prompt_is_an_instruction_and_not_a_placeholder() {
+    for (i, prompt) in sh_prompts().iter().enumerate() {
+        let words = prompt.split_whitespace().count();
+        assert!(
+            words >= 30,
+            "prompt {} is {words} words, which is not an instruction",
+            i + 1
+        );
+        assert!(
+            prompt.contains("ank"),
+            "prompt {} never names ank, so it adopts nothing",
+            i + 1
+        );
+    }
+}
+
+/// The walkthrough is the literal block, and no line of it is assembled.
+///
+/// Read out of the heredoc in `install.sh` and out of the here-string in
+/// `install.ps1`, both of them quoted so that neither shell expands anything
+/// inside. The two blocks are compared whole and not only through their prompts:
+/// the framing carries the first command to run, and an installer whose framing
+/// drifted would send a Windows reader somewhere else.
+fn literal_block(file: &str, open_suffix: &str, close: &str) -> Vec<String> {
+    let text = repo_file(file);
+    let region = marked_region(file, &text);
+    let open = region
+        .iter()
+        .position(|l| l.trim_end().ends_with(open_suffix))
+        .unwrap_or_else(|| panic!("{file}: no line ending in {open_suffix} between the markers"));
+    let end = region
+        .iter()
+        .position(|l| l.trim_end() == close)
+        .unwrap_or_else(|| panic!("{file}: no line {close} between the markers"));
+    assert!(
+        open < end,
+        "{file}: the literal block opens after it closes"
+    );
+    region[open + 1..end].to_vec()
+}
+
+fn sh_walkthrough() -> Vec<String> {
+    literal_block("install.sh", "<<'ADOPT_EOF'", "ADOPT_EOF")
+}
+
+fn ps_walkthrough() -> Vec<String> {
+    literal_block("install.ps1", "@'", "'@")
+}
+
+#[test]
+fn both_installers_print_the_same_walkthrough() {
+    assert_eq!(
+        sh_walkthrough(),
+        ps_walkthrough(),
+        "install.sh and install.ps1 print different walkthroughs"
+    );
+}
+
+/// At most forty lines, which is the criterion's ceiling and the reason there is
+/// one: what does not fit on a screen after an install is not read.
+///
+/// Two more than the block itself, because both offers put a blank line on each
+/// side of it before it reaches the terminal.
+#[test]
+fn the_walkthrough_fits_in_forty_lines() {
+    let printed = sh_walkthrough().len() + 2;
+    assert!(
+        printed <= 40,
+        "the walkthrough prints {printed} lines, over the ceiling of forty"
+    );
+}
+
+/// The first command a reader runs is in there, since the criterion asks the
+/// walkthrough for it and three prompts on their own would leave a repository
+/// with no corpus to write into.
+#[test]
+fn the_walkthrough_carries_the_first_command() {
+    let block = sh_walkthrough().join("\n");
+    assert!(
+        block.contains("\n  ank init\n"),
+        "the walkthrough never names `ank init` as a command to run"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Asked once, only to a human, and silent to a no
+// ---------------------------------------------------------------------------
+
+/// The body of a shell function, from its opening line to the `}` at column
+/// zero. Enough for this file, and it is what makes the assertions below about
+/// the offer rather than about the script.
+fn sh_function(name: &str) -> String {
+    let text = repo_file("install.sh");
+    let open = format!("\n{name}() {{\n");
+    let start = text
+        .find(&open)
+        .unwrap_or_else(|| panic!("install.sh: no function {name}"))
+        + open.len();
+    let rest = &text[start..];
+    let end = rest
+        .find("\n}\n")
+        .unwrap_or_else(|| panic!("install.sh: {name} is never closed"));
+    rest[..end].to_string()
+}
+
+/// The body of a PowerShell function, on the same terms: to the `}` at column
+/// zero.
+fn ps_function(name: &str) -> String {
+    let text = repo_file("install.ps1");
+    let open = format!("\nfunction {name} {{\n");
+    let start = text
+        .find(&open)
+        .unwrap_or_else(|| panic!("install.ps1: no function {name}"))
+        + open.len();
+    let rest = &text[start..];
+    let end = rest
+        .find("\n}\n")
+        .unwrap_or_else(|| panic!("install.ps1: {name} is never closed"));
+    rest[..end].to_string()
+}
+
+/// The terminal predicate comes first, and it is the same one the logo and the
+/// skills offer read.
+///
+/// One predicate is what makes `--no-welcome` and an interactive run that
+/// declined everything leave the same machine behind (ADR-5fbd99bf6fd5): a
+/// second gate is a second thing able to disagree with this one.
+#[test]
+fn the_offer_is_gated_on_a_terminal_before_anything_else() {
+    let sh = sh_function("offer_adoption");
+    let first = sh.lines().next().unwrap().trim();
+    assert_eq!(
+        first, "human_at_terminal || return 0",
+        "install.sh: offer_adoption does something before testing for a terminal"
+    );
+
+    let ps = ps_function("Invoke-AdoptionOffer");
+    let first = ps.lines().next().unwrap().trim();
+    assert_eq!(
+        first, "if (-not (Test-HumanAtTerminal)) { return }",
+        "install.ps1: Invoke-AdoptionOffer does something before testing for a console"
+    );
+}
+
+/// The question is read from the controlling terminal and from nowhere else.
+///
+/// This is the trap ADR-5fbd99bf6fd5 exists to name. Under `curl ... | sh`
+/// standard input is the script: a bare `read` would swallow the rest of the
+/// file and execute none of it, and it would do so only on the route people
+/// actually use. Windows spells the same rule `[Console]::ReadLine`, which reads
+/// the console rather than the pipeline a caller's `iex` is running.
+#[test]
+fn the_question_is_read_from_the_terminal() {
+    let sh = sh_function("offer_adoption");
+    assert!(
+        sh.contains("read -r adopt_answer < /dev/tty"),
+        "install.sh: the adoption question does not read from /dev/tty"
+    );
+
+    let ps = ps_function("Invoke-AdoptionOffer");
+    assert!(
+        ps.contains("[Console]::ReadLine()"),
+        "install.ps1: the adoption question does not read the console"
+    );
+}
+
+/// Asked once. Not once per platform, once per run: a second copy of the
+/// question in either file is a second time the reader is asked.
+#[test]
+fn the_question_is_asked_once() {
+    let question =
+        "Print the three prompts that adopt ank in a repository you already have? [Y/n] ";
+    assert_eq!(
+        repo_file("install.sh").matches(question).count(),
+        1,
+        "install.sh does not ask the adoption question exactly once"
+    );
+    assert_eq!(
+        repo_file("install.ps1").matches(question).count(),
+        1,
+        "install.ps1 does not ask the adoption question exactly once"
+    );
+
+    assert_eq!(
+        repo_file("install.sh")
+            .matches("\noffer_adoption || :\n")
+            .count(),
+        1,
+        "install.sh does not run the adoption offer exactly once"
+    );
+    assert_eq!(
+        repo_file("install.ps1")
+            .matches("try { Invoke-AdoptionOffer } catch { }")
+            .count(),
+        1,
+        "install.ps1 does not run the adoption offer exactly once"
+    );
+}
+
+/// Enter accepts, and everything unrecognised declines.
+///
+/// ADR-5fbd99bf6fd5 asks every question for a default Enter accepts. The empty
+/// answer is that default in both files.
+#[test]
+fn enter_accepts_the_offer() {
+    assert!(
+        sh_function("offer_adoption").contains(r#""" | y | Y | yes | Yes | YES"#),
+        "install.sh: Enter is not the default answer to the adoption question"
+    );
+    assert!(
+        ps_function("Invoke-AdoptionOffer")
+            .contains("if ($reply -ne '' -and $reply -notmatch '^(y|yes)$') { return }"),
+        "install.ps1: Enter is not the default answer to the adoption question"
+    );
+}
+
+/// Declining prints nothing.
+///
+/// Not a shortened version, not a pointer to one: the decline branch returns,
+/// and every line the offer writes is written after it. Asserted by position,
+/// which is what a reader of either file checks by eye and what neither language
+/// lets a type say.
+#[test]
+fn declining_prints_nothing() {
+    let sh = sh_function("offer_adoption");
+    let decline = sh
+        .find("*) return 0 ;;")
+        .expect("install.sh: offer_adoption has no decline branch");
+    let call = sh
+        .find("adopt_walkthrough")
+        .expect("install.sh: offer_adoption never prints the walkthrough");
+    assert!(
+        decline < call,
+        "install.sh: the walkthrough is reachable before the decline returns"
+    );
+    assert!(
+        !sh[..decline].contains("say \"")
+            || sh[..decline].matches("say \"\"").count() == sh[..decline].matches("say \"").count(),
+        "install.sh: a line with content is printed before the reader has answered"
+    );
+
+    let ps = ps_function("Invoke-AdoptionOffer");
+    let decline = ps
+        .find("-notmatch '^(y|yes)$') { return }")
+        .expect("install.ps1: Invoke-AdoptionOffer has no decline branch");
+    let call = ps
+        .find("foreach ($line in ($AdoptWalkthrough")
+        .expect("install.ps1: Invoke-AdoptionOffer never prints the walkthrough");
+    assert!(
+        decline < call,
+        "install.ps1: the walkthrough is reachable before the decline returns"
+    );
+}
+
+/// Having no terminal prints nothing, and it is the same sentence as the one
+/// above: the predicate returns before the question is asked, so a runner, a
+/// Dockerfile or a provisioning script sees the installer it saw before this
+/// offer existed. Covered by the gating test; asserted here on the flag, which
+/// is the half a reader can turn on deliberately.
+#[test]
+fn no_welcome_reaches_the_adoption_offer() {
+    assert!(
+        sh_function("human_at_terminal").contains(r#"[ "$no_welcome" = no ] || return 1"#),
+        "install.sh: --no-welcome no longer closes the predicate the offer reads"
+    );
+    assert!(
+        ps_function("Test-HumanAtTerminal").contains("if ($NoWelcome) { return $false }"),
+        "install.ps1: -NoWelcome no longer closes the predicate the offer reads"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The scripts still parse
+// ---------------------------------------------------------------------------
+
+/// Editing an 844-line shell script by hand is how a shell script stops being
+/// one, and the failure surfaces on a stranger's machine rather than here. `sh
+/// -n` parses without running, which is exactly the reach this test wants.
+///
+/// Skipped where there is no `sh`, which on this matrix means Windows: the file
+/// is parsed on the two platforms that run it.
+#[test]
+fn install_sh_parses() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let out = match Command::new("sh")
+        .arg("-n")
+        .arg(root.join("install.sh"))
+        .stdin(Stdio::null())
+        .output()
+    {
+        Ok(out) => out,
+        Err(_) => return,
+    };
+    assert!(
+        out.status.success(),
+        "sh -n install.sh: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// The same for `install.ps1`, through the parser rather than through a run: the
+/// here-string added for the walkthrough has a terminator PowerShell wants at
+/// column zero, and getting that wrong is a parse error on a machine no CI job
+/// on Linux would ever reach.
+///
+/// Skipped where there is no PowerShell, which is every platform but the one
+/// this file is for.
+#[test]
+fn install_ps1_parses() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let script = root.join("install.ps1");
+    let program = ["pwsh", "powershell"].into_iter().find(|p| {
+        Command::new(p)
+            .arg("-Help")
+            .stdin(Stdio::null())
+            .output()
+            .is_ok()
+    });
+    let Some(program) = program else {
+        return;
+    };
+    let out = Command::new(program)
+        .args(["-NoProfile", "-NonInteractive", "-Command"])
+        .arg(format!(
+            "$e = $null; [void][System.Management.Automation.Language.Parser]::ParseFile('{}', [ref]$null, [ref]$e); if ($e.Count) {{ $e | ForEach-Object {{ $_.Message }}; exit 1 }}",
+            script.display()
+        ))
+        .stdin(Stdio::null())
+        .output()
+        .expect("running PowerShell");
+    assert!(
+        out.status.success(),
+        "install.ps1 does not parse: {}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -632,6 +632,66 @@ The shortest of them, which detects what you run and links it to a single copy:
 That installs the skill, not the binary. The skill teaches one page, and it is
 loaded on every session, which is why its content is deliberately small.
 
+## Adopting ank where there is already code
+
+Everything above happened in an empty directory, which is the one repository
+nobody has. `ank init` on two years of history leaves you with a corpus and no
+content, and the question it raises is not how to write an ADR: it is which
+decisions this code has already made, and which of them were worth writing down
+all along. That reading is an agent's work, and these are the three prompts that
+ask for it. Both installers offer to print the same three, character for
+character, and a test holds the three copies together.
+
+Run this once, at the root of the repository:
+
+    ank init
+
+Then paste each prompt into your agent, one at a time, reading what comes back
+before you send the next. They follow the three moments of an adoption: what the
+code already decided, what it still owes, and whether the answer holds.
+
+**What the code already decided.** This is the one you judge the tool on. A
+constraint you recognise on sight is a constraint that was true and unwritten,
+and the reason it now has an id is that the next agent reads it without being
+told.
+
+<!-- adopt-prompts:begin -->
+
+    Read this repository and write, as ank ADRs, the decisions its code
+    has already made: the ones a newcomer would break without knowing
+    they existed. One ADR per decision, each with a scope glob covering
+    the files it binds and a constraint stated as a rule. Leave them
+    proposed; I ratify them myself.
+
+They land `proposed`, which binds nobody. `ank review` lists what is waiting, and
+`ank accept <id>` stays yours: a signed act, on the default branch, one at a
+time. An agent proposes and says it is waiting.
+
+**What it still owes.** Intentions scattered across TODOs, an issue tracker and a
+README are not work an agent can take. A scope and a criterion are, which is what
+`ank claim` freezes and `ank done` measures.
+
+    Read the TODOs, the open issues and the README of this repository,
+    and turn what they promise into ank tasks. Give each one a scope
+    glob and a done_criteria a test could settle, and use blocked_by
+    only where a task genuinely waits on another.
+
+**Whether the answer holds.** The third is the uncomfortable one, and it is meant
+to be: a constraint the code already breaks is the ordinary result of writing
+down what was implicit, not a sign the first prompt went wrong. What you want out
+of it is the list, before anybody starts repairing.
+
+    Run ank check and ank review here, then read every ADR back against
+    the code its scope matches. Tell me which constraints the code
+    already breaks and which scopes match no file, and change nothing
+    until I have read your answer.
+
+<!-- adopt-prompts:end -->
+
+None of the three is a step the tool waits on. A corpus with nothing but the ADRs
+from the first prompt is already worth `ank context`, and the other two can wait
+until you want them.
+
 ## Why it works this way
 
 You have now done the loop once, which is the right moment for the four claims

--- a/install.ps1
+++ b/install.ps1
@@ -140,13 +140,16 @@ function Show-Usage {
     Say '  Linux and macOS are installed by install.sh:'
     Say "    curl -fsSL https://raw.githubusercontent.com/$Repo/main/install.sh | sh"
     Say ''
-    Say 'the skills:'
-    Say '  With a console attached, once ank is installed and verified, this offers'
-    Say '  to run:'
+    Say 'the two questions:'
+    Say '  With a console attached, once ank is installed and verified, this asks two'
+    Say '  things and nothing else. The first offers to run:'
     Say "    npx skills add $Repo"
-    Say '  They teach an agent how to use ank. It is one question, Enter accepts it,'
-    Say '  declining installs nothing more, and nothing that command does can change'
-    Say '  any of the codes below.'
+    Say '  which teaches an agent how to use ank. The second offers to print three'
+    Say '  prompts that adopt ank in a repository that already has code and no .ank;'
+    Say '  they are in docs/getting-started.md too, and printing them writes nothing'
+    Say '  anywhere.'
+    Say '  Enter accepts each, declining either does nothing at all, and nothing'
+    Say '  either does can change any of the codes below.'
     Say ''
     Say 'exit codes:'
     Say '  1 usage   2 unsupported platform   3 download   4 checksum   5 missing runtime'
@@ -372,6 +375,102 @@ function Invoke-SkillOffer {
         Say 'Run that line again when you want them:'
         Say "  npx skills add $Repo"
     }
+}
+
+# ---------------------------------------------------------------------------
+# Adopting ank where there is already code
+# ---------------------------------------------------------------------------
+
+# ADR-5fbd99bf6fd5's second offer, and the last question this script asks.
+# Installing ank is the easy half. The half nobody had written down is what to
+# say to an agent so that a repository with two years of history acquires a
+# corpus worth having, and the moment after an install is the one moment the
+# person is certainly reading.
+#
+# Three prompts, because the adoption has three moments: state as ADRs what the
+# code already decided, so the constraints that exist implicitly become
+# readable; turn a list of intentions into tasks carrying a scope and a
+# criterion; and check what came out. The first one is the one the reader judges
+# the tool on, which is why it is first.
+#
+# The same three prose blocks live in install.sh and in docs/getting-started.md,
+# and a test holds the three copies character for character
+# (crates/ank-cli/tests/adopt.rs). Prose duplicated in three files diverges, and
+# this is the prose where divergence is worst: an installer teaching a prompt the
+# documentation has since corrected. The markers below are what the test reads;
+# the block between them is the one to edit, and the other two follow.
+#
+# A single-quoted here-string, so nothing in it is expanded: the text carries $
+# and backticks in no place today, and a literal block is what keeps that from
+# becoming a rule somebody has to remember. Its terminator sits at column zero
+# because Windows PowerShell 5.1 requires it there.
+# adopt-prompts:begin
+$AdoptWalkthrough = @'
+In a repository that already has code and no .ank, start with:
+
+  ank init
+
+Then paste these three into your agent, one at a time, and read what each
+one produces before you send the next.
+
+1. What the code already decided:
+
+    Read this repository and write, as ank ADRs, the decisions its code
+    has already made: the ones a newcomer would break without knowing
+    they existed. One ADR per decision, each with a scope glob covering
+    the files it binds and a constraint stated as a rule. Leave them
+    proposed; I ratify them myself.
+
+2. What is still owed:
+
+    Read the TODOs, the open issues and the README of this repository,
+    and turn what they promise into ank tasks. Give each one a scope
+    glob and a done_criteria a test could settle, and use blocked_by
+    only where a task genuinely waits on another.
+
+3. What you now have:
+
+    Run ank check and ank review here, then read every ADR back against
+    the code its scope matches. Tell me which constraints the code
+    already breaks and which scopes match no file, and change nothing
+    until I have read your answer.
+
+The same three are in docs/getting-started.md, which says what to expect
+from each:
+
+  https://github.com/haksolot/ank/blob/main/docs/getting-started.md
+'@
+# adopt-prompts:end
+
+# The second question, asked on the same terms as the first: only with a human
+# at a console, through [Console]::ReadLine so that a caller's `iex` pipeline is
+# never what answers it, and with a default Enter accepts. Declining prints
+# nothing -- not a shortened version, not a pointer to one. An offer that
+# answers a no with half of a yes is an offer that was not really asked.
+#
+# Nothing in here is allowed to reach the caller as a failure. The call site
+# wraps it, and the exit code is stamped after it returns.
+function Invoke-AdoptionOffer {
+    if (-not (Test-HumanAtTerminal)) { return }
+
+    Say ''
+    Say -NoNewline 'Print the three prompts that adopt ank in a repository you already have? [Y/n] '
+    $answer = $null
+    try { $answer = [Console]::ReadLine() } catch { $answer = $null }
+    if ($null -eq $answer) {
+        Say ''
+        return
+    }
+
+    $reply = $answer.Trim()
+    if ($reply -ne '' -and $reply -notmatch '^(y|yes)$') { return }
+
+    Say ''
+    # Split on either ending rather than on [Environment]::NewLine: this file is
+    # fetched by `irm` on one machine and checked out by git on another, and the
+    # bytes between two lines are not the same in both.
+    foreach ($line in ($AdoptWalkthrough -split "\r?\n")) { Say $line }
+    Say ''
 }
 
 # ---------------------------------------------------------------------------
@@ -944,6 +1043,7 @@ try {
     # global scope, because an assignment inside a script writes a script-local
     # variable that shadows it and changes nothing the host reads.
     try { Invoke-SkillOffer } catch { }
+    try { Invoke-AdoptionOffer } catch { }
     $global:LASTEXITCODE = 0
 } finally {
     if ($tmp -and (Test-Path -Path $tmp)) {

--- a/install.sh
+++ b/install.sh
@@ -251,13 +251,16 @@ $(supported_lines)
   Windows is published as a .zip and this script does not install it:
     ${releases_url}
 
-the skills:
-  With a terminal attached, once ank is installed and verified, this offers
-  to run:
+the two questions:
+  With a terminal attached, once ank is installed and verified, this asks
+  two things and nothing else. The first offers to run:
     npx skills add ${repo}
-  They teach an agent how to use ank. It is one question, Enter accepts it,
-  declining installs nothing more, and nothing that command does can change
-  any of the codes below.
+  which teaches an agent how to use ank. The second offers to print three
+  prompts that adopt ank in a repository that already has code and no
+  .ank; they are in docs/getting-started.md too, and printing them writes
+  nothing anywhere.
+  Enter accepts each, declining either does nothing at all, and nothing
+  either does can change any of the codes below.
 
 exit codes:
   1 usage   2 unsupported platform   3 download   4 checksum   5 missing tool
@@ -834,11 +837,103 @@ offer_skills() {
   fi
 }
 
-# `|| :` and not a bare call, and it is the whole guarantee in one line. This
-# is the last command in the file, so the script's status is its status: with
-# `set -e` in force a single failure anywhere inside would become the exit code
-# of an install that has already succeeded. Called this way, the failure is
-# tested rather than fatal, `set -e` is suspended for the duration, and the
-# status this script leaves with is the status it had before the question was
+# --------------------------------------------------------------------------
+# Adopting ank where there is already code
+# --------------------------------------------------------------------------
+
+# ADR-5fbd99bf6fd5's second offer, and the last question this script asks.
+# Installing ank is the easy half. The half nobody had written down is what to
+# say to an agent so that a repository with two years of history acquires a
+# corpus worth having, and the moment after an install is the one moment the
+# person is certainly reading.
+#
+# Three prompts, because the adoption has three moments: state as ADRs what the
+# code already decided, so the constraints that exist implicitly become
+# readable; turn a list of intentions into tasks carrying a scope and a
+# criterion; and check what came out. The first one is the one the reader
+# judges the tool on, which is why it is first.
+#
+# The same three prose blocks live in install.ps1 and in docs/getting-started.md,
+# and a test holds the three copies character for character
+# (crates/ank-cli/tests/adopt.rs). Prose duplicated in three files diverges, and
+# this is the prose where divergence is worst: an installer teaching a prompt
+# the documentation has since corrected. The markers below are what the test
+# reads; the block between them is the one to edit, and the other two follow.
+# adopt-prompts:begin
+adopt_walkthrough() {
+  cat >&2 <<'ADOPT_EOF'
+In a repository that already has code and no .ank, start with:
+
+  ank init
+
+Then paste these three into your agent, one at a time, and read what each
+one produces before you send the next.
+
+1. What the code already decided:
+
+    Read this repository and write, as ank ADRs, the decisions its code
+    has already made: the ones a newcomer would break without knowing
+    they existed. One ADR per decision, each with a scope glob covering
+    the files it binds and a constraint stated as a rule. Leave them
+    proposed; I ratify them myself.
+
+2. What is still owed:
+
+    Read the TODOs, the open issues and the README of this repository,
+    and turn what they promise into ank tasks. Give each one a scope
+    glob and a done_criteria a test could settle, and use blocked_by
+    only where a task genuinely waits on another.
+
+3. What you now have:
+
+    Run ank check and ank review here, then read every ADR back against
+    the code its scope matches. Tell me which constraints the code
+    already breaks and which scopes match no file, and change nothing
+    until I have read your answer.
+
+The same three are in docs/getting-started.md, which says what to expect
+from each:
+
+  https://github.com/haksolot/ank/blob/main/docs/getting-started.md
+ADOPT_EOF
+}
+# adopt-prompts:end
+
+# The second question, asked on the same terms as the first: only with a human
+# at a terminal, from /dev/tty and nowhere else, with a default Enter accepts.
+# Declining prints nothing -- not a shortened version, not a pointer to one.
+# An offer that answers a no with half of a yes is an offer that was not really
 # asked.
+offer_adoption() {
+  human_at_terminal || return 0
+
+  say ""
+  printf 'Print the three prompts that adopt ank in a repository you already have? [Y/n] ' >&2
+  if ! IFS= read -r adopt_answer < /dev/tty; then
+    # End of input rather than an answer. The newline is ours because no Enter
+    # was pressed to echo one.
+    say ""
+    return 0
+  fi
+
+  case "$adopt_answer" in
+    "" | y | Y | yes | Yes | YES) : ;;
+    *) return 0 ;;
+  esac
+
+  say ""
+  # To stderr, for the reason `say` writes there: the interesting use of this
+  # script is `curl ... | sh`, and stdout belongs to whoever is reading it.
+  adopt_walkthrough
+  say ""
+}
+
+# `|| :` on each and not a bare call, and it is the whole guarantee in two
+# lines. These are the last commands in the file, so the script's status is the
+# status of the last of them: with `set -e` in force a single failure anywhere
+# inside either would become the exit code of an install that has already
+# succeeded. Called this way, the failure is tested rather than fatal, `set -e`
+# is suspended for the duration, and the status this script leaves with is the
+# status it had before the first question was asked.
 offer_skills || :
+offer_adoption || :


### PR DESCRIPTION
Closes TASK-567084d21d2b, the last of ADR-5fbd99bf6fd5's offers.

## What it does

Both installers ask a second question once ank is on disk and verified, on the
same terms as the skills offer: only with a human at a terminal, with a default
Enter accepts. On acceptance they print a walkthrough of 35 lines against the
criterion's ceiling of forty -- `ank init`, then three prompts a reader pastes
into an agent to adopt ank in a repository that already has code and no `.ank`.

Three prompts, because the adoption has three moments: state as ADRs what the
code already decided, so the constraints that exist implicitly become readable;
turn a list of intentions into tasks carrying a scope and a criterion; and check
what came out. The first is the one the reader judges the tool on, which is why
it is first. `docs/getting-started.md` gains a section carrying the same three
with what to expect from each.

## The drift test is the substance

The prompts live in three files, which is what `crates/ank-cli/tests/adopt.rs`
exists for. Prose duplicated in three files diverges, and this is the prose
where divergence is worst: an installer teaching a prompt the documentation has
since corrected, on the route where the reader cannot know the two disagree.

The block between the markers in `install.sh` is the source; `install.ps1` and
the document carry copies. Thirteen tests hold the three character for
character, hold the two installers to the same walkthrough whole, and hold the
offer to its terminal predicate, its one question, its Enter default and its
silent decline. It earned itself immediately: the heredoc had a trailing blank
line the here-string did not, and the test found it first.

## Verified

`cargo test --workspace` green, 733 passed. `cargo fmt --check` clean.
`ank check` ok on each of the four scoped files.

The shell offer was driven for real under a pty rather than asserted from the
source alone: Enter prints 33 lines of block between two blanks; `n` prints the
question and then nothing; with the terminal predicate false both streams are
empty and the exit code is 0. `install.ps1` is held by a parser check that runs
where PowerShell exists, which on this matrix is the Windows leg.

## Scope

`ank amend --scope` added `crates/ank-cli/tests/adopt.rs`: the criterion asks
for a test and none of the three files carrying the prose can assert anything.
Logged before the amend.

## One thing to know

`8a3c738` records an incident rather than a change. While finishing this task I
pushed `+refs/ank/*:refs/ank/*`, force-updating 83 refs from a copy this
checkout had last fetched on 2026-08-18. Any run id `attest` recorded on those
83 since then is gone and is not recoverable. Nothing lost its attested status
-- after a fetch `ank check` reports no task done without a test proof -- and no
entity, claim or branch was touched. Written into the corpus because the files
do not show it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015NhfJPVGYNaA5w82bPqNPn