### PR TITLE
The worked example in the integration guide is bytes the binary produced

### DIFF
--- a/.ank/entities/LOG-7f58c1cb5441.md
+++ b/.ank/entities/LOG-7f58c1cb5441.md
@@ -1,0 +1,15 @@
+---
+id: LOG-7f58c1cb5441
+type: log
+title: Rebuilt the demo corpus with the binary built from this worktree (target/debug/ank, 0.6.0/90cf9db)
+created: 2026-08-26T00:21:23Z
+author: claude-code/opus-5+guide-example
+scope:
+  - docs/integrating.md
+about: TASK-2f04e979b388
+seq: 0
+schema: 4
+version: 1
+---
+
+ rather than hand-editing the quotes. Recipe, in a throwaway repo: git init -b main, commit.gpgsign false, one src/ file committed, ank init; then as ANK_AGENT=tool/1.0 -- new adr (scope src/**), new task --criteria 'A caller reads every entity.', amend --criteria 'A caller reads every entity through the CLI.', claim, log 'the layout is not the contract'. The amend has to precede the claim, because --criteria under a live claim is the 6 the freeze exists to give; that ordering is why the machinery entry lands at seq 0 and the work entry at seq 1. Ids are not reproducible (EntityId::generate mixes pid and nanos), so the doc gets whatever that run produced: TASK-eae278cc1709, LOG-d504254e3781 (work), LOG-ddd736d4d521 (records: edit), ADR-841036b31480.

--- a/.ank/entities/LOG-fbba840eecd0.md
+++ b/.ank/entities/LOG-fbba840eecd0.md
@@ -1,0 +1,13 @@
+---
+id: LOG-fbba840eecd0
+type: log
+title: done, proof commit:dadd1ed5cc89b61acbc91284007d1e56aa59938e
+created: 2026-08-26T00:30:06Z
+author: claude-code/opus-5+guide-example
+scope:
+  - docs/integrating.md
+about: TASK-2f04e979b388
+seq: 1
+schema: 4
+version: 1
+---

--- a/.ank/entities/TASK-2f04e979b388.md
+++ b/.ank/entities/TASK-2f04e979b388.md
@@ -5,13 +5,18 @@ slug: the-show-json-example-in-the-integration-guide-a
 title: The show --json example in the integration guide answers with the fields the binary emits
 created: 2026-08-25T22:08:01Z
 author: claude-code/opus-5+guide
-status: in_progress
+status: done
 scope:
   - docs/integrating.md
 blocked_by: []
 done_criteria: |
   The 'ank show TASK-a0a7 --json' block in docs/integrating.md is bytes a run of the built binary produced, carrying every field show now emits: machinery, and records inside each log entry. The corpus behind the worked example -- the task file, the log entity and the CLI answer quoted around it -- is reconstructed and the three blocks agree with each other, schema number included. cargo test is green.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: dadd1ed5cc89b61acbc91284007d1e56aa59938e
+    criteria: 3b4b739b4d75
+    via: submitted
 schema: 4
-version: 2
+version: 3
 ---

--- a/.ank/entities/TASK-2f04e979b388.md
+++ b/.ank/entities/TASK-2f04e979b388.md
@@ -5,7 +5,7 @@ slug: the-show-json-example-in-the-integration-guide-a
 title: The show --json example in the integration guide answers with the fields the binary emits
 created: 2026-08-25T22:08:01Z
 author: claude-code/opus-5+guide
-status: open
+status: in_progress
 scope:
   - docs/integrating.md
 blocked_by: []
@@ -13,5 +13,5 @@ done_criteria: |
   The 'ank show TASK-a0a7 --json' block in docs/integrating.md is bytes a run of the built binary produced, carrying every field show now emits: machinery, and records inside each log entry. The corpus behind the worked example -- the task file, the log entity and the CLI answer quoted around it -- is reconstructed and the three blocks agree with each other, schema number included. cargo test is green.
 criteria_by: creator
 schema: 4
-version: 1
+version: 2
 ---

--- a/docs/integrating.md
+++ b/docs/integrating.md
@@ -102,8 +102,8 @@ stable too:
     error[2]: entity not found: TASK-9999
       -> ank find TASK-9999
 
-    $ ank claim TASK-a0a7
-    error[4]: TASK-a0a7a75fbb9c held by tool/1.0 (expires in 30m)
+    $ ank claim TASK-6da1
+    error[4]: TASK-6da126c832be held by tool/1.0 (expires in 30m)
       -> ank context
 
 ## A task's state is not in its file
@@ -121,30 +121,51 @@ are not in it:
 - the **log entities** whose `about` names the task, one file per entry, stored
   beside the entities and not inside them:
 
-      $ cat .ank/entities/LOG-bc49fad834f1.md
+      $ cat .ank/entities/LOG-c0f96bc669ae.md
       ---
-      id: LOG-bc49fad834f1
+      id: LOG-c0f96bc669ae
       type: log
       title: the layout is not the contract
-      created: 2026-08-17T19:09:30Z
+      created: 2026-08-26T00:22:04Z
       author: tool/1.0
       scope:
         - src/**
-      about: TASK-a0a7a75fbb9c
+      about: TASK-6da126c832be
+      seq: 1
+      schema: 4
+      version: 1
+      ---
+
+  An entry carrying `records` is **machinery** rather than work: written by a
+  verb that changed the entity's content, not by the agent holding it. This
+  task carries one, because the criterion in the file below was amended before
+  a claim froze it, and the entry's message is the whole of that accounting:
+
+      $ cat .ank/entities/LOG-e6c24bc5f3e2.md
+      ---
+      id: LOG-e6c24bc5f3e2
+      type: log
+      title: done_criteria (version 1 to 2, replaced b1f3aa97873c, produced 83947c872580)
+      created: 2026-08-26T00:22:04Z
+      author: tool/1.0
+      scope:
+        - src/**
+      about: TASK-6da126c832be
       seq: 0
-      schema: 3
+      records: edit
+      schema: 4
       version: 1
       ---
 
 Read the file alone and here is what you see:
 
-    $ cat .ank/entities/TASK-a0a7a75fbb9c.md
+    $ cat .ank/entities/TASK-6da126c832be.md
     ---
-    id: TASK-a0a7a75fbb9c
+    id: TASK-6da126c832be
     type: task
     slug: the-parser-reads-a-corpus-without-opening-a-file
     title: The parser reads a corpus without opening a file
-    created: 2026-08-17T19:09:19Z
+    created: 2026-08-26T00:22:04Z
     author: tool/1.0
     status: in_progress
     scope:
@@ -153,18 +174,25 @@ Read the file alone and here is what you see:
     done_criteria: |
       A caller reads every entity through the CLI.
     criteria_by: creator
-    schema: 3
-    version: 2
+    schema: 4
+    version: 3
     ---
 
-`in_progress`, and not one word about who is holding it, when the lease expires,
-or what they have learned. Ask the CLI instead and the same task answers whole:
+`in_progress`, `version: 3`, and not one word about who is holding it, when the
+lease expires, what they have learned, or what the two versions before this one
+were. Ask the CLI instead and the same task answers whole:
 
-    $ ank show TASK-a0a7 --json
-    {"contract":1,"id":"TASK-a0a7a75fbb9c","coordination":"claimed by tool/1.0","blocked_by":[],"unblocks":[],"detached_proofs":[],"log_total":1,"log_shown":1,"log":[{"id":"LOG-bc49fad834f1","timestamp":"2026-08-17T19:09:30Z","who":"tool/1.0","message":"the layout is not the contract"}],"content":"---\nid: TASK-a0a7a75fbb9c\ntype: task\n…"}
+    $ ank show TASK-6da1 --json
+    {"contract":1,"id":"TASK-6da126c832be","coordination":"claimed by tool/1.0","blocked_by":[],"unblocks":[],"detached_proofs":[],"log_total":1,"log_shown":1,"log":[{"id":"LOG-c0f96bc669ae","timestamp":"2026-08-26T00:22:04Z","who":"tool/1.0","message":"the layout is not the contract","records":null}],"machinery":[{"id":"LOG-e6c24bc5f3e2","timestamp":"2026-08-26T00:22:04Z","who":"tool/1.0","message":"done_criteria (version 1 to 2, replaced b1f3aa97873c, produced 83947c872580)","records":"edit"}],"content":"---\nid: TASK-6da126c832be\ntype: task\nslug: the-parser-reads-a-corpus-without-opening-a-file\ntitle: The parser reads a corpus without opening a file\ncreated: 2026-08-26T00:22:04Z\nauthor: tool/1.0\nstatus: in_progress\nscope:\n  - src/**\nblocked_by: []\ndone_criteria: |\n  A caller reads every entity through the CLI.\ncriteria_by: creator\nschema: 4\nversion: 3\n---\n"}
 
-`coordination` came from the ref. `log` came from the log entities. `content` is
-the file, byte for byte, so nothing is lost by going through the verb.
+`coordination` came from the ref. `log` and `machinery` came from the log
+entities, split on `records`: the work trace is what a holder wrote and is what
+the budget is spent on, the machinery is what the verbs wrote and is listed
+under it, so a task edited eight times does not answer "what did the last holder
+learn" with eight mechanical lines. `records` is `null` on a work entry, and a
+client reading `log` alone still sees the field. `log_total` and `log_shown`
+count the work trace and never the machinery. `content` is the file, byte for
+byte, so nothing is lost by going through the verb.
 
 **So read through the CLI, not through the directory.** Not as a matter of taste:
 a reader that walks `.ank/` is reading one of the three sources and will report a
@@ -212,7 +240,7 @@ Exit 8 is findings, meaning faults. Signals leave it 0, and that is deliberate:
 reddening a build over an observation teaches a team to stop reading `check`.
 
     $ ank check --json
-    {"contract":1,"faults":0,"signals":4,"tasks":1,"adr":1,"pruned":[],"findings":[{"level":"signal","subject":"ADR-4bed8b557e89","message":"written by an agent and read by no human","note":[],"charge":[]},{"level":"signal","subject":"TASK-a0a7a75fbb9c","message":"written by an agent and read by no human","note":[],"charge":[]},{"level":"signal","subject":"allowed_signers","message":"no ratification key declared: permissions are advisory, not enforced (§8)","note":[],"charge":[]},{"level":"signal","subject":"coordination","message":"default branch indeterminable, completion refs neither pruned nor judged (ank config default_branch <name>)","note":[],"charge":[]}]}
+    {"contract":1,"faults":0,"signals":4,"tasks":1,"adr":1,"pruned":[],"findings":[{"level":"signal","subject":"ADR-57715ae64348","message":"written by an agent and read by no human","note":[],"charge":[]},{"level":"signal","subject":"TASK-6da126c832be","message":"written by an agent and read by no human","note":[],"charge":[]},{"level":"signal","subject":"allowed_signers","message":"no ratification key declared: permissions are advisory, not enforced (§8)","note":[],"charge":[]},{"level":"signal","subject":"coordination","message":"default branch indeterminable, completion refs neither pruned nor judged (ank config default_branch <name>)","note":[],"charge":[]}]}
 
 ## The conformance suite is offered to you
 


### PR DESCRIPTION
## What the criterion asked

The `ank show TASK-a0a7 --json` block in `docs/integrating.md` predated two
fields — `machinery`, the sibling of `log`, and `records` inside every log
entry — and predated `schema: 4`. Its `content` also ended in a hand-typed
ellipsis, so no run of any binary ever emitted those bytes.

Fixing it honestly meant rebuilding the corpus the section reads three ways,
not editing fields into a quote nobody ran.

## What I did

Built `target/debug/ank` from this branch (`ank 0.6.0 (90cf9db, skill
c5bae2a5f350)`) and reconstructed the demo corpus in a throwaway repository:

```
git init -b main && git config commit.gpgsign false   # a temp corpus will not commit otherwise
mkdir src && touch src/main.rs && git add -A && git commit -m "the parser"
ank init
export ANK_AGENT=tool/1.0
ank new adr  --title "A caller reaches the corpus through the CLI, never through the directory" \
             --scope "src/**" --constraint "..."
ank new task --title "The parser reads a corpus without opening a file" \
             --scope "src/**" --criteria "A caller reads every entity."
ank amend <task> --criteria "A caller reads every entity through the CLI."
ank claim <task>
ank log   <task> "the layout is not the contract"
```

The amend **has to** precede the claim: `--criteria` under a live claim is the
`6` the freeze exists to give. That ordering is why the machinery entry sits at
`seq: 0` and the work entry at `seq: 1`, and it is worth showing rather than
hiding — so the guide now prints the machinery entity too. A task file that
says `version: 3` and not one word about why is exactly the point that section
is making.

Ids are not reproducible (`EntityId::generate` mixes pid and nanos), so the
document carries the ids that run produced. Five quoted commands read that one
corpus and now agree on all of them, `schema: 4` included.

## Every quoted command in the file, re-run

`docs/integrating.md` has been wrong twice — TASK-d9b167250aa8 found two stale
quotes, the agent after it found two more — so every quoted command in the file
was re-run against the built binary, not only the one under the criterion.

| Quoted command | Verdict |
|---|---|
| `ank help --json \| cut -c1-64` | reproduced byte for byte |
| `ank help close --json` | reproduced byte for byte |
| `ank show TASK-9999` | reproduced byte for byte |
| `ank help check` | reproduced byte for byte |
| `ank config --user corpora.<id> /srv/back` + the `corpora.yml` it writes | reproduced byte for byte (identity substituted) |
| MCP: `ank_find` with a `corpus` argument | reproduced byte for byte (identity and task id substituted) |
| MCP: `error[9]` on an undeclared identity | reproduced byte for byte |
| MCP: `error[9]` on a path where an identity belongs | reproduced byte for byte |
| MCP: `-32602` on `--repo` | reproduced byte for byte |
| MCP: `error[2]` inherited from the CLI | reproduced byte for byte |
| `events.jsonl` `change:"entities"` line | reproduced byte for byte (corpus substituted) |
| `events.jsonl` `change:"refs"` line | reproduced byte for byte (corpus substituted) |
| `watch.yml` as printed | parses; `--list` refuses only on the fictional paths |
| The exit-code table | matches `crates/ank-contract/src/exit.rs`, 0 through 9 |
| The four test names cited | all four exist (`watch.rs` ×2, `cli.rs`, `tui.rs`) |
| Both golden fixture directories | both exist; the quoted `golden.rs` header line is verbatim |
| Every `ADR-*` cited in prose | all eight resolve through `ank show` |
| **`cat` on the log entity** | **rebuilt** |
| **`cat` on the task file** | **rebuilt** |
| **`ank show <task> --json`** | **rebuilt** |
| **`ank check --json`** | **rebuilt** |
| **`ank claim <task>` refusing with 4** | **rebuilt** |

Nothing outside the criterion turned out to be stale, so nothing was filed and
nothing outside `docs/integrating.md` was touched. The identities and paths
marked "substituted" belong to the `/srv/back` and `/home/me/work` fictions,
which are a reader's configuration rather than a corpus this repository holds;
their shape is what was verified, and it holds.

## An observation, not a change

Nothing in this repository verifies what it *shows* a reader. The corpus checks
its ADRs by hash, its verbs against the spec, its citations against superseded
documents, its versions against the tag — and never a single quoted command
output. That is why this file has now been wrong three times, and why each
round of repairs is archaeology rather than a test failure.

The shape of a fix is already here, twice over. `crates/ank-cli/tests/golden-json/`
already captures one fixture per document the CLI returns, *from the process*.
A quoted block in `docs/` is the same kind of artifact with none of the
machinery: a command, an environment, and the bytes it produced.

What would close the gap is a fixture corpus the documentation is generated
against — the demo corpus above, built by a test rather than by an agent in a
scratch directory, with each quoted block in `docs/` carrying the command that
produces it, and the test asserting that running it against that corpus yields
what the file shows. `ank check` would stay out of it: this is a `cargo test`
concern, not a corpus invariant, because what it validates is prose in `docs/`
and not an entity in `.ank/`. The cost is that the demo corpus needs
reproducible ids, which `EntityId::generate` does not currently offer — which
is itself the first task such a plan would have to file.

I did not build it. It is well outside `docs/integrating.md`, and a task that
quietly widens is worse than one that reports.

---

`cargo test --workspace` green (17 binaries, 0 failures). `cargo fmt --check`
passing. `ank check` 0 faults, exit 0.

Proof: `commit:dadd1ed5cc89b61acbc91284007d1e56aa59938e`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Td7RRJU1WuABjonP9JDxnk
