### PR TITLE
The protocol surface reports the version the tag gates, not the library's

### DIFF
--- a/.ank/entities/LOG-4478aa3d140f.md
+++ b/.ank/entities/LOG-4478aa3d140f.md
@@ -1,0 +1,16 @@
+---
+id: LOG-4478aa3d140f
+type: log
+title: "Chosen and built: the surface reports the version the dispatch hands it (Address::version, set from"
+created: 2026-08-25T22:19:09Z
+author: claude-code/opus-5+surface-version
+scope:
+  - crates/ank-mcp/**
+  - .github/scripts/check-version.sh
+about: TASK-ae64d1c5678d
+seq: 1
+schema: 4
+version: 1
+---
+
+ ank-cli's CARGO_PKG_VERSION in cli.rs::mcp), read by both serverInfo and call::identity, so the two cannot disagree. crates/ank-mcp's own number is now internal and gated by nothing; check-version.sh's loop keeps its rule (what a release publishes as a file) and its comment now says why the surface's absence is safe rather than only why the gate went. Negative-checked: with the crate bumped to 0.99.0 the surface still reports 0.6.0 and the test passes; reverting serverInfo to env!(CARGO_PKG_VERSION) makes it fail on 0.99.0. Test lives in crates/ank-cli/tests/mcp.rs -- CARGO_BIN_EXE_ank exists only for the package declaring the binary, the same mechanical reason tests/tui.rs and the rest of the mcp suite sit there. It runs ank --version, drives ank mcp with ANK_AGENT removed, and asserts serverInfo.version and the holder ank-mcp/<version> on the claim record both equal the word the binary printed.

--- a/.ank/entities/LOG-5b430a16a6cf.md
+++ b/.ank/entities/LOG-5b430a16a6cf.md
@@ -1,0 +1,16 @@
+---
+id: LOG-5b430a16a6cf
+type: log
+title: Two honest fixes weighed. Restoring ank-mcp to check-version.sh's loop would re-erect a rule whose
+created: 2026-08-25T21:59:31Z
+author: claude-code/opus-5+surface-version
+scope:
+  - crates/ank-mcp/**
+  - .github/scripts/check-version.sh
+about: TASK-ae64d1c5678d
+seq: 0
+schema: 4
+version: 1
+---
+
+ stated justification (the release ships ank-mcp as a file) died with ADR-1ea31c2f3c5a, and would leave two numbers agreeing by rule -- one more of the 'nine more chances to be careful than anyone gets right forever' the script itself names. Taking the other: the surface reports the binary's version, the crate's own number becomes internal, and one number reaches a reader. Where it comes from: Address is what the dispatch already hands the surface because the surface cannot compute it (exe, repo), and Address::exe IS current_exe(), so ank-cli's CARGO_PKG_VERSION handed down is by construction the number that same process prints for --version. No link to ank-cli (tests/dependencies.rs), no parse of a spawned --version.

--- a/.ank/entities/LOG-8729a6e56508.md
+++ b/.ank/entities/LOG-8729a6e56508.md
@@ -1,0 +1,14 @@
+---
+id: LOG-8729a6e56508
+type: log
+title: done, proof commit:1e84563
+created: 2026-08-25T22:21:39Z
+author: claude-code/opus-5+surface-version
+scope:
+  - crates/ank-mcp/**
+  - .github/scripts/check-version.sh
+about: TASK-ae64d1c5678d
+seq: 2
+schema: 4
+version: 1
+---

--- a/.ank/entities/TASK-ae64d1c5678d.md
+++ b/.ank/entities/TASK-ae64d1c5678d.md
@@ -5,7 +5,7 @@ slug: the-protocol-surface-reports-the-version-the-tag
 title: The protocol surface reports the version the tag gates
 created: 2026-08-25T21:29:25Z
 author: haksolot@vmi3223161
-status: in_progress
+status: done
 scope:
   - crates/ank-mcp/**
   - .github/scripts/check-version.sh
@@ -13,6 +13,11 @@ blocked_by: []
 done_criteria: |
   The version a client reads in serverInfo, and the one in the ank-mcp/<version> identity, is a number the release gates against the tag. Either check-version.sh holds crates/ank-mcp's version to the tag again, or the surface reports ank-cli's version and the crate's own number stops reaching a client; the choice is stated in the code where it is made. A test drives the built binary and shows the version a client is told matches the one ank --version prints. cargo test is green and cargo fmt --check passes.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: "1e84563"
+    criteria: 5234baab472f
+    via: submitted
 schema: 4
-version: 2
+version: 3
 ---

--- a/.ank/entities/TASK-ae64d1c5678d.md
+++ b/.ank/entities/TASK-ae64d1c5678d.md
@@ -5,7 +5,7 @@ slug: the-protocol-surface-reports-the-version-the-tag
 title: The protocol surface reports the version the tag gates
 created: 2026-08-25T21:29:25Z
 author: haksolot@vmi3223161
-status: open
+status: in_progress
 scope:
   - crates/ank-mcp/**
   - .github/scripts/check-version.sh
@@ -14,5 +14,5 @@ done_criteria: |
   The version a client reads in serverInfo, and the one in the ank-mcp/<version> identity, is a number the release gates against the tag. Either check-version.sh holds crates/ank-mcp's version to the tag again, or the surface reports ank-cli's version and the crate's own number stops reaching a client; the choice is stated in the code where it is made. A test drives the built binary and shows the version a client is told matches the one ank --version prints. cargo test is green and cargo fmt --check passes.
 criteria_by: creator
 schema: 4
-version: 1
+version: 2
 ---

--- a/.github/scripts/check-version.sh
+++ b/.github/scripts/check-version.sh
@@ -97,6 +97,21 @@ compare() {
 # -- are not gated here, for the reason ADR-1ea31c2f3c5a removed the gate that
 # used to be: nothing published carries any of them as a file of its own, so a
 # version they disagree on is not a version anybody downloads.
+#
+# **That reason is about files, and one of those libraries was also telling
+# people a number** (TASK-ae64d1c5678d). `ank-mcp` used to be gated here and was
+# dropped with the rest of the second executable's machinery, while its
+# `CARGO_PKG_VERSION` went on reaching a client in `serverInfo` and landing in
+# the `ank-mcp/<version>` identity of every claim taken through the surface. The
+# repair is not a gate back: the surface reports the version the dispatch hands
+# it, which is `ank-cli`'s, so the number a client reads is a number already
+# compared above. Gating the library too would have put a second literal here
+# whose only job was to be equal to the first -- one more of the ten, and the
+# whole argument of this script is that nobody keeps ten right forever.
+#
+# So the rule for this loop is what a release publishes as a file, and nothing
+# else. A library that starts telling a reader its own number belongs in one of
+# the two lists: this one, or `Address::version`'s.
 for crate in ank-cli ank-core; do
   f="crates/$crate/Cargo.toml"
   compare "$f" "$f" "$(cargo_version "$f" 2>/dev/null)" \

--- a/crates/ank-cli/src/cli.rs
+++ b/crates/ank-cli/src/cli.rs
@@ -836,6 +836,16 @@ fn mcp(inv: &Invocation, cwd: &std::path::Path, out: &mut dyn std::io::Write) ->
     let address = ank_mcp::Address {
         exe,
         repo: repo.corpus,
+        // **The version a client is told, handed over here because the surface
+        // cannot honestly work it out** (TASK-ae64d1c5678d). `crates/ank-mcp`
+        // must not link this crate (ADR-fd98f4bc6dea), so its own
+        // `CARGO_PKG_VERSION` can only ever name the library; this one is the
+        // executable's, the same literal `version_line` above prints, and the
+        // one the release gates against the tag. `exe` is this very process, so
+        // the number handed down is the number that binary answers `--version`
+        // with -- by construction and not by anyone keeping two literals in
+        // step. The argument in full is on `ank_mcp::Address::version`.
+        version: env!("CARGO_PKG_VERSION").to_string(),
     };
     // Standard input is the client's half of the transport and is read nowhere
     // else in this binary, so it is locked here rather than threaded through a

--- a/crates/ank-cli/tests/mcp.rs
+++ b/crates/ank-cli/tests/mcp.rs
@@ -14,8 +14,9 @@
 //! reason `tests/tui.rs` gives for sitting here. A suite that could not name the
 //! binary would be back to testing the function instead of the process.
 //!
-//! Three claims are asserted here and all three come from the table rather than
-//! from a list written beside it. The advertised tools **equal** `COMMANDS`, so
+//! Three claims about the surface are asserted here and all three come from the
+//! table rather than from a list written beside it. The advertised tools
+//! **equal** `COMMANDS`, so
 //! a verb added there reaches this surface with no edit in this crate and a verb
 //! removed stops being advertised. A refused call carries **the code the table
 //! declares for that refusal**, read out of `spec.refuses` rather than typed as
@@ -23,6 +24,11 @@
 //! publishes. And the document a call answers with is **the document the binary
 //! prints**, compared against a direct run of the same verb, because the whole
 //! of what the fold left alone is that a call is still a run of `ank`.
+//!
+//! A fourth claim is about a number rather than about the table: the version a
+//! client is told, and the one in the identity a claim is written under, is the
+//! one `ank --version` prints (TASK-ae64d1c5678d). It is read out of the process
+//! for the same reason everything else here is.
 
 use ank_contract::{ExitCode, COMMANDS};
 use std::io::Write;
@@ -183,6 +189,44 @@ fn talk_at(repo: &Path, home: Option<&Path>, requests: &[&str]) -> Vec<String> {
         .collect()
 }
 
+/// A session under no named identity, which is the only way to see the one the
+/// server gives itself.
+///
+/// `ANK_AGENT` is *removed* rather than left alone: every other session here
+/// sets it, and a machine that happened to have it exported would otherwise
+/// make the typed identity untestable exactly where it matters -- an agent's
+/// own shell, which is where this suite runs.
+fn talk_unnamed(repo: &Path, requests: &[&str]) -> Vec<String> {
+    let mut child = Command::new(ANK)
+        .arg("mcp")
+        .arg("--repo")
+        .arg(repo)
+        .env_remove("ANK_AGENT")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("the binary must have been built");
+    {
+        let stdin = child.stdin.as_mut().expect("piped");
+        for request in requests {
+            writeln!(stdin, "{request}").expect("the server must accept a request");
+        }
+    }
+    let out = child.wait_with_output().expect("the server must finish");
+    assert!(
+        out.status.success(),
+        "the server exited {:?}: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| l.to_string())
+        .collect()
+}
+
 /// A crude field read, deliberately: pulling one value out of a reply needs no
 /// parser, and a parser here would be a second reading of the surface under test.
 fn field(line: &str, key: &str) -> Option<String> {
@@ -198,6 +242,31 @@ fn field(line: &str, key: &str) -> Option<String> {
         .find(|c: char| c == ',' || c == '}')
         .unwrap_or(rest.len());
     Some(rest[..end].trim().to_string())
+}
+
+/// The version out of `serverInfo`, and not merely the first `"version"` in the
+/// reply.
+///
+/// [`field`] would find the right one today, since `protocolVersion` is spelled
+/// with a capital and nothing else in the handshake carries the key. That is a
+/// fact about how the reply is written rather than about what is being asserted,
+/// so the object is sliced first: a key added above it must not quietly turn
+/// this into a test of something else.
+fn server_info_version(reply: &str) -> Option<String> {
+    let at = reply.find("\"serverInfo\"")?;
+    field(&reply[at..], "version")
+}
+
+/// A fragment as it reads once the surface has escaped a document into a `text`
+/// block.
+///
+/// The same escaper both sides share (ADR-6fd69efb629c), applied to a fragment
+/// instead of a whole document, with the quotes it wraps a string in taken back
+/// off. Escaping by hand here would be a second escaper to keep in step with the
+/// one under test.
+fn escaped(fragment: &str) -> String {
+    let quoted = ank_contract::json::string(fragment);
+    quoted[1..quoted.len() - 1].to_string()
 }
 
 /// The tool names a `tools/list` reply advertises, in the order it advertises
@@ -706,5 +775,89 @@ fn every_advertised_tool_carries_the_corpus_argument() {
          corpora a client can reach per verb (ADR-fd98f4bc6dea): {}",
         replies[0]
     );
+    let _ = std::fs::remove_dir_all(&repo);
+}
+
+/// The version a client is told is the version the binary prints, in both places
+/// one leaves this surface (TASK-ae64d1c5678d).
+///
+/// **Read out of the process, never out of `CARGO_PKG_VERSION`.** A test that
+/// compared the constant with itself would pass on the very day the surface went
+/// back to reporting the library's number, which is the defect this closes: the
+/// crate's version used to reach a client here, and the gate that held it to the
+/// release tag went away with the second executable it was written for
+/// (ADR-1ea31c2f3c5a). So `ank --version` is run, and what it says is the
+/// expectation. CLAUDE.md states the rule this is an instance of.
+///
+/// **Two places and one number.** `serverInfo` is what a client reads at the
+/// handshake; `ank-mcp/<version>` is the typed identity every claim taken
+/// through this surface is written under, and it outlives the session in the
+/// ref. They are asserted against the same value, because two numbers reaching a
+/// reader are two numbers that can drift and only one of them would ever be
+/// looked at again.
+///
+/// The claim is taken through the surface rather than read off a struct: the
+/// identity is an environment variable handed to a spawned process, so what
+/// proves it is a record the corpus wrote.
+#[test]
+fn the_surface_reports_the_version_the_binary_prints_and_writes_under_it() {
+    let repo = corpus();
+    let id = seeded_task(&repo);
+
+    // `ank <version> (<commit>, skill <revision>)` -- the second word, and the
+    // only part of that line this is about.
+    let printed = ank(&repo, &["--version"]);
+    assert!(
+        printed.status.success(),
+        "ank --version must answer: {}",
+        String::from_utf8_lossy(&printed.stderr)
+    );
+    let line = String::from_utf8_lossy(&printed.stdout).trim().to_string();
+    let version = line
+        .split_whitespace()
+        .nth(1)
+        .unwrap_or_default()
+        .to_string();
+    assert!(
+        !version.is_empty() && version.chars().next().is_some_and(|c| c.is_ascii_digit()),
+        "the shape of `ank --version` moved and this test is reading the wrong \
+         word of it: {line}"
+    );
+
+    let claim = format!(
+        r#"{{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{{"name":"ank_claim","arguments":{{"arguments":["{id}"]}}}}}}"#
+    );
+    let replies = talk_unnamed(
+        &repo,
+        &[
+            r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{}}}"#,
+            &claim,
+        ],
+    );
+    assert_eq!(replies.len(), 2, "{replies:?}");
+
+    assert_eq!(
+        server_info_version(&replies[0]).as_deref(),
+        Some(version.as_str()),
+        "a client is told a version the binary does not answer with. The number \
+         in serverInfo is the executable's, handed down by the dispatch, and the \
+         release gates that one against the tag: {}",
+        replies[0]
+    );
+
+    assert_eq!(
+        field(&replies[1], "exitCode").as_deref(),
+        Some("0"),
+        "the claim must have been taken for its holder to say anything: {}",
+        replies[1]
+    );
+    assert!(
+        replies[1].contains(&escaped(&format!(r#""holder":"ank-mcp/{version}""#))),
+        "the claim was written under an identity carrying a version the binary \
+         does not answer with. It is the same number serverInfo reports, and it \
+         is in a ref that outlives this session: {}",
+        replies[1]
+    );
+
     let _ = std::fs::remove_dir_all(&repo);
 }

--- a/crates/ank-mcp/Cargo.toml
+++ b/crates/ank-mcp/Cargo.toml
@@ -1,10 +1,20 @@
 [package]
 name = "ank-mcp"
-# ank-cli's version, and not a version of its own. Both are built out of one
-# build and land in one archive today, so a caller holding both has no way to
-# ask which of two numbers describes the pair -- and the release asserts
-# they answer `--version` alike, on all three platforms, before it publishes
-# anything. check-version.sh holds this literal to the tag with the others.
+# **Internal, and nobody is ever told this number** (TASK-ae64d1c5678d). It read
+# `ank-cli's version, and not a version of its own` while there were two files
+# in one archive and a caller holding both had to know which number described
+# the pair. There is one file (ADR-1ea31c2f3c5a), so there is no pair, and
+# check-version.sh stopped holding this literal to the tag along with the rest of
+# the machinery for the second executable.
+#
+# What outlived that reason is that the number went on leaving the process: a
+# client read it in `serverInfo` and every claim taken through the surface was
+# written under `ank-mcp/<it>`. Both now report the version the dispatch hands
+# down, which is the binary's -- so this literal describes a library nothing
+# publishes, is gated by nothing, and is free to move or not move for the
+# reasons a crate version exists. `crates/ank-mcp/src/lib.rs` states the choice
+# where it is made, and `crates/ank-cli/tests/mcp.rs` holds the surface to it
+# through the binary.
 version = "0.6.0"
 edition = "2021"
 # The workspace floor, for the reason ank-core's manifest gives: one lockfile,

--- a/crates/ank-mcp/src/call.rs
+++ b/crates/ank-mcp/src/call.rs
@@ -141,7 +141,7 @@ pub fn run(
 ) -> std::io::Result<Outcome> {
     let out = Command::new(&address.exe)
         .args(argv(spec, corpus, args))
-        .env("ANK_AGENT", identity())
+        .env("ANK_AGENT", identity(&address.version))
         .current_dir(corpus)
         .output()?;
     Ok(Outcome {
@@ -156,9 +156,21 @@ pub fn run(
 /// `$ANK_AGENT` from the environment wins, so a deployment that already names its
 /// agents keeps naming them; otherwise the process names itself and its version,
 /// which is the convention of §3 rather than a hostname.
-pub fn identity() -> String {
+///
+/// **The name is the server's and the number is the binary's**
+/// (TASK-ae64d1c5678d). `ank-mcp` is what wrote the record, which is what §3
+/// asks a typed identity to say and is the same name `serverInfo` gives a
+/// client. The version beside it is [`Address::version`] and not this crate's
+/// `CARGO_PKG_VERSION`: a claim record outlives the session that took it, and a
+/// reader who wants the build that wrote it needs a number `ank --version`
+/// answers with -- one the release gates against the tag -- rather than the
+/// number of a library nobody can install. `serverInfo` reads the same value, so
+/// the two cannot disagree.
+///
+/// [`Address::version`]: crate::Address::version
+pub fn identity(version: &str) -> String {
     std::env::var("ANK_AGENT")
         .ok()
         .filter(|v| !v.trim().is_empty())
-        .unwrap_or_else(|| format!("ank-mcp/{}", env!("CARGO_PKG_VERSION")))
+        .unwrap_or_else(|| format!("ank-mcp/{version}"))
 }

--- a/crates/ank-mcp/src/lib.rs
+++ b/crates/ank-mcp/src/lib.rs
@@ -42,6 +42,12 @@
 //! is the file and never the dispatch, and `crates/ank-mcp/tests/dependencies.rs`
 //! reads that back out of the build rather than trusting this paragraph.
 //!
+//! **The version a client is told is the binary's, and this crate's own number
+//! reaches nobody.** Both places a version leaves this surface -- `serverInfo`
+//! at the handshake and the `ank-mcp/<version>` identity a call writes under --
+//! read [`Address::version`], which the dispatch hands down. The argument is on
+//! that field.
+//!
 //! **This does not make a protocol the preferred route.** §2's common denominator
 //! is shell, that is still what the skill teaches, and this exists for the client
 //! that has no shell at all.
@@ -59,7 +65,7 @@ const PROTOCOL_VERSION: &str = "2025-06-18";
 
 /// Where the surface reaches, resolved by the dispatch and never here.
 ///
-/// Both halves are the caller's foundation rather than this crate's: the verb
+/// Every field is the caller's foundation rather than this crate's: the verb
 /// resolves the corpus the way every other verb resolves it, so a missing
 /// `.ank/` is the refusal it already is instead of a JSON-RPC error a client
 /// would have to decode, and it names the binary so that this crate has one
@@ -68,6 +74,39 @@ pub struct Address {
     /// The binary a call runs. `std::env::current_exe()` of the process serving
     /// the verb -- see the note on [`call`].
     pub exe: PathBuf,
+    /// The version that binary answers `--version` with, and the only version
+    /// this surface ever tells anyone (TASK-ae64d1c5678d).
+    ///
+    /// **This is the choice, and it is made here.** `crates/ank-mcp` carries a
+    /// version of its own, as every crate must, and until now that number was
+    /// what a client read in `serverInfo` and what landed in the
+    /// `ank-mcp/<version>` identity every claim taken through this surface is
+    /// written under. It was held to the release tag by
+    /// `.github/scripts/check-version.sh`, and the reason that gate gave was
+    /// that the release shipped `ank-mcp` as a file of its own. It does not any
+    /// more (ADR-1ea31c2f3c5a): the surface is a verb, so the file went and the
+    /// gate went with it -- correctly, by the reason as written. What the reason
+    /// never covered is that the number went on reaching a client anyway.
+    ///
+    /// Two repairs were available. Gate this crate's version against the tag
+    /// again: that restores a rule whose stated justification is gone, and
+    /// leaves two numbers that agree only because somebody remembered -- one
+    /// more of the literals `check-version.sh` exists because nobody gets right
+    /// forever. Or stop the crate's number reaching a client at all, which is
+    /// this: what a client is told is the version of the executable it is
+    /// talking to, and `crates/ank-mcp/Cargo.toml`'s literal becomes what a
+    /// crate version is for, a number cargo resolves the workspace with.
+    ///
+    /// **Handed down, because it cannot honestly be computed here.** This crate
+    /// must not link `ank-cli` -- that is ADR-fd98f4bc6dea and
+    /// `tests/dependencies.rs` reads it back out of the build -- so
+    /// `CARGO_PKG_VERSION` here can only ever name this crate. The dispatch
+    /// already hands over what the surface cannot work out for itself, and this
+    /// is one more of those. It is exact rather than approximately right:
+    /// [`Address::exe`] is `current_exe()`, the process serving the verb, so the
+    /// version compiled into that process *is* the version it prints. There is
+    /// nothing to parse and nothing to keep in step.
+    pub version: String,
     /// The corpus the process was addressed with, which is where a call goes
     /// when it names none.
     ///
@@ -144,11 +183,17 @@ fn handle(line: &str, reach: &corpora::Reach) -> Option<String> {
                 // it: renaming it would rename every entry in every client
                 // that already talks to this surface, to say something the
                 // command line beside it already says.
+                //
+                // The version beside it is the binary's, not this crate's, and
+                // is the same value `call::identity` writes into the process
+                // identity: a client reads a version here and an agent reads
+                // one off a claim record, and the two are one number or they
+                // are a drift nobody can see (see [`Address::version`]).
                 .obj(
                     "serverInfo",
                     Obj::new()
                         .str("name", "ank-mcp")
-                        .str("version", env!("CARGO_PKG_VERSION")),
+                        .str("version", &reach.address().version),
                 )
                 .str(
                     "instructions",


### PR DESCRIPTION
## The hole, and how it opened

`.github/scripts/check-version.sh` held `crates/ank-mcp`'s version to the release
tag. The reason it gave was distribution: the release shipped `ank-mcp` as a file
of its own, and a tag that bumped `ank-cli` and left `ank-mcp` behind would break
on the tag itself.

TASK-d9b167250aa8 made the surface a verb (ADR-1ea31c2f3c5a). The file stopped
existing, and the gate went with the rest of the second executable's machinery —
correct by the reason as written.

What the reason never covered is that the number went on **leaving the process**:

- `crates/ank-mcp/src/lib.rs:151` put it in `serverInfo.version`, which is what a
  client is told at the handshake;
- `crates/ank-mcp/src/call.rs:163` put it in the `ank-mcp/<version>` process
  identity, which lands in `refs/ank/claims/<id>` and outlives the session.

So a number a client reads, and a number in a claim record, could drift from the
release with nothing turning red.

## The choice, and why this one

**Gate `crates/ank-mcp` against the tag again.** Honest, and rejected: it
restores a rule whose stated justification is gone, and it leaves two literals
that agree only because somebody remembered. The script's own argument is that
ten literals are "nine more chances to be careful than anyone gets right
forever"; adding an eleventh whose only job is to equal one of the other ten
works against it.

**Have the surface report `ank-cli`'s version.** Taken. The number a client reads
is the number `ank --version` prints, and the crate's own becomes what a crate
version is for — something cargo resolves the workspace with, published as a file
by nothing, gated by nothing.

The choice is stated where it is made: `ank_mcp::Address::version`, with pointers
from `crates/ank-mcp/Cargo.toml` (whose old comment asserted the gate that no
longer exists), from both call sites, and from the loop in `check-version.sh`
that no longer names it.

## Where the number comes from

`crates/ank-mcp` must not link `ank-cli` — ADR-fd98f4bc6dea, enforced by
`crates/ank-mcp/tests/dependencies.rs` — so `CARGO_PKG_VERSION` in that crate can
only ever name the library. The dispatch already hands the surface what it cannot
work out for itself (`exe`, `repo`); this is one more of those.

It is exact rather than approximately right: `Address::exe` is `current_exe()`,
the very process serving the verb, so the version compiled into that process *is*
the version it prints. Nothing is parsed and nothing is kept in step.

`serverInfo` and `call::identity` both read `address.version`, so the two places
a number reaches a reader cannot disagree.

## The test

`crates/ank-cli/tests/mcp.rs`, driving the built binary — CLAUDE.md's rule, and
the file's own mechanical reason for sitting in `ank-cli`: `CARGO_BIN_EXE_ank` is
defined only for the package that declares the binary.

It runs `ank --version` and takes the expectation from **what the process
printed**, never from `CARGO_PKG_VERSION` — a test comparing the constant with
itself would pass on the day the surface went back to reporting the library's.
Then one `ank mcp` session with `ANK_AGENT` removed asserts both numbers a reader
ever sees: `serverInfo.version`, and the `holder` on a claim record the corpus
actually wrote.

Checked in both directions:

- crate bumped to `0.99.0` → surface still reports `0.6.0`, test passes (the
  library's number no longer leaks);
- `serverInfo` reverted to `env!("CARGO_PKG_VERSION")` → test fails on `0.99.0`.

## Verification

- `cargo test --workspace` — 880 passed, 0 failed, exit 0
- `cargo fmt --check` — exit 0
- `ank check` — exit 0, no faults
- `check-version.sh 0.6.0` — agrees with all 10 literals; a mismatch still exits 1

## Scope note

The task's scope is `crates/ank-mcp/**` and `.github/scripts/check-version.sh`.
Two edits fall outside it and neither was avoidable:

- `crates/ank-cli/src/cli.rs` — the dispatch is the only place that holds the
  binary's version, and `Address` is a struct literal;
- `crates/ank-cli/tests/mcp.rs` — the whole `ank mcp` suite lives there for the
  `CARGO_BIN_EXE_ank` reason above, and a test in `crates/ank-mcp/tests/` could
  not name the binary.

`README.md` and `docs/integrating.md` are untouched. `docs/integrating.md:314`
still reads correctly — it says the surface writes under `ank-mcp/<version>`,
which remains true and is now the version a reader would assume.

TASK-ae64d1c5678d, proof `commit:1e84563`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N8GFMa5Jk3rsbG2x59Jxvw