### PR TITLE
The workspace stops citing the CLI surface document this supersession retires

### DIFF
--- a/.ank/entities/LOG-7676882b2b47.md
+++ b/.ank/entities/LOG-7676882b2b47.md
@@ -1,0 +1,15 @@
+---
+id: LOG-7676882b2b47
+type: log
+title: done, proof commit:d00e01dcb1ffe8ce2a7b58b5f01af324129057c1
+created: 2026-08-25T18:28:06Z
+author: claude-code/opus-5+citations
+scope:
+  - crates/ank-contract/src/verbs.rs
+  - crates/ank-tui/src/view.rs
+  - crates/ank-cli/tests/skill.rs
+about: TASK-d86955470592
+seq: 1
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-9f21c6f2f0b7.md
+++ b/.ank/entities/LOG-9f21c6f2f0b7.md
@@ -1,0 +1,21 @@
+---
+id: LOG-9f21c6f2f0b7
+type: log
+title: Six citations were the count; seven was the number. verbs.rs states the refusal every path-taking
+created: 2026-08-25T18:27:35Z
+author: claude-code/opus-5+citations
+scope:
+  - crates/ank-contract/src/verbs.rs
+  - crates/ank-tui/src/view.rs
+  - crates/ank-cli/tests/skill.rs
+about: TASK-d86955470592
+seq: 0
+schema: 4
+version: 1
+---
+
+ verb performs and cites the document that states it for all six at once, and SPEC-fe8bdb84faca carries that sentence verbatim (a path naming nothing inside the repository, because it is absolute or because it climbs above the root, is refused with the command to run next), so the citation moves and the comment keeps saying what binds. skill.rs recounts what TASK-8108e3771ba0 did once -- it put the tui line in the Commands block of SPEC-20357e21a45a, not of the successor -- so re-pointing there would have produced a sentence citing SPEC-fe8bdb84faca for an edit never made to it. That identifier drops; the two task ids stay, and ank show serves the rest.
+
+view.rs holds four fixture values and none of them was chosen for naming a retired document, which the workspace has a convention for: a_superseded_constraint_is_shown_with_its_status_and_never_counted_active writes ADR-0000ffff0001 and says why in the comment beside it. These four stand for an accepted spec titled 'The CLI surface' -- a snapshot row, the row a search for 'cli surface' narrows to, the entity open in the detail view, and the id the act passes through -- and the successor is that document under the same title, so all four move.
+
+The seventh was not in the full-id grep: the renderer abbreviates to eight characters, and the_list_names_every_kind_with_its_status_and_who_holds_what asserts on the literal 'SPEC-2035'. no_superseded_document_is_cited_in_the_workspace would never have caught it, and it turned the suite red on the rename instead. Now SPEC-fe8b. Swept 20357e21 and SPEC-2035 across the workspace afterwards: nothing outside .ank/, where entities cite history legitimately and the walk does not go.

--- a/.ank/entities/TASK-d86955470592.md
+++ b/.ank/entities/TASK-d86955470592.md
@@ -5,7 +5,7 @@ slug: the-workspace-stops-citing-the-cli-surface-docum
 title: The workspace stops citing the CLI surface document this supersession retires
 created: 2026-08-25T17:38:48Z
 author: claude-code/opus-5+spec-declares
-status: in_progress
+status: done
 scope:
   - crates/ank-contract/src/verbs.rs
   - crates/ank-tui/src/view.rs
@@ -14,8 +14,13 @@ blocked_by: [TASK-36666e36744e]
 done_criteria: |
   No file in the workspace cites SPEC-20357e21a45a. The six citations that survive its supersession -- crates/ank-contract/src/verbs.rs, four fixture values in crates/ank-tui/src/view.rs, and the history sentence in crates/ank-cli/tests/skill.rs -- either name the document that binds today or drop the citation and leave the history to ank show, read one sentence at a time as TASK-5f5752d724af read the previous set. no_superseded_document_is_cited_in_the_workspace passes. cargo test --workspace is green, cargo fmt --check passes, and ank check reports no fault.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: d00e01dcb1ffe8ce2a7b58b5f01af324129057c1
+    criteria: eb134e6d7ee2
+    via: submitted
 schema: 4
-version: 2
+version: 3
 ---
 
 The successor written by TASK-36666e36744e is `SPEC-fe8bdb84faca`, and the

--- a/.ank/entities/TASK-d86955470592.md
+++ b/.ank/entities/TASK-d86955470592.md
@@ -5,7 +5,7 @@ slug: the-workspace-stops-citing-the-cli-surface-docum
 title: The workspace stops citing the CLI surface document this supersession retires
 created: 2026-08-25T17:38:48Z
 author: claude-code/opus-5+spec-declares
-status: open
+status: in_progress
 scope:
   - crates/ank-contract/src/verbs.rs
   - crates/ank-tui/src/view.rs
@@ -15,7 +15,7 @@ done_criteria: |
   No file in the workspace cites SPEC-20357e21a45a. The six citations that survive its supersession -- crates/ank-contract/src/verbs.rs, four fixture values in crates/ank-tui/src/view.rs, and the history sentence in crates/ank-cli/tests/skill.rs -- either name the document that binds today or drop the citation and leave the history to ank show, read one sentence at a time as TASK-5f5752d724af read the previous set. no_superseded_document_is_cited_in_the_workspace passes. cargo test --workspace is green, cargo fmt --check passes, and ank check reports no fault.
 criteria_by: creator
 schema: 4
-version: 1
+version: 2
 ---
 
 The successor written by TASK-36666e36744e is `SPEC-fe8bdb84faca`, and the

--- a/crates/ank-cli/tests/skill.rs
+++ b/crates/ank-cli/tests/skill.rs
@@ -231,11 +231,11 @@ fn help_order() -> Vec<String> {
 /// puts it in §4: between the two sits a signed `accept`, which is a human act.
 ///
 /// `tui` went the same way. TASK-8108e3771ba0 put the line in the Commands
-/// block of SPEC-20357e21a45a and declared the verb here, the ratification of
-/// that document was signed, and TASK-49746735127f dispatched the verb and
-/// removed the declaration in the commit that did it -- which is what the
-/// second test below forces: a declared verb that has started shipping fails
-/// until the line is gone.
+/// block of the §4 document of the day and declared the verb here, the
+/// ratification of that revision was signed, and TASK-49746735127f dispatched
+/// the verb and removed the declaration in the commit that did it -- which is
+/// what the second test below forces: a declared verb that has started
+/// shipping fails until the line is gone.
 ///
 /// These two are in exactly that state (ADR-fd98f4bc6dea, ADR-a22cd3196529,
 /// TASK-36666e36744e). The protocol surface and the watcher stop being sibling

--- a/crates/ank-contract/src/verbs.rs
+++ b/crates/ank-contract/src/verbs.rs
@@ -409,7 +409,7 @@ const fn refuses(code: ExitCode, when: &'static str) -> Refusal {
 /// The refusal every path-taking verb performs, declared once and named six
 /// times.
 ///
-/// SPEC-20357e21a45a states it for all of them at once — a path naming nothing
+/// SPEC-fe8bdb84faca states it for all of them at once — a path naming nothing
 /// inside the repository, because it is absolute or because it climbs above the
 /// root, is refused with the command to run next and never answered — and the
 /// six verbs reach it through one helper, `context::normalised`. One sentence

--- a/crates/ank-tui/src/view.rs
+++ b/crates/ank-tui/src/view.rs
@@ -1062,7 +1062,7 @@ mod tests {
             entities: vec![
                 row("ADR-8bd76e8d7c4e", "adr", "accepted", "A terminal reader"),
                 row("TASK-49746735127f", "task", "in_progress", "ank tui opens"),
-                row("SPEC-20357e21a45a", "spec", "accepted", "The CLI surface"),
+                row("SPEC-fe8bdb84faca", "spec", "accepted", "The CLI surface"),
             ],
             total: 3,
         }
@@ -1151,7 +1151,7 @@ mod tests {
         for expected in [
             "ADR-8bd7",
             "TASK-4974",
-            "SPEC-2035",
+            "SPEC-fe8b",
             "accepted",
             "in_progress",
             "claude-code/opus-5+tui-verb",
@@ -1200,7 +1200,7 @@ mod tests {
         a.act(Command::Search(Some("cli surface".to_string())), &ank);
         let f = a.list_frame();
         assert!(f.contains("matching 'cli surface'"), "{f}");
-        assert_eq!(rendered_rows(&a), ["SPEC-20357e21a45a"], "{f}");
+        assert_eq!(rendered_rows(&a), ["SPEC-fe8bdb84faca"], "{f}");
     }
 
     #[test]
@@ -1398,7 +1398,7 @@ mod tests {
     fn an_act_in_the_entity_view_is_about_the_entity_that_is_open() {
         let mut a = app();
         let ank = nowhere();
-        a.detail = Some(detail("SPEC-20357e21a45a", "body\n"));
+        a.detail = Some(detail("SPEC-fe8bdb84faca", "body\n"));
         a.view = View::Entity;
         // The cursor is still on the first row of the list, which is the ADR.
         assert_eq!(
@@ -1414,7 +1414,7 @@ mod tests {
         );
         let said = a.note.clone().unwrap_or_default();
         assert!(
-            said.contains("ank claim SPEC-20357e21a45a --json"),
+            said.contains("ank claim SPEC-fe8bdb84faca --json"),
             "{said}"
         );
     }


### PR DESCRIPTION
Closes TASK-d86955470592 (`ank show TASK-d86955470592`), proof `commit:d00e01dcb1ffe8ce2a7b58b5f01af324129057c1`.

SPEC-fe8bdb84faca is `proposed` and supersedes SPEC-20357e21a45a. The moment it is signed, `no_superseded_document_is_cited_in_the_workspace` reads every surviving citation of the predecessor as stale and turns main red on all three platforms — the sequence that broke main after ADR-372b82af1ec7 and ADR-e39a44f80e0e, and that TASK-cf075f0e287d repaired afterwards. **This lands the repair before the signature**, so `accept` has nothing to break.

## The reading

Both halves of what the test allows were needed, and telling them apart was the work.

**Re-pointed** — `crates/ank-contract/src/verbs.rs`. The comment states the refusal every path-taking verb performs and cites the document that states it for all six at once. SPEC-fe8bdb84faca carries that sentence verbatim (*a path naming nothing inside the repository, because it is absolute or because it climbs above the root, is refused with the command to run next*), so the citation moves and the comment keeps saying what binds.

**Dropped** — `crates/ank-cli/tests/skill.rs`. The sentence recounts what TASK-8108e3771ba0 did once, and what it did was put the `tui` line in the Commands block of *SPEC-20357e21a45a*, not of the successor. Re-pointing would have produced a comment citing SPEC-fe8bdb84faca for an edit nobody made to it: it reads as sourced, it is wrong, and no grep would ever find it again. The identifier goes; both task ids stay, and `ank show` serves the history.

**Re-pointed** — four fixture values in `crates/ank-tui/src/view.rs`. None was chosen for naming a retired document, and the workspace has a convention for the case that is: `a_superseded_constraint_is_shown_with_its_status_and_never_counted_active` writes `ADR-0000ffff0001` and says why in the comment beside it. These four stand for an *accepted* spec titled "The CLI surface" — a snapshot row, the row a search for `cli surface` narrows to, the entity open in the detail view, and the id the act passes through. The successor is that document under that title, so all four move.

## A seventh the guard could not have caught

The list renderer abbreviates identifiers to eight characters, and `the_list_names_every_kind_with_its_status_and_who_holds_what` asserts on the literal `SPEC-2035`. A full-id grep misses it and so does `no_superseded_document_is_cited_in_the_workspace`; it turned the suite red on the rename instead. Now `SPEC-fe8b`.

Swept `20357e21` and `SPEC-2035` across the workspace afterwards: **nothing survives outside `.ank/`**, where entities cite their own history legitimately and the walk does not go.

## Gates

- `cargo test --workspace` green — 322 + 309 + 69 + … , 0 failed
- `cargo fmt --check` passes
- `ank check` exit 0 — `ok — 301 tasks, 70 adr, 396 signal(s)`, no fault

No behaviour, no interface and no assertion changes beyond the identifiers themselves.

Not for this task, but noted for whoever lands the ratification: the paragraph under the dropped citation in `skill.rs` says SPEC-fe8bdb84faca "is `proposed`, so the test below does not check either entry yet — it walks the *ratified* block, which is the predecessor and does not carry the lines." That sentence is true today and stops being true on the signed `accept`. It names no retired identifier, so it is outside this criterion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Au7eZDohXTSLUrcvbnWr4e