### PR TITLE
File the three the distribution task flagged rather than reached for

### DIFF
--- a/.ank/entities/TASK-90247d16a676.md
+++ b/.ank/entities/TASK-90247d16a676.md
@@ -1,0 +1,17 @@
+---
+id: TASK-90247d16a676
+type: task
+slug: the-readme-stops-promising-a-second-binary
+title: The README stops promising a second binary
+created: 2026-08-25T21:29:25Z
+author: haksolot@vmi3223161
+status: open
+scope:
+  - README.md
+blocked_by: []
+done_criteria: |
+  README.md carries no sentence saying ank-mcp installs beside the binary, and the line that teaches a client with no shell names the verb ank mcp instead. No occurrence of ank-mcp survives in README.md except as the typed process identity if it names one, and grep is the check.
+criteria_by: creator
+schema: 4
+version: 1
+---

--- a/.ank/entities/TASK-ae64d1c5678d.md
+++ b/.ank/entities/TASK-ae64d1c5678d.md
@@ -1,0 +1,18 @@
+---
+id: TASK-ae64d1c5678d
+type: task
+slug: the-protocol-surface-reports-the-version-the-tag
+title: The protocol surface reports the version the tag gates
+created: 2026-08-25T21:29:25Z
+author: haksolot@vmi3223161
+status: open
+scope:
+  - crates/ank-mcp/**
+  - .github/scripts/check-version.sh
+blocked_by: []
+done_criteria: |
+  The version a client reads in serverInfo, and the one in the ank-mcp/<version> identity, is a number the release gates against the tag. Either check-version.sh holds crates/ank-mcp's version to the tag again, or the surface reports ank-cli's version and the crate's own number stops reaching a client; the choice is stated in the code where it is made. A test drives the built binary and shows the version a client is told matches the one ank --version prints. cargo test is green and cargo fmt --check passes.
+criteria_by: creator
+schema: 4
+version: 1
+---

--- a/.ank/entities/TASK-bfe86a55c5d8.md
+++ b/.ank/entities/TASK-bfe86a55c5d8.md
@@ -1,0 +1,17 @@
+---
+id: TASK-bfe86a55c5d8
+type: task
+slug: the-integration-guide-stops-saying-a-deployment
+title: The integration guide stops saying a deployment over several repositories is several servers
+created: 2026-08-25T21:29:33Z
+author: haksolot@vmi3223161
+status: open
+scope:
+  - docs/integrating.md
+blocked_by: []
+done_criteria: |
+  No document states that a deployment over several repositories is several servers: ADR-fd98f4bc6dea permits one server to address several corpora, each on its own, and docs/integrating.md says so with the corpus argument named and an example a reader can paste. What the same paragraph must keep saying, because that decision keeps it in the same words, is that there is no merged claim space. ank check reports no fault.
+criteria_by: creator
+schema: 4
+version: 1
+---


### PR DESCRIPTION
`TASK-d9b167250aa8` named three things it found and did not fix, each outside its scope and each correctly left alone. Filing them turns a note in a merged PR body into work the corpus can hand somebody.

| task | what |
|---|---|
| `TASK-90247d16a676` | `README.md:15,41` still promise `ank-mcp` installs beside the binary — false as of #281 |
| `TASK-ae64d1c5678d` | the version a client reads can now drift from the tag |
| `TASK-bfe86a55c5d8` | the integration guide still says a deployment over several repositories is several servers |

**The second is a hole #281 opened rather than found**, and it is the one worth reading twice. `check-version.sh` gated `crates/ank-mcp`'s version against the tag *because the release shipped it as a file*. The file is gone, so the gate went with it — correctly, by that reasoning. But that crate's `CARGO_PKG_VERSION` is still what a client is told in `serverInfo` and in the `ank-mcp/<version>` process identity, so a number a client reads can now drift from the release with nothing turning red. The criterion names both honest fixes and asks for the choice to be stated where it is made.

The third is pre-existing drift that `ADR-fd98f4bc6dea` created and nobody had swept: that decision permits one server to address several corpora, each on its own. What the paragraph must keep saying, in the same words the decision keeps, is that there is no merged claim space.

`ank check` 0 faults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhWoNxFoF1e5S2n5cbkoPC