### PR TITLE
A change becomes an event, and the reader repaints instead of polling

### DIFF
--- a/.ank/entities/LOG-5203a5ca18c0.md
+++ b/.ank/entities/LOG-5203a5ca18c0.md
@@ -1,0 +1,20 @@
+---
+id: LOG-5203a5ca18c0
+type: log
+title: +scope crates/ank-contract/src/events.rs, +scope crates/ank-contract/src/lib.rs (version 2 to 3,
+created: 2026-08-25T07:36:44Z
+author: claude-code/opus-5+reader-events
+scope:
+  - crates/ank-daemon/**
+  - crates/ank-tui/**
+  - docs/integrating.md
+  - crates/ank-contract/src/events.rs
+  - crates/ank-contract/src/lib.rs
+about: TASK-2f7777a1fdff
+seq: 1
+records: edit
+schema: 4
+version: 1
+---
+
+ replaced 5fca7040b572, produced 17e0625952d1)

--- a/.ank/entities/LOG-862e59af33d3.md
+++ b/.ank/entities/LOG-862e59af33d3.md
@@ -1,0 +1,19 @@
+---
+id: LOG-862e59af33d3
+type: log
+title: Three findings the criterion did not anticipate, and each one changed the code. (1) A change is two
+created: 2026-08-25T08:09:46Z
+author: claude-code/opus-5+reader-events
+scope:
+  - crates/ank-daemon/**
+  - crates/ank-tui/**
+  - docs/integrating.md
+  - crates/ank-contract/src/events.rs
+  - crates/ank-contract/src/lib.rs
+about: TASK-2f7777a1fdff
+seq: 3
+schema: 4
+version: 1
+---
+
+ changes, not one. The files under .ank moving and the mirror of somebody else's refs/ank/* moving are different news, and only the first was visible to the watcher: git answers zero on a fetch that brought nothing, so 'did anything move' is a question only for-each-ref answers. The stream carries entities and refs as two words, one for-each-ref per fetch cycle rather than per poll. (2) The reader could not be told anything while it was blocked on read_line, so the session now takes an iterator of wakeups rather than a reader, with the terminal on a thread of its own. That is the whole cost of an event, and it changes nothing else: the same lines arrive in the same order, and a session with no stream behind it is the one TASK-b50b340c0bb1 measured. (3) The idle assertion needed an instrument that could not be fooled. Refs and files unchanged is what the previous wave used, and it says nothing about a screen that asks and asks without writing. Every read this reader makes is ank <verb> --json, and every verb asks git something (ADR-9307e5d214a7), so a shim git on PATH that records each call and hands it on counts every query whatever route it took. Three seconds of a connected stream with nobody typing moves that count by zero, and one event moves it. And a mutation check was run rather than assumed: making the repaint re-read the open entity turns an_event_repaints_the_list_and_renews_no_claim red on the exact sentence ADR-0bb7ea8991bc writes.

--- a/.ank/entities/LOG-b61e0689289e.md
+++ b/.ank/entities/LOG-b61e0689289e.md
@@ -1,0 +1,17 @@
+---
+id: LOG-b61e0689289e
+type: log
+title: The shape, settled before any code, and the one thing the four previous waves make impossible.
+created: 2026-08-25T07:36:36Z
+author: claude-code/opus-5+reader-events
+scope:
+  - crates/ank-daemon/**
+  - crates/ank-tui/**
+  - docs/integrating.md
+about: TASK-2f7777a1fdff
+seq: 0
+schema: 4
+version: 1
+---
+
+ Transport: an append-only newline-delimited file the daemon writes and any reader tails, beside watch.yml under the reader's own configuration home. Not a socket: ADR-a22cd3196529 forbids a query surface, and a socket is a place a caller connects to and can then be tempted to ask something of; a file is a place the daemon writes and nobody asks anything. It also costs no platform code, and a reader written outside this repository needs a file reader and nothing more. Where it lives: crates/ank-contract, as an events module, because the writer and the reader of a stream are exactly the pair ank-contract exists to keep from drifting, and the alternative was the same key names and the same escaper written twice in two crates. Scope has to widen there. And the trap: ank show renews the lease when the id is the task the caller holds (TASK-49746735127f found this), so an event repaint may run status and find and must never run show. An event is a repaint of what a read gives for free, never the one read that writes. The open body stays as it was until the person asks for it, and that is the decision rather than an omission.

--- a/.ank/entities/LOG-c55e67017359.md
+++ b/.ank/entities/LOG-c55e67017359.md
@@ -1,0 +1,17 @@
+---
+id: LOG-c55e67017359
+type: log
+title: done, proof commit:c3b5833
+created: 2026-08-25T08:10:13Z
+author: claude-code/opus-5+reader-events
+scope:
+  - crates/ank-daemon/**
+  - crates/ank-tui/**
+  - docs/integrating.md
+  - crates/ank-contract/src/events.rs
+  - crates/ank-contract/src/lib.rs
+about: TASK-2f7777a1fdff
+seq: 4
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-d9f2f5d1e206.md
+++ b/.ank/entities/LOG-d9f2f5d1e206.md
@@ -1,0 +1,19 @@
+---
+id: LOG-d9f2f5d1e206
+type: log
+title: Scope widened by two files, both in crates/ank-contract, and neither is a place the work could have
+created: 2026-08-25T07:36:54Z
+author: claude-code/opus-5+reader-events
+scope:
+  - crates/ank-daemon/**
+  - crates/ank-tui/**
+  - docs/integrating.md
+  - crates/ank-contract/src/events.rs
+  - crates/ank-contract/src/lib.rs
+about: TASK-2f7777a1fdff
+seq: 2
+schema: 4
+version: 1
+---
+
+ stayed. The event stream has a writer in ank-daemon and a reader in ank-tui, and its key names, its schema number, its change vocabulary and its escaper have to be one thing or they are two that will disagree; ank-contract is the crate whose whole reason is that a surface cannot drift from what describes it, and both crates already depend on it. The directory rule for the reader's configuration home moves there with it, so declare.rs delegates rather than keeping a second copy: that removes a duplication instead of adding one, and the cross-binary assertion in the daemon's suite still holds ank-cli's own copy to it.

--- a/.ank/entities/TASK-2f7777a1fdff.md
+++ b/.ank/entities/TASK-2f7777a1fdff.md
@@ -5,17 +5,19 @@ slug: a-change-becomes-an-event-and-the-reader-repaint
 title: A change becomes an event, and the reader repaints instead of polling
 created: 2026-08-24T22:03:25Z
 author: claude-code/opus-5+planning
-status: open
+status: in_progress
 scope:
   - crates/ank-daemon/**
   - crates/ank-tui/**
   - docs/integrating.md
+  - crates/ank-contract/src/events.rs
+  - crates/ank-contract/src/lib.rs
 blocked_by: [TASK-a73b41660413, TASK-49746735127f]
 done_criteria: |
   The daemon emits an event when a corpus it watches changes, stating which corpus by its repository identity and what kind of change occurred, and stating nothing about what a reader should do. The stream is documented in docs/integrating.md well enough for a reader written outside this repository to consume it. ank tui consumes it where it is available and falls back to its own reading where it is not, and a test shows the interface reaching the same displayed state by both routes. A test asserts the interface issues no repeating query while idle with the stream connected, and that no event ever carries entity content a reader would otherwise get from the CLI. cargo test is green and cargo fmt --check passes.
 criteria_by: creator
 schema: 4
-version: 1
+version: 3
 ---
 
 The last of ADR-a22cd3196529, and the one with a real consumer at last: the

--- a/.ank/entities/TASK-2f7777a1fdff.md
+++ b/.ank/entities/TASK-2f7777a1fdff.md
@@ -5,7 +5,7 @@ slug: a-change-becomes-an-event-and-the-reader-repaint
 title: A change becomes an event, and the reader repaints instead of polling
 created: 2026-08-24T22:03:25Z
 author: claude-code/opus-5+planning
-status: in_progress
+status: done
 scope:
   - crates/ank-daemon/**
   - crates/ank-tui/**
@@ -16,8 +16,13 @@ blocked_by: [TASK-a73b41660413, TASK-49746735127f]
 done_criteria: |
   The daemon emits an event when a corpus it watches changes, stating which corpus by its repository identity and what kind of change occurred, and stating nothing about what a reader should do. The stream is documented in docs/integrating.md well enough for a reader written outside this repository to consume it. ank tui consumes it where it is available and falls back to its own reading where it is not, and a test shows the interface reaching the same displayed state by both routes. A test asserts the interface issues no repeating query while idle with the stream connected, and that no event ever carries entity content a reader would otherwise get from the CLI. cargo test is green and cargo fmt --check passes.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: c3b5833
+    criteria: 4e5fb79e2bb9
+    via: submitted
 schema: 4
-version: 3
+version: 4
 ---
 
 The last of ADR-a22cd3196529, and the one with a real consumer at last: the

--- a/crates/ank-cli/tests/tui.rs
+++ b/crates/ank-cli/tests/tui.rs
@@ -1093,3 +1093,535 @@ fn every_verb_of_the_writing_half_is_reachable_from_a_selected_entity() {
         "with the proof that was typed:\n{shown}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// The change stream (TASK-2f7777a1fdff)
+// ---------------------------------------------------------------------------
+//
+// The reader is told that the corpus moved instead of asking on a timer, and
+// three things have to be true of that. It must reach the same screen the
+// reload reaches, or the fast path and the slow path drift until only the one
+// the developer runs is correct. It must ask nothing at all while nobody is
+// typing and nothing is changing, or it is the refresh loop this crate spent
+// TASK-b50b340c0bb1 not having. And it must renew nothing, ever: `ank show`
+// renews the lease when the id is the task the caller holds, so an event that
+// re-read the open entity would keep a claim alive for somebody who went home,
+// which ADR-0bb7ea8991bc forbids in exactly those words.
+//
+// All three are facts about a running process, a real terminal and a git
+// repository, so all three are asserted against one.
+
+/// The reader's own configuration home: where the watcher would put a stream,
+/// and where this suite puts one instead.
+///
+/// **The watcher is not run here, and that is the point.** What `ank tui`
+/// consumes is a file of lines, and the lines are built by
+/// `ank_contract::events`, which is the encoder `ank-daemon` writes with -- so
+/// the two ends are held together by the code they share rather than by two
+/// processes agreeing on a Tuesday. That the watcher writes those lines, into
+/// this path, is asserted in its own suite, which is where a watcher belongs.
+///
+/// `XDG_CONFIG_HOME` alone, and never `HOME`: this has to move where the reader
+/// looks for its stream without moving where git looks for a user's
+/// configuration, and a fixture that changed the second would be testing this
+/// machine's git rather than this binary.
+#[cfg(unix)]
+struct Home(PathBuf);
+
+#[cfg(unix)]
+impl Drop for Home {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+#[cfg(unix)]
+impl Home {
+    /// A home whose stream exists and is empty: a watcher has run here, and
+    /// nothing has happened yet.
+    fn following(what: &str) -> Home {
+        let home = Home::empty(what);
+        std::fs::write(home.stream(), "").unwrap();
+        home
+    }
+
+    /// A home with no stream in it at all: no watcher has ever run for this
+    /// reader, which is the mode every checkout without one is in.
+    fn empty(what: &str) -> Home {
+        let root = scratch(what);
+        std::fs::create_dir_all(root.join("ank")).unwrap();
+        Home(root)
+    }
+
+    fn stream(&self) -> PathBuf {
+        self.0.join("ank").join(ank_contract::events::STREAM_FILE)
+    }
+
+    /// One line of news, exactly as the watcher writes one.
+    fn says(&self, corpus: &str, change: ank_contract::events::Change) {
+        use std::io::Write;
+        let mut file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(self.stream())
+            .unwrap();
+        file.write_all(
+            ank_contract::events::Event::new(corpus, change)
+                .line()
+                .as_bytes(),
+        )
+        .unwrap();
+    }
+}
+
+/// A session that can be watched while it is still running.
+///
+/// [`drive`] writes every command before reading anything, which is all a
+/// keystroke-driven screen ever needed. A screen that repaints on its own has to
+/// be observed *between* keystrokes, and often with no keystroke at all, so the
+/// drain here writes into a buffer the test can read at any moment.
+#[cfg(unix)]
+struct Live {
+    child: std::process::Child,
+    writer: std::fs::File,
+    seen: std::sync::Arc<std::sync::Mutex<Vec<u8>>>,
+}
+
+#[cfg(unix)]
+impl Live {
+    /// Opens `ank tui` on a real terminal, with whatever environment the test
+    /// needs on top of the usual one.
+    fn open(repo: &Repo, agent: &str, env: &[(&str, String)]) -> Live {
+        use std::io::Read;
+
+        let (master, slave_path) = pty::open();
+        let mut command = Command::new(ANK);
+        command
+            .arg("tui")
+            .current_dir(&repo.0)
+            .env("ANK_AGENT", agent)
+            .env("COLUMNS", "120")
+            .env("LINES", "40")
+            .env("NO_COLOR", "1");
+        for (key, value) in env {
+            command.env(key, value);
+        }
+        let child = command
+            .stdin(pty::stdio(pty::slave(&slave_path)))
+            .stdout(pty::stdio(pty::slave(&slave_path)))
+            .stderr(pty::stdio(pty::slave(&slave_path)))
+            .spawn()
+            .expect("the binary must have been built");
+
+        let seen = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let into = std::sync::Arc::clone(&seen);
+        let mut reader = master
+            .try_clone()
+            .expect("the master side must be clonable for the drain");
+        std::thread::spawn(move || {
+            let mut buf = [0u8; 4096];
+            loop {
+                match reader.read(&mut buf) {
+                    Ok(0) | Err(_) => return,
+                    Ok(n) => into.lock().unwrap().extend_from_slice(&buf[..n]),
+                }
+            }
+        });
+        Live {
+            child,
+            writer: master,
+            seen,
+        }
+    }
+
+    fn text(&self) -> String {
+        String::from_utf8_lossy(&self.seen.lock().unwrap()).to_string()
+    }
+
+    /// Waits for the screen to say something.
+    ///
+    /// Bounded and generous, on the rule the watcher's suite states: this is
+    /// asserting that something happens at all, not how fast, so the wall is
+    /// high enough that a loaded runner never reports the runner instead of the
+    /// code.
+    fn until(&self, what: &str, done: impl Fn(&str) -> bool) {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        while std::time::Instant::now() < deadline {
+            if done(&self.text()) {
+                return;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(25));
+        }
+        panic!("timed out waiting for {what}:\n{}", self.text());
+    }
+
+    /// The last frame drawn, once the screen has stopped moving.
+    ///
+    /// Settled first, because a frame read the instant a needle appeared is
+    /// half a frame: the reader writes a screen in one call but a terminal
+    /// hands it over in whatever pieces it likes.
+    fn frame(&self) -> String {
+        let mut last = String::new();
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        while std::time::Instant::now() < deadline {
+            let now = self.text();
+            if !now.is_empty() && now == last {
+                return last_frame(&now);
+            }
+            last = now;
+            std::thread::sleep(std::time::Duration::from_millis(200));
+        }
+        panic!("the screen never stopped moving:\n{last}");
+    }
+
+    fn send(&mut self, line: &str) {
+        use std::io::Write;
+        writeln!(self.writer, "{line}").expect("the terminal must accept a command");
+        self.writer.flush().unwrap();
+    }
+
+    fn quit(mut self) {
+        self.send("q");
+        let status = self.child.wait().expect("the session must end");
+        assert!(status.success(), "the session ended with {status}");
+    }
+}
+
+/// The last whole frame of a byte stream a session wrote.
+///
+/// Frames are separated by the sequence that homes the cursor and clears the
+/// screen, and the session's last act is to leave the alternate buffer, which is
+/// chrome rather than a frame.
+#[cfg(unix)]
+fn last_frame(seen: &str) -> String {
+    const HOME: &str = "\x1b[H\x1b[2J";
+    const LEAVE: &str = "\x1b[?1049l";
+    let at = seen
+        .rfind(HOME)
+        .expect("a session draws at least one frame");
+    seen[at + HOME.len()..].replace(LEAVE, "")
+}
+
+/// A frame with the one line that names the route taken out of it.
+///
+/// The two routes must reach the same displayed state, and the one thing that
+/// must *not* be the same is the line saying which route the screen is on: a
+/// comparison that demanded byte equality there would be demanding the reader
+/// lie about how it is being kept current. Everything else -- the claims, every
+/// row, the counts, the note -- is compared byte for byte.
+#[cfg(unix)]
+fn without_the_route(frame: &str) -> String {
+    frame
+        .lines()
+        .map(
+            |line| match (line.starts_with("identity "), line.find("stream ")) {
+                (true, Some(at)) => line[..at].to_string(),
+                _ => line.to_string(),
+            },
+        )
+        .collect::<Vec<String>>()
+        .join("\n")
+}
+
+/// The repository identity the stream keys on, as the CLI states it.
+#[cfg(unix)]
+fn corpus_of(repo: &Repo) -> String {
+    let doc = repo.stdout(READER, &["status", "--json"]);
+    let at = doc.find("\"corpus\":\"").expect("status names the corpus");
+    let rest = &doc[at + 10..];
+    rest[..rest.find('"').expect("a closed string")].to_string()
+}
+
+/// Both routes, on one corpus, reaching one screen.
+///
+/// **Two sessions open at once, and one change.** The fast path and the slow
+/// path have to be compared against the same corpus at the same state, and a
+/// test that ran them one after the other would be comparing two states. So
+/// both screens are opened before anything moves: one with a stream to follow
+/// and one without, the corpus gains a task, and each screen catches up the way
+/// it can -- the first because it was told, the second because somebody typed
+/// `r`.
+///
+/// What is asserted is the frame, byte for byte, minus the one line that says
+/// which of the two it was. That line is asserted to differ, because two routes
+/// that turned out to be one route would otherwise pass this test perfectly.
+#[cfg(unix)]
+#[test]
+fn the_event_and_the_reload_reach_the_same_displayed_state() {
+    let repo = Repo::seeded("routes");
+    repo.warm(READER);
+    let corpus = corpus_of(&repo);
+    let following = Home::following("routes-stream");
+    let alone = Home::empty("routes-none");
+
+    let told = Live::open(
+        &repo,
+        READER,
+        &[("XDG_CONFIG_HOME".into(), following.0.display().to_string())],
+    );
+    told.until("the told screen to open", |t| t.contains("ENTITIES"));
+    let mut asking = Live::open(
+        &repo,
+        READER,
+        &[("XDG_CONFIG_HOME".into(), alone.0.display().to_string())],
+    );
+    asking.until("the asking screen to open", |t| t.contains("ENTITIES"));
+    assert!(
+        told.text().contains("stream following"),
+        "the first screen has a stream:\n{}",
+        told.text()
+    );
+    assert!(
+        asking.text().contains("stream none"),
+        "and the second has none:\n{}",
+        asking.text()
+    );
+
+    let arrived = repo.spare(
+        "A task that arrives while two screens are open",
+        "both screens name it, and neither polled for it",
+    );
+    let needle = short_of(&arrived);
+
+    // Nobody types into this one.
+    following.says(&corpus, ank_contract::events::Change::Entities);
+    told.until("the event to reach the screen", |t| t.contains(&needle));
+    let by_event = told.frame();
+
+    asking.send("r");
+    asking.until("the reload to reach the screen", |t| t.contains(&needle));
+    let by_reload = asking.frame();
+
+    assert_eq!(
+        without_the_route(&by_event),
+        without_the_route(&by_reload),
+        "the two routes drew two different screens"
+    );
+    assert_ne!(
+        by_event, by_reload,
+        "the two frames are identical, so the route line says nothing and this \
+         test compared one route with itself"
+    );
+
+    told.quit();
+    asking.quit();
+}
+
+/// A screen with a stream connected, and nobody typing, asks nothing.
+///
+/// **The instrument is git.** Every read this reader makes is `ank <verb>
+/// --json` spawned as a child, and every one of those verbs asks git something
+/// (ADR-9307e5d214a7 requires it per verb). So a shim on `PATH` that records
+/// each invocation and hands the call to the real binary counts every query the
+/// reader makes, whatever route it took to make one -- which is stronger than
+/// counting the spawns this crate knows about, because it would also catch a
+/// query made some other way.
+///
+/// The corpus is changed from the test process, which does not carry the shim,
+/// so what the log holds is the reader's own asking and nothing else.
+#[cfg(unix)]
+#[test]
+fn a_screen_with_the_stream_connected_asks_nothing_while_it_is_idle() {
+    let repo = Repo::seeded("idle-stream");
+    repo.warm(READER);
+    let corpus = corpus_of(&repo);
+    let home = Home::following("idle-stream-home");
+    let shim = Shim::new("idle-stream-shim");
+
+    let live = Live::open(
+        &repo,
+        READER,
+        &[
+            ("XDG_CONFIG_HOME".into(), home.0.display().to_string()),
+            ("PATH".into(), shim.path()),
+            ("ANK_GIT_LOG".into(), shim.log.display().to_string()),
+        ],
+    );
+    live.until("the screen to open", |t| t.contains("ENTITIES"));
+    assert!(
+        live.text().contains("stream following"),
+        "the stream is connected:\n{}",
+        live.text()
+    );
+    let opened = shim.settled();
+    assert!(
+        opened > 0,
+        "the instrument counted nothing, so it counts nothing"
+    );
+
+    // Three seconds, the length TASK-b50b340c0bb1 chose for the same reason: a
+    // renewal writes at second resolution, and anything that happens here would
+    // have to be visible at that scale.
+    std::thread::sleep(std::time::Duration::from_secs(3));
+    assert_eq!(
+        shim.count(),
+        opened,
+        "a screen with a stream connected asked again while nobody typed"
+    );
+
+    // And the instrument reads a query when there is one: an event arrives, the
+    // reader answers it by reading the corpus, and the count moves.
+    let arrived = repo.spare(
+        "A task that arrives while the screen is idle",
+        "the screen names it without anybody typing",
+    );
+    home.says(&corpus, ank_contract::events::Change::Entities);
+    live.until("the event to reach the screen", |t| {
+        t.contains(&short_of(&arrived))
+    });
+    assert!(
+        shim.count() > opened,
+        "the reader repainted without asking the corpus anything, so the \
+         comparison above proves nothing"
+    );
+    live.quit();
+}
+
+/// An event repaints, and renews nothing (ADR-0bb7ea8991bc).
+///
+/// **This is the trap the previous wave laid bare.** `ank show <id>` renews the
+/// lease when the id is the task the caller holds, so a reader that answered an
+/// event by re-reading the entity on screen would have made a watcher's news
+/// renew somebody's claim -- a claim renewed by reporting rather than by
+/// working, which is the thing that decision exists to refuse and which
+/// TASK-b50b340c0bb1 already forbade an idle session to do.
+///
+/// So the session is put where the damage would be: the entity view, on the very
+/// task this identity holds. Then events arrive for three seconds. Afterwards
+/// `b` goes back to the list, which runs nothing at all -- and the list names a
+/// task that did not exist when the entity was opened, which is only possible if
+/// every one of those events did repaint. The refs are byte for byte where they
+/// were.
+#[cfg(unix)]
+#[test]
+fn an_event_repaints_the_list_and_renews_no_claim() {
+    let repo = Repo::seeded("event-claim");
+    let held = repo.only(&["--type", "task"]);
+    repo.warm(HOLDER);
+    let corpus = corpus_of(&repo);
+    let home = Home::following("event-claim-home");
+
+    let mut live = Live::open(
+        &repo,
+        HOLDER,
+        &[("XDG_CONFIG_HOME".into(), home.0.display().to_string())],
+    );
+    live.until("the screen to open", |t| t.contains("ENTITIES"));
+    // Opening the task you hold renews the lease, and it is supposed to: it is
+    // `ank show`, run because a person typed an identifier (TASK-49746735127f).
+    // What follows is about what happens with nobody typing.
+    live.send(&short_of(&held));
+    live.until("the held task to open", |t| t.contains(TAIL));
+    let _ = live.frame();
+
+    let before = ank_refs(&repo);
+    assert!(!before.is_empty(), "a claim is held, so there is a ref");
+
+    let arrived = repo.spare(
+        "A task that arrives while the held one is open",
+        "the list names it, and the lease did not move",
+    );
+    for _ in 0..6 {
+        home.says(&corpus, ank_contract::events::Change::Entities);
+        std::thread::sleep(std::time::Duration::from_millis(500));
+    }
+
+    // `b` draws the list out of what is already in hand: it reads nothing.
+    live.send("b");
+    live.until("the list to name the task that arrived", |t| {
+        t.contains(&short_of(&arrived))
+    });
+    assert_eq!(
+        before,
+        ank_refs(&repo),
+        "an event renewed a lease, which is a claim renewed by reporting"
+    );
+
+    // The instrument reads a renewal when there is one.
+    let _ = repo.stdout(HOLDER, &["show", &held, "--json"]);
+    assert_ne!(
+        before,
+        ank_refs(&repo),
+        "three seconds of events and a renewing verb left the refs identical, \
+         so the comparison above proves nothing"
+    );
+    live.quit();
+}
+
+/// A shim `git` on `PATH` that records every call and hands it to the real one.
+///
+/// Four symbols' worth of shell rather than a crate: what is needed is a count
+/// of invocations, and the honest place to count them is where they happen.
+/// The real binary is resolved once, here, so the shim cannot find itself.
+#[cfg(unix)]
+struct Shim {
+    dir: PathBuf,
+    log: PathBuf,
+}
+
+#[cfg(unix)]
+impl Drop for Shim {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.dir);
+    }
+}
+
+#[cfg(unix)]
+impl Shim {
+    fn new(what: &str) -> Shim {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = scratch(what);
+        let real = String::from_utf8_lossy(
+            &Command::new("sh")
+                .args(["-c", "command -v git"])
+                .output()
+                .expect("a shell is a hard dependency of this suite")
+                .stdout,
+        )
+        .trim()
+        .to_string();
+        assert!(!real.is_empty(), "git must be on PATH for this suite");
+        let script = dir.join("git");
+        std::fs::write(
+            &script,
+            format!("#!/bin/sh\necho call >> \"$ANK_GIT_LOG\"\nexec {real} \"$@\"\n"),
+        )
+        .unwrap();
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+        Shim {
+            log: dir.join("calls"),
+            dir,
+        }
+    }
+
+    fn path(&self) -> String {
+        format!(
+            "{}:{}",
+            self.dir.display(),
+            std::env::var("PATH").unwrap_or_default()
+        )
+    }
+
+    fn count(&self) -> usize {
+        std::fs::read_to_string(&self.log)
+            .unwrap_or_default()
+            .lines()
+            .count()
+    }
+
+    /// The count once the reader has stopped making calls: two identical
+    /// readings a moment apart.
+    fn settled(&self) -> usize {
+        let mut last = usize::MAX;
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        while std::time::Instant::now() < deadline {
+            let now = self.count();
+            if now > 0 && now == last {
+                return now;
+            }
+            last = now;
+            std::thread::sleep(std::time::Duration::from_millis(300));
+        }
+        panic!("the reader never stopped asking");
+    }
+}

--- a/crates/ank-contract/src/events.rs
+++ b/crates/ank-contract/src/events.rs
@@ -1,0 +1,252 @@
+//! The change stream: what the watcher says happened, and where it says it
+//! (ADR-a22cd3196529, TASK-2f7777a1fdff).
+//!
+//! `ank-daemon` already knows when a corpus it watches moves. Until this module
+//! that knowledge reached a person as a line on stderr and reached a program not
+//! at all, so a reader that wanted to be current had to ask again on a timer --
+//! which is the one thing a long-lived screen must not do, because the verbs
+//! that answer best are the verbs that renew a lease (ADR-0bb7ea8991bc).
+//!
+//! **An event says what changed, and never what to do about it.** That is the
+//! line ADR-a22cd3196529 draws to keep the watcher from becoming a third
+//! dispatch path, and it is easy to cross by kindness: an event carrying the new
+//! state of a task would save its reader a call, and would make the watcher a
+//! source of entity content that nothing generated from `COMMANDS` ever
+//! validated. So [`Event`] carries a repository identity and a word, there is no
+//! constructor that takes anything else, and the test at the foot of this file
+//! is what keeps it that way.
+//!
+//! **A file, and deliberately not a socket.** ADR-a22cd3196529 says the watcher
+//! answers no verb and exposes no query surface of its own. A socket is a place
+//! a caller connects *to*, and the first convenient question asked over one is
+//! the beginning of the surface that decision refused. A file is a place the
+//! watcher writes: nothing is asked of it, nothing is negotiated, several
+//! readers follow the same bytes without it knowing they exist, and a reader
+//! written outside this repository needs a file reader and nothing else. It also
+//! costs no platform code, which a socket would on Windows.
+//!
+//! **This module is shared because a stream has two ends.** `ank-daemon` writes
+//! it and `ank-tui` follows it; the key names, the schema number, the vocabulary
+//! of changes and the escaper have to be one thing or they are two things that
+//! will disagree, and the disagreement would land on whoever wrote a third
+//! reader. That is the reason this crate exists, applied to a surface that is
+//! not a verb.
+
+use crate::json::Obj;
+use std::path::PathBuf;
+
+/// The stream, under [`user_dir`], beside the `watch.yml` that declares what is
+/// watched.
+///
+/// One file for every corpus the watcher was handed, rather than one per
+/// corpus: a reader following several corpora then follows one file, and a
+/// reader following one skips the lines that are not its own. The line says
+/// which corpus it is about, so nothing is inferred from a path.
+pub const STREAM_FILE: &str = "events.jsonl";
+
+/// The shape of a line, versioned the way `watch.yml` and `.ank/config.yml` are.
+///
+/// **Not [`crate::CONTRACT_VERSION`].** That number describes the documents
+/// verbs answer with, and this stream is not a verb answering: the two move for
+/// different reasons and a single number would tie a change in one to a release
+/// of the other. Within this one, a line may *gain* a field and may never lose,
+/// rename or retype one -- the same promise, made separately.
+pub const SCHEMA: u32 = 1;
+
+/// The key carrying [`SCHEMA`].
+pub const SCHEMA_KEY: &str = "schema";
+
+/// The key carrying the repository identity of ADR-621a7fd96ce1.
+pub const CORPUS_KEY: &str = "corpus";
+
+/// The key carrying the word from [`Change`].
+pub const CHANGE_KEY: &str = "change";
+
+/// How large the stream is allowed to grow before the watcher starts it over.
+///
+/// A stream is news and not a log: nothing is anchored in it, nothing hashes
+/// over it, and a reader that was not running missed what happened while it was
+/// not running whatever this number is. So it is bounded rather than rotated
+/// into a second file, and a follower that finds the file shorter than the
+/// offset it holds reads it from the beginning again -- which costs it a repaint
+/// of a corpus that has certainly changed.
+pub const CAP: u64 = 64 * 1024;
+
+/// What kind of change the watcher saw. Two, because it can see two.
+///
+/// **Neither says what it means.** `Entities` is "the files under `.ank/`
+/// moved", not "a task was claimed"; `Refs` is "the mirror of `refs/ank/*`
+/// moved", not "somebody else took your task". Which entity, and what is now
+/// true of it, is what the CLI answers, and a reader that wants to know runs it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Change {
+    /// A file under the corpus directory was written, added or removed.
+    Entities,
+    /// The watcher's mirror of the remote's `refs/ank/*` moved.
+    Refs,
+}
+
+impl Change {
+    /// The word this change is written as, and the whole of what it says.
+    pub fn word(self) -> &'static str {
+        match self {
+            Change::Entities => "entities",
+            Change::Refs => "refs",
+        }
+    }
+
+    /// The change a word names, or `None` for a word this build does not know.
+    ///
+    /// A reader that meets an unknown word has met a watcher newer than itself.
+    /// The honest answer there is to repaint anyway -- something changed, and
+    /// the CLI is what says what -- so this returns an absence rather than an
+    /// error, and no caller is asked to fail on it.
+    pub fn of(word: &str) -> Option<Change> {
+        CHANGES.iter().copied().find(|c| c.word() == word)
+    }
+}
+
+/// The whole vocabulary, so a reader can state it and a test can walk it.
+pub const CHANGES: &[Change] = &[Change::Entities, Change::Refs];
+
+/// One line of the stream.
+///
+/// Two fields, and there is no third to be tempted by. A constructor that took
+/// an entity, a title or a status would be the kindness this decision refuses,
+/// so there is none.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Event {
+    /// The repository identity of ADR-621a7fd96ce1: the root commit, never a
+    /// path. Two worktrees of one repository are one corpus and therefore one
+    /// value here, which is the whole reason the key is not the path -- and the
+    /// reason no path is carried alongside it, since a field naming one is an
+    /// invitation to key on it.
+    pub corpus: String,
+    pub change: Change,
+}
+
+impl Event {
+    pub fn new(corpus: impl Into<String>, change: Change) -> Event {
+        Event {
+            corpus: corpus.into(),
+            change,
+        }
+    }
+
+    /// The event as it goes onto the stream: one JSON object, one line.
+    ///
+    /// Written through [`crate::json`] rather than with `format!`, so the one
+    /// escaper this project has is the one escaper this stream has too.
+    pub fn line(&self) -> String {
+        format!(
+            "{}\n",
+            Obj::new()
+                .num(SCHEMA_KEY, SCHEMA)
+                .str(CORPUS_KEY, &self.corpus)
+                .str(CHANGE_KEY, self.change.word())
+                .finish()
+        )
+    }
+}
+
+/// Where this reader's own files live: the watch declaration, and the stream
+/// the watcher writes into it.
+///
+/// `%APPDATA%\ank` on Windows; `$XDG_CONFIG_HOME/ank` elsewhere, falling back to
+/// `$HOME/.config/ank`. An empty value counts as unset, because a shell that
+/// exports a variable to nothing has said nothing, and joining onto it would
+/// name a relative path under whatever directory the process happens to be in.
+///
+/// **The rule lives here because two crates now need it.** `ank-daemon` reads
+/// its declaration from this directory and writes the stream into it; `ank-tui`
+/// follows the stream out of it. A copy in each is a rule written twice, and
+/// this crate is where this project puts the thing that must not be written
+/// twice. `ank-cli` keeps its own for `ank config --user`, because it is a
+/// binary with no library target, and `the_watch_file_sits_beside_the_corpora_file`
+/// in the watcher's suite drives both binaries to hold that copy to this one.
+pub fn user_dir() -> Option<PathBuf> {
+    let var = |key: &str| {
+        std::env::var_os(key)
+            .filter(|v| !v.is_empty())
+            .map(PathBuf::from)
+    };
+    if cfg!(windows) {
+        return var("APPDATA").map(|p| p.join("ank"));
+    }
+    if let Some(xdg) = var("XDG_CONFIG_HOME") {
+        return Some(xdg.join("ank"));
+    }
+    var("HOME").map(|p| p.join(".config").join("ank"))
+}
+
+/// The stream itself, or `None` where the environment names no home.
+///
+/// An absent home is not an error on either end: the watcher refuses to start
+/// because it has no declaration to read, and a reader with nowhere to follow
+/// falls back to reading the corpus when its person asks it to.
+pub fn stream_path() -> Option<PathBuf> {
+    user_dir().map(|d| d.join(STREAM_FILE))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The property the criterion asks to be asserted rather than argued: no
+    /// event carries entity content a reader would otherwise get from the CLI.
+    ///
+    /// Stated as a closed key set, because that is the form an addition fails
+    /// against. A field carrying a title, a status or a body cannot arrive
+    /// without this test naming it.
+    #[test]
+    fn a_line_carries_the_three_keys_and_no_other() {
+        for change in CHANGES {
+            let line = Event::new("a".repeat(40), *change).line();
+            assert!(line.ends_with('\n'), "one event is one line: {line:?}");
+            let body = line.trim_end();
+            let keys: Vec<&str> = body
+                .trim_start_matches('{')
+                .trim_end_matches('}')
+                .split(',')
+                .map(|pair| pair.split(':').next().unwrap_or_default().trim_matches('"'))
+                .collect();
+            assert_eq!(
+                keys,
+                [SCHEMA_KEY, CORPUS_KEY, CHANGE_KEY],
+                "an event states which corpus and what kind of change, and nothing else: {body}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_schema_is_stated_and_is_not_the_verb_contract() {
+        let line = Event::new("b".repeat(40), Change::Refs).line();
+        assert!(
+            line.contains(&format!("\"{SCHEMA_KEY}\":{SCHEMA}")),
+            "{line}"
+        );
+        assert!(!line.contains("\"contract\""), "{line}");
+    }
+
+    /// A word and the change it names are one mapping, walked in both
+    /// directions: a variant added to the enum and forgotten in `of` would
+    /// answer `None` for its own word.
+    #[test]
+    fn every_change_is_read_back_from_the_word_it_is_written_as() {
+        for change in CHANGES {
+            assert_eq!(Change::of(change.word()), Some(*change));
+        }
+        assert_eq!(Change::of("claimed"), None, "a vocabulary of two, closed");
+        assert_eq!(Change::of(""), None);
+    }
+
+    #[test]
+    fn the_stream_sits_beside_the_declaration_it_belongs_to() {
+        let Some(dir) = user_dir() else {
+            // A machine with no home in the environment: the absence is the
+            // answer, and it is not a fault.
+            return;
+        };
+        assert_eq!(stream_path(), Some(dir.join(STREAM_FILE)));
+    }
+}

--- a/crates/ank-contract/src/lib.rs
+++ b/crates/ank-contract/src/lib.rs
@@ -22,6 +22,11 @@
 //! caller needs before it calls: [`ExitCode`] is what a refusal *means*, and
 //! [`Renews`] is a property of a verb the compiler has to ask of every verb
 //! ever added (§3, ADR-0bb7ea8991bc).
+//!
+//! [`events`] is here for the same reason and is not a verb: the watcher's
+//! change stream has a writer in one crate and a reader in another, so its key
+//! names and its vocabulary are exactly the pair this crate exists to keep from
+//! disagreeing.
 
 /// The version of the machine contract every `--json` document is written
 /// against, and carries (ADR-6fd69efb629c).
@@ -43,6 +48,7 @@
 /// a shape is what freezes that shape, and there is none yet.
 pub const CONTRACT_VERSION: u32 = 1;
 
+pub mod events;
 pub mod exit;
 pub mod json;
 pub mod renews;

--- a/crates/ank-daemon/src/declare.rs
+++ b/crates/ank-daemon/src/declare.rs
@@ -121,28 +121,17 @@ pub struct Declaration {
 /// **The same rule `ank config --user` applies to `corpora.yml`**, deliberately
 /// and not by coincidence: a reader who declared a corpus in one file and a
 /// watch in another, under two different directories, would have two homes and
-/// no way to know it. `%APPDATA%\ank` on Windows; `$XDG_CONFIG_HOME/ank`
-/// elsewhere, falling back to `$HOME/.config/ank`. An empty value counts as
-/// unset, because a shell that exports a variable to nothing has said nothing
-/// and joining onto it would name a relative path under the current directory.
+/// no way to know it.
 ///
-/// The rule is three lines of platform difference and the environment, so it is
-/// written here rather than depended on: `ank-cli` is a binary with no library
-/// target, and `the_watch_file_sits_beside_the_corpora_file` in this crate's
-/// suite drives both binaries to assert the two agree.
+/// It used to be written out here, because `ank-cli` is a binary with no
+/// library target and there was nowhere shared to put it. There is now: the
+/// change stream of TASK-2f7777a1fdff lands in this same directory and is
+/// followed out of it by `ank-tui`, so the rule moved to
+/// [`ank_contract::events::user_dir`] and this is the one name the rest of the
+/// crate uses. `the_watch_file_sits_beside_the_corpora_file` in this crate's
+/// suite still drives both binaries to assert `ank-cli`'s own copy agrees.
 pub fn user_dir() -> Option<PathBuf> {
-    let var = |key: &str| {
-        std::env::var_os(key)
-            .filter(|v| !v.is_empty())
-            .map(PathBuf::from)
-    };
-    if cfg!(windows) {
-        return var("APPDATA").map(|p| p.join("ank"));
-    }
-    if let Some(xdg) = var("XDG_CONFIG_HOME") {
-        return Some(xdg.join("ank"));
-    }
-    var("HOME").map(|p| p.join(".config").join("ank"))
+    ank_contract::events::user_dir()
 }
 
 /// The declaration file, wherever this reader's home is.

--- a/crates/ank-daemon/src/fetch.rs
+++ b/crates/ank-daemon/src/fetch.rs
@@ -114,6 +114,41 @@ pub fn mirror(root: &Path) -> Result<Fetched, String> {
         .to_string())
 }
 
+/// What the mirror holds right now: every tracking ref with the object it
+/// points at, one per line, sorted as git sorts them.
+///
+/// This is how a change to somebody else's claims becomes news. The fetch above
+/// says whether git succeeded, never whether anything moved -- `--quiet` and a
+/// zero exit are the same on a remote that has not changed since the last
+/// minute -- so what moved is answered by looking, and looking is one
+/// `for-each-ref` per fetch cycle rather than per poll.
+///
+/// A repository git cannot answer about reads as an empty mirror, which is what
+/// a repository with no tracking refs is. The caller compares two readings and
+/// nothing else, so a failure costs a comparison that says "unchanged" and never
+/// a wrong event.
+pub fn mirrored(root: &Path) -> Vec<String> {
+    Command::new("git")
+        .args([
+            "for-each-ref",
+            "--format=%(refname)%09%(objectname)",
+            TRACKING,
+        ])
+        .current_dir(root)
+        .stdin(Stdio::null())
+        .stderr(Stdio::null())
+        .output()
+        .ok()
+        .filter(|out| out.status.success())
+        .map(|out| {
+            String::from_utf8_lossy(&out.stdout)
+                .lines()
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/ank-daemon/src/main.rs
+++ b/crates/ank-daemon/src/main.rs
@@ -30,16 +30,23 @@
 //! being. What it buys is that `ank status` stops reporting who holds what out
 //! of somebody's last manual fetch.
 //!
-//! What this build does not yet do, and where it is decided: the change it
-//! notices reaches the reader as a line on stderr rather than as an event a
-//! program subscribes to (TASK-2f775b1cb32b). That is an addition to this floor
-//! and it changes nothing about what a verb answers.
+//! **A change it notices becomes an event** (TASK-2f7777a1fdff). The line on
+//! stderr is for the person reading the log; the event is for the program that
+//! wanted to know, and it goes onto the stream of
+//! [`ank_contract::events`] -- a file beside `watch.yml`, which any reader may
+//! follow and which asks nothing of this process. An event states which corpus
+//! changed and what kind of change it was, and nothing else: no title, no
+//! status, no entity content of any kind, because a watcher that carried those
+//! would be a source of corpus data nothing generated from `COMMANDS` ever
+//! validated. What changed is here; what it means is what the CLI answers.
 
 mod declare;
 mod fail;
 mod fetch;
+mod stream;
 mod warm;
 
+use ank_contract::events;
 use ank_contract::ExitCode;
 use declare::Declaration;
 use fail::{Fail, Result};
@@ -73,8 +80,10 @@ ank-daemon                keeps the corpora you declared warm, so the ank you ru
 It declares nothing, answers no verb and holds no claim. The only thing it
 writes into a repository is that repository's own index and a mirror of
 refs/ank/* under refs/ank/watch/, on the interval watch.yml states; it moves no
-branch, no tag and no claim of yours. Every verb behaves the same with it
-stopped, which is why stopping it is always safe.
+branch, no tag and no claim of yours. A change it sees becomes a line on
+events.jsonl beside watch.yml, which says which corpus moved and what kind of
+change it was, and never what to do about it. Every verb behaves the same with
+it stopped, which is why stopping it is always safe.
 ";
 
 fn main() {
@@ -271,7 +280,22 @@ fn identity_of(root: &Path) -> Option<String> {
 /// all of the time that matters after a `git checkout`. That pass is a warming
 /// and not a change, so it says so: an event states what changed
 /// (ADR-a22cd3196529), and a first sighting is not one.
+///
+/// **Two kinds of change, because there are two things to see.** The files
+/// under `.ank/` moving is one; the mirror of somebody else's `refs/ank/*`
+/// moving is the other, and they are not the same news -- the first is work in
+/// this checkout, the second is a claim taken or released somewhere the reader
+/// cannot see. Both go onto the stream under their own word, and neither says
+/// what to do about it.
 fn watch(declared: &Declaration, ank: &Path, once: bool, interval: Duration, err: &mut dyn Write) {
+    // Resolved once, and never per event: the directory a reader declared their
+    // watch in is the directory their stream belongs in, and asking the
+    // environment again every half-second would let the two answer differently.
+    // A home the environment does not name is not a failure -- the declaration
+    // was read out of one, so this is `None` only where something removed it --
+    // and a watcher that stopped for want of a stream would have made the
+    // stream a condition of the thing nothing depends on.
+    let stream = stream::path();
     // Flattened once, so the state and the checkout it belongs to are one
     // value. The loop below indexes nothing.
     let mut posts: Vec<Post> = Vec::new();
@@ -293,6 +317,7 @@ fn watch(declared: &Declaration, ank: &Path, once: bool, interval: Duration, err
                 root: root.clone(),
                 seen: None,
                 mirrored: None,
+                refs: None,
             });
         }
     }
@@ -326,6 +351,16 @@ fn watch(declared: &Declaration, ank: &Path, once: bool, interval: Duration, err
                 // down for a while, and retrying it every poll would turn one
                 // failure into a spin against a network that is not answering.
                 post.mirrored = Some(Instant::now());
+                // What the fetch left behind, compared with what was there
+                // before it. git answers zero on a remote that had nothing new,
+                // so "did anything move" is a question only the refs themselves
+                // answer. The first reading is a sighting and not a change, for
+                // the reason the first warming is not one.
+                let now = fetch::mirrored(&post.root);
+                if post.refs.as_ref().is_some_and(|before| before != &now) {
+                    report_change(&stream, post, events::Change::Refs, err);
+                }
+                post.refs = Some(now);
             }
             let now = warm::fingerprint(&warm::ank_dir(&post.root));
             let first = post.seen.is_none();
@@ -335,8 +370,7 @@ fn watch(declared: &Declaration, ank: &Path, once: bool, interval: Duration, err
                 continue;
             }
             if !first {
-                // What changed, and never what to do about it.
-                let _ = writeln!(err, "changed {} {}", post.identity, post.root.display());
+                report_change(&stream, post, events::Change::Entities, err);
             }
             // Degrades and never fails: nothing depends on this process, so one
             // corpus the CLI refuses costs a line and the next poll.
@@ -351,6 +385,38 @@ fn watch(declared: &Declaration, ank: &Path, once: bool, interval: Duration, err
     }
 }
 
+/// Says what changed, to the person reading the log and to the program that
+/// asked to be told.
+///
+/// Both, and in that order, because they are two audiences and not one. The
+/// line on stderr names the checkout, which is what somebody debugging a
+/// watcher needs; the event names the corpus and never the path, because a
+/// corpus reached by two paths is one corpus (ADR-621a7fd96ce1) and a field
+/// carrying a path is an invitation to key on one.
+///
+/// A stream that cannot be written costs a line and nothing else. Nothing
+/// depends on this process, so nothing may be broken by the one part of it that
+/// writes outside a repository.
+fn report_change(
+    stream: &Option<std::path::PathBuf>,
+    post: &Post,
+    change: events::Change,
+    err: &mut dyn Write,
+) {
+    // What changed, and never what to do about it.
+    let _ = writeln!(
+        err,
+        "changed {} {} {}",
+        change.word(),
+        post.identity,
+        post.root.display()
+    );
+    let Some(path) = stream else { return };
+    if let Err(reason) = stream::emit(path, &post.identity, change) {
+        let _ = writeln!(err, "stream: {reason}");
+    }
+}
+
 /// One checkout being watched, and what its `.ank/` looked like last time.
 struct Post {
     identity: String,
@@ -360,6 +426,10 @@ struct Post {
     /// process has not yet reached. `None` is due immediately, so `--once`
     /// mirrors once and a fresh start does not leave the reader a minute behind.
     mirrored: Option<Instant>,
+    /// The tracking refs as the last mirror left them, or `None` for a checkout
+    /// this process has not yet fetched for. A first reading is a sighting and
+    /// not a change.
+    refs: Option<Vec<String>>,
 }
 
 #[cfg(test)]

--- a/crates/ank-daemon/src/stream.rs
+++ b/crates/ank-daemon/src/stream.rs
@@ -1,0 +1,120 @@
+//! Putting a change onto the stream (ADR-a22cd3196529, TASK-2f7777a1fdff).
+//!
+//! The shape of an event, where it goes and what it may carry are
+//! [`ank_contract::events`], because a stream has two ends and they must not
+//! drift. What is here is the writing: opening the file, appending one line, and
+//! starting it over when it has grown past what news is worth.
+//!
+//! **Writing is best-effort, in the way everything this process does is.**
+//! Nothing depends on the watcher (ADR-a22cd3196529), so a stream that cannot be
+//! written is a stream nobody gets, exactly as if no watcher were running. A
+//! full disk, a configuration directory somebody removed, a permission somebody
+//! changed: each costs a line on stderr and the next poll, and none of them
+//! reaches the exit code of anything the person is running.
+//!
+//! **An event is not a log entry**, and the difference is why this file is
+//! allowed to be thrown away. `.ank/log/` is a work trace with a grammar and an
+//! append-only rule (ADR-ff29); this is news, nothing is anchored in it and no
+//! hash chains over it, so a reader that was not running missed what happened
+//! while it was not running, and the file is bounded rather than kept.
+
+use ank_contract::events::{self, Change, Event};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+/// The stream this watcher writes into, or `None` where the environment names
+/// no home.
+///
+/// Resolved once at start rather than per event: the directory a reader
+/// declared their watch in is the directory their stream belongs in, and asking
+/// the environment again every half-second would let the two answer differently.
+pub fn path() -> Option<PathBuf> {
+    events::stream_path()
+}
+
+/// Appends one event, or says why it could not.
+///
+/// The directory is created rather than required, for the one case that
+/// actually occurs: a reader whose declaration lives somewhere `ank-daemon`
+/// reached through `XDG_CONFIG_HOME` has that directory, and a reader who has
+/// somehow lost it between two polls is better served by a stream that comes
+/// back than by a watcher that stops writing one.
+pub fn emit(path: &Path, identity: &str, change: Change) -> Result<(), String> {
+    if let Some(dir) = path.parent() {
+        std::fs::create_dir_all(dir).map_err(|e| format!("{}: {e}", dir.display()))?;
+    }
+    start_over_if_long(path)?;
+    let line = Event::new(identity, change).line();
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .map_err(|e| format!("{}: {e}", path.display()))?;
+    // One `write_all` per event, and the line carries its own terminator, so a
+    // follower reading between two events reads whole lines or nothing. A
+    // follower that read a half-written line would repaint on a corpus it could
+    // not name, which is the one way this stream could mislead.
+    file.write_all(line.as_bytes())
+        .map_err(|e| format!("{}: {e}", path.display()))
+}
+
+/// Truncates the stream once it has grown past [`events::CAP`].
+///
+/// Started over rather than rotated into a second file: there is no second
+/// reader of the old bytes, nothing refers back to them, and a rotation would
+/// leave a directory of files somebody has to clean up. A follower notices
+/// because the file is suddenly shorter than the offset it holds, which
+/// ADR-a22cd3196529's reader handles by reading from the beginning again.
+fn start_over_if_long(path: &Path) -> Result<(), String> {
+    let long = std::fs::metadata(path).map(|m| m.len() >= events::CAP);
+    if !matches!(long, Ok(true)) {
+        return Ok(());
+    }
+    std::fs::File::create(path)
+        .map(|_| ())
+        .map_err(|e| format!("{}: {e}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scratch(what: &str) -> PathBuf {
+        let dir =
+            std::env::temp_dir().join(format!("ank-daemon-stream-{what}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn one_event_is_one_line_and_the_next_goes_after_it() {
+        let path = scratch("append").join(events::STREAM_FILE);
+        emit(&path, &"a".repeat(40), Change::Entities).unwrap();
+        emit(&path, &"b".repeat(40), Change::Refs).unwrap();
+        let text = std::fs::read_to_string(&path).unwrap();
+        let lines: Vec<&str> = text.lines().collect();
+        assert_eq!(lines.len(), 2, "{text}");
+        assert!(lines[0].contains("\"entities\""), "{text}");
+        assert!(lines[1].contains("\"refs\""), "{text}");
+    }
+
+    #[test]
+    fn a_stream_past_the_cap_is_started_over_rather_than_kept() {
+        let path = scratch("cap").join(events::STREAM_FILE);
+        std::fs::write(&path, vec![b'x'; events::CAP as usize + 1]).unwrap();
+        emit(&path, &"c".repeat(40), Change::Entities).unwrap();
+        let text = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(text.lines().count(), 1, "the old bytes are gone");
+        assert!(text.contains("\"entities\""), "{text}");
+    }
+
+    /// The directory a reader lost between two polls comes back, because the
+    /// alternative is a watcher that quietly stops reporting.
+    #[test]
+    fn a_missing_directory_is_made_rather_than_refused() {
+        let path = scratch("mkdir").join("gone").join(events::STREAM_FILE);
+        emit(&path, &"d".repeat(40), Change::Refs).unwrap();
+        assert!(path.is_file());
+    }
+}

--- a/crates/ank-daemon/tests/daemon.rs
+++ b/crates/ank-daemon/tests/daemon.rs
@@ -16,6 +16,7 @@
 //! being trusted -- the moment a warm listing and a cold one differ, the daemon
 //! has become a source of truth nobody voted for.
 
+use ank_contract::events;
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Output, Stdio};
@@ -91,6 +92,19 @@ impl Home {
 
     fn watch_file(&self) -> PathBuf {
         self.0.join("ank").join("watch.yml")
+    }
+
+    /// The change stream, where this reader's environment puts it.
+    ///
+    /// Named through the contract rather than spelled here: the daemon writes
+    /// it and `ank-tui` follows it, and a suite carrying its own copy of the
+    /// name would agree with a stream that moved.
+    fn stream(&self) -> PathBuf {
+        self.0.join("ank").join(events::STREAM_FILE)
+    }
+
+    fn stream_text(&self) -> String {
+        std::fs::read_to_string(self.stream()).unwrap_or_default()
     }
 
     fn apply(&self, cmd: &mut Command) {
@@ -1111,4 +1125,213 @@ fn an_unreachable_remote_is_reported_and_the_watcher_keeps_watching() {
         logged.matches("fetch:").count() >= 1,
         "the watcher went quiet about a remote it never reached: {logged}"
     );
+}
+
+// ---------------------------------------------------------------------------
+// The stream: a change becomes an event (TASK-2f7777a1fdff)
+// ---------------------------------------------------------------------------
+
+/// A running daemon that has certainly finished its first look at a corpus.
+///
+/// **The first look is a sighting and not a change**, which is the property this
+/// crate is careful about and the one that makes starting a watcher racy to test
+/// against: a change made before the opening pass is part of what that pass
+/// sees, so it produces no event and never will. Dropping the index and waiting
+/// for it to come back is what says the pass happened -- the loop mirrors, takes
+/// the fingerprint and then warms, so an index that exists again is a
+/// fingerprint that has already been taken.
+fn started_and_looked(home: &Home, corpus: &Corpus, args: &[&str]) -> Running {
+    corpus.drop_index();
+    let daemon = start(home, args);
+    until("the watcher's first look", || corpus.index().is_file());
+    daemon
+}
+
+/// Every line the stream could carry about one corpus, built by the encoder
+/// both ends share.
+///
+/// The set is finite and it is two, which is what makes the assertion below
+/// exhaustive rather than a sample: a line that is not one of these is a line
+/// carrying something an event is not allowed to carry.
+fn every_possible_line(identity: &str) -> Vec<String> {
+    events::CHANGES
+        .iter()
+        .map(|c| {
+            events::Event::new(identity, *c)
+                .line()
+                .trim_end()
+                .to_string()
+        })
+        .collect()
+}
+
+fn lines_of(text: &str) -> Vec<String> {
+    text.lines().map(str::to_string).collect()
+}
+
+/// The change the reader was waiting for: what moved, and about which corpus.
+///
+/// **A first sighting is not a change**, and that is asserted first. The opening
+/// pass warms every checkout it was handed, and a watcher that called its own
+/// first look a change would wake every reader on the machine at startup for
+/// news that is not news.
+#[test]
+fn a_change_becomes_an_event_naming_the_corpus_and_the_kind() {
+    let home = Home::new();
+    let corpus = Corpus::new(scratch("event").join("tree"), &home);
+    let identity = corpus.identity(&home);
+    home.declare(&format!(
+        "schema: 1\nwatch:\n  {}: {}\n",
+        identity,
+        corpus.root.display()
+    ));
+
+    let warmed = home.daemon(&["--once"]).output().unwrap();
+    assert!(warmed.status.success(), "{warmed:?}");
+    assert_eq!(
+        home.stream_text(),
+        "",
+        "the first look at a corpus is a sighting and not a change"
+    );
+
+    let daemon = started_and_looked(&home, &corpus, &["--interval", "50"]);
+    corpus.ank(
+        &home,
+        &[
+            "new",
+            "task",
+            "--title",
+            "A second task",
+            "--scope",
+            "src/**",
+        ],
+    );
+    until("the stream to carry the change", || {
+        !home.stream_text().is_empty()
+    });
+    daemon.stop();
+
+    let seen = lines_of(&home.stream_text());
+    let expected = events::Event::new(&identity, events::Change::Entities)
+        .line()
+        .trim_end()
+        .to_string();
+    assert!(
+        seen.contains(&expected),
+        "the event names this corpus and says the entities moved:\n{seen:?}"
+    );
+}
+
+/// The other kind of change, and the one no local look could see: a claim taken
+/// in a clone this reader cannot read, arriving through the mirror.
+///
+/// Two clones for the reason `a_claim_taken_in_one_clone_is_reported_by_status_in_the_other`
+/// gives: a claim moving in the same checkout would be a file under `.ank/`
+/// moving, which is the other event entirely.
+#[test]
+fn a_claim_taken_in_another_clone_becomes_a_refs_event() {
+    let home = Home::new();
+    let root = scratch("refsevent");
+    let origin = root.join("origin.git");
+    bare(&home, &origin);
+
+    let first = Corpus::new(root.join("first"), &home);
+    first.git(
+        &home,
+        &["config", "remote.origin.url", &origin.display().to_string()],
+    );
+    first.git(&home, &["push", "-q", "-u", "origin", "main"]);
+    let second = clone(&home, &origin, &root.join("second"));
+    let identity = first.identity(&home);
+    let task = first.task_id(&home);
+
+    // Only the second clone is watched, so nothing the first one does to its own
+    // files can reach this stream: the only route left is the mirror.
+    home.declare(&format!(
+        "schema: 1\nfetch: 1\nwatch:\n  {}: {}\n",
+        identity,
+        second.root.display()
+    ));
+    // The first mirror has to have happened before the claim is taken, or the
+    // claim is part of what the opening pass saw and is therefore not a change.
+    let daemon = started_and_looked(&home, &second, &["--interval", "50"]);
+
+    first.ank_as(
+        &home,
+        "first@ank.local",
+        &["claim", &task, "--criteria", "the stream carries it"],
+    );
+    first.git(&home, &["push", "-q", "origin", "refs/ank/claims/*"]);
+
+    let expected = events::Event::new(&identity, events::Change::Refs)
+        .line()
+        .trim_end()
+        .to_string();
+    until("the stream to say the refs moved", || {
+        lines_of(&home.stream_text()).contains(&expected)
+    });
+    daemon.stop();
+}
+
+/// The property the criterion asks to be asserted rather than argued: an event
+/// says what changed and never carries what the CLI answers.
+///
+/// **Stated exhaustively.** Every line of the stream is byte-identical to one of
+/// the two the shared encoder can produce for this corpus, so there is no room
+/// for a title, a status, a body or an identifier to have arrived -- the set of
+/// possible lines is enumerated, not sampled.
+///
+/// The second half is the same statement made the way a person would check it,
+/// against a corpus whose content is distinctive enough that a leak could not
+/// hide: the identifier, the title and a log entry's message are all things a
+/// reader gets by running `ank show`, and none of them is here.
+#[test]
+fn no_event_carries_entity_content_a_reader_would_get_from_the_cli() {
+    let home = Home::new();
+    let corpus = Corpus::new(scratch("content").join("tree"), &home);
+    let identity = corpus.identity(&home);
+    home.declare(&format!(
+        "schema: 1\nwatch:\n  {}: {}\n",
+        identity,
+        corpus.root.display()
+    ));
+
+    let daemon = started_and_looked(&home, &corpus, &["--interval", "50"]);
+    let title = "Piezoelectric ratchets in the transept";
+    corpus.ank(
+        &home,
+        &["new", "task", "--title", title, "--scope", "src/**"],
+    );
+    until("the first change to reach the stream", || {
+        !lines_of(&home.stream_text()).is_empty()
+    });
+    // The second is made after the first has landed, so it is a second event
+    // and not the same one: two writes inside one poll are one change, which is
+    // the watcher being a watcher rather than a journal.
+    let second = "The transept was measured and the ratchet was not";
+    corpus.ank(
+        &home,
+        &["new", "task", "--title", second, "--scope", "src/**"],
+    );
+    until("the second change to reach the stream", || {
+        lines_of(&home.stream_text()).len() >= 2
+    });
+    let task = corpus.task_id(&home);
+    daemon.stop();
+
+    let text = home.stream_text();
+    let possible = every_possible_line(&identity);
+    for line in lines_of(&text) {
+        assert!(
+            possible.contains(&line),
+            "an event carried something an event may not:\n{line}\nof {possible:?}"
+        );
+    }
+
+    for leaked in [title, second, task.as_str(), "test@ank.local", "open"] {
+        assert!(
+            !text.contains(leaked),
+            "the stream carries '{leaked}', which is what ank show answers:\n{text}"
+        );
+    }
 }

--- a/crates/ank-tui/src/lib.rs
+++ b/crates/ank-tui/src/lib.rs
@@ -22,6 +22,22 @@
 //! is no timer to put anything on. The assertion is in the suite, not in this
 //! sentence.
 //!
+//! **A change reaches the screen as an event, never as a poll**
+//! (TASK-2f7777a1fdff). `ank-daemon` appends a line when a corpus it watches
+//! moves, and [`stream`] follows that file: an event wakes the session and the
+//! screen is drawn again from the corpus. Where there is no stream -- no
+//! watcher has ever run here, or this reader has no home to find one in -- the
+//! screen is drawn again when its person types `r`, which is what it always
+//! did. Both routes reach the same displayed state, and the suite compares
+//! them.
+//!
+//! An event is a repaint and never a write. It runs `status` and `find` and
+//! deliberately not `show`, because `show` renews the lease when the id is the
+//! task the caller holds (ADR-0bb7ea8991bc): a reader that re-read the open
+//! entity on an event would have made a watcher's news renew a claim, which is
+//! the one thing this reader has been forbidden twice over. The reasoning sits
+//! on [`view::App::repaint`], next to the code that keeps it true.
+//!
 //! **And a write is the verb, run as a shell would run it.** Nothing here
 //! composes a claim record, moves a ref or edits an entity: `ank claim <id>`
 //! does that, and this crate spawns it. So ADR-052accd6e3b2 names an
@@ -59,13 +75,14 @@
 //! * [`view::View::Entity`] -- one entity: what holds it, the constraints
 //!   binding its declared scope, and its body, paged rather than cut.
 
-use std::io::IsTerminal;
+use std::io::{BufRead, IsTerminal};
 use std::path::PathBuf;
 
 pub mod ank;
 pub mod frame;
 pub mod input;
 pub mod model;
+pub mod stream;
 pub mod view;
 
 pub use ank::Ank;
@@ -146,9 +163,68 @@ pub fn run(
         let _ = writeln!(out, "{}", snapshot.document());
         return Ok(ExitCode::Ok);
     }
-    let stdin = std::io::stdin();
-    let mut input = stdin.lock();
-    session(&ank, &mut input, out, terminal_size())
+    // The corpus this reader is on, asked once and never again. The stream
+    // names corpora by the repository identity of ADR-621a7fd96ce1, so a
+    // follower has to know which lines are its own before the first one
+    // arrives, and an identity does not change under a session. A refusal here
+    // is not one: the reader simply has no stream to follow and falls back to
+    // reading when its person asks, which is what the next line already does.
+    let corpus = ank
+        .json("status", &[])
+        .map(|v| ank::text(&v, "corpus"))
+        .unwrap_or_default();
+    let (wake, waking) = std::sync::mpsc::channel::<Wake>();
+    typing(wake.clone());
+    let stream = stream::follow(&corpus, wake);
+    // Blocking, and there is nothing else in it: with nobody typing and nothing
+    // changing, this reader is a process asleep on a channel. No verb runs, no
+    // clock ticks and no claim moves.
+    let mut wakes = std::iter::from_fn(move || waking.recv().ok());
+    session(&ank, &mut wakes, out, terminal_size(), stream)
+}
+
+/// What can wake a drawn screen. There are exactly three things, and two of them
+/// end the session.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Wake {
+    /// A line the person typed, terminator and all.
+    Line(String),
+    /// The watcher said this corpus moved (TASK-2f7777a1fdff). It carries what
+    /// happened and not what to do about it, which is why there is nothing in
+    /// this variant: the answer is to read the corpus again.
+    Changed,
+    /// End of input. A session whose terminal went away has nothing left to
+    /// draw to, and that is a quit and never an error.
+    Closed,
+    /// The terminal could not be read from. An environment to repair, and the
+    /// one way out of a session that is not a zero.
+    Broken(String),
+}
+
+/// Reads the terminal on a thread, so the drawn screen can be woken by
+/// something other than a keystroke.
+///
+/// **This is what an event costs, and it is the whole of it.** A reader blocked
+/// on `read_line` cannot be told anything; a reader blocked on a channel can be
+/// told by whatever holds a sender. Nothing else changes: the same lines arrive
+/// in the same order, and a session with no stream behind it is the session
+/// TASK-b50b340c0bb1 measured, one command at a time.
+fn typing(wake: std::sync::mpsc::Sender<Wake>) {
+    std::thread::spawn(move || {
+        let stdin = std::io::stdin();
+        loop {
+            let mut line = String::new();
+            let said = match stdin.lock().read_line(&mut line) {
+                Ok(0) => Wake::Closed,
+                Ok(_) => Wake::Line(line),
+                Err(e) => Wake::Broken(e.to_string()),
+            };
+            let ending = !matches!(said, Wake::Line(_));
+            if wake.send(said).is_err() || ending {
+                return;
+            }
+        }
+    });
 }
 
 /// Whether there is a screen to draw on.
@@ -180,40 +256,55 @@ fn refused_by_the_cli(failed: ank::Failed) -> Refused {
     }
 }
 
-/// The session, with its three edges injected so the suite can drive it.
+/// The session, with its edges injected so the suite can drive it.
 ///
 /// `size` is passed in rather than measured here: measuring the window is an
 /// `ioctl` on Unix and a console call on Windows, which is the FFI this crate
 /// declines (see the module header), and a test that could not choose the
 /// window could not assert what a frame holds.
+///
+/// `wakes` is an iterator and not a reader, because a screen now has two things
+/// that can move it and a `read_line` can only ever be one. It blocks in
+/// `next`, which is where an idle session sits: no verb, no clock, nothing.
+///
+/// `stream` is what the screen says about how it is being kept current, and
+/// `None` where there is nothing to follow.
 pub fn session(
     ank: &Ank,
-    input: &mut dyn std::io::BufRead,
+    wakes: &mut dyn Iterator<Item = Wake>,
     out: &mut dyn std::io::Write,
     size: (usize, usize),
+    stream: Option<stream::Stream>,
 ) -> Result<ExitCode, Refused> {
-    let mut app = view::App::new(size);
+    let mut app = view::App::new(size, stream);
     app.reload(ank);
     let _ = write!(out, "{}", frame::ENTER);
     let code = loop {
         let _ = write!(out, "{}{}", frame::HOME, app.frame());
         let _ = out.flush();
-        let mut line = String::new();
-        match input.read_line(&mut line) {
-            // End of input is a quit and never an error: a session whose
-            // terminal went away has nothing left to draw to.
-            Ok(0) => break ExitCode::Ok,
-            Ok(_) => {}
-            Err(e) => {
+        // Exhausted means every sender is gone, which is the same end of input
+        // by another road.
+        let Some(wake) = wakes.next() else {
+            break ExitCode::Ok;
+        };
+        match wake {
+            Wake::Closed => break ExitCode::Ok,
+            Wake::Broken(e) => {
                 app.note(format!("cannot read from the terminal: {e}"));
                 break ExitCode::Environment;
             }
-        }
-        if app.act(
-            input::parse(line.trim_end_matches(['\n', '\r']), app.view()),
-            ank,
-        ) {
-            break ExitCode::Ok;
+            // News, and never an instruction: what the screen does about it is
+            // read the corpus again, and `repaint` is where the one read it may
+            // not run is refused.
+            Wake::Changed => app.repaint(ank),
+            Wake::Line(line) => {
+                if app.act(
+                    input::parse(line.trim_end_matches(['\n', '\r']), app.view()),
+                    ank,
+                ) {
+                    break ExitCode::Ok;
+                }
+            }
         }
     };
     let _ = write!(out, "{}", frame::LEAVE);

--- a/crates/ank-tui/src/stream.rs
+++ b/crates/ank-tui/src/stream.rs
@@ -1,0 +1,339 @@
+//! Following the watcher's change stream (TASK-2f7777a1fdff, ADR-a22cd3196529).
+//!
+//! The corpus is a working tree and it moves under a screen left open. Until
+//! this module the only answer was `r`, and the only alternative anybody ever
+//! reaches for is a refresh loop -- which this crate must not have, because the
+//! verbs that answer best are verbs that renew a lease (ADR-0bb7ea8991bc) and a
+//! screen nobody is sitting at would then keep a claim alive for somebody who
+//! went home. So the reader is *told*: `ank-daemon` appends a line when a corpus
+//! it watches changes, and this follows that file.
+//!
+//! **Following is not asking.** Nothing here talks to the watcher, and there is
+//! nothing to talk to: the stream is a file, the watcher writes it, and several
+//! readers follow the same bytes without it knowing any of them exist. That is
+//! what keeps ADR-a22cd3196529's "answers no verb" true with a consumer
+//! attached, and it is why the watcher's absence costs a repaint that has to be
+//! typed rather than an error.
+//!
+//! **An event is a repaint and never a read of the entity.** What arrives says
+//! which corpus moved and what kind of change it was, and nothing else. What is
+//! now true of a task is what the CLI answers, and asking it is
+//! [`crate::view::App::repaint`] -- which runs the verbs that read and never the
+//! one that writes. See the note there: it is the whole of why an event cannot
+//! renew anything.
+//!
+//! **The file is not the corpus.** This is the reader's own configuration
+//! directory, not `.ank/`, and nothing here reads an entity, a ref or a byte of
+//! a repository. ADR-8bd76e8d7c4e's rule is untouched: the corpus is reached by
+//! running the CLI with `--json` and by nothing else.
+
+use crate::Wake;
+use ank_contract::events;
+use std::io::{Read, Seek, SeekFrom};
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::Sender;
+use std::sync::Arc;
+use std::time::Duration;
+
+/// How often the stream is looked at.
+///
+/// A poll of one file in the reader's own configuration directory, and never of
+/// the corpus: no verb runs on this clock, nothing is spawned, no ref is read
+/// and nothing is renewed. It is the same call `ank-daemon` makes about the
+/// files it watches, for the same reason §13 gives -- a subscription is a
+/// third-party crate, and what it would buy over a stat is latency a person
+/// cannot perceive.
+///
+/// A quarter of a second is under the time a person takes to notice, and four
+/// stats a second on one small file is nothing to measure.
+const TICK: Duration = Duration::from_millis(250);
+
+/// Whether there is a stream to follow, as the follower last saw it.
+///
+/// A handle and not a value, because the answer moves: a watcher started after
+/// the session opened makes one appear, and a person who wiped their
+/// configuration directory makes one go away. The frame reads it at every paint,
+/// so what the screen says is what was true when it was drawn.
+///
+/// It says a stream exists, never that a watcher is running. Nothing here can
+/// honestly say the second without polling something, and polling something is
+/// the thing this module exists to remove.
+#[derive(Clone)]
+pub struct Stream {
+    live: Arc<AtomicBool>,
+}
+
+impl Stream {
+    pub fn following(&self) -> bool {
+        self.live.load(Ordering::Relaxed)
+    }
+
+    /// A stream for a test to state, without a file or a thread.
+    #[cfg(test)]
+    pub fn stated(following: bool) -> Stream {
+        Stream {
+            live: Arc::new(AtomicBool::new(following)),
+        }
+    }
+}
+
+/// Starts following the stream on this reader's behalf, or answers `None` where
+/// there is nothing to follow.
+///
+/// `None` is not a fault and is never reported as one: a reader whose
+/// environment names no home, or which could not learn its own corpus identity,
+/// falls back to what it always did, which is to read when its person asks. The
+/// watcher is optional by construction and so is this.
+///
+/// **The starting offset is the file's length, read here and not in the
+/// thread.** Events from before this session opened are old news -- the screen
+/// was drawn from the corpus as it is now -- so replaying them would cost a
+/// repaint that says nothing. A file that appears *later* is read from its
+/// beginning, because then every line in it is news.
+pub fn follow(corpus: &str, wake: Sender<Wake>) -> Option<Stream> {
+    if corpus.is_empty() {
+        return None;
+    }
+    let path = events::stream_path()?;
+    let offset = std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
+    let live = Arc::new(AtomicBool::new(path.is_file()));
+    let mine = corpus.to_string();
+    let flag = Arc::clone(&live);
+    std::thread::spawn(move || {
+        let mut follower = Follower {
+            path,
+            offset,
+            carry: String::new(),
+            corpus: mine,
+        };
+        loop {
+            let (exists, changed) = follower.look();
+            flag.store(exists, Ordering::Relaxed);
+            // One wake per look, however many lines arrived: the reader answers
+            // an event by reading the corpus once, so ten events in a tick are
+            // one repaint and not ten.
+            if changed && wake.send(Wake::Changed).is_err() {
+                return;
+            }
+            std::thread::sleep(TICK);
+        }
+    });
+    Some(Stream { live })
+}
+
+/// The follower's own state: where it had read to, and the tail of a line it has
+/// not yet seen the end of.
+struct Follower {
+    path: PathBuf,
+    offset: u64,
+    carry: String,
+    corpus: String,
+}
+
+impl Follower {
+    /// One look: whether the stream is there, and whether it said this corpus
+    /// moved.
+    fn look(&mut self) -> (bool, bool) {
+        let Ok(meta) = std::fs::metadata(&self.path) else {
+            return (false, false);
+        };
+        let len = meta.len();
+        if len < self.offset {
+            // The watcher started the file over (ADR-a22cd3196529's stream is
+            // news and is bounded, not kept). Reading from the beginning again
+            // costs at most one repaint of a corpus that has certainly changed.
+            self.offset = 0;
+            self.carry.clear();
+        }
+        if len == self.offset {
+            return (true, false);
+        }
+        let Ok(mut file) = std::fs::File::open(&self.path) else {
+            return (true, false);
+        };
+        if file.seek(SeekFrom::Start(self.offset)).is_err() {
+            return (true, false);
+        }
+        let mut fresh = String::new();
+        // Lossy, and deliberately: a line this reader cannot decode is a line it
+        // skips, and a stream that stopped being followed because one byte was
+        // wrong would be worse than one that missed an event.
+        let mut raw = Vec::new();
+        if file.read_to_end(&mut raw).is_err() {
+            return (true, false);
+        }
+        self.offset += raw.len() as u64;
+        fresh.push_str(&String::from_utf8_lossy(&raw));
+        self.carry.push_str(&fresh);
+        // Whole lines only. The watcher writes one line per call, but a follower
+        // that consumed a half-written one would repaint on a corpus it could
+        // not name.
+        let mut changed = false;
+        while let Some(at) = self.carry.find('\n') {
+            let line: String = self.carry.drain(..=at).collect();
+            if self.mine(line.trim_end()) {
+                changed = true;
+            }
+        }
+        (true, changed)
+    }
+
+    /// Whether one line is an event about the corpus this reader is on.
+    ///
+    /// Read with `serde_yaml`, which is how this crate reads every document the
+    /// CLI answers with, and by the key names [`events`] declares rather than by
+    /// strings written here.
+    ///
+    /// **A line of a schema this build does not read is skipped**, on the rule
+    /// `watch.yml` already holds: a reader that guessed at a shape it does not
+    /// know would be repainting on something nobody wrote. A line that does not
+    /// parse is skipped for the same reason and neither is an error, because
+    /// there is nobody to report it to and nothing depends on it.
+    fn mine(&self, line: &str) -> bool {
+        let Ok(value) = serde_yaml::from_str::<serde_yaml::Value>(line) else {
+            return false;
+        };
+        let schema = value
+            .get(events::SCHEMA_KEY)
+            .and_then(|v| v.as_u64())
+            .unwrap_or_default();
+        if schema != events::SCHEMA as u64 {
+            return false;
+        }
+        value
+            .get(events::CORPUS_KEY)
+            .and_then(|v| v.as_str())
+            .is_some_and(|c| c == self.corpus)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ank_contract::events::{Change, Event};
+
+    fn scratch(what: &str) -> PathBuf {
+        use std::sync::atomic::AtomicU64;
+        static SEQ: AtomicU64 = AtomicU64::new(0);
+        let dir = std::env::temp_dir().join(format!(
+            "ank-tui-stream-{what}-{}-{}",
+            std::process::id(),
+            SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir.join(events::STREAM_FILE)
+    }
+
+    fn follower(path: PathBuf, corpus: &str) -> Follower {
+        Follower {
+            offset: std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0),
+            path,
+            carry: String::new(),
+            corpus: corpus.to_string(),
+        }
+    }
+
+    fn append(path: &PathBuf, line: &str) {
+        use std::io::Write;
+        let mut f = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .unwrap();
+        f.write_all(line.as_bytes()).unwrap();
+    }
+
+    #[test]
+    fn a_line_about_another_corpus_is_not_this_readers_news() {
+        let path = scratch("other");
+        append(&path, &Event::new("a".repeat(40), Change::Entities).line());
+        let mut f = follower(path.clone(), &"z".repeat(40));
+        assert_eq!(f.look(), (true, false), "the backlog is skipped anyway");
+        append(&path, &Event::new("a".repeat(40), Change::Entities).line());
+        assert_eq!(f.look(), (true, false), "another corpus is not mine");
+        append(&path, &Event::new("z".repeat(40), Change::Refs).line());
+        assert_eq!(f.look(), (true, true));
+    }
+
+    /// Ten events in one tick are one repaint: the reader answers an event by
+    /// reading the corpus, and reading it ten times would say the same thing
+    /// ten times.
+    #[test]
+    fn many_lines_in_one_look_are_one_wake() {
+        let path = scratch("coalesce");
+        let mut f = follower(path.clone(), &"c".repeat(40));
+        for _ in 0..10 {
+            append(&path, &Event::new("c".repeat(40), Change::Entities).line());
+        }
+        assert_eq!(f.look(), (true, true));
+        assert_eq!(f.look(), (true, false), "and nothing is replayed");
+    }
+
+    #[test]
+    fn a_half_written_line_waits_for_its_end() {
+        let path = scratch("partial");
+        let mut f = follower(path.clone(), &"d".repeat(40));
+        let whole = Event::new("d".repeat(40), Change::Entities).line();
+        let (head, tail) = whole.split_at(whole.len() / 2);
+        append(&path, head);
+        assert_eq!(f.look(), (true, false), "half a line is not an event");
+        append(&path, tail);
+        assert_eq!(f.look(), (true, true));
+    }
+
+    #[test]
+    fn a_stream_started_over_is_read_from_the_beginning_again() {
+        let path = scratch("rotate");
+        let mut f = follower(path.clone(), &"e".repeat(40));
+        append(&path, &Event::new("e".repeat(40), Change::Entities).line());
+        assert_eq!(f.look(), (true, true));
+        // The watcher truncated and wrote one line, so the file is shorter than
+        // where this follower had read to.
+        std::fs::write(&path, Event::new("e".repeat(40), Change::Refs).line()).unwrap();
+        assert_eq!(f.look(), (true, true));
+    }
+
+    #[test]
+    fn a_stream_that_is_not_there_is_an_absence_and_never_an_error() {
+        let mut f = follower(scratch("absent"), &"f".repeat(40));
+        assert_eq!(f.look(), (false, false));
+        append(
+            &f.path.clone(),
+            &Event::new("f".repeat(40), Change::Refs).line(),
+        );
+        assert_eq!(
+            f.look(),
+            (true, true),
+            "a watcher started later is followed"
+        );
+    }
+
+    /// A line of a schema this build does not read is skipped rather than
+    /// guessed at, and a line that is not a document at all is skipped too.
+    #[test]
+    fn an_unreadable_line_is_skipped_and_stops_nothing() {
+        let path = scratch("junk");
+        let mut f = follower(path.clone(), &"g".repeat(40));
+        append(&path, "not a document at all\n");
+        append(
+            &path,
+            &format!(
+                "{{\"{}\":99,\"{}\":\"{}\"}}\n",
+                events::SCHEMA_KEY,
+                events::CORPUS_KEY,
+                "g".repeat(40)
+            ),
+        );
+        assert_eq!(f.look(), (true, false));
+        append(&path, &Event::new("g".repeat(40), Change::Entities).line());
+        assert_eq!(f.look(), (true, true), "and the next good line still lands");
+    }
+
+    #[test]
+    fn a_reader_with_no_corpus_identity_follows_nothing() {
+        let (tx, _rx) = std::sync::mpsc::channel();
+        assert!(follow("", tx).is_none());
+    }
+}

--- a/crates/ank-tui/src/view.rs
+++ b/crates/ank-tui/src/view.rs
@@ -31,6 +31,7 @@ use crate::ank::{Ank, Failed, Ran};
 use crate::frame::{self, fit, pad, window, wrap};
 use crate::input::{Act, Command};
 use crate::model::{short_of, Detail, Row, Snapshot};
+use crate::stream::Stream;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum View {
@@ -60,10 +61,14 @@ pub struct App {
     search: Option<String>,
     /// The first line of the pane on screen.
     offset: usize,
+    /// The change stream this reader is following, or `None` where there is
+    /// nothing to follow. Read at every paint rather than stored as a word,
+    /// because a watcher started after the session opened makes one appear.
+    stream: Option<Stream>,
 }
 
 impl App {
-    pub fn new(size: (usize, usize)) -> App {
+    pub fn new(size: (usize, usize), stream: Option<Stream>) -> App {
         App {
             size,
             view: View::List,
@@ -76,6 +81,7 @@ impl App {
             kind: None,
             search: None,
             offset: 0,
+            stream,
         }
     }
 
@@ -104,6 +110,34 @@ impl App {
                 self.clamp();
             }
             Err(failed) => self.fail(failed),
+        }
+    }
+
+    /// Draw again because the watcher said the corpus moved, and for no other
+    /// reason (TASK-2f7777a1fdff).
+    ///
+    /// **It runs the two verbs that read the corpus and never the one that
+    /// writes.** `ank show <id>` renews the lease when the id is the task the
+    /// caller holds (ADR-0bb7ea8991bc, and TASK-49746735127f found it the hard
+    /// way), so re-reading the open entity here would be a watcher's news
+    /// renewing somebody's claim -- a claim renewed by reporting rather than by
+    /// working, which is what that decision refuses and what
+    /// TASK-b50b340c0bb1 forbade a session to do by sitting still. So `reload`
+    /// and nothing else: the list and the claims come back current, and the body
+    /// on screen stays as it was until its person asks for it with `r`.
+    ///
+    /// That is a decision and not an omission. The alternative -- refreshing the
+    /// open entity too -- is one line, and it is the line that would make an
+    /// unattended screen keep a lease alive.
+    ///
+    /// **The note survives.** An event arriving a second after a `done` must not
+    /// wipe what the CLI answered, which is the one thing on the screen the
+    /// person cannot get back.
+    pub fn repaint(&mut self, ank: &Ank) {
+        let said = self.note.take();
+        self.reload(ank);
+        if self.note.is_none() {
+            self.note = said;
         }
     }
 
@@ -433,9 +467,10 @@ impl App {
         ));
         lines.push(fit(
             &format!(
-                "identity {}   {} claim(s) live",
+                "identity {}   {} claim(s) live   {}",
                 snapshot.identity,
-                snapshot.claims.len()
+                snapshot.claims.len(),
+                self.route()
             ),
             width,
         ));
@@ -491,6 +526,23 @@ impl App {
         lines.push(fit(KEYS, width));
         lines.push(fit(ACT_KEYS, width));
         lines.join("\n") + "\n"
+    }
+
+    /// How this screen is being kept current, in the two words a person needs.
+    ///
+    /// It says a stream exists, never that a watcher is running: nothing here
+    /// can honestly say the second without polling something, and polling
+    /// something is what the stream exists to remove.
+    ///
+    /// **On the list and not on an entity**, deliberately. An event refreshes
+    /// the list and leaves the open body where it was, for the reason
+    /// [`App::repaint`] gives, so a line promising a live screen over a body
+    /// that is not one would be the reader overstating what it does.
+    fn route(&self) -> &'static str {
+        match &self.stream {
+            Some(s) if s.following() => "stream following",
+            _ => "stream none, r to reload",
+        }
     }
 
     fn filter_note(&self) -> String {
@@ -804,9 +856,37 @@ mod tests {
     }
 
     fn app() -> App {
-        let mut a = App::new((100, 30));
+        let mut a = App::new((100, 30), None);
         a.snapshot = Some(snapshot());
         a
+    }
+
+    /// The list says how the screen is being kept current, and it says the
+    /// truth in all three states (TASK-2f7777a1fdff).
+    ///
+    /// The word matters to a person deciding whether to type `r`, and the three
+    /// cases are genuinely different: a stream being followed, a stream that is
+    /// not there yet, and a reader with nowhere to look for one.
+    #[test]
+    fn the_list_says_which_route_is_keeping_it_current() {
+        let mut a = app();
+        assert!(
+            a.list_frame().contains("stream none, r to reload"),
+            "with no stream at all:\n{}",
+            a.list_frame()
+        );
+        a.stream = Some(Stream::stated(false));
+        assert!(
+            a.list_frame().contains("stream none, r to reload"),
+            "a stream that is not there is not a stream:\n{}",
+            a.list_frame()
+        );
+        a.stream = Some(Stream::stated(true));
+        assert!(
+            a.list_frame().contains("stream following"),
+            "and one that is:\n{}",
+            a.list_frame()
+        );
     }
 
     /// The CLI, addressed where there is none: every call fails to spawn and
@@ -867,7 +947,7 @@ mod tests {
 
     #[test]
     fn no_line_of_a_frame_overflows_the_window() {
-        let mut a = App::new((40, 24));
+        let mut a = App::new((40, 24), None);
         a.snapshot = Some(snapshot());
         for line in a.list_frame().lines() {
             assert!(
@@ -1119,7 +1199,7 @@ mod tests {
 
     #[test]
     fn an_act_with_nothing_selected_names_that_and_runs_nothing() {
-        let mut a = App::new((100, 30));
+        let mut a = App::new((100, 30), None);
         let ank = nowhere();
         a.act(
             Command::Act(Act {
@@ -1209,7 +1289,7 @@ mod tests {
         let long: String = (1..=6).map(|n| format!("a note line {n}\n")).collect();
         for size in [(100, 40), (80, 24), (60, 20)] {
             for note in [None, Some(long.clone())] {
-                let mut a = App::new(size);
+                let mut a = App::new(size, None);
                 a.snapshot = Some(snapshot());
                 a.note = note.clone();
                 let rows = a.list_frame().lines().count();

--- a/docs/integrating.md
+++ b/docs/integrating.md
@@ -305,11 +305,14 @@ Everything else worth knowing about it as an integrator is what it refuses to be
 (ADR-a22cd3196529).
 
 **It is not a surface.** No socket, no protocol, no query of its own, and no
-subset of the verbs. There is nothing here to bind to: a caller that wants an
-answer runs the CLI, or talks to `ank-mcp`. A daemon answering the three
-questions a dashboard finds convenient would be the curated subset
-ADR-372b82af1ec7 refused, reached from the other direction, and it would be a
-third dispatch path in a project that has spent its history reducing to one.
+subset of the verbs. There is nothing here to ask: a caller that wants an answer
+runs the CLI, or talks to `ank-mcp`. A daemon answering the three questions a
+dashboard finds convenient would be the curated subset ADR-372b82af1ec7 refused,
+reached from the other direction, and it would be a third dispatch path in a
+project that has spent its history reducing to one. It does *tell* you when a
+corpus it watches changes, on a stream described below, and that is push and
+never pull: it says what moved, it says nothing about what moved, and there is
+still nothing to connect to.
 
 **Nothing depends on it.** Every verb gives the same output and the same exit
 code with it stopped; its absence is never an error, and no installation route
@@ -367,6 +370,75 @@ be one product. That is asserted rather than promised, in
 `a_claim_a_watcher_mirrored_is_reported_by_status_and_by_nothing_else`, which
 compares every listing verb byte for byte with the mirror present and absent.
 
+## A change becomes an event, and the stream is yours to follow
+
+The watcher appends a line when a corpus it watches changes, and any program may
+follow it. That is the one thing it offers a consumer, and it is offered as a
+file rather than as a connection: there is nothing to bind to, nothing to
+negotiate, and nothing you can ask it. Several readers follow the same bytes
+without the watcher knowing any of them exist.
+
+**Where it is.** `events.jsonl`, beside the `watch.yml` above and under the same
+directory rule -- `%APPDATA%\ank` on Windows, `$XDG_CONFIG_HOME/ank` elsewhere,
+falling back to `$HOME/.config/ank`. One file for every corpus the watcher was
+handed; each line says which corpus it is about.
+
+**What a line is.** One JSON object, one line, newline-terminated:
+
+    {"schema":1,"corpus":"4f0b8c2d1e6a39572c84ab0d6f31e75c9a2b48d0","change":"entities"}
+    {"schema":1,"corpus":"4f0b8c2d1e6a39572c84ab0d6f31e75c9a2b48d0","change":"refs"}
+
+- `schema` is the shape of the line, and it is **not** the contract version that
+  `--json` documents carry: the two move for different reasons. Within a schema a
+  line may gain a field and may never lose, rename or retype one. Skip a line
+  whose schema you do not know rather than guessing at it.
+- `corpus` is the repository identity of the watched corpus -- the root commit,
+  which `ank status --json` prints under `"corpus"`. Never a path, and no path is
+  carried beside it: a corpus reached by two paths is one corpus, and a field
+  naming one would be an invitation to key on it. Two checkouts of one corpus
+  changing produce two lines carrying the same identity, and the answer to both
+  is the same one read.
+- `change` says what moved. `entities` is "a file under that corpus's `.ank/`
+  was written, added or removed"; `refs` is "the watcher's mirror of the remote's
+  `refs/ank/*` moved", which is how a claim taken in a clone you cannot see
+  reaches you. The vocabulary is closed at those two today and may gain a word.
+
+**What a line is not.** It carries no title, no status, no body, no identifier
+and no entity content of any kind, and it never will: an event that carried the
+new state of a task would save you a call and would make the watcher a source of
+corpus data that nothing generated from the verb table ever validated
+(ADR-a22cd3196529). What changed is on the stream; what is now true of it is what
+the CLI answers, and `no_event_carries_entity_content_a_reader_would_get_from_the_cli`
+asserts the absence rather than promising it. An event also never says what to do
+about itself. There is one sensible thing to do, which is to read the corpus
+again, and the stream does not presume to say so.
+
+**How to follow it.** Open the file, remember the offset you have read to, and
+read the bytes past it whenever you like. Three rules and they are the whole
+protocol:
+
+- Consume **whole lines only**. The watcher writes one line per call, but a
+  reader that took a half-written one would repaint on a corpus it could not
+  name.
+- If the file is **shorter than your offset**, the watcher started it over and
+  you read from the beginning again. The stream is news and not a log: nothing is
+  anchored in it, nothing hashes over it, so it is bounded rather than kept, and
+  what you missed while you were not running is missed whatever the bound is.
+- If the file is **not there**, no watcher has ever run for this reader. That is
+  not an error and not a degraded mode: read the corpus when your person asks, as
+  every installation without a watcher does. If it appears later, follow it from
+  its beginning.
+
+**What it does not license.** Following the stream is not a second way into the
+corpus, and it must not become one. `ank tui` follows it and still reaches every
+byte it shows by running the CLI with `--json`, because the event says a corpus
+moved and nothing more. And an event is a repaint, never a write: the reader
+answers one by running `status` and `find`, and deliberately not `show`, which
+renews the lease when the id is the task the caller holds (ADR-0bb7ea8991bc). A
+screen nobody is sitting at is told the corpus changed all night and keeps
+nobody's claim alive; `an_event_repaints_the_list_and_renews_no_claim` is what
+holds that true.
+
 ## What binds and what does not
 
 - **Bind to `--json`**, never to the human output. One line, stdout only, never
@@ -386,3 +458,7 @@ compares every listing verb byte for byte with the mirror present and absent.
   construction. Write your integration against the CLI or the protocol surface,
   and let the watcher make those answers arrive sooner where somebody chose to
   run one.
+- **You may bind to `events.jsonl`**, which is the one exception and a narrow
+  one: it tells you a corpus changed so you can stop asking on a timer. Every
+  answer still comes from the CLI, and your integration has to work with no
+  stream at all, because most installations have none.


### PR DESCRIPTION
Closes TASK-2f7777a1fdff, the last of ADR-a22cd3196529 and the first with a
real consumer.

## The stream

The watcher already knew when a corpus it watches moved. That knowledge
reached a person as a line on stderr and reached a program not at all, so a
reader that wanted to be current had to ask again on a timer -- which is the
one thing a long-lived screen must not do, because the verbs that answer best
are the verbs that renew a lease.

It is now a file, `events.jsonl`, beside the `watch.yml` that declares what is
watched, and deliberately not a socket. ADR-a22cd3196529 says the watcher
answers no verb and exposes no query surface of its own; a socket is a place a
caller connects to and is then tempted to ask something of, and a file is a
place the watcher writes. Several readers follow the same bytes without it
knowing any of them exist, it costs no platform code, and a reader written
outside this repository needs a file reader and nothing more.

One line, one JSON object:

    {"schema":1,"corpus":"<root commit>","change":"entities"}
    {"schema":1,"corpus":"<root commit>","change":"refs"}

`entities` is "a file under that corpus's `.ank/` moved"; `refs` is "the
mirror of the remote's `refs/ank/*` moved", which is how a claim taken in a
clone you cannot see reaches you. Detecting the second needed a `for-each-ref`
per fetch cycle: git answers zero on a fetch that brought nothing, so what
moved is a question only the refs answer.

The corpus is named by the repository identity of ADR-621a7fd96ce1 and no path
travels beside it -- a corpus reached by two paths is one corpus, and a field
naming one is an invitation to key on it.

`docs/integrating.md` documents the whole of it: where it lives, the three
keys, the closed vocabulary, and the three rules of following one (whole lines
only; shorter than your offset means it was started over; absent means no
watcher has run here, which is not an error).

## Nothing an event may not carry

`no_event_carries_entity_content_a_reader_would_get_from_the_cli` states the
absence exhaustively rather than by sample: every line of a stream is
byte-identical to one of the two lines the shared encoder can produce for that
corpus, so there is no room for a title, a status, a body or an identifier to
have arrived.

`ank_contract::events` is shared because a stream has two ends. The key names,
the schema number, the vocabulary and the escaper would otherwise be written
twice in two crates, which is the drift that crate exists to prevent. The
directory rule for the reader's configuration home moves there with it, so
`ank-daemon` delegates instead of keeping a second copy.

## The reader

`ank tui` follows the stream where there is one and falls back to `r` where
there is none, and the list says which of the two it is on.

`the_event_and_the_reload_reach_the_same_displayed_state` opens two sessions
over one corpus before anything moves -- one with a stream, one without -- then
changes the corpus once. The first catches up because it was told; the second
because somebody typed `r`. The frames are compared byte for byte, minus the
one line that names the route, and that line is asserted to differ so that two
routes which turned out to be one route cannot pass.

`a_screen_with_the_stream_connected_asks_nothing_while_it_is_idle` counts
queries through a shim `git` on `PATH`: every read the reader makes is
`ank <verb> --json`, and every verb asks git something (ADR-9307e5d214a7), so
the shim counts every query whatever route it took. Three seconds of a
connected stream with nobody typing move that count by zero, and one event
moves it.

## An event is a repaint, never a write

`ank show <id>` renews the lease when the id is the task the caller holds
(ADR-0bb7ea8991bc), so an event that re-read the entity on screen would have
made a watcher's news renew a claim -- exactly what TASK-b50b340c0bb1 forbade
an idle session to do. The repaint therefore runs `status` and `find` and
deliberately not `show`: the list and the claims come back current, and the
open body stays as it was until its person asks. That is the decision, not an
omission.

`an_event_repaints_the_list_and_renews_no_claim` puts the session in the
entity view on the task it holds, tells it six times over three seconds that
the corpus moved, then types `b` -- which reads nothing -- and finds the list
naming a task that did not exist when the entity was opened. The refs are byte
for byte where they were, and a `show` run by hand afterwards proves the
comparison was measuring something. Making the repaint re-read the open entity
turns that test red on the exact sentence the ADR writes.

## Verification

`cargo test --workspace` green, `cargo fmt --check` green, `ank check` green.
Proof `commit:c3b5833`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEcsxkW4GRYRNjMkh6qXQu