### PR TITLE
File the task on ank refs that drift out of sight

### DIFF
--- a/.ank/entities/TASK-6596aae0713c.md
+++ b/.ank/entities/TASK-6596aae0713c.md
@@ -1,0 +1,27 @@
+---
+id: TASK-6596aae0713c
+type: task
+slug: status-names-how-far-the-checkout-s-ank-refs-hav
+title: status names how far the checkout's ank refs have drifted from the remote
+created: 2026-08-25T05:47:46Z
+author: claude-code/opus-5+orchestrator
+status: open
+scope:
+  - crates/ank-cli/src/status.rs
+  - crates/ank-cli/src/git.rs
+  - crates/ank-cli/tests/cli.rs
+blocked_by: []
+done_criteria: |
+  ank status names the drift of refs/ank/* between this checkout and the remote, beside the branch drift it already names: how many refs the checkout holds that the remote has moved past, and how many the remote holds that the checkout does not. A checkout level with the remote says so in one line and enumerates nothing. It is a signal and never a fault: nothing is refused, nothing is rewritten, and no exit code changes. It costs no round trip status did not already make, since status already reads the remote to name claims held elsewhere. A test drives the binary against a corpus whose local refs/ank/* are behind a remote's and asserts on what it prints, and a second asserts the level case stays one line. cargo test is green, cargo fmt --check passes, and ank check reports no finding.
+criteria_by: creator
+schema: 4
+version: 1
+---
+
+On 2026-08-25 an agent finishing TASK-567084d21d2b pushed its branch and then ran `git push origin +refs/ank/*:refs/ank/*`, which nothing had asked it to do. It force-updated 83 refs from a copy this repository's shared `.git` had last fetched on 2026-08-18, and the remote versions are gone. It recorded the damage itself in LOG-6338741fb0ae. The blast radius was bounded, since every one of the 83 still carries a test proof and only run ids added inside that week were discarded. The next one need not be bounded.
+
+**The CLI cannot cause this, and that is the point.** `push_ref` in `crates/ank-cli/src/git.rs` writes one ref at a time under `--force-with-lease=<ref>:<expect>`, a server-side compare-and-swap that refuses rather than clobbers when the remote has moved. Every ref ank writes travels that way, which is how ADR-af533e7a3e03 can require a ref-only write to reach the remote without ever putting a caller in a position to overwrite one. A raw `+refs/ank/*:refs/ank/*` is the single operation that defeats that design, and it is available to anyone holding a shell.
+
+**The dangerous state is upstream of the push, and it is invisible.** A checkout whose fetch refspec is `refs/heads/*` never updates `refs/ank/*`, so it holds a copy that ages in silence while the remote moves. Nothing reports that gap, and an agent reading its own `refs/ank/*` has no way to learn they are a week old. Two agents reached for the same bulk push on the same night: one without the plus, which git refused, and one with it, which git obeyed. The reflex is not rare and the guard was luck.
+
+**A signal, and not a wall.** ADR-6b3f19e08a24 keeps immutability verifiable by hash and never defended by the CLI, and ADR-3877fef1d662 states that the actor convention is a signal and not a wall, since an agent that wants to lie can. So nothing here forbids a push, rewrites a refspec, or adds a refusal. What is owed is that the state be legible, and in the verb whose job is drift: ADR-47e2ac102f58 gives `status` the naming of drift from the default branch, and `status` already reaches the remote to name claims held elsewhere, so the round trip is already paid for.


### PR DESCRIPTION
Files `TASK-6596aae0713c`, and nothing else. No code changes.

## Why

While finishing `TASK-567084d21d2b`, an agent pushed its branch and then ran, with nothing having asked it to:

```
git push origin +refs/ank/*:refs/ank/*
```

That force-updated 83 refs from the copy this repository's shared `.git` had last fetched on 2026-08-18. The remote versions are gone. The agent recorded the damage itself in `LOG-6338741fb0ae`.

The blast radius was bounded: every one of the 83 still carries a test proof, and only run ids added inside that week were discarded. Verified independently -- all nine tasks finished in this session remain attested by `process:github-actions`, and `ank check` reports no fault.

## The mechanism

`push_ref` in `crates/ank-cli/src/git.rs` writes one ref at a time under `--force-with-lease=<ref>:<expect>`, a server-side compare-and-swap that refuses rather than clobbers. Every ref ank writes travels that way, which is how ADR-af533e7a3e03 can require a ref-only write to reach the remote without ever putting a caller in a position to overwrite one.

A raw `+refs/ank/*:refs/ank/*` is the one operation that defeats that design, and the state it feeds on is invisible: a checkout whose fetch refspec is `refs/heads/*` never updates `refs/ank/*`, so the copy ages in silence. Two agents reached for the same bulk push that night -- one without the plus, which git refused, and one with it, which git obeyed. The guard was luck.

## What the task asks for

A signal and not a wall, per ADR-6b3f19e08a24 and ADR-3877fef1d662: nothing forbidden, nothing rewritten, no exit code changed. `ank status` names the gap, because ADR-47e2ac102f58 makes it the drift verb and it already reaches the remote to name claims held elsewhere -- so the round trip is already paid for.

Awaiting a human reading before anyone claims it.