### PR TITLE
The workspace stops citing the presentation decision this supersession retires

### DIFF
--- a/.ank/entities/LOG-2b515ff7c064.md
+++ b/.ank/entities/LOG-2b515ff7c064.md
@@ -1,0 +1,21 @@
+---
+id: LOG-2b515ff7c064
+type: log
+title: done, proof commit:527912a29663ba890aa90c6a1ec3eff718c0c060
+created: 2026-08-25T23:28:38Z
+author: claude-code/opus-5+cite-0c8a
+scope:
+  - crates/ank-tui/src/frame.rs
+  - crates/ank-contract/src/verbs.rs
+  - crates/ank-cli/tests/cli.rs
+  - crates/ank-cli/src/status.rs
+  - crates/ank-cli/src/cli.rs
+  - crates/ank-cli/src/style.rs
+  - crates/ank-cli/src/context.rs
+  - crates/ank-cli/src/paint.rs
+  - crates/ank-cli/src/commands.rs
+about: TASK-0722ebfc5775
+seq: 1
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-c4d6ce3437dc.md
+++ b/.ank/entities/LOG-c4d6ce3437dc.md
@@ -1,0 +1,23 @@
+---
+id: LOG-c4d6ce3437dc
+type: log
+title: Nineteen citations, nine files, and the guard names every one. Eighteen are the clauses
+created: 2026-08-25T23:20:27Z
+author: claude-code/opus-5+cite-0c8a
+scope:
+  - crates/ank-tui/src/frame.rs
+  - crates/ank-contract/src/verbs.rs
+  - crates/ank-cli/tests/cli.rs
+  - crates/ank-cli/src/status.rs
+  - crates/ank-cli/src/cli.rs
+  - crates/ank-cli/src/style.rs
+  - crates/ank-cli/src/context.rs
+  - crates/ank-cli/src/paint.rs
+  - crates/ank-cli/src/commands.rs
+about: TASK-0722ebfc5775
+seq: 0
+schema: 4
+version: 1
+---
+
+ ADR-1f70ce2c3eac carries forward verbatim -- the short-form table of section 4, structure-is-text-for-every-reader, --json carrying neither -- so the citation moves and the sentence stands. One is not: frame.rs's module header concludes that ank-tui emits no colour at all because the palette it may not reach is the only one allowed to exist. ADR-1f70ce2c3eac names that file and ends exactly that conclusion: the meaning becomes a shared table holding no escape sequence and each surface paints it with what it draws with. Re-pointing there would cite the successor for the monochrome it overturns. That one is rewritten to what the crate does today, naming TASK-4fa385c1772d and TASK-6cd41d23b7d1.

--- a/.ank/entities/TASK-0722ebfc5775.md
+++ b/.ank/entities/TASK-0722ebfc5775.md
@@ -5,7 +5,7 @@ slug: the-workspace-stops-citing-the-presentation-deci
 title: The workspace stops citing the presentation decision this supersession retires
 created: 2026-08-25T22:54:24Z
 author: haksolot@vmi3223161
-status: open
+status: in_progress
 scope:
   - crates/ank-tui/src/frame.rs
   - crates/ank-contract/src/verbs.rs
@@ -21,5 +21,5 @@ done_criteria: |
   No file outside .ank/ cites ADR-0c8ab846d262: every site names the decision that binds it today, or drops the citation and leaves the history to ank show. Where the successor carries the sentence forward the citation moves; where the supersession made the sentence false the citation goes rather than being re-pointed, because a comment citing the successor in support of something it does not say reads as sourced and is not. Abbreviated forms are swept too, not only whole identifiers. no_superseded_document_is_cited_in_the_workspace passes, cargo test --workspace is green and cargo fmt --check passes, and no behaviour or assertion changes beyond the identifiers themselves.
 criteria_by: creator
 schema: 4
-version: 1
+version: 2
 ---

--- a/.ank/entities/TASK-0722ebfc5775.md
+++ b/.ank/entities/TASK-0722ebfc5775.md
@@ -5,7 +5,7 @@ slug: the-workspace-stops-citing-the-presentation-deci
 title: The workspace stops citing the presentation decision this supersession retires
 created: 2026-08-25T22:54:24Z
 author: haksolot@vmi3223161
-status: in_progress
+status: done
 scope:
   - crates/ank-tui/src/frame.rs
   - crates/ank-contract/src/verbs.rs
@@ -20,6 +20,11 @@ blocked_by: []
 done_criteria: |
   No file outside .ank/ cites ADR-0c8ab846d262: every site names the decision that binds it today, or drops the citation and leaves the history to ank show. Where the successor carries the sentence forward the citation moves; where the supersession made the sentence false the citation goes rather than being re-pointed, because a comment citing the successor in support of something it does not say reads as sourced and is not. Abbreviated forms are swept too, not only whole identifiers. no_superseded_document_is_cited_in_the_workspace passes, cargo test --workspace is green and cargo fmt --check passes, and no behaviour or assertion changes beyond the identifiers themselves.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 527912a29663ba890aa90c6a1ec3eff718c0c060
+    criteria: 0409ff0897ad
+    via: submitted
 schema: 4
-version: 2
+version: 3
 ---

--- a/.ank/entities/TASK-1003ef0c5b16.md
+++ b/.ank/entities/TASK-1003ef0c5b16.md
@@ -1,0 +1,47 @@
+---
+id: TASK-1003ef0c5b16
+type: task
+slug: three-abbreviated-citations-of-the-presentation
+title: Three abbreviated citations of the presentation decision survive the guard's reach
+created: 2026-08-25T23:27:38Z
+author: claude-code/opus-5+cite-0c8a
+status: open
+scope:
+  - crates/ank-tui/src/lib.rs
+  - crates/ank-cli/src/human.rs
+  - crates/ank-daemon/src/lib.rs
+blocked_by: []
+done_criteria: |
+  None of the three files names the retired presentation decision in an abbreviated form: crates/ank-tui/src/lib.rs and crates/ank-cli/src/human.rs each carry a bare (ADR-0c8a), and crates/ank-daemon/src/lib.rs carries ADR-0c8a12b4e0a1, which names no entity this corpus holds. Each site names the decision that binds it today or drops the citation, on the same test the whole-identifier repair applied: where ADR-1f70ce2c3eac carries the sentence forward the citation moves, and where it does not the citation goes rather than being re-pointed. no_superseded_document_is_cited_in_the_workspace still passes, cargo test --workspace is green and cargo fmt --check passes, and no behaviour or assertion changes beyond the identifiers themselves.
+criteria_by: creator
+schema: 4
+version: 1
+---
+
+TASK-0722ebfc5775 swept `ADR-0c8ab846d262`, `0c8ab846` and `ADR-0c8a` and
+repaired the nineteen whole-identifier citations its scope declared. The
+abbreviated sweep found three more, and all three fall outside those nine
+files, so they were reported rather than edited.
+
+The guard cannot reach any of them. `stale_citations` asks the corpus for the
+superseded ids and matches `line.contains(id)` on the whole identifier, so a
+four-character abbreviation is invisible to it -- the same hole
+TASK-d86955470592 hit from the other side, where a list renderer's eight
+character form put a literal `SPEC-2035` in an assertion and turned the suite
+red on a rename the guard had passed.
+
+`crates/ank-daemon/src/lib.rs:217` is the odd one and the worst. It cites
+`ADR-0c8a12b4e0a1`, which is not an abbreviation of anything: `ank show` answers
+`entity not found`. It shares four characters with the retired decision and
+states that decision's split correctly, so it reads as a citation and resolves
+to nothing. That is a defect the supersession did not create and the guard would
+never have announced.
+
+`crates/ank-tui/src/lib.rs:122` and `crates/ank-cli/src/human.rs:3884` both cite
+`(ADR-0c8a)` for the structure half -- one rendering lives in `ank-cli`, and a
+reader who piped this to a file must read the same bytes. ADR-1f70ce2c3eac
+carries that sentence forward word for word, so on the face of it both move.
+Whoever takes this should still read them rather than run sed: `ank-tui/src/lib.rs`
+is inside ADR-0b55983421dd's scope and TASK-4fa385c1772d rewrites the crate onto
+ratatui, which is the same ground on which `frame.rs`'s header had to be
+rewritten instead of re-pointed.

--- a/crates/ank-cli/src/cli.rs
+++ b/crates/ank-cli/src/cli.rs
@@ -1081,7 +1081,7 @@ fn warn_if_schema_ahead(inv: &Invocation, repo: &crate::repo::Repo) {
 /// The corpus, and whatever resolving it had to say.
 ///
 /// **The note is printed here and never inside the resolution**, on the split
-/// ADR-0c8ab846d262 draws: what a reader is told is presentation, and a
+/// ADR-1f70ce2c3eac draws: what a reader is told is presentation, and a
 /// resolver that printed would be a second place deciding what `--quiet` means.
 /// Standard error, because stdout is a parser's input (§4) and a declaration
 /// answering instead of the tree changes no answer, only where it came from.

--- a/crates/ank-cli/src/commands.rs
+++ b/crates/ank-cli/src/commands.rs
@@ -1212,7 +1212,7 @@ pub fn find(
     if inv.json() {
         // `state` beside `status`, from the plane already read above and in the
         // spelling `context --json` uses: the marker the human listing prints,
-        // brackets stripped. A marker is not colour — ADR-0c8ab846d262 keeps
+        // brackets stripped. A marker is not colour — ADR-1f70ce2c3eac keeps
         // colour for the reader and structure for everyone — so the answer a
         // terminal gets about a row finished on a branch is the answer a pipe
         // gets, and a caller filtering on this JSON no longer schedules work the

--- a/crates/ank-cli/src/context.rs
+++ b/crates/ank-cli/src/context.rs
@@ -1229,7 +1229,7 @@ fn visible_len(s: &str) -> usize {
 /// so a painted page costs a reader exactly what a piped one does. Fitting once
 /// and in plain turns that from a property two renderers happen to share into
 /// one they cannot disagree about, and it is what lets `--json` — which carries
-/// no style at all (ADR-0c8ab846d262) — be served the very rows the terminal
+/// no style at all (ADR-1f70ce2c3eac) — be served the very rows the terminal
 /// was.
 #[derive(Clone)]
 pub(crate) struct Fitted {
@@ -1867,9 +1867,9 @@ mod tests {
     /// because of a drawing.
     #[test]
     fn a_gutter_costs_the_columns_the_indent_already_spent() {
-        for short in ["ADR-962c", "ADR-0c8ab846d262", "A"] {
+        for short in ["ADR-962c", "ADR-1f70ce2c3eac", "A"] {
             let c = ConstraintLine {
-                id: EntityId::parse("ADR-0c8ab846d262").unwrap(),
+                id: EntityId::parse("ADR-1f70ce2c3eac").unwrap(),
                 short: short.to_string(),
                 title: "a rule".into(),
                 text: "First line of the rule.

--- a/crates/ank-cli/src/paint.rs
+++ b/crates/ank-cli/src/paint.rs
@@ -6,7 +6,7 @@
 //! occupies no column, so stripping the escapes from what this writes yields
 //! the byte sequence `show` wrote before it existed — same characters, same
 //! order, nothing aligned, nothing re-indented. The file is not re-laid-out for
-//! a human: ADR-0c8ab846d262 already refused to give one corpus two shapes.
+//! a human: ADR-1f70ce2c3eac already refused to give one corpus two shapes.
 //!
 //! **No escape sequence is written here.** The palette stays in
 //! [`crate::style`] and this module only calls its accessors, so the rule

--- a/crates/ank-cli/src/status.rs
+++ b/crates/ank-cli/src/status.rs
@@ -496,7 +496,7 @@ pub fn run(
     // claim is held by somebody else — and that message talks about claims,
     // correctly, while the reader's actual mistake was one line higher.
     //
-    // Plain text, source included, both ways round (ADR-0c8ab846d262). The
+    // Plain text, source included, both ways round (ADR-1f70ce2c3eac). The
     // source is not decoration on the value: `claude-code/6f4f` names a
     // session and `seanl@sean-laptop` names a machine, so two sessions in one
     // checkout that both let it fall back are one agent to every ref the tool
@@ -639,7 +639,7 @@ pub fn run(
 /// from `claim::way_out` rather than restated (TASK-38b384543551).
 ///
 /// Plain text either way. What is said here is a state a reader must be able to
-/// act on, so none of it is carried by colour (ADR-0c8ab846d262) — the same
+/// act on, so none of it is carried by colour (ADR-1f70ce2c3eac) — the same
 /// bytes reach a terminal and a pipe.
 fn also_claimed(
     out: &mut dyn Write,

--- a/crates/ank-cli/src/style.rs
+++ b/crates/ank-cli/src/style.rs
@@ -1,4 +1,4 @@
-//! ANSI styling, and the whole of it (§4, ADR-0c8ab846d262).
+//! ANSI styling, and the whole of it (§4, ADR-1f70ce2c3eac).
 //!
 //! Every escape sequence this binary can emit is written here, in one table of
 //! eight codes. That is deliberate: color is presentation, and presentation
@@ -20,7 +20,7 @@
 
 use std::io::IsTerminal;
 
-/// The structure alphabet of §4 (ADR-0c8ab846d262).
+/// The structure alphabet of §4 (ADR-1f70ce2c3eac).
 ///
 /// Text, not escapes, and therefore not gated on [`Style`] at all: a tree is
 /// what the `blocked_by` edges are, and drawing it one way for a human and

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -4205,7 +4205,7 @@ fn a_done_through_the_binary_leaves_a_completion_ref_naming_commit_and_branch() 
 }
 
 // ---------------------------------------------------------------------------
-// Short forms (TASK-f3e92656b5df, ADR-0c8ab846d262)
+// Short forms (TASK-f3e92656b5df, ADR-1f70ce2c3eac)
 // ---------------------------------------------------------------------------
 
 /// The short form is the long form, and the output proves it byte for byte.
@@ -10906,7 +10906,7 @@ fn a_blocker_that_does_not_exist_is_refused_at_creation() {
 }
 
 // ---------------------------------------------------------------------------
-// Color: the guarantee is negative (§4, ADR-0c8ab846d262)
+// Color: the guarantee is negative (§4, ADR-1f70ce2c3eac)
 // ---------------------------------------------------------------------------
 
 /// Every verb worth styling, exercised against a corpus that actually has
@@ -10955,7 +10955,7 @@ fn color_fixture() -> Repo {
 ///
 /// A spawned process writes to a pipe, so this suite *is* the piped case — the
 /// same shape an agent shelling out to `ank` sees. An escape byte anywhere in
-/// either stream is the defect ADR-0c8ab846d262 forbids, and `--json` is
+/// either stream is the defect ADR-1f70ce2c3eac forbids, and `--json` is
 /// checked beside the plain form because it is the one surface that must stay
 /// clean even at a terminal.
 #[test]
@@ -10985,7 +10985,7 @@ fn no_verb_writes_an_escape_sequence_to_a_pipe() {
 
 /// Structure ships in the bytes, and `--json` carries none of it.
 ///
-/// The other half of ADR-0c8ab846d262, and the half a test can only make in a
+/// The other half of ADR-1f70ce2c3eac, and the half a test can only make in a
 /// pipe: this suite spawns the binary, so its stdout *is* the pipe an agent
 /// reads. Colour must be absent from it and the connectors must be present —
 /// the two assertions point in opposite directions on purpose, because a
@@ -12568,7 +12568,7 @@ fn a_listing_counts_the_open_rows_a_claim_would_refuse_and_names_free() {
 /// work already finished on a branch — exactly the window the completion ref
 /// exists to close, reopened for whoever automated the question.
 ///
-/// ADR-0c8ab846d262 is the argument: colour depends on the reader, structure
+/// ADR-1f70ce2c3eac is the argument: colour depends on the reader, structure
 /// does not, and a marker is not colour. It is the answer, and it reads the
 /// same in a pipe.
 ///
@@ -14033,7 +14033,7 @@ fn the_note_reaches_json_as_a_list_and_not_as_drawn_text() {
     for glyph in ["└", "├", "│"] {
         assert!(
             !text.contains(glyph),
-            "--json carries no structure layer (ADR-0c8ab846d262): {text}"
+            "--json carries no structure layer (ADR-1f70ce2c3eac): {text}"
         );
     }
     // A finding with nothing to add carries the key and an empty list, so a

--- a/crates/ank-contract/src/verbs.rs
+++ b/crates/ank-contract/src/verbs.rs
@@ -435,7 +435,7 @@ pub const GLOBAL_FLAGS: &[FlagSpec] = &[
     flag("--worktree"),
 ];
 
-/// The short forms of §4 (ADR-0c8ab846d262), and the whole of them.
+/// The short forms of §4 (ADR-1f70ce2c3eac), and the whole of them.
 ///
 /// One table rather than a letter beside each declaration: `--scope` and
 /// `--criteria` are declared in three [`CommandSpec`]s each, and three

--- a/crates/ank-tui/src/frame.rs
+++ b/crates/ank-tui/src/frame.rs
@@ -2,16 +2,27 @@
 //!
 //! **Three escape sequences, and they are the whole of what this crate emits.**
 //! They move the cursor and swap the screen buffer; none of them is colour.
-//! That is deliberate rather than an omission: the palette of §4 lives in
-//! `ank-cli`'s `style.rs`, this crate may not link `ank-cli`, and a second
-//! palette would be a second place deciding what a status looks like. Nothing
-//! here is carried by colour, so what is given up is decoration and not
-//! information -- which is the rule ADR-0c8ab846d262 states, kept by having no
-//! colour at all rather than by being careful.
+//! That is where this crate stands today, and the reason is still worth
+//! stating: the palette of §4 lives in `ank-cli`'s `style.rs`, this crate may
+//! not link `ank-cli`, and a second palette would be a second place deciding
+//! what a status looks like. With no route to the first one, monochrome was
+//! the only answer left rather than the answer that was chosen.
 //!
-//! The structure layer is that ADR's, unchanged: the tree connectors and the
-//! marker on a held row are text, and they are the same bytes on every
-//! platform.
+//! **The other route is open now, and this file has not taken it yet.**
+//! ADR-1f70ce2c3eac makes what a status means one table, held where every
+//! surface reads it and holding no escape sequence, and each surface paints
+//! that meaning its own way: two renderers are allowed and a second table is
+//! not. The reason above is the one that decision keeps; the monochrome it
+//! forced is not.
+//!
+//! TASK-4fa385c1772d is where this file is drawn again through ratatui, and
+//! TASK-6cd41d23b7d1 is where the reader paints that table and NO_COLOR
+//! reaches it. Until then nothing here is carried by colour, so what is given
+//! up is decoration and not information.
+//!
+//! The structure layer is ADR-1f70ce2c3eac's and the supersession left it
+//! word for word: the tree connectors and the marker on a held row are text,
+//! and they are the same bytes on every platform.
 
 /// The alternate screen buffer. What a full-screen reader owes the shell it was
 /// launched from: leaving restores the scrollback the session was covering.
@@ -24,7 +35,7 @@ pub const LEAVE: &str = "\x1b[?1049l";
 pub const HOME: &str = "\x1b[H\x1b[2J";
 
 /// The marker on the row the cursor is on, in the two columns every listing in
-/// this tool already spends on its left margin (ADR-0c8ab846d262).
+/// this tool already spends on its left margin (ADR-1f70ce2c3eac).
 pub const CURSOR: &str = "> ";
 /// The same two columns on every other row.
 pub const PLAIN: &str = "  ";


### PR DESCRIPTION
`main` is red. Ratifying ADR-1f70ce2c3eac superseded ADR-0c8ab846d262, and
`no_superseded_document_is_cited_in_the_workspace` reads every surviving
citation of the predecessor as a failing test. Nineteen of them, across the nine
files TASK-0722ebfc5775 declares. Nothing else is in flight, so this branch is
the whole repair.

Closes TASK-0722ebfc5775, which unblocks TASK-1745 and TASK-4fa3.

## Both halves of what the test allows

ADR-1f70ce2c3eac keeps its predecessor whole except in one clause. The
short-form table of §4, structure-is-text-for-every-reader and `--json` carrying
neither survive word for word.

**Eighteen move.** Each supports one of those three, so the citation is
re-pointed and the sentence stands unchanged: the section banner over the
short-form tests, the negative colour guarantee, `--json` carrying no structure
layer, a marker not being colour, a resolver that must not print, the `CURSOR`
marker's two columns of left margin.

**One could not.** `crates/ank-tui/src/frame.rs:9` concluded that the crate
emits no colour at all *because* the palette it may not link is the only one
allowed to exist. ADR-1f70ce2c3eac names that file and ends exactly that
conclusion — what a status means becomes one table holding no escape sequence,
each surface paints it with what it draws with, and two renderers are allowed
where a second table is not. Re-pointing there would have cited the successor
for the monochrome it overturns: sourced-looking, wrong, and past the reach of
any grep.

So that header is rewritten. The *reason* survives, because the decision keeps
it in as many words; the *conclusion* is stated as where the crate stands today,
and the tasks that change it are named. ADR-0b55983421dd makes the whole premise
temporary, TASK-4fa385c1772d rewrites this file onto ratatui, TASK-6cd41d23b7d1
is where the reader paints the table and `NO_COLOR` reaches it. Nothing here
pre-empts either — the same handling the `ank-mcp` comments got this afternoon.

## What each sweep found

| sweep | outside `.ank/` | in the nine declared files |
| --- | --- | --- |
| `ADR-0c8ab846d262` | 19 | 19 |
| `0c8ab846` | 19 — the same 19, no extras | 19 |
| `ADR-0c8a` | 22 | 19 |

The third sweep is the one that pays. `stale_citations` matches
`line.contains(id)` on the whole identifier, so a four-character form is
invisible to the guard — the hole TASK-d86955470592 hit from the other side,
where a list renderer's eight-character form put a literal `SPEC-2035` in an
assertion and turned the suite red on a rename the guard had passed.

Its three extras are all **outside** this task's nine files, so they are
reported and filed rather than edited:

- `crates/ank-tui/src/lib.rs:122` — a bare `(ADR-0c8a)`
- `crates/ank-cli/src/human.rs:3884` — a bare `(ADR-0c8a)`
- `crates/ank-daemon/src/lib.rs:217` — `ADR-0c8a12b4e0a1`, which **names no
  entity this corpus holds** (`ank show` answers `entity not found`). It shares
  four characters with the retired decision and states that decision's split
  correctly, so it reads as sourced and resolves to nothing. It predates this
  supersession and no guard would ever have announced it.

**TASK-1003ef0c5b16** is filed for all three.

`ADR-962c` stays in the gutter-width fixture at `context.rs:1870`: it
abbreviates ADR-962c25797569, a different supersession, and this criterion is
not about it. Flagged here rather than silently swept.

Everything else that survives is inside `.ank/`, where entities cite their own
history and the walk does not go.

## No behaviour, no assertions

Every changed line is a comment or a doc comment, except the two fixture strings
in `context.rs`'s gutter test — and those are the same character count as what
they replace, which is the whole of what that test measures.

- `cargo test --workspace` green (0 failed; `no_superseded_document_is_cited_in_the_workspace` passes)
- `cargo fmt --check` passes
- `ank check` exit 0

Proof `commit:527912a29663ba890aa90c6a1ec3eff718c0c060`; `attest` records the
run id once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ECwY1exkcbV9gwaQpRbeB
