### PR TITLE
Plan: one executable, and a protocol surface that speaks for several corpora

### DIFF
--- a/.ank/entities/ADR-1ea31c2f3c5a.md
+++ b/.ank/entities/ADR-1ea31c2f3c5a.md
@@ -1,0 +1,48 @@
+---
+id: ADR-1ea31c2f3c5a
+type: adr
+slug: distribution-carries-one-executable-and-parity-o
+title: Distribution carries one executable, and parity of reach stops being a rule
+created: 2026-08-25T16:52:19Z
+author: haksolot@vmi3223161
+status: proposed
+scope:
+  - install.sh
+  - install.ps1
+  - npm/**
+  - .github/workflows/**
+  - docs/**
+constraint: |
+  Every route that carries ank carries one executable, for the three platforms ADR-221aa5da440a names, out of one build. No route places a second file beside it, and no route exists for a surface alone: the protocol surface and the watcher are verbs of that executable (ADR-fd98f4bc6dea), so what reaches a reader is what the binary dispatches. The documentation that teaches installing ank states in the same place how a client reaches the protocol surface, with a configuration a reader can paste, and that configuration names the binary and the verb.
+supersedes: ADR-e39a44f80e0e
+schema: 4
+version: 1
+---
+
+ADR-e39a44f80e0e made distribution a rule because the surface was freight: a
+generated passthrough cannot fall behind the CLI in what it exposes, and nothing
+yet stopped it falling behind in whether it arrived. Its own sentence was
+"Generation solves parity of content. Only distribution solves parity of reach."
+
+A verb solves parity of reach the way generation solved parity of content: by
+construction rather than by rule. There is nothing left for the rule to hold, so
+it goes, and what replaces it is one clause about documentation -- the half of
+ADR-e39a44f80e0e that was never about the second file.
+
+## What this deletes
+
+The workflow builds `--bin ank --bin ank-mcp` and copies two files into every
+archive under two branches of a shell conditional; `install.yml` maintains a
+stand-in `ank-mcp` and a second staged release older than it, to prove an
+installer meeting one or the other does not break; `npm-assemble.sh` names two
+binaries in three platform packages. Every line of that exists to answer "did the
+second one arrive". None of it survives a single file.
+
+## The break, and why it is not softened
+
+A client configured against `ank-mcp` stops working, and gets `command not
+found` rather than a wrong answer. No shim is shipped: ADR-221aa5da440a fixes
+distribution at three commands and makes a fourth thing a decision, and a
+forwarding executable kept for one release is a fourth thing to build, sign,
+publish and then remember to remove. The change a reader makes is one line, and
+the documentation that teaches the surface carries it.

--- a/.ank/entities/ADR-ed3e14d0f991.md
+++ b/.ank/entities/ADR-ed3e14d0f991.md
@@ -1,0 +1,52 @@
+---
+id: ADR-ed3e14d0f991
+type: adr
+slug: one-live-claim-per-identity-is-per-corpus-and-th
+title: One live claim per identity is per corpus, and the claims held elsewhere are named
+created: 2026-08-25T16:52:42Z
+author: haksolot@vmi3223161
+status: proposed
+scope:
+  - crates/ank-cli/src/claim.rs
+constraint: |
+  The one live claim per identity of section 3 is per corpus, and it is stated rather than left to be discovered: refs/ank/* is per repository, so an identity holds at most one live claim in each corpus it works in, and a refusal that reached across corpora would be an arbitration the refs cannot carry. Nothing refuses on a claim held in another corpus.
+  
+  What a caller gets instead is the fact. Where the reader can see another corpus without being told about one -- a corpus declared in corpora.yml, or the further corpora a protocol surface was addressed with -- claim names the live claims that identity already holds elsewhere, with the corpus each is in, and takes the task anyway. A corpus the reader was not told about is not searched for and is never named. This is ADR-052accd6e3b2's rule applied across a boundary instead of across a scope: the fact is stated at claim time and never refused.
+schema: 4
+version: 1
+---
+
+SPEC-183dd2eb4dc0 left this open in writing, and said why it had to be settled
+somewhere: "The one-claim-per-identity rule is silently per repository, since the
+refusal reads the refs of the resolved root, so one identity holds a claim in
+every repository at once and nothing notices -- doubtful by the rule's own
+reasoning, which is that a caller already holding one is not available."
+
+The behaviour is measured and not inferred: one identity took a claim in two
+corpora a second apart, and each `status` reported its own with no mention of
+the other.
+
+## Why the rule stays per corpus
+
+The objection is real -- an agent holding five leases in five repositories is
+not available five times over -- and the answer to it cannot be a refusal. A
+refusal has to be arbitrated, and the only mechanism this project trusts for
+arbitration is a compare-and-swap on a ref that both parties can reach.
+`refs/ank/*` is per repository by ADR-4e7c and ADR-a1de673043b4, so a
+cross-corpus refusal could only be enforced by whatever process happened to see
+both corpora at once. Two such processes would not see each other, which is an
+arbitration that holds until the moment it matters.
+
+## Why it is named rather than counted
+
+ADR-052accd6e3b2 met the same shape and answered it once already: two live
+claims whose scopes intersect are named at claim time and never refused, because
+the tool refuses on state and the state here is somebody else's business to
+weigh. Availability is exactly that kind of fact. A person or an agent taking a
+sixth task while five leases are outstanding should be told, in the answer to the
+command they typed, and then allowed to proceed.
+
+**And it is named only where the reader was already told where to look.** Nothing
+walks a filesystem for a corpus (ADR-621a7fd96ce1, ADR-96174f1ac2b7), so a
+single-corpus caller with no declaration sees exactly what it sees today: this
+adds a line where a reader has declared others, and adds nothing anywhere else.

--- a/.ank/entities/ADR-fd98f4bc6dea.md
+++ b/.ank/entities/ADR-fd98f4bc6dea.md
@@ -1,0 +1,82 @@
+---
+id: ADR-fd98f4bc6dea
+type: adr
+slug: the-protocol-surface-is-a-verb-of-the-one-binary
+title: The protocol surface is a verb of the one binary, and it speaks for the corpora its reader declared
+created: 2026-08-25T16:52:02Z
+author: haksolot@vmi3223161
+status: proposed
+scope:
+  - crates/ank-cli/src/cli.rs
+  - crates/ank-mcp/**
+constraint: |
+  A protocol surface exposes every verb the CLI dispatches, generated from the same table the CLI dispatches from, or it does not exist. No curated subset, under any protocol. It refuses on state exactly as the CLI does and never on identity, and it carries the CLI's exit codes as the reason for a refusal. It writes under a typed process identity.
+  
+  It is a verb, ank mcp, and not a sibling binary: ank ships one executable, and crates/ank-mcp is a library linked into it. One executable is not one process. The verb still spawns ank <verb> --repo <corpus> --json per call, so there is no second dispatch path and every refusal remains the one the binary gave.
+  
+  It may speak for several corpora, and never for a merged one. Every tool carries an optional corpus argument holding the repository identity of ADR-621a7fd96ce1; absent, the call goes to the corpus the process was addressed with at startup. The set a server may reach is what the reader declared in corpora.yml (ADR-96174f1ac2b7) plus that startup corpus, and nothing is discovered: a corpus argument naming an identity the reader did not declare is refused by name. Each corpus is addressed on its own, the way --repo addresses one. Claims stay per clone and no server arbitrates across clones: there is no merged claim space, no claim held on a client's behalf, and no pooling of clients under one identity.
+supersedes: ADR-372b82af1ec7
+schema: 4
+version: 1
+---
+
+ADR-372b82af1ec7 is kept whole except in two clauses, and both are amended here
+rather than in two documents because the format allows one successor per
+document and both are edits to the same ratified text.
+
+## The sibling binary, and the reason that expired
+
+That decision chose a sibling binary over a verb, and it named its reason: "The
+live one-surface decision says the verbs themselves do not change, and what
+`skill/SKILL.md` teaches is frozen by revision hash. A twenty-third verb would
+cost a second supersession and a second human signature, and would buy nothing."
+
+Neither half is true any more. The one-surface chain ran
+ADR-9ede1ffd04e2 to ADR-c656cbcc33a9 to ADR-e17e1bbd93ff to ADR-f61e2d2c75e8 to
+ADR-5dd7b4a9c875 and ends on ADR-91b77f036884, whose constraint states that no
+skill's content is frozen by revision hash any more; and the sentence about the
+verbs not changing left the live constraint somewhere along that chain.
+ADR-8bd76e8d7c4e then added a verb and argued the case in the opposite
+direction, for an audience this one shares: a separate executable is invisible
+to precisely the people it exists for, and has to be distributed, documented and
+discovered as a third thing.
+
+**And the price it avoided was paid anyway, twice.** ADR-e39a44f80e0e exists
+only because the second binary reached nobody: `release.yml` built one,
+`install.sh` unpacked one, no document mentioned it. That is a rule, a workflow
+matrix and an installer branch, all of whose work is to make a second file
+arrive beside the first. A verb cannot fail to arrive.
+
+## One executable is not one process
+
+The trade ADR-372b82af1ec7 took deliberately survives untouched, and this is the
+clause that keeps it: `ank mcp` spawns `ank <verb>` exactly as `ank-mcp` did.
+Linking `ank-cli` into the surface would re-derive every refusal, and anything
+re-derived can differ; spawning inherits them by construction. So what is folded
+here is the *file*, never the dispatch. The same reading applies to
+`crates/ank-tui`, which is linked in and still reaches the corpus only by
+running the binary.
+
+## Several corpora, and why that is not a merged claim space
+
+The clause this amends reads "It speaks for exactly one corpus", and its stated
+reason is that `refs/ank/*` is per repository, so a server that merged two claim
+spaces would be inventing an arbitration the refs cannot carry. That reason
+forbids merging. It does not forbid multiplexing, and ADR-621a7fd96ce1 already
+permits the shape: a reader may hold several corpora at once and present them
+together, each addressed on its own.
+
+So each call names its corpus or takes the default, and every call still becomes
+`ank --repo <one corpus>`. Nothing is pooled, nothing is merged, and the ban on
+a merged claim space is carried forward in the same words. What a multi-corpus
+server does acquire is one identity holding a lease in several corpora at once,
+which SPEC-183dd2eb4dc0 left open on purpose; that question is settled by its
+own decision and not by this one.
+
+## What is still true
+
+Shell remains the common denominator and remains what the skill teaches. This
+does not make a protocol the preferred route for an agent that has a shell.
+`skill/SKILL.md` does not move: an agent has `context`, `find` and `show`, and
+teaching it a protocol it should not reach for would spend the contract to no
+end -- the same reading ADR-8bd76e8d7c4e gave for `tui`.

--- a/.ank/entities/LOG-110083dc3ed3.md
+++ b/.ank/entities/LOG-110083dc3ed3.md
@@ -1,0 +1,15 @@
+---
+id: LOG-110083dc3ed3
+type: log
+title: +blocked_by TASK-36666e36744e (version 1 to 2, replaced 6af654f4a491, produced 3f278826ec13)
+created: 2026-08-25T16:53:25Z
+author: haksolot@vmi3223161
+scope:
+  - crates/ank-mcp/**
+  - crates/ank-cli/src/cli.rs
+about: TASK-e655d28c83cb
+seq: 0
+records: edit
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-d2d83f2ff531.md
+++ b/.ank/entities/LOG-d2d83f2ff531.md
@@ -1,0 +1,16 @@
+---
+id: LOG-d2d83f2ff531
+type: log
+title: +blocked_by TASK-e655d28c83cb, +blocked_by TASK-1317adb617e8 (version 1 to 2, replaced
+created: 2026-08-25T16:53:26Z
+author: haksolot@vmi3223161
+scope:
+  - crates/ank-mcp/**
+about: TASK-2f31789f6af2
+seq: 0
+records: edit
+schema: 4
+version: 1
+---
+
+ 9979a0b251f7, produced 4e50e2592146)

--- a/.ank/entities/LOG-db0fde3c66a6.md
+++ b/.ank/entities/LOG-db0fde3c66a6.md
@@ -1,0 +1,15 @@
+---
+id: LOG-db0fde3c66a6
+type: log
+title: +blocked_by TASK-36666e36744e (version 1 to 2, replaced 269a5c2a8692, produced 2e83977423d4)
+created: 2026-08-25T16:53:25Z
+author: haksolot@vmi3223161
+scope:
+  - crates/ank-daemon/**
+  - crates/ank-cli/src/cli.rs
+about: TASK-9dd22f2b0430
+seq: 0
+records: edit
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-e62b011f705a.md
+++ b/.ank/entities/LOG-e62b011f705a.md
@@ -1,0 +1,20 @@
+---
+id: LOG-e62b011f705a
+type: log
+title: +blocked_by TASK-e655d28c83cb, +blocked_by TASK-9dd22f2b0430 (version 1 to 2, replaced
+created: 2026-08-25T16:53:26Z
+author: haksolot@vmi3223161
+scope:
+  - .github/workflows/**
+  - install.sh
+  - install.ps1
+  - npm/**
+  - docs/**
+about: TASK-d9b167250aa8
+seq: 0
+records: edit
+schema: 4
+version: 1
+---
+
+ 7de290df7a06, produced 27fe57cd6af8)

--- a/.ank/entities/TASK-1317adb617e8.md
+++ b/.ank/entities/TASK-1317adb617e8.md
@@ -1,0 +1,17 @@
+---
+id: TASK-1317adb617e8
+type: task
+slug: claim-names-the-live-claims-this-identity-holds
+title: claim names the live claims this identity holds in the corpora the reader declared
+created: 2026-08-25T16:53:18Z
+author: haksolot@vmi3223161
+status: open
+scope:
+  - crates/ank-cli/src/claim.rs
+blocked_by: []
+done_criteria: |
+  Where the reader declares corpora in corpora.yml, claim names each live claim the identity in effect already holds in another declared corpus, with the corpus it is in, and takes the task all the same: the exit code is the one a claim with nothing to report gives, and --json carries the same facts under a field of its own. A corpus that is not declared is never read and never named, and a caller with no declaration sees bytes identical to today's, asserted against a golden. A declared corpus that cannot be read warns once and does not fail the claim. cargo test is green and cargo fmt --check passes.
+criteria_by: creator
+schema: 4
+version: 1
+---

--- a/.ank/entities/TASK-2f31789f6af2.md
+++ b/.ank/entities/TASK-2f31789f6af2.md
@@ -1,0 +1,17 @@
+---
+id: TASK-2f31789f6af2
+type: task
+slug: a-protocol-surface-call-names-its-corpus-and-rea
+title: A protocol surface call names its corpus, and reaches no corpus nobody declared
+created: 2026-08-25T16:53:18Z
+author: haksolot@vmi3223161
+status: open
+scope:
+  - crates/ank-mcp/**
+blocked_by: [TASK-e655d28c83cb, TASK-1317adb617e8]
+done_criteria: |
+  Every tool the surface generates carries an optional corpus argument holding the repository identity of ADR-621a7fd96ce1, and a call omitting it reaches the corpus ank mcp was addressed with at startup. An identity the reader declared in corpora.yml resolves to that corpus and the call runs against it; an identity nobody declared is refused by name, with the code section 4 declares and the command that resolves it, and nothing is spawned. A test drives the built ank against two temporary corpora through one server and shows a claim landing in each on its own refs/ank/claims, with neither corpus naming the other's task. cargo test is green and cargo fmt --check passes.
+criteria_by: creator
+schema: 4
+version: 2
+---

--- a/.ank/entities/TASK-36666e36744e.md
+++ b/.ank/entities/TASK-36666e36744e.md
@@ -1,0 +1,17 @@
+---
+id: TASK-36666e36744e
+type: task
+slug: section-4-gains-mcp-and-watch-and-the-suite-decl
+title: Section 4 gains mcp and watch, and the suite declares them not yet dispatched
+created: 2026-08-25T16:53:00Z
+author: haksolot@vmi3223161
+status: open
+scope:
+  - crates/ank-cli/tests/skill.rs
+blocked_by: []
+done_criteria: |
+  A revision of SPEC-20357e21a45a carries mcp and watch in its Commands block, in the order section 4 states, each with the one-line summary ank help will print. NOT_YET_DISPATCHED in crates/ank-cli/tests/skill.rs names both, so every_dispatched_verb_is_listed_in_section_4 and the test that fails a declared verb which has started shipping are both green with the binary dispatching neither. cargo test is green and ank check reports no fault.
+criteria_by: creator
+schema: 4
+version: 1
+---

--- a/.ank/entities/TASK-9dd22f2b0430.md
+++ b/.ank/entities/TASK-9dd22f2b0430.md
@@ -1,0 +1,18 @@
+---
+id: TASK-9dd22f2b0430
+type: task
+slug: ank-watch-dispatches-and-the-watcher-stops-being
+title: ank watch dispatches, and the watcher stops being a binary nothing ships
+created: 2026-08-25T16:53:00Z
+author: haksolot@vmi3223161
+status: open
+scope:
+  - crates/ank-daemon/**
+  - crates/ank-cli/src/cli.rs
+blocked_by: [TASK-36666e36744e]
+done_criteria: |
+  crates/ank-daemon declares a library target and no [[bin]], and ank dispatches watch, carrying --list, --once, --interval and --where unchanged. A test drives the built ank against a temporary declaration naming two corpora and shows that a change in each becomes a line on events.jsonl keyed on that corpus, as the sibling binary produced. stopping_the_daemon_changes_no_verbs_output_and_no_verbs_exit_code still holds against the verb. cargo build --workspace produces no ank-daemon. The line naming watch is gone from NOT_YET_DISPATCHED in the same commit. cargo test is green and cargo fmt --check passes.
+criteria_by: creator
+schema: 4
+version: 2
+---

--- a/.ank/entities/TASK-d9b167250aa8.md
+++ b/.ank/entities/TASK-d9b167250aa8.md
@@ -1,0 +1,21 @@
+---
+id: TASK-d9b167250aa8
+type: task
+slug: every-route-carries-one-executable-and-the-machi
+title: Every route carries one executable, and the machinery for the second is removed
+created: 2026-08-25T16:53:17Z
+author: haksolot@vmi3223161
+status: open
+scope:
+  - .github/workflows/**
+  - install.sh
+  - install.ps1
+  - npm/**
+  - docs/**
+blocked_by: [TASK-e655d28c83cb, TASK-9dd22f2b0430]
+done_criteria: |
+  release.yml builds and packages one binary per target, install.sh and install.ps1 place one file, and npm-assemble.sh names one per platform package. No workflow, script or manifest in the tree mentions ank-mcp or ank-daemon as a file to build, copy, stage or install, and grep is the check. install.yml no longer stages a stand-in for a second binary. docs/integrating.md states how a client reaches the protocol surface with a configuration naming ank and the verb mcp, and no document still tells a reader the watcher is built from the workspace and shipped by nothing. cargo test is green and ank check reports no fault.
+criteria_by: creator
+schema: 4
+version: 2
+---

--- a/.ank/entities/TASK-e655d28c83cb.md
+++ b/.ank/entities/TASK-e655d28c83cb.md
@@ -1,0 +1,18 @@
+---
+id: TASK-e655d28c83cb
+type: task
+slug: ank-mcp-dispatches-and-the-sibling-binary-is-gon
+title: ank mcp dispatches, and the sibling binary is gone
+created: 2026-08-25T16:53:00Z
+author: haksolot@vmi3223161
+status: open
+scope:
+  - crates/ank-mcp/**
+  - crates/ank-cli/src/cli.rs
+blocked_by: [TASK-36666e36744e]
+done_criteria: |
+  crates/ank-mcp declares a library target and no [[bin]], and ank dispatches mcp: the verb serves the same JSON-RPC over stdio the sibling binary served, over every verb COMMANDS carries, and it spawns ank per call rather than linking the dispatch. A test drives the built ank through initialize, tools/list and one tools/call over a temporary corpus and shows the same tool count and the same document the sibling binary answered. cargo build --workspace produces one executable named ank and no ank-mcp. The line naming mcp is gone from NOT_YET_DISPATCHED in the same commit. cargo test is green and cargo fmt --check passes.
+criteria_by: creator
+schema: 4
+version: 2
+---


### PR DESCRIPTION
Three proposals and six tasks, from an audit of two demands: fold the sibling binaries into `ank`, and let the protocol surface and the watcher work across several repositories.

**Nothing here is accepted.** Three ADRs are waiting for a signature on `main`, and no verb dispatches until the spec revision the first task produces is ratified too.

## The audit

`ADR-372b` chose a sibling binary over a verb and named its reason: *"The live one-surface decision says the verbs themselves do not change, and what `skill/SKILL.md` teaches is frozen by revision hash."* Neither half survives. The one-surface chain — 9ede → c656 → e17e → f61e → 5dd7 — ends on `ADR-91b7`, whose constraint states no skill's content is frozen by revision hash any more; and `ADR-8bd7` has since added a verb arguing the opposite case for the same audience. The price that decision avoided was paid twice over regardless: `ADR-e39a` exists **only** because the second binary reached nobody.

The watcher is worse off — `grep ank-daemon .github/workflows/release.yml` returns nothing, and `docs/integrating.md` says so outright.

## What is proposed

| | supersedes | change |
|---|---|---|
| `ADR-fd98` | `ADR-372b` | the surface becomes the verb `ank mcp`, and may speak for several corpora |
| `ADR-1ea3` | `ADR-e39a` | distribution carries one executable |
| `ADR-ed3e` | — | one live claim per identity is **per corpus**, and the others are named |

`ADR-fd98` carries both amendments because one entity may supersede one entity, and both are edits to the same ratified text.

**What is conserved.** `ADR-372b` bans a merged claim space, and its stated reason is that `refs/ank/*` is per repository. That reason forbids merging, not multiplexing — `ADR-621a` already permits a reader to hold several corpora, each addressed on its own. The ban is carried forward in the same words; only "exactly one corpus" moves. `call::argv` already emits `--repo` per call.

**One executable is not one process.** `ank mcp` still spawns `ank <verb>` per call. Linking `ank-cli` into the surface would re-derive every refusal, and anything re-derived can differ. What folds is the file, never the dispatch — the reading `crates/ank-tui` already lives under.

**The open question, settled.** `SPEC-183d` names it and says it needs its own decision: *"one identity holds a claim in every repository at once and nothing notices — doubtful by the rule's own reasoning."* Measured, not inferred: one identity took a claim in two corpora a second apart and neither `status` mentioned the other. A multi-repo server makes that routine. Settled per corpus, because a cross-corpus refusal could only be arbitrated by whatever process saw both — and two such processes would not see each other. Named at claim time instead, which is `ADR-052a`'s answer to the same shape applied across a boundary rather than across a scope.

## The order, and why it is the signature's

```
TASK-3666  section 4 gains mcp and watch, suite declares them not yet dispatched
├── TASK-e655  ank mcp dispatches, the sibling binary is gone
│   ├── TASK-2f31  a call names its corpus   (also blocked by TASK-1317)
│   └── TASK-d9b1  one route, one executable
└── TASK-9dd2  ank watch dispatches

TASK-1317  claim names the claims held elsewhere   (independent)
└── TASK-2f31
```

`crates/ank-cli/tests/skill.rs` holds every dispatched verb to section 4's Commands block and fails a declared verb that has started shipping. So the spec revision lands alone, passes through a signed `accept`, and everything else waits on it — the road `read` and `tui` both took.

## Judgment calls made without asking

- **`corpora.yml`, not a third file.** `ADR-9617` already defines it as the reader's identity → path map held outside every repository. `watch.yml` stays the watcher's: same shape, distinct role.
- **`ADR-a22c` is not superseded.** Its "It answers no verb" means the watcher serves no verbs, not that it may not be invoked by one. `ank watch` makes it answer nothing. `ADR-fd98` states the distinction so no reader has to infer it — but that is a reading, and amending `a22c` to say it itself is a defensible alternative.

## The break

A client configured against `ank-mcp` gets `command not found`, not a wrong answer. No shim: `ADR-221a` fixes distribution at three commands, and a forwarding executable kept for one release is a fourth thing to build, sign, publish and remember to remove.

`ank check` reports 0 faults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhWoNxFoF1e5S2n5cbkoPC