### PR TITLE
The README stops promising a second binary

### DIFF
--- a/.ank/entities/LOG-4be404923f24.md
+++ b/.ank/entities/LOG-4be404923f24.md
@@ -1,0 +1,15 @@
+---
+id: LOG-4be404923f24
+type: log
+title: Read the README whole rather than the two false lines. Three things were stale, not two. (1) The
+created: 2026-08-25T21:59:01Z
+author: claude-code/opus-5+readme
+scope:
+  - README.md
+about: TASK-90247d16a676
+seq: 0
+schema: 4
+version: 1
+---
+
+ install comment promised 'the binary, and ank-mcp beside it'; (2) the MCP paragraph said ank-mcp installs beside the binary by every route. Both are now one sentence saying every surface is a verb of the one executable, and naming ank mcp. (3) The third is the one grep would never have found: the README's account of what installing gives you predates ank tui and ank watch entirely, so a reader learned about neither. Confirmed against the tree rather than the changelog -- crates/ank-mcp and crates/ank-daemon both declare [lib] with no [[bin]], only crates/ank-cli carries [[bin]] name = "ank", and verbs.rs carries tui, mcp and watch as CommandSpecs in the 'look around' group. Deliberately invented no second phrasing for the configuration: getting-started.md and integrating.md both carry the pasteable block naming command 'ank' and 'mcp' as first argument, per ADR-1ea31c2f3c5a's clause that the configuration names the binary and the verb, and the README keeps delegating to getting-started for it rather than adding a fourth copy that can drift. Borrowed their words for the claim itself ('a verb of the one executable every route installs'). Zero occurrences of ank-mcp survive in README.md.

--- a/.ank/entities/LOG-e78a74587d3c.md
+++ b/.ank/entities/LOG-e78a74587d3c.md
@@ -1,0 +1,13 @@
+---
+id: LOG-e78a74587d3c
+type: log
+title: done, proof commit:996cc4fa41cd7cfc3d3a6246d8e4b3551a84b748
+created: 2026-08-25T22:07:12Z
+author: claude-code/opus-5+readme
+scope:
+  - README.md
+about: TASK-90247d16a676
+seq: 1
+schema: 4
+version: 1
+---

--- a/.ank/entities/TASK-90247d16a676.md
+++ b/.ank/entities/TASK-90247d16a676.md
@@ -5,7 +5,7 @@ slug: the-readme-stops-promising-a-second-binary
 title: The README stops promising a second binary
 created: 2026-08-25T21:29:25Z
 author: haksolot@vmi3223161
-status: open
+status: in_progress
 scope:
   - README.md
 blocked_by: []
@@ -13,5 +13,5 @@ done_criteria: |
   README.md carries no sentence saying ank-mcp installs beside the binary, and the line that teaches a client with no shell names the verb ank mcp instead. No occurrence of ank-mcp survives in README.md except as the typed process identity if it names one, and grep is the check.
 criteria_by: creator
 schema: 4
-version: 1
+version: 2
 ---

--- a/.ank/entities/TASK-90247d16a676.md
+++ b/.ank/entities/TASK-90247d16a676.md
@@ -5,13 +5,18 @@ slug: the-readme-stops-promising-a-second-binary
 title: The README stops promising a second binary
 created: 2026-08-25T21:29:25Z
 author: haksolot@vmi3223161
-status: in_progress
+status: done
 scope:
   - README.md
 blocked_by: []
 done_criteria: |
   README.md carries no sentence saying ank-mcp installs beside the binary, and the line that teaches a client with no shell names the verb ank mcp instead. No occurrence of ank-mcp survives in README.md except as the typed process identity if it names one, and grep is the check.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 996cc4fa41cd7cfc3d3a6246d8e4b3551a84b748
+    criteria: 78241c50d8b5
+    via: submitted
 schema: 4
-version: 2
+version: 3
 ---

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Tasks and architecture decisions in your repo, behind one CLI any coding agent c
 <a href="LICENSE"><img alt="Licence" src="https://img.shields.io/badge/licence-Apache--2.0-blue"></a></p>
 
 ```sh
-npm install -g @haksolot/ank     # the binary, and ank-mcp beside it
+npm install -g @haksolot/ank     # one executable, and nothing beside it
 npx skills add haksolot/ank      # the skill, into whichever agent you run
 ```
 
@@ -38,9 +38,14 @@ Four verbs carry the loop: `ank context` for what binds here and what is takeabl
 `ank done` to finish with a proof that `ank check` can verify afterwards.
 [Getting started][start] walks all of it with real output, from `ank init` onward.
 
-A client with no shell reaches the same verbs over MCP. `ank-mcp` installs beside
-the binary by every route that installs it, and [getting started][start] carries
-the configuration to paste, for Claude Code, Claude Desktop and Cursor.
+Installing puts one executable on your `PATH`, and every surface ank has is a
+verb of it. A client with no shell reaches the same verbs over MCP through
+`ank mcp`, with no second file to fetch or discover, and [getting started][start]
+carries the configuration to paste, for Claude Code, Claude Desktop and Cursor.
+
+`ank tui` is the same corpus full-screen, for a human at a terminal. `ank watch`
+keeps the corpora you declare warm so the next `ank` answers sooner, and nothing
+depends on it running.
 
 ## What it is not
 


### PR DESCRIPTION
`ADR-1ea31c2f3c5a` superseded `ADR-e39a44f80e0e` and `TASK-d9b167250aa8` landed it. There is one executable: `crates/ank-mcp` and `crates/ank-daemon` declare `[lib]` with no `[[bin]]`, only `crates/ank-cli` carries `[[bin]] name = "ank"`, and a clean `cargo build --workspace` produces one file. The README had not caught up.

## What changed

**The two false sentences.** README.md:15 promised `# the binary, and ank-mcp beside it`, and README.md:41 said `ank-mcp` installs beside the binary by every route that installs it. Both now say every surface is a verb of the one executable, and the MCP paragraph names `ank mcp`. No occurrence of `ank-mcp` survives in README.md.

**A third thing was stale, which grep would not have found.** The README's account of what installing gives you predates `ank tui` and `ank watch` entirely — both are `CommandSpec`s in the `look around` group of `verbs.rs`, and a reader of the README learned about neither. The paragraph that claims one executable is the right place to say what that one executable carries, so it now names all three verbs.

## Consistency with the docs, deliberately

`docs/getting-started.md` and `docs/integrating.md` were rewritten this afternoon by `TASK-d9b167250aa8` and both carry the pasteable configuration naming `command: "ank"` with `mcp` as the first argument — which is `ADR-1ea31c2f3c5a`'s own clause, that the configuration names the binary and the verb. The README does **not** add a fourth copy of it. It keeps delegating to getting started, which is what it already did, and borrows their claim rather than inventing a second phrasing that can drift. A one-liner at the top level would be a third place to keep in step for no reader who is not already going to getting started for the rest of the install.

## Verification

- `cargo test --workspace` green, 0 failed
- `cargo fmt --check` clean
- `ank check` exit 0, 0 faults
- `grep -c ank-mcp README.md` → 0
- `ank done --proof commit:996cc4f`

Scope was README.md and nothing else; `crates/ank-mcp/**` and `docs/integrating.md` are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0139p8wDbrBZkhBqSETmmo88