### PR TITLE
A protocol surface call names its corpus, and reaches no corpus nobody declared

### DIFF
--- a/.ank/entities/LOG-9f58fbde1b22.md
+++ b/.ank/entities/LOG-9f58fbde1b22.md
@@ -1,0 +1,14 @@
+---
+id: LOG-9f58fbde1b22
+type: log
+title: done, proof commit:6315d6a99226ccc3fbdebe52d9022c16225629eb
+created: 2026-08-25T20:10:15Z
+author: claude-code/opus-5+multi-corpus
+scope:
+  - crates/ank-mcp/**
+  - crates/ank-cli/tests/mcp.rs
+about: TASK-2f31789f6af2
+seq: 4
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-bc3605d099db.md
+++ b/.ank/entities/LOG-bc3605d099db.md
@@ -1,0 +1,15 @@
+---
+id: LOG-bc3605d099db
+type: log
+title: A call names its corpus by the identity of ADR-621a7fd96ce1, resolved in
+created: 2026-08-25T20:09:23Z
+author: claude-code/opus-5+multi-corpus
+scope:
+  - crates/ank-mcp/**
+about: TASK-2f31789f6af2
+seq: 1
+schema: 4
+version: 1
+---
+
+ crates/ank-mcp/src/corpora.rs. Resolution returns ONE path and nothing above or below it ever holds two corpora at once: declared map lookup, then the startup corpus, then a refusal. Reachable = corpora.yml (read with serde_yaml and ank_contract::events::user_dir, no new dependency, no link to ank-cli) plus the corpus ank mcp was addressed with, whose own identity is asked of the binary once via ank status --json and cached. Both halves sit behind a OnceCell that a call omitting the argument never touches, so a single-corpus client reads no file, spawns nothing extra and sees byte-identical bytes. A value that is not 40 hex is refused before any lookup, which is what stops a path reaching --repo through the back door; an identity nobody declared is refused with error[9] and 'ank config --user corpora.<id> <path>', rendered through Outcome::to_result so a surface refusal and a spawned one cannot drift in shape. Code 9 follows ank-daemon/src/declare.rs, which uses Environment for every corpora-declaration failure; a declared path that is not a directory reuses repo.rs's own sentence and its Generic code. A declared corpus that cannot be read: consistent with TASK-1317adb617e8, the map is read silently and never fails a call, but the reason is kept so the refusal says 'could not be read' rather than accusing the caller of naming nothing.

--- a/.ank/entities/LOG-bdff73731190.md
+++ b/.ank/entities/LOG-bdff73731190.md
@@ -1,0 +1,15 @@
+---
+id: LOG-bdff73731190
+type: log
+title: +scope crates/ank-cli/tests/mcp.rs (version 3 to 4, replaced 770db7125ed3, produced 67852f7e1b0b)
+created: 2026-08-25T20:09:39Z
+author: claude-code/opus-5+multi-corpus
+scope:
+  - crates/ank-mcp/**
+  - crates/ank-cli/tests/mcp.rs
+about: TASK-2f31789f6af2
+seq: 3
+records: edit
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-f16ceca97f5a.md
+++ b/.ank/entities/LOG-f16ceca97f5a.md
@@ -1,0 +1,15 @@
+---
+id: LOG-f16ceca97f5a
+type: log
+title: "Scope excursion, stated rather than made quietly: the criterion demands a test driving the BUILT"
+created: 2026-08-25T20:09:37Z
+author: claude-code/opus-5+multi-corpus
+scope:
+  - crates/ank-mcp/**
+about: TASK-2f31789f6af2
+seq: 2
+schema: 4
+version: 1
+---
+
+ ank against two corpora through one server, and CARGO_BIN_EXE_ank is defined only for the package declaring that binary. TASK-e655d28c83cb moved the surface's integration suite to crates/ank-cli/tests/mcp.rs for exactly that mechanical reason and wrote it into that file's header. A suite in crates/ank-mcp/tests could only have found the binary by guessing a path under target/, which is the search ADR-fd98f4bc6dea celebrates having removed. So two_corpora_through_one_server_land_two_claims_and_no_third and its two siblings live in crates/ank-cli/tests/mcp.rs, and the task scope is amended to say so. Nothing under crates/ank-daemon/** or crates/ank-cli/src/cli.rs was touched: Address kept both its fields, so the dispatch compiles unchanged.

--- a/.ank/entities/TASK-2f31789f6af2.md
+++ b/.ank/entities/TASK-2f31789f6af2.md
@@ -5,7 +5,7 @@ slug: a-protocol-surface-call-names-its-corpus-and-rea
 title: A protocol surface call names its corpus, and reaches no corpus nobody declared
 created: 2026-08-25T16:53:18Z
 author: haksolot@vmi3223161
-status: in_progress
+status: done
 scope:
   - crates/ank-mcp/**
   - crates/ank-cli/tests/mcp.rs
@@ -13,6 +13,11 @@ blocked_by: [TASK-e655d28c83cb, TASK-1317adb617e8]
 done_criteria: |
   Every tool the surface generates carries an optional corpus argument holding the repository identity of ADR-621a7fd96ce1, and a call omitting it reaches the corpus ank mcp was addressed with at startup. An identity the reader declared in corpora.yml resolves to that corpus and the call runs against it; an identity nobody declared is refused by name, with the code section 4 declares and the command that resolves it, and nothing is spawned. A test drives the built ank against two temporary corpora through one server and shows a claim landing in each on its own refs/ank/claims, with neither corpus naming the other's task. cargo test is green and cargo fmt --check passes.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 6315d6a99226ccc3fbdebe52d9022c16225629eb
+    criteria: 8cab7e5084cd
+    via: submitted
 schema: 4
-version: 4
+version: 5
 ---

--- a/.ank/entities/TASK-2f31789f6af2.md
+++ b/.ank/entities/TASK-2f31789f6af2.md
@@ -5,13 +5,14 @@ slug: a-protocol-surface-call-names-its-corpus-and-rea
 title: A protocol surface call names its corpus, and reaches no corpus nobody declared
 created: 2026-08-25T16:53:18Z
 author: haksolot@vmi3223161
-status: open
+status: in_progress
 scope:
   - crates/ank-mcp/**
+  - crates/ank-cli/tests/mcp.rs
 blocked_by: [TASK-e655d28c83cb, TASK-1317adb617e8]
 done_criteria: |
   Every tool the surface generates carries an optional corpus argument holding the repository identity of ADR-621a7fd96ce1, and a call omitting it reaches the corpus ank mcp was addressed with at startup. An identity the reader declared in corpora.yml resolves to that corpus and the call runs against it; an identity nobody declared is refused by name, with the code section 4 declares and the command that resolves it, and nothing is spawned. A test drives the built ank against two temporary corpora through one server and shows a claim landing in each on its own refs/ank/claims, with neither corpus naming the other's task. cargo test is green and cargo fmt --check passes.
 criteria_by: creator
 schema: 4
-version: 2
+version: 4
 ---

--- a/crates/ank-cli/tests/mcp.rs
+++ b/crates/ank-cli/tests/mcp.rs
@@ -34,6 +34,16 @@ const ANK: &str = env!("CARGO_BIN_EXE_ank");
 
 /// A corpus with one task, built through the binary rather than by writing files.
 fn corpus() -> PathBuf {
+    corpus_titled("A task to find", None)
+}
+
+/// The same, with the task's title chosen and the reader's home named.
+///
+/// Both are what the multi-corpus suite needs and no other test does. A title
+/// tells two corpora apart in an answer, which is how "neither names the other's
+/// task" is asserted on content rather than on an id alone; a home is what makes
+/// the reader's declarations the test's and not the machine's.
+fn corpus_titled(title: &str, home: Option<&Path>) -> PathBuf {
     static SEQ: AtomicU64 = AtomicU64::new(0);
     let root = std::env::temp_dir().join(format!(
         "ank-mcp-it-{}-{}",
@@ -62,7 +72,7 @@ fn corpus() -> PathBuf {
     git(&["config", "commit.gpgsign", "false"]);
 
     let run = |args: &[&str]| {
-        let out = ank(&root, args);
+        let out = ank_at(&root, home, args);
         assert!(
             out.status.success(),
             "ank {args:?}: {}",
@@ -75,7 +85,7 @@ fn corpus() -> PathBuf {
         "new",
         "task",
         "--title",
-        "A task to find",
+        title,
         "--scope",
         "src/**",
         "--criteria",
@@ -94,12 +104,37 @@ fn corpus() -> PathBuf {
 /// back through the surface, and a call that ran under another identity or from
 /// another directory would be a different call.
 fn ank(repo: &Path, args: &[&str]) -> std::process::Output {
-    Command::new(ANK)
-        .args(args)
+    ank_at(repo, None, args)
+}
+
+/// The same run, with the reader's home named.
+///
+/// `None` leaves the machine's, which is what every single-corpus test wants:
+/// the corpora it builds are keyed on root commits nobody has declared anywhere,
+/// so the reader's real map answers nothing about them either way.
+fn ank_at(repo: &Path, home: Option<&Path>, args: &[&str]) -> std::process::Output {
+    let mut cmd = Command::new(ANK);
+    cmd.args(args)
         .current_dir(repo)
-        .env("ANK_AGENT", "test@ank.local")
-        .output()
-        .expect("the binary must have been built")
+        .env("ANK_AGENT", "test@ank.local");
+    if let Some(home) = home {
+        let (key, value) = reader_home(home);
+        cmd.env(key, value);
+    }
+    cmd.output().expect("the binary must have been built")
+}
+
+/// The environment variable that names where a reader's declarations live, and
+/// the value to give it for `home`.
+///
+/// The rule is `ank_contract::events::user_dir`'s, read from the outside: this
+/// is a test of the file the surface actually opens, so it must name it the way
+/// the surface resolves it and not the way one platform spells it.
+fn reader_home(home: &Path) -> (&'static str, PathBuf) {
+    match cfg!(windows) {
+        true => ("APPDATA", home.to_path_buf()),
+        false => ("XDG_CONFIG_HOME", home.to_path_buf()),
+    }
 }
 
 /// Sends every request, closes stdin, and returns the reply lines in order.
@@ -109,16 +144,25 @@ fn ank(repo: &Path, args: &[&str]) -> std::process::Output {
 /// -- which is what the verb bought over the sibling that had to go looking
 /// (ADR-fd98f4bc6dea).
 fn talk(repo: &Path, requests: &[&str]) -> Vec<String> {
-    let mut child = Command::new(ANK)
-        .arg("mcp")
+    talk_at(repo, None, requests)
+}
+
+/// The same session, with the reader's home named: one server, addressed with
+/// one corpus at startup, reaching whatever that home declares and nothing else.
+fn talk_at(repo: &Path, home: Option<&Path>, requests: &[&str]) -> Vec<String> {
+    let mut cmd = Command::new(ANK);
+    cmd.arg("mcp")
         .arg("--repo")
         .arg(repo)
         .env("ANK_AGENT", "test@ank.local")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("the binary must have been built");
+        .stderr(Stdio::piped());
+    if let Some(home) = home {
+        let (key, value) = reader_home(home);
+        cmd.env(key, value);
+    }
+    let mut child = cmd.spawn().expect("the binary must have been built");
     {
         let stdin = child.stdin.as_mut().expect("piped");
         for request in requests {
@@ -342,6 +386,325 @@ fn the_server_refuses_a_flag_that_would_make_it_two_corpora() {
         replies[1].contains("takes no --nonsense"),
         "a flag the verb does not take is refused by name, against the table: {}",
         replies[1]
+    );
+    let _ = std::fs::remove_dir_all(&repo);
+}
+
+// ---------------------------------------------------------------------------
+// Several corpora, and never a merged one (ADR-fd98f4bc6dea, TASK-2f31789f6af2)
+// ---------------------------------------------------------------------------
+//
+// **The clause under test is a distinction, so the test is about what does not
+// happen.** Multiplexing is permitted: one server may address several corpora,
+// each on its own, the way `--repo` addresses one. Merging is forbidden in the
+// same words the superseded decision used -- no merged claim space, no claim
+// held on a client's behalf, no arbitration across clones. Two claims taken
+// through one server is the permitted half; the forbidden half is only visible
+// as an absence, and the place an absence can be read is `refs/ank/claims`,
+// which is per repository and is where a merged claim space would have had to
+// leave a trace.
+//
+// **A temporary home, and not the machine's.** What a server may reach is what
+// the reader declared, so a test that used the developer's own `corpora.yml`
+// would be asserting something about their laptop. The declaration is written
+// with `ank config --user`, which is the verb that owns the file (§4,
+// ADR-96174f1ac2b7): the surface then finds it by resolving the same home, so a
+// disagreement about where that file lives fails here rather than in prose.
+
+/// A reader's home, empty, with no corpus declared in it yet.
+fn declaring_home() -> PathBuf {
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let home = std::env::temp_dir().join(format!(
+        "ank-mcp-home-{}-{}",
+        std::process::id(),
+        SEQ.fetch_add(1, Ordering::Relaxed)
+    ));
+    let _ = std::fs::remove_dir_all(&home);
+    std::fs::create_dir_all(&home).unwrap();
+    home
+}
+
+/// The repository identity of a corpus, read out of the binary.
+///
+/// `ank status --json` under `"corpus"` is where ADR-96174f1ac2b7 sends a reader
+/// looking for the key, and it is what the surface's own argument documents. So
+/// the value this test names a corpus with is the value a client would have
+/// obtained, rather than a root commit read out of git here.
+fn corpus_identity(repo: &Path, home: &Path) -> String {
+    let out = ank_at(repo, Some(home), &["status", "--json"]);
+    let text = String::from_utf8_lossy(&out.stdout).to_string();
+    let id = field(&text, "corpus").expect("status names the corpus it answered about");
+    assert_eq!(id.len(), 40, "an identity is a root commit: {id}");
+    id
+}
+
+/// Every claim ref a corpus holds, by the task each one names.
+fn claimed_tasks(repo: &Path) -> Vec<String> {
+    let out = Command::new("git")
+        .args(["for-each-ref", "--format=%(refname)", "refs/ank/claims"])
+        .current_dir(repo)
+        .output()
+        .expect("git is a hard dependency of this repository");
+    assert!(out.status.success(), "git for-each-ref failed");
+    String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .filter_map(|l| l.rsplit('/').next().map(str::to_string))
+        .collect()
+}
+
+/// One server, two corpora, two claims, and neither corpus carrying a trace of
+/// the other.
+///
+/// **This is the criterion, and every assertion below is one of its clauses.**
+/// A call omitting the argument reaches the corpus the process was addressed
+/// with, which is the backwards compatibility clause and is asserted first
+/// because every client that exists today makes exactly that call. A call naming
+/// a declared identity reaches that corpus and takes a claim there. An identity
+/// nobody declared is refused by name, with a §4 code and the command that
+/// resolves it, and -- the half that matters -- does not quietly fall back to
+/// the corpus the caller did not name. And each corpus ends holding its own
+/// claim on its own `refs/ank/claims`, naming its own task and nothing of the
+/// other's, which is the ban on a merged claim space made observable.
+#[test]
+fn two_corpora_through_one_server_land_two_claims_and_no_third() {
+    let home = declaring_home();
+    let one = corpus_titled("The task of the first corpus", Some(&home));
+    let two = corpus_titled("The task of the second corpus", Some(&home));
+    let id_two = corpus_identity(&two, &home);
+    let task_one = seeded_task(&one);
+    let task_two = seeded_task(&two);
+    assert_ne!(task_one, task_two, "two corpora mint two ids");
+
+    // Declared with the verb that owns the map. The startup corpus is
+    // deliberately *not* declared: it is reachable because it is the startup
+    // corpus, and asserting that is asserting the set is "what the reader
+    // declared plus that one" rather than "what the reader declared".
+    let declare = ank_at(
+        &two,
+        Some(&home),
+        &[
+            "config",
+            "--user",
+            &format!("corpora.{id_two}"),
+            &two.display().to_string(),
+        ],
+    );
+    assert!(
+        declare.status.success(),
+        "the declaration must be written: {}",
+        String::from_utf8_lossy(&declare.stderr)
+    );
+
+    // A root commit of the right shape that no corpus has and nobody declared.
+    let nobodys = "0".repeat(40);
+
+    let replies = talk_at(
+        &one,
+        Some(&home),
+        &[
+            &format!(
+                r#"{{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{{"name":"ank_claim","arguments":{{"arguments":["{task_one}"]}}}}}}"#
+            ),
+            &format!(
+                r#"{{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{{"name":"ank_claim","arguments":{{"arguments":["{task_two}"],"corpus":"{id_two}"}}}}}}"#
+            ),
+            &format!(
+                r#"{{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{{"name":"ank_find","arguments":{{"corpus":"{nobodys}"}}}}}}"#
+            ),
+            &format!(
+                r#"{{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{{"name":"ank_find","arguments":{{"corpus":"{id_two}"}}}}}}"#
+            ),
+            r#"{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"ank_find","arguments":{}}}"#,
+        ],
+    );
+    assert_eq!(replies.len(), 5, "{replies:?}");
+
+    // 1. No corpus named: the corpus the process was addressed with, unchanged
+    //    from every client that existed before the argument did.
+    assert_eq!(
+        field(&replies[0], "exitCode").as_deref(),
+        Some("0"),
+        "a call naming no corpus must reach the startup corpus: {}",
+        replies[0]
+    );
+    assert!(
+        replies[0].contains(&task_one),
+        "the claim was taken on the startup corpus's own task: {}",
+        replies[0]
+    );
+
+    // 2. A declared identity: that corpus, addressed on its own.
+    assert_eq!(
+        field(&replies[1], "exitCode").as_deref(),
+        Some("0"),
+        "a declared corpus must be reachable by name: {}",
+        replies[1]
+    );
+    assert!(
+        replies[1].contains(&task_two),
+        "the claim was taken on the named corpus's own task: {}",
+        replies[1]
+    );
+
+    // 3. An identity nobody declared: refused by name, and nothing runs.
+    //    The code is what settles that no fallback happened -- a call that had
+    //    quietly gone to the startup corpus would have answered that corpus's
+    //    listing with exit 0.
+    assert_eq!(
+        field(&replies[2], "exitCode").as_deref(),
+        Some(ExitCode::Environment.code().to_string().as_str()),
+        "an undeclared corpus is refused with the code §4 declares for an \
+         environment to repair: {}",
+        replies[2]
+    );
+    assert_eq!(
+        field(&replies[2], "isError").as_deref(),
+        Some("true"),
+        "a refusal is an error result: {}",
+        replies[2]
+    );
+    assert!(
+        replies[2].contains(&nobodys),
+        "refused by name, so the name is in the refusal: {}",
+        replies[2]
+    );
+    assert!(
+        replies[2].contains(&format!("ank config --user corpora.{nobodys}")),
+        "every refusal names the command that resolves it (§4): {}",
+        replies[2]
+    );
+    assert!(
+        !replies[2].contains("\"contract\""),
+        "the refused call answered a document, so something ran: {}",
+        replies[2]
+    );
+
+    // 4 and 5. Each corpus answers about itself, and about nothing else. This is
+    // the aggregation ADR-621a7fd96ce1 permits: two readings presented one after
+    // the other, never one corpus with two sources.
+    assert!(
+        replies[3].contains("The task of the second corpus")
+            && !replies[3].contains("The task of the first corpus"),
+        "the named corpus answered about the other one: {}",
+        replies[3]
+    );
+    assert!(
+        replies[4].contains("The task of the first corpus")
+            && !replies[4].contains("The task of the second corpus"),
+        "the startup corpus answered about the other one: {}",
+        replies[4]
+    );
+
+    // The claim spaces, which are the refs and are per repository. A merged one
+    // is what ADR-fd98f4bc6dea forbids in the same words the decision it
+    // supersedes used, and this is where it would have had to leave a trace.
+    assert_eq!(
+        claimed_tasks(&one),
+        vec![task_one.clone()],
+        "the first corpus must hold its own claim and only its own"
+    );
+    assert_eq!(
+        claimed_tasks(&two),
+        vec![task_two.clone()],
+        "the second corpus must hold its own claim and only its own"
+    );
+
+    let _ = std::fs::remove_dir_all(&one);
+    let _ = std::fs::remove_dir_all(&two);
+    let _ = std::fs::remove_dir_all(&home);
+}
+
+/// The startup corpus is reachable by its own name too, and a path is reachable
+/// by no name at all.
+///
+/// **The set is "what the reader declared plus the startup corpus"**, so the
+/// startup corpus has to answer to its identity and not only to the absence of
+/// one -- otherwise a client looping over the corpora it can see would be able
+/// to name every one of them except the one it is talking to.
+///
+/// **And a corpus is named by an identity, never by a path.** That is the clause
+/// that keeps a declared set from becoming a merged one: a caller who could put
+/// a path here would reach every corpus on the machine, which is `--repo` back
+/// under another name. The refusal names the command that prints a real one.
+#[test]
+fn the_startup_corpus_answers_to_its_own_identity_and_a_path_answers_to_nothing() {
+    let home = declaring_home();
+    let repo = corpus_titled("The only task", Some(&home));
+    let id = corpus_identity(&repo, &home);
+    let path = repo.display().to_string().replace('\\', "/");
+
+    let replies = talk_at(
+        &repo,
+        Some(&home),
+        &[
+            &format!(
+                r#"{{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{{"name":"ank_find","arguments":{{"corpus":"{id}"}}}}}}"#
+            ),
+            &format!(
+                r#"{{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{{"name":"ank_find","arguments":{{"corpus":"{path}"}}}}}}"#
+            ),
+        ],
+    );
+    assert_eq!(replies.len(), 2, "{replies:?}");
+
+    assert_eq!(
+        field(&replies[0], "exitCode").as_deref(),
+        Some("0"),
+        "the corpus the server was addressed with is in the set it may reach, \
+         and is reachable by its own identity: {}",
+        replies[0]
+    );
+    assert!(
+        replies[0].contains("The only task"),
+        "and it answered about itself: {}",
+        replies[0]
+    );
+
+    assert_eq!(
+        field(&replies[1], "isError").as_deref(),
+        Some("true"),
+        "a path is not a corpus name: {}",
+        replies[1]
+    );
+    assert!(
+        replies[1].contains("is not a repository identity")
+            && replies[1].contains("ank status --json"),
+        "the refusal says what a name is and names the command that prints one: \
+         {}",
+        replies[1]
+    );
+
+    let _ = std::fs::remove_dir_all(&repo);
+    let _ = std::fs::remove_dir_all(&home);
+}
+
+/// Every tool advertises the argument, asserted through the process.
+///
+/// The unit test in `crates/ank-mcp` asserts the same property of the generated
+/// schema; this asserts it of the bytes that leave the server, which is the rule
+/// CLAUDE.md states and this file's own header repeats: what a protocol promises
+/// is what leaves the process. A schema that was right in the function and
+/// absent from the reply would be exactly the failure the golden harness exists
+/// to catch elsewhere.
+#[test]
+fn every_advertised_tool_carries_the_corpus_argument() {
+    let repo = corpus();
+    let replies = talk(
+        &repo,
+        &[r#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#],
+    );
+    let listed = advertised(&replies[0]);
+    assert_eq!(listed.len(), COMMANDS.len(), "{listed:?}");
+    // One tool is one object, and every one of them has to carry the property.
+    // Counting is the assertion: a subset would still contain the substring.
+    assert_eq!(
+        replies[0]
+            .matches("\"corpus\":{\"type\":\"string\"")
+            .count(),
+        COMMANDS.len(),
+        "the corpus argument is on every tool or it is a curated subset of the \
+         corpora a client can reach per verb (ADR-fd98f4bc6dea): {}",
+        replies[0]
     );
     let _ = std::fs::remove_dir_all(&repo);
 }

--- a/crates/ank-mcp/src/call.rs
+++ b/crates/ank-mcp/src/call.rs
@@ -77,8 +77,14 @@ impl Outcome {
 /// The argv for a call, from the table and the client's arguments.
 ///
 /// `--repo` and `--json` are the server's, added here and never accepted from a
-/// caller: one process speaks for one corpus, and the machine document is the
-/// only shape this surface can describe.
+/// caller: the corpus is resolved from the identity a call named
+/// ([`crate::corpora`]) and never written by hand into a flag, and the machine
+/// document is the only shape this surface can describe.
+///
+/// **One `--repo`, and it names one corpus.** This is where the ban on a merged
+/// claim space is mechanical rather than argued: whatever a server may reach,
+/// what leaves it is one process addressed to one repository, exactly as a shell
+/// would have addressed it.
 pub fn argv(spec: &CommandSpec, repo: &Path, args: &Arguments) -> Vec<String> {
     let mut out = vec![spec.name.to_string()];
     out.extend(args.positionals.iter().cloned());
@@ -107,7 +113,7 @@ pub struct Arguments {
     pub flags: Vec<(String, Vec<String>)>,
 }
 
-/// Runs the verb and returns what the process said.
+/// Runs the verb in one corpus and returns what the process said.
 ///
 /// The identity is the server's and is typed (§3, ADR-3877d2b7c0f5). One stdio
 /// server serves one client, so one process is one caller: nothing here pools
@@ -115,11 +121,28 @@ pub struct Arguments {
 /// nothing holds a claim on a client's behalf either. The claim a call takes is
 /// the claim the CLI would have taken in that clone, on the same ref, arbitrated
 /// by the same compare-and-swap.
-pub fn run(spec: &CommandSpec, address: &Address, args: &Arguments) -> std::io::Result<Outcome> {
+///
+/// **The corpus is an argument and the address is not.** A server may be able to
+/// reach several (ADR-fd98f4bc6dea), and this function still sees exactly one --
+/// which is why a claim taken through it is a claim in one clone and why no
+/// arbitration across clones can be expressed here at all. The identity a call
+/// writes under does not change with the corpus, and neither does the ref that
+/// arbitrates it: one identity holding a lease in two corpora is two leases,
+/// each on its own `refs/ank/*`, and that is the shape ADR-fd98f4bc6dea permits.
+///
+/// The working directory moves with the corpus. A relative path in an argument
+/// is resolved by the process that receives it, so a call addressed to one
+/// corpus and run from another would resolve `crates/**` against the wrong tree.
+pub fn run(
+    spec: &CommandSpec,
+    address: &Address,
+    corpus: &Path,
+    args: &Arguments,
+) -> std::io::Result<Outcome> {
     let out = Command::new(&address.exe)
-        .args(argv(spec, &address.repo, args))
+        .args(argv(spec, corpus, args))
         .env("ANK_AGENT", identity())
-        .current_dir(&address.repo)
+        .current_dir(corpus)
         .output()?;
     Ok(Outcome {
         code: out.status.code().unwrap_or(1),

--- a/crates/ank-mcp/src/corpora.rs
+++ b/crates/ank-mcp/src/corpora.rs
@@ -1,0 +1,528 @@
+//! Which corpus a call is addressed to, and which corpora exist to be addressed
+//! (ADR-fd98f4bc6dea, ADR-621a7fd96ce1, ADR-96174f1ac2b7).
+//!
+//! **Multiplexing, and never a merged claim space.** The clause this module
+//! implements supersedes "it speaks for exactly one corpus", and it supersedes
+//! only that: every call still becomes `ank --repo <one corpus> <verb> --json`,
+//! every claim is still arbitrated by the refs of the clone it was taken in, and
+//! nothing here ever holds two corpora in one thought. There is no set operation
+//! anywhere below, no claim held on a client's behalf, and no pooling of clients
+//! under one identity. What a call names is *one* corpus, and what this module
+//! does is turn a name into the one path [`crate::call`] hands to `--repo`.
+//!
+//! **Declared, never discovered.** The set a server may reach is what the reader
+//! declared in `corpora.yml` plus the corpus the process was addressed with at
+//! startup. Nothing walks a filesystem looking for a corpus, nothing reads a
+//! remote, and nothing derives a location from a path or a slug -- the rule
+//! ADR-621a7fd96ce1 states and ADR-96174f1ac2b7 restates, for the reason
+//! ADR-a1de673043b4 gives about peers: inference is how a corpus starts
+//! depending on where somebody happened to check something out. An identity
+//! nobody declared is refused by name, and refusing is the point: a corpus
+//! quietly not found is the one outcome worse than a refusal.
+//!
+//! **A name is an identity and never a path**, which is what keeps a declared
+//! set from becoming a merged one. `--repo` stays the server's flag and stays
+//! refused; a caller says which corpus by naming the root commit of one, and a
+//! root commit that nobody declared resolves to nothing. A caller that could
+//! write a path here would reach every corpus on the machine, which is the shape
+//! the ban exists to prevent.
+//!
+//! **Nothing is read until a call names a corpus.** A client that never passes
+//! the argument is a single-corpus client, and it reads no declaration file,
+//! asks the binary no question, and sees byte for byte what it saw before this
+//! module existed. That is a property of the code below rather than a hope:
+//! both halves of the reachable set sit behind a [`OnceCell`] that the absent
+//! argument never touches.
+
+use crate::call::{Arguments, Outcome};
+use crate::Address;
+use ank_contract::ExitCode;
+use std::cell::OnceCell;
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+/// The argument every tool carries, and the one argument of this surface that
+/// is not a flag of the verb.
+///
+/// It is not `--repo` renamed. `--repo` takes a path and belongs to the server;
+/// this takes an identity and belongs to the caller, and the difference is the
+/// whole of what makes several corpora a set the reader declared rather than
+/// every directory on the machine.
+pub const ARGUMENT: &str = "corpus";
+
+/// What a client reads beside the argument in every tool's schema.
+///
+/// It names the command that prints the identity, because a value a caller
+/// cannot obtain is an argument that does not exist. `ank status --json` is
+/// where ADR-96174f1ac2b7 already sends a reader looking for a key.
+pub const HELP: &str = "Optional. The corpus this call runs against, named by the repository \
+                        identity of ADR-621a7fd96ce1 -- the root commit, which ank status --json \
+                        prints under \"corpus\". Absent, the call goes to the corpus this server \
+                        was addressed with at startup. Reachable are that corpus and the corpora \
+                        the reader declared in corpora.yml; an identity nobody declared is \
+                        refused by name, and nothing is discovered.";
+
+/// The reader's map of repository identity to corpus, under the same home
+/// `ank config --user` writes.
+///
+/// **The literal, and not a constant borrowed from `ank-cli`.** This crate does
+/// not link the dispatch (ADR-fd98f4bc6dea) and will not start in order to
+/// share a file name. What keeps the two spellings from drifting is not this
+/// comment: `two_corpora_through_one_server_land_two_claims_and_no_third` in
+/// `crates/ank-cli/tests/mcp.rs` writes this file with the CLI's own verb and
+/// then names both corpora through this surface, so a name that stopped
+/// matching would fail there rather than in prose.
+const CORPORA_FILE: &str = "corpora.yml";
+
+/// The schema of that file, which `ank config --user` writes and refuses to
+/// read at any other number.
+const SUPPORTED_SCHEMA: u64 = 1;
+
+/// A repository identity as ADR-621a7fd96ce1 defines it: the root commit, and
+/// therefore forty lowercase hex characters.
+///
+/// Applied to what a *caller* passes and not only to what a file holds, which
+/// is the check that makes this argument an identity rather than a location. A
+/// path, a remote URL or a slug fails it, and each of those is the mistake
+/// ADR-96174f1ac2b7 predicts by name.
+fn is_identity(key: &str) -> bool {
+    key.len() == 40
+        && key
+            .bytes()
+            .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+}
+
+/// A path as this corpus renders one: forward slashes, on every platform.
+///
+/// The same rule `claim` applies to the same sentences, and for the reason
+/// Windows CI taught it there: a message naming `C:/corpora/front` in one
+/// clause and `C:\Users\...` in the next gives one directory two spellings, and
+/// an agent keying on the corpus reads two spellings as two corpora.
+fn rendered(path: &str) -> String {
+    path.replace('\\', "/")
+}
+
+/// Where this reader's declarations live, or `None` where the environment names
+/// no home.
+///
+/// The rule itself comes from `ank_contract::events::user_dir`, which is where
+/// `ank-daemon` already reaches for it rather than keeping a second copy of
+/// three lines of platform difference. A home that moved would otherwise move
+/// for one surface and not the other.
+fn corpora_path() -> Option<PathBuf> {
+    ank_contract::events::user_dir().map(|d| d.join(CORPORA_FILE))
+}
+
+/// The declarations file as a sentence, for a hint that has to name it.
+fn corpora_file() -> String {
+    corpora_path()
+        .map(|p| rendered(&p.display().to_string()))
+        .unwrap_or_else(|| CORPORA_FILE.to_string())
+}
+
+/// A refusal this surface raises itself, in the vocabulary of §4.
+///
+/// **It carries an exit code because every other refusal a client sees does.**
+/// ADR-fd98f4bc6dea requires the surface to carry the CLI's exit codes as the
+/// reason for a refusal, and a client branching on `exitCode` must not have to
+/// learn that some refusals arrive with one and some do not. So this renders
+/// through [`Outcome::to_result`] -- the same renderer a spawned refusal goes
+/// through -- and the two shapes cannot drift apart, because there is one.
+///
+/// **It is a result and not a JSON-RPC error**, which is the line
+/// [`Outcome::refused`] already draws: a request naming a flag the verb does not
+/// take is malformed and answers `-32602`, and a request naming a corpus is well
+/// formed. The answer is no, and no is a fact about what this reader declared.
+pub struct Refusal {
+    pub code: ExitCode,
+    pub message: String,
+    pub hint: String,
+}
+
+impl Refusal {
+    /// The refusal as a call's outcome: nothing ran, and the exit code says what
+    /// would have refused it.
+    ///
+    /// Written on standard error's side of the outcome because that is where a
+    /// refusal leaves the binary (§4), so a client reading `stderr` or reading
+    /// the text block finds the same sentence either way.
+    pub fn outcome(&self) -> Outcome {
+        Outcome {
+            code: self.code.code(),
+            stdout: String::new(),
+            stderr: format!("error[{}]: {}\n  -> {}", self.code, self.message, self.hint),
+        }
+    }
+}
+
+/// What the reader declared, and why the map is empty when it is.
+///
+/// The reason is kept rather than dropped because it is the difference between
+/// two refusals a caller would otherwise have to tell apart by guessing: an
+/// identity nobody declared, and an identity declared in a file that could not
+/// be read. Both refuse; only one of them is repaired by writing a declaration.
+struct Declared {
+    map: BTreeMap<String, String>,
+    unreadable: Option<String>,
+}
+
+impl Declared {
+    fn empty() -> Declared {
+        Declared {
+            map: BTreeMap::new(),
+            unreadable: None,
+        }
+    }
+
+    fn broken(why: String) -> Declared {
+        Declared {
+            map: BTreeMap::new(),
+            unreadable: Some(why),
+        }
+    }
+}
+
+/// The corpora one server may address, resolved on demand and never discovered.
+///
+/// **Both halves are lazy, and that is the backwards compatibility clause.** A
+/// client that passes no `corpus` argument is served by [`Address::repo`] alone:
+/// no file is opened, no process is spawned, and the reachable set is never
+/// built at all. A client that passes one pays for the map the first time and
+/// for the startup corpus's own name at most once per session.
+pub struct Reach<'a> {
+    address: &'a Address,
+    declared: OnceCell<Declared>,
+    /// The identity of the corpus the process was addressed with, asked of the
+    /// binary once. `None` where the corpus has no root commit to be keyed on,
+    /// which ADR-621a7fd96ce1 calls the honest answer rather than a fabricated
+    /// one.
+    startup: OnceCell<Option<String>>,
+}
+
+impl<'a> Reach<'a> {
+    pub fn new(address: &'a Address) -> Reach<'a> {
+        Reach {
+            address,
+            declared: OnceCell::new(),
+            startup: OnceCell::new(),
+        }
+    }
+
+    /// Where the surface runs and what it runs, unchanged by any of this.
+    pub fn address(&self) -> &Address {
+        self.address
+    }
+
+    /// The corpus a call is addressed to: the one it named, or the one the
+    /// process was addressed with.
+    ///
+    /// **One corpus comes out, always.** Nothing above this function sees a set,
+    /// and nothing below it sees more than a path — which is what keeps the
+    /// merged claim space unreachable by construction rather than by review.
+    ///
+    /// The order is the reader's declaration first, then the startup corpus,
+    /// because ADR-96174f1ac2b7 makes the declaration the precedence and because
+    /// a map lookup costs nothing where naming the startup corpus costs a
+    /// process.
+    pub fn resolve(&self, named: Option<&str>) -> Result<PathBuf, Refusal> {
+        let Some(named) = named else {
+            return Ok(self.address.repo.clone());
+        };
+        let named = named.trim();
+        if !is_identity(named) {
+            return Err(not_an_identity(named));
+        }
+        if let Some(declared) = self.declared().map.get(named) {
+            let root = PathBuf::from(declared);
+            // **The declaration is confronted with the filesystem here, in the
+            // CLI's own sentence.** A directory that is not there would
+            // otherwise fail as a process that could not be started, which
+            // reports the environment where the fact is a stale entry in a map.
+            // A directory that is there and carries no corpus is left to the
+            // binary, whose refusal for exactly that is the one a client should
+            // see (ADR-fd98f4bc6dea).
+            if !root.is_dir() {
+                return Err(not_there(named, declared));
+            }
+            return Ok(root);
+        }
+        if self.startup_identity() == Some(named) {
+            return Ok(self.address.repo.clone());
+        }
+        Err(undeclared(named, self.declared().unreadable.as_deref()))
+    }
+
+    fn declared(&self) -> &Declared {
+        self.declared.get_or_init(read_declarations)
+    }
+
+    /// The startup corpus's own identity, asked of the binary and cached.
+    ///
+    /// **Asked, because there is nothing else to ask.** The identity is a root
+    /// commit, this crate touches no git and no `.ank/`, and `ank status --json`
+    /// is where ADR-96174f1ac2b7 itself sends a reader looking for the key. So
+    /// the server asks its own address for its own name, once, through the same
+    /// road out of the process every call takes.
+    ///
+    /// **It is not a spawn of the caller's verb**, which is the thing a refusal
+    /// must not perform: a call naming a corpus nobody declared runs nothing,
+    /// takes no claim and touches no corpus. What runs is this one reading, of
+    /// the corpus the server was already addressed with.
+    fn startup_identity(&self) -> Option<&str> {
+        self.startup
+            .get_or_init(|| self.ask_its_own_name())
+            .as_deref()
+    }
+
+    fn ask_its_own_name(&self) -> Option<String> {
+        let spec = ank_contract::spec_of("status")?;
+        let out = crate::call::run(
+            spec,
+            self.address,
+            &self.address.repo,
+            &Arguments::default(),
+        )
+        .ok()?;
+        if out.refused() {
+            return None;
+        }
+        let doc: serde_yaml::Value = serde_yaml::from_str(&out.stdout).ok()?;
+        doc.get("corpus")
+            .and_then(|v| v.as_str())
+            .filter(|v| is_identity(v))
+            .map(str::to_string)
+    }
+}
+
+/// The reader's declarations, or an empty map and the reason it is empty.
+///
+/// **Silent where `claim` is silent** (ADR-96174f1ac2b7, TASK-1317adb617e8).
+/// A map that cannot be read declares nothing, and by the time this runs the
+/// CLI's own resolution has already read the file once and refused on it —
+/// `ank mcp` does not start on a `corpora.yml` that will not parse. What is kept
+/// rather than dropped is the reason, so that the one caller who can still meet
+/// a broken map, the one who started the server with `--repo`, is told why the
+/// identity they named is not there instead of being told nobody declared it.
+fn read_declarations() -> Declared {
+    let Some(path) = corpora_path() else {
+        return Declared::empty();
+    };
+    let text = match std::fs::read_to_string(&path) {
+        Ok(text) => text,
+        // The ordinary case and not a failure: a reader who has declared
+        // nothing has no file, and gets the corpus the server was addressed
+        // with.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Declared::empty(),
+        Err(e) => return Declared::broken(format!("{}: {e}", corpora_file())),
+    };
+    parse_declarations(&text)
+}
+
+/// The file's own content as a map, split from the reading so a test can hand in
+/// bytes instead of a home directory.
+fn parse_declarations(text: &str) -> Declared {
+    let doc: serde_yaml::Value = match serde_yaml::from_str(text) {
+        Ok(doc) => doc,
+        Err(e) => return Declared::broken(format!("{}: {e}", corpora_file())),
+    };
+    if doc.get("schema").and_then(|v| v.as_u64()) != Some(SUPPORTED_SCHEMA) {
+        return Declared::broken(format!(
+            "{}: schema is not {SUPPORTED_SCHEMA}",
+            corpora_file()
+        ));
+    }
+    let mut map = BTreeMap::new();
+    if let Some(entries) = doc.get("corpora").and_then(|v| v.as_mapping()) {
+        for (key, value) in entries {
+            let (Some(key), Some(value)) = (key.as_str(), value.as_str()) else {
+                continue;
+            };
+            // A key that is not an identity is a key no caller can name, since
+            // what a caller passes is checked against the same rule before it
+            // is looked up. The CLI refuses such a file outright and this
+            // surface never starts on one; dropping the row here is what keeps
+            // the two from disagreeing about a file only one of them refused.
+            if is_identity(key) {
+                map.insert(key.to_string(), value.to_string());
+            }
+        }
+    }
+    Declared {
+        map,
+        unreadable: None,
+    }
+}
+
+/// A `corpus` that is not an identity at all.
+///
+/// The hint names the command that prints one, because the mistake this catches
+/// is a caller reaching for something they can type — a path, a remote, a
+/// directory name — where the value is a root commit.
+fn not_an_identity(named: &str) -> Refusal {
+    Refusal {
+        code: ExitCode::Environment,
+        message: format!("'{}' is not a repository identity", rendered(named)),
+        hint: "a corpus is named by its root commit, never a path, a remote or a slug: \
+               ank status --json prints it under \"corpus\""
+            .to_string(),
+    }
+}
+
+/// An identity nobody declared.
+///
+/// **Refused by name**, and this is the sentence that says the surface discovers
+/// nothing: there is no directory it could have looked in, so the only thing it
+/// can report is that this reader has not said where that corpus is. The hint is
+/// the verb that says it (ADR-96174f1ac2b7).
+fn undeclared(named: &str, unreadable: Option<&str>) -> Refusal {
+    let message = match unreadable {
+        None => format!(
+            "no corpus is declared under {named}, and this server reaches no corpus \
+             nobody declared"
+        ),
+        Some(why) => format!("no corpus is declared under {named}: {why}"),
+    };
+    Refusal {
+        code: ExitCode::Environment,
+        message,
+        hint: format!("ank config --user corpora.{named} <path>"),
+    }
+}
+
+/// A declaration pointing at a directory that is not there.
+///
+/// The CLI's own sentence for the same fact, with the CLI's own code and hint
+/// (`crates/ank-cli/src/repo.rs`). A stale entry reads the same through either
+/// surface, which is what a reader repairing it needs and what keeps this from
+/// being a second account of one failure.
+fn not_there(named: &str, declared: &str) -> Refusal {
+    Refusal {
+        code: ExitCode::Generic,
+        message: format!(
+            "the corpus declared for {named} is not at {}",
+            rendered(declared)
+        ),
+        hint: format!(
+            "ank init --at {}, or correct the entry in {}",
+            rendered(declared),
+            corpora_file()
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ID: &str = "0123456789abcdef0123456789abcdef01234567";
+
+    /// The rule ADR-621a7fd96ce1 states, applied to what a caller passes.
+    ///
+    /// The three rejected values are the three ADR-96174f1ac2b7 names as the
+    /// mistake: a path, a remote URL and a slug.
+    #[test]
+    fn an_identity_is_a_root_commit_and_never_a_path_a_remote_or_a_slug() {
+        assert!(is_identity(ID));
+        for wrong in [
+            "",
+            "/home/someone/corpora/front",
+            "git@github.com:someone/front.git",
+            "front",
+            "0123456789ABCDEF0123456789ABCDEF01234567",
+            "0123456789abcdef0123456789abcdef0123456",
+            "0123456789abcdef0123456789abcdef012345678",
+        ] {
+            assert!(!is_identity(wrong), "{wrong:?} is not an identity");
+        }
+    }
+
+    /// The map is the file's, and a row that is not keyed on an identity is not
+    /// a row a caller could ever name.
+    #[test]
+    fn the_map_is_read_from_the_file_and_keyed_on_identities() {
+        let declared = parse_declarations(&format!(
+            "schema: 1\ncorpora:\n  {ID}: /somewhere/front\n  front: /somewhere/slug\n"
+        ));
+        assert_eq!(declared.unreadable, None);
+        assert_eq!(
+            declared.map.get(ID).map(String::as_str),
+            Some("/somewhere/front")
+        );
+        assert_eq!(
+            declared.map.len(),
+            1,
+            "a slug is not a key: {:?}",
+            declared.map
+        );
+    }
+
+    /// A file that will not parse declares nothing and says why, so the refusal
+    /// a caller meets names the file rather than accusing them of naming a
+    /// corpus that does not exist.
+    #[test]
+    fn a_file_that_will_not_parse_declares_nothing_and_keeps_the_reason() {
+        for text in ["", "schema: 2\ncorpora: {}\n", "schema: 1\ncorpora: [\n"] {
+            let declared = parse_declarations(text);
+            assert!(declared.map.is_empty(), "{text:?} declared something");
+            assert!(
+                declared.unreadable.is_some(),
+                "{text:?} left no reason to report"
+            );
+        }
+    }
+
+    /// A refusal carries a §4 code, names the corpus, and names the command that
+    /// resolves it — the three things ADR-fd98f4bc6dea and §4 require of one.
+    #[test]
+    fn a_refusal_names_the_corpus_the_code_and_the_command() {
+        let refusal = undeclared(ID, None);
+        assert_eq!(refusal.code, ExitCode::Environment);
+        let outcome = refusal.outcome();
+        assert!(outcome.refused(), "a refusal is not a success");
+        assert_eq!(outcome.code, ExitCode::Environment.code());
+        assert!(
+            outcome.stderr.contains(ID),
+            "refused by name: {}",
+            outcome.stderr
+        );
+        assert!(
+            outcome
+                .stderr
+                .contains(&format!("error[{}]:", ExitCode::Environment)),
+            "the code is rendered as §4 renders it: {}",
+            outcome.stderr
+        );
+        assert!(
+            outcome
+                .stderr
+                .contains(&format!("ank config --user corpora.{ID}")),
+            "the command that resolves it travels with it: {}",
+            outcome.stderr
+        );
+        let result = outcome.to_result();
+        assert!(
+            result.contains("\"isError\":true") && result.contains("\"exitCode\":9"),
+            "a refusal reaches a client in the shape every other refusal has: {result}"
+        );
+    }
+
+    /// The reason a broken map is kept: two refusals a caller must be able to
+    /// tell apart.
+    #[test]
+    fn a_broken_map_refuses_differently_from_an_undeclared_identity() {
+        let plain = undeclared(ID, None).message;
+        let broken = undeclared(ID, Some("corpora.yml: schema is not 1")).message;
+        assert_ne!(plain, broken);
+        assert!(broken.contains("schema is not 1"), "{broken}");
+    }
+
+    /// A value that is not an identity is refused before anything is looked up,
+    /// which is what stops a path from reaching `--repo` through the back door.
+    #[test]
+    fn a_path_in_the_argument_is_refused_and_never_resolved() {
+        let refusal = not_an_identity("/home/someone/other-corpus");
+        assert_eq!(refusal.code, ExitCode::Environment);
+        assert!(refusal.message.contains("/home/someone/other-corpus"));
+        assert!(refusal.hint.contains("ank status --json"));
+    }
+}

--- a/crates/ank-mcp/src/lib.rs
+++ b/crates/ank-mcp/src/lib.rs
@@ -13,13 +13,21 @@
 //! has is what the CLI dispatches, and it cannot be otherwise without an edit to
 //! the table both consume.
 //!
-//! **One process speaks for one corpus, for now.** Addressed once, at startup,
-//! the way `--repo` addresses one. ADR-fd98f4bc6dea permits several, each
-//! addressed on its own, and TASK-2f31789f6af2 is where a call learns to name
-//! which; what that decision keeps in the same words is the ban this paragraph
-//! was written for. A server may never merge two claim spaces, because
-//! `refs/ank/*` is per repository and merging them would invent an arbitration
-//! the refs cannot carry.
+//! **A call names its corpus, and a server never merges two.** Every tool
+//! carries an optional `corpus` argument holding the repository identity of
+//! ADR-621a7fd96ce1; absent, the call goes to the corpus the process was
+//! addressed with at startup, the way `--repo` addresses one. The set a server
+//! may reach is that corpus plus what the reader declared in `corpora.yml`, and
+//! nothing is discovered: an identity nobody declared is refused by name.
+//! [`corpora`] is the whole of it, and it hands [`call`] one path.
+//!
+//! **Multiplexing is what was permitted; merging is what stays forbidden**, in
+//! the same words the superseded decision used. There is no merged claim space,
+//! no claim held on a client's behalf, and no pooling of clients under one
+//! identity — because `refs/ank/*` is per repository, and a server that merged
+//! two claim spaces would be inventing an arbitration the refs cannot carry.
+//! Nothing in this crate reasons about two corpora at once: a resolution returns
+//! one path, and every call is `ank --repo <one corpus> <verb> --json`.
 //!
 //! **This is a library, and the surface is the verb `ank mcp`** (ADR-fd98f4bc6dea).
 //! It was a sibling executable, and the file folded into the one binary every
@@ -39,6 +47,7 @@
 //! that has no shell at all.
 
 mod call;
+mod corpora;
 mod tools;
 
 use ank_contract::json::{string, Obj};
@@ -59,8 +68,14 @@ pub struct Address {
     /// The binary a call runs. `std::env::current_exe()` of the process serving
     /// the verb -- see the note on [`call`].
     pub exe: PathBuf,
-    /// The corpus every call is addressed to, for now the only one
-    /// (TASK-2f31789f6af2).
+    /// The corpus the process was addressed with, which is where a call goes
+    /// when it names none.
+    ///
+    /// **The startup corpus, and not the only one a server can reach.** A call
+    /// may name another by the identity of ADR-621a7fd96ce1, resolved against
+    /// what the reader declared ([`corpora`]). This one is the default and is
+    /// resolved by the dispatch, so a client that names nothing is served
+    /// exactly as it was before a call could name anything.
     pub repo: PathBuf,
 }
 
@@ -77,12 +92,18 @@ pub struct Address {
 /// the client's other work with it. The loop ends on end of input, which is what
 /// a client closing its side means, and on nothing else.
 pub fn serve(address: &Address, input: &mut dyn BufRead, out: &mut dyn Write) {
+    // Built once and per session, because what it resolves is per session: the
+    // reader's declarations and the startup corpus's own name do not change
+    // under a running server, and reading them per call would ask the same
+    // question of the same file for every message a client sends. It resolves
+    // nothing until a call names a corpus.
+    let reach = corpora::Reach::new(address);
     for line in input.lines() {
         let Ok(line) = line else { break };
         if line.trim().is_empty() {
             continue;
         }
-        if let Some(reply) = handle(&line, address) {
+        if let Some(reply) = handle(&line, &reach) {
             let _ = writeln!(out, "{reply}");
             let _ = out.flush();
         }
@@ -94,7 +115,7 @@ pub fn serve(address: &Address, input: &mut dyn BufRead, out: &mut dyn Write) {
 /// `None` for a notification, which is a message with no `id` and must never be
 /// answered: a reply to one is a protocol error on our side, and the client that
 /// sent `notifications/initialized` is waiting for nothing.
-fn handle(line: &str, address: &Address) -> Option<String> {
+fn handle(line: &str, reach: &corpora::Reach) -> Option<String> {
     let request: serde_yaml::Value = match serde_yaml::from_str(line) {
         Ok(value) => value,
         // Unparseable and therefore unattributable: no id to answer against, so
@@ -133,8 +154,14 @@ fn handle(line: &str, address: &Address) -> Option<String> {
                     "instructions",
                     "Every verb the ank CLI dispatches is a tool here, generated \
                      from one table. Start with ank_context: it answers what binds \
-                     this perimeter and what is claimable. This server speaks for \
-                     one corpus, fixed when it started.",
+                     this perimeter and what is claimable. Every tool takes an \
+                     optional corpus argument, the root commit ank status --json \
+                     prints under \"corpus\": absent, a call goes to the corpus this \
+                     server was addressed with at startup; given, it goes to that \
+                     corpus alone, and only corpora the reader declared can be \
+                     named. Each corpus is addressed on its own and none is merged \
+                     with another: a claim is taken in one repository, by the refs \
+                     of that repository.",
                 )
                 .finish(),
         )),
@@ -143,13 +170,25 @@ fn handle(line: &str, address: &Address) -> Option<String> {
             id_json,
             &Obj::new().raw("tools", &tools::list()).finish(),
         )),
-        "tools/call" => Some(call_tool(id_json, request.get("params"), address)),
+        "tools/call" => Some(call_tool(id_json, request.get("params"), reach)),
         other => Some(error(id_json, -32601, &format!("no such method '{other}'"))),
     }
 }
 
-/// `tools/call`, which is the only method that reaches the corpus.
-fn call_tool(id: Option<String>, params: Option<&serde_yaml::Value>, address: &Address) -> String {
+/// `tools/call`, which is the only method that reaches a corpus.
+///
+/// **The corpus is settled before anything runs, and exactly once.** A call
+/// names one or names none, [`corpora::Reach::resolve`] turns that into one
+/// path, and a name it cannot resolve is refused with a §4 code and the command
+/// that resolves it -- the verb is not spawned, no corpus is opened, and nothing
+/// falls back to the corpus the caller did not ask for. Falling back would be
+/// the worst answer available here: a claim taken in a corpus the client did not
+/// name, reported as success.
+fn call_tool(
+    id: Option<String>,
+    params: Option<&serde_yaml::Value>,
+    reach: &corpora::Reach,
+) -> String {
     let params = match params {
         Some(p) => p,
         None => return error(id, -32602, "tools/call needs params"),
@@ -162,9 +201,18 @@ fn call_tool(id: Option<String>, params: Option<&serde_yaml::Value>, address: &A
     };
 
     let mut args = call::Arguments::default();
+    let mut named: Option<String> = None;
     if let Some(map) = params.get("arguments").and_then(|a| a.as_mapping()) {
         for (key, value) in map {
             let Some(key) = key.as_str() else { continue };
+            // The one argument that is the surface's rather than the verb's, so
+            // it is taken out before the table is consulted: the table knows
+            // nothing about it and would refuse it by name, which is the right
+            // answer for every key except this one.
+            if key == corpora::ARGUMENT {
+                named = Some(scalar(value));
+                continue;
+            }
             if key == "arguments" {
                 if let Some(list) = value.as_sequence() {
                     for item in list {
@@ -188,7 +236,12 @@ fn call_tool(id: Option<String>, params: Option<&serde_yaml::Value>, address: &A
                 return error(
                     id,
                     -32602,
-                    &format!("{flag} belongs to the server: one process, one corpus"),
+                    &format!(
+                        "{flag} belongs to the server: name a corpus with the \
+                         {} argument, by the identity ank status --json prints, \
+                         never by a path",
+                        corpora::ARGUMENT
+                    ),
                 );
             }
             let values = match (known.takes_value, value.as_sequence()) {
@@ -200,14 +253,23 @@ fn call_tool(id: Option<String>, params: Option<&serde_yaml::Value>, address: &A
         }
     }
 
-    match call::run(spec, address, &args) {
+    // A corpus this server cannot reach is a refusal and not a protocol error:
+    // the request is well formed and the answer is no, which is the line
+    // `Outcome::refused` already draws. It reaches the client through the same
+    // renderer a refusal from the binary does, so the two shapes cannot drift.
+    let corpus = match reach.resolve(named.as_deref()) {
+        Ok(corpus) => corpus,
+        Err(refusal) => return result(id, &refusal.outcome().to_result()),
+    };
+
+    match call::run(spec, reach.address(), &corpus, &args) {
         Ok(outcome) => result(id, &outcome.to_result()),
         // The binary itself could not be run. That is the environment and not the
         // corpus, and §4 keeps the two apart on purpose.
         Err(e) => error(
             id,
             -32603,
-            &format!("cannot run {}: {e}", address.exe.display()),
+            &format!("cannot run {}: {e}", reach.address().exe.display()),
         ),
     }
 }

--- a/crates/ank-mcp/src/tools.rs
+++ b/crates/ank-mcp/src/tools.rs
@@ -21,12 +21,13 @@ use ank_contract::{CommandSpec, COMMANDS};
 /// the arguments the table gives it. What is withheld is the three flags that
 /// would let a caller contradict the process it is talking to.
 ///
-/// `--repo` because the corpus a call runs against is the server's to choose and
-/// never the caller's: today that is the one it was addressed with at startup,
-/// and under ADR-fd98f4bc6dea it becomes one of the several its reader declared,
-/// named by a `corpus` argument the table validates (TASK-2f31789f6af2). Either
-/// way a caller cannot reach a corpus by writing a path into a flag, which is
-/// what would turn a declared set into a merged one.
+/// `--repo` because a corpus is named by its identity here and never by a path
+/// (ADR-fd98f4bc6dea, [`crate::corpora`]). A server may reach several corpora --
+/// the one it was addressed with at startup, and the ones its reader declared --
+/// and every one of them is reached by naming a root commit that resolves to a
+/// declaration. A caller that could write a path into a flag would reach every
+/// corpus on the machine, which is exactly what turns a declared set into a
+/// merged one.
 /// `--json` because the server always wants the machine document and a client
 /// asking for the human one would get a shape nothing describes. `--quiet` means
 /// nothing to a caller that reads a return value rather than a terminal.
@@ -123,6 +124,23 @@ fn input_schema(spec: &CommandSpec) -> String {
         };
         props = props.obj(name, value);
     }
+    // **Every tool, and never a list of the ones it would suit**
+    // (ADR-fd98f4bc6dea). The argument says which corpus a call is addressed to,
+    // and a tool that did not carry it would be a verb a multi-corpus client can
+    // only reach in one of them -- the curated subset this surface was permitted
+    // on condition of not having, arriving through the back door as a curated
+    // set of *corpora* per verb.
+    //
+    // Last, after the verb's own arguments, so that a schema a client already
+    // reads is extended rather than rewritten: no property it knew has moved.
+    // It is never in `required`, which is the whole of what optional means here
+    // -- absent, the call goes where every call went before this existed.
+    props = props.obj(
+        crate::corpora::ARGUMENT,
+        Obj::new()
+            .str("type", "string")
+            .str("description", crate::corpora::HELP),
+    );
     Obj::new()
         .str("type", "object")
         .obj("properties", props)
@@ -139,4 +157,74 @@ pub fn list() -> String {
             .finish()
     });
     ank_contract::json::array(tools)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every tool carries the argument, and the table cannot take the name back.
+    ///
+    /// Two assertions and they are two different failures. The first is the
+    /// criterion: a verb the table gains reaches this surface addressable in
+    /// every corpus the server can reach, with no edit here. The second is the
+    /// collision that would make the first one silently false -- a verb
+    /// declaring a `--corpus` flag would put two properties of that name in one
+    /// schema, and the surface's own argument is the one a client would stop
+    /// being able to pass.
+    #[test]
+    fn every_tool_carries_the_corpus_argument_and_no_verb_shadows_it() {
+        let needle = format!("\"{}\":", crate::corpora::ARGUMENT);
+        for spec in COMMANDS {
+            let schema = input_schema(spec);
+            assert!(
+                schema.contains(&needle),
+                "{} does not advertise the corpus argument, so a client can \
+                 reach it in one corpus only (ADR-fd98f4bc6dea): {schema}",
+                spec.name
+            );
+            assert_eq!(
+                schema.matches(&needle).count(),
+                1,
+                "{} advertises the corpus argument twice: a verb has grown a \
+                 --corpus flag and the table now shadows the surface's own \
+                 argument",
+                spec.name
+            );
+            assert!(
+                ank_contract::find_flag(spec, "--corpus").is_none(),
+                "{} declares a --corpus flag: the surface names a corpus by its \
+                 identity and a verb naming one by anything else would be a \
+                 second answer to one question",
+                spec.name
+            );
+        }
+    }
+
+    /// The argument is optional, and optional is a property of the document
+    /// rather than of the prose: nothing in a generated schema is required, so a
+    /// client that passed no corpus yesterday passes none today.
+    #[test]
+    fn the_corpus_argument_is_never_required() {
+        for spec in COMMANDS {
+            let schema = input_schema(spec);
+            assert!(
+                !schema.contains("\"required\""),
+                "{} requires something, and the corpus argument must not be it: \
+                 {schema}",
+                spec.name
+            );
+        }
+    }
+
+    /// The three global flags stay the server's, `--repo` most of all: it is the
+    /// one that takes a path, and a path is how a declared set becomes a merged
+    /// one.
+    #[test]
+    fn the_globals_stay_the_servers() {
+        for flag in SERVER_FLAGS {
+            assert!(!client_flag(flag), "{flag} reached the client");
+        }
+        assert!(client_flag("--json-lines"), "a flag is not a prefix match");
+    }
 }


### PR DESCRIPTION
Closes TASK-2f31789f6af2, under ADR-fd98f4bc6dea.

## The line this holds

**Multiplexing is permitted. Merging is not.** A server may address several corpora, each on its own, exactly as `--repo` addresses one. What stays forbidden, in the same words the superseded decision used, is a merged claim space: no claim held on a client's behalf, no pooling of clients under one identity, no arbitration across clones.

That is a property of the code and not a promise about it. `corpora::Reach::resolve` returns **one** `PathBuf`; nothing above it or below it ever holds two corpora at once, and every call is still `ank --repo <one corpus> <verb> --json` from `call::run`. There is no set operation anywhere in the crate.

## The shape

- Every tool the surface generates carries an optional `corpus` argument holding the repository identity of ADR-621a7fd96ce1 — the root commit, which `ank status --json` prints under `"corpus"`.
- **Absent, the call goes to the corpus the process was addressed with at startup.** Backwards compatibility is a criterion, and it is met by construction rather than by care: both halves of the reachable set sit behind a `OnceCell` that a call omitting the argument never touches, so a single-corpus client opens no file, spawns nothing extra, and sees byte-identical bytes. The suite's existing tests, which all pass no corpus and compare against a direct run of the binary, are what assert it.
- **The reachable set is what the reader declared in `corpora.yml` (ADR-96174f1ac2b7) plus the startup corpus**, whose own identity is asked of the binary once and cached. Nothing is discovered.
- **A name is an identity, never a path.** A value that is not forty hex characters is refused before any lookup — which is what stops a caller reaching every corpus on the machine by writing a path where `--repo` was refused.
- **An identity nobody declared is refused by name**, with the code §4 declares and the command that resolves it, and the verb is not spawned and nothing falls back to a corpus the caller did not name.

## Decisions worth reviewing

**Exit code 9.** `ank-daemon/src/declare.rs` uses `ExitCode::Environment` for every failure of a corpus declaration, and §4 reserves 9 for "an environment to repair rather than work that failed". Repairing it means writing a declaration, which is neither a fact about a corpus's state nor a malformed request. The refusal is an MCP *result* carrying that code, not a JSON-RPC error: the request was well formed and the answer is no, the same line `Outcome::refused` already draws. It renders through `Outcome::to_result`, the same renderer a spawned refusal goes through, so the two shapes cannot drift.

**A declared corpus that cannot be read.** Consistent with TASK-1317adb617e8's landed answer in `claim.rs` rather than a second one: the map is read silently and never fails a call. What is kept, and `claim.rs` had no use for, is the *reason* — so a caller meeting a broken map is told the map could not be read instead of being told nobody declared the corpus they named. A declared path that is not a directory reuses `repo.rs`'s own sentence, hint and `Generic` code.

**No new dependency and no link to the dispatch.** `corpora.yml` is read with `serde_yaml`, already in the manifest, and located through `ank_contract::events::user_dir` — where `ank-daemon` already reaches for it rather than keeping a second copy of three lines of platform difference. `crates/ank-mcp/tests/dependencies.rs` still passes: no `ank-cli`, no `ank-core`, no git, and one road out of the process.

## Scope, stated rather than taken quietly

The task's scope was `crates/ank-mcp/**`, and the criterion demands a test driving the **built** `ank` against two corpora through one server. `CARGO_BIN_EXE_ank` is defined only for the package that declares that binary, which is the mechanical reason TASK-e655d28c83cb moved the surface's integration suite to `crates/ank-cli/tests/mcp.rs` and wrote that reason into the file's header. A suite in `crates/ank-mcp/tests` could only have found the binary by guessing a path under `target/` — the search ADR-fd98f4bc6dea celebrates having removed.

So `two_corpora_through_one_server_land_two_claims_and_no_third` and its two siblings live in `crates/ank-cli/tests/mcp.rs`, and the task's scope is amended to say so. Existing helpers were generalised (`corpus_titled`, `ank_at`, `talk_at`) and no existing test changed behaviour.

**Nothing under `crates/ank-daemon/**` or `crates/ank-cli/src/cli.rs` was touched.** `Address` kept both its fields, so the dispatch compiles unchanged — which is also why the reader's declarations are resolved inside `ank-mcp` rather than handed in.

## Tests

- `crates/ank-mcp/src/corpora.rs` — identity is a root commit and never a path, a remote or a slug; the map is keyed on identities; a file that will not parse declares nothing and keeps the reason; a refusal carries the code, the name and the command.
- `crates/ank-mcp/src/tools.rs` — every tool advertises the argument, no verb shadows it with a `--corpus` flag of its own, nothing is `required`.
- `crates/ank-cli/tests/mcp.rs` — two corpora, one server: a claim lands in each on its own `refs/ank/claims`, each corpus answers about itself and names nothing of the other's task, an undeclared identity is refused with 9 and the command and answers no document, the startup corpus answers to its own identity, and a path answers to nothing.

`cargo test --workspace` green, `cargo fmt --check` clean, `ank check` ok.

Proof: `commit:6315d6a99226ccc3fbdebe52d9022c16225629eb`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFsreFPfoNoNzjoGGZgszc