### PR TITLE
done: TASK-7a58ebe12ca6, proof commit:1cda7a8

### DIFF
--- a/.ank/entities/LOG-5d02b297053d.md
+++ b/.ank/entities/LOG-5d02b297053d.md
@@ -1,0 +1,13 @@
+---
+id: LOG-5d02b297053d
+type: log
+title: done, proof commit:1cda7a8e0819f9f4eec0bf872c443d510e1e6276
+created: 2026-08-25T06:17:57Z
+author: claude-code/opus-5+probe-repair
+scope:
+  - .github/workflows/install.yml
+about: TASK-7a58ebe12ca6
+seq: 3
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-d38e906e108f.md
+++ b/.ank/entities/LOG-d38e906e108f.md
@@ -1,0 +1,15 @@
+---
+id: LOG-d38e906e108f
+type: log
+title: "CI run 32813063160 (install, push): all four runners green. accept/enter/decline/eof/noflag/nonode"
+created: 2026-08-25T05:31:31Z
+author: claude-code/opus-5+probe-repair
+scope:
+  - .github/workflows/install.yml
+about: TASK-7a58ebe12ca6
+seq: 2
+schema: 4
+version: 1
+---
+
+ each report 'skills asked 1 | adoption asked 1' (0/0 for noflag), no FAIL line and no timeout, on ubuntu-latest, macos-latest, macos-15-intel and windows-latest. The two ^D queued in the pty do give two zero-length reads on BSD as well as on Linux, which was the one thing this repair could not be proved on from a Linux worktree.

--- a/.ank/entities/TASK-7a58ebe12ca6.md
+++ b/.ank/entities/TASK-7a58ebe12ca6.md
@@ -5,15 +5,20 @@ slug: the-probe-counts-each-offer-by-its-own-question
 title: The probe counts each offer by its own question, and a second one stops failing the first
 created: 2026-08-25T05:10:54Z
 author: claude-code/opus-5+orchestrator
-status: in_progress
+status: done
 scope:
   - .github/workflows/install.yml
 blocked_by: []
 done_criteria: |
   The install.yml probe counts each offer by its own question rather than by the [Y/n] marker the two share, and asserts of each that it was asked exactly once. The property TASK-5a2f1b47f204 wrote the probe to defend is kept and never relaxed: a skills offer asked twice still fails the probe, and so does an adopt offer asked twice. All five cases -- accept, enter, decline, eof, nonode -- pass on ubuntu-latest, macos-latest, macos-15-intel and windows-latest, in the sh half and the PowerShell half alike. install.sh, install.ps1 and docs/getting-started.md are not touched by this task: the installers are right and the assertion was not. cargo test is green, cargo fmt --check passes, and ank check reports no finding.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 1cda7a8e0819f9f4eec0bf872c443d510e1e6276
+    criteria: 91c4cb79d36c
+    via: submitted
 schema: 4
-version: 2
+version: 3
 ---
 
 TASK-5a2f1b47f204 gave `install.yml` a probe that drives the installer with a console attached and asserts, over five cases, that the offer was asked once. It counts the asks with `out.count("[Y/n]")`, which was exact while one offer existed and stopped being exact the moment a second one did.


### PR DESCRIPTION
The completion record for TASK-7a58ebe12ca6. #266 was merged at its head `1cda7a8`, which carried the repair itself; `ank done` ran afterwards, so the corpus on main still shows the task unfinished and `attest` has nothing to anchor. This PR is that record and nothing else.

The delta against main is three files, all in `.ank/`:

```
.ank/entities/LOG-5d02b297053d.md  | 13 +++++++++++++
.ank/entities/LOG-d38e906e108f.md  | 15 +++++++++++++++
.ank/entities/TASK-7a58ebe12ca6.md |  9 +++++++--
```

`ank done` reported:

```
proof recorded: commit -> 1cda7a8e0819f9f4eec0bf872c443d510e1e6276
TASK-7a58ebe12ca6 -> done
```

recorded against the frozen criteria hash `91c4cb79d36c`. No `refs/ank/*` was pushed; there are none in the worktree, and `attest` records `test:<run-id>` itself once this lands.

The criterion was measured before `done` ran, not after. `install` run [32813063160](https://github.com/haksolot/ank/actions/runs/32813063160) was green on all four runners, both halves, all six cases:

```
accept  -> exit 0 | skills asked 1 | adoption asked 1 | npx ran True  | timed out False
enter   -> exit 0 | skills asked 1 | adoption asked 1 | npx ran True  | timed out False
decline -> exit 0 | skills asked 1 | adoption asked 1 | npx ran False | timed out False
eof     -> exit 0 | skills asked 1 | adoption asked 1 | npx ran False | timed out False
noflag  -> exit 0 | skills asked 0 | adoption asked 0 | npx ran False | timed out False
nonode  -> exit 0 | skills asked 1 | adoption asked 1 | npx ran False | timed out False
```

`cargo test` green, `cargo fmt --check` clean, `ank check` exit 0 after the merge of main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GcrK2WALLMJZ8DvM4REJSK