### PR TITLE
The ratification queue is worked from the reader, and the signature stays the person's

### DIFF
--- a/.ank/entities/LOG-69501c2bf786.md
+++ b/.ank/entities/LOG-69501c2bf786.md
@@ -1,0 +1,13 @@
+---
+id: LOG-69501c2bf786
+type: log
+title: done, proof commit:0b2f483dd5e59d72d0bcf6e9beabe163561f6bff
+created: 2026-08-25T15:58:10Z
+author: haksolot@vmi3223161
+scope:
+  - crates/ank-tui/**
+about: TASK-d90e94afca08
+seq: 1
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-e0b02cbcd019.md
+++ b/.ank/entities/LOG-e0b02cbcd019.md
@@ -1,0 +1,15 @@
+---
+id: LOG-e0b02cbcd019
+type: log
+title: "The reader drives accept as a sixth ACT rather than through a third road: driving a ratification is"
+created: 2026-08-25T15:46:19Z
+author: haksolot@vmi3223161
+scope:
+  - crates/ank-tui/**
+about: TASK-d90e94afca08
+seq: 0
+schema: 4
+version: 1
+---
+
+ spawning the verb, and one gate is one thing to keep true. What keeps it a human act is subtraction, in three places that are not the gate -- Tail::Nothing so no tail can travel, parse() taking the word only in View::Entity so the body has been on screen, and output()'s null stdin so no passphrase can be answered from this process. The queue is a third view (v) rather than a block in the list: ank review costs ~2s where find costs 0.3, and a queue in the list frame would put that on every watcher event.

--- a/.ank/entities/TASK-d90e94afca08.md
+++ b/.ank/entities/TASK-d90e94afca08.md
@@ -5,15 +5,20 @@ slug: the-ratification-queue-is-worked-from-the-reader
 title: The ratification queue is worked from the reader, and the signature stays the person's
 created: 2026-08-24T22:01:53Z
 author: claude-code/opus-5+planning
-status: in_progress
+status: done
 scope:
   - crates/ank-tui/**
 blocked_by: [TASK-b50b340c0bb1]
 done_criteria: |
   The reader shows the ratification queue and drives ank accept on one selected proposed document at a time. It supplies no key, answers no passphrase prompt, and accepts nothing beyond the single document under an explicit keystroke. Where the checkout is not on the default branch, or the identity in effect may not ratify, it shows the CLI's refusal and the command that resolves it. A test drives the built binary against a temporary corpus and shows that a document accepted through the interface is verifiable exactly as a shell accept's is, and that with the keystroke withheld nothing in the queue changes state. cargo test is green and cargo fmt --check passes.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 0b2f483dd5e59d72d0bcf6e9beabe163561f6bff
+    criteria: fd715c464284
+    via: submitted
 schema: 4
-version: 2
+version: 3
 ---
 
 Ratification is the act this project guards hardest, and it is also the one whose

--- a/.ank/entities/TASK-d90e94afca08.md
+++ b/.ank/entities/TASK-d90e94afca08.md
@@ -5,7 +5,7 @@ slug: the-ratification-queue-is-worked-from-the-reader
 title: The ratification queue is worked from the reader, and the signature stays the person's
 created: 2026-08-24T22:01:53Z
 author: claude-code/opus-5+planning
-status: open
+status: in_progress
 scope:
   - crates/ank-tui/**
 blocked_by: [TASK-b50b340c0bb1]
@@ -13,7 +13,7 @@ done_criteria: |
   The reader shows the ratification queue and drives ank accept on one selected proposed document at a time. It supplies no key, answers no passphrase prompt, and accepts nothing beyond the single document under an explicit keystroke. Where the checkout is not on the default branch, or the identity in effect may not ratify, it shows the CLI's refusal and the command that resolves it. A test drives the built binary against a temporary corpus and shows that a document accepted through the interface is verifiable exactly as a shell accept's is, and that with the keystroke withheld nothing in the queue changes state. cargo test is green and cargo fmt --check passes.
 criteria_by: creator
 schema: 4
-version: 1
+version: 2
 ---
 
 Ratification is the act this project guards hardest, and it is also the one whose

--- a/crates/ank-cli/tests/tui.rs
+++ b/crates/ank-cli/tests/tui.rs
@@ -70,9 +70,24 @@ impl Repo {
         repo.git(&["config", "user.email", "suite@example.invalid"]);
         repo.git(&["config", "user.name", "The Suite"]);
         repo.git(&["config", "commit.gpgsign", "false"]);
+        // **The signing regime is stated here rather than inherited.** `accept`
+        // signs where the repository can sign (ADR-964be4d940b2), and "can" is
+        // read out of git's configuration -- which, unset locally, is whatever
+        // the developer running this suite happens to have globally. A test
+        // whose corpus is signed on one machine and advisory on the next is a
+        // test that reports the machine. Set empty, this corpus is squarely in
+        // §8's advisory mode, which is the regime `review` then names on the
+        // screen and the one both roads through `accept` take.
+        repo.git(&["config", "user.signingkey", ""]);
         std::fs::create_dir_all(repo.0.join("src")).unwrap();
         std::fs::write(repo.0.join("src/lib.rs"), "// code\n").unwrap();
         repo.ank(HOLDER, &["init"]);
+        // Without this, `accept` cannot tell where ratification is allowed to
+        // happen: there is no origin here, so `default_branch` has no second
+        // source (§12). A corpus that cannot name its default branch is a
+        // corpus in which no ratification is possible at all, which is not the
+        // repository this suite is modelling.
+        repo.ank(HOLDER, &["config", "default_branch", "main"]);
         repo.ank(
             HOLDER,
             &[
@@ -1624,4 +1639,359 @@ impl Shim {
         }
         panic!("the reader never stopped asking");
     }
+}
+
+// ---------------------------------------------------------------------------
+// Ratification (TASK-d90e94afca08)
+// ---------------------------------------------------------------------------
+//
+// The act this project guards hardest, driven from a screen. What has to be
+// true of that is four things, and every one of them is a fact about a process
+// and a git repository rather than about a function.
+//
+// The queue has to be the CLI's queue. A document ratified through the screen
+// has to be verifiable exactly as one ratified in a shell is -- same entity,
+// same anchor, same commit, judged the same by `check`. With the word withheld,
+// nothing may move: a screen that has a proposal open and is never typed at
+// leaves the queue where it found it. And where the CLI refuses -- the wrong
+// branch above all -- what reaches the screen has to be the CLI's own refusal,
+// with the command it named as the way out.
+
+/// A proposed ADR of this corpus, and its identifier.
+///
+/// `new adr` lands `proposed` (§3), which is the state the queue is made of.
+///
+/// The identifier is read as the one that was not there a moment ago, rather
+/// than by looking for the title. Two proposals in this suite deliberately
+/// carry the *same* title -- it is what makes their two ratifications
+/// comparable -- so a title is not a name here and finding one by it would find
+/// whichever came first.
+#[cfg(unix)]
+fn proposal(repo: &Repo, title: &str) -> String {
+    let before = ids_of(&repo.stdout(HOLDER, &["find", "--type", "adr", "--json"]));
+    repo.ank(
+        OTHER,
+        &[
+            "new",
+            "adr",
+            "--title",
+            title,
+            "--scope",
+            "src/**",
+            "--constraint",
+            "A rule this suite ratifies from a screen.",
+        ],
+    );
+    ids_of(&repo.stdout(HOLDER, &["find", "--type", "adr", "--json"]))
+        .into_iter()
+        .find(|id| !before.contains(id))
+        .expect("the proposal exists")
+}
+
+/// The queue names what is waiting and who may sign it, and both are `review`'s
+/// own answer.
+///
+/// The seeded corpus declares no signing key, so the second half is §8's
+/// advisory sentence rather than a section with no rows -- which is the
+/// distinction `review` itself insists on, carried onto the screen.
+#[cfg(unix)]
+#[test]
+fn the_queue_names_what_is_waiting_and_the_regime_the_corpus_is_in() {
+    let repo = Repo::seeded("queue");
+    let waiting = proposal(&repo, "A decision waiting for a person");
+    let task = repo.only(&["--type", "task"]);
+
+    let seen = drive(&repo, READER, &["v", "q"]);
+    assert!(seen.contains("QUEUE"), "the queue was drawn:\n{seen}");
+    assert!(
+        seen.contains(&short_of(&waiting)),
+        "and it names the proposal:\n{seen}"
+    );
+    assert!(
+        seen.contains("A decision waiting for a person"),
+        "with its title:\n{seen}"
+    );
+    assert!(
+        seen.contains("permissions are advisory"),
+        "a corpus declaring no key says which regime it is in:\n{seen}"
+    );
+    // A task is not waiting for a signature and has no business in this queue.
+    let queue = seen
+        .rsplit("QUEUE")
+        .next()
+        .expect("the queue heading was drawn");
+    assert!(
+        !queue.contains(&short_of(&task)),
+        "a task is in the ratification queue:\n{queue}"
+    );
+}
+
+/// A document ratified through the reader is what a shell `accept` makes
+/// (ADR-8bd76e8d7c4e).
+///
+/// The point of the whole crate, on the one act it matters most for. Two
+/// proposals identical but for their identifiers: one is ratified by opening it
+/// on the screen and typing the word, the other by running `ank accept` in this
+/// suite. What is compared is everything a later reader would verify -- the
+/// entity as `show` prints it, the ratification commit's message, and what
+/// `check` says about each -- with the identifiers and the instants masked,
+/// because those are what two documents must differ in.
+///
+/// They are equal because there is no second dispatch path: the reader spawned
+/// the verb this suite spawned.
+#[cfg(unix)]
+#[test]
+fn a_document_ratified_through_the_reader_is_what_a_shell_accept_makes() {
+    let repo = Repo::seeded("ratify");
+    // One title for both, so the two documents differ in nothing a
+    // ratification could legitimately depend on: same slug, same scope, same
+    // constraint, same author. What is left to differ is the identifier and the
+    // instants, and those are masked below.
+    const TITLE: &str = "A decision ratified twice over";
+    let by_screen = proposal(&repo, TITLE);
+    let by_shell = proposal(&repo, TITLE);
+
+    let seen = drive(&repo, READER, &[&by_screen, "accept", "q"]);
+    assert!(
+        seen.contains(&format!("ank accept {by_screen}")),
+        "the reader ran the verb, and said which one:\n{seen}"
+    );
+    assert!(
+        !seen.contains("error["),
+        "the ratification was refused:\n{seen}"
+    );
+
+    repo.ank(READER, &["accept", &by_shell]);
+
+    assert_eq!(
+        ratification(&repo, &by_screen),
+        ratification(&repo, &by_shell),
+        "the screen's ratification and the shell's are two different acts"
+    );
+    // And both are verifiable, which is what "ratified" is worth: `check`
+    // reports no fault about either.
+    let report = repo.stdout(READER, &["check", "--json"]);
+    for id in [&by_screen, &by_shell] {
+        assert!(
+            !faulted(&report, id),
+            "{id} is a fault after ratification:\n{report}"
+        );
+    }
+}
+
+/// Everything a later reader verifies about one ratification, with what must
+/// differ between two of them masked.
+///
+/// The entity as `show` prints it -- which carries `status`, the anchor under
+/// `ratified` and the reading recorded by the act -- and the message of the
+/// commit that made it binding. Two things are replaced and no more: the
+/// identifier, and every instant. Two documents are two documents and two acts
+/// happen at two moments, so a comparison that kept either would be asserting
+/// something false.
+///
+/// **The anchor is compared and never masked**, and that is the assertion doing
+/// the most work here. These two proposals carry the same constraint over the
+/// same scope, so the text `accept` hashes is the same text -- which means the
+/// two ratifications must arrive at the same anchor, byte for byte, or one of
+/// the two roads hashed something the other did not.
+#[cfg(unix)]
+fn ratification(repo: &Repo, id: &str) -> String {
+    let shown = repo.stdout(READER, &["show", id, "--json"]);
+    let message = String::from_utf8_lossy(
+        &repo
+            .git(&[
+                "log",
+                "-1",
+                "--format=%B",
+                "--grep",
+                &format!("ratify {id}"),
+            ])
+            .stdout,
+    )
+    .to_string();
+    assert!(
+        message.contains("ratify"),
+        "no ratification commit for {id}:\n{message}"
+    );
+    masked_instants(&format!("{shown}\n--\n{message}").replace(id, "<id>"))
+}
+
+/// Every RFC 3339 instant of a text, replaced.
+///
+/// Two acts happen at two moments, and a comparison that kept them would be
+/// asserting the clock stood still -- the same reason
+/// [`masked_record`] masks `claimed` and `expires`. Matched on the shape rather
+/// than on the field name, because these instants are inside a JSON string
+/// where there are no fields to name.
+#[cfg(unix)]
+fn masked_instants(text: &str) -> String {
+    const SHAPE: &str = "dddd-dd-ddTdd:dd:ddZ";
+    let chars: Vec<char> = text.chars().collect();
+    let shape: Vec<char> = SHAPE.chars().collect();
+    let mut out = String::new();
+    let mut at = 0;
+    while at < chars.len() {
+        let fits = at + shape.len() <= chars.len()
+            && shape.iter().enumerate().all(|(i, want)| {
+                let got = chars[at + i];
+                if *want == 'd' {
+                    got.is_ascii_digit()
+                } else {
+                    got == *want
+                }
+            });
+        if fits {
+            out.push_str("<instant>");
+            at += shape.len();
+        } else {
+            out.push(chars[at]);
+            at += 1;
+        }
+    }
+    out
+}
+
+/// Whether `check` reports a fault about this entity.
+#[cfg(unix)]
+fn faulted(report: &str, id: &str) -> bool {
+    report
+        .split("{\"subject\"")
+        .any(|f| f.contains(id) && f.contains("\"severity\":\"fault\""))
+}
+
+/// With the word withheld, nothing in the queue changes state
+/// (TASK-d90e94afca08).
+///
+/// The negative that matters more than the positive: a session that opens the
+/// queue, opens the proposal, reads its body to the end and goes back has done
+/// everything a ratification does except the one thing that is a ratification.
+/// Afterwards the document is still `proposed`, the corpus is byte for byte
+/// where it was, and history has not moved -- which is what "the reader may
+/// drive one and never perform one" means when nobody is at the keyboard.
+#[cfg(unix)]
+#[test]
+fn with_the_word_withheld_nothing_in_the_queue_changes_state() {
+    let repo = Repo::seeded("withheld");
+    let waiting = proposal(&repo, "A decision nobody ratifies");
+    repo.warm(READER);
+    let before = corpus_files(&repo);
+    let head = String::from_utf8_lossy(&repo.git(&["rev-parse", "HEAD"]).stdout)
+        .trim()
+        .to_string();
+
+    let seen = drive(
+        &repo,
+        READER,
+        &["v", &short_of(&waiting), "n", "n", "c", "b", "v", "q"],
+    );
+    assert!(
+        seen.contains(&short_of(&waiting)),
+        "the proposal was on the screen:\n{seen}"
+    );
+    assert!(
+        seen.contains("accept   (this document"),
+        "and the reader offered the word it never typed:\n{seen}"
+    );
+
+    let found = repo.stdout(READER, &["find", "--type", "adr", "--json"]);
+    assert!(
+        found.contains("\"status\":\"proposed\""),
+        "the proposal left the queue with nobody typing:\n{found}"
+    );
+    assert_eq!(
+        before,
+        corpus_files(&repo),
+        "a file under .ank/ moved with no word typed"
+    );
+    assert_eq!(
+        head,
+        String::from_utf8_lossy(&repo.git(&["rev-parse", "HEAD"]).stdout)
+            .trim()
+            .to_string(),
+        "a ratification commit was made with no word typed"
+    );
+}
+
+/// Off the default branch the CLI refuses, and the screen shows that refusal
+/// with the command that resolves it (§12).
+///
+/// The code is read out of the verb table rather than written here, on the rule
+/// `a_done_refused_for_a_missing_proof_leaves_the_task_untouched` already
+/// follows: "the code the table declares" is the criterion's phrase, and a
+/// number typed into this file would agree with a table that moved.
+#[cfg(unix)]
+#[test]
+fn a_ratification_off_the_default_branch_shows_the_clis_refusal_and_the_way_out() {
+    let repo = Repo::seeded("wrong-branch");
+    let waiting = proposal(&repo, "A decision on the wrong branch");
+    repo.git(&["switch", "-c", "wave7/not-the-default"]);
+    repo.warm(READER);
+    let before = corpus_files(&repo);
+
+    let seen = drive(&repo, READER, &[&short_of(&waiting), "accept", "q"]);
+
+    let code = declared("accept", "not on the default branch");
+    assert_eq!(
+        code,
+        ank_contract::ExitCode::Prerequisite,
+        "the table moved"
+    );
+    assert!(
+        seen.contains(&format!("error[{code}]:")),
+        "the code the table declares is on the screen:\n{seen}"
+    );
+    assert!(
+        seen.contains("git switch main"),
+        "and the command the CLI named as the way out:\n{seen}"
+    );
+    assert!(
+        seen.contains("BODY") || seen.contains("ENTITIES"),
+        "and the session kept its shape:\n{seen}"
+    );
+    assert_eq!(
+        before,
+        corpus_files(&repo),
+        "a refused ratification moved a file"
+    );
+}
+
+/// The word is refused off the document, and refused with a tail, and neither
+/// refusal spawns anything (TASK-d90e94afca08).
+///
+/// Both are the reader's own and both are about the line that was typed, which
+/// is the line this crate draws: a refusal on the state of the corpus is always
+/// the CLI's, and a refusal about what somebody wrote is always this one's.
+#[cfg(unix)]
+#[test]
+fn accept_is_refused_off_the_document_and_refused_with_a_tail() {
+    let repo = Repo::seeded("accept-grammar");
+    let waiting = proposal(&repo, "A decision typed at wrongly");
+    repo.warm(READER);
+    let before = corpus_files(&repo);
+
+    // From the queue, where the row is under the cursor and the body is not on
+    // the screen; then on the document, with something after the word.
+    let seen = drive(
+        &repo,
+        READER,
+        &["v", "accept", &short_of(&waiting), "accept ADR-0000", "q"],
+    );
+    assert!(
+        seen.contains("open it first"),
+        "a ratification off a row named the way in:\n{seen}"
+    );
+    assert!(
+        seen.contains("takes nothing after it"),
+        "a ratification carrying a tail was refused:\n{seen}"
+    );
+    assert!(
+        !seen.contains("ank accept"),
+        "one of the two reached the verb:\n{seen}"
+    );
+    let found = repo.stdout(READER, &["find", "--type", "adr", "--json"]);
+    assert!(
+        found.contains("\"status\":\"proposed\""),
+        "something was ratified:\n{found}"
+    );
+    assert_eq!(before, corpus_files(&repo), "a file under .ank/ moved");
 }

--- a/crates/ank-tui/src/ank.rs
+++ b/crates/ank-tui/src/ank.rs
@@ -1,20 +1,29 @@
 //! The one road to the corpus: running `ank <verb> --json` (ADR-8bd76e8d7c4e).
 //!
-//! Nine verbs are reached from here, in two lists that are policy made
-//! mechanical rather than policy stated in prose. [`READS`] is the four that
-//! only read -- `status`, `find`, `show` and `scope` -- and [`Ank::json`]
-//! refuses anything else before spawning. [`ACTS`] is the five the person at
-//! the keyboard may ask for -- `claim`, `log`, `release`, `done` and `amend` --
-//! and [`Ank::act`] refuses anything else the same way. Two gates and not one,
-//! because the difference between them is the whole of what a reader is allowed
-//! to do on its own: a screen repaints by reading, and it writes only where a
-//! command was typed.
+//! Eleven verbs are reached from here, in two lists that are policy made
+//! mechanical rather than policy stated in prose. [`READS`] is the five that
+//! only read -- `status`, `find`, `show`, `scope` and `review` -- and
+//! [`Ank::json`] refuses anything else before spawning. [`ACTS`] is the six the
+//! person at the keyboard may ask for -- `claim`, `log`, `release`, `done`,
+//! `amend` and `accept` -- and [`Ank::act`] refuses anything else the same way.
+//! Two gates and not one, because the difference between them is the whole of
+//! what a reader is allowed to do on its own: a screen repaints by reading, and
+//! it writes only where a command was typed.
 //!
-//! **`accept` is in neither list, and the test below is what keeps it out.** It
-//! is a signed human act the reader may drive and never perform
-//! (ADR-8bd76e8d7c4e), and a verb absent from a list is absent silently -- so
-//! the absence is asserted rather than left to whoever reads the two constants
-//! next.
+//! **`accept` is on the acting list, and the reader still never performs one**
+//! (TASK-d90e94afca08). ADR-8bd76e8d7c4e lets the reader *drive* a
+//! ratification and forbids it performing one unattended, and the line between
+//! those two words is drawn here rather than described: driving is spawning
+//! `ank accept <id>`, which is the same road `claim` takes and runs only where
+//! a word was typed whole. Performing would be supplying a key or answering a
+//! passphrase prompt, and [`Ank::spawn`] gives every child `output()`'s null
+//! stdin -- so this process has no channel through which a secret could reach
+//! one, whatever a later edit intends. The signature is git's and the person's,
+//! and it is unreachable from here by construction rather than by restraint.
+//!
+//! The four that must stay out of both lists are `close`, `check`, `attest` and
+//! `init`, and a verb absent from a list is absent silently -- so the absence
+//! is asserted below rather than left to whoever reads the two constants next.
 //!
 //! **An act runs with `--json` like a read does.** ADR-8bd76e8d7c4e and
 //! SPEC-93531977642f both say the reader reaches the corpus only by running the
@@ -39,11 +48,29 @@ pub use serde_yaml::Value;
 
 /// The verbs this reader may run on its own, and the whole of them.
 ///
-/// Every one of them only reads: `status`, `find`, `show` and `scope` write no
-/// file and no ref (§4). Repainting the screen therefore cannot write by
-/// accident, and the property is enforced one function below rather than
+/// Every one of them only reads: `status`, `find`, `show`, `scope` and `review`
+/// write no file and no ref (§4). Repainting the screen therefore cannot write
+/// by accident, and the property is enforced one function below rather than
 /// asserted in a comment.
-pub const READS: &[&str] = &["status", "find", "show", "scope"];
+///
+/// **`review` is here and not on the acting list**, which is the answer to the
+/// obvious objection that a ratification queue sounds like part of ratifying.
+/// The verb answers a question and changes nothing: §4 gives it
+/// `renews: Never` and `coordinates: false`, so a screen that redraws the queue
+/// on a watcher's news renews no lease and takes no ref -- which is what lets
+/// the queue be repainted at all (ADR-0bb7ea8991bc).
+pub const READS: &[&str] = &["status", "find", "show", "scope", "review"];
+
+/// The verbs whose exit 8 carries a document rather than a refusal.
+///
+/// `review` shares `check`'s report and therefore its exit code, and §4 says so
+/// on the verb: findings leave 8, a signal alone leaves 0. The document is
+/// written all the same, so a reader that read 8 as a refusal would show an
+/// empty queue to every corpus with a fault in it -- which is the corpus most
+/// in need of one. Named as a list rather than tolerated everywhere: `find`
+/// and `status` never answer 8, and a blanket rule would silently swallow the
+/// day one of them starts to.
+const FINDINGS_ARE_AN_ANSWER: &[&str] = &["review"];
 
 /// The verbs this reader may run *because somebody typed one*, and the whole of
 /// them.
@@ -54,10 +81,17 @@ pub const READS: &[&str] = &["status", "find", "show", "scope"];
 /// night renews nothing: there is no second dispatch path here for either rule
 /// to be reimplemented on.
 ///
-/// `accept` is not here and must not arrive: it is signed, on the default
-/// branch, and a human act the reader may drive and never perform
-/// (ADR-8bd76e8d7c4e).
-pub const ACTS: &[&str] = &["claim", "log", "release", "done", "amend"];
+/// **`accept` is the sixth, and it arrived by a decision rather than by being
+/// typed into the list** (TASK-d90e94afca08). It is here because driving a
+/// ratification *is* spawning the verb, and the reader has no other way to do
+/// it; what keeps it a human act is stated in the module header and enforced in
+/// three places that are not this one -- the grammar takes no tail after the
+/// word, so nothing beyond the single identifier is ever passed; `input::parse`
+/// takes it only where the document is open on the screen; and the child is
+/// given no stdin, so no prompt of git's can be answered from this process.
+///
+/// `close`, `check`, `attest` and `init` are not here and must not arrive.
+pub const ACTS: &[&str] = &["claim", "log", "release", "done", "amend", "accept"];
 
 /// A call that did not produce a document, in the three ways it can fail.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -223,7 +257,7 @@ impl Ank {
                 args: shown.clone(),
                 error: e.to_string(),
             })?;
-        if !out.status.success() {
+        if !out.status.success() && !answered_with_findings(verb, &out.status) {
             return Err(Failed::Refused {
                 args: shown,
                 code: out.status.code().unwrap_or(ExitCode::Generic.code()),
@@ -240,6 +274,11 @@ impl Ank {
             answered,
         })
     }
+}
+
+/// Whether a non-zero exit is this verb saying "there are findings" (§4).
+fn answered_with_findings(verb: &str, status: &std::process::ExitStatus) -> bool {
+    FINDINGS_ARE_AN_ANSWER.contains(&verb) && status.code() == Some(ExitCode::Findings.code())
 }
 
 /// A call that answered: the command line it was, and the document it gave.
@@ -363,10 +402,16 @@ mod tests {
     }
 
     /// The acting gate, and the same proof that it comes first.
+    ///
+    /// **`accept` left this list and the other four did not** (TASK-d90e94afca08).
+    /// The reader drives a ratification now, so the verb reaches the spawn; that
+    /// is a decision about one verb, and it says nothing whatever about `close`,
+    /// `check`, `attest` or `init`, which stay out for the reasons they always
+    /// had. The list below is the whole of what widened, and it widened by one.
     #[test]
     fn a_verb_outside_the_acting_list_is_refused_before_anything_is_spawned() {
         let ank = nowhere();
-        for verb in ["accept", "close", "check", "attest", "init"] {
+        for verb in ["close", "check", "attest", "init"] {
             assert_eq!(
                 ank.act(verb, &["TASK-0001".to_string()]),
                 Err(Failed::NotAnAct {
@@ -383,19 +428,63 @@ mod tests {
         }
     }
 
-    /// `accept` is signed, on the default branch, and a human act the reader may
-    /// drive and never perform (ADR-8bd76e8d7c4e).
+    /// `accept` is an act and never a read, and the two lists do not overlap.
     ///
-    /// Stated as an assertion because the alternative is a verb that arrives in
-    /// a list by being typed into it, which is a change nothing would fail on.
+    /// The half that matters most is the first line. A repaint calls
+    /// [`Ank::json`] and nothing else, so `accept` being absent from [`READS`]
+    /// is what makes "the reader never performs one unattended" a property of
+    /// the code: there is no road from a watcher's news to this verb, whatever
+    /// a screen is showing when the news arrives.
     #[test]
-    fn accept_is_in_neither_list_and_the_two_lists_do_not_overlap() {
+    fn accept_is_an_act_and_never_a_read() {
+        let ank = nowhere();
         assert!(!READS.contains(&"accept"));
-        assert!(!ACTS.contains(&"accept"));
+        assert_eq!(
+            ank.json("accept", &["ADR-0001"]),
+            Err(Failed::NotARead {
+                verb: "accept".to_string()
+            }),
+            "a repaint reached accept"
+        );
+        assert!(ACTS.contains(&"accept"));
         for verb in ACTS {
             assert!(
                 !READS.contains(verb),
                 "{verb} is on both roads, and the gates then say nothing"
+            );
+        }
+    }
+
+    /// `review` is a read, and the four the reader may never run stay out of
+    /// both lists.
+    #[test]
+    fn review_reads_and_the_four_that_must_stay_out_are_on_neither_road() {
+        assert!(
+            READS.contains(&"review"),
+            "the queue is read by asking review"
+        );
+        for verb in ["close", "check", "attest", "init"] {
+            assert!(
+                !READS.contains(&verb),
+                "{verb} is not a read of this reader"
+            );
+            assert!(!ACTS.contains(&verb), "{verb} is not an act of this reader");
+        }
+    }
+
+    /// A verb that answers 8 with a document is not refused (§4).
+    ///
+    /// Asserted on the table rather than on a spawn: what the reader has to get
+    /// right is which verbs answer that way, and `review` is the one -- a
+    /// corpus with a fault in it is exactly the corpus whose queue a person
+    /// most needs to see.
+    #[test]
+    fn a_verb_that_answers_with_findings_is_the_queue_and_only_the_queue() {
+        assert_eq!(FINDINGS_ARE_AN_ANSWER, &["review"]);
+        for verb in FINDINGS_ARE_AN_ANSWER {
+            assert!(
+                READS.contains(verb),
+                "{verb} tolerates 8 on a road it is not on"
             );
         }
     }

--- a/crates/ank-tui/src/input.rs
+++ b/crates/ank-tui/src/input.rs
@@ -12,10 +12,10 @@
 //!
 //! # A reading command is one letter, and an act never is
 //!
-//! `j`, `k`, `n`, `p`, `c`, `b`, `g`, `r`, `q` -- every command that only moves
-//! the screen is a single letter, and it is the whole word too. The five that
-//! write are `claim`, `log`, `release`, `done` and `amend`, spelled whole, with
-//! no abbreviation and no letter of their own.
+//! `j`, `k`, `n`, `p`, `c`, `b`, `g`, `r`, `v`, `q` -- every command that only
+//! moves the screen is a single letter, and it is the whole word too. The six
+//! that write are `claim`, `log`, `release`, `done`, `amend` and `accept`,
+//! spelled whole, with no abbreviation and no letter of their own.
 //!
 //! That asymmetry is the criterion's "no action is taken without an explicit
 //! keystroke", made into something the grammar enforces rather than something
@@ -23,6 +23,23 @@
 //! typed nothing; there is no `d`. And it costs the reading half nothing,
 //! because a one-letter command is what a reader types a hundred times a
 //! session and a `done` is what they type once.
+//!
+//! # What `accept` costs on top of that, and why
+//!
+//! Ratification is the act this project guards hardest, so the word alone is
+//! not the whole of the gate (TASK-d90e94afca08). Two more things are true of
+//! it here, and both are the grammar's rather than the renderer's.
+//!
+//! **It takes no tail.** [`Tail::Nothing`] refuses the rest of the line instead
+//! of forwarding it, so what leaves this module is always the verb and the one
+//! identifier the view puts in front -- "nothing beyond the single document",
+//! held by there being no shape in which a second argument could travel.
+//!
+//! **It is only a command where the document is open.** In the list it is
+//! refused, naming the way in: a proposal binds nobody until somebody reads it,
+//! and a queue that could be ratified from a row is a queue nobody reads. The
+//! parse already takes the view for the empty line, so this costs no new input
+//! and puts the rule where a later edit has to see it.
 
 use crate::view::View;
 
@@ -55,6 +72,10 @@ pub enum Command {
     Search(Option<String>),
     /// Show the constraints binding the open entity, or hide them for the body.
     Constraints,
+    /// The ratification queue: what is proposed, and who may sign it
+    /// (TASK-d90e94afca08). A read and nothing else -- `ank review` writes no
+    /// file, takes no ref and renews no lease (§4).
+    Queue,
     /// Run one verb of the writing half against the entity under the cursor.
     ///
     /// The identifier is not in here: it is the selected entity, which the view
@@ -109,6 +130,17 @@ enum Tail {
     /// CLI is left to answer for the missing one -- which is exactly the
     /// refusal a person typing `done` on a task with no verifier needs to see.
     Behind(&'static str),
+    /// Nothing at all: the verb takes the identifier the view supplies and not
+    /// one byte more, and a line that carries a tail is refused rather than
+    /// trimmed.
+    ///
+    /// Refused and not ignored, because the two read identically on the screen
+    /// and only one of them is honest: somebody who typed `accept ADR-8bd7`
+    /// meant that identifier, and running the verb against whatever is open
+    /// while silently dropping what they wrote would be the reader choosing a
+    /// document for them. §4 gives `accept` no flags either, so there is
+    /// nothing a tail could legitimately be.
+    Nothing,
 }
 
 /// The writing half of the loop, and how each verb reads a line.
@@ -122,13 +154,14 @@ const ACTS: &[(&str, Tail)] = &[
     ("release", Tail::Behind("--reason")),
     ("done", Tail::Behind("--proof")),
     ("amend", Tail::Words),
+    ("accept", Tail::Nothing),
 ];
 
 pub fn parse(line: &str, view: View) -> Command {
     let line = line.trim();
     if line.is_empty() {
         return match view {
-            View::List => Command::Open,
+            View::List | View::Queue => Command::Open,
             View::Entity => Command::Page(1),
         };
     }
@@ -148,17 +181,29 @@ pub fn parse(line: &str, view: View) -> Command {
         "o" | "open" => Command::Open,
         "?" | "h" | "help" => Command::Help,
         "f" | "filter" => Command::Kind(non_empty(rest).map(|k| k.to_ascii_lowercase())),
+        // `v` and not a letter closer to the word: `q` is quit, and a queue one
+        // keystroke from the way out is a queue nobody opens twice.
+        "v" | "queue" => Command::Queue,
         "n" | "next" => Command::Page(1),
         "p" | "prev" => Command::Page(-1),
         _ => match ACTS.iter().find(|(name, _)| *name == word) {
-            Some((verb, tail)) => act(verb, *tail, rest),
+            Some((verb, tail)) => act(verb, *tail, rest, view),
             None => repeated(word).unwrap_or_else(|| other(line)),
         },
     }
 }
 
 /// One act, with the rest of the line read the way its verb reads one.
-fn act(verb: &'static str, tail: Tail, rest: &str) -> Command {
+///
+/// The view is consulted for exactly one verb, and the module header says why:
+/// a ratification is typed on the document, not at a row that names it.
+fn act(verb: &'static str, tail: Tail, rest: &str, view: View) -> Command {
+    if verb == "accept" && view != View::Entity {
+        return Command::Malformed(
+            "'accept' is typed on the document itself: open it first, and read it              (Enter opens the row under the cursor)"
+                .to_string(),
+        );
+    }
     let args = match tail {
         Tail::Words => words(rest),
         Tail::Message => match non_empty(rest) {
@@ -172,6 +217,14 @@ fn act(verb: &'static str, tail: Tail, rest: &str) -> Command {
         Tail::Behind(flag) => match non_empty(rest) {
             Some(value) => vec![flag.to_string(), value],
             None => Vec::new(),
+        },
+        Tail::Nothing => match non_empty(rest) {
+            None => Vec::new(),
+            Some(said) => {
+                return Command::Malformed(format!(
+                    "'{verb}' takes nothing after it, and '{said}' is something: it                      ratifies the document on the screen and no other"
+                ))
+            }
         },
     };
     Command::Act(Act { verb, args })
@@ -264,6 +317,7 @@ mod tests {
     #[test]
     fn an_empty_line_means_the_obvious_next_thing_in_each_view() {
         assert_eq!(parse("", View::List), Command::Open);
+        assert_eq!(parse("", View::Queue), Command::Open);
         assert_eq!(parse("", View::Entity), Command::Page(1));
         assert_eq!(parse("   ", View::Entity), Command::Page(1));
     }
@@ -276,6 +330,7 @@ mod tests {
             ("g", "top", Command::Top),
             ("b", "back", Command::Back),
             ("c", "constraints", Command::Constraints),
+            ("v", "queue", Command::Queue),
             ("n", "next", Command::Page(1)),
             ("p", "prev", Command::Page(-1)),
         ] {
@@ -401,16 +456,68 @@ mod tests {
     /// rather than a habit of the renderer.
     #[test]
     fn no_single_letter_line_can_write() {
-        for c in 'a'..='z' {
-            let line = c.to_string();
-            assert!(
-                !matches!(list(&line), Command::Act(_)),
-                "'{line}' writes, and one letter must not"
-            );
+        for view in [View::List, View::Queue, View::Entity] {
+            for c in 'a'..='z' {
+                let line = c.to_string();
+                assert!(
+                    !matches!(parse(&line, view), Command::Act(_)),
+                    "'{line}' writes in {view:?}, and one letter must not"
+                );
+            }
+            // Nor does a near miss on one of the six.
+            for line in ["d", "cl", "clai", "don", "rel", "am", "acce", "close"] {
+                assert!(
+                    !matches!(parse(line, view), Command::Act(_)),
+                    "'{line}' writes in {view:?}"
+                );
+            }
         }
-        // Nor does a near miss on one of the five.
-        for line in ["d", "cl", "clai", "don", "rel", "am", "accept", "close"] {
-            assert!(!matches!(list(line), Command::Act(_)), "'{line}' writes");
+    }
+
+    /// `accept` is a command where the document is open, and a refusal
+    /// everywhere else (TASK-d90e94afca08).
+    ///
+    /// The refusal is the reader's own and names the way in, because the person
+    /// who typed it wants to ratify and the answer is "read it first" rather
+    /// than "no".
+    #[test]
+    fn accept_is_typed_on_the_document_and_nowhere_else() {
+        assert_eq!(
+            parse("accept", View::Entity),
+            Command::Act(Act {
+                verb: "accept",
+                args: Vec::new()
+            }),
+            "the identifier is the view's, and there is nothing else to pass"
+        );
+        for view in [View::List, View::Queue] {
+            match parse("accept", view) {
+                Command::Malformed(said) => {
+                    assert!(said.contains("open it first"), "{view:?}: {said}");
+                }
+                other => panic!("{view:?} took an accept off a row: {other:?}"),
+            }
+        }
+    }
+
+    /// Nothing travels after the word, and a line that carries something is
+    /// refused rather than trimmed.
+    ///
+    /// This is "accepts nothing beyond the single document", held by the
+    /// grammar: there is no shape in which a second argument reaches the verb.
+    #[test]
+    fn accept_takes_no_tail_and_says_so_rather_than_dropping_it() {
+        for line in ["accept ADR-8bd7", "accept --force", "accept  everything"] {
+            match parse(line, View::Entity) {
+                Command::Malformed(said) => {
+                    assert!(said.contains("takes nothing after it"), "{line}: {said}");
+                    assert!(
+                        said.contains("the document on the screen"),
+                        "it names what it would have ratified: {said}"
+                    );
+                }
+                other => panic!("'{line}' carried a tail: {other:?}"),
+            }
         }
     }
 

--- a/crates/ank-tui/src/lib.rs
+++ b/crates/ank-tui/src/lib.rs
@@ -2,8 +2,8 @@
 //!
 //! **It reaches the corpus by running the CLI, and by nothing else.** Every row
 //! of corpus data on the screen arrives as a `--json` document written by
-//! `ank find`, `ank status`, `ank show` or `ank scope`, spawned as a shell would
-//! spawn them. Nothing here links `ank-core`, opens `.ank/`, or touches
+//! `ank find`, `ank status`, `ank show`, `ank scope` or `ank review`, spawned as
+//! a shell would spawn them. Nothing here links `ank-core`, opens `.ank/`, or touches
 //! `refs/ank/*`. That is slower than linking the core and the trade is taken
 //! deliberately: every refusal in this project is a refusal on state, a reader
 //! that reproduced them would get one subtly wrong, and the first symptom would
@@ -15,9 +15,9 @@
 //! entities the corpus actually carries.
 //!
 //! **It writes nothing the person at the keyboard did not ask for**
-//! (ADR-8bd76e8d7c4e). Repainting runs the four verbs that only read, so a
-//! screen left open all night runs no command at all and renews no claim; the
-//! five that write -- `claim`, `log`, `release`, `done` and `amend` -- run once
+//! (ADR-8bd76e8d7c4e). Repainting runs the verbs that only read, so a screen
+//! left open all night runs no command at all and renews no claim; the six that
+//! write -- `claim`, `log`, `release`, `done`, `amend` and `accept` -- run once
 //! each, when their word is typed whole. Nothing here is on a timer, and there
 //! is no timer to put anything on. The assertion is in the suite, not in this
 //! sentence.
@@ -67,13 +67,32 @@
 //!
 //! # The layout
 //!
-//! Two views, one screen each, because a criterion that asks for a body *whole*
-//! and a list of every kind on one screen asks for two screens.
+//! Three views, one screen each, because a criterion that asks for a body
+//! *whole* and a list of every kind on one screen asks for two screens, and the
+//! ratification queue asks a different question from either.
 //!
 //! * [`view::View::List`] -- who holds what, then every entity of every kind
 //!   with its status, windowed and filterable.
+//! * [`view::View::Queue`] -- what is proposed and waiting for a signature, and
+//!   who may give one: `ank review`, asked when its person types `v` and never
+//!   on the reader's own initiative.
 //! * [`view::View::Entity`] -- one entity: what holds it, the constraints
-//!   binding its declared scope, and its body, paged rather than cut.
+//!   binding its declared scope, and its body, paged rather than cut. This is
+//!   the only screen `accept` can be typed on.
+//!
+//! # Ratification, and the two words that are not the same
+//!
+//! ADR-8bd76e8d7c4e lets this reader *drive* `ank accept` and forbids it
+//! *performing* one unattended, and TASK-d90e94afca08 is where that sentence
+//! became code. Driving is spawning the verb, exactly as `claim` is spawned:
+//! one identifier, no flags, because a person typed the word whole on a
+//! document they had opened. Performing would be holding a key, answering a
+//! prompt, or moving more than one document at a time -- and none of the three
+//! is reachable from here. The queue is never accepted in bulk because the
+//! grammar has no shape for it; no secret can reach git through this process
+//! because the child is given no stdin; and a screen left open all night still
+//! runs nothing at all, because `accept` is on the acting list and a repaint
+//! only ever reads.
 
 use std::io::{BufRead, IsTerminal};
 use std::path::PathBuf;

--- a/crates/ank-tui/src/model.rs
+++ b/crates/ank-tui/src/model.rs
@@ -3,7 +3,20 @@
 //! [`Snapshot`] is `ank status --json` and `ank find --json` put side by side:
 //! who holds what, and every entity of every kind with its status. [`Detail`]
 //! is `ank show <id> --json` and one `ank scope <glob> --json` per glob the
-//! entity declares: the body whole, and the constraints binding it.
+//! entity declares: the body whole, and the constraints binding it. [`Queue`]
+//! is `ank review --json`: what is waiting for a signature, and who may give
+//! one.
+//!
+//! **The queue is asked for and not computed**, though the rows are in the
+//! snapshot already and filtering them on `proposed` would have been one line.
+//! Two reasons, and the second is the one that decides it. `find` answers
+//! within an attention budget and says what it withheld (ADR-3e6ce108edcd), so
+//! a queue derived from it is a queue that can be silently short -- and a
+//! ratification queue missing an entry is the one wrong answer here that a
+//! person would act on by not acting. And `review` is where §4 puts this
+//! question: what is proposed, and who may sign it. Deriving the first while
+//! having to ask for the second would leave one screen answering out of two
+//! sources that can disagree.
 //!
 //! **Nothing here derives a fact the CLI did not state.** The one exception is
 //! the `scope:` block, which is lifted out of the frontmatter the CLI printed
@@ -182,6 +195,55 @@ impl Snapshot {
                 }),
             )
             .finish()
+    }
+}
+
+/// The ratification queue, as `review` answers it.
+///
+/// Both halves of the question §4 gives that verb: the documents waiting for a
+/// signature, and the principals `.ank/allowed_signers` declares. The second is
+/// not filtered by anything -- a signer is a fact about the repository and not
+/// about a path -- and an empty list is a state of its own rather than "nobody
+/// yet", which is why [`Queue::signers`] being empty is rendered as the
+/// sentence §8 gives it rather than as a section with no rows.
+#[derive(Debug, Clone, Default)]
+pub struct Queue {
+    pub proposed: Vec<Row>,
+    pub signers: Vec<String>,
+}
+
+impl Queue {
+    pub fn load(ank: &Ank) -> Result<Queue, Failed> {
+        let answer = ank.json("review", &[])?;
+        Ok(Queue {
+            proposed: ank::rows(&answer, "proposed").iter().map(waiting).collect(),
+            signers: ank::rows(&answer, "signers")
+                .iter()
+                .map(|s| format!("{}  {}", ank::text(s, "principal"), ank::text(s, "keytype")))
+                .collect(),
+        })
+    }
+}
+
+/// One row of the queue, out of the two fields `review` gives it.
+///
+/// `status` is filled in rather than read, and it is the one value on this
+/// screen the CLI did not spell: `review` has no `status` field on a queue
+/// entry because the queue *is* the proposed set -- §4 defines it that way and
+/// the human page heads the section `PROPOSED`. `kind` comes off the
+/// identifier, which carries it by construction (ADR-c9f9d1a05b23), and not off
+/// a lookup in the snapshot: the snapshot is budgeted and the queue is not, so
+/// a row missing from one must still be whole in the other.
+fn waiting(value: &ank::Value) -> Row {
+    let id = ank::text(value, "id");
+    Row {
+        kind: id
+            .split_once('-')
+            .map(|(kind, _)| kind.to_ascii_lowercase())
+            .unwrap_or_default(),
+        id,
+        status: "proposed".to_string(),
+        title: ank::text(value, "title"),
     }
 }
 

--- a/crates/ank-tui/src/view.rs
+++ b/crates/ank-tui/src/view.rs
@@ -1,4 +1,4 @@
-//! The two views and the state between them.
+//! The three views and the state between them.
 //!
 //! [`App`] holds what was read, where the cursor is, and what is filtered. It
 //! reads by calling [`Ank`] and by nothing else, and it renders by returning a
@@ -20,6 +20,19 @@
 //! -- there is no timer in this crate, and [`App::frame`] is a pure function of
 //! what the last command left behind.
 //!
+//! **`accept` runs through that same function, and the difference is what it is
+//! *not* allowed to be** (TASK-d90e94afca08). It is one more verb spawned
+//! against one selected identifier, which is the point: a ratification taken
+//! from this screen is the ratification a shell takes, because it *is* the
+//! command a shell runs. What the reader adds is subtraction. The grammar takes
+//! no tail after the word and takes the word only where the document is open,
+//! so the entity a ratification lands on is always one somebody put on the
+//! screen and read; [`App::ratify_line`] offers the word only where the verb
+//! would accept it; and the child is spawned with no stdin, so nothing in this
+//! process can answer a passphrase prompt on a person's behalf. Every refusal
+//! that follows -- the wrong branch, a document already ratified, a signature
+//! git would not make -- is the CLI's, shown in the CLI's own bytes.
+//!
 //! **The split on what reaches the screen is the crate header's, applied to an
 //! answer.** The chrome is this crate's own -- the line naming the command that
 //! ran, the two columns of gutter -- and every value under it is the document's,
@@ -30,12 +43,29 @@
 use crate::ank::{Ank, Failed, Ran};
 use crate::frame::{self, fit, pad, window, wrap};
 use crate::input::{Act, Command};
-use crate::model::{short_of, Detail, Row, Snapshot};
+use crate::model::{short_of, Detail, Queue, Row, Snapshot};
 use crate::stream::Stream;
 
+/// # The ratification queue is a third view and not a section of the first
+///
+/// It could have been a block above the entities, the way the claims are, and
+/// that was the first shape (TASK-d90e94afca08). Two facts sent it to a view of
+/// its own. `ank review` runs a whole inspection of the corpus and costs
+/// seconds where the other four verbs cost tenths, so a queue in the list frame
+/// is a queue paid for on every repaint, including the ones a watcher's news
+/// causes -- and this crate spent a wave making an idle screen cost nothing.
+/// And the queue answers a different question with a different second half:
+/// what is waiting, and *who may sign it*, which is a fact about the repository
+/// that has no place among rows about work.
+///
+/// So it is asked for, by `v`, and it shares everything the list already has:
+/// [`App::rows`] answers with the queue's rows there, so the cursor, the row
+/// numbers, `j`/`k` and Enter are the same code and behave the same way. Enter
+/// opens the document, which is where `accept` is typed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum View {
     List,
+    Queue,
     Entity,
 }
 
@@ -65,6 +95,13 @@ pub struct App {
     /// nothing to follow. Read at every paint rather than stored as a word,
     /// because a watcher started after the session opened makes one appear.
     stream: Option<Stream>,
+    /// The ratification queue, once somebody has asked for it, and `None`
+    /// before that. Never loaded on the reader's own initiative: `review` is
+    /// the one read here that costs a full inspection of the corpus.
+    queue: Option<Queue>,
+    /// The listing an open entity was opened from, so `b` goes back where the
+    /// person came from rather than always to the entities.
+    origin: View,
 }
 
 impl App {
@@ -82,6 +119,8 @@ impl App {
             search: None,
             offset: 0,
             stream,
+            queue: None,
+            origin: View::List,
         }
     }
 
@@ -102,6 +141,7 @@ impl App {
             Ok(snapshot) => {
                 self.snapshot = Some(snapshot);
                 self.note = None;
+                self.requeue(ank);
                 if let Some(id) = held {
                     if let Some(at) = self.rows().iter().position(|r| r.id == id) {
                         self.cursor = at;
@@ -109,6 +149,26 @@ impl App {
                 }
                 self.clamp();
             }
+            Err(failed) => self.fail(failed),
+        }
+    }
+
+    /// Asks `review` again, but only where the queue is what somebody is
+    /// looking at.
+    ///
+    /// **The condition is the whole of the design.** `review` inspects the
+    /// corpus and costs what a `check` costs, so running it on every reload
+    /// would put that price on every event a watcher sends and undo what
+    /// TASK-2f7777a1fdff bought. A queue nobody has opened is not stale, and one
+    /// that is open has to be current -- a ratification queue showing a document
+    /// somebody else ratified a minute ago is the one row a person would act on
+    /// wrongly.
+    fn requeue(&mut self, ank: &Ank) {
+        if self.view != View::Queue {
+            return;
+        }
+        match Queue::load(ank) {
+            Ok(queue) => self.queue = Some(queue),
             Err(failed) => self.fail(failed),
         }
     }
@@ -149,14 +209,26 @@ impl App {
     // The rows a filter leaves
     // -----------------------------------------------------------------------
 
+    /// The rows the current listing offers, filtered.
+    ///
+    /// One function for both listings rather than two, which is what makes the
+    /// cursor, the row numbers, `j`/`k` and Enter behave identically in the
+    /// queue without a line of their own. The filters apply there too: a queue
+    /// of two hundred proposals is a list like any other, and `f adr` narrows
+    /// it the way it narrows everything else.
     fn rows(&self) -> Vec<&Row> {
-        let Some(snapshot) = &self.snapshot else {
-            return Vec::new();
+        let all: &[Row] = match self.view {
+            View::Queue => match &self.queue {
+                Some(queue) => &queue.proposed,
+                None => &[],
+            },
+            _ => match &self.snapshot {
+                Some(snapshot) => &snapshot.entities,
+                None => return Vec::new(),
+            },
         };
         let needle = self.search.as_ref().map(|s| s.to_ascii_lowercase());
-        snapshot
-            .entities
-            .iter()
+        all.iter()
             .filter(|r| self.kind.as_ref().is_none_or(|k| &r.kind == k))
             .filter(|r| {
                 needle.as_ref().is_none_or(|n| {
@@ -206,7 +278,7 @@ impl App {
                 self.clamp();
             }
             Command::Page(by) => match self.view {
-                View::List => {
+                View::List | View::Queue => {
                     let page = self.list_page().max(1) as isize;
                     self.cursor = step(self.cursor, by * page, self.rows().len());
                     self.clamp();
@@ -221,18 +293,33 @@ impl App {
                 }
             },
             Command::Top => match self.view {
-                View::List => {
+                View::List | View::Queue => {
                     self.cursor = 0;
                     self.top = 0;
                 }
                 View::Entity => self.offset = 0,
             },
             Command::Open => self.open_selected(ank),
+            Command::Queue => {
+                // The person asked, so the price is theirs to spend: this is
+                // the one read here that inspects the whole corpus.
+                self.view = View::Queue;
+                self.cursor = 0;
+                self.top = 0;
+                self.requeue(ank);
+                self.clamp();
+            }
             Command::Back => {
-                self.view = View::List;
+                self.view = match self.view {
+                    // Back out of a document to the listing it was opened
+                    // from, and out of the queue to the entities.
+                    View::Entity => self.origin,
+                    _ => View::List,
+                };
                 self.detail = None;
                 self.pane = Pane::Body;
                 self.offset = 0;
+                self.clamp();
             }
             Command::Select(needle) => match self.rows().iter().position(|r| {
                 r.id.to_ascii_uppercase()
@@ -303,7 +390,7 @@ impl App {
     fn target(&self) -> Option<String> {
         match self.view {
             View::Entity => self.detail.as_ref().map(|d| d.id.clone()),
-            View::List => self.selected().map(|r| r.id.clone()),
+            View::List | View::Queue => self.selected().map(|r| r.id.clone()),
         }
     }
 
@@ -324,9 +411,10 @@ impl App {
             self.note = Some("no entity is selected: move onto a row, or open one".to_string());
             return;
         };
+        let verb = act.verb;
         let mut args = vec![id.clone()];
         args.extend(act.args);
-        let said = match ank.act(act.verb, &args) {
+        let said = match ank.act(verb, &args) {
             Ok(ran) => answered(&ran),
             // Whole and unaltered: `error[N]:` and the command the CLI named as
             // the way out are already in these bytes, and rewording them would
@@ -336,6 +424,15 @@ impl App {
         self.reload(ank);
         if self.view == View::Entity {
             self.open_selected(ank);
+        }
+        // A ratification leaves the queue, so a queue somebody opened before
+        // typing the word is wrong the moment it lands. Asked again here and
+        // nowhere else: `reload` refreshes it only where it is on the screen,
+        // and after an `accept` the screen is the document.
+        if verb == "accept" && self.queue.is_some() {
+            if let Ok(queue) = Queue::load(ank) {
+                self.queue = Some(queue);
+            }
         }
         // Under whatever the reread had to say, and never instead of it: a
         // reload that failed after a write that landed is the one moment a
@@ -354,6 +451,9 @@ impl App {
         match Detail::load(ank, &id) {
             Ok(detail) => {
                 self.detail = Some(detail);
+                if self.view != View::Entity {
+                    self.origin = self.view;
+                }
                 self.view = View::Entity;
                 self.offset = 0;
             }
@@ -367,7 +467,7 @@ impl App {
 
     pub fn frame(&self) -> String {
         match self.view {
-            View::List => self.list_frame(),
+            View::List | View::Queue => self.list_frame(),
             View::Entity => self.entity_frame(),
         }
     }
@@ -398,15 +498,63 @@ impl App {
         }
     }
 
-    /// The rows the list has room for, once the header, the claims and the
-    /// trailer are paid for.
+    /// The rows the list has room for, once the header, the standing section
+    /// and the trailer are paid for.
     fn list_page(&self) -> usize {
-        // At least one: an empty claim list still costs the line that says so.
-        let claims = self.claim_lines().len().max(1);
-        // 2 header, 1 rule, 1 claims heading, the claims, 1 blank, 1 list
+        // At least one: an empty section still costs the line that says so.
+        let standing = self.standing_lines().len().max(1);
+        // 2 header, 1 rule, 1 section heading, the section, 1 blank, 1 list
         // heading, 1 blank, the note, 2 key lines.
-        let fixed = 2 + 1 + 1 + claims + 1 + 1 + 1 + self.note_lines().len() + 2;
+        let fixed = 2 + 1 + 1 + standing + 1 + 1 + 1 + self.note_lines().len() + 2;
         self.size.1.saturating_sub(fixed).max(1)
+    }
+
+    /// The block between the rule and the rows: who holds what on the
+    /// entities, who may sign on the queue.
+    ///
+    /// Two answers in one place because they are the same kind of thing -- a
+    /// standing fact about the corpus that the rows below are read against --
+    /// and because the arithmetic above has one section to pay for either way.
+    fn standing_lines(&self) -> Vec<String> {
+        match self.view {
+            View::Queue => self.signer_lines(),
+            _ => self.claim_lines(),
+        }
+    }
+
+    /// The heading over that block, and the sentence for an empty one.
+    ///
+    /// The empty queue sentence is §8's own, carried through from `review`
+    /// rather than written again here: an empty signer list is not "declared,
+    /// and nobody yet" -- it is the advisory regime, and a reader that rendered
+    /// a section with no rows would let a person mistake one for the other.
+    fn standing_heading(&self) -> (String, &'static str) {
+        match self.view {
+            View::Queue => (
+                format!("MAY RATIFY ({})", self.signer_lines().len()),
+                "  no ratification key declared: permissions are advisory, not enforced (§8)",
+            ),
+            _ => (
+                format!(
+                    "CLAIMS ({})",
+                    self.snapshot.as_ref().map_or(0, |s| s.claims.len())
+                ),
+                "  nothing is held",
+            ),
+        }
+    }
+
+    /// The principals `.ank/allowed_signers` declares, as `review` reads them.
+    fn signer_lines(&self) -> Vec<String> {
+        let width = self.width();
+        match &self.queue {
+            None => Vec::new(),
+            Some(queue) => queue
+                .signers
+                .iter()
+                .map(|s| fit(&format!("  {s}"), width))
+                .collect(),
+        }
     }
 
     fn claim_lines(&self) -> Vec<String> {
@@ -476,12 +624,13 @@ impl App {
         ));
         lines.push(frame::rule(width));
 
-        lines.push(format!("CLAIMS ({})", snapshot.claims.len()));
-        let claims = self.claim_lines();
-        if claims.is_empty() {
-            lines.push("  nothing is held".to_string());
+        let (heading, empty) = self.standing_heading();
+        lines.push(heading);
+        let standing = self.standing_lines();
+        if standing.is_empty() {
+            lines.push(fit(empty, width));
         } else {
-            lines.extend(claims);
+            lines.extend(standing);
         }
         lines.push(String::new());
 
@@ -489,12 +638,22 @@ impl App {
         let page = self.list_page();
         let shown = page.min(rows.len().saturating_sub(self.top));
         lines.push(fit(
-            &format!(
-                "ENTITIES {}{}   (of {} in the corpus)",
-                window(self.top, shown, rows.len()),
-                self.filter_note(),
-                snapshot.total
-            ),
+            &match self.view {
+                // The queue is answered whole: `review` carries no attention
+                // budget, so there is no "of N in the corpus" to state and
+                // stating one would imply a withholding that did not happen.
+                View::Queue => format!(
+                    "QUEUE {}{}   (proposed, and waiting for a person)",
+                    window(self.top, shown, rows.len()),
+                    self.filter_note()
+                ),
+                _ => format!(
+                    "ENTITIES {}{}   (of {} in the corpus)",
+                    window(self.top, shown, rows.len()),
+                    self.filter_note(),
+                    snapshot.total
+                ),
+            },
             width,
         ));
         for (i, row) in rows.iter().skip(self.top).take(page).enumerate() {
@@ -518,13 +677,33 @@ impl App {
             ));
         }
         if rows.is_empty() {
-            lines.push("  no entity matches this filter".to_string());
+            lines.push(
+                match (self.view, self.kind.is_some() || self.search.is_some()) {
+                    // Said even where there is nothing to say, on `review`'s own
+                    // reasoning: an empty queue and an unprinted queue read
+                    // identically, and this screen is where the question has an
+                    // answer.
+                    (View::Queue, false) => "  nothing proposed for ratification".to_string(),
+                    (View::Queue, true) => "  nothing in the queue matches this filter".to_string(),
+                    _ => "  no entity matches this filter".to_string(),
+                },
+            );
         }
 
         lines.push(String::new());
         lines.extend(self.note_lines());
         lines.push(fit(KEYS, width));
-        lines.push(fit(ACT_KEYS, width));
+        lines.push(fit(
+            match self.view {
+                // `accept` is deliberately not offered here, and neither are the
+                // five: a ratification is typed on the document, and a trailer
+                // that offered one at a row would be making an offer the
+                // grammar turns down (TASK-84cfad83c308's rule, on this screen).
+                View::Queue => QUEUE_ACT,
+                _ => ACT_KEYS,
+            },
+            width,
+        ));
         lines.join("\n") + "\n"
     }
 
@@ -588,12 +767,36 @@ impl App {
         // 4 header, 1 rule, then what differs: the body pane carries the
         // constraint heading, the summary under it, a blank and its own heading;
         // the constraints pane carries one heading and a blank. Both end on a
-        // blank, the note and the two key lines.
+        // blank, the note, the two key lines, and the ratification line where
+        // this document is one that could take a signature.
+        let ratify = usize::from(self.ratify_line().is_some());
         let fixed = match self.pane {
             Pane::Body => 4 + 1 + 1 + self.constraint_summary().len() + 1 + 1 + 1 + notes + 2,
             Pane::Constraints => 4 + 1 + 1 + 1 + 1 + notes + 2,
-        };
+        } + ratify;
         self.size.1.saturating_sub(fixed).max(1)
+    }
+
+    /// The offer to ratify, where this document is one that can be ratified.
+    ///
+    /// **Shown on a proposed ADR or spec and on nothing else.** `accept` refuses
+    /// a task, and it refuses a document already accepted, so a trailer that
+    /// carried the word over every open entity would be offering what the verb
+    /// turns down -- the defect TASK-84cfad83c308 named on `help`, which is the
+    /// same defect wherever an interface makes a promise the dispatch does not
+    /// keep. A person reading a task therefore never sees the word at all, and
+    /// one reading a proposal sees what it costs: their signature, on the
+    /// default branch, on this document.
+    ///
+    /// The status is the snapshot's and not this crate's judgement. Where the
+    /// snapshot does not carry the row -- `find` answers within a budget -- no
+    /// line is drawn, which errs towards saying nothing rather than towards
+    /// offering something.
+    fn ratify_line(&self) -> Option<&'static str> {
+        let detail = self.detail.as_ref()?;
+        let row = self.snapshot.as_ref()?.row(&detail.id)?;
+        let ratifiable = row.status == "proposed" && matches!(row.kind.as_str(), "adr" | "spec");
+        ratifiable.then_some(RATIFY_KEY)
     }
 
     /// The first few constraints, so the body view still answers "what binds
@@ -708,6 +911,9 @@ impl App {
         }
         lines.push(fit(ENTITY_KEYS, width));
         lines.push(fit(ACT_KEYS, width));
+        if let Some(ratify) = self.ratify_line() {
+            lines.push(fit(ratify, width));
+        }
         lines.join("\n") + "\n"
     }
 }
@@ -809,8 +1015,15 @@ fn step(at: usize, by: isize, total: usize) -> usize {
 }
 
 pub const KEYS: &str =
-    "j/k move  n/p page  <row> or <id> select  Enter open  f <kind>  /<text>  r reload  q quit";
+    "j/k move  n/p page  <row> or <id> select  Enter open  f <kind>  /<text>  v queue  r reload  q quit";
 pub const ENTITY_KEYS: &str = "Enter/n/p page  g top  c constraints  r reload  b back  q quit";
+/// What the queue offers instead of the writing half.
+///
+/// It names the one road to a ratification and no verb at all, which is the
+/// honest shape of this screen: nothing here can be signed, and the way to sign
+/// is to read the document first.
+pub const QUEUE_ACT: &str =
+    "Enter opens a document   (accept is typed there, on the body -- the signature stays yours)";
 /// The writing half, on its own line and spelled whole.
 ///
 /// Separate from the other two because it is a different kind of offer: the keys
@@ -819,6 +1032,15 @@ pub const ENTITY_KEYS: &str = "Enter/n/p page  g top  c constraints  r reload  b
 /// do, and one line mixing them would make that a matter of remembering.
 pub const ACT_KEYS: &str =
     "claim  log <message>  release <reason>  done <proof>  amend <flags>   (the entity on screen)";
+/// The sixth act, on a line of its own, and only where the verb would take it.
+///
+/// A third line for a third kind of offer, on the reasoning [`ACT_KEYS`] gives
+/// for being a second one: those five move the corpus, and this one asks a
+/// person for a signature that ank has no way to produce. It says so, because
+/// somebody about to type it should know what they are being asked for and
+/// where it has to happen.
+pub const RATIFY_KEY: &str =
+    "accept   (this document, on the default branch -- ank signs nothing, your key does)";
 
 #[cfg(test)]
 mod tests {
@@ -1310,6 +1532,185 @@ mod tests {
                 }
             }
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // The ratification queue (TASK-d90e94afca08)
+    // -----------------------------------------------------------------------
+
+    fn queued() -> Queue {
+        Queue {
+            proposed: vec![
+                row("ADR-0000ffff0002", "adr", "proposed", "A decision waiting"),
+                row(
+                    "SPEC-0000ffff0003",
+                    "spec",
+                    "proposed",
+                    "A specification waiting",
+                ),
+            ],
+            signers: vec!["marie@laptop  ssh-ed25519".to_string()],
+        }
+    }
+
+    /// The queue names what is waiting and who may sign it, and both halves are
+    /// `review`'s own answer.
+    #[test]
+    fn the_queue_names_what_is_waiting_and_who_may_ratify() {
+        let mut a = app();
+        a.queue = Some(queued());
+        a.view = View::Queue;
+        let f = a.list_frame();
+        for expected in [
+            "QUEUE",
+            "ADR-0000",
+            "SPEC-0000",
+            "A decision waiting",
+            "MAY RATIFY (1)",
+            "marie@laptop",
+        ] {
+            assert!(f.contains(expected), "{expected} missing from:\n{f}");
+        }
+        assert!(
+            !f.contains("CLAIMS"),
+            "the queue answers a different question:\n{f}"
+        );
+    }
+
+    /// An empty queue says so, and a corpus declaring no key says which regime
+    /// it is in rather than showing an empty section.
+    #[test]
+    fn an_empty_queue_and_an_undeclared_key_are_both_stated() {
+        let mut a = app();
+        a.queue = Some(Queue::default());
+        a.view = View::Queue;
+        let f = a.list_frame();
+        assert!(f.contains("nothing proposed for ratification"), "{f}");
+        assert!(
+            f.contains("permissions are advisory"),
+            "the advisory regime is a state, not an empty list:\n{f}"
+        );
+    }
+
+    /// The queue's rows are the list's rows: one cursor, one set of keys, one
+    /// road to the document.
+    #[test]
+    fn the_queue_moves_and_opens_the_way_the_list_does() {
+        let mut a = app();
+        let ank = nowhere();
+        a.queue = Some(queued());
+        a.act(Command::Queue, &ank);
+        // `Command::Queue` asked `review`, which cannot be spawned here, so the
+        // frame carries the refusal -- and the rows already in hand stay.
+        a.queue = Some(queued());
+        assert_eq!(a.view, View::Queue);
+        assert_eq!(rendered_rows(&a), ["ADR-0000ffff0002", "SPEC-0000ffff0003"]);
+        a.act(Command::Move(1), &ank);
+        assert_eq!(
+            a.selected().map(|r| r.id.clone()).as_deref(),
+            Some("SPEC-0000ffff0003"),
+            "j moves in the queue"
+        );
+        a.act(Command::Row(1), &ank);
+        assert_eq!(a.cursor, 0, "a row number selects in the queue");
+    }
+
+    /// `b` out of a document goes back to the listing it was opened from.
+    #[test]
+    fn back_out_of_a_document_returns_to_the_listing_it_was_opened_from() {
+        let mut a = app();
+        let ank = nowhere();
+        a.queue = Some(queued());
+        a.view = View::Queue;
+        a.detail = Some(detail("ADR-0000ffff0002", "body\n"));
+        a.origin = View::Queue;
+        a.view = View::Entity;
+        a.act(Command::Back, &ank);
+        assert_eq!(a.view, View::Queue, "the queue is where the person was");
+        a.act(Command::Back, &ank);
+        assert_eq!(a.view, View::List, "and out of the queue is the entities");
+    }
+
+    /// The word is offered on a document that could take it, and on nothing
+    /// else (TASK-84cfad83c308's rule: no offer the verb turns down).
+    #[test]
+    fn the_ratification_line_is_drawn_only_where_accept_would_take_it() {
+        let mut a = App::new((100, 30), None);
+        a.snapshot = Some(Snapshot {
+            entities: vec![
+                row("ADR-0000ffff0002", "adr", "proposed", "A decision waiting"),
+                row("ADR-8bd76e8d7c4e", "adr", "accepted", "A terminal reader"),
+                row("TASK-49746735127f", "task", "open", "A task"),
+            ],
+            ..snapshot()
+        });
+        a.view = View::Entity;
+        for (id, offered) in [
+            ("ADR-0000ffff0002", true),
+            ("ADR-8bd76e8d7c4e", false),
+            ("TASK-49746735127f", false),
+        ] {
+            a.detail = Some(detail(id, "body\n"));
+            let f = a.entity_frame();
+            assert_eq!(
+                f.contains("accept   (this document"),
+                offered,
+                "{id} was offered {}:\n{f}",
+                f.contains("accept   (this document")
+            );
+        }
+    }
+
+    /// A ratification is one verb, one identifier, and nothing else on the
+    /// command line.
+    ///
+    /// Read off the failure, the way the other acts are: the binary is not
+    /// there, so `Failed` carries the whole `argv` that would have been spawned.
+    #[test]
+    fn a_ratification_runs_accept_with_the_open_document_and_nothing_else() {
+        let mut a = app();
+        let ank = nowhere();
+        a.detail = Some(detail("ADR-8bd76e8d7c4e", "body\n"));
+        a.view = View::Entity;
+        a.act(
+            Command::Act(Act {
+                verb: "accept",
+                args: Vec::new(),
+            }),
+            &ank,
+        );
+        let said = a.note.clone().unwrap_or_default();
+        assert!(
+            said.contains("ank accept ADR-8bd76e8d7c4e --json"),
+            "{said}"
+        );
+    }
+
+    /// The queue is never asked for on the reader's own initiative.
+    ///
+    /// `review` inspects the whole corpus, and this is the property that keeps
+    /// an event cheap: a repaint refreshes the queue where it is on the screen
+    /// and leaves it alone where it is not.
+    #[test]
+    fn a_repaint_asks_review_only_where_the_queue_is_on_the_screen() {
+        let mut a = app();
+        let ank = nowhere();
+        a.queue = Some(queued());
+        // The binary is not there, so a call that is made says so and a call
+        // that is not made leaves the note alone. That is the whole
+        // instrument, and it reads in both directions.
+        a.requeue(&ank);
+        assert_eq!(
+            a.note, None,
+            "a repaint of the entities asked review for the queue"
+        );
+        a.view = View::Queue;
+        a.requeue(&ank);
+        let said = a.note.clone().unwrap_or_default();
+        assert!(
+            said.contains("review"),
+            "a repaint of the queue did not ask review: {said}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes TASK-d90e94afca08.

The ratification queue was a list you copied an identifier out of, into a command in another window. It is now a screen, and `accept` is typed on the document itself.

## `accept` joins the acting list, and is still never performed

Driving a ratification *is* spawning the verb, so `accept` goes on `ank::ACTS` beside the other five rather than taking a road of its own: one gate, one dispatch path, and the commit that comes out is the commit a shell makes. What keeps it a human act is subtraction, in three places that are not the gate:

- the grammar gives it `Tail::Nothing`, so nothing beyond the single identifier can travel — a line with a tail is refused, not trimmed;
- `input::parse` takes the word only in `View::Entity`, so nothing is ratified that was not put on a screen and read;
- the child is spawned through `output()`, which gives it a null stdin, so no passphrase prompt can be answered from this process.

`close`, `check`, `attest` and `init` stay out of both lists, and the test that held them there still holds them there — it lost exactly one entry.

## The queue is a third view

`ank review` inspects the whole corpus and costs seconds where `find` and `status` cost tenths, so a queue rendered into the list frame is a queue paid for on every watcher event — and this crate spent TASK-2f7777a1fdff making an idle screen cost nothing. So it is asked for by `v`, refreshed only while it is what somebody is looking at, and it reuses the list's cursor, row numbers and Enter rather than growing its own. `review` also joins `READS`, with its exit 8 read as "there are findings" rather than as a refusal: a corpus with a fault in it is the one whose queue a person most needs to see.

`accept` is offered in the trailer only on a proposed ADR or spec — no offer the verb turns down.

## What the suite measures, through a real terminal

- two proposals identical but for their identifiers, one ratified from the screen and one from a shell: the entity, the anchor and the ratification commit compared byte for byte, and `check` reporting no fault about either;
- with the word withheld — queue opened, body paged to its end, back out — the document is still `proposed`, `.ank/` is unchanged and `HEAD` has not moved;
- off the default branch, the screen carries `error[7]:` and `git switch main`, and nothing is written;
- `accept` off a row and `accept` with a tail are both refused by the reader, and neither reaches the verb.

`Repo::seeded` now states its own signing regime instead of inheriting the developer's global git config, which is what made the first run of the comparison depend on the machine.

`cargo test --workspace` is green, `cargo fmt --check` passes, `ank check` is 0 faults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhWoNxFoF1e5S2n5cbkoPC