### PR TITLE
Every route carries one executable, and the machinery for the second is removed

### DIFF
--- a/.ank/entities/LOG-195f562df521.md
+++ b/.ank/entities/LOG-195f562df521.md
@@ -1,0 +1,18 @@
+---
+id: LOG-195f562df521
+type: log
+title: done, proof commit:eb8e979
+created: 2026-08-25T20:49:46Z
+author: claude-code/opus-5+distribution
+scope:
+  - .github/workflows/**
+  - install.sh
+  - install.ps1
+  - npm/**
+  - docs/**
+  - .github/scripts/**
+about: TASK-d9b167250aa8
+seq: 3
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-5497a1d8de51.md
+++ b/.ank/entities/LOG-5497a1d8de51.md
@@ -1,0 +1,20 @@
+---
+id: LOG-5497a1d8de51
+type: log
+title: install.sh and install.ps1 place one file by taking ank out of the unpacked directory and reading
+created: 2026-08-25T20:48:50Z
+author: claude-code/opus-5+distribution
+scope:
+  - .github/workflows/**
+  - install.sh
+  - install.ps1
+  - npm/**
+  - docs/**
+  - .github/scripts/**
+about: TASK-d9b167250aa8
+seq: 2
+schema: 4
+version: 1
+---
+
+ nothing else in it, so an archive published before ADR-1ea31c2f3c5a -- which carries a second executable -- installs the one file the script promises through the same code path a new archive does. No branch, no note, nothing to stage: that is why install.yml can drop the whole stand-in apparatus and still not break an old release. The real-release step in install.yml is where the two-file case is measured, on a published archive rather than a fake one, by counting the install directory.

--- a/.ank/entities/TASK-d9b167250aa8.md
+++ b/.ank/entities/TASK-d9b167250aa8.md
@@ -5,7 +5,7 @@ slug: every-route-carries-one-executable-and-the-machi
 title: Every route carries one executable, and the machinery for the second is removed
 created: 2026-08-25T16:53:17Z
 author: haksolot@vmi3223161
-status: in_progress
+status: done
 scope:
   - .github/workflows/**
   - install.sh
@@ -17,6 +17,11 @@ blocked_by: [TASK-e655d28c83cb, TASK-9dd22f2b0430]
 done_criteria: |
   release.yml builds and packages one binary per target, install.sh and install.ps1 place one file, and npm-assemble.sh names one per platform package. No workflow, script or manifest in the tree mentions ank-mcp or ank-daemon as a file to build, copy, stage or install, and grep is the check. install.yml no longer stages a stand-in for a second binary. docs/integrating.md states how a client reaches the protocol surface with a configuration naming ank and the verb mcp, and no document still tells a reader the watcher is built from the workspace and shipped by nothing. cargo test is green and ank check reports no fault.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: eb8e979
+    criteria: 774d9c032bdc
+    via: submitted
 schema: 4
-version: 4
+version: 5
 ---

--- a/.ank/entities/TASK-d9b167250aa8.md
+++ b/.ank/entities/TASK-d9b167250aa8.md
@@ -5,7 +5,7 @@ slug: every-route-carries-one-executable-and-the-machi
 title: Every route carries one executable, and the machinery for the second is removed
 created: 2026-08-25T16:53:17Z
 author: haksolot@vmi3223161
-status: open
+status: in_progress
 scope:
   - .github/workflows/**
   - install.sh
@@ -18,5 +18,5 @@ done_criteria: |
   release.yml builds and packages one binary per target, install.sh and install.ps1 place one file, and npm-assemble.sh names one per platform package. No workflow, script or manifest in the tree mentions ank-mcp or ank-daemon as a file to build, copy, stage or install, and grep is the check. install.yml no longer stages a stand-in for a second binary. docs/integrating.md states how a client reaches the protocol surface with a configuration naming ank and the verb mcp, and no document still tells a reader the watcher is built from the workspace and shipped by nothing. cargo test is green and ank check reports no fault.
 criteria_by: creator
 schema: 4
-version: 3
+version: 4
 ---

--- a/.github/scripts/check-version-fixtures.sh
+++ b/.github/scripts/check-version-fixtures.sh
@@ -21,7 +21,6 @@ check="$root/.github/scripts/check-version.sh"
 manifests=(
   crates/ank-cli/Cargo.toml
   crates/ank-core/Cargo.toml
-  crates/ank-mcp/Cargo.toml
   npm/ank/package.json
   npm/ank-linux-x64-musl/package.json
   npm/ank-darwin-arm64/package.json
@@ -41,7 +40,7 @@ fi
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 
-# plant <dir> -- the eight manifests, at their real paths, byte for byte.
+# plant <dir> -- the seven manifests, at their real paths, byte for byte.
 plant() {
   local dir="$1" m
   for m in "${manifests[@]}"; do

--- a/.github/scripts/check-version.sh
+++ b/.github/scripts/check-version.sh
@@ -12,7 +12,7 @@
 # with itself, which is a correct test of the wrapper and no test at all of the
 # version.
 #
-# Eleven literals across eight files carry the version today, which is ten more
+# Ten literals across seven files carry the version today, which is nine more
 # chances to be careful than anyone gets right forever. This makes the
 # disagreement fail instead.
 #
@@ -21,7 +21,7 @@
 # here costs a tag.
 #
 # The parsing is sed and awk. jq is on the runner but not on every machine a
-# maintainer would run this from, and the shapes read here are eight files this
+# maintainer would run this from, and the shapes read here are seven files this
 # repository writes itself. A literal the parser cannot find is a failure and
 # never a pass -- a shape that moved must turn this red, or the check quietly
 # stops checking.
@@ -91,12 +91,13 @@ compare() {
   bad_fix+=("$fix")
 }
 
-# ank-mcp is here for the same reason ank-cli is: the release ships it, in every
-# archive and every npm package, and the smoke job asserts it answers --version
-# with the number ank answers with. A tag that bumped ank-cli
-# and left ank-mcp behind would pass this gate and then break on the tag itself,
-# which is the loop this whole job exists to spare.
-for crate in ank-cli ank-core ank-mcp; do
+# The two crates whose version a release is about: `ank-cli` is the executable
+# every route carries, and `ank-core` is what it is. The libraries linked into
+# it -- the verb table, the protocol surface, the watcher, the terminal reader
+# -- are not gated here, for the reason ADR-1ea31c2f3c5a removed the gate that
+# used to be: nothing published carries any of them as a file of its own, so a
+# version they disagree on is not a version anybody downloads.
+for crate in ank-cli ank-core; do
   f="crates/$crate/Cargo.toml"
   compare "$f" "$f" "$(cargo_version "$f" 2>/dev/null)" \
     "$f: version = \"$version\""

--- a/.github/scripts/npm-assemble.sh
+++ b/.github/scripts/npm-assemble.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 #
-# Fills the npm packages with the binaries the build job produced, stamps one
+# Fills the npm packages with the binary the build job produced, stamps one
 # version across all four, and packs them.
 #
-# The binaries come from the same artefacts the GitHub release publishes: one
+# The binary comes from the same artefacts the GitHub release publishes: one
 # build, two channels, and no second compilation that could disagree with the
 # first. Nothing here downloads anything, which is the property the whole
 # channel exists for (npm/README.md).
 #
-# Two executables per platform package, never one: ank-mcp is freight of every
-# route that carries ank, so the pair travels in one package under one version
-# and an install cannot end up holding half of it. TASK-d9b167250aa8 reduces this to one.
+# One executable per platform package (ADR-1ea31c2f3c5a). The protocol surface
+# and the watcher are verbs of it, so there is no second file for a package to
+# be short of and no half an install can end up holding.
 #
 #   npm-assemble.sh <version> [package ...]
 #
@@ -42,8 +42,7 @@ target_of() {
   esac
 }
 
-# The extension, applied to both names rather than each name written out twice
-# per platform. Windows is the only row that has one.
+# The extension. Windows is the only row that has one.
 suffix_of() {
   case "$1" in
     ank-win32-x64) echo .exe ;;
@@ -51,30 +50,26 @@ suffix_of() {
   esac
 }
 
-# The two executables a platform package carries, in the order the wrapper
-# declares them. A name added here is a name the release must have built, and a
-# missing one below stops the assembly rather than shipping a package that is
-# short a binary.
-executables=(ank ank-mcp)
-
 for p in "${packages[@]}"; do
   target="$(target_of "$p")"
   suffix="$(suffix_of "$p")"
   mkdir -p "npm/$p/bin"
-  for name in "${executables[@]}"; do
-    exe="${name}${suffix}"
-    # The loose binaries the build job uploads beside the archives. Reaching for
-    # them rather than unpacking a .zip keeps this script free of unzip, which
-    # the Windows runner's bash does not have.
-    src="$(find dist -type f -path "*${target}*" -name "$exe" | head -n 1)"
-    if [ -z "$src" ]; then
-      echo "no $exe built for $target under dist/" >&2
-      exit 1
-    fi
-    cp "$src" "npm/$p/bin/$exe"
-    chmod +x "npm/$p/bin/$exe"
-    echo "  npm/$p/bin/$exe from $src"
-  done
+  exe="ank${suffix}"
+  # The loose binary the build job uploads beside the archives. Reaching for it
+  # rather than unpacking a .zip keeps this script free of unzip, which the
+  # Windows runner's bash does not have.
+  #
+  # A missing one stops the assembly rather than publishing a package that
+  # carries no binary at all: the wrapper would resolve nothing and every
+  # install of that platform would exit 9.
+  src="$(find dist -type f -path "*${target}*" -name "$exe" | head -n 1)"
+  if [ -z "$src" ]; then
+    echo "no $exe built for $target under dist/" >&2
+    exit 1
+  fi
+  cp "$src" "npm/$p/bin/$exe"
+  chmod +x "npm/$p/bin/$exe"
+  echo "  npm/$p/bin/$exe from $src"
   cp LICENSE "npm/$p/LICENSE"
   (
     cd "npm/$p"

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -28,11 +28,6 @@ env:
   # this project has ever published, so a step that silently reached the real
   # release instead of the staged one cannot pass.
   STAGED_VERSION: "9.9.9"
-  # A second staged release, older than ank-mcp: the same layout with the
-  # protocol surface absent. --version reaches releases published before
-  # ank-mcp existed, and an installer that failed on one would break a route
-  # that works today, so that archive is staged rather than imagined.
-  STAGED_LEGACY_VERSION: "9.9.8"
   STAGED_PORT: "8731"
 
 jobs:
@@ -94,13 +89,21 @@ jobs:
             echo "--help does not name the command the offer runs"
             exit 1
           }
-          # Two executables land, so --help says two land: a caller who reads it
-          # and then finds one file has been told the wrong thing.
-          printf '%s' "$out" | grep -q -- 'ank-mcp' || {
-            echo "--help does not name ank-mcp"
+          # One executable lands, so --help says one lands, and it names the
+          # two verbs that used to be the reason to look for a second file: a
+          # caller who reads this and then goes hunting for a protocol surface
+          # on disk has been told the wrong thing (ADR-1ea31c2f3c5a).
+          printf '%s' "$out" | grep -q -- 'One executable lands' || {
+            echo "--help does not say one executable lands"
             exit 1
           }
-          echo "--help names all three targets, the flag that draws nothing, and ank-mcp"
+          for v in 'ank mcp' 'ank watch'; do
+            printf '%s' "$out" | grep -q -- "$v" || {
+              echo "--help does not name $v"
+              exit 1
+            }
+          done
+          echo "--help names all three targets, the flag that draws nothing, and the one file it places"
 
       # The first of the two failures that matter. A fake `uname` on PATH is
       # what makes this testable on a machine that is one of the supported
@@ -173,55 +176,19 @@ jobs:
           chmod +x "stage/$name/ank"
           echo "staged" > "stage/$name/README.md"
 
-          # The protocol surface, beside it in the one directory the archive
-          # carries, because that is where release.yml puts it and where
-          # install.sh looks. Field two of each --version line is the version:
-          # `ank` prints the commit and the skill revision beside its number and
-          # `ank-mcp` prints neither, which is the same shape release.yml's own
-          # npm assertion compares.
-          cat > "stage/$name/ank-mcp" <<EOF
-          #!/bin/sh
-          if [ "\$1" = "--version" ]; then
-            echo "ank-mcp ${STAGED_VERSION}"
-            exit 0
-          fi
-          echo "staged stand-in for ank-mcp" >&2
-          exit 2
-          EOF
-          chmod +x "stage/$name/ank-mcp"
-
-          # The release older than ank-mcp, in the same layout with the second
-          # executable absent.
-          legacy="ank-${STAGED_LEGACY_VERSION}-${{ matrix.target }}"
-          mkdir -p "stage/$legacy"
-          cat > "stage/$legacy/ank" <<EOF
-          #!/bin/sh
-          if [ "\$1" = "--version" ]; then
-            echo "ank ${STAGED_LEGACY_VERSION} (staged)"
-            exit 0
-          fi
-          echo "staged stand-in for ank" >&2
-          exit 2
-          EOF
-          chmod +x "stage/$legacy/ank"
-          echo "staged" > "stage/$legacy/README.md"
-
           cd stage
           # The same layout release.yml packages: one directory named after the
           # archive, and the checksum in sha256sum's own format beside it. The
           # script parses that file, so a shape invented here would test a
           # parser against nothing.
-          for pack in "$name" "$legacy"; do
-            tar czf "${pack}.tar.gz" "$pack"
-            if command -v sha256sum >/dev/null 2>&1; then
-              sha256sum "${pack}.tar.gz" > "${pack}.tar.gz.sha256"
-            else
-              shasum -a 256 "${pack}.tar.gz" > "${pack}.tar.gz.sha256"
-            fi
-          done
-          mkdir -p "srv/v${STAGED_VERSION}" "srv/v${STAGED_LEGACY_VERSION}"
+          tar czf "${name}.tar.gz" "$name"
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum "${name}.tar.gz" > "${name}.tar.gz.sha256"
+          else
+            shasum -a 256 "${name}.tar.gz" > "${name}.tar.gz.sha256"
+          fi
+          mkdir -p "srv/v${STAGED_VERSION}"
           cp "${name}.tar.gz" "${name}.tar.gz.sha256" "srv/v${STAGED_VERSION}/"
-          cp "${legacy}.tar.gz" "${legacy}.tar.gz.sha256" "srv/v${STAGED_LEGACY_VERSION}/"
 
           cd srv
           nohup python3 -m http.server "$STAGED_PORT" --bind 127.0.0.1 >/dev/null 2>&1 &
@@ -276,14 +243,14 @@ jobs:
           }
           echo "no escape sequence, no frame, and the binary answers --version"
 
-          # And the last thing it printed has to name the second executable: a
-          # caller who never lists the directory learns what landed from that
+          # And the last thing it printed has to name what landed, by its full
+          # path: a caller who never lists the directory learns that from that
           # block and from nowhere else.
-          grep -q "staged-bin/ank-mcp" staged.log || {
-            echo "the install did not name ank-mcp in what it printed"
+          grep -q "staged-bin/ank" staged.log || {
+            echo "the install did not name the file it placed"
             exit 1
           }
-          echo "and it named ank-mcp in what it installed"
+          echo "and it named what it installed"
 
           # And it asked nothing. ADR-5fbd99bf6fd5 read as an absence covers
           # the offer as well as the animation: where no terminal is attached
@@ -305,87 +272,33 @@ jobs:
           }
           echo "--no-welcome is accepted, and changes nothing"
 
-      # What the pairing rule asks for, measured where the criterion puts it:
-      # not that the script contains a line about ank-mcp, but that the
-      # directory it installed into holds two executables, that both answer
-      # --version, and that they answer with one version.
+      # What ADR-1ea31c2f3c5a asks for, measured where the criterion puts it:
+      # not that the script contains a line saying one file lands, but that the
+      # directory it installed into holds exactly one, and that it runs.
       #
-      # The number and not the line, for the reason the stand-ins print what
-      # they print: it is field two of each. Asserted non-empty first, because
-      # two versions that are both empty are equal and that is not the news.
-      - name: both executables are installed, and report the same version
+      # The count, and not only the presence of `ank`: a route that grew a
+      # second file back would pass a test that only asked whether `ank` is
+      # there. `--dir` is given a directory of this step's own, so what is
+      # counted is what this install put in it and nothing a previous one did.
+      - name: one executable is installed, and it is the only file there
         run: |
           set -e
+          ls -l "$PWD/staged-bin"
           test -x "$PWD/staged-bin/ank" || { echo "ank is not installed"; exit 1; }
-          test -x "$PWD/staged-bin/ank-mcp" || {
-            echo "ank-mcp was not installed beside ank"
-            ls -l "$PWD/staged-bin"
+
+          count=$(ls -A "$PWD/staged-bin" | wc -l | tr -d ' ')
+          test "$count" -eq 1 || {
+            echo "the install directory holds $count files, and one is the contract"
             exit 1
           }
 
-          ank_line=$("$PWD/staged-bin/ank" --version)
-          mcp_line=$("$PWD/staged-bin/ank-mcp" --version)
-          echo "ank:     $ank_line"
-          echo "ank-mcp: $mcp_line"
-          ank_version=$(printf '%s\n' "$ank_line" | awk '{print $2}')
-          mcp_version=$(printf '%s\n' "$mcp_line" | awk '{print $2}')
-          test -n "$ank_version" || { echo "ank --version printed no version"; exit 1; }
-          test "$ank_version" = "$mcp_version" || {
-            echo "ank reports $ank_version and ank-mcp reports $mcp_version"
-            exit 1
-          }
-
-          # "with the same permissions" is a claim about two files on disk, so
-          # it is read off them rather than off the script that wrote them. The
-          # first field of `ls -l` is the one spelling GNU and BSD both print.
-          ank_mode=$(ls -l "$PWD/staged-bin/ank" | awk '{print $1}')
-          mcp_mode=$(ls -l "$PWD/staged-bin/ank-mcp" | awk '{print $1}')
-          echo "modes: ank $ank_mode, ank-mcp $mcp_mode"
-          test "$ank_mode" = "$mcp_mode" || {
-            echo "the two executables were installed with different permissions"
-            exit 1
-          }
-          echo "two executables, one version, one mode"
-
-      # The older release, which is the case that decides the shape. --version
-      # points this script at archives published before ank-mcp existed, and a
-      # hard failure there would break a route that works today: the person
-      # asked for ank, and ank is what that archive can give them.
-      #
-      # Only stderr is captured -- `2>&1 >/dev/null` sends stdout to the void
-      # and stderr to the capture -- because "says so on standard error" is the
-      # claim, and reading both streams together would not tell them apart.
-      - name: an archive with no ank-mcp still installs ank, and says so
-        env:
-          ANK_BASE_URL: http://127.0.0.1:${{ env.STAGED_PORT }}
-        run: |
-          set +e
-          err=$(sh install.sh --version "$STAGED_LEGACY_VERSION" --dir "$PWD/legacy-bin" 2>&1 >/dev/null)
-          code=$?
-          set -e
-          echo "$err"
-          echo "exit $code"
-
-          test "$code" -eq 0 || {
-            echo "an archive without ank-mcp has to install ank rather than fail"
-            exit 1
-          }
-          test -x "$PWD/legacy-bin/ank" || { echo "ank was not installed"; exit 1; }
-          test ! -e "$PWD/legacy-bin/ank-mcp" || {
-            echo "it installed an ank-mcp the archive does not carry"
-            exit 1
-          }
-          printf '%s' "$err" | grep -q 'carries no ank-mcp' || {
-            echo "the install did not say on stderr that the archive carries no ank-mcp"
-            exit 1
-          }
-          got=$("$PWD/legacy-bin/ank" --version)
+          got=$("$PWD/staged-bin/ank" --version)
           echo "ank --version: $got"
-          test "$got" = "ank ${STAGED_LEGACY_VERSION} (staged)" || {
-            echo "expected: ank ${STAGED_LEGACY_VERSION} (staged)"
+          test "$got" = "ank ${STAGED_VERSION} (staged)" || {
+            echo "expected: ank ${STAGED_VERSION} (staged)"
             exit 1
           }
-          echo "installed ank, said on stderr what the archive is missing, exited 0"
+          echo "one executable, and it answers"
 
       # The offer ADR-5fbd99bf6fd5 describes, driven through a real pty, which
       # is the only place it exists: it is gated on a terminal, and a workflow
@@ -402,7 +315,7 @@ jobs:
       # `npx` is replaced by one that fails on purpose, which is the last
       # clause of the criterion asked as a falsification rather than as a
       # review: an install that has already finished stays finished, so the
-      # exit code is 0, both executables are in place, and the failure is
+      # exit code is 0, the binary is in place, and the failure is
       # reported instead of swallowed.
       - name: the offer is asked at a terminal, and no failure of it changes the exit code
         env:
@@ -534,8 +447,7 @@ jobs:
                   failures.append(run["label"] + ": " + why)
 
           def installed(run):
-              return (os.access(os.path.join(run["dir"], "ank"), os.X_OK)
-                      and os.access(os.path.join(run["dir"], "ank-mcp"), os.X_OK))
+              return os.access(os.path.join(run["dir"], "ank"), os.X_OK)
 
           # Once each, asserted of each: this is the property the probe exists
           # for, and it is stricter than the total it replaces. Two questions
@@ -561,7 +473,7 @@ jobs:
           want(run, run["code"] == 0, "a failing skill step changed the exit code to %d" % run["code"])
           asked_once(run)
           want(run, run["ran"], "it accepted and never ran npx")
-          want(run, installed(run), "the binaries are not in place after the offer failed")
+          want(run, installed(run), "the binary is not in place after the offer failed")
           want(run, "npx skills add haksolot/ank" in run["out"], "it never named the command it ran")
           want(run, "exited 1" in run["out"], "it swallowed the failure instead of reporting it")
 
@@ -578,7 +490,7 @@ jobs:
           want(run, run["code"] == 0, "exit %d" % run["code"])
           asked_once(run)
           want(run, not run["ran"], "it ran npx after being declined")
-          want(run, installed(run), "declining cost the install its binaries")
+          want(run, installed(run), "declining cost the install its binary")
 
           # ^D on an empty line, which is end of input rather than an answer.
           # Twice, because each question opens /dev/tty for itself and a single
@@ -598,7 +510,7 @@ jobs:
           want(run, run["adopt_asked"] == 0, "--no-welcome asked the adoption offer anyway")
           want(run, not run["ran"], "--no-welcome ran npx anyway")
           want(run, "####" not in run["out"], "--no-welcome drew the logo at a terminal")
-          want(run, installed(run), "--no-welcome cost the install its binaries")
+          want(run, installed(run), "--no-welcome cost the install its binary")
 
           # node absent: the command, and one line saying why it was not run.
           run = case("nonode", b"y\ny\n", node=False)
@@ -607,7 +519,7 @@ jobs:
           want(run, not run["ran"], "it ran npx with no node to run it")
           want(run, "npx skills add haksolot/ank" in run["out"], "it did not print the command")
           want(run, "node is not on PATH" in run["out"], "it did not say why it was not run")
-          want(run, installed(run), "the binaries are not in place")
+          want(run, installed(run), "the binary is not in place")
 
           print("=" * 70)
           if failures:
@@ -615,8 +527,8 @@ jobs:
                   print("FAIL", line)
               sys.exit(1)
           print("each offer asked once at a terminal, both defaulted to yes on Enter, and")
-          print("a skill step that failed left the install reporting success with both")
-          print("binaries in place")
+          print("a skill step that failed left the install reporting success with the")
+          print("binary in place")
           PY
 
           python3 offer.py
@@ -713,25 +625,19 @@ jobs:
                 exit 1
                 ;;
             esac
-            # ank-mcp lives inside the archive, so the release page cannot be
-            # asked whether this one carries it; the install directory can.
-            # Written as a test for the reason the branch above is: the first
-            # release that carries the pair turns this into an assertion with
-            # no edit here, and until then the staged release measures it.
-            if [ -e "$PWD/real-bin/ank-mcp" ]; then
-              real_mcp=$("$PWD/real-bin/ank-mcp" --version)
-              echo "ank-mcp --version: $real_mcp"
-              real_ank_version=$(printf '%s\n' "$got" | awk '{print $2}')
-              real_mcp_version=$(printf '%s\n' "$real_mcp" | awk '{print $2}')
-              test -n "$real_ank_version" || { echo "ank --version printed no version"; exit 1; }
-              test "$real_ank_version" = "$real_mcp_version" || {
-                echo "ank reports $real_ank_version and ank-mcp reports $real_mcp_version"
-                exit 1
-              }
-              echo "the released pair reports one version"
-            else
-              echo "$tag carries no ank-mcp; the staged release is where the pair is measured"
-            fi
+            # And this is where "do not break installing an old release" is
+            # measured, on a real archive rather than a staged one. Every
+            # release published before ADR-1ea31c2f3c5a carries a second
+            # executable beside `ank`; this step installs from exactly those
+            # until a newer tag exists, and the assertion is that the install
+            # directory holds one file whichever archive it came out of.
+            real_count=$(ls -A "$PWD/real-bin" | wc -l | tr -d ' ')
+            ls -l "$PWD/real-bin"
+            test "$real_count" -eq 1 || {
+              echo "$tag installed $real_count files, and one is the contract"
+              exit 1
+            }
+            echo "$tag installed one file, whatever else its archive carries"
           else
             test "$code" -eq 3 || {
               echo "$tag does not carry $archive, so the script had to refuse with 3"
@@ -747,10 +653,9 @@ jobs:
 
   # The Windows half of the same claim. It asserts the same properties the job
   # above does -- it explains itself, it refuses a platform by name, it places
-  # both executables and they report one version, an archive older than ank-mcp
-  # still installs ank, it refuses a tampered archive before unpacking, and the
-  # real release installs and answers with its version -- in the language
-  # Windows actually has.
+  # one executable and that is the only file in the directory, it refuses a
+  # tampered archive before unpacking, and the real release installs and
+  # answers with its version -- in the language Windows actually has.
   #
   # Both shells, and that is the point of the last two steps: install.ps1 claims
   # Windows PowerShell 5.1 as its floor because that is what a clean Windows
@@ -787,15 +692,17 @@ jobs:
           $out = (& ./install.ps1 -Help *>&1 | Out-String)
           # -NoWelcome is in the list for the reason the others are: a switch
           # a caller cannot find is a switch they cannot use.
-          # ank-mcp.exe is in the list for the reason the switch is: two
-          # executables land, and a caller who reads -Help and then finds one
-          # file has been told the wrong thing.
+          # `ank mcp` and `ank watch` are in it for the reason the switch is:
+          # one executable lands, and a caller who reads -Help and then goes
+          # hunting for a protocol surface on disk has been told the wrong
+          # thing (ADR-1ea31c2f3c5a).
           # The offer is a thing this script does to the machine, so it is a
           # thing -Help says it does: a caller who reads this and is then asked
           # a question they were not told about has been surprised by their
           # installer.
           foreach ($needle in 'x86_64-pc-windows-msvc', 'ANK_BASE_URL', 'install.sh',
-                              '-NoWelcome', 'ANK_NO_WELCOME', 'ank-mcp.exe',
+                              '-NoWelcome', 'ANK_NO_WELCOME',
+                              'One executable lands', 'ank mcp', 'ank watch',
                               'npx skills add haksolot/ank') {
             if ($out -notmatch [regex]::Escape($needle)) {
               "-Help does not name $needle"
@@ -803,7 +710,7 @@ jobs:
             }
           }
           "-Help names the target, the environment, the other script, the switch,"
-          "ank-mcp and the command the offer runs"
+          "the one file it places and the command the offer runs"
 
       # The first of the two failures that matter. The architecture is read out
       # of the environment precisely so this is testable on a machine that is
@@ -842,9 +749,7 @@ jobs:
       - name: stage a release and serve it
         run: |
           $name = "ank-$env:STAGED_VERSION-x86_64-pc-windows-msvc"
-          $legacy = "ank-$env:STAGED_LEGACY_VERSION-x86_64-pc-windows-msvc"
           New-Item -ItemType Directory -Path "stage/pack/$name" -Force | Out-Null
-          New-Item -ItemType Directory -Path "stage/pack-legacy/$legacy" -Force | Out-Null
 
           # A real executable and not a text file wearing the name, because the
           # claim under test is that the installed binary answers --version and
@@ -858,10 +763,9 @@ jobs:
             -ErrorAction SilentlyContinue | Select-Object -Last 1
           if (-not $csc) { "no csc.exe on this image, so no runnable stand-in can be built"; exit 1 }
 
-          # Three stand-ins: the pair the staged release carries, and the lone
-          # ank of a release older than ank-mcp. Written once and called three
-          # times, since stand-ins differing in more than the line they print
-          # would be testing that difference instead of the script.
+          # One stand-in, and it is a function all the same: what it does is
+          # long enough that inlining it would bury the one line that matters,
+          # which is the version the archive claims to carry.
           function New-StandIn {
               param([string]$Source, [string]$Exe, [string]$Line, [string]$What)
 
@@ -881,35 +785,22 @@ jobs:
               if ($LASTEXITCODE -ne 0) { "the stand-in for $What did not compile"; exit 1 }
           }
 
-          # Field two of each --version line is the version: `ank` prints the
-          # commit and the skill revision beside its number and `ank-mcp` prints
-          # neither, which is the shape release.yml's own npm assertion compares.
-          #
-          # The sources stay outside the pack directories, so the archives carry
-          # the executables and the README and nothing these lines needed to
+          # The source stays outside the pack directory, so the archive carries
+          # the executable and the README and nothing these lines needed to
           # build them.
           New-StandIn 'stage\ank.cs' "stage\pack\$name\ank.exe" "ank $env:STAGED_VERSION (staged)" 'ank'
-          New-StandIn 'stage\ank-mcp.cs' "stage\pack\$name\ank-mcp.exe" "ank-mcp $env:STAGED_VERSION" 'ank-mcp'
-          New-StandIn 'stage\ank-legacy.cs' "stage\pack-legacy\$legacy\ank.exe" "ank $env:STAGED_LEGACY_VERSION (staged)" 'ank'
 
           Set-Content -Path "stage/pack/$name/README.md" -Value 'staged'
-          Set-Content -Path "stage/pack-legacy/$legacy/README.md" -Value 'staged'
 
           Add-Type -AssemblyName System.IO.Compression.FileSystem
           [System.IO.Compression.ZipFile]::CreateFromDirectory(
             (Resolve-Path 'stage/pack'), (Join-Path $PWD "stage/$name.zip"))
-          [System.IO.Compression.ZipFile]::CreateFromDirectory(
-            (Resolve-Path 'stage/pack-legacy'), (Join-Path $PWD "stage/$legacy.zip"))
 
-          foreach ($pack in $name, $legacy) {
-            $hash = (Get-FileHash -Path "stage/$pack.zip" -Algorithm SHA256).Hash.ToLowerInvariant()
-            Set-Content -Path "stage/$pack.zip.sha256" -Value "$hash  $pack.zip"
-          }
+          $hash = (Get-FileHash -Path "stage/$name.zip" -Algorithm SHA256).Hash.ToLowerInvariant()
+          Set-Content -Path "stage/$name.zip.sha256" -Value "$hash  $name.zip"
 
           New-Item -ItemType Directory -Path "stage/srv/v$env:STAGED_VERSION" -Force | Out-Null
-          New-Item -ItemType Directory -Path "stage/srv/v$env:STAGED_LEGACY_VERSION" -Force | Out-Null
           Copy-Item "stage/$name.zip", "stage/$name.zip.sha256" "stage/srv/v$env:STAGED_VERSION/"
-          Copy-Item "stage/$legacy.zip", "stage/$legacy.zip.sha256" "stage/srv/v$env:STAGED_LEGACY_VERSION/"
 
           Start-Process -FilePath 'python' `
             -ArgumentList '-m', 'http.server', $env:STAGED_PORT, '--bind', '127.0.0.1' `
@@ -967,14 +858,14 @@ jobs:
           }
           "no escape sequence, no frame, and the binary answers --version"
 
-          # And the last thing it printed has to name the second executable: a
-          # caller who never lists the directory learns what landed from that
+          # And the last thing it printed has to name what landed, by its full
+          # path: a caller who never lists the directory learns that from that
           # block and from nowhere else.
-          if ($out -notmatch 'ank-mcp\.exe') {
-            "the install did not name ank-mcp.exe in what it printed"
+          if ($out -notmatch 'staged-bin\\ank\.exe') {
+            "the install did not name the file it placed"
             exit 1
           }
-          "and it named ank-mcp.exe in what it installed"
+          "and it named what it installed"
 
           # And it asked nothing. ADR-5fbd99bf6fd5 read as an absence covers
           # the offer as well as the animation: where no console is attached
@@ -999,88 +890,32 @@ jobs:
           "-NoWelcome is accepted, and changes nothing"
           exit 0
 
-      # What the pairing rule asks for, measured where the criterion puts it:
-      # not that the script contains a line about ank-mcp, but that the
-      # directory it installed into holds two executables, that both answer
-      # --version, and that they answer with one version.
-      - name: both executables are installed, and report the same version
-        run: |
-          if (-not (Test-Path "$PWD/staged-bin/ank.exe")) { "ank.exe is not installed"; exit 1 }
-          if (-not (Test-Path "$PWD/staged-bin/ank-mcp.exe")) {
-            "ank-mcp.exe was not installed beside ank.exe"
-            Get-ChildItem "$PWD/staged-bin" | Format-Table -AutoSize | Out-String
-            exit 1
-          }
-
-          $ankLine = & "$PWD/staged-bin/ank.exe" --version
-          $mcpLine = & "$PWD/staged-bin/ank-mcp.exe" --version
-          "ank:     $ankLine"
-          "ank-mcp: $mcpLine"
-          # Field two of each, for the reason the stand-ins print what they
-          # print. Asserted non-empty first, because two versions that are both
-          # empty are equal and that is not the news.
-          $ankVersion = ($ankLine -split '\s+')[1]
-          $mcpVersion = ($mcpLine -split '\s+')[1]
-          if (-not $ankVersion) { "ank --version printed no version"; exit 1 }
-          if ($ankVersion -ne $mcpVersion) {
-            "ank reports $ankVersion and ank-mcp reports $mcpVersion"
-            exit 1
-          }
-
-          # "with the same permissions" is a claim about two files on disk, so
-          # it is read off them rather than off the script that wrote them. On
-          # Windows that is the access rules, which two files moved into one
-          # directory inherit alike.
-          $ankAcl = (Get-Acl "$PWD/staged-bin/ank.exe").AccessToString
-          $mcpAcl = (Get-Acl "$PWD/staged-bin/ank-mcp.exe").AccessToString
-          if ($ankAcl -ne $mcpAcl) {
-            "the two executables were installed with different access rules"
-            $ankAcl
-            $mcpAcl
-            exit 1
-          }
-          "two executables, one version, one set of access rules"
-          exit 0
-
-      # The older release, which is the case that decides the shape. -Version
-      # points this script at archives published before ank-mcp existed, and a
-      # hard failure there would break a route that works today: the person
-      # asked for ank, and ank is what that archive can give them.
+      # What ADR-1ea31c2f3c5a asks for, measured where the criterion puts it:
+      # not that the script contains a line saying one file lands, but that the
+      # directory it installed into holds exactly one, and that it runs.
       #
-      # install.sh says it on standard error; this file says everything through
-      # Write-Host, for the reason it records where Say is defined, so the
-      # stream asserted here is the host stream and that is the same decision
-      # spelled the way Windows spells it.
-      - name: an archive with no ank-mcp still installs ank, and says so
-        env:
-          ANK_BASE_URL: http://127.0.0.1:${{ env.STAGED_PORT }}
+      # The count, and not only the presence of ank.exe: a route that grew a
+      # second file back would pass a test that only asked whether ank.exe is
+      # there. -Dir is given a directory of this job's own, so what is counted
+      # is what this install put in it and nothing a previous one did.
+      - name: one executable is installed, and it is the only file there
         run: |
-          $LASTEXITCODE = 0
-          $out = (& ./install.ps1 -Version $env:STAGED_LEGACY_VERSION -Dir "$PWD/legacy-bin" *>&1 | Out-String)
-          $code = $LASTEXITCODE
-          $out
-          "exit $code"
+          Get-ChildItem "$PWD/staged-bin" | Format-Table -AutoSize | Out-String
+          if (-not (Test-Path "$PWD/staged-bin/ank.exe")) { "ank.exe is not installed"; exit 1 }
 
-          if ($code -ne 0) {
-            "an archive without ank-mcp has to install ank rather than fail"
+          $count = @(Get-ChildItem -Force "$PWD/staged-bin").Count
+          if ($count -ne 1) {
+            "the install directory holds $count files, and one is the contract"
             exit 1
           }
-          if (-not (Test-Path "$PWD/legacy-bin/ank.exe")) { "ank.exe was not installed"; exit 1 }
-          if (Test-Path "$PWD/legacy-bin/ank-mcp.exe") {
-            "it installed an ank-mcp.exe the archive does not carry"
-            exit 1
-          }
-          if ($out -notmatch 'carries no ank-mcp') {
-            "the install did not say the archive carries no ank-mcp"
-            exit 1
-          }
-          $got = & "$PWD/legacy-bin/ank.exe" --version
+
+          $got = & "$PWD/staged-bin/ank.exe" --version
           "ank --version: $got"
-          if ($got -ne "ank $env:STAGED_LEGACY_VERSION (staged)") {
-            "expected: ank $env:STAGED_LEGACY_VERSION (staged)"
+          if ($got -ne "ank $env:STAGED_VERSION (staged)") {
+            "expected: ank $env:STAGED_VERSION (staged)"
             exit 1
           }
-          "installed ank, said what the archive is missing, exited 0"
+          "one executable, and it answers"
           exit 0
 
       # The Windows half of the same claim, and the place the two files stop
@@ -1282,8 +1117,7 @@ jobs:
 
           function Installed {
               param($Run)
-              return ((Test-Path (Join-Path $Run.Dir 'ank.exe')) -and
-                      (Test-Path (Join-Path $Run.Dir 'ank-mcp.exe')))
+              return (Test-Path (Join-Path $Run.Dir 'ank.exe'))
           }
 
           # Once each, asserted of each: this is the property the probe exists
@@ -1457,25 +1291,19 @@ jobs:
               exit 1
             }
             "the binary answers with the released version"
-            # ank-mcp.exe lives inside the archive, so the release page cannot
-            # be asked whether this one carries it; the install directory can.
-            # Written as a test for the reason the branch above is: the first
-            # release that carries the pair turns this into an assertion with no
-            # edit here, and until then the staged release measures it.
-            if (Test-Path "$PWD/real-bin/ank-mcp.exe") {
-              $mcp = & "$PWD/real-bin/ank-mcp.exe" --version
-              "ank-mcp --version: $mcp"
-              $realAnk = ($got -split '\s+')[1]
-              $realMcp = ($mcp -split '\s+')[1]
-              if (-not $realAnk) { "ank --version printed no version"; exit 1 }
-              if ($realAnk -ne $realMcp) {
-                "ank reports $realAnk and ank-mcp reports $realMcp"
-                exit 1
-              }
-              "the released pair reports one version"
-            } else {
-              "$tag carries no ank-mcp; the staged release is where the pair is measured"
+            # And this is where "do not break installing an old release" is
+            # measured, on a real archive rather than a staged one. Every
+            # release published before ADR-1ea31c2f3c5a carries a second
+            # executable beside ank.exe; this step installs from exactly those
+            # until a newer tag exists, and the assertion is that the install
+            # directory holds one file whichever archive it came out of.
+            Get-ChildItem "$PWD/real-bin" | Format-Table -AutoSize | Out-String
+            $realCount = @(Get-ChildItem -Force "$PWD/real-bin").Count
+            if ($realCount -ne 1) {
+              "$tag installed $realCount files, and one is the contract"
+              exit 1
             }
+            "$tag installed one file, whatever else its archive carries"
           } else {
             if (-not $failed) { "$tag does not carry $archive, so the script had to refuse"; exit 1 }
             if ($reason -notmatch 'code 3') { "the refusal is not the download code"; exit 1 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,15 +127,14 @@ jobs:
       - name: test
         run: cargo test --workspace --target ${{ matrix.target }}
 
-      # Both executables, one invocation, one checkout. Two
-      # `cargo build` lines would compile the same table twice and could be
-      # made to disagree; one line cannot. `ank-mcp` is a generated passthrough
-      # over `ank_contract::COMMANDS`, so a surface built from an older table
-      # than the CLI beside it advertises verbs that CLI does not dispatch --
-      # a refusal section 4 gives no code for, because it should not be
-      # reachable.
+      # One binary, and the workspace is what makes it one: the protocol
+      # surface and the watcher are libraries linked into `ank` and dispatched
+      # by the verbs `mcp` and `watch` (ADR-1ea31c2f3c5a, ADR-fd98f4bc6dea,
+      # ADR-a22cd3196529). A surface built from an older table than the CLI
+      # beside it used to be a thing that could happen; one executable built
+      # once cannot disagree with itself.
       - name: build
-        run: cargo build --release --bin ank --bin ank-mcp --target ${{ matrix.target }}
+        run: cargo build --release --bin ank --target ${{ matrix.target }}
 
       # Named for what it runs on, because that is the question someone
       # downloading it is asking.
@@ -150,15 +149,12 @@ jobs:
           esac
           name="ank-${version}-${{ matrix.target }}"
           mkdir -p "dist/${name}"
-          # Both, into every archive: where a route places
-          # ank, it places ank-mcp next to it, and the archive is the route
-          # install.sh and install.ps1 unpack.
+          # One executable into every archive, which is the archive
+          # install.sh and install.ps1 unpack (ADR-1ea31c2f3c5a).
           if [ "${{ matrix.archive }}" = "zip" ]; then
             cp "target/${{ matrix.target }}/release/ank.exe" "dist/${name}/"
-            cp "target/${{ matrix.target }}/release/ank-mcp.exe" "dist/${name}/"
           else
             cp "target/${{ matrix.target }}/release/ank" "dist/${name}/"
-            cp "target/${{ matrix.target }}/release/ank-mcp" "dist/${name}/"
           fi
           cp README.md LICENSE "dist/${name}/"
           # The contract alone, and not the three activity policies beside
@@ -204,10 +200,12 @@ jobs:
       # release page serves and what install.sh and install.ps1 unpack, and a
       # `cp` that silently did not happen leaves the executable in `target/`
       # and out of the tarball -- where nothing else in this file would notice.
-      # No route carries one without the other; this is
-      # that condition, asserted on the artefact rather than assumed from the
-      # step above it.
-      - name: the archive carries both executables
+      #
+      # One executable, and the count is asserted rather than only the name:
+      # every route carries one file (ADR-1ea31c2f3c5a), so an archive that
+      # grew a second one has stopped being what install.sh promises, and a
+      # test that only looked for `ank` would not see it.
+      - name: the archive carries one executable
         shell: bash
         run: |
           set -e
@@ -219,26 +217,42 @@ jobs:
             # only listing shape that survives a name with a space in it. `tr`
             # because 7z is a native Windows program and ends its lines CRLF,
             # and a trailing carriage return would make every name below miss.
-            *.zip) listing=$(7z l -ba -slt "$archive" | tr -d '\r' | sed -n 's/^Path = //p'); exes="ank.exe ank-mcp.exe" ;;
-            *)     listing=$(tar tzf "$archive"); exes="ank ank-mcp" ;;
+            *.zip) listing=$(7z l -ba -slt "$archive" | tr -d '\r' | sed -n 's/^Path = //p'); exe="ank.exe" ;;
+            *)     listing=$(tar tzf "$archive"); exe="ank" ;;
           esac
           # Basenames, because 7z on Windows separates with a backslash and tar
           # with a slash, and the question here is which files are inside.
           names=$(printf '%s\n' "$listing" | sed 's|.*[/\\]||')
           printf '%s\n' "$listing" | sed 's/^/  /'
-          for exe in $exes; do
-            printf '%s\n' "$names" | grep -qx "$exe"
-            echo "  carries $exe"
-          done
+          printf '%s\n' "$names" | grep -qx "$exe"
+          echo "  carries $exe"
+          # The rest of the archive is prose and a licence: README.md, LICENSE
+          # and SKILL.md, copied above. Anything else in there is a second file
+          # this route no longer places.
+          #
+          # The directory the archive is named after is skipped too, and it is
+          # skipped by name rather than by kind: tar lists it with a trailing
+          # slash, which leaves an empty basename, and 7z lists it without one,
+          # which leaves the directory's own name.
+          dir=$(basename "$archive" | sed -e 's/\.tar\.gz$//' -e 's/\.zip$//')
+          extra=$(printf '%s\n' "$names" |
+            grep -v -e '^$' -e "^${dir}\$" -e "^${exe}\$" \
+              -e '^README.md$' -e '^LICENSE$' -e '^SKILL.md$' || true)
+          test -z "$extra" || {
+            echo "the archive carries more than the one executable and its papers:"
+            printf '%s\n' "$extra" | sed 's/^/    /'
+            exit 1
+          }
+          echo "  and nothing else beside README.md, LICENSE and SKILL.md"
 
-      # The loose binaries travel beside the archives, for the npm packages
+      # The loose binary travels beside the archives, for the npm packages
       # below: extracting a .zip would need `unzip`, which the Windows runner's
       # bash does not have, and building a second time to avoid that would be
       # two binaries where the point is one.
       #
-      # Both of them, named one per line rather than as `ank*`: a glob would
-      # also sweep up whatever the packaging step leaves in that directory
-      # next, and what the npm packages are entitled to take is exactly these.
+      # Named rather than globbed as `ank*`: a glob would also sweep up
+      # whatever the packaging step leaves in that directory next, and what the
+      # npm packages are entitled to take is exactly this file.
       - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.target }}
@@ -248,8 +262,6 @@ jobs:
             dist/*.sha256
             dist/*/ank
             dist/*/ank.exe
-            dist/*/ank-mcp
-            dist/*/ank-mcp.exe
           if-no-files-found: error
 
   # The npm channel exists for the workstation whose firewall blocks downloading
@@ -423,39 +435,16 @@ jobs:
           echo "npx:    $actual"
           test "$expected" = "$actual"
 
-      # The pairing criterion, on the machine that will run it. The
-      # two executables come out of one `cargo build`, and the observable form
-      # of that is answering `--version` with one number.
-      #
-      # Read out of the installed package and not off `dist/`: what a user holds
-      # is what npm resolved through optionalDependencies, and a platform
-      # package assembled without ank-mcp would pass every assertion above this
-      # one. Compared against each other rather than against a literal, so the
-      # check cannot drift from the version it ships.
-      #
-      # The number, not the line: `ank` prints the commit and the skill revision
-      # beside it (section 4) and `ank-mcp` prints neither, so it is field two
-      # of each. Field two is asserted non-empty first, because two versions
-      # that are both empty are equal and that is not the news.
-      - name: ank-mcp reports the version ank reports
-        shell: bash
-        run: |
-          set -e
-          cd smoke
-          ank_line=$(npx ank --version)
-          mcp_line=$(npx ank-mcp --version)
-          echo "ank:     $ank_line"
-          echo "ank-mcp: $mcp_line"
-          ank_version=$(printf '%s\n' "$ank_line" | awk '{print $2}')
-          mcp_version=$(printf '%s\n' "$mcp_line" | awk '{print $2}')
-          test -n "$ank_version"
-          test "$ank_version" = "$mcp_version"
-
       # A version is printed on stdout; a protocol surface is a conversation on
       # stdin. The wrapper spawns with `stdio: inherit` precisely so that a
       # client's request reaches the server, and nothing above this line would
       # notice if it stopped: `--version` never reads a byte. One `initialize`
       # is the smallest exchange that does.
+      #
+      # Reached as a verb of the installed binary (ADR-1ea31c2f3c5a): the same
+      # `npx ank` the step above ran, given `mcp`. That is the configuration
+      # docs/integrating.md hands a reader to paste, exercised on the machine
+      # that will run it.
       #
       # `--repo` is given the checkout, which is the one directory on this
       # runner holding a `.ank/`, in the runner's own path shape rather than
@@ -467,9 +456,10 @@ jobs:
           set -e
           cd smoke
           reply=$(echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' \
-            | npx ank-mcp --repo "$GITHUB_WORKSPACE")
+            | npx ank mcp --repo "$GITHUB_WORKSPACE")
           echo "$reply"
-          printf '%s\n' "$reply" | grep -q '"name":"ank-mcp"'
+          printf '%s\n' "$reply" | grep -q '"serverInfo"'
+          printf '%s\n' "$reply" | grep -q '"protocolVersion"'
 
       # The exit codes carry meaning (section 4) and a wrapper is where they go
       # to die. An unknown verb is a 2, and 2 rather than 1 is the point: a
@@ -477,11 +467,16 @@ jobs:
       # test that only asked for non-zero. It also needs no repository, so what
       # is under test is the wrapper and not the fixture.
       #
-      # Both bins, because both now go through one wrapper.js and a shim of
-      # their own: `ank-mcp` refuses an unknown argument with the environment
-      # code, and 9 is the one code this wrapper also produces by itself, so a
-      # 9 that came from the wrapper instead of the server would read the same.
-      # The line on stderr is what tells them apart, and it is asserted.
+      # One bin now, so one shim and one wrapper: what a client launches to
+      # reach the protocol surface is this same `ank`, given `mcp`
+      # (ADR-1ea31c2f3c5a). 2 rather than 1 is the point of the first case: a
+      # wrapper collapsing every failure into "it failed" would still pass a
+      # test that only asked for non-zero. It also needs no repository, so what
+      # is under test is the wrapper and not the fixture.
+      #
+      # The second case is the verb the surface lives behind, refusing before
+      # any client is listening. It travels through the same shim, so a
+      # wrapper that ate the refusal on the way back would show here.
       - name: the exit code survives the wrapper
         shell: bash
         run: |
@@ -495,13 +490,13 @@ jobs:
           test "$code" -eq 2
 
           set +e
-          err=$(npx ank-mcp --nosuchflag 2>&1)
+          err=$(npx ank mcp --nosuchflag 2>&1)
           code=$?
           set -e
           echo "$err"
-          echo "an unknown argument to ank-mcp exited $code"
-          test "$code" -eq 9
-          printf '%s\n' "$err" | grep -q "unknown argument"
+          echo "an unknown flag on the protocol surface exited $code"
+          test "$code" -eq 1
+          printf '%s\n' "$err" | grep -q -- "--nosuchflag"
 
   publish-npm:
     # Only on a tag, and only once all three smoke tests agree. Publishing is

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -34,20 +34,13 @@ revision answers the same question about the other half: it is the value
 that file can compare two strings it already holds and see that its
 instructions predate its tool.
 
-### The protocol surface installs with it
+### The protocol surface is a verb of the same binary
 
-Every route places a second executable beside `ank`: **`ank-mcp`**, the same
-verbs over MCP, for a client that has no shell to run them in. It is freight of
-the three install routes rather than a fourth beside them,
-so there is nothing further to fetch:
-
-    $ ank-mcp --version
-    ank-mcp <version>
-
-The same version `ank` reports, because the two are freight of one release and
-come out of one build. They are not versionable apart on purpose: a server built
-from an older table would advertise verbs the installed CLI does not dispatch,
-and the refusal a caller got back would be one no exit code describes.
+A client that has no shell to run verbs in reaches the same verbs over MCP, and
+there is nothing further to install for it: the surface is **`ank mcp`**, a verb
+of the executable you just put on your `PATH` (ADR-1ea31c2f3c5a). Every route
+carries one file, so a route cannot deliver the CLI and fail to deliver the
+surface.
 
 It speaks JSON-RPC over stdio and the client spawns it, which means it is
 configured rather than started. Three configurations, and each of them is
@@ -55,7 +48,7 @@ pasted rather than derived.
 
 **Claude Code**, one line, which writes the entry for you:
 
-    claude mcp add ank -- ank-mcp --repo /path/to/your/repo
+    claude mcp add ank -- ank mcp --repo /path/to/your/repo
 
 or `.mcp.json` at the root of the repository, which is the form that travels
 with the tree and reaches everyone who clones it:
@@ -63,8 +56,8 @@ with the tree and reaches everyone who clones it:
     {
       "mcpServers": {
         "ank": {
-          "command": "ank-mcp",
-          "args": ["--repo", "/path/to/your/repo"]
+          "command": "ank",
+          "args": ["mcp", "--repo", "/path/to/your/repo"]
         }
       }
     }
@@ -76,8 +69,8 @@ directory of its own and so has nothing else to go on:
     {
       "mcpServers": {
         "ank": {
-          "command": "ank-mcp",
-          "args": ["--repo", "/path/to/your/repo"]
+          "command": "ank",
+          "args": ["mcp", "--repo", "/path/to/your/repo"]
         }
       }
     }
@@ -88,32 +81,33 @@ for every project at once:
     {
       "mcpServers": {
         "ank": {
-          "command": "ank-mcp",
-          "args": ["--repo", "/path/to/your/repo"]
+          "command": "ank",
+          "args": ["mcp", "--repo", "/path/to/your/repo"]
         }
       }
     }
+
+**`command` is `ank` and `mcp` is the first argument, in all three.** If you
+have a configuration written against `ank-mcp`, that is the one line to change:
+releases up to 0.6.0 placed a second executable by that name and no route places
+one any more, so a client still naming it gets `command not found` rather than a
+wrong answer.
 
 **`--repo` is written out in all three, and that is the point of showing them.**
 A client spawns the server in whatever directory it happens to be in, and with
 no `--repo` the server takes that directory. The failure mode is not an error:
 it is a process quietly speaking for a corpus nobody meant, or for none. The
-configuration is also the *only* place it can be named, because one process
-speaks for exactly one corpus, fixed at startup, and a call that tries to pass
-`--repo` itself is refused by name:
+configuration is also where it is named rather than something a call may
+override, and a call that tries to pass `--repo` itself is refused by name:
 
-    {"jsonrpc":"2.0","id":3,"error":{"code":-32602,"message":"--repo belongs to the server: one process, one corpus"}}
-
-So several repositories are several entries, one server each. That is the same
-answer the refs give everywhere else: claims live in `refs/ank/*`, which is per
-repository, and nothing merges the claim spaces of two clones.
+    {"jsonrpc":"2.0","id":3,"error":{"code":-32602,"message":"--repo belongs to the server: name a corpus with the corpus argument, by the identity ank status --json prints, never by a path"}}
 
 A path with no corpus under it is refused before any client is listening, rather
 than after, so it reaches a person rather than a log:
 
-    $ ank-mcp --repo /tmp
-    error[9]: no .ank/ under /tmp
-      -> ank-mcp --repo <path to a directory holding .ank/>
+    $ ank mcp --repo /tmp
+    error[1]: no .ank/ found from /tmp
+      -> ank init
 
 Every verb the CLI dispatches is a tool on that surface, under the name
 `ank_<verb>`, and what a call gets back is the document `--json` returns with

--- a/docs/integrating.md
+++ b/docs/integrating.md
@@ -236,11 +236,34 @@ side, which is what makes them worth copying.
 
 ## The protocol surface is the same verbs, over MCP
 
-A client with no shell reaches ank through `ank-mcp`, which installs beside the
-CLI by every route that installs the CLI. The configuration
-to paste is in [getting-started.md](getting-started.md); what it *is* belongs
-here, because four properties of it are load-bearing and none of them is
-visible from a tool list.
+A client with no shell reaches ank through `ank mcp`, a verb of the one
+executable every route installs (ADR-1ea31c2f3c5a). There is no second file to
+fetch, sign or discover: what the CLI dispatches is what the surface serves,
+because they are the same file.
+
+The configuration is `command` naming the binary and `mcp` as its first
+argument, and it is pasted rather than derived:
+
+    {
+      "mcpServers": {
+        "ank": {
+          "command": "ank",
+          "args": ["mcp", "--repo", "/path/to/your/repo"]
+        }
+      }
+    }
+
+`--repo` is written out because a client spawns the server in whatever
+directory it happens to be in, and with no `--repo` the server takes that
+directory -- which is a process quietly speaking for a corpus nobody meant, or
+for none, rather than an error anyone sees.
+[getting-started.md](getting-started.md) carries the same block per client, for
+somebody installing rather than integrating. If you hold a configuration
+written against a second executable named `ank-mcp`, releases up to 0.6.0
+placed one and no route places one any more: the change is that one line.
+
+What the surface *is* belongs here, because four properties of it are
+load-bearing and none of them is visible from a tool list.
 
 **Every verb `COMMANDS` carries, generated from that table.** Not a curated
 subset, under any protocol (ADR-fd98f4bc6dea). It is the same table `ank help
@@ -254,13 +277,13 @@ exactly as they sit on the command line; flags arrive under their own names with
 the leading dashes stripped. Nothing in the server names a verb, so the two
 surfaces cannot disagree about what exists.
 
-**One process speaks for one corpus.** `--repo` is resolved once, at startup, and
-that value is what every call is given, so a server cannot drift between corpora
-while a client holds a claim in one. A call that passes `--repo`, `--json` or
-`--quiet` is refused by name rather than being allowed to contradict the process
-it is talking to:
+**One process is addressed with one corpus, at startup.** `--repo` is resolved
+once, there, and that value is what a call naming no corpus of its own is given,
+so a server cannot drift between corpora while a client holds a claim in one. A
+call that passes `--repo`, `--json` or `--quiet` is refused by name rather than
+being allowed to contradict the process it is talking to:
 
-    {"jsonrpc":"2.0","id":3,"error":{"code":-32602,"message":"--repo belongs to the server: one process, one corpus"}}
+    {"jsonrpc":"2.0","id":3,"error":{"code":-32602,"message":"--repo belongs to the server: name a corpus with the corpus argument, by the identity ank status --json prints, never by a path"}}
 
 Nothing is hidden by that and nothing is curated: every verb takes exactly the
 arguments the table gives it, and what is withheld is three flags that are the
@@ -297,16 +320,17 @@ it still refuses off the default branch, with no way around it.
 
 ## The watcher keeps a cache warm, and answers nothing
 
-`ank-daemon` is a background process that keeps the derived index of the corpora
+`ank watch` is a background process that keeps the derived index of the corpora
 you declare current, so the `ank` you run finds a cache it does not have to
-rebuild. It is built from this workspace and no installation route ships it,
-which is the same statement as the one below about nothing depending on it.
-Everything else worth knowing about it as an integrator is what it refuses to be
-(ADR-a22cd3196529).
+rebuild. It is a verb of the same one executable every route installs
+(ADR-1ea31c2f3c5a), so every installation already has it -- and running one is
+still nobody's condition for anything, which is the statement below about
+nothing depending on it. Everything else worth knowing about it as an
+integrator is what it refuses to be (ADR-a22cd3196529).
 
 **It is not a surface.** No socket, no protocol, no query of its own, and no
 subset of the verbs. There is nothing here to ask: a caller that wants an answer
-runs the CLI, or talks to `ank-mcp`. A daemon answering the three questions a
+runs the CLI, or talks to `ank mcp`. A watcher answering the three questions a
 dashboard finds convenient would be the curated subset ADR-fd98f4bc6dea refuses,
 reached from the other direction, and it would be a third dispatch path in a
 project that has spent its history reducing to one. It does *tell* you when a
@@ -348,8 +372,9 @@ Two worktrees of one repository are two paths under one key, and therefore one
 watched corpus -- which is the whole reason the key is not the path. A key that
 is not a root commit is refused by name, a checkout filed under another
 repository's identity is refused with both identities, and a directory carrying
-no `.ank/` is refused rather than searched around: `ank-daemon --list` prints
-what would be watched without watching anything.
+no `.ank/` is refused rather than searched around: `ank watch --list` prints
+what would be watched without watching anything, and `ank watch --where` prints
+where the declaration is read from.
 
 **The only things it writes into a repository are that repository's own
 `index.db` and a mirror of `refs/ank/*`.** The mirror lands in
@@ -454,7 +479,7 @@ holds that true.
 - **`--repo <path>` addresses a corpus**, so a tool holding several addresses
   each on its own. Claims are per repository: nothing merges the claim spaces of
   two clones, because `refs/ank/*` cannot carry such an arbitration.
-- **Do not bind to `ank-daemon`.** It answers nothing, and it is optional by
+- **Do not bind to `ank watch`.** It answers nothing, and it is optional by
   construction. Write your integration against the CLI or the protocol surface,
   and let the watcher make those answers arrive sooner where somebody chose to
   run one.

--- a/install.ps1
+++ b/install.ps1
@@ -10,12 +10,15 @@ the release published, verify it against the .sha256 published beside it, unpack
 it, and never end in silence. What differs is only what Windows spells
 differently.
 
-Two executables land and not one: ank.exe, and ank-mcp.exe beside it, the
-protocol surface a client speaks to. They come out of one archive and go into
-one directory, and no route carries one without the other. That pairing ends
-with TASK-d9b167250aa8, which leaves one executable to install. An archive published before ank-mcp existed carries only ank.exe, and
--Version points this script at exactly those: such a release installs ank.exe
-and is told what is missing, rather than becoming a route that stopped working.
+One executable lands: ank.exe. The protocol surface and the watcher are verbs
+of it (ADR-1ea31c2f3c5a), so there is no second file for this script to place
+and no way for one to fail to arrive.
+
+-Version reaches releases published before that was true, whose archive carries
+a second executable beside ank.exe. Nothing here asks: the archive is unpacked,
+ank.exe is taken out of it, and whatever else the directory holds goes with the
+temporary directory. So an old release installs the one file this script
+promises, by the same code path a new one does.
 
 Windows PowerShell 5.1 is the floor, because that is what a clean Windows ships
 and this channel exists for the machine that has nothing installed yet. Two
@@ -105,10 +108,10 @@ function Fail {
 function Show-Usage {
     Say 'install ank from a GitHub release'
     Say ''
-    Say 'Two executables land in the install directory: ank.exe, and ank-mcp.exe'
-    Say 'beside it, the protocol surface a client speaks to. A release published'
-    Say 'before ank-mcp existed carries only ank.exe; this installs it and says'
-    Say 'what is missing.'
+    Say 'One executable lands in the install directory: ank.exe. The protocol'
+    Say 'surface and the watcher are verbs of it -- ank mcp, ank watch -- so'
+    Say 'there is nothing further to fetch and nothing further to configure a'
+    Say 'client against.'
     Say ''
     Say 'usage:'
     Say "  irm $RawUrl | iex"
@@ -569,11 +572,10 @@ function Expand-Zip {
 # one takes the name; the stale copies are swept on the next run, since the
 # process holding one is still holding it now.
 #
-# Written once and called twice rather than inlined per executable: ank.exe and
-# ank-mcp.exe are locked by the same rule, and a second copy of this dance is a
-# second place for it to stop being true. Returns the message of the failure it
-# could not work around, or $null, because the two callers have different things
-# to say afterwards -- one has installed nothing, the other has installed ank.
+# A function rather than an inlined block: what it does is subtle enough to be
+# worth reading on its own, and its one caller is easier to read for not
+# carrying it. Returns the message of the failure it could not work around, or
+# $null.
 function Move-IntoPlace {
     param([string]$Source, [string]$Destination, [string]$Name)
 
@@ -884,7 +886,14 @@ try {
     }
 
     # The layout release.yml packages: one directory named after the archive,
-    # carrying the two executables beside README.md, LICENSE and SKILL.md.
+    # carrying the executable beside README.md, LICENSE and SKILL.md.
+    #
+    # ank.exe is required and the rest of the directory is not read at all. An
+    # archive published before ADR-1ea31c2f3c5a carries a second executable
+    # there, and the answer to it is the same as the answer to README.md: it is
+    # not what was asked for, so it is not moved anywhere. A check that refused
+    # an archive holding more than this would refuse every release published so
+    # far.
     $unpacked = Join-Path $tmp "ank-$bare-$target"
     $binary = Join-Path $unpacked 'ank.exe'
     if (-not (Test-Path -Path $binary -PathType Leaf)) {
@@ -896,13 +905,6 @@ try {
             'Nothing was installed.'
         )
     }
-
-    # The other half of the same rule: where this route places ank, it places
-    # ank-mcp next to it. Missing only from an archive older than the protocol
-    # surface itself, which is a release -Version still reaches, so its absence
-    # is reported at the end rather than refused here.
-    $mcpBinary = Join-Path $unpacked 'ank-mcp.exe'
-    $mcpInstalled = Test-Path -Path $mcpBinary -PathType Leaf
 
     if (-not $Dir) {
         if (-not $env:LOCALAPPDATA) {
@@ -945,28 +947,6 @@ try {
         )
     }
 
-    # The same call in the same order, which is what gives the pair the same
-    # permissions rather than a second mechanism that hopes to: both files were
-    # unpacked out of one archive into one directory, so they carry the same
-    # access rules before this line, and a move into $Dir treats them alike.
-    $mcpDestination = Join-Path $Dir 'ank-mcp.exe'
-    if ($mcpInstalled) {
-        $failure = Move-IntoPlace -Source $mcpBinary -Destination $mcpDestination -Name 'ank-mcp.exe'
-        if ($failure) {
-            Fail 1 @(
-                "could not write $mcpDestination.",
-                '',
-                "  $failure",
-                '',
-                'Something is holding the file open and it could not be renamed either.',
-                'Close any client running ank-mcp and try again.',
-                '',
-                "ank is installed at $destination. ank-mcp is not, so a client has",
-                'no protocol surface to reach until this is run again.'
-            )
-        }
-    }
-
     $installedVersion = ''
     try {
         $installedVersion = (& $destination --version 2>$null | Select-Object -First 1)
@@ -974,31 +954,9 @@ try {
         $installedVersion = ''
     }
 
-    $mcpVersion = ''
-    if ($mcpInstalled) {
-        try {
-            $mcpVersion = (& $mcpDestination --version 2>$null | Select-Object -First 1)
-        } catch {
-            $mcpVersion = ''
-        }
-    }
-
     Say ''
     Say "installed  $destination"
     if ($installedVersion) { Say "           $installedVersion" }
-    if ($mcpInstalled) {
-        Say "           $mcpDestination"
-        if ($mcpVersion) { Say "           $mcpVersion" }
-    } else {
-        # Said rather than swallowed. The caller asked for ank and has ank, so
-        # this is not a failure; but a client pointed at this directory will
-        # find no ank-mcp.exe in it, and this is the only place able to say why.
-        Say ''
-        Say "$archive carries no ank-mcp.exe, so only ank was installed."
-        Say 'That archive predates the protocol surface. A release that carries'
-        Say 'both installs both:'
-        Say "  irm $RawUrl | iex"
-    }
 
     # The last way left to leave a caller without a working `ank`: a binary in a
     # directory nothing looks in. Naming the command to run is the difference

--- a/install.sh
+++ b/install.sh
@@ -5,13 +5,17 @@
 #   curl -fsSL https://raw.githubusercontent.com/haksolot/ank/main/install.sh | sh
 #   curl -fsSL https://raw.githubusercontent.com/haksolot/ank/main/install.sh | sh -s -- --version v0.2.0
 #
-# Two executables land and not one: `ank`, and `ank-mcp` beside it, the protocol
-# surface a client speaks to. They come out of one archive and go into one
-# directory, and no route carries one without the other. That pairing ends with
-# TASK-d9b167250aa8, which leaves one executable to install. An archive published before ank-mcp existed carries only `ank`, and
-# --version points this script at exactly those: such a release installs `ank`
-# and is told what is missing, rather than becoming a route that stopped
-# working.
+# One executable lands: `ank`. The protocol surface and the watcher are verbs of
+# it (ADR-1ea31c2f3c5a), so there is no second file for this script to place and
+# no way for one to fail to arrive.
+#
+# `--version` reaches releases published before that was true, whose archive
+# carries a second executable beside `ank`. Nothing here asks: the archive is
+# unpacked, `ank` is taken out of it, and whatever else the directory holds goes
+# with the temporary directory. So an old release installs the one file this
+# script promises, by the same code path a new one does -- an installer that
+# only worked on releases that do not exist yet would not be a working
+# installer.
 #
 # POSIX sh and no bashisms, deliberately. This is the channel for the Linux
 # distribution that will never have a native package, and the smallest of those
@@ -218,9 +222,9 @@ usage() {
   cat >&2 <<EOF
 install ank from a GitHub release
 
-Two executables land in the install directory: ank, and ank-mcp beside it,
-the protocol surface a client speaks to. A release published before ank-mcp
-existed carries only ank; this installs it and says what is missing.
+One executable lands in the install directory: ank. The protocol surface and
+the watcher are verbs of it -- ank mcp, ank watch -- so there is nothing
+further to fetch and nothing further to configure a client against.
 
 usage:
   install.sh [--version <version>] [--dir <path>]
@@ -619,7 +623,13 @@ tar xzf "${tmp}/${archive}" -C "$tmp" ||
   die 3 "could not unpack ${archive}." "" "Nothing was installed."
 
 # The layout release.yml packages: one directory named after the archive,
-# carrying the two executables beside README.md, LICENSE and SKILL.md.
+# carrying the executable beside README.md, LICENSE and SKILL.md.
+#
+# `ank` is required and the rest of the directory is not read at all. An
+# archive published before ADR-1ea31c2f3c5a carries a second executable there,
+# and the answer to it is the same as the answer to README.md: it is not what
+# was asked for, so it is not moved anywhere. A check that refused an archive
+# holding more than this would refuse every release published so far.
 unpacked="${tmp}/ank-${bare}-${target}"
 binary="${unpacked}/ank"
 if [ ! -f "$binary" ]; then
@@ -629,12 +639,6 @@ if [ ! -f "$binary" ]; then
     "" \
     "Nothing was installed."
 fi
-
-# The other half of the same rule: where this route places ank, it places
-# ank-mcp next to it. Missing only from an archive older than the protocol
-# surface itself, which is a release --version still reaches, so its absence is
-# reported at the end rather than refused here.
-mcp_binary="${unpacked}/ank-mcp"
 
 if [ -z "$install_dir" ]; then
   [ -n "${HOME:-}" ] ||
@@ -663,53 +667,13 @@ chmod +x "$binary"
 mv -f "$binary" "${install_dir}/ank" ||
   die 1 "could not write ${install_dir}/ank." "" "Nothing was installed."
 
-# The same two operations in the same order, which is what gives the pair the
-# same permissions rather than a second mechanism that hopes to: tar restored
-# both files out of one archive under one umask, so their modes are equal
-# before this line, and `chmod +x` adds to the mode it is applied to instead of
-# imposing one. Reading ank's mode back and copying it onto ank-mcp would need
-# two spellings of stat, GNU's and BSD's, to buy a guarantee already held.
-if [ -f "$mcp_binary" ]; then
-  chmod +x "$mcp_binary"
-  mv -f "$mcp_binary" "${install_dir}/ank-mcp" ||
-    die 1 "could not write ${install_dir}/ank-mcp." \
-      "" \
-      "ank is installed at ${install_dir}/ank. ank-mcp is not, so a client" \
-      "has no protocol surface to reach until this is run again."
-  mcp_installed=yes
-else
-  mcp_installed=no
-fi
-
 installed_version=$("${install_dir}/ank" --version 2>/dev/null | head -1) ||
   installed_version=""
-
-mcp_version=""
-if [ "$mcp_installed" = yes ]; then
-  mcp_version=$("${install_dir}/ank-mcp" --version 2>/dev/null | head -1) ||
-    mcp_version=""
-fi
 
 say ""
 say "installed  ${install_dir}/ank"
 if [ -n "$installed_version" ]; then
   say "           ${installed_version}"
-fi
-if [ "$mcp_installed" = yes ]; then
-  say "           ${install_dir}/ank-mcp"
-  if [ -n "$mcp_version" ]; then
-    say "           ${mcp_version}"
-  fi
-else
-  # Said rather than swallowed, and on stderr like everything else here. The
-  # caller asked for ank and has ank, so this is not a failure; but a client
-  # pointed at this directory will find no ank-mcp in it, and this is the only
-  # place able to say why.
-  say ""
-  say "${archive} carries no ank-mcp, so only ank was installed."
-  say "That archive predates the protocol surface. A release that carries both"
-  say "installs both:"
-  say "  curl -fsSL ${raw_url} | sh"
 fi
 
 # The last way left to leave a caller without a working `ank`: a binary in a

--- a/npm/README.md
+++ b/npm/README.md
@@ -19,15 +19,12 @@ fetched the binary would die behind exactly the firewall this package exists to
 cross. `bin/wrapper.js` is therefore a resolver, never a downloader: it finds
 the platform package with `require.resolve` and executes what it finds.
 
-**Two executables, one package, one version.** Each platform package carries
-`ank` and `ank-mcp`, the protocol surface, out of the same build
-: no route carries one without the other, so there is no
-install holding a CLI and a passthrough generated from a different table. The
-wrapper declares both as `bin` and resolves them by one route -- `bin/ank` and
-`bin/ank-mcp` are two lines each, and `bin/wrapper.js` is the resolution, the
-diagnostics and the exit code for both. Two copies of that file is the
-arrangement where the protocol surface quietly stops resolving the way the CLI
-does and nothing turns red.
+**One executable, one package, one version.** Each platform package carries
+`ank` and nothing else (ADR-1ea31c2f3c5a). The protocol surface is the verb
+`ank mcp` and the watcher is `ank watch`, so there is no second file that could
+arrive from a different build, or fail to arrive at all. The wrapper declares
+one `bin` -- `bin/ank` is two lines, and `bin/wrapper.js` is the resolution,
+the diagnostics and the exit code behind it.
 
 **The Linux package declares no `libc`.** The build is `x86_64-unknown-linux-musl`
 and statically linked, so it runs on a glibc distribution just as well; declaring
@@ -39,13 +36,13 @@ not because it restricts where it runs.
 gives 4, 6, 8 and 9 distinct meanings that an agent branches on. A wrapper that
 collapsed them into 0 and 1 would break every caller reading them, which is why
 `bin/wrapper.js` exits with the child's status and reserves 9, the environment
-code, for its own failures. `ank-mcp` reaches its client the same way, and `stdio` is
-inherited rather than captured, because a surface that speaks JSON-RPC on stdin
-has nothing to say to a wrapper holding the pipe.
+code, for its own failures. `ank mcp` reaches its client through the same shim,
+and `stdio` is inherited rather than captured, because a surface that speaks
+JSON-RPC on stdin has nothing to say to a wrapper holding the pipe.
 
 ## What is not in git
 
-`npm/ank-*/bin/` is empty here and ignored. Both binaries land in it during the
+`npm/ank-*/bin/` is empty here and ignored. The binary lands in it during the
 release run, from the same artefacts the GitHub release publishes: one build,
 two channels, no second compilation that could disagree with the first.
 
@@ -60,7 +57,6 @@ only ever the last released one.
 `release.yml` does it on a `v*` tag, with `NPM_TOKEN` from the repository
 secrets and `--access public`, which a scoped package needs on its first
 publish. On `workflow_dispatch` the same job assembles the packages, installs
-them from the tarballs on all three platforms, and shows `ank-mcp` answering
-`--version` with the number `ank` answers with, so the pipeline is proved before
-a tag depends on it, and a tag is the one thing here that is awkward to take
-back.
+them from the tarballs on all three platforms, and holds one `initialize`
+conversation with `npx ank mcp`, so the pipeline is proved before a tag depends
+on it, and a tag is the one thing here that is awkward to take back.

--- a/npm/ank-darwin-arm64/package.json
+++ b/npm/ank-darwin-arm64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@haksolot/ank-darwin-arm64",
   "version": "0.6.0",
-  "description": "The ank and ank-mcp binaries for macOS on Apple silicon.",
+  "description": "The ank binary for macOS on Apple silicon.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/haksolot/ank",
   "repository": {
@@ -16,7 +16,6 @@
   ],
   "files": [
     "bin/ank",
-    "bin/ank-mcp",
     "LICENSE"
   ]
 }

--- a/npm/ank-linux-x64-musl/package.json
+++ b/npm/ank-linux-x64-musl/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@haksolot/ank-linux-x64-musl",
   "version": "0.6.0",
-  "description": "The ank and ank-mcp binaries for Linux x86_64, statically linked against musl.",
+  "description": "The ank binary for Linux x86_64, statically linked against musl.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/haksolot/ank",
   "repository": {
@@ -16,7 +16,6 @@
   ],
   "files": [
     "bin/ank",
-    "bin/ank-mcp",
     "LICENSE"
   ]
 }

--- a/npm/ank-win32-x64/package.json
+++ b/npm/ank-win32-x64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@haksolot/ank-win32-x64",
   "version": "0.6.0",
-  "description": "The ank and ank-mcp binaries for Windows x86_64.",
+  "description": "The ank binary for Windows x86_64.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/haksolot/ank",
   "repository": {
@@ -16,7 +16,6 @@
   ],
   "files": [
     "bin/ank.exe",
-    "bin/ank-mcp.exe",
     "LICENSE"
   ]
 }

--- a/npm/ank/README.md
+++ b/npm/ank/README.md
@@ -11,11 +11,21 @@ this channel works where fetching a bare executable does not. It covers
 `linux x64`, `darwin arm64` and `win32 x64`; on any other platform the wrapper
 exits 9 and names `cargo install`. ank needs **git 2.34 or newer**.
 
-Two commands are installed, out of one build and under one version: `ank`, the
-CLI, and `ank-mcp`, the protocol surface a client with no shell reaches instead.
-Every verb the CLI dispatches is a tool there, generated from the same table.
+One command is installed, and everything ank does is a verb of it. A client
+with no shell reaches the same verbs over MCP by launching that command with
+`mcp`, and every verb the CLI dispatches is a tool there, generated from the
+same table:
 
-This package carries both. The skill an agent loads is a separate install, and
+    {
+      "mcpServers": {
+        "ank": {
+          "command": "ank",
+          "args": ["mcp", "--repo", "/path/to/your/repo"]
+        }
+      }
+    }
+
+The skill an agent loads is a separate install, and
 [the documentation](https://github.com/haksolot/ank) covers both, along with the
 specification and the source.
 

--- a/npm/ank/bin/ank
+++ b/npm/ank/bin/ank
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 "use strict";
 
-// The CLI. Every word about how this resolves is in wrapper.js, which ank-mcp
-// beside it uses unchanged.
+// The CLI, and the only executable this package installs: the protocol surface
+// and the watcher are verbs of it (ADR-1ea31c2f3c5a). Every word about how it
+// resolves is in wrapper.js.
 require("./wrapper.js").run("ank");

--- a/npm/ank/bin/ank-mcp
+++ b/npm/ank/bin/ank-mcp
@@ -1,7 +1,0 @@
-#!/usr/bin/env node
-"use strict";
-
-// The protocol surface, resolved through the same platform package as `ank` by
-// the same wrapper. A client points its MCP configuration at
-// this name; the reasoning is in wrapper.js.
-require("./wrapper.js").run("ank-mcp");

--- a/npm/ank/bin/wrapper.js
+++ b/npm/ank/bin/wrapper.js
@@ -1,22 +1,21 @@
 "use strict";
 
-// One wrapper, two names.
+// The resolver behind `bin/ank`.
 //
 // This wrapper resolves a binary. It never downloads one.
 //
 // The driving case is the corporate workstation: a firewall that blocks
 // downloading a bare executable usually lets the npm registry through. A
 // postinstall script that fetched the binary would therefore die behind the
-// very firewall this package exists to cross. The binaries travel inside the
+// very firewall this package exists to cross. The binary travels inside the
 // platform packages instead, and npm installs exactly one of them by matching
 // `os` and `cpu` through optionalDependencies.
 //
-// `ank` and `ank-mcp` come out of one build and travel in one platform package
-// out of one package, so they resolve by one route. Two copies of this file,
-// one per bin, is the arrangement where the protocol surface quietly stops
-// resolving the way the CLI does and nothing turns red: the resolution, the
-// diagnostics and the exit-code passthrough are written once and `run` is
-// given the name to look for.
+// One name reaches everything this package carries: the protocol surface is
+// `ank mcp` and the watcher is `ank watch` (ADR-1ea31c2f3c5a), so there is one
+// bin, one shim and one resolution. It stayed a module of its own rather than
+// being folded into `bin/ank` because what lives here is the diagnostics and
+// the exit-code passthrough, which are the parts worth reading on their own.
 
 const { spawnSync } = require("child_process");
 
@@ -39,8 +38,8 @@ function fail(lines) {
 // run(name) -- spawn `name` out of the platform package, and be its exit code.
 //
 // `name` is the bin npm wrote a shim for, and it is also the file inside the
-// platform package: the assembly script copies both executables under the
-// names they were built with, so there is nothing here to map.
+// platform package: the assembly script copies the executable under the name
+// it was built with, so there is nothing here to map.
 function run(name) {
   const platform = process.platform + " " + process.arch;
   const pkg = PACKAGES[platform];
@@ -69,8 +68,8 @@ function run(name) {
   // 1 would break every caller that reads them.
   //
   // `stdio: inherit` is also what makes the protocol surface work at all:
-  // ank-mcp speaks JSON-RPC over stdin and stdout, so a wrapper that captured
-  // either would leave the client waiting forever.
+  // `ank mcp` speaks JSON-RPC over stdin and stdout, so a wrapper that
+  // captured either would leave the client waiting forever.
   const child = spawnSync(binary, process.argv.slice(2), { stdio: "inherit" });
   if (child.error) {
     fail([name + ": " + child.error.message, "  -> " + binary]);

--- a/npm/ank/package.json
+++ b/npm/ank/package.json
@@ -22,8 +22,7 @@
     "pi-package"
   ],
   "bin": {
-    "ank": "bin/ank",
-    "ank-mcp": "bin/ank-mcp"
+    "ank": "bin/ank"
   },
   "pi": {
     "skills": [
@@ -33,7 +32,6 @@
   },
   "files": [
     "bin/ank",
-    "bin/ank-mcp",
     "bin/wrapper.js",
     "skills/",
     "README.md",


### PR DESCRIPTION
Executes **ADR-1ea31c2f3c5a**, which superseded ADR-e39a44f80e0e. Closes TASK-d9b167250aa8.

`crates/ank-mcp` and `crates/ank-daemon` are already libraries with no `[[bin]]`, so `cargo build --workspace` produces one file named `ank`. Everything deleted here existed to answer *"did the second one arrive"* — a question a verb cannot fail.

## grep is the check

After this change, over every workflow, script and manifest that builds, copies, stages or installs a file:

```
$ grep -rn "ank-mcp\|ank-daemon" .github/ install.sh install.ps1 npm/
(no output)
```

Whole-tree, the surviving mentions are:

| where | what it is |
|---|---|
| `Cargo.toml`, `Cargo.lock` | the two crates as workspace members — libraries with no `[[bin]]`, which is the shape the ADR requires |
| `docs/integrating.md:262`, `docs/getting-started.md:91` | the one-line migration note the ADR's documentation clause asks for |
| `docs/integrating.md:314` | `ank-mcp/<version>`, the typed process identity the surface actually writes under (`crates/ank-mcp/src/call.rs`) |
| `README.md:15`, `README.md:41` | **out of scope and now false** — see below |

## What went

- **release.yml** builds `--bin ank`, copies one file into every archive, uploads one loose binary. The archive assertion became a *count*: it carries `ank` and nothing beside `README.md`, `LICENSE` and `SKILL.md`, so a route that grows a second file back turns red instead of passing. The npm smoke job lost the version-pairing step; the protocol surface is reached as `npx ank mcp --repo …` and the exit-code test runs through the same shim.
- **npm-assemble.sh** names one executable per platform package. The four manifests declare one `bin` and one `files` entry; `npm/ank/bin/ank-mcp` is deleted; `wrapper.js` stops being "one wrapper, two names".
- **check-version.sh** stops holding a second crate literal to the tag (and the fixtures follow: seven manifests, ten literals).
- **install.yml** drops the whole staged stand-in apparatus — the fake `ank-mcp`, `STAGED_LEGACY_VERSION`, the second staged release, and the pair/permissions assertions on both halves. What replaces them, on Linux, macOS ×2 and Windows: *the install directory holds exactly one file*.

## Installing an old release is not broken

`install.sh` and `install.ps1` take `ank` out of the unpacked directory and do not read the rest of it. An archive published before this change carries a second executable there; the answer to it is the answer to `README.md` — it is not what was asked for, so it is not moved anywhere, and it goes with the temporary directory. That is the sibling of what these scripts already did for an archive published *before* `ank-mcp` existed: tolerate the difference rather than assert the layout.

So there is no branch, no note and nothing to stage — which is exactly why install.yml can delete the stand-in apparatus without losing coverage. **The two-file case is measured on a real archive**: the *"latest release installs, or says why it cannot"* step installs from the published release, which today is a two-file one, and now asserts the install directory holds one file whichever archive it came out of.

Verified locally against staged one-file and two-file archives over a local HTTP server: both exit 0, both leave exactly one file.

## docs

`docs/integrating.md` now carries the pasteable configuration naming the binary and the verb:

```json
{ "mcpServers": { "ank": { "command": "ank", "args": ["mcp", "--repo", "/path/to/your/repo"] } } }
```

…and the same block per client in `docs/getting-started.md`, whose three examples all moved off `ank-mcp`. The watcher section no longer says it is built from the workspace and shipped by no route: it is `ank watch`, every installation has it, and `ank-daemon --list` became `ank watch --list`. Two quoted outputs were byte-stale against the current binary (`--repo` refusal, `no .ank/`) and now match what it prints.

## Green

- `cargo test --workspace` — all suites pass, 0 failed
- `cargo fmt --check` — clean
- `ank check` — `ok — 301 tasks, 70 adr, 392 signal(s)`, exit 0, no faults
- `.github/scripts/check-version-fixtures.sh` — every fixture behaves

## Flagged, not fixed

- **`README.md:15` and `README.md:41`** still say `ank-mcp` installs beside the binary. Outside this task's scope and outside ADR-1ea31c2f3c5a's perimeter, but false as of this PR. Two lines; happy to add them here or take a follow-up task.
- **`check-version.sh` no longer gates `crates/ank-mcp`'s version.** Its stated reason (the release ships it as a file) is gone, but that crate's `CARGO_PKG_VERSION` is what the surface reports to clients in `serverInfo` and in the `ank-mcp/<version>` identity, so it can now drift from the tag with nothing red. The clean fix is for `serverInfo` to report the CLI's version — `crates/**` is outside this task's scope.
- **`docs/integrating.md`'s "a deployment over several repositories is several servers"** predates ADR-fd98f4bc6dea v2's multi-corpus clause. Pre-existing drift, that decision's territory, untouched here beyond making the paragraph agree with the refusal it quotes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SMorusqwyDQ7GxXCuEKHdu