### PR TITLE
Plan: a supersession does not land while the workspace still cites what it retires

### DIFF
--- a/.ank/entities/ADR-3b6ba766a42e.md
+++ b/.ank/entities/ADR-3b6ba766a42e.md
@@ -1,0 +1,75 @@
+---
+id: ADR-3b6ba766a42e
+type: adr
+slug: a-supersession-does-not-land-while-the-workspace
+title: A supersession does not land while the workspace still cites what it retires
+created: 2026-08-25T23:23:36Z
+author: haksolot@vmi3223161
+status: proposed
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-contract/src/verbs.rs
+constraint: |
+  accept refuses a supersession while any tracked file outside a .ank/ directory still cites the document that supersession retires. The refusal is computed before anything is written, names every site with its line, and gives the two ways out: write the successor instead, or drop the citation and leave the history to ank show. It carries the code section 4 gives a missing prerequisite, it is not suppressed by --quiet, and it takes no bypass flag -- accept has none and gains none.
+  
+  check reports the same condition as a fault, over the same walk, so a corpus can be judged without cargo and on any platform. One implementation answers both: the verb and the verifier never disagree about whether a citation is stale.
+  
+  A citation naming a proposed successor is not a defect and is never reported as one. It is the state this refusal exists to produce: it is honest, because ank show reports that document as proposed, and it becomes correct at the signature that follows -- where a citation of the retired document becomes wrong at that same instant.
+schema: 4
+version: 1
+---
+
+`accept` already computes this. It walks the tracked files, skips every `.ank/`
+wherever it sits, skips what is not text, and prints the sites it found. What it
+does with the answer is the defect: it prints it as a warning, *after* the commit
+that made it true, and `--quiet` suppresses it entirely.
+
+## Measured three times in one day
+
+ADR-372b82af1ec7 and ADR-e39a44f80e0e were ratified and `main` went red on all
+three platforms; TASK-cf075f0e287d repaired it afterwards. SPEC-20357e21a45a was
+caught in time only because TASK-d86955470592 had been filed by hand for the
+purpose. ADR-0c8ab846d262 was ratified and `main` went red again, nineteen
+citations in nine files, with the repair already filed and not yet landed.
+
+Three ratifications, two red branches, and the difference between them was
+whether somebody remembered. That is the shape of a rule that belongs in the
+tool.
+
+## Why a refusal and not a louder warning
+
+`accept` is the one verb that writes into history rather than into the working
+tree, and it is authoritative the instant it exists, on the branch where it
+exists. There is no pull request between it and the default branch and no CI in
+front of it -- which is exactly why the branch precondition is a refusal and not
+advice. The condition here has the same shape: something must be true *before*
+the commit, because after it there is nothing to review and no gate left to fail.
+
+A warning cannot be the answer for the same reason. It arrives after the fact,
+and it is silenced by a flag somebody running in a script has every reason to
+pass.
+
+## The order this makes mandatory, and the position it reverses
+
+The refusal forces one order: re-point the citations, then sign. That was argued
+against twice today, on the grounds that the workspace would name as binding a
+document nobody has signed, and the argument was wrong.
+
+A citation naming a proposed successor is provisional and honest -- `ank show`
+answers `status: proposed`, so a reader following it learns exactly where the
+document stands. A citation naming the retired one is not provisional: it
+becomes false at the signature and stays false until somebody sweeps it. Between
+a citation that is briefly incomplete and one that will be wrong, the choice is
+not close, and the window is closed by the very act that follows it.
+
+## check carries it too, over one walk
+
+The guard that has been failing the build lives in `crates/ank-cli/tests/cli.rs`
+and runs only under `cargo test`, over the crates alone. `ank check` -- the verb
+whose stated job is the mechanical invariants -- reported `0 faults` on a red
+tree, twice, because it has never looked. A corpus that can be validated without
+cargo is one of the things `check` is for, and its walk reaches `docs/`,
+`.github/` and the installers, which the test never did.
+
+One walk serves both. Two would be two answers to "is this citation stale", and
+the day they disagreed the one nobody ran would be the one that was right.

--- a/.ank/entities/LOG-8e65db20547f.md
+++ b/.ank/entities/LOG-8e65db20547f.md
@@ -1,0 +1,16 @@
+---
+id: LOG-8e65db20547f
+type: log
+title: +blocked_by TASK-0722ebfc5775 (version 1 to 2, replaced def4a6628663, produced 856be511f414)
+created: 2026-08-25T23:24:08Z
+author: haksolot@vmi3223161
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-contract/src/verbs.rs
+  - crates/ank-cli/tests/cli.rs
+about: TASK-c90651901f22
+seq: 0
+records: edit
+schema: 4
+version: 1
+---

--- a/.ank/entities/TASK-c90651901f22.md
+++ b/.ank/entities/TASK-c90651901f22.md
@@ -1,0 +1,19 @@
+---
+id: TASK-c90651901f22
+type: task
+slug: accept-refuses-a-supersession-the-workspace-stil
+title: accept refuses a supersession the workspace still cites, and check reports it
+created: 2026-08-25T23:23:48Z
+author: haksolot@vmi3223161
+status: open
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-contract/src/verbs.rs
+  - crates/ank-cli/tests/cli.rs
+blocked_by: [TASK-0722ebfc5775]
+done_criteria: |
+  accept refuses, before writing anything, when a tracked file outside a .ank/ directory cites the document the supersession would retire: it names every site with its line and both ways out, carries the code the verb table declares for a missing prerequisite, and answers the same with --quiet. A test drives the built binary against a temporary corpus carrying one such citation and shows the entity still proposed, no ratification commit, and the worktree byte for byte as it was; a second shows the same accept succeeding once the citation names the successor instead. check reports the same condition as a fault over the same walk, and one function computes it for both. A citation naming a proposed successor is reported by neither. accept still declares no bypass flag. cargo test --workspace is green and cargo fmt --check passes.
+criteria_by: creator
+schema: 4
+version: 2
+---


### PR DESCRIPTION
One proposal and one task, for the thing that turned `main` red twice today.

**Nothing here is accepted.** `ADR-3b6ba766a42e` is waiting for a signature.

## Measured, three times in one day

| ratification | outcome |
|---|---|
| `ADR-372b` + `ADR-e39a` | `main` red on all three platforms; `TASK-cf075f0e287d` repaired it afterwards |
| `SPEC-2035` | caught in time — only because `TASK-d869` had been filed by hand for the purpose |
| `ADR-0c8a` | `main` red again, 19 citations in 9 files; repair filed, not yet landed |

Three ratifications, two red default branches, and the difference was **whether somebody remembered**. That is a rule that belongs in the tool.

## `accept` already computes this

`crates/ank-cli/src/human.rs` walks the tracked files, skips every `.ank/` wherever it sits, skips what is not text, and prints every site with its line. The logic is right and stays. What is wrong is what it does with the answer:

- it prints it **as a warning**,
- **after** the commit that made it true,
- and `--quiet` suppresses it entirely — so `ank accept -q` breaks the default branch in silence.

## Why a refusal, and not a louder warning

`accept` is the one verb that writes into history rather than the working tree, and it is authoritative the instant it exists, on the branch where it exists. There is **no pull request between it and `main`, and no CI in front of it** — which is exactly why the branch precondition is a refusal and not advice. This condition has the same shape: it must hold *before* the commit, because afterwards there is no gate left to fail.

## `check` gains it, over the same walk

The guard that has been failing the build lives in `crates/ank-cli/tests/cli.rs`, runs only under `cargo test`, and walks the crates alone. `ank check` — the verb whose stated job is the mechanical invariants — reported `0 faults` on a red tree **twice**, because it has never looked.

One function answers both. Two would be two answers to "is this citation stale", and the day they disagreed, the one nobody ran would be the one that was right. `check`'s walk also reaches `docs/`, `.github/` and the installers, which the Rust test never did.

## This reverses a position I argued twice today

I twice refused to re-point citations before a signature, on the grounds that the workspace would name as binding a document nobody had signed. That was wrong.

A citation naming a **proposed** successor is provisional and honest — `ank show` answers `status: proposed`, so a reader following it learns exactly where the document stands. A citation naming the **retired** one is not provisional: it becomes false at the signature and stays false until somebody sweeps it. Between briefly incomplete and eventually wrong, the choice is not close — and the window is closed by the very act that follows.

So the refusal makes one order mandatory: re-point, then sign.

## Cost: one signature, not two

The suite binds a verb's refusals to the **table** `ank help` renders (`crates/ank-cli/tests/cli.rs:7094`), not to §4's prose. Adding a refusal to `accept` therefore needs no spec revision — and no second supersession that would orphan citations of its own.

`TASK-c90651901f22` is blocked by `TASK-0722ebfc5775`: the citation repair has to land first, or the new refusal would be measured against a tree it is already correct about.

`ank check` 0 faults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhWoNxFoF1e5S2n5cbkoPC