### PR TITLE
Repair main: re-point the citations the two supersessions orphaned, and close two scope gaps

### DIFF
--- a/.ank/entities/LOG-08d4eff41d4d.md
+++ b/.ank/entities/LOG-08d4eff41d4d.md
@@ -1,0 +1,16 @@
+---
+id: LOG-08d4eff41d4d
+type: log
+title: +scope crates/ank-contract/src/lib.rs (version 2 to 3, replaced eb6512cebba3, produced 0431b4afdf5f)
+created: 2026-08-25T17:22:11Z
+author: haksolot@vmi3223161
+scope:
+  - crates/ank-mcp/**
+  - crates/ank-cli/src/cli.rs
+  - crates/ank-contract/src/lib.rs
+about: TASK-e655d28c83cb
+seq: 1
+records: edit
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-1b1eb4bd1aae.md
+++ b/.ank/entities/LOG-1b1eb4bd1aae.md
@@ -1,0 +1,20 @@
+---
+id: LOG-1b1eb4bd1aae
+type: log
+title: done, proof commit:737d204179536e8ef2244dd6b37ced362eb03e94
+created: 2026-08-25T17:41:03Z
+author: claude-code/opus-5+citation-repair
+scope:
+  - crates/ank-contract/src/lib.rs
+  - crates/ank-mcp/**
+  - crates/ank-daemon/**
+  - .github/**
+  - install.sh
+  - install.ps1
+  - npm/**
+  - docs/**
+about: TASK-cf075f0e287d
+seq: 0
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-3ec72c6104bf.md
+++ b/.ank/entities/LOG-3ec72c6104bf.md
@@ -1,0 +1,19 @@
+---
+id: LOG-3ec72c6104bf
+type: log
+title: +scope .github/scripts/** (version 2 to 3, replaced 60320e25e8e6, produced 1319b82479b0)
+created: 2026-08-25T17:22:11Z
+author: haksolot@vmi3223161
+scope:
+  - .github/workflows/**
+  - install.sh
+  - install.ps1
+  - npm/**
+  - docs/**
+  - .github/scripts/**
+about: TASK-d9b167250aa8
+seq: 1
+records: edit
+schema: 4
+version: 1
+---

--- a/.ank/entities/TASK-cf075f0e287d.md
+++ b/.ank/entities/TASK-cf075f0e287d.md
@@ -1,0 +1,24 @@
+---
+id: TASK-cf075f0e287d
+type: task
+slug: re-point-every-citation-the-two-supersessions-or
+title: Re-point every citation the two supersessions orphaned
+created: 2026-08-25T17:33:12Z
+author: haksolot@vmi3223161
+status: in_progress
+scope:
+  - crates/ank-contract/src/lib.rs
+  - crates/ank-mcp/**
+  - crates/ank-daemon/**
+  - .github/**
+  - install.sh
+  - install.ps1
+  - npm/**
+  - docs/**
+blocked_by: []
+done_criteria: |
+  No file in the workspace cites ADR-372b82af1ec7 or ADR-e39a44f80e0e: every site names the decision that binds it today, or drops the citation and leaves the history to ank show. no_superseded_document_is_cited_in_the_workspace passes. Nothing else changes: no behaviour, no interface, no test assertion beyond the citations themselves, and cargo test --workspace is green with cargo fmt --check passing.
+criteria_by: creator
+schema: 4
+version: 2
+---

--- a/.ank/entities/TASK-cf075f0e287d.md
+++ b/.ank/entities/TASK-cf075f0e287d.md
@@ -5,7 +5,7 @@ slug: re-point-every-citation-the-two-supersessions-or
 title: Re-point every citation the two supersessions orphaned
 created: 2026-08-25T17:33:12Z
 author: haksolot@vmi3223161
-status: in_progress
+status: done
 scope:
   - crates/ank-contract/src/lib.rs
   - crates/ank-mcp/**
@@ -19,6 +19,11 @@ blocked_by: []
 done_criteria: |
   No file in the workspace cites ADR-372b82af1ec7 or ADR-e39a44f80e0e: every site names the decision that binds it today, or drops the citation and leaves the history to ank show. no_superseded_document_is_cited_in_the_workspace passes. Nothing else changes: no behaviour, no interface, no test assertion beyond the citations themselves, and cargo test --workspace is green with cargo fmt --check passing.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 737d204179536e8ef2244dd6b37ced362eb03e94
+    criteria: 6dbd4b930046
+    via: submitted
 schema: 4
-version: 2
+version: 4
 ---

--- a/.ank/entities/TASK-d9b167250aa8.md
+++ b/.ank/entities/TASK-d9b167250aa8.md
@@ -12,10 +12,11 @@ scope:
   - install.ps1
   - npm/**
   - docs/**
+  - .github/scripts/**
 blocked_by: [TASK-e655d28c83cb, TASK-9dd22f2b0430]
 done_criteria: |
   release.yml builds and packages one binary per target, install.sh and install.ps1 place one file, and npm-assemble.sh names one per platform package. No workflow, script or manifest in the tree mentions ank-mcp or ank-daemon as a file to build, copy, stage or install, and grep is the check. install.yml no longer stages a stand-in for a second binary. docs/integrating.md states how a client reaches the protocol surface with a configuration naming ank and the verb mcp, and no document still tells a reader the watcher is built from the workspace and shipped by nothing. cargo test is green and ank check reports no fault.
 criteria_by: creator
 schema: 4
-version: 2
+version: 3
 ---

--- a/.ank/entities/TASK-e655d28c83cb.md
+++ b/.ank/entities/TASK-e655d28c83cb.md
@@ -9,10 +9,11 @@ status: open
 scope:
   - crates/ank-mcp/**
   - crates/ank-cli/src/cli.rs
+  - crates/ank-contract/src/lib.rs
 blocked_by: [TASK-36666e36744e]
 done_criteria: |
   crates/ank-mcp declares a library target and no [[bin]], and ank dispatches mcp: the verb serves the same JSON-RPC over stdio the sibling binary served, over every verb COMMANDS carries, and it spawns ank per call rather than linking the dispatch. A test drives the built ank through initialize, tools/list and one tools/call over a temporary corpus and shows the same tool count and the same document the sibling binary answered. cargo build --workspace produces one executable named ank and no ank-mcp. The line naming mcp is gone from NOT_YET_DISPATCHED in the same commit. cargo test is green and cargo fmt --check passes.
 criteria_by: creator
 schema: 4
-version: 2
+version: 3
 ---

--- a/.github/scripts/check-version.sh
+++ b/.github/scripts/check-version.sh
@@ -93,7 +93,7 @@ compare() {
 
 # ank-mcp is here for the same reason ank-cli is: the release ships it, in every
 # archive and every npm package, and the smoke job asserts it answers --version
-# with the number ank answers with (ADR-e39a44f80e0e). A tag that bumped ank-cli
+# with the number ank answers with. A tag that bumped ank-cli
 # and left ank-mcp behind would pass this gate and then break on the tag itself,
 # which is the loop this whole job exists to spare.
 for crate in ank-cli ank-core ank-mcp; do

--- a/.github/scripts/npm-assemble.sh
+++ b/.github/scripts/npm-assemble.sh
@@ -8,9 +8,9 @@
 # first. Nothing here downloads anything, which is the property the whole
 # channel exists for (npm/README.md).
 #
-# Two executables per platform package, never one: ADR-e39a44f80e0e makes
-# ank-mcp freight of every route that carries ank, so the pair travels in one
-# package under one version and an install cannot end up holding half of it.
+# Two executables per platform package, never one: ank-mcp is freight of every
+# route that carries ank, so the pair travels in one package under one version
+# and an install cannot end up holding half of it. TASK-d9b167250aa8 reduces this to one.
 #
 #   npm-assemble.sh <version> [package ...]
 #

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -305,7 +305,7 @@ jobs:
           }
           echo "--no-welcome is accepted, and changes nothing"
 
-      # What ADR-e39a44f80e0e asks for, measured where the criterion puts it:
+      # What the pairing rule asks for, measured where the criterion puts it:
       # not that the script contains a line about ank-mcp, but that the
       # directory it installed into holds two executables, that both answer
       # --version, and that they answer with one version.
@@ -999,7 +999,7 @@ jobs:
           "-NoWelcome is accepted, and changes nothing"
           exit 0
 
-      # What ADR-e39a44f80e0e asks for, measured where the criterion puts it:
+      # What the pairing rule asks for, measured where the criterion puts it:
       # not that the script contains a line about ank-mcp, but that the
       # directory it installed into holds two executables, that both answer
       # --version, and that they answer with one version.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,7 +127,7 @@ jobs:
       - name: test
         run: cargo test --workspace --target ${{ matrix.target }}
 
-      # Both executables, one invocation, one checkout (ADR-e39a44f80e0e). Two
+      # Both executables, one invocation, one checkout. Two
       # `cargo build` lines would compile the same table twice and could be
       # made to disagree; one line cannot. `ank-mcp` is a generated passthrough
       # over `ank_contract::COMMANDS`, so a surface built from an older table
@@ -150,7 +150,7 @@ jobs:
           esac
           name="ank-${version}-${{ matrix.target }}"
           mkdir -p "dist/${name}"
-          # Both, into every archive. ADR-e39a44f80e0e: where a route places
+          # Both, into every archive: where a route places
           # ank, it places ank-mcp next to it, and the archive is the route
           # install.sh and install.ps1 unpack.
           if [ "${{ matrix.archive }}" = "zip" ]; then
@@ -204,7 +204,7 @@ jobs:
       # release page serves and what install.sh and install.ps1 unpack, and a
       # `cp` that silently did not happen leaves the executable in `target/`
       # and out of the tarball -- where nothing else in this file would notice.
-      # ADR-e39a44f80e0e says no route carries one without the other; this is
+      # No route carries one without the other; this is
       # that condition, asserted on the artefact rather than assumed from the
       # step above it.
       - name: the archive carries both executables
@@ -423,7 +423,7 @@ jobs:
           echo "npx:    $actual"
           test "$expected" = "$actual"
 
-      # The criterion of ADR-e39a44f80e0e, on the machine that will run it. The
+      # The pairing criterion, on the machine that will run it. The
       # two executables come out of one `cargo build`, and the observable form
       # of that is answering `--version` with one number.
       #

--- a/crates/ank-contract/src/lib.rs
+++ b/crates/ank-contract/src/lib.rs
@@ -13,7 +13,7 @@
 //!
 //! **Nothing here decides anything.** The table says what the surface *is*; it
 //! never says what a verb does. `ank-cli` parses against it, dispatches from
-//! it, and renders `help` out of it; ADR-372b82af1ec7's protocol surface is
+//! it, and renders `help` out of it; ADR-fd98f4bc6dea's protocol surface is
 //! generated from the same table for the same reason. A reader who wants the
 //! description rather than the types has `ank help --json`, which is generated
 //! from exactly what is here.

--- a/crates/ank-daemon/src/main.rs
+++ b/crates/ank-daemon/src/main.rs
@@ -3,9 +3,9 @@
 //!
 //! **It answers no verb.** There is no query surface here, no socket, no
 //! protocol and no subset of the CLI wearing a different name. A caller that
-//! wants an answer runs `ank`, which finds a cache already warm. ADR-372b82af1ec7
-//! settled that a second surface is a generated full passthrough or it does not
-//! exist, and a daemon answering the three questions a board finds convenient
+//! wants an answer runs `ank`, which finds a cache already warm.
+//! ADR-fd98f4bc6dea settles that a second surface is a generated full
+//! passthrough or it does not exist, and a daemon answering the three questions a board finds convenient
 //! would be the curated subset that decision refused, arrived at from the other
 //! direction.
 //!
@@ -157,9 +157,9 @@ fn run(args: &[String], out: &mut dyn Write, err: &mut dyn Write) -> Result<Exit
         return Ok(ExitCode::Ok);
     }
     if args.iter().any(|a| a == "--version") {
-        // The shape `ank --version` uses, and the same number: the binaries come
-        // out of one build (ADR-e39a44f80e0e), so a caller holding both reads
-        // one answer rather than two it has to reconcile.
+        // The shape `ank --version` uses, and the same number: both come out of
+        // one build, so a caller holding both reads one answer rather than two
+        // it has to reconcile.
         let _ = writeln!(out, "ank-daemon {}", env!("CARGO_PKG_VERSION"));
         return Ok(ExitCode::Ok);
     }

--- a/crates/ank-daemon/src/warm.rs
+++ b/crates/ank-daemon/src/warm.rs
@@ -44,9 +44,8 @@ use std::process::{Command, Stdio};
 /// binaries in unusual places uses; it is checked first so neither has to
 /// arrange a `PATH`.
 ///
-/// **Then beside this binary**, which is the rule the release already follows
-/// for the pair it ships (ADR-e39a44f80e0e): where a route places `ank`, it
-/// places its siblings next to it. Then `PATH`, which is where a reader who
+/// **Then beside this binary**, which is where the release puts `ank` today:
+/// what a route places, it places together. Then `PATH`, which is where a reader who
 /// installed one and built the other will have it.
 pub fn locate_ank() -> Result<PathBuf> {
     if let Some(told) = std::env::var_os("ANK_BIN").filter(|v| !v.is_empty()) {

--- a/crates/ank-mcp/Cargo.toml
+++ b/crates/ank-mcp/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "ank-mcp"
-# ank-cli's version, and not a version of its own. The two binaries ship out of
-# one build and one archive (ADR-e39a44f80e0e), so a caller holding both has no
-# way to ask which of two numbers describes the pair -- and the release asserts
+# ank-cli's version, and not a version of its own. Both are built out of one
+# build and land in one archive today, so a caller holding both has no way to
+# ask which of two numbers describes the pair -- and the release asserts
 # they answer `--version` alike, on all three platforms, before it publishes
 # anything. check-version.sh holds this literal to the tag with the others.
 version = "0.6.0"
@@ -21,7 +21,7 @@ path = "src/main.rs"
 [dependencies]
 # The table this surface is generated from, and the writer it shares with the
 # CLI (ADR-6fd69efb629c). A verb the table does not carry is a verb neither
-# surface has, which is the whole condition ADR-372b82af1ec7 set.
+# surface has, which is the whole condition ADR-fd98f4bc6dea carries forward.
 ank-contract = { path = "../ank-contract" }
 # **No new crate enters the tree for this.** JSON-RPC has to be *read*, and
 # nothing here wrote a parser before: `ank-contract::json` writes and does not

--- a/crates/ank-mcp/src/call.rs
+++ b/crates/ank-mcp/src/call.rs
@@ -18,9 +18,11 @@ use std::process::Command;
 
 /// Where the `ank` binary is, given that this one is its sibling.
 ///
-/// Beside this executable first, because ADR-372b82af1ec7 says the protocol
-/// surface ships from this repository as a sibling binary: the two travel
-/// together, so the copy next to us is the copy we were released with. `PATH` is
+/// Beside this executable first: the two travel together today, so the copy
+/// next to us is the copy we were released with. That siblinghood is on its way
+/// out -- ADR-fd98f4bc6dea makes this surface a verb of the one binary, and
+/// TASK-e655d28c83cb is where the file folds in -- but the road out of this
+/// process does not change with it: the verb spawns `ank` exactly as this does. `PATH` is
 /// the fallback, and `ANK_BIN` overrides both for a caller that has a reason.
 ///
 /// Getting this wrong silently would be the worst failure available here: a
@@ -120,7 +122,7 @@ pub struct Arguments {
 ///
 /// The identity is the server's and is typed (§3, ADR-3877d2b7c0f5). One stdio
 /// server serves one client, so one process is one caller: nothing here pools
-/// several clients under a single identity, which ADR-372b82af1ec7 forbids, and
+/// several clients under a single identity, which ADR-fd98f4bc6dea forbids, and
 /// nothing holds a claim on a client's behalf either. The claim a call takes is
 /// the claim the CLI would have taken in that clone, on the same ref, arbitrated
 /// by the same compare-and-swap.

--- a/crates/ank-mcp/src/main.rs
+++ b/crates/ank-mcp/src/main.rs
@@ -1,6 +1,6 @@
 //! The Ank protocol surface: every verb, over MCP, generated from one table.
 //!
-//! ADR-372b82af1ec7 permits this and permits nothing else: a full-surface
+//! ADR-fd98f4bc6dea permits this and permits nothing else: a full-surface
 //! passthrough or no surface at all. It supersedes an earlier refusal, kept
 //! whole as the shape of what is now allowed. The proposal that refusal rejected
 //! exposed four verbs out of twenty-two, which rebuilt under a
@@ -13,11 +13,13 @@
 //! has is what the CLI dispatches, and it cannot be otherwise without an edit to
 //! the table both consume.
 //!
-//! **One process speaks for one corpus.** Addressed once, at startup, the way
-//! `--repo` addresses one. A per-call repository would make one server several
-//! corpora and invent an arbitration `refs/ank/*` cannot carry, which is the one
-//! thing ADR-372b82af1ec7 spells out at length: claims stay per repository, and a
-//! deployment over several is several servers.
+//! **One process speaks for one corpus, for now.** Addressed once, at startup,
+//! the way `--repo` addresses one. ADR-fd98f4bc6dea permits several, each
+//! addressed on its own, and TASK-2f31789f6af2 is where a call learns to name
+//! which; what that decision keeps in the same words is the ban this paragraph
+//! was written for. A server may never merge two claim spaces, because
+//! `refs/ank/*` is per repository and merging them would invent an arbitration
+//! the refs cannot carry.
 //!
 //! **This does not make a protocol the preferred route.** §2's common denominator
 //! is shell, that is still what the skill teaches, and this exists for the client

--- a/crates/ank-mcp/src/tools.rs
+++ b/crates/ank-mcp/src/tools.rs
@@ -1,10 +1,10 @@
-//! The tool list, generated from the verb table (ADR-372b82af1ec7).
+//! The tool list, generated from the verb table (ADR-fd98f4bc6dea).
 //!
 //! **Nothing here names a verb.** The list is [`COMMANDS`] walked, so a verb the
 //! table gains reaches this surface with no edit in this crate, and a verb it
 //! does not carry is a verb this surface does not have. That is the condition
-//! ADR-372b82af1ec7 answered, on terms the refusal it replaced had written for
-//! itself: not a curated subset, not parity kept by review, generated.
+//! this surface was permitted on (ADR-fd98f4bc6dea), on terms the refusal it
+//! replaced had written for itself: not a curated subset, not parity kept by review, generated.
 //!
 //! What a tool advertises is what the table already knows: the summary as the
 //! description, the positionals and flags as the input schema, the refusals with
@@ -21,9 +21,12 @@ use ank_contract::{CommandSpec, COMMANDS};
 /// the arguments the table gives it. What is withheld is the three flags that
 /// would let a caller contradict the process it is talking to.
 ///
-/// `--repo` because the server speaks for **exactly one corpus**, addressed once
-/// at startup: a per-call repository would make one process several corpora,
-/// which is the merged claim space ADR-372b82af1ec7 forbids in as many words.
+/// `--repo` because the corpus a call runs against is the server's to choose and
+/// never the caller's: today that is the one it was addressed with at startup,
+/// and under ADR-fd98f4bc6dea it becomes one of the several its reader declared,
+/// named by a `corpus` argument the table validates (TASK-2f31789f6af2). Either
+/// way a caller cannot reach a corpus by writing a path into a flag, which is
+/// what would turn a declared set into a merged one.
 /// `--json` because the server always wants the machine document and a client
 /// asking for the human one would get a shape nothing describes. `--quiet` means
 /// nothing to a caller that reads a return value rather than a terminal.

--- a/crates/ank-mcp/tests/mcp.rs
+++ b/crates/ank-mcp/tests/mcp.rs
@@ -19,9 +19,9 @@ use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicU64, Ordering};
 
 fn bin(name: &str) -> PathBuf {
-    // The sibling rule the server itself follows: `ank` sits beside `ank-mcp`
-    // because ADR-372b82af1ec7 ships them together. In a test tree that is
-    // `target/<profile>/`, which is also where cargo puts both.
+    // The rule the server itself follows: `ank` sits beside `ank-mcp`, because
+    // the two are built together. In a test tree that is `target/<profile>/`,
+    // which is also where cargo puts both.
     let mcp = PathBuf::from(env!("CARGO_BIN_EXE_ank-mcp"));
     let dir = mcp.parent().expect("a built binary has a directory");
     let exe = if cfg!(windows) {
@@ -175,7 +175,7 @@ fn the_surface_it_advertises_is_the_table_and_nothing_else() {
     assert_eq!(
         listed, table,
         "the advertised surface is not the table, in the table's order. \
-         ADR-372b82af1ec7 allows a full-surface passthrough and nothing else, so \
+         ADR-fd98f4bc6dea allows a full-surface passthrough and nothing else, so \
          any difference here is either a curated subset or a list somebody wrote \
          by hand"
     );
@@ -238,8 +238,8 @@ fn the_server_refuses_a_flag_that_would_make_it_two_corpora() {
     );
     assert!(
         replies[0].contains("belongs to the server"),
-        "--repo must be refused by name: one process speaks for one corpus \
-         (ADR-372b82af1ec7): {}",
+        "--repo must be refused by name: the corpus is the server's to choose \
+         and never the caller's (ADR-fd98f4bc6dea): {}",
         replies[0]
     );
     assert!(

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -38,7 +38,7 @@ instructions predate its tool.
 
 Every route places a second executable beside `ank`: **`ank-mcp`**, the same
 verbs over MCP, for a client that has no shell to run them in. It is freight of
-the three install routes rather than a fourth beside them (ADR-e39a44f80e0e),
+the three install routes rather than a fourth beside them,
 so there is nothing further to fetch:
 
     $ ank-mcp --version

--- a/docs/integrating.md
+++ b/docs/integrating.md
@@ -237,13 +237,13 @@ side, which is what makes them worth copying.
 ## The protocol surface is the same verbs, over MCP
 
 A client with no shell reaches ank through `ank-mcp`, which installs beside the
-CLI by every route that installs the CLI (ADR-e39a44f80e0e). The configuration
+CLI by every route that installs the CLI. The configuration
 to paste is in [getting-started.md](getting-started.md); what it *is* belongs
 here, because four properties of it are load-bearing and none of them is
 visible from a tool list.
 
 **Every verb `COMMANDS` carries, generated from that table.** Not a curated
-subset, under any protocol (ADR-372b82af1ec7). It is the same table `ank help
+subset, under any protocol (ADR-fd98f4bc6dea). It is the same table `ank help
 --json` is generated from, walked: the summary becomes the tool description, the
 refusals and their exit codes are written into it so a client can read what a
 call will refuse before making it, and the flags become the input schema. One
@@ -307,7 +307,7 @@ Everything else worth knowing about it as an integrator is what it refuses to be
 **It is not a surface.** No socket, no protocol, no query of its own, and no
 subset of the verbs. There is nothing here to ask: a caller that wants an answer
 runs the CLI, or talks to `ank-mcp`. A daemon answering the three questions a
-dashboard finds convenient would be the curated subset ADR-372b82af1ec7 refused,
+dashboard finds convenient would be the curated subset ADR-fd98f4bc6dea refuses,
 reached from the other direction, and it would be a third dispatch path in a
 project that has spent its history reducing to one. It does *tell* you when a
 corpus it watches changes, on a stream described below, and that is push and

--- a/install.ps1
+++ b/install.ps1
@@ -12,8 +12,8 @@ differently.
 
 Two executables land and not one: ank.exe, and ank-mcp.exe beside it, the
 protocol surface a client speaks to. They come out of one archive and go into
-one directory, because ADR-e39a44f80e0e says no route carries one without the
-other. An archive published before ank-mcp existed carries only ank.exe, and
+one directory, and no route carries one without the other. That pairing ends
+with TASK-d9b167250aa8, which leaves one executable to install. An archive published before ank-mcp existed carries only ank.exe, and
 -Version points this script at exactly those: such a release installs ank.exe
 and is told what is missing, rather than becoming a route that stopped working.
 
@@ -897,7 +897,7 @@ try {
         )
     }
 
-    # The other half of ADR-e39a44f80e0e: where a route places ank, it places
+    # The other half of the same rule: where this route places ank, it places
     # ank-mcp next to it. Missing only from an archive older than the protocol
     # surface itself, which is a release -Version still reaches, so its absence
     # is reported at the end rather than refused here.

--- a/install.sh
+++ b/install.sh
@@ -7,8 +7,8 @@
 #
 # Two executables land and not one: `ank`, and `ank-mcp` beside it, the protocol
 # surface a client speaks to. They come out of one archive and go into one
-# directory, because ADR-e39a44f80e0e says no route carries one without the
-# other. An archive published before ank-mcp existed carries only `ank`, and
+# directory, and no route carries one without the other. That pairing ends with
+# TASK-d9b167250aa8, which leaves one executable to install. An archive published before ank-mcp existed carries only `ank`, and
 # --version points this script at exactly those: such a release installs `ank`
 # and is told what is missing, rather than becoming a route that stopped
 # working.
@@ -630,7 +630,7 @@ if [ ! -f "$binary" ]; then
     "Nothing was installed."
 fi
 
-# The other half of ADR-e39a44f80e0e: where a route places ank, it places
+# The other half of the same rule: where this route places ank, it places
 # ank-mcp next to it. Missing only from an archive older than the protocol
 # surface itself, which is a release --version still reaches, so its absence is
 # reported at the end rather than refused here.

--- a/npm/README.md
+++ b/npm/README.md
@@ -21,7 +21,7 @@ the platform package with `require.resolve` and executes what it finds.
 
 **Two executables, one package, one version.** Each platform package carries
 `ank` and `ank-mcp`, the protocol surface, out of the same build
-(ADR-e39a44f80e0e): no route carries one without the other, so there is no
+: no route carries one without the other, so there is no
 install holding a CLI and a passthrough generated from a different table. The
 wrapper declares both as `bin` and resolves them by one route -- `bin/ank` and
 `bin/ank-mcp` are two lines each, and `bin/wrapper.js` is the resolution, the

--- a/npm/ank/bin/ank-mcp
+++ b/npm/ank/bin/ank-mcp
@@ -2,6 +2,6 @@
 "use strict";
 
 // The protocol surface, resolved through the same platform package as `ank` by
-// the same wrapper (ADR-e39a44f80e0e). A client points its MCP configuration at
+// the same wrapper. A client points its MCP configuration at
 // this name; the reasoning is in wrapper.js.
 require("./wrapper.js").run("ank-mcp");

--- a/npm/ank/bin/wrapper.js
+++ b/npm/ank/bin/wrapper.js
@@ -12,7 +12,7 @@
 // `os` and `cpu` through optionalDependencies.
 //
 // `ank` and `ank-mcp` come out of one build and travel in one platform package
-// (ADR-e39a44f80e0e), so they resolve by one route. Two copies of this file,
+// out of one package, so they resolve by one route. Two copies of this file,
 // one per bin, is the arrangement where the protocol surface quietly stops
 // resolving the way the CLI does and nothing turns red: the resolution, the
 // diagnostics and the exit-code passthrough are written once and `run` is


### PR DESCRIPTION
**`main` is red and this makes it green.** Ratifying `ADR-fd98f4bc6dea` and `ADR-1ea31c2f3c5a` failed `no_superseded_document_is_cited_in_the_workspace` on all three platforms. That test walks every crate and fails on a citation of a superseded document, so the 35 warnings `accept` printed were not advisory: sixteen were a failing test, and the rest were the same defect in files the test does not walk.

That gap was mine — the plan should have carried a citation-repair task landing with the ratification. It is now `TASK-cf075f0e287d`, done, proof `commit:737d204`.

## Telling the two repairs apart was the work

The test asks for one of two things: name the decision that binds today, or drop the citation and leave the history to `ank show`. Both were needed.

**Re-pointed** where the successor carries the rule forward in the same words — generated from the table, no curated subset under any protocol, no pooling of clients under one identity. `ADR-fd98` keeps all three.

**Dropped or rewritten** where the ratification made the sentence false. This is the half that mattered: re-pointing mechanically would have produced comments citing `ADR-fd98` in support of claims it does not make — sourced-looking, wrong, and invisible to grep forever after.

Six sites were in that class:

- `call.rs` explained the sibling binary as something `ADR-372b` *required*
- `main.rs` stated "one process speaks for exactly one corpus" as settled
- `tools.rs` justified refusing `--repo` by a merged claim space

Behaviour is untouched — that is `TASK-e655d28c83cb` and `TASK-2f31789f6af2`. Each site now describes what the code does today and names the task that changes it.

The packaging and documentation citations drop rather than move: they describe machinery `TASK-d9b167250aa8` removes.

## Also: two scope gaps the same warnings exposed

- `.github/scripts/check-version.sh` and `npm-assemble.sh` — `TASK-d9b1` declared `.github/workflows/**`, which does not reach `.github/scripts/`.
- `crates/ank-contract/src/lib.rs` — cited `ADR-372b` for the table both surfaces read, and belonged to no task.

A citation nobody's scope reaches survives the wave meant to rewrite it.

`cargo test --workspace` green, `cargo fmt --check` passing, `ank check` 0 faults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhWoNxFoF1e5S2n5cbkoPC