### PR TITLE
The reader draws with ratatui and reads keystrokes with crossterm

### DIFF
--- a/.ank/entities/LOG-374e7ec131ae.md
+++ b/.ank/entities/LOG-374e7ec131ae.md
@@ -1,0 +1,13 @@
+---
+id: LOG-374e7ec131ae
+type: log
+title: attested commit:faa0f756c621d1f4286306c40a0d7da0f86a3c37
+created: 2026-08-26T01:48:25Z
+author: claude-code/opus-5+ratatui-engine
+scope:
+  - crates/ank-tui/**
+about: TASK-4fa385c1772d
+seq: 4
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-5c7626b7cc76.md
+++ b/.ank/entities/LOG-5c7626b7cc76.md
@@ -1,0 +1,15 @@
+---
+id: LOG-5c7626b7cc76
+type: log
+title: "The seam held: ank.rs, model.rs and stream.rs are untouched, and frame.rs/input.rs/view.rs took the"
+created: 2026-08-26T00:47:48Z
+author: claude-code/opus-5+ratatui-engine
+scope:
+  - crates/ank-tui/**
+about: TASK-4fa385c1772d
+seq: 1
+schema: 4
+version: 1
+---
+
+ whole change. frame.rs became text.rs -- fit/pad/wrap/window survive because they are not drawing: Paragraph wraps inside its own render and reports no count, so a heading saying '41-60 of 1275' over a body has to have counted the rows itself. New: term.rs (raw mode, alternate screen, the crossterm event thread), keys.rs (one key per command). input.rs keeps the line grammar for the prompt 'a' opens, which is what keeps accept's two refusals -- no tail, only on the document -- and their tests alive. Three things cost real time. KeyEventKind::Release must be filtered or Windows runs every command twice. The ank-cli PTY suite could not survive as a substring search over the byte stream: ratatui diffs, so a space that did not change is skipped and 'CLAIMS (1)' reaches the wire as CLAIMS, a cursor move, (1) -- the suite now applies the bytes to a grid, which is more honest than what it did before. And a frame must be sampled where the frame ended, not where a read stopped: ratatui closes every draw with ESC[?25l or ESC[?25h, and sampling on read boundaries loses a transient refusal whenever two frames arrive together.

--- a/.ank/entities/LOG-d62e37e4858c.md
+++ b/.ank/entities/LOG-d62e37e4858c.md
@@ -1,0 +1,13 @@
+---
+id: LOG-d62e37e4858c
+type: log
+title: done, proof commit:7d8717403f24931f75925ed69b8fb6611d5874a3
+created: 2026-08-26T01:23:29Z
+author: claude-code/opus-5+ratatui-engine
+scope:
+  - crates/ank-tui/**
+about: TASK-4fa385c1772d
+seq: 2
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-da22cd2b10db.md
+++ b/.ank/entities/LOG-da22cd2b10db.md
@@ -1,0 +1,15 @@
+---
+id: LOG-da22cd2b10db
+type: log
+title: "CI found two the local run could not. The dependency test ran cargo tree --target all --offline:"
+created: 2026-08-26T01:39:51Z
+author: claude-code/opus-5+ratatui-engine
+scope:
+  - crates/ank-tui/**
+about: TASK-4fa385c1772d
+seq: 3
+schema: 4
+version: 1
+---
+
+ --target all needs the manifest of every package on every target, --offline forbids fetching one, and a host build downloads only what it compiles. Before ratatui the two happened to agree; ratatui reaches bumpalo through a wasm32-only edge of time, no runner ever downloads it, and the test went red on all three asking for the network it is forbidden to use. The graph is read out of Cargo.lock now, which records every target and every optional dependency, is checked in, and is broader than --target all rather than narrower -- the safe direction for a rule that says a name must not appear. And macOS refused TIOCSWINSZ on the pseudo-terminal master with -1: there the master is a cloning device answering only the three ioctls grantpt, unlockpt and ptsname are built from, so the window is set through the slave, which is a tty on both and is where a window size belongs. The child's three slave descriptors are now opened before the size is stated, so no moment exists in which the terminal has hung up.

--- a/.ank/entities/TASK-4fa385c1772d.md
+++ b/.ank/entities/TASK-4fa385c1772d.md
@@ -5,13 +5,18 @@ slug: the-reader-draws-with-ratatui-and-reads-keystrok
 title: The reader draws with ratatui and reads keystrokes with crossterm
 created: 2026-08-25T22:45:12Z
 author: haksolot@vmi3223161
-status: in_progress
+status: done
 scope:
   - crates/ank-tui/**
 blocked_by: [TASK-0722ebfc5775]
 done_criteria: |
   crates/ank-tui declares ratatui and crossterm and draws through them: the session runs in raw mode on the alternate screen, an event loop takes keys, resize and the change stream, and a terminal made narrower or wider redraws to its new size without a command being typed. Every view the reader has today is drawn again through ratatui and shows the same entities, the same claims, the same constraints and the same body, whole and paged rather than cut. Navigation is one key per command. The six verbs that write are reachable and each still runs the CLI as a shell would, spawned with no stdin. The suite drives the built binary through a real pseudo-terminal as it does today, and no dependency test regresses: the crate links neither ank-cli nor ank-core, and no FFI enters the tree. cargo test is green on all three platforms and cargo fmt --check passes.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 7d8717403f24931f75925ed69b8fb6611d5874a3
+    criteria: 4856886326d2
+    via: submitted
 schema: 4
-version: 3
+version: 4
 ---

--- a/.ank/entities/TASK-4fa385c1772d.md
+++ b/.ank/entities/TASK-4fa385c1772d.md
@@ -5,7 +5,7 @@ slug: the-reader-draws-with-ratatui-and-reads-keystrok
 title: The reader draws with ratatui and reads keystrokes with crossterm
 created: 2026-08-25T22:45:12Z
 author: haksolot@vmi3223161
-status: open
+status: in_progress
 scope:
   - crates/ank-tui/**
 blocked_by: [TASK-0722ebfc5775]
@@ -13,5 +13,5 @@ done_criteria: |
   crates/ank-tui declares ratatui and crossterm and draws through them: the session runs in raw mode on the alternate screen, an event loop takes keys, resize and the change stream, and a terminal made narrower or wider redraws to its new size without a command being typed. Every view the reader has today is drawn again through ratatui and shows the same entities, the same claims, the same constraints and the same body, whole and paged rather than cut. Navigation is one key per command. The six verbs that write are reachable and each still runs the CLI as a shell would, spawned with no stdin. The suite drives the built binary through a real pseudo-terminal as it does today, and no dependency test regresses: the crate links neither ank-cli nor ank-core, and no FFI enters the tree. cargo test is green on all three platforms and cargo fmt --check passes.
 criteria_by: creator
 schema: 4
-version: 2
+version: 3
 ---

--- a/.ank/entities/TASK-4fa385c1772d.md
+++ b/.ank/entities/TASK-4fa385c1772d.md
@@ -17,6 +17,10 @@ proof:
     ref: 7d8717403f24931f75925ed69b8fb6611d5874a3
     criteria: 4856886326d2
     via: submitted
+  - type: commit
+    ref: faa0f756c621d1f4286306c40a0d7da0f86a3c37
+    criteria: 4856886326d2
+    via: submitted
 schema: 4
-version: 4
+version: 5
 ---

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "ank-cli"
 version = "0.6.0"
 dependencies = [
@@ -40,7 +46,7 @@ dependencies = [
  "serde",
  "serde_yaml",
  "sha2",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -65,8 +71,67 @@ name = "ank-tui"
 version = "0.6.0"
 dependencies = [
  "ank-contract",
+ "crossterm",
+ "ratatui",
  "serde_yaml",
 ]
+
+[[package]]
+name = "anyhow"
+version = "1.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
+
+[[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -94,6 +159,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,12 +202,74 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "compact_str"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags 2.13.1",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -129,6 +283,87 @@ dependencies = [
 ]
 
 [[package]]
+name = "csscolorparser"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
+dependencies = [
+ "lab",
+ "phf",
+]
+
+[[package]]
+name = "darling"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed17f5901b6630b993ca003def43f2f8ef4014fc13b047b57aad617ff32bc2ec"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6837e2cf7485aaae18f86181d2f0e9a7ed297a025e220aeabf63fdebd3a2ddff"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 3.0.4",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
+name = "deltae"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -139,10 +374,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
+name = "either"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "fallible-iterator"
@@ -157,10 +426,79 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set",
+ "regex",
+]
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "finl_unicode"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "futures-core"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
+
+[[package]]
+name = "futures-task"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
+
+[[package]]
+name = "futures-util"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "generic-array"
@@ -170,6 +508,29 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
 ]
 
 [[package]]
@@ -192,10 +553,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
@@ -204,7 +599,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf84e73fa6f27f299dec58e13223cf70db80da872eb921d4f6138342a0eabc8"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -214,10 +640,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "js-sys"
+version = "0.3.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "kasuari"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
+dependencies = [
+ "hashbrown 0.16.1",
+ "portable-atomic",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "lab"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -231,10 +697,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "line-clipping"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e752191d037c44ad111a8caa762921926658402f01cc1253f7bef2020ece4f5e"
+dependencies = [
+ "bitflags 2.13.1",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "lru"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
+dependencies = [
+ "hashbrown 0.17.1",
+]
+
+[[package]]
+name = "mac_address"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix",
+ "winapi",
+]
 
 [[package]]
 name = "memchr"
@@ -243,10 +758,284 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "memmem"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "mio"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "palette"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddeed8580d347d2abf3dcf06a5f0b3dc020258338526b277847cd4248a70fc64"
+dependencies = [
+ "approx",
+ "libm",
+ "palette_derive",
+ "palette_math",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88537020289b719d81be994ccf1bbf4990f477e2f69ee52fe3e45f43a02e56be"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "palette_math"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e6eb142958d64335fb0e345c5b9ead2ecd6fc438c307e9d7d3c4fd428dbaf12"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "pest"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a07a60cc7a4d00c91f95c685609d1d2f79050e6804b70ebedd7650f0b839bcf"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a83744a5c8455b8b3e0dc5031362780a347c878bdd11584d1a8984228cc88d"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0cd3451aa3de60d4b9a1e736885e4dea6b31617598026f12256ad566d63304a"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d3a0849e241d7dfce834c83b1c5edc8622009e8dd51a12ba1927c32f05496"
+dependencies = [
+ "pest",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "portable-atomic"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
@@ -264,6 +1053,130 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "ratatui"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-termwiz",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c"
+dependencies = [
+ "bitflags 2.13.1",
+ "compact_str",
+ "critical-section",
+ "hashbrown 0.17.1",
+ "itertools",
+ "kasuari",
+ "lru",
+ "palette",
+ "serde",
+ "strum 0.28.0",
+ "thiserror 2.0.20",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567584a3b0e6a8203c23de40b4861497266725eb5363dbfd18a1edd603cca9f0"
+dependencies = [
+ "cfg-if",
+ "crossterm",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-termwiz"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf03e0380b7744054d6cb74224fe3adf062a029754933f575ca1e3b4c2ce977"
+dependencies = [
+ "ratatui-core",
+ "termwiz",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
+dependencies = [
+ "bitflags 2.13.1",
+ "hashbrown 0.16.1",
+ "indoc",
+ "instability",
+ "itertools",
+ "line-clipping",
+ "ratatui-core",
+ "strum 0.27.2",
+ "time",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.13.1",
+]
+
+[[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -289,7 +1202,7 @@ version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11438310b19e3109b6446c33d1ed5e889428cf2e278407bc7896bc4aaea43323"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "libsqlite3-sys",
@@ -297,10 +1210,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.13.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -319,7 +1272,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -353,10 +1306,118 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros 0.27.2",
+]
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -370,12 +1431,95 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "terminfo"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
+dependencies = [
+ "fnv",
+ "nom",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "termwiz"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bitflags 2.13.1",
+ "fancy-regex",
+ "filedescriptor",
+ "finl_unicode",
+ "fixedbitset",
+ "hex",
+ "lazy_static",
+ "libc",
+ "log",
+ "memmem",
+ "nix",
+ "num-derive",
+ "num-traits",
+ "ordered-float",
+ "pest",
+ "pest_derive",
+ "phf",
+ "sha2",
+ "signal-hook",
+ "siphasher",
+ "terminfo",
+ "termios",
+ "thiserror 1.0.69",
+ "ucd-trie",
+ "unicode-segmentation",
+ "vtparse",
+ "wezterm-bidi",
+ "wezterm-blob-leases",
+ "wezterm-color-types",
+ "wezterm-dynamic",
+ "wezterm-input-types",
+ "winapi",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
+dependencies = [
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -386,8 +1530,40 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
+name = "time"
+version = "0.3.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+dependencies = [
+ "deranged",
+ "libc",
+ "num-conv",
+ "num_threads",
+ "powerfmt",
+ "serde",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
 
 [[package]]
 name = "typenum"
@@ -396,16 +1572,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-truncate"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f053576934f05a761a402421fbbe3d425d9366f75f978806a037b3ca481abecc"
+dependencies = [
+ "atomic",
+ "getrandom 0.4.3",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "vcpkg"
@@ -418,3 +1641,187 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vtparse"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "wezterm-bidi"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0a6e355560527dd2d1cf7890652f4f09bb3433b6aadade4c9b5ed76de5f3ec"
+dependencies = [
+ "log",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-blob-leases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
+dependencies = [
+ "getrandom 0.3.4",
+ "mac_address",
+ "sha2",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
+name = "wezterm-color-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de81ef35c9010270d63772bebef2f2d6d1f2d20a983d27505ac850b8c4b4296"
+dependencies = [
+ "csscolorparser",
+ "deltae",
+ "lazy_static",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-dynamic"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
+dependencies = [
+ "log",
+ "ordered-float",
+ "strsim",
+ "thiserror 1.0.69",
+ "wezterm-dynamic-derive",
+]
+
+[[package]]
+name = "wezterm-dynamic-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "wezterm-input-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7012add459f951456ec9d6c7e6fc340b1ce15d6fc9629f8c42853412c029e57e"
+dependencies = [
+ "bitflags 1.3.2",
+ "euclid",
+ "lazy_static",
+ "serde",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"

--- a/crates/ank-cli/tests/tui.rs
+++ b/crates/ank-cli/tests/tui.rs
@@ -1,25 +1,55 @@
-//! `ank tui` through the binary (TASK-49746735127f, ADR-8bd76e8d7c4e).
+//! `ank tui` through the binary (TASK-49746735127f, ADR-8bd76e8d7c4e,
+//! ADR-0b55983421dd).
 //!
 //! CLAUDE.md leaves no choice about where this suite lives: a criterion that
 //! talks about the binary is tested through the binary, and twice in this
 //! repository green unit tests covered code that was right on a path the binary
 //! never reached. A TUI is the extreme case of that trap -- every interesting
 //! behaviour sits behind terminal setup a unit test does not perform -- so the
-//! session here is driven through a real pseudo-terminal and the frames are
-//! read off the master side.
+//! session here is driven through a real pseudo-terminal and the screen is read
+//! off the master side.
 //!
 //! It lives in `ank-cli` rather than in `ank-tui` for one mechanical reason:
 //! `CARGO_BIN_EXE_ank` is defined only for the package that declares the
 //! binary, and a suite that could not name the binary would be back to testing
 //! the function instead of the process.
 //!
+//! # What changed when the reader moved onto ratatui, and what did not
+//!
+//! **What is asserted did not move.** Quitting leaves no file and no ref
+//! changed; a session left idle renews no claim; an event repaints and renews
+//! nothing; the event route and the reload route reach the same displayed
+//! state; the frames carry no identifier the corpus does not. Those are facts
+//! about the reader's behaviour and not about how it draws, so they survived
+//! the engine whole.
+//!
+//! **How the session is driven did move, twice.** A command is a key now
+//! (ADR-0b55983421dd), so a list of lines became a list of keystrokes, with the
+//! four verbs that carry a message, a reason, a proof or a flag spelled into
+//! the prompt that `a` opens -- see [`on_a_terminal`] for what an entry of one
+//! of those lists is.
+//!
+//! And the screen is no longer the byte stream. ratatui draws by diffing: it
+//! writes the cells that changed and moves the cursor over the ones that did
+//! not, so a space that stayed a space is never sent and `CLAIMS (1)` reaches
+//! the wire as `CLAIMS`, a cursor move and `(1)`. A substring search over those
+//! bytes would have been asserting something no longer true of them, so the
+//! bytes are applied to a grid ([`Screen`]) and every assertion here is made
+//! against what a person would have been looking at. That is stricter than
+//! what it replaced rather than looser: a frame is compared as a frame, and
+//! [`Seen::raw`] keeps the stream for the one assertion that is genuinely about
+//! it.
+//!
 //! **What is covered on which platform.** The refusal with no terminal runs
 //! everywhere, which matters most: it is the one an agent meets. The driven
 //! session is `#[cfg(unix)]`, because a pseudo-terminal on Windows is ConPTY
 //! and reaching it means the console API this workspace does not otherwise
-//! call. The reader itself is platform-independent by construction -- it does
-//! no FFI, and the escape sequences it writes are the same bytes on all three
-//! (`crates/ank-tui/src/frame.rs`).
+//! call. What CLAUDE.md's three-platform rule asks of raw mode is answered a
+//! rung down: this crate declares no foreign symbol at all
+//! (`crates/ank-tui/tests/dependencies.rs`), the two implementations of it are
+//! crossterm's and are exercised far beyond what this workspace could give
+//! them, and what runs on all three here is everything above them -- the
+//! keystroke mapping, the layout, the render, and the refusal an agent meets.
 //!
 //! **The writing half is measured here too** (TASK-b50b340c0bb1). What a unit
 //! test can say about `claim` from a screen is which `argv` would have been
@@ -233,6 +263,16 @@ fn ids_of(doc: &str) -> Vec<String> {
     out
 }
 
+/// One entry of a key list that opens an entity by its identifier.
+///
+/// An identifier is a line by nature -- it is fourteen characters and no key
+/// spells it -- so it goes through the prompt, which is where the grammar reads
+/// one and jumps to it.
+#[cfg(unix)]
+fn open(id: &str) -> String {
+    format!(":{}", short_of(id))
+}
+
 /// The short form every listing prints: the kind, then four characters.
 fn short_of(id: &str) -> String {
     let (kind, rest) = id.split_once('-').expect("an identifier has a kind");
@@ -306,20 +346,32 @@ fn json_does_not_exempt_a_caller_from_the_terminal() {
 // The driven session
 // ---------------------------------------------------------------------------
 
-/// A pseudo-terminal, opened with the four calls POSIX names for it.
+/// A pseudo-terminal, opened with the four calls POSIX names for it, and sized.
 ///
 /// Declared here rather than taken from a crate. `libc` is in the lockfile and
 /// would have been the tidier road, but it is not compiled for this target
-/// today and §13 spends a dependency only on necessity: what is needed is four
-/// symbols and one flag, `O_RDWR`, whose value POSIX fixes at 2 on every system
-/// this suite runs on. Rust links the platform's C library already, so nothing
-/// is added to the link line either.
+/// today and §13 spends a dependency only on necessity: what is needed is six
+/// symbols and two flags, and Rust links the platform's C library already, so
+/// nothing is added to the link line either.
+///
+/// **The window is set here and it has to be.** The reader asks the terminal
+/// how big it is (ADR-0b55983421dd), and a pseudo-terminal nobody sized is nought
+/// by nought -- so a suite that skipped this would be asserting what a reader
+/// draws into no window at all. It is also what makes the resize measurable:
+/// setting it again while a session is running is exactly what a person
+/// dragging the corner of a window does.
+///
+/// A test may declare what this crate may not, which is the rule
+/// `crates/ank-tui/tests/dependencies.rs` states from the other side: the
+/// reader reaches raw mode, the window and a keystroke through crossterm and
+/// declares no foreign symbol at all. The `extern` below is the instrument, not
+/// the subject.
 #[cfg(unix)]
 mod pty {
     use std::ffi::CStr;
     use std::fs::File;
-    use std::os::fd::{FromRawFd, IntoRawFd};
-    use std::os::raw::{c_char, c_int};
+    use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd};
+    use std::os::raw::{c_char, c_int, c_ulong};
     use std::path::PathBuf;
 
     extern "C" {
@@ -327,18 +379,39 @@ mod pty {
         fn grantpt(fd: c_int) -> c_int;
         fn unlockpt(fd: c_int) -> c_int;
         fn ptsname(fd: c_int) -> *mut c_char;
+        fn ioctl(fd: c_int, request: c_ulong, ...) -> c_int;
+        fn kill(pid: c_int, signal: c_int) -> c_int;
     }
 
     const O_RDWR: c_int = 2;
 
+    /// The two constants that are not POSIX, spelled per platform because they
+    /// are per platform: an `ioctl` number encodes the direction and the size
+    /// of its argument, and the two kernels encode them differently.
+    #[cfg(target_os = "linux")]
+    const TIOCSWINSZ: c_ulong = 0x5414;
+    #[cfg(not(target_os = "linux"))]
+    const TIOCSWINSZ: c_ulong = 0x8008_7467;
+
+    /// `SIGWINCH`, which is 28 on every platform this suite runs on.
+    const SIGWINCH: c_int = 28;
+
+    #[repr(C)]
+    struct WinSize {
+        rows: u16,
+        columns: u16,
+        x_pixels: u16,
+        y_pixels: u16,
+    }
+
     /// The master side as a `File`, and the path of the slave to hand the
     /// child.
-    pub fn open() -> (File, PathBuf) {
+    pub fn open(columns: u16, rows: u16) -> (File, PathBuf) {
         // SAFETY: the four calls are the POSIX pseudo-terminal sequence, in
         // order, and every return is checked before the next is made. The
         // pointer `ptsname` answers with is owned by the C library and is
         // copied out before anything else can invalidate it.
-        unsafe {
+        let (master, path) = unsafe {
             let master = posix_openpt(O_RDWR);
             assert!(master >= 0, "posix_openpt failed");
             assert_eq!(grantpt(master), 0, "grantpt failed");
@@ -352,7 +425,41 @@ mod pty {
                     .to_string(),
             );
             (File::from_raw_fd(master), path)
-        }
+        };
+        resize(&master, columns, rows);
+        (master, path)
+    }
+
+    /// The window, stated on the master side, which is where a terminal
+    /// emulator states it.
+    pub fn resize(master: &File, columns: u16, rows: u16) {
+        let size = WinSize {
+            rows,
+            columns,
+            x_pixels: 0,
+            y_pixels: 0,
+        };
+        // SAFETY: the descriptor is open and owned by `master`, and the third
+        // argument is a `winsize` by value, which is what TIOCSWINSZ reads.
+        let set = unsafe { ioctl(master.as_raw_fd(), TIOCSWINSZ, &size) };
+        assert_eq!(set, 0, "the window could not be set on the pseudo-terminal");
+    }
+
+    /// The signal a terminal sends when its window changed.
+    ///
+    /// **Sent by name rather than left to the kernel**, and the reason is worth
+    /// stating: the kernel sends `SIGWINCH` to the foreground process group of
+    /// the terminal's *session*, and this child was never given the slave as a
+    /// controlling terminal -- no `setsid`, no `TIOCSCTTY`, because neither is
+    /// needed for anything else here. So the delivery is done explicitly, which
+    /// is the same signal arriving by a shorter road: what is under test is what
+    /// the reader does when it is told the window moved, and not which of the
+    /// two roads told it.
+    pub fn winch(child: &std::process::Child) {
+        // SAFETY: the child is alive -- it has not been waited on -- and
+        // SIGWINCH is a valid signal number.
+        let sent = unsafe { kill(child.id() as c_int, SIGWINCH) };
+        assert_eq!(sent, 0, "SIGWINCH could not be delivered to the session");
     }
 
     /// The slave, opened once per standard stream the child is given.
@@ -372,72 +479,560 @@ mod pty {
     }
 }
 
-/// Runs `ank tui` on a real terminal and answers everything it drew.
+/// A terminal, as far as this suite needs one.
 ///
-/// The output is drained on a thread of its own. A session that painted more
-/// than the pseudo-terminal's buffer holds while nobody was reading would
-/// deadlock, and a deadlock in a suite is a timeout with no message.
+/// **The reader draws by diffing now, and that is what forced this.** ratatui
+/// writes the cells that changed and moves the cursor over the ones that did
+/// not, so a byte stream carrying `CLAIMS (1)` may well carry `CLAIMS`, a
+/// cursor move and `(1)` -- the screen is right and a substring search over the
+/// bytes is wrong. So the bytes are applied to a grid, exactly as a terminal
+/// applies them, and every assertion in this file is made against what a person
+/// would have been looking at.
+///
+/// It is deliberately the smallest emulator that is honest about this stream:
+/// cursor position, the two erases, and text. Everything else a CSI can say --
+/// colour, attributes, the alternate buffer, the cursor's visibility -- moves
+/// no character on the grid, so it is consumed and dropped rather than half
+/// understood. [`Screen::raw`] keeps the bytes for the one assertion that is
+/// genuinely about them.
 #[cfg(unix)]
-fn drive(repo: &Repo, agent: &str, commands: &[&str]) -> String {
-    on_a_terminal(repo, agent, &["tui"], commands)
+struct Screen {
+    grid: Vec<Vec<char>>,
+    columns: usize,
+    rows: usize,
+    x: usize,
+    y: usize,
+    /// Bytes of an escape sequence whose end has not arrived yet. A terminal
+    /// hands over a frame in whatever pieces it likes, and half a `MoveTo` is
+    /// not a character.
+    pending: Vec<u8>,
+    raw: Vec<u8>,
+    /// Every screen that was displayed, in order, without the repeats.
+    ///
+    /// The current grid answers "what is on the screen"; this answers "was this
+    /// ever on it", which is what a session driven by a list of keys is asked --
+    /// a refusal a person reads and then presses past is on one frame and gone
+    /// from the next.
+    shown: Vec<String>,
+}
+
+#[cfg(unix)]
+impl Screen {
+    fn new(columns: u16, rows: u16) -> Screen {
+        Screen {
+            grid: vec![vec![' '; columns as usize]; rows as usize],
+            columns: columns as usize,
+            rows: rows as usize,
+            x: 0,
+            y: 0,
+            pending: Vec::new(),
+            raw: Vec::new(),
+            shown: Vec::new(),
+        }
+    }
+
+    /// The window changed under the session, so the grid does too.
+    ///
+    /// Cleared rather than kept: a terminal being resized redraws from
+    /// whatever the application sends next, and a grid holding rows of the old
+    /// width would let an assertion pass on a line nobody can still see.
+    fn resized(&mut self, columns: u16, rows: u16) {
+        self.grid = vec![vec![' '; columns as usize]; rows as usize];
+        self.columns = columns as usize;
+        self.rows = rows as usize;
+        self.x = 0;
+        self.y = 0;
+    }
+
+    fn feed(&mut self, bytes: &[u8]) {
+        self.raw.extend_from_slice(bytes);
+        self.pending.extend_from_slice(bytes);
+        let taken = self.apply();
+        self.pending.drain(..taken);
+        self.snapshot();
+    }
+
+    /// The screen as it stands, kept if it is not the one already kept.
+    fn snapshot(&mut self) {
+        let now = self.text();
+        if self.shown.last() != Some(&now) {
+            self.shown.push(now);
+        }
+    }
+
+    /// Applies whole sequences and characters, answering how many bytes it
+    /// consumed. What is left is the tail of something unfinished.
+    fn apply(&mut self) -> usize {
+        let bytes = std::mem::take(&mut self.pending);
+        let mut at = 0;
+        while at < bytes.len() {
+            match bytes[at] {
+                0x1b => match escape(&bytes[at..]) {
+                    // Not all here yet: stop, and keep it for the next read.
+                    None => break,
+                    Some((len, csi)) => {
+                        if let Some((params, final_byte, private)) = csi {
+                            // **A frame is kept where the frame ended**, and
+                            // not where a read happened to stop. ratatui closes
+                            // every `draw` by hiding the cursor or by showing
+                            // it and placing it, so `?25l` and `?25h` are where
+                            // one screen becomes the next -- and a suite that
+                            // sampled on read boundaries instead would lose a
+                            // frame whenever two of them arrived together,
+                            // which under load is most of them.
+                            if self.csi(&params, final_byte, private) {
+                                self.snapshot();
+                            }
+                        }
+                        at += len;
+                    }
+                },
+                b'\r' => {
+                    self.x = 0;
+                    at += 1;
+                }
+                b'\n' => {
+                    self.y = (self.y + 1).min(self.rows.saturating_sub(1));
+                    at += 1;
+                }
+                _ => {
+                    // UTF-8, and a character split across two reads waits like
+                    // an escape sequence does.
+                    let width = utf8_width(bytes[at]);
+                    if at + width > bytes.len() {
+                        break;
+                    }
+                    match std::str::from_utf8(&bytes[at..at + width]) {
+                        Ok(s) => {
+                            for c in s.chars() {
+                                self.put(c);
+                            }
+                        }
+                        // Not a character: dropped rather than guessed at.
+                        Err(_) => {}
+                    }
+                    at += width;
+                }
+            }
+        }
+        self.pending = bytes;
+        at
+    }
+
+    fn put(&mut self, c: char) {
+        if self.y < self.rows && self.x < self.columns {
+            self.grid[self.y][self.x] = c;
+        }
+        self.x += 1;
+        if self.x >= self.columns {
+            self.x = 0;
+            self.y = (self.y + 1).min(self.rows.saturating_sub(1));
+        }
+    }
+
+    /// Applies one CSI, answering whether it ended a frame.
+    fn csi(&mut self, params: &[usize], final_byte: u8, private: bool) -> bool {
+        if private {
+            // `?1049h`, `?25l` and their kind move no character. The cursor's
+            // visibility is the one that says something all the same: it is
+            // the last thing a `draw` writes.
+            return matches!(final_byte, b'h' | b'l') && params.first() == Some(&25);
+        }
+        let at = |i: usize, default: usize| params.get(i).copied().unwrap_or(default);
+        match final_byte {
+            b'H' | b'f' => {
+                self.y = at(0, 1).saturating_sub(1).min(self.rows.saturating_sub(1));
+                self.x = at(1, 1)
+                    .saturating_sub(1)
+                    .min(self.columns.saturating_sub(1));
+            }
+            b'J' => match at(0, 0) {
+                // To the end of the screen, from the cursor.
+                0 => {
+                    for x in self.x..self.columns {
+                        self.grid[self.y][x] = ' ';
+                    }
+                    for y in self.y + 1..self.rows {
+                        self.grid[y] = vec![' '; self.columns];
+                    }
+                }
+                // To the start of it.
+                1 => {
+                    for y in 0..self.y {
+                        self.grid[y] = vec![' '; self.columns];
+                    }
+                    for x in 0..=self.x.min(self.columns - 1) {
+                        self.grid[self.y][x] = ' ';
+                    }
+                }
+                // The whole of it.
+                _ => self.grid = vec![vec![' '; self.columns]; self.rows],
+            },
+            b'K' => match at(0, 0) {
+                0 => {
+                    for x in self.x..self.columns {
+                        self.grid[self.y][x] = ' ';
+                    }
+                }
+                1 => {
+                    for x in 0..=self.x.min(self.columns - 1) {
+                        self.grid[self.y][x] = ' ';
+                    }
+                }
+                _ => self.grid[self.y] = vec![' '; self.columns],
+            },
+            // Colour, attributes, scroll regions, anything else: no character
+            // moves, so nothing here does either.
+            _ => {}
+        }
+        false
+    }
+
+    /// What is on the screen now, one row per line, trailing space cut.
+    fn text(&self) -> String {
+        self.grid
+            .iter()
+            .map(|row| row.iter().collect::<String>().trim_end().to_string())
+            .collect::<Vec<String>>()
+            .join("\n")
+    }
+
+    /// Every screen that was displayed, for a session driven by a list of keys.
+    fn everything(&self) -> String {
+        self.shown.join("\n")
+    }
+
+    fn raw(&self) -> String {
+        String::from_utf8_lossy(&self.raw).to_string()
+    }
+}
+
+/// One escape sequence at the head of `bytes`: how long it is, and the CSI it
+/// was if it was one.
+///
+/// `None` means it is not all here yet.
+#[cfg(unix)]
+#[allow(clippy::type_complexity)]
+fn escape(bytes: &[u8]) -> Option<(usize, Option<(Vec<usize>, u8, bool)>)> {
+    if bytes.len() < 2 {
+        return None;
+    }
+    match bytes[1] {
+        b'[' => {
+            let mut at = 2;
+            let private = bytes.get(2).is_some_and(|b| b"<=>?".contains(b));
+            if private {
+                at += 1;
+            }
+            let start = at;
+            while at < bytes.len() && (bytes[at].is_ascii_digit() || bytes[at] == b';') {
+                at += 1;
+            }
+            let final_byte = *bytes.get(at)?;
+            let params = String::from_utf8_lossy(&bytes[start..at])
+                .split(';')
+                .map(|p| p.parse::<usize>().unwrap_or(0))
+                .collect();
+            Some((at + 1, Some((params, final_byte, private))))
+        }
+        // An OSC runs to a BEL or an ST, and says nothing about the grid.
+        b']' => {
+            let end = bytes.iter().position(|b| *b == 0x07).or_else(|| {
+                bytes
+                    .windows(2)
+                    .position(|w| w == [0x1b, b'\\'])
+                    .map(|i| i + 1)
+            })?;
+            Some((end + 1, None))
+        }
+        // Two-byte escapes: consumed and dropped.
+        _ => Some((2, None)),
+    }
+}
+
+#[cfg(unix)]
+fn utf8_width(first: u8) -> usize {
+    match first {
+        0x00..=0x7f => 1,
+        0xc0..=0xdf => 2,
+        0xe0..=0xef => 3,
+        0xf0..=0xf7 => 4,
+        // A continuation byte with no lead: one byte, dropped as invalid.
+        _ => 1,
+    }
+}
+
+/// What a driven session was shown, with the bytes kept for the one assertion
+/// that is about them.
+///
+/// It derefs to the screens, so `seen.contains(...)` asks what this suite has
+/// always asked: was this ever on the screen.
+#[cfg(unix)]
+struct Seen {
+    screens: String,
+    raw: String,
+}
+
+#[cfg(unix)]
+impl std::ops::Deref for Seen {
+    type Target = str;
+    fn deref(&self) -> &str {
+        &self.screens
+    }
+}
+
+#[cfg(unix)]
+impl std::fmt::Display for Seen {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.screens)
+    }
+}
+
+/// The window every session in this suite opens in.
+#[cfg(unix)]
+const WINDOW: (u16, u16) = (120, 40);
+
+/// Runs `ank tui` on a real terminal and answers every screen it drew.
+#[cfg(unix)]
+fn drive(repo: &Repo, agent: &str, keys: &[&str]) -> Seen {
+    on_a_terminal(repo, agent, &["tui"], keys)
 }
 
 /// The same, for a call that takes flags and ends on its own.
+///
+/// **What an entry of `keys` is.** Anything beginning with `:` is a line typed
+/// into the prompt: the key that opens it, the rest of the entry, and Enter.
+/// Anything else is the keys themselves, byte for byte -- `"q"`, `"j"`, `"\r"`
+/// for Enter. That is the shape of the reader now (ADR-0b55983421dd): every
+/// command that only moves the screen is one key, and the four verbs that carry
+/// a message, a reason, a proof or a flag are spelled into a prompt.
 #[cfg(unix)]
-fn on_a_terminal(repo: &Repo, agent: &str, args: &[&str], commands: &[&str]) -> String {
-    use std::io::{Read, Write};
-
-    let (master, slave_path) = pty::open();
-    let mut child = Command::new(ANK)
-        .args(args)
-        .current_dir(&repo.0)
-        .env("ANK_AGENT", agent)
-        // The window, stated rather than measured: the reader declines the
-        // ioctl for the reason its module header gives, and a suite that could
-        // not choose the window could not assert what a frame holds.
-        .env("COLUMNS", "120")
-        .env("LINES", "40")
-        .env("NO_COLOR", "1")
-        .stdin(pty::stdio(pty::slave(&slave_path)))
-        .stdout(pty::stdio(pty::slave(&slave_path)))
-        .stderr(pty::stdio(pty::slave(&slave_path)))
-        .spawn()
-        .expect("the binary must have been built");
-
-    let mut reader = master
-        .try_clone()
-        .expect("the master side must be clonable for the drain");
-    let drain = std::thread::spawn(move || {
-        let mut seen = Vec::new();
-        let mut buf = [0u8; 4096];
-        loop {
-            match reader.read(&mut buf) {
-                // Linux answers EIO once the last slave is closed; macOS
-                // answers zero. Both mean the session is over.
-                Ok(0) | Err(_) => break,
-                Ok(n) => seen.extend_from_slice(&buf[..n]),
-            }
-        }
-        seen
-    });
-
-    let mut writer = master;
-    for command in commands {
-        writeln!(writer, "{command}").expect("the terminal must accept a command");
-        writer.flush().unwrap();
+fn on_a_terminal(repo: &Repo, agent: &str, args: &[&str], keys: &[&str]) -> Seen {
+    let mut live = Live::open_with(repo, agent, args, &[]);
+    // **The first frame is waited for, and it is not politeness.** Bytes
+    // written before the reader has taken the terminal sit in the line
+    // discipline, which echoes them and holds them until a newline -- so a
+    // suite that wrote straight after spawning would be measuring the terminal
+    // it opened rather than the program it started.
+    if !args.contains(&"--json") {
+        live.until("the session to open", |t| t.contains("ank tui"));
     }
-    let status = child.wait().expect("the session must end");
-    assert!(
-        status.success(),
-        "the session ended with {status}, and a reader that quits answers 0"
-    );
-    // The child's slave descriptors went with it; dropping the master ends the
-    // drain, which is otherwise blocked reading a terminal nobody will write
-    // to again.
-    drop(writer);
-    let seen = drain.join().expect("the drain must not panic");
-    String::from_utf8_lossy(&seen).to_string()
+    for entry in keys {
+        live.press(entry);
+    }
+    live.finished("a reader that quits answers 0")
 }
+
+/// A session that is opened, left alone for `quiet`, and then told to quit.
+///
+/// The one thing a list of keys cannot express, and the whole of what "a
+/// session left idle" means: the quit is pressed *after* the wait rather than
+/// before it, so the reader spends that time blocked on a terminal nobody is
+/// typing at -- which is where a refresh loop, had this crate one, would be
+/// doing its work.
+#[cfg(unix)]
+fn idle(repo: &Repo, agent: &str, quiet: std::time::Duration) -> Seen {
+    let mut live = Live::open(repo, agent, &[]);
+    live.until("the session to open", |t| t.contains("ank tui"));
+    std::thread::sleep(quiet);
+    live.press("q");
+    live.finished("a reader that quits answers 0")
+}
+
+/// A session that can be watched while it is still running.
+///
+/// The drain feeds a [`Screen`] the test can read at any moment: what is on it
+/// now, and everything that was ever on it.
+#[cfg(unix)]
+struct Live {
+    child: std::process::Child,
+    writer: std::fs::File,
+    screen: std::sync::Arc<std::sync::Mutex<Screen>>,
+    /// The thread draining the master side. Held so that a session read after
+    /// it ended is read *after* the last frame arrived: a child that has
+    /// exited is not a terminal that has been read to the end, and the frame
+    /// carrying whatever the last command answered is the one most likely to
+    /// still be in flight.
+    drain: Option<std::thread::JoinHandle<()>>,
+}
+
+#[cfg(unix)]
+impl Live {
+    /// Opens `ank tui` on a real terminal, with whatever environment the test
+    /// needs on top of the usual one.
+    fn open(repo: &Repo, agent: &str, env: &[(&str, String)]) -> Live {
+        Live::open_with(repo, agent, &["tui"], env)
+    }
+
+    fn open_with(repo: &Repo, agent: &str, args: &[&str], env: &[(&str, String)]) -> Live {
+        use std::io::Read;
+
+        let (master, slave_path) = pty::open(WINDOW.0, WINDOW.1);
+        let mut command = Command::new(ANK);
+        command
+            .args(args)
+            .current_dir(&repo.0)
+            .env("ANK_AGENT", agent)
+            .env("NO_COLOR", "1");
+        for (key, value) in env {
+            command.env(key, value);
+        }
+        let child = command
+            .stdin(pty::stdio(pty::slave(&slave_path)))
+            .stdout(pty::stdio(pty::slave(&slave_path)))
+            .stderr(pty::stdio(pty::slave(&slave_path)))
+            .spawn()
+            .expect("the binary must have been built");
+
+        let screen = std::sync::Arc::new(std::sync::Mutex::new(Screen::new(WINDOW.0, WINDOW.1)));
+        let into = std::sync::Arc::clone(&screen);
+        let mut reader = master
+            .try_clone()
+            .expect("the master side must be clonable for the drain");
+        // Drained on a thread of its own: a session that painted more than the
+        // pseudo-terminal's buffer holds while nobody was reading would
+        // deadlock, and a deadlock in a suite is a timeout with no message.
+        let drain = std::thread::spawn(move || {
+            let mut buf = [0u8; 4096];
+            loop {
+                match reader.read(&mut buf) {
+                    // Linux answers EIO once the last slave is closed; macOS
+                    // answers zero. Both mean the session is over.
+                    Ok(0) | Err(_) => return,
+                    Ok(n) => into.lock().unwrap().feed(&buf[..n]),
+                }
+            }
+        });
+        Live {
+            child,
+            writer: master,
+            screen,
+            drain: Some(drain),
+        }
+    }
+
+    /// Waits for the session to end and for the last of it to be read.
+    ///
+    /// The order is the whole of it: wait for the child, then drop the master
+    /// so the drain stops being blocked on a terminal nobody will write to
+    /// again, then join it. Reading the screen before that join is reading it
+    /// while a frame is still on its way.
+    fn finished(mut self, why: &str) -> Seen {
+        let status = self.child.wait().expect("the session must end");
+        assert!(
+            status.success(),
+            "the session ended with {status}, and {why}"
+        );
+        drop(self.writer);
+        if let Some(drain) = self.drain.take() {
+            drain.join().expect("the drain must not panic");
+        }
+        let screen = self.screen.lock().unwrap();
+        Seen {
+            screens: screen.everything(),
+            raw: screen.raw(),
+        }
+    }
+
+    /// Everything that was ever on the screen.
+    fn text(&self) -> String {
+        self.screen.lock().unwrap().everything()
+    }
+
+    /// Waits for the screen as it is now to say something.
+    ///
+    /// Different from [`Live::until`] in the one way that matters to a resize:
+    /// that one asks whether this was *ever* on the screen, and a reflow is a
+    /// question about what is on it now.
+    fn until_screen(&self, what: &str, done: impl Fn(&str) -> bool) {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        while std::time::Instant::now() < deadline {
+            if done(&self.screen.lock().unwrap().text()) {
+                return;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(25));
+        }
+        panic!(
+            "timed out waiting for {what}:\n{}",
+            self.screen.lock().unwrap().text()
+        );
+    }
+
+    /// Waits for the screen to say something.
+    ///
+    /// Bounded and generous, on the rule the watcher's suite states: this is
+    /// asserting that something happens at all, not how fast, so the wall is
+    /// high enough that a loaded runner never reports the runner instead of the
+    /// code.
+    fn until(&self, what: &str, done: impl Fn(&str) -> bool) {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        while std::time::Instant::now() < deadline {
+            if done(&self.text()) {
+                return;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(25));
+        }
+        panic!("timed out waiting for {what}:\n{}", self.text());
+    }
+
+    /// The screen as it is, once it has stopped moving.
+    ///
+    /// Settled first, because a screen read the instant a needle appeared is
+    /// half a screen: the reader writes a frame in one call but a terminal
+    /// hands it over in whatever pieces it likes.
+    fn frame(&self) -> String {
+        let mut last = String::new();
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        while std::time::Instant::now() < deadline {
+            let now = self.screen.lock().unwrap().text();
+            if !now.trim().is_empty() && now == last {
+                return now;
+            }
+            last = now;
+            std::thread::sleep(std::time::Duration::from_millis(200));
+        }
+        panic!("the screen never stopped moving:\n{last}");
+    }
+
+    /// One entry of a key list: a line typed into the prompt, or the keys
+    /// themselves.
+    fn press(&mut self, entry: &str) {
+        match entry.strip_prefix(':') {
+            Some(line) => {
+                self.send(&ACT.to_string());
+                self.send(line);
+                self.send("\r");
+            }
+            None => self.send(entry),
+        }
+    }
+
+    fn send(&mut self, bytes: &str) {
+        use std::io::Write;
+        self.writer
+            .write_all(bytes.as_bytes())
+            .expect("the terminal must accept a keystroke");
+        self.writer.flush().unwrap();
+    }
+
+    /// The window moved, and the session was told.
+    fn resize(&mut self, columns: u16, rows: u16) {
+        pty::resize(&self.writer, columns, rows);
+        self.screen.lock().unwrap().resized(columns, rows);
+        pty::winch(&self.child);
+    }
+
+    fn quit(mut self) {
+        self.press("q");
+        let _ = self.finished("a reader that quits answers 0");
+    }
+}
+
+/// The key that opens the prompt, read out of the reader rather than typed as a
+/// letter here: it is the one key this suite has to know, and a suite carrying
+/// its own copy of it would agree with a mapping that moved.
+#[cfg(unix)]
+const ACT: char = ank_tui::keys::ACT;
 
 #[cfg(unix)]
 #[test]
@@ -450,10 +1045,13 @@ fn a_driven_session_names_the_entities_the_corpus_carries() {
     // this suite took: "which claim is held by whom", with a name on it. The
     // task is what is opened, because the criterion is written into its body
     // and that is what "whole" is asserted against.
-    let seen = drive(&repo, HOLDER, &["f task", "", "b", "f", "q"]);
+    let seen = drive(&repo, HOLDER, &[":f task", "\r", "b", ":f", "q"]);
 
+    // The one assertion here that is genuinely about the bytes rather than
+    // about the screen: what a full-screen reader owes the shell it was
+    // launched from is the scrollback it was covering.
     assert!(
-        seen.contains("\x1b[?1049h") && seen.contains("\x1b[?1049l"),
+        seen.raw.contains("\x1b[?1049h") && seen.raw.contains("\x1b[?1049l"),
         "the session used the alternate screen and gave it back"
     );
     for expected in [
@@ -509,10 +1107,11 @@ fn the_frames_carry_no_identifier_the_corpus_does_not() {
         .iter()
         .map(|id| short_of(id))
         .collect();
-    let seen = drive(&repo, HOLDER, &["", "b", "j", "", "b", "q"]);
+    let seen = drive(&repo, HOLDER, &["\r", "b", "j", "\r", "b", "q"]);
 
     let mut found = 0;
-    let mut rest = seen.as_str();
+    let text = seen.to_string();
+    let mut rest = text.as_str();
     while let Some(at) = rest.find('-') {
         // A short identifier is `<KIND>-xxxx`; the kinds are the four this
         // corpus has (ADR-c9f9d1a05b23).
@@ -536,6 +1135,85 @@ fn the_frames_carry_no_identifier_the_corpus_does_not() {
         rest = &rest[at + 1..];
     }
     assert!(found >= 2, "the frames named no identifier at all");
+}
+
+/// A terminal made narrower, then wider, redraws to its new size with nobody
+/// typing (TASK-4fa385c1772d, ADR-0b55983421dd).
+///
+/// **The whole of the assertion is that no key was pressed.** The window is
+/// changed on the master side, exactly as a terminal emulator changes it, and
+/// the session is told the way a terminal tells one. What has to follow is a
+/// frame in the new shape: a row whose title no longer fits is cut and says so,
+/// no line runs past the new right edge, and the trailer sits on the last row
+/// of the new height rather than off the bottom of it. Widened again, the title
+/// comes back whole -- so what happened was a fit and never a loss.
+///
+/// Measured through the binary, on a real pseudo-terminal, because the window
+/// is an `ioctl` and a signal: the reader asks crossterm for the size and
+/// crossterm asks the kernel, and no unit test stands anywhere near that.
+#[cfg(unix)]
+#[test]
+fn a_terminal_resized_redraws_to_its_new_size_with_nothing_typed() {
+    // Wide enough that sixty columns cannot hold it once a row has spent
+    // thirty-five on its number, its identifier and its status, and narrow
+    // enough that a hundred and twenty can.
+    const LONG: &str = "A title a narrow window must cut and a wide one need not";
+    let repo = Repo::seeded("resize");
+    repo.spare(
+        LONG,
+        "The row carrying it is fitted to whatever window there is.",
+    );
+    repo.warm(READER);
+    let before = corpus_files(&repo);
+
+    let mut live = Live::open(&repo, READER, &[]);
+    live.until("the session to open", |t| t.contains("ank tui"));
+    live.until_screen("the wide frame to carry the title whole", |s| {
+        s.contains(LONG)
+    });
+    let wide = live.frame();
+    assert_eq!(wide.lines().count(), WINDOW.1 as usize, "{wide}");
+
+    live.resize(60, 20);
+    live.until_screen("the narrow frame", |s| {
+        s.contains("ank tui") && !s.contains(LONG)
+    });
+    let narrow = live.frame();
+    for line in narrow.lines() {
+        assert!(
+            line.chars().count() <= 60,
+            "{} columns in a 60 column window: {line}\n{narrow}",
+            line.chars().count()
+        );
+    }
+    assert!(
+        narrow.contains('~'),
+        "nothing was cut, so nothing was fitted to the narrower window:\n{narrow}"
+    );
+    // The trailer is on the last row there is, which is what says the layout
+    // used the new height rather than the old one.
+    let rows: Vec<&str> = narrow.lines().collect();
+    assert_eq!(rows.len(), 20, "{narrow}");
+    assert!(
+        rows[19].starts_with("a then"),
+        "the key line is not on the last row of the new window:\n{narrow}"
+    );
+
+    // Wider again, and nothing was lost: the title is whole.
+    live.resize(140, 44);
+    live.until_screen("the wide frame again", |s| s.contains(LONG));
+    let again = live.frame();
+    assert_eq!(again.lines().count(), 44, "{again}");
+    assert!(again.contains("ENTITIES"), "{again}");
+
+    // And a window being dragged about reads nothing and writes nothing: a
+    // resize is a fact about the terminal, never about the corpus.
+    assert_eq!(
+        before,
+        corpus_files(&repo),
+        "a resize moved a file under .ank/"
+    );
+    live.quit();
 }
 
 /// Quitting leaves the corpus exactly as it was found (ADR-8bd76e8d7c4e).
@@ -569,7 +1247,9 @@ fn quitting_leaves_no_file_and_no_ref_changed() {
     let seen = drive(
         &repo,
         HOLDER,
-        &["f adr", "", "n", "c", "g", "b", "f", "/task", "j", "k", "q"],
+        &[
+            ":f adr", "\r", "n", "c", "g", "b", ":f", "/task\r", "j", "k", "q",
+        ],
     );
     assert!(seen.contains("ENTITIES"), "the session ran:\n{seen}");
     assert!(seen.contains("CONSTRAINTS"), "it opened an entity:\n{seen}");
@@ -604,7 +1284,7 @@ fn opening_the_task_you_hold_takes_nothing_and_creates_nothing() {
 
     let files = corpus_files(&repo);
     let names = ref_names(&repo);
-    let seen = drive(&repo, HOLDER, &["f task", "", "q"]);
+    let seen = drive(&repo, HOLDER, &[":f task", "\r", "q"]);
     assert!(seen.contains(TAIL), "the held task was opened:\n{seen}");
 
     assert_eq!(
@@ -717,7 +1397,7 @@ fn a_refusal_on_screen_is_the_one_the_cli_gave() {
     let repo = Repo::seeded("refusal");
     // `LOG-000000000000` is not in this corpus, so `show` refuses with the
     // sentence and the code it always gives.
-    let seen = drive(&repo, HOLDER, &["LOG-000000000000", "q"]);
+    let seen = drive(&repo, HOLDER, &[":LOG-000000000000", "q"]);
     assert!(
         seen.contains("no entity") || seen.contains("LOG-000000000000"),
         "the refusal reached the screen:\n{seen}"
@@ -745,13 +1425,19 @@ fn json_on_a_terminal_answers_one_document_and_opens_no_session() {
     let seen = on_a_terminal(&repo, HOLDER, &["tui", "--json"], &[]);
 
     assert!(
-        !seen.contains("\x1b[?1049h"),
-        "a screen was opened under --json:\n{seen}"
+        !seen.raw.contains("\x1b[?1049h"),
+        "a screen was opened under --json:\n{}",
+        seen.raw
     );
+    // The bytes and not the screen: `--json` opens no session, so nothing draws
+    // and there is no screen to read. A document written to a terminal is a
+    // line as long as it is, and reading it off a 120 column grid would be
+    // reading it wrapped.
     let document = seen
+        .raw
         .lines()
         .find(|l| l.trim_start().starts_with('{'))
-        .unwrap_or_else(|| panic!("no document on the stream:\n{seen}"))
+        .unwrap_or_else(|| panic!("no document on the stream:\n{}", seen.raw))
         .trim()
         .to_string();
     assert!(
@@ -777,55 +1463,6 @@ fn json_on_a_terminal_answers_one_document_and_opens_no_session() {
 // ---------------------------------------------------------------------------
 // The writing half (TASK-b50b340c0bb1)
 // ---------------------------------------------------------------------------
-
-/// A session that is opened, left alone for `quiet`, and then told to quit.
-///
-/// The one thing [`drive`] cannot express, and the whole of what "a session left
-/// idle" means: the commands are written *after* the wait rather than before it,
-/// so the reader spends that time blocked on a terminal nobody is typing at --
-/// which is where a refresh loop, had this crate one, would be doing its work.
-#[cfg(unix)]
-fn idle(repo: &Repo, agent: &str, quiet: std::time::Duration) -> String {
-    use std::io::{Read, Write};
-
-    let (master, slave_path) = pty::open();
-    let mut child = Command::new(ANK)
-        .arg("tui")
-        .current_dir(&repo.0)
-        .env("ANK_AGENT", agent)
-        .env("COLUMNS", "120")
-        .env("LINES", "40")
-        .env("NO_COLOR", "1")
-        .stdin(pty::stdio(pty::slave(&slave_path)))
-        .stdout(pty::stdio(pty::slave(&slave_path)))
-        .stderr(pty::stdio(pty::slave(&slave_path)))
-        .spawn()
-        .expect("the binary must have been built");
-
-    let mut reader = master
-        .try_clone()
-        .expect("the master side must be clonable for the drain");
-    let drain = std::thread::spawn(move || {
-        let mut seen = Vec::new();
-        let mut buf = [0u8; 4096];
-        loop {
-            match reader.read(&mut buf) {
-                Ok(0) | Err(_) => break,
-                Ok(n) => seen.extend_from_slice(&buf[..n]),
-            }
-        }
-        seen
-    });
-
-    std::thread::sleep(quiet);
-    let mut writer = master;
-    writeln!(writer, "q").expect("the terminal must accept a command");
-    writer.flush().unwrap();
-    let status = child.wait().expect("the session must end");
-    assert!(status.success(), "the session ended with {status}");
-    drop(writer);
-    String::from_utf8_lossy(&drain.join().expect("the drain must not panic")).to_string()
-}
 
 /// The claim state of one task: every ref this corpus carries by name, and the
 /// record at the task's own address with its two instants masked.
@@ -897,7 +1534,7 @@ fn a_claim_taken_through_the_reader_is_the_ref_a_shell_claim_makes() {
         "Claimed twice over, once from the screen and once from a shell.",
     );
 
-    let seen = drive(&repo, READER, &[&short_of(&task), "claim", "q"]);
+    let seen = drive(&repo, READER, &[&open(&task), ":claim", "q"]);
     assert!(
         seen.contains(&format!("ank claim {task}")),
         "the reader ran the verb, and said which one:\n{seen}"
@@ -946,7 +1583,7 @@ fn a_done_refused_for_a_missing_proof_leaves_the_task_untouched() {
     let before = corpus_files(&repo);
     let names = ref_names(&repo);
 
-    let seen = drive(&repo, HOLDER, &["f task", "", "done", "q"]);
+    let seen = drive(&repo, HOLDER, &[":f task", "\r", ":done", "q"]);
 
     let code = declared("done", "no proof");
     assert_eq!(code, ank_contract::ExitCode::Proof, "the table moved");
@@ -1053,11 +1690,11 @@ fn every_verb_of_the_writing_half_is_reachable_from_a_selected_entity() {
         &repo,
         READER,
         &[
-            &short_of(&task),
-            "claim",
-            "log the glob was one directory short",
-            "amend --scope src/deeper/**",
-            "release the criterion measures the wrong thing",
+            &open(&task),
+            ":claim",
+            ":log the glob was one directory short",
+            ":amend --scope src/deeper/**",
+            ":release the criterion measures the wrong thing",
             "q",
         ],
     );
@@ -1090,12 +1727,7 @@ fn every_verb_of_the_writing_half_is_reachable_from_a_selected_entity() {
     let seen = drive(
         &repo,
         READER,
-        &[
-            &short_of(&task),
-            "claim",
-            &format!("done commit:{head}"),
-            "q",
-        ],
+        &[&open(&task), ":claim", &format!(":done commit:{head}"), "q"],
     );
     assert!(!seen.contains("error["), "the finish was refused:\n{seen}");
     let shown = repo.stdout(READER, &["show", &task, "--json"]);
@@ -1189,134 +1821,6 @@ impl Home {
     }
 }
 
-/// A session that can be watched while it is still running.
-///
-/// [`drive`] writes every command before reading anything, which is all a
-/// keystroke-driven screen ever needed. A screen that repaints on its own has to
-/// be observed *between* keystrokes, and often with no keystroke at all, so the
-/// drain here writes into a buffer the test can read at any moment.
-#[cfg(unix)]
-struct Live {
-    child: std::process::Child,
-    writer: std::fs::File,
-    seen: std::sync::Arc<std::sync::Mutex<Vec<u8>>>,
-}
-
-#[cfg(unix)]
-impl Live {
-    /// Opens `ank tui` on a real terminal, with whatever environment the test
-    /// needs on top of the usual one.
-    fn open(repo: &Repo, agent: &str, env: &[(&str, String)]) -> Live {
-        use std::io::Read;
-
-        let (master, slave_path) = pty::open();
-        let mut command = Command::new(ANK);
-        command
-            .arg("tui")
-            .current_dir(&repo.0)
-            .env("ANK_AGENT", agent)
-            .env("COLUMNS", "120")
-            .env("LINES", "40")
-            .env("NO_COLOR", "1");
-        for (key, value) in env {
-            command.env(key, value);
-        }
-        let child = command
-            .stdin(pty::stdio(pty::slave(&slave_path)))
-            .stdout(pty::stdio(pty::slave(&slave_path)))
-            .stderr(pty::stdio(pty::slave(&slave_path)))
-            .spawn()
-            .expect("the binary must have been built");
-
-        let seen = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
-        let into = std::sync::Arc::clone(&seen);
-        let mut reader = master
-            .try_clone()
-            .expect("the master side must be clonable for the drain");
-        std::thread::spawn(move || {
-            let mut buf = [0u8; 4096];
-            loop {
-                match reader.read(&mut buf) {
-                    Ok(0) | Err(_) => return,
-                    Ok(n) => into.lock().unwrap().extend_from_slice(&buf[..n]),
-                }
-            }
-        });
-        Live {
-            child,
-            writer: master,
-            seen,
-        }
-    }
-
-    fn text(&self) -> String {
-        String::from_utf8_lossy(&self.seen.lock().unwrap()).to_string()
-    }
-
-    /// Waits for the screen to say something.
-    ///
-    /// Bounded and generous, on the rule the watcher's suite states: this is
-    /// asserting that something happens at all, not how fast, so the wall is
-    /// high enough that a loaded runner never reports the runner instead of the
-    /// code.
-    fn until(&self, what: &str, done: impl Fn(&str) -> bool) {
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
-        while std::time::Instant::now() < deadline {
-            if done(&self.text()) {
-                return;
-            }
-            std::thread::sleep(std::time::Duration::from_millis(25));
-        }
-        panic!("timed out waiting for {what}:\n{}", self.text());
-    }
-
-    /// The last frame drawn, once the screen has stopped moving.
-    ///
-    /// Settled first, because a frame read the instant a needle appeared is
-    /// half a frame: the reader writes a screen in one call but a terminal
-    /// hands it over in whatever pieces it likes.
-    fn frame(&self) -> String {
-        let mut last = String::new();
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
-        while std::time::Instant::now() < deadline {
-            let now = self.text();
-            if !now.is_empty() && now == last {
-                return last_frame(&now);
-            }
-            last = now;
-            std::thread::sleep(std::time::Duration::from_millis(200));
-        }
-        panic!("the screen never stopped moving:\n{last}");
-    }
-
-    fn send(&mut self, line: &str) {
-        use std::io::Write;
-        writeln!(self.writer, "{line}").expect("the terminal must accept a command");
-        self.writer.flush().unwrap();
-    }
-
-    fn quit(mut self) {
-        self.send("q");
-        let status = self.child.wait().expect("the session must end");
-        assert!(status.success(), "the session ended with {status}");
-    }
-}
-
-/// The last whole frame of a byte stream a session wrote.
-///
-/// Frames are separated by the sequence that homes the cursor and clears the
-/// screen, and the session's last act is to leave the alternate buffer, which is
-/// chrome rather than a frame.
-#[cfg(unix)]
-fn last_frame(seen: &str) -> String {
-    const HOME: &str = "\x1b[H\x1b[2J";
-    const LEAVE: &str = "\x1b[?1049l";
-    let at = seen
-        .rfind(HOME)
-        .expect("a session draws at least one frame");
-    seen[at + HOME.len()..].replace(LEAVE, "")
-}
-
 /// A frame with the one line that names the route taken out of it.
 ///
 /// The two routes must reach the same displayed state, and the one thing that
@@ -1403,7 +1907,7 @@ fn the_event_and_the_reload_reach_the_same_displayed_state() {
     told.until("the event to reach the screen", |t| t.contains(&needle));
     let by_event = told.frame();
 
-    asking.send("r");
+    asking.press("r");
     asking.until("the reload to reach the screen", |t| t.contains(&needle));
     let by_reload = asking.frame();
 
@@ -1525,7 +2029,7 @@ fn an_event_repaints_the_list_and_renews_no_claim() {
     // Opening the task you hold renews the lease, and it is supposed to: it is
     // `ank show`, run because a person typed an identifier (TASK-49746735127f).
     // What follows is about what happens with nobody typing.
-    live.send(&short_of(&held));
+    live.press(&open(&held));
     live.until("the held task to open", |t| t.contains(TAIL));
     let _ = live.frame();
 
@@ -1542,7 +2046,7 @@ fn an_event_repaints_the_list_and_renews_no_claim() {
     }
 
     // `b` draws the list out of what is already in hand: it reads nothing.
-    live.send("b");
+    live.press("b");
     live.until("the list to name the task that arrived", |t| {
         t.contains(&short_of(&arrived))
     });
@@ -1751,7 +2255,7 @@ fn a_document_ratified_through_the_reader_is_what_a_shell_accept_makes() {
     let by_screen = proposal(&repo, TITLE);
     let by_shell = proposal(&repo, TITLE);
 
-    let seen = drive(&repo, READER, &[&by_screen, "accept", "q"]);
+    let seen = drive(&repo, READER, &[&format!(":{by_screen}"), ":accept", "q"]);
     assert!(
         seen.contains(&format!("ank accept {by_screen}")),
         "the reader ran the verb, and said which one:\n{seen}"
@@ -1882,7 +2386,7 @@ fn with_the_word_withheld_nothing_in_the_queue_changes_state() {
     let seen = drive(
         &repo,
         READER,
-        &["v", &short_of(&waiting), "n", "n", "c", "b", "v", "q"],
+        &["v", &open(&waiting), "n", "n", "c", "b", "v", "q"],
     );
     assert!(
         seen.contains(&short_of(&waiting)),
@@ -1928,7 +2432,7 @@ fn a_ratification_off_the_default_branch_shows_the_clis_refusal_and_the_way_out(
     repo.warm(READER);
     let before = corpus_files(&repo);
 
-    let seen = drive(&repo, READER, &[&short_of(&waiting), "accept", "q"]);
+    let seen = drive(&repo, READER, &[&open(&waiting), ":accept", "q"]);
 
     let code = declared("accept", "not on the default branch");
     assert_eq!(
@@ -1974,7 +2478,7 @@ fn accept_is_refused_off_the_document_and_refused_with_a_tail() {
     let seen = drive(
         &repo,
         READER,
-        &["v", "accept", &short_of(&waiting), "accept ADR-0000", "q"],
+        &["v", ":accept", &open(&waiting), ":accept ADR-0000", "q"],
     );
     assert!(
         seen.contains("open it first"),

--- a/crates/ank-cli/tests/tui.rs
+++ b/crates/ank-cli/tests/tui.rs
@@ -406,12 +406,15 @@ mod pty {
 
     /// The master side as a `File`, and the path of the slave to hand the
     /// child.
-    pub fn open(columns: u16, rows: u16) -> (File, PathBuf) {
+    ///
+    /// The window is not set here: it is set through a slave, and the caller is
+    /// what holds one open. See [`resize`].
+    pub fn open() -> (File, PathBuf) {
         // SAFETY: the four calls are the POSIX pseudo-terminal sequence, in
         // order, and every return is checked before the next is made. The
         // pointer `ptsname` answers with is owned by the C library and is
         // copied out before anything else can invalidate it.
-        let (master, path) = unsafe {
+        unsafe {
             let master = posix_openpt(O_RDWR);
             assert!(master >= 0, "posix_openpt failed");
             assert_eq!(grantpt(master), 0, "grantpt failed");
@@ -425,24 +428,35 @@ mod pty {
                     .to_string(),
             );
             (File::from_raw_fd(master), path)
-        };
-        resize(&master, columns, rows);
-        (master, path)
+        }
     }
 
-    /// The window, stated on the master side, which is where a terminal
-    /// emulator states it.
-    pub fn resize(master: &File, columns: u16, rows: u16) {
+    /// The window, stated on the slave side.
+    ///
+    /// **On the slave and never on the master, and macOS is why.** Linux takes
+    /// `TIOCSWINSZ` on `/dev/ptmx` and this suite did that first; macOS does
+    /// not, because there the master is a cloning device answering only the
+    /// three ioctls `grantpt`, `unlockpt` and `ptsname` are built out of, and a
+    /// general tty ioctl on it answers `-1`. The slave is a tty on both, which
+    /// is where a window size belongs anyway: it is a property of the terminal
+    /// the program is looking at.
+    pub fn resize(slave_path: &PathBuf, columns: u16, rows: u16) {
+        let tty = slave(slave_path);
         let size = WinSize {
             rows,
             columns,
             x_pixels: 0,
             y_pixels: 0,
         };
-        // SAFETY: the descriptor is open and owned by `master`, and the third
-        // argument is a `winsize` by value, which is what TIOCSWINSZ reads.
-        let set = unsafe { ioctl(master.as_raw_fd(), TIOCSWINSZ, &size) };
-        assert_eq!(set, 0, "the window could not be set on the pseudo-terminal");
+        // SAFETY: the descriptor is open and owned by `tty`, and the third
+        // argument is a pointer to a `winsize`, which is what TIOCSWINSZ reads.
+        let set = unsafe { ioctl(tty.as_raw_fd(), TIOCSWINSZ, &size) };
+        assert_eq!(
+            set,
+            0,
+            "the window could not be set on the pseudo-terminal: {}",
+            std::io::Error::last_os_error()
+        );
     }
 
     /// The signal a terminal sends when its window changed.
@@ -847,6 +861,9 @@ fn idle(repo: &Repo, agent: &str, quiet: std::time::Duration) -> Seen {
 struct Live {
     child: std::process::Child,
     writer: std::fs::File,
+    /// The slave's path, kept because the window is set through it: see
+    /// [`pty::resize`] for why it cannot be set through the master.
+    slave_path: PathBuf,
     screen: std::sync::Arc<std::sync::Mutex<Screen>>,
     /// The thread draining the master side. Held so that a session read after
     /// it ended is read *after* the last frame arrived: a child that has
@@ -867,7 +884,18 @@ impl Live {
     fn open_with(repo: &Repo, agent: &str, args: &[&str], env: &[(&str, String)]) -> Live {
         use std::io::Read;
 
-        let (master, slave_path) = pty::open(WINDOW.0, WINDOW.1);
+        let (master, slave_path) = pty::open();
+        // **The child's streams are opened before the window is set, and that
+        // ordering is deliberate.** A pseudo-terminal whose last slave
+        // descriptor closes is a terminal that hung up, and how permanently
+        // depends on the platform. Holding these three from here means one is
+        // always open from before the size is stated until the session ends.
+        let (stdin, stdout, stderr) = (
+            pty::slave(&slave_path),
+            pty::slave(&slave_path),
+            pty::slave(&slave_path),
+        );
+        pty::resize(&slave_path, WINDOW.0, WINDOW.1);
         let mut command = Command::new(ANK);
         command
             .args(args)
@@ -878,9 +906,9 @@ impl Live {
             command.env(key, value);
         }
         let child = command
-            .stdin(pty::stdio(pty::slave(&slave_path)))
-            .stdout(pty::stdio(pty::slave(&slave_path)))
-            .stderr(pty::stdio(pty::slave(&slave_path)))
+            .stdin(pty::stdio(stdin))
+            .stdout(pty::stdio(stdout))
+            .stderr(pty::stdio(stderr))
             .spawn()
             .expect("the binary must have been built");
 
@@ -906,6 +934,7 @@ impl Live {
         Live {
             child,
             writer: master,
+            slave_path,
             screen,
             drain: Some(drain),
         }
@@ -1017,7 +1046,7 @@ impl Live {
 
     /// The window moved, and the session was told.
     fn resize(&mut self, columns: u16, rows: u16) {
-        pty::resize(&self.writer, columns, rows);
+        pty::resize(&self.slave_path, columns, rows);
         self.screen.lock().unwrap().resized(columns, rows);
         pty::winch(&self.child);
     }

--- a/crates/ank-tui/Cargo.toml
+++ b/crates/ank-tui/Cargo.toml
@@ -12,21 +12,50 @@ rust-version = "1.95"
 license = "Apache-2.0"
 description = "The Ank terminal reader: it draws what the CLI prints, and reaches the corpus only by running it."
 
-# **The dependency list is the constraint made mechanical** (ADR-8bd76e8d7c4e).
-# `ank-core` is absent and must stay absent, and so is every git library: this
-# crate reaches the corpus by running `ank ... --json` and by nothing else, so
-# the refusals it shows are the refusals the binary gave and there is no second
-# dispatch path to keep in step. `tests/dependencies.rs` reads the graph back
-# out of cargo and fails when either arrives.
+# **The dependency list is the constraint made mechanical** (ADR-8bd76e8d7c4e,
+# ADR-0b55983421dd). `ank-core` is absent and must stay absent, and so is every
+# git library: this crate reaches the corpus by running `ank ... --json` and by
+# nothing else, so the refusals it shows are the refusals the binary gave and
+# there is no second dispatch path to keep in step. `tests/dependencies.rs`
+# reads the graph back out of cargo and fails when either arrives, holds this
+# list to what is declared below, and reads the sources for the `extern` block
+# ADR-0b55983421dd forbids on any platform.
 [dependencies]
 # The exit codes, read out of the contract rather than typed as numbers
 # (ADR-6fd69efb629c). This is what `ank-daemon` takes from it and for the same
 # reason: this crate dispatches no verb, so the verb table is not its business.
 ank-contract = { path = "../ank-contract" }
-# **No new crate enters the tree for this.** The CLI's `--json` has to be
-# *read*, and `ank-contract::json` writes and does not read. `serde_yaml` is
-# already a dependency of `ank-core`, `ank-cli`, `ank-daemon` and `ank-mcp`, and
-# YAML 1.2 is a superset of JSON, so a one-line document parses as flow YAML.
+# **The two the decision spends, and the whole of what they buy**
+# (ADR-0b55983421dd). The reader is a full-screen application: raw mode, the
+# alternate buffer, a keystroke, a resize, and a layout with panels to come.
+# Every one of those is two implementations of one behaviour -- `tcsetattr` and
+# `SetConsoleMode`, an `ioctl` and a console call, a byte and a key record --
+# and CLAUDE.md's rule is that OS-dependent behaviour is not verified until it
+# has run on all three platforms. crossterm *is* that implementation, so what
+# this crate spends is a dependency and not an `extern` block: `tests/
+# dependencies.rs` reads back out of the sources that none arrived.
+#
+# **The number, written here rather than left for whoever runs `cargo tree`.**
+# This crate compiled 15 crates before and compiles 82 now. The workspace
+# lockfile went from 50 entries to 200, and the two counts differ because a
+# lockfile carries a package whether or not a feature enables it: the termion
+# and termwiz backends, `palette` and their trees are locked and never built.
+# ADR-0b55983421dd priced this at fifty-five, which is what ratatui 0.29 costs
+# by the same instrument; 0.30 is 8 crates more compiled than that, and it is
+# the current release rather than a major this project would owe an upgrade.
+#
+# The default features are off and four are named. `all-widgets` and
+# `widget-calendar` are what they buy back: this reader draws no calendar, and
+# §13 spends a dependency only on necessity. `layout-cache` is what makes the
+# solver's answer cheap enough to ask for at every paint *and* while a key is
+# being answered, which `view.rs` does deliberately so that the heading over a
+# window and the rows inside it are one arithmetic.
+crossterm = { version = "0.29", default-features = false, features = ["events", "windows"] }
+ratatui = { version = "0.30", default-features = false, features = ["std", "crossterm", "layout-cache", "underline-color"] }
+# **The CLI's `--json` has to be *read*, and no crate entered for that.**
+# `ank-contract::json` writes and does not read, and `serde_yaml` is already a
+# dependency of `ank-core`, `ank-cli`, `ank-daemon` and `ank-mcp`. YAML 1.2 is a
+# superset of JSON, so a one-line document parses as flow YAML.
 # `ank-mcp` reads JSON-RPC requests this way already (§13 spends a dependency
 # only on necessity), and the escaper on the other side emits only `\"`, `\\`,
 # `\n` and `\u00xx`, every one of which a double-quoted YAML scalar carries.

--- a/crates/ank-tui/src/input.rs
+++ b/crates/ank-tui/src/input.rs
@@ -1,28 +1,27 @@
-//! The command grammar: one short word, and Enter.
+//! The grammar of the one-line prompt: a verb spelled whole, and its tail.
 //!
-//! The reader takes a line rather than a keystroke, for the reason the crate
-//! header gives, and the grammar is shaped around what that buys: a command may
-//! carry an argument, so filtering and jumping are commands rather than modes
-//! with a prompt of their own.
+//! **This is no longer how the screen is moved, and that is the whole of what
+//! ADR-0b55983421dd changed here.** Every command that only moves the screen is
+//! a key now, and `keys.rs` is where those live. What is left for a line is
+//! what a key cannot carry: `log <what you learned>`, `done --proof <p>`,
+//! `release <reason>`, `amend <flags>` -- four of the six verbs that write take
+//! something a keystroke has no room for, so `a` opens a prompt and this reads
+//! what is typed into it. `/` opens the same prompt on a search.
 //!
-//! **An empty line means "the obvious next thing", and what that is depends on
-//! the view**: opening the row under the cursor in the list, turning the page in
-//! an entity. That is the one place the parse consults the view, and it is why
-//! [`parse`] takes one.
+//! The reading commands stay in the grammar, spelled whole, and that is not
+//! vestigial: `q`, `open`, `top` and the rest cost nothing to keep, a row
+//! number and an identifier are lines by nature, and a person who reaches the
+//! prompt and types the word they know gets what they meant.
 //!
-//! # A reading command is one letter, and an act never is
+//! # A verb that writes is spelled whole, and none of the six is a key
 //!
-//! `j`, `k`, `n`, `p`, `c`, `b`, `g`, `r`, `v`, `q` -- every command that only
-//! moves the screen is a single letter, and it is the whole word too. The six
-//! that write are `claim`, `log`, `release`, `done`, `amend` and `accept`,
-//! spelled whole, with no abbreviation and no letter of their own.
-//!
-//! That asymmetry is the criterion's "no action is taken without an explicit
-//! keystroke", made into something the grammar enforces rather than something
-//! the renderer is careful about. A finger that slips onto `d` and Enter has
-//! typed nothing; there is no `d`. And it costs the reading half nothing,
-//! because a one-letter command is what a reader types a hundred times a
-//! session and a `done` is what they type once.
+//! The six are `claim`, `log`, `release`, `done`, `amend` and `accept`, with no
+//! abbreviation and no letter of their own. Under the line discipline that
+//! asymmetry *was* the guarantee -- a slipped finger typed nothing, because
+//! there was no `d`. It is still worth having and it is no longer the whole of
+//! it: what replaces it is the confirmation that shows the argv before anything
+//! is spawned, which ADR-0b55983421dd requires and TASK-d4a882345837 builds.
+//! `keys.rs` says which of the two regimes this reader is in today.
 //!
 //! # What `accept` costs on top of that, and why
 //!
@@ -37,9 +36,8 @@
 //!
 //! **It is only a command where the document is open.** In the list it is
 //! refused, naming the way in: a proposal binds nobody until somebody reads it,
-//! and a queue that could be ratified from a row is a queue nobody reads. The
-//! parse already takes the view for the empty line, so this costs no new input
-//! and puts the rule where a later edit has to see it.
+//! and a queue that could be ratified from a row is a queue nobody reads. That
+//! is why [`parse`] takes a view, and it is now the only reason it takes one.
 
 use crate::view::View;
 
@@ -87,8 +85,8 @@ pub enum Command {
     /// on the state of the corpus stays the CLI's (ADR-8bd76e8d7c4e).
     Malformed(String),
     Help,
-    /// A line that asked for nothing: whitespace in the list, where an empty
-    /// line already means open.
+    /// A line that asked for nothing: an empty prompt, or one carrying only
+    /// whitespace.
     Nothing,
     Unknown(String),
 }
@@ -159,11 +157,12 @@ const ACTS: &[(&str, Tail)] = &[
 
 pub fn parse(line: &str, view: View) -> Command {
     let line = line.trim();
+    // A prompt opened and submitted empty asked for nothing, and answering it
+    // with the obvious next thing would be the reader choosing a command for
+    // somebody who chose none. Under the line discipline this was Enter and
+    // meant "open"; Enter is a key now, and it still does.
     if line.is_empty() {
-        return match view {
-            View::List | View::Queue => Command::Open,
-            View::Entity => Command::Page(1),
-        };
+        return Command::Nothing;
     }
     if let Some(text) = line.strip_prefix('/') {
         return Command::Search(non_empty(text));
@@ -314,12 +313,15 @@ mod tests {
         parse(line, View::List)
     }
 
+    /// A prompt submitted empty runs nothing, in every view. Enter is a key and
+    /// opening a row is what it does; a line that says nothing must not be
+    /// turned into a command nobody typed.
     #[test]
-    fn an_empty_line_means_the_obvious_next_thing_in_each_view() {
-        assert_eq!(parse("", View::List), Command::Open);
-        assert_eq!(parse("", View::Queue), Command::Open);
-        assert_eq!(parse("", View::Entity), Command::Page(1));
-        assert_eq!(parse("   ", View::Entity), Command::Page(1));
+    fn an_empty_line_asks_for_nothing_in_every_view() {
+        for view in [View::List, View::Queue, View::Entity] {
+            assert_eq!(parse("", view), Command::Nothing, "{view:?}");
+            assert_eq!(parse("   ", view), Command::Nothing, "{view:?}");
+        }
     }
 
     #[test]
@@ -451,9 +453,9 @@ mod tests {
         }
     }
 
-    /// An act is never one letter, and a reading command always is. That is what
-    /// makes "no action without an explicit keystroke" a property of the grammar
-    /// rather than a habit of the renderer.
+    /// An act is never one letter, so no key can be one either: `keys.rs` maps
+    /// letters to commands, and a letter this grammar refuses to read as a verb
+    /// is a letter no mapping can quietly turn into one.
     #[test]
     fn no_single_letter_line_can_write() {
         for view in [View::List, View::Queue, View::Entity] {

--- a/crates/ank-tui/src/keys.rs
+++ b/crates/ank-tui/src/keys.rs
@@ -1,0 +1,323 @@
+//! One key per command, and the one place a line is still typed
+//! (ADR-0b55983421dd).
+//!
+//! **Every command that only moves the screen is a key.** `j` and `k` move, `n`
+//! and `p` page, `g` goes to the top, Enter opens, `b` goes back, `c` shows the
+//! constraints, `v` opens the queue, `r` reads the corpus again, `f` narrows to
+//! the next kind, `?` says what all of them are, `q` quits. Each has an arrow or
+//! a named key beside it -- Down for `j`, PageDown for `n`, Home for `g`, Escape
+//! for `b` -- because a person who has never read the key line still has hands.
+//!
+//! **No command requires a modifier chord**, which ADR-0b55983421dd asks for and
+//! a phone makes literal: a terminal keyboard on a phone has no comfortable
+//! Control. Control-C is the one exception and it is not a command -- it is the
+//! way out of a program that has taken the terminal, which raw mode has stopped
+//! the line discipline from providing, and `q` reaches the same place without
+//! it.
+//!
+//! # Why there is still a line, and where
+//!
+//! Four of the six verbs that write carry something a key cannot: a message, a
+//! reason, a proof, a flag. So `a` opens a one-line prompt and what is typed
+//! there goes through [`crate::input::parse`], which is the grammar this reader
+//! already had -- the same one that spells the six whole, refuses `accept` off
+//! the document and refuses a tail after it. `/` opens the same prompt seeded
+//! with a slash, which is that grammar's search.
+//!
+//! **The asymmetry the line discipline used to provide is gone, and this is not
+//! where it comes back.** Under a line reader a slipped finger typed nothing,
+//! because a command was a word and Enter. Under a keystroke reader `a` then
+//! `claim` then Enter is three deliberate acts, which is better than one Enter
+//! but is not the guarantee: that is the confirmation showing the argv, and it
+//! is TASK-d4a882345837. Until it lands, what stands between a slip and a write
+//! is the prompt and the word spelled whole -- stated here rather than implied,
+//! because a reader of this file should know which of the two regimes it is
+//! looking at.
+
+use crate::input::Command;
+use crate::view::View;
+use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+/// What a key press asks for, once the view is known.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Press {
+    /// A command of the grammar, ready to run.
+    Run(Command),
+    /// `f`: narrow to the next kind, which needs the one in force and is
+    /// therefore the view's to compute rather than this module's.
+    Cycle,
+    /// Open the one-line prompt, seeded with this much of a line.
+    Prompt(&'static str),
+    /// A key this screen has nothing to do with. Named as a variant rather than
+    /// answered with [`Command::Unknown`]: an unmapped key is not a person
+    /// getting a command wrong, and a note saying so on every stray arrow would
+    /// be noise where the line reader had a typo.
+    Ignored,
+}
+
+/// The key that opens the prompt on nothing, for a verb to be spelled into.
+pub const ACT: char = 'a';
+/// The key that opens it seeded with the grammar's search.
+pub const FIND: char = '/';
+
+pub fn typed(key: KeyEvent, view: View) -> Press {
+    // The one chord, and it is the way out rather than a command: raw mode has
+    // taken the line discipline's interrupt, so a reader that did not answer
+    // this would be a full-screen program a person cannot leave without knowing
+    // its own vocabulary.
+    if key.modifiers.contains(KeyModifiers::CONTROL) {
+        return match key.code {
+            KeyCode::Char('c') => Press::Run(Command::Quit),
+            _ => Press::Ignored,
+        };
+    }
+    match key.code {
+        KeyCode::Char('q') => Press::Run(Command::Quit),
+        KeyCode::Char('j') | KeyCode::Down => Press::Run(Command::Move(1)),
+        KeyCode::Char('k') | KeyCode::Up => Press::Run(Command::Move(-1)),
+        KeyCode::Char('n') | KeyCode::PageDown | KeyCode::Char(' ') => Press::Run(Command::Page(1)),
+        KeyCode::Char('p') | KeyCode::PageUp => Press::Run(Command::Page(-1)),
+        KeyCode::Char('g') | KeyCode::Home => Press::Run(Command::Top),
+        KeyCode::Enter => Press::Run(Command::Open),
+        KeyCode::Char('b') | KeyCode::Esc | KeyCode::Backspace | KeyCode::Left => {
+            Press::Run(Command::Back)
+        }
+        KeyCode::Char('c') => Press::Run(Command::Constraints),
+        KeyCode::Char('r') => Press::Run(Command::Reload),
+        KeyCode::Char('v') => Press::Run(Command::Queue),
+        KeyCode::Char('?') => Press::Run(Command::Help),
+        KeyCode::Char('f') => Press::Cycle,
+        KeyCode::Char(ACT) => Press::Prompt(""),
+        KeyCode::Char(FIND) => Press::Prompt("/"),
+        // Right opens, on the listings only: a phone's arrow cluster is how a
+        // person who never read the key line moves, and going *into* a row is
+        // what right means everywhere else. On a document there is nothing to
+        // the right, so it is left alone rather than given a second meaning.
+        KeyCode::Right if view != View::Entity => Press::Run(Command::Open),
+        _ => Press::Ignored,
+    }
+}
+
+/// The kinds `f` walks through, and back to every kind again.
+///
+/// The registry of ADR-c9f9d1a05b23 in the order `find --type` takes them, with
+/// `None` -- every kind -- as the step after the last. A cycle and not a prompt
+/// because narrowing a list is a command that only moves the screen, and those
+/// are keys.
+pub const KINDS: &[&str] = &["adr", "spec", "task", "log"];
+
+/// The kind after this one.
+pub fn next_kind(kind: Option<&str>) -> Option<String> {
+    let at = match kind {
+        None => return Some(KINDS[0].to_string()),
+        Some(k) => KINDS.iter().position(|known| *known == k),
+    };
+    match at {
+        Some(i) if i + 1 < KINDS.len() => Some(KINDS[i + 1].to_string()),
+        // The last kind, or one this reader does not know: both step to every
+        // kind, which is the state a person can always get back to.
+        _ => None,
+    }
+}
+
+/// What one key did to an open prompt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Editing {
+    /// The line changed, or the key meant nothing here. Either way the prompt
+    /// stays open and nothing runs.
+    Typing,
+    /// Enter: the line is a command now.
+    Submit,
+    /// Escape, or a backspace that emptied it. The prompt closes and nothing
+    /// runs -- which is what a person who opened it by accident needs, and the
+    /// only road back out.
+    Cancel,
+}
+
+pub fn edit(line: &mut String, key: KeyEvent) -> Editing {
+    if key.modifiers.contains(KeyModifiers::CONTROL) {
+        return match key.code {
+            KeyCode::Char('c') => Editing::Cancel,
+            // The line, cleared: a long `log` message typed wrongly is not a
+            // reason to hold Backspace.
+            KeyCode::Char('u') => {
+                line.clear();
+                Editing::Typing
+            }
+            _ => Editing::Typing,
+        };
+    }
+    match key.code {
+        KeyCode::Enter => Editing::Submit,
+        KeyCode::Esc => Editing::Cancel,
+        KeyCode::Backspace => match line.pop() {
+            // Backspacing off the end of an empty line closes the prompt. A
+            // person deleting what they typed and then one more has said they
+            // did not mean to be here.
+            None => Editing::Cancel,
+            Some(_) => Editing::Typing,
+        },
+        KeyCode::Char(c) => {
+            line.push(c);
+            Editing::Typing
+        }
+        _ => Editing::Typing,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::input::Act;
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    fn press(c: char, view: View) -> Press {
+        typed(key(KeyCode::Char(c)), view)
+    }
+
+    /// Every command that only moves the screen is one key, in every view
+    /// (ADR-0b55983421dd).
+    #[test]
+    fn a_reading_command_is_one_key_and_the_named_keys_agree_with_the_letters() {
+        for view in [View::List, View::Queue, View::Entity] {
+            for (letter, named, expected) in [
+                ('j', KeyCode::Down, Command::Move(1)),
+                ('k', KeyCode::Up, Command::Move(-1)),
+                ('n', KeyCode::PageDown, Command::Page(1)),
+                ('p', KeyCode::PageUp, Command::Page(-1)),
+                ('g', KeyCode::Home, Command::Top),
+                ('b', KeyCode::Esc, Command::Back),
+            ] {
+                assert_eq!(
+                    press(letter, view),
+                    Press::Run(expected.clone()),
+                    "{letter}"
+                );
+                assert_eq!(typed(key(named), view), Press::Run(expected), "{named:?}");
+            }
+            assert_eq!(press('q', view), Press::Run(Command::Quit));
+            assert_eq!(press('r', view), Press::Run(Command::Reload));
+            assert_eq!(press('v', view), Press::Run(Command::Queue));
+            assert_eq!(press('c', view), Press::Run(Command::Constraints));
+            assert_eq!(press('?', view), Press::Run(Command::Help));
+            assert_eq!(typed(key(KeyCode::Enter), view), Press::Run(Command::Open));
+            assert_eq!(press('f', view), Press::Cycle);
+        }
+    }
+
+    /// No command is a chord, and the one that is is the way out rather than a
+    /// command (ADR-0b55983421dd: no command anywhere requires a modifier).
+    #[test]
+    fn nothing_but_the_way_out_is_reached_with_a_modifier() {
+        for view in [View::List, View::Queue, View::Entity] {
+            for c in 'a'..='z' {
+                let held = KeyEvent::new(KeyCode::Char(c), KeyModifiers::CONTROL);
+                let press = typed(held, view);
+                if c == 'c' {
+                    assert_eq!(press, Press::Run(Command::Quit), "the way out");
+                } else {
+                    assert_eq!(press, Press::Ignored, "control-{c} is a command");
+                }
+            }
+        }
+    }
+
+    /// A key that writes does not exist: the six are spelled into the prompt,
+    /// and the prompt is where the grammar refuses them.
+    #[test]
+    fn no_bare_key_can_write() {
+        for view in [View::List, View::Queue, View::Entity] {
+            for c in 'a'..='z' {
+                assert!(
+                    !matches!(press(c, view), Press::Run(Command::Act(_))),
+                    "'{c}' writes in {view:?}"
+                );
+            }
+            for named in [KeyCode::Enter, KeyCode::Esc, KeyCode::Down, KeyCode::Home] {
+                assert!(!matches!(
+                    typed(key(named), view),
+                    Press::Run(Command::Act(_))
+                ));
+            }
+        }
+    }
+
+    #[test]
+    fn the_two_prompt_keys_seed_the_grammar_they_open() {
+        assert_eq!(press(ACT, View::List), Press::Prompt(""));
+        assert_eq!(press(FIND, View::List), Press::Prompt("/"));
+        // And what they seed is what the grammar reads: a bare line is a verb,
+        // a slashed one is a search.
+        assert_eq!(
+            crate::input::parse("claim", View::List),
+            Command::Act(Act {
+                verb: "claim",
+                args: Vec::new()
+            })
+        );
+        assert_eq!(
+            crate::input::parse("/a needle", View::List),
+            Command::Search(Some("a needle".to_string()))
+        );
+    }
+
+    #[test]
+    fn an_unmapped_key_is_ignored_rather_than_named() {
+        for code in [KeyCode::F(5), KeyCode::Insert, KeyCode::Char('z')] {
+            assert_eq!(typed(key(code), View::List), Press::Ignored, "{code:?}");
+        }
+        // Right opens a row and means nothing on a document.
+        assert_eq!(
+            typed(key(KeyCode::Right), View::List),
+            Press::Run(Command::Open)
+        );
+        assert_eq!(typed(key(KeyCode::Right), View::Entity), Press::Ignored);
+    }
+
+    /// `f` walks the registry and comes back to every kind, so a person who
+    /// pressed it once too often is one press from where they were.
+    #[test]
+    fn the_kind_filter_cycles_through_the_registry_and_back_to_all_of_them() {
+        let mut kind = None;
+        let mut walked = Vec::new();
+        for _ in 0..KINDS.len() {
+            kind = next_kind(kind.as_deref());
+            walked.push(kind.clone().expect("a kind"));
+        }
+        assert_eq!(walked, KINDS);
+        assert_eq!(next_kind(kind.as_deref()), None, "and back to every kind");
+        // A kind this build does not know steps back to all of them rather than
+        // sticking.
+        assert_eq!(next_kind(Some("epic")), None);
+    }
+
+    #[test]
+    fn the_prompt_takes_a_line_and_gives_two_ways_out() {
+        let mut line = String::new();
+        for c in "claim".chars() {
+            assert_eq!(edit(&mut line, key(KeyCode::Char(c))), Editing::Typing);
+        }
+        assert_eq!(line, "claim");
+        assert_eq!(edit(&mut line, key(KeyCode::Backspace)), Editing::Typing);
+        assert_eq!(line, "clai");
+        assert_eq!(edit(&mut line, key(KeyCode::Enter)), Editing::Submit);
+        assert_eq!(edit(&mut line, key(KeyCode::Esc)), Editing::Cancel);
+    }
+
+    /// Backspacing off the end of an empty line closes the prompt, and clearing
+    /// it does not.
+    #[test]
+    fn an_emptied_prompt_closes_and_a_cleared_one_stays_open() {
+        let mut line = String::from("x");
+        assert_eq!(edit(&mut line, key(KeyCode::Backspace)), Editing::Typing);
+        assert_eq!(edit(&mut line, key(KeyCode::Backspace)), Editing::Cancel);
+
+        let mut line = String::from("done commit:2d9c847");
+        let cleared = KeyEvent::new(KeyCode::Char('u'), KeyModifiers::CONTROL);
+        assert_eq!(edit(&mut line, cleared), Editing::Typing);
+        assert!(line.is_empty());
+    }
+}

--- a/crates/ank-tui/src/lib.rs
+++ b/crates/ank-tui/src/lib.rs
@@ -1,4 +1,5 @@
-//! The `tui` verb: a full-screen reader over one corpus (ADR-8bd76e8d7c4e, §4).
+//! The `tui` verb: a full-screen reader over one corpus (ADR-8bd76e8d7c4e, §4),
+//! drawn with ratatui over crossterm (ADR-0b55983421dd).
 //!
 //! **It reaches the corpus by running the CLI, and by nothing else.** Every row
 //! of corpus data on the screen arrives as a `--json` document written by
@@ -18,16 +19,16 @@
 //! (ADR-8bd76e8d7c4e). Repainting runs the verbs that only read, so a screen
 //! left open all night runs no command at all and renews no claim; the six that
 //! write -- `claim`, `log`, `release`, `done`, `amend` and `accept` -- run once
-//! each, when their word is typed whole. Nothing here is on a timer, and there
-//! is no timer to put anything on. The assertion is in the suite, not in this
-//! sentence.
+//! each, when their word is typed whole into the prompt. Nothing here is on a
+//! timer, and there is no timer to put anything on. The assertion is in the
+//! suite, not in this sentence.
 //!
 //! **A change reaches the screen as an event, never as a poll**
 //! (TASK-2f7777a1fdff). `ank-daemon` appends a line when a corpus it watches
 //! moves, and [`stream`] follows that file: an event wakes the session and the
 //! screen is drawn again from the corpus. Where there is no stream -- no
 //! watcher has ever run here, or this reader has no home to find one in -- the
-//! screen is drawn again when its person types `r`, which is what it always
+//! screen is drawn again when its person presses `r`, which is what it always
 //! did. Both routes reach the same displayed state, and the suite compares
 //! them.
 //!
@@ -46,35 +47,50 @@
 //! refusal on the screen is the one the binary gave -- with its exit code and
 //! the command it named as the way out, unaltered.
 //!
-//! # Why the input is a line and not a keystroke
+//! # The engine
 //!
-//! Raw mode is two implementations of one behaviour: `tcsetattr` on Unix and
-//! `SetConsoleMode` on Windows, each behind an `extern` block this workspace
-//! does not otherwise have. CLAUDE.md's rule is that OS-dependent behaviour is
-//! not verified until it has run on all three platforms, and only one of those
-//! two can be run from where this was written. So the reader uses the terminal's
-//! own line discipline as its input layer -- the same reflex that sends git
-//! plumbing through the git binary rather than reimplementing it -- and a
-//! command is a short word followed by Enter. The screen is full-screen all the
-//! same: it lives on the alternate buffer and is repainted whole on every
-//! command.
+//! Raw mode, on the alternate buffer, drawn by ratatui and woken by three
+//! things: a key, a resize, and the change stream. That is [`term`], and the
+//! reason it may exist is stated there -- raw mode and the window are two
+//! implementations of one behaviour on the platforms this project ships to,
+//! crossterm is that implementation, and taking it puts no `extern` block in
+//! this workspace at all.
 //!
-//! It buys something back, too. A line can carry an argument, so `f adr`,
-//! `/claim` and `TASK-4974` are commands rather than modes, which a
-//! keystroke reader would have had to build a prompt for -- and so are
-//! `log <what you learned>` and `done commit:<sha>`, which a keystroke reader
-//! could not have taken at all without one.
+//! **The window is the terminal's answer and no longer an environment
+//! variable.** A resize is an event the loop takes like any other, so a
+//! terminal made narrower redraws to its new size with nobody typing -- which
+//! is not a nicety: a reader that only reflowed when a command arrived would be
+//! a reader whose screen is wrong for as long as its person is reading rather
+//! than acting.
+//!
+//! # Input is a key, and the one line that is left
+//!
+//! Every command that only moves the screen is one key ([`keys`]). Four of the
+//! six that write carry something a key has no room for -- a message, a reason,
+//! a proof, a flag -- so `a` opens a one-line prompt and what is typed there
+//! goes through [`input`], which is the grammar that spells the six whole. `/`
+//! opens the same prompt on a search.
+//!
+//! **What the line discipline used to guarantee is not yet replaced, and this
+//! is the honest state of it.** Under a line reader a slipped finger typed
+//! nothing, because a command was a word and Enter and no word was one letter.
+//! Under a keystroke reader the guarantee is the confirmation that shows the
+//! argv before anything is spawned, which ADR-0b55983421dd requires and
+//! TASK-d4a882345837 builds. Until it lands, what stands between a slip and a
+//! write is that no key writes at all: the road to a spawned verb runs through
+//! a prompt somebody opened and a word somebody spelled.
 //!
 //! # The layout
 //!
 //! Three views, one screen each, because a criterion that asks for a body
 //! *whole* and a list of every kind on one screen asks for two screens, and the
-//! ratification queue asks a different question from either.
+//! ratification queue asks a different question from either. Panels with focus
+//! are TASK-bb43cfe2192b, and this is the engine they will be drawn on.
 //!
 //! * [`view::View::List`] -- who holds what, then every entity of every kind
 //!   with its status, windowed and filterable.
 //! * [`view::View::Queue`] -- what is proposed and waiting for a signature, and
-//!   who may give one: `ank review`, asked when its person types `v` and never
+//!   who may give one: `ank review`, asked when its person presses `v` and never
 //!   on the reader's own initiative.
 //! * [`view::View::Entity`] -- one entity: what holds it, the constraints
 //!   binding its declared scope, and its body, paged rather than cut. This is
@@ -88,24 +104,29 @@
 //! one identifier, no flags, because a person typed the word whole on a
 //! document they had opened. Performing would be holding a key, answering a
 //! prompt, or moving more than one document at a time -- and none of the three
-//! is reachable from here. The queue is never accepted in bulk because the
-//! grammar has no shape for it; no secret can reach git through this process
-//! because the child is given no stdin; and a screen left open all night still
-//! runs nothing at all, because `accept` is on the acting list and a repaint
-//! only ever reads.
+//! is reachable from here. No key is `accept` and no key is any of the six, so
+//! a held key repeats a movement and nothing else; the queue is never accepted
+//! in bulk because the grammar has no shape for it; no secret can reach git
+//! through this process because the child is given no stdin; and a screen left
+//! open all night still runs nothing at all, because `accept` is on the acting
+//! list and a repaint only ever reads.
 
-use std::io::{BufRead, IsTerminal};
+use ratatui::crossterm::event::KeyEvent;
+use std::io::IsTerminal;
 use std::path::PathBuf;
 
 pub mod ank;
-pub mod frame;
 pub mod input;
+pub mod keys;
 pub mod model;
 pub mod stream;
+pub mod term;
+pub mod text;
 pub mod view;
 
 pub use ank::Ank;
 pub use ank_contract::ExitCode;
+pub use term::Painter;
 
 /// Where the reader is told to look when it cannot open a screen.
 ///
@@ -119,7 +140,8 @@ pub const INSTEAD: &str = "ank context";
 /// that resolves it.
 ///
 /// Returned rather than printed. This crate knows nothing about how `ank-cli`
-/// renders an error -- that is one rendering and it lives there (ADR-0c8a) --
+/// renders an error -- that is one rendering and it lives there
+/// (ADR-1f70ce2c3eac) --
 /// so what crosses the boundary is the code, the message and the next command.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Refused {
@@ -193,57 +215,37 @@ pub fn run(
         .map(|v| ank::text(&v, "corpus"))
         .unwrap_or_default();
     let (wake, waking) = std::sync::mpsc::channel::<Wake>();
-    typing(wake.clone());
-    let stream = stream::follow(&corpus, wake);
-    // Blocking, and there is nothing else in it: with nobody typing and nothing
-    // changing, this reader is a process asleep on a channel. No verb runs, no
-    // clock ticks and no claim moves.
+    let stream = stream::follow(&corpus, wake.clone());
+    // The terminal is taken last, and given back by [`term::Screen`]'s `Drop`
+    // on every road out of what follows.
+    let mut screen = term::Screen::open().map_err(no_screen)?;
+    term::typing(wake);
+    // Blocking, and there is nothing else in it: with nobody typing, nothing
+    // changing and the window still, this reader is a process asleep on a
+    // channel. No verb runs, no clock ticks and no claim moves.
     let mut wakes = std::iter::from_fn(move || waking.recv().ok());
-    session(&ank, &mut wakes, out, terminal_size(), stream)
+    session(&ank, &mut wakes, &mut screen, stream)
 }
 
-/// What can wake a drawn screen. There are exactly three things, and two of them
-/// end the session.
+/// What can wake a drawn screen. There are exactly three things, and a fourth
+/// that ends the session.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Wake {
-    /// A line the person typed, terminator and all.
-    Line(String),
+    /// A key the person pressed, which is a press or a repeat and never a
+    /// release (see [`term::typing`]).
+    Key(KeyEvent),
+    /// The terminal is a different size now. It carries the new one, and what
+    /// the screen does about it is draw again -- nothing is read, and no verb
+    /// runs, because a window is a fact about the terminal and never about the
+    /// corpus.
+    Resize(u16, u16),
     /// The watcher said this corpus moved (TASK-2f7777a1fdff). It carries what
     /// happened and not what to do about it, which is why there is nothing in
     /// this variant: the answer is to read the corpus again.
     Changed,
-    /// End of input. A session whose terminal went away has nothing left to
-    /// draw to, and that is a quit and never an error.
-    Closed,
     /// The terminal could not be read from. An environment to repair, and the
     /// one way out of a session that is not a zero.
     Broken(String),
-}
-
-/// Reads the terminal on a thread, so the drawn screen can be woken by
-/// something other than a keystroke.
-///
-/// **This is what an event costs, and it is the whole of it.** A reader blocked
-/// on `read_line` cannot be told anything; a reader blocked on a channel can be
-/// told by whatever holds a sender. Nothing else changes: the same lines arrive
-/// in the same order, and a session with no stream behind it is the session
-/// TASK-b50b340c0bb1 measured, one command at a time.
-fn typing(wake: std::sync::mpsc::Sender<Wake>) {
-    std::thread::spawn(move || {
-        let stdin = std::io::stdin();
-        loop {
-            let mut line = String::new();
-            let said = match stdin.lock().read_line(&mut line) {
-                Ok(0) => Wake::Closed,
-                Ok(_) => Wake::Line(line),
-                Err(e) => Wake::Broken(e.to_string()),
-            };
-            let ending = !matches!(said, Wake::Line(_));
-            if wake.send(said).is_err() || ending {
-                return;
-            }
-        }
-    });
 }
 
 /// Whether there is a screen to draw on.
@@ -266,6 +268,21 @@ pub fn no_terminal() -> Refused {
     }
 }
 
+/// The terminal could not be taken: raw mode was refused, or the alternate
+/// buffer was.
+///
+/// An environment to repair rather than a defect of the corpus, so it leaves by
+/// the same road the missing terminal does and names the same command. Nothing
+/// has been drawn at this point and nothing needs giving back: `Screen::open`
+/// undoes whatever half it had taken before it answers.
+fn no_screen(error: std::io::Error) -> Refused {
+    Refused {
+        code: ExitCode::Environment,
+        message: format!("'tui' could not take this terminal: {error}"),
+        hint: INSTEAD,
+    }
+}
+
 /// A refusal the child gave, carried out whole.
 fn refused_by_the_cli(failed: ank::Failed) -> Refused {
     Refused {
@@ -275,87 +292,68 @@ fn refused_by_the_cli(failed: ank::Failed) -> Refused {
     }
 }
 
-/// The session, with its edges injected so the suite can drive it.
+/// The session, with its edges injected so it can be driven.
 ///
-/// `size` is passed in rather than measured here: measuring the window is an
-/// `ioctl` on Unix and a console call on Windows, which is the FFI this crate
-/// declines (see the module header), and a test that could not choose the
-/// window could not assert what a frame holds.
+/// `wakes` is an iterator and not a reader, because a screen has three things
+/// that can move it and a `read` can only ever be one. It blocks in `next`,
+/// which is where an idle session sits: no verb, no clock, nothing.
 ///
-/// `wakes` is an iterator and not a reader, because a screen now has two things
-/// that can move it and a `read_line` can only ever be one. It blocks in
-/// `next`, which is where an idle session sits: no verb, no clock, nothing.
+/// `screen` is a [`Painter`] and not the terminal, so the loop's own edges can
+/// be stated without owning one. What a session does on a real terminal is the
+/// suite's question and it drives a real one; what is asserted here is that a
+/// resize redraws, a broken terminal ends the session with an environment code,
+/// and an exhausted stream of wakes is a quit.
 ///
 /// `stream` is what the screen says about how it is being kept current, and
 /// `None` where there is nothing to follow.
+///
+/// **The window is read from the terminal before every frame**, and the resize
+/// event is answered as well. Two roads to one fact, deliberately: the event is
+/// what wakes a screen nobody is typing at, and the reading before the paint is
+/// what keeps the size the page arithmetic used and the size ratatui draws into
+/// from ever being two different numbers.
 pub fn session(
     ank: &Ank,
     wakes: &mut dyn Iterator<Item = Wake>,
-    out: &mut dyn std::io::Write,
-    size: (usize, usize),
+    screen: &mut dyn Painter,
     stream: Option<stream::Stream>,
 ) -> Result<ExitCode, Refused> {
-    let mut app = view::App::new(size, stream);
+    let opened = screen.size().unwrap_or((80, 24));
+    let mut app = view::App::new((opened.0 as usize, opened.1 as usize), stream);
     app.reload(ank);
-    let _ = write!(out, "{}", frame::ENTER);
     let code = loop {
-        let _ = write!(out, "{}{}", frame::HOME, app.frame());
-        let _ = out.flush();
+        if let Ok((columns, rows)) = screen.size() {
+            app.resize(columns, rows);
+        }
+        if let Err(e) = screen.draw(&app) {
+            // Nothing to draw the reason on, so it leaves by the exit code and
+            // by stderr once the terminal has been given back.
+            app.note(format!("cannot draw to the terminal: {e}"));
+            break ExitCode::Environment;
+        }
         // Exhausted means every sender is gone, which is the same end of input
         // by another road.
         let Some(wake) = wakes.next() else {
             break ExitCode::Ok;
         };
         match wake {
-            Wake::Closed => break ExitCode::Ok,
             Wake::Broken(e) => {
                 app.note(format!("cannot read from the terminal: {e}"));
                 break ExitCode::Environment;
             }
+            Wake::Resize(columns, rows) => app.resize(columns, rows),
             // News, and never an instruction: what the screen does about it is
             // read the corpus again, and `repaint` is where the one read it may
             // not run is refused.
             Wake::Changed => app.repaint(ank),
-            Wake::Line(line) => {
-                if app.act(
-                    input::parse(line.trim_end_matches(['\n', '\r']), app.view()),
-                    ank,
-                ) {
+            Wake::Key(key) => {
+                if app.press(key, ank) {
                     break ExitCode::Ok;
                 }
             }
         }
     };
-    let _ = write!(out, "{}", frame::LEAVE);
-    let _ = out.flush();
     Ok(code)
-}
-
-/// The window, as the environment states it, or the classic default.
-///
-/// `COLUMNS` and `LINES` are what a shell exports when it knows, and 80x24 is
-/// what every terminal is at least. A wrong guess costs a narrower frame and
-/// never a wrong row: the renderer clamps rather than assuming.
-pub fn terminal_size() -> (usize, usize) {
-    sized(std::env::var("COLUMNS").ok(), std::env::var("LINES").ok())
-}
-
-/// The measurement itself, given the two values rather than reading them.
-///
-/// Split out so the suite can state a window without writing to the process
-/// environment, which is shared by every test in a binary and is therefore the
-/// one input a test must never set.
-fn sized(columns: Option<String>, lines: Option<String>) -> (usize, usize) {
-    // Below twenty columns or ten rows there is no frame to draw, only a
-    // vertical smear, so a value that small is treated as absent rather than
-    // honoured: `COLUMNS=0` is what a shell leaves behind, not a window.
-    let read = |value: Option<String>, floor: usize, fallback: usize| {
-        value
-            .and_then(|v| v.trim().parse::<usize>().ok())
-            .filter(|n| *n >= floor)
-            .unwrap_or(fallback)
-    };
-    (read(columns, 20, 80), read(lines, 10, 24))
 }
 
 #[cfg(test)]
@@ -387,16 +385,173 @@ mod tests {
         assert!(r.message.contains("terminal"), "{}", r.message);
     }
 
+    /// A screen a test can hold, so the loop's own edges can be stated without
+    /// a terminal.
+    ///
+    /// It keeps every frame it was given, which is what makes "the screen was
+    /// drawn again, and at the new size" an assertion rather than an inference.
+    struct Paper {
+        size: std::rc::Rc<std::cell::Cell<(u16, u16)>>,
+        frames: Vec<String>,
+        broken: Option<&'static str>,
+    }
+
+    impl Paper {
+        fn new(size: std::rc::Rc<std::cell::Cell<(u16, u16)>>) -> Paper {
+            Paper {
+                size,
+                frames: Vec::new(),
+                broken: None,
+            }
+        }
+    }
+
+    impl Painter for Paper {
+        fn size(&mut self) -> std::io::Result<(u16, u16)> {
+            Ok(self.size.get())
+        }
+
+        fn draw(&mut self, app: &view::App) -> std::io::Result<()> {
+            match self.broken {
+                Some(e) => Err(std::io::Error::other(e)),
+                None => {
+                    self.frames.push(app.frame());
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    /// The CLI, addressed where there is none: every read fails to spawn, the
+    /// session survives it and draws the refusal, which is what lets the loop
+    /// be driven with no corpus at all.
+    fn nowhere() -> Ank {
+        Ank::new(Address {
+            exe: "/nonexistent/ank".into(),
+            cwd: ".".into(),
+            repo: None,
+            worktree: None,
+        })
+    }
+
+    /// A terminal whose window moves with the events it sends, which is what a
+    /// terminal is: the `ioctl` and the `SIGWINCH` agree.
+    fn driven(
+        first: (u16, u16),
+        said: Vec<Wake>,
+    ) -> (
+        Paper,
+        impl Iterator<Item = Wake>,
+        std::rc::Rc<std::cell::Cell<(u16, u16)>>,
+    ) {
+        let size = std::rc::Rc::new(std::cell::Cell::new(first));
+        let moving = std::rc::Rc::clone(&size);
+        let mut said = said.into_iter();
+        let wakes = std::iter::from_fn(move || {
+            let next = said.next()?;
+            if let Wake::Resize(columns, rows) = next {
+                moving.set((columns, rows));
+            }
+            Some(next)
+        });
+        (Paper::new(std::rc::Rc::clone(&size)), wakes, size)
+    }
+
+    fn key(code: ratatui::crossterm::event::KeyCode) -> Wake {
+        Wake::Key(KeyEvent::new(
+            code,
+            ratatui::crossterm::event::KeyModifiers::NONE,
+        ))
+    }
+
+    /// A terminal made narrower redraws to its new size, with nobody typing
+    /// (TASK-4fa385c1772d, ADR-0b55983421dd).
+    ///
+    /// The only wake in the session is the resize, so a second frame existing at
+    /// all is the reader answering the window rather than a command. What is
+    /// asserted about that frame is the shape of the new window in both
+    /// directions: as many rows as the terminal now has, and no line wider than
+    /// it is.
     #[test]
-    fn a_window_too_small_to_draw_in_is_not_believed() {
-        let s = |c: &str, l: &str| sized(Some(c.to_string()), Some(l.to_string()));
+    fn a_resize_draws_the_screen_again_at_the_new_size_with_nothing_typed() {
+        let (mut paper, mut wakes, _size) = driven((120, 40), vec![Wake::Resize(60, 20)]);
+        let code = session(&nowhere(), &mut wakes, &mut paper, None).expect("a session");
+        assert_eq!(code, ExitCode::Ok);
         assert_eq!(
-            s("0", "4"),
-            (80, 24),
-            "a shell's leftover zero is not a window"
+            paper.frames.len(),
+            2,
+            "the screen was not drawn again for the resize"
         );
-        assert_eq!(s("not a number", "x"), (80, 24));
-        assert_eq!(s("120", "48"), (120, 48), "a stated window is honoured");
-        assert_eq!(sized(None, None), (80, 24));
+        let (before, after) = (&paper.frames[0], &paper.frames[1]);
+        assert_eq!(before.lines().count(), 40);
+        assert_eq!(after.lines().count(), 20, "the new height:\n{after}");
+        for line in after.lines() {
+            assert!(
+                line.chars().count() <= 60,
+                "{} columns in a 60 column window: {line}",
+                line.chars().count()
+            );
+        }
+        // And the frame is still this reader's: a resize reads nothing, so what
+        // was on the screen is what is on it.
+        assert!(after.contains("ank tui"), "{after}");
+    }
+
+    /// A key that quits ends the session, and the exit is a zero.
+    #[test]
+    fn a_key_that_quits_ends_the_session() {
+        let (mut paper, mut wakes, _size) = driven(
+            (100, 30),
+            vec![
+                key(ratatui::crossterm::event::KeyCode::Char('j')),
+                key(ratatui::crossterm::event::KeyCode::Char('q')),
+            ],
+        );
+        assert_eq!(
+            session(&nowhere(), &mut wakes, &mut paper, None).expect("a session"),
+            ExitCode::Ok
+        );
+        // One for the opening frame, one after the `j`, and none after the quit:
+        // a session that drew again on its way out would be painting a screen
+        // it is about to take away.
+        assert_eq!(paper.frames.len(), 2);
+    }
+
+    /// Nothing left to wake it is a quit, not a fault: every sender is gone.
+    #[test]
+    fn a_session_with_nothing_left_to_wake_it_is_a_quit() {
+        let (mut paper, mut wakes, _size) = driven((100, 30), Vec::new());
+        assert_eq!(
+            session(&nowhere(), &mut wakes, &mut paper, None).expect("a session"),
+            ExitCode::Ok
+        );
+        assert_eq!(paper.frames.len(), 1, "the opening frame was drawn");
+    }
+
+    /// A terminal that cannot be read from is an environment to repair, and it
+    /// is the one way out of a session that is not a zero.
+    #[test]
+    fn a_terminal_that_broke_ends_the_session_with_the_environment_code() {
+        let (mut paper, mut wakes, _size) = driven(
+            (100, 30),
+            vec![Wake::Broken("input/output error".to_string())],
+        );
+        assert_eq!(
+            session(&nowhere(), &mut wakes, &mut paper, None).expect("a session"),
+            ExitCode::Environment
+        );
+    }
+
+    /// And a terminal that cannot be drawn to is the same fact from the other
+    /// side.
+    #[test]
+    fn a_terminal_that_cannot_be_drawn_to_ends_the_session_the_same_way() {
+        let (mut paper, mut wakes, _size) = driven((100, 30), Vec::new());
+        paper.broken = Some("no space left on device");
+        assert_eq!(
+            session(&nowhere(), &mut wakes, &mut paper, None).expect("a session"),
+            ExitCode::Environment
+        );
+        assert!(paper.frames.is_empty());
     }
 }

--- a/crates/ank-tui/src/term.rs
+++ b/crates/ank-tui/src/term.rs
@@ -1,0 +1,162 @@
+//! The engine: raw mode, the alternate screen, and the three things that wake a
+//! drawn screen (ADR-0b55983421dd).
+//!
+//! **No `extern` block enters this workspace for any of it, and that is the
+//! whole of why this file may exist at all.** Raw mode is `tcsetattr` on Unix
+//! and `SetConsoleMode` on Windows; the window is an `ioctl` on one and a
+//! console call on the other; a keystroke is a byte on one and a console record
+//! on the other. Each of those is two implementations of one behaviour, and
+//! CLAUDE.md's rule is that OS-dependent behaviour is not verified until it has
+//! run on all three platforms. crossterm *is* that cross-platform
+//! implementation, maintained and exercised far beyond what this workspace
+//! could give it, so what this crate spends is a dependency and not an
+//! `extern`. `tests/dependencies.rs` reads that back out of the sources.
+//!
+//! **Every road out of a session gives the terminal back.** A process that
+//! exits in raw mode leaves a shell nobody can type into, and a process that
+//! exits on the alternate buffer leaves a screen nobody asked for. So the
+//! restoration is a [`Drop`] and never a line at the end of the loop: a `?`, a
+//! refusal, a quit and a panic all take it. The panic case gets a hook of its
+//! own on top, because a panic message painted onto the alternate screen is a
+//! message the teardown then hides.
+//!
+//! **What the session is woken by is three things and no clock.** A key, a
+//! resize, and the change stream (`stream`). Nothing here is on a timer and
+//! there is no timer to put anything on: with nobody typing, nothing changing
+//! and the window still, this reader is a process asleep on a channel. That is
+//! what keeps ADR-0bb7ea8991bc's "a claim is renewed by working" true of a
+//! screen somebody left open and went home.
+
+use crate::view::App;
+use crate::Wake;
+use ratatui::backend::CrosstermBackend;
+use ratatui::crossterm::event::{self, Event, KeyEventKind};
+use ratatui::crossterm::execute;
+use ratatui::crossterm::terminal::{
+    disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
+};
+use std::io::Stdout;
+use std::sync::mpsc::Sender;
+
+/// What a session draws on.
+///
+/// A trait and not the concrete terminal, for the reason [`crate::session`]
+/// takes its wakes as an iterator: the loop is the one piece of this crate that
+/// cannot be driven from a unit test while it owns a real terminal, and a loop
+/// nothing can drive is a loop that is only ever tested through a
+/// pseudo-terminal. The suite in `ank-cli` still drives one, because that is
+/// where the criterion lives; this is what lets the loop's own edges -- a
+/// resize, a broken terminal, an exhausted stream -- be stated here too.
+pub trait Painter {
+    /// The window, as the terminal states it now.
+    fn size(&mut self) -> std::io::Result<(u16, u16)>;
+    /// One frame.
+    fn draw(&mut self, app: &App) -> std::io::Result<()>;
+}
+
+/// A terminal in raw mode, on the alternate buffer, with ratatui over it.
+pub struct Screen {
+    terminal: ratatui::Terminal<CrosstermBackend<Stdout>>,
+}
+
+impl Screen {
+    /// Takes the terminal, or gives back whatever half it had taken.
+    ///
+    /// The order is raw mode, then the alternate buffer, then ratatui, and each
+    /// failure undoes exactly what succeeded before it. A reader that returned
+    /// an error while leaving the terminal raw would be handing its caller a
+    /// shell it could not type into, which is worse than the failure it was
+    /// reporting.
+    pub fn open() -> std::io::Result<Screen> {
+        hook();
+        enable_raw_mode()?;
+        let mut out = std::io::stdout();
+        if let Err(e) = execute!(out, EnterAlternateScreen) {
+            let _ = disable_raw_mode();
+            return Err(e);
+        }
+        match ratatui::Terminal::new(CrosstermBackend::new(out)) {
+            Ok(terminal) => Ok(Screen { terminal }),
+            Err(e) => {
+                let _ = restore();
+                Err(e)
+            }
+        }
+    }
+}
+
+impl Painter for Screen {
+    fn size(&mut self) -> std::io::Result<(u16, u16)> {
+        let size = self.terminal.size()?;
+        Ok((size.width, size.height))
+    }
+
+    fn draw(&mut self, app: &App) -> std::io::Result<()> {
+        self.terminal.draw(|frame| app.draw(frame))?;
+        Ok(())
+    }
+}
+
+impl Drop for Screen {
+    fn drop(&mut self) {
+        let _ = restore();
+    }
+}
+
+/// The terminal, given back.
+///
+/// Both halves attempted whatever the first one answers: a failure to leave the
+/// alternate buffer is no reason to leave the terminal raw as well, and there
+/// is nobody left to report either failure to.
+fn restore() -> std::io::Result<()> {
+    let left = execute!(std::io::stdout(), LeaveAlternateScreen);
+    let cooked = disable_raw_mode();
+    left.and(cooked)
+}
+
+/// The panic hook, installed once.
+///
+/// A panic unwinds through [`Screen`]'s `Drop`, which is what actually restores
+/// the terminal; this is about the *message*. The default hook prints to stderr,
+/// which at that moment is the alternate buffer -- so the sentence explaining
+/// what went wrong is painted onto a screen the unwind then tears down. Leaving
+/// first means the panic lands in the scrollback, where somebody can read it.
+fn hook() {
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    ONCE.call_once(|| {
+        let previous = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |panicked| {
+            let _ = restore();
+            previous(panicked);
+        }));
+    });
+}
+
+/// Reads the terminal on a thread, so the drawn screen can be woken by
+/// something other than a keystroke.
+///
+/// **A release is not a press, and Windows is where that matters.** A terminal
+/// on Unix sends bytes and crossterm reports one event per key; a Windows
+/// console sends key records for the way down *and* the way up, and crossterm
+/// reports both. A reader that took either would run every command twice there
+/// and nowhere else -- the exact shape of defect CLAUDE.md's three-platform rule
+/// exists to catch, and one no Linux run would ever show. A repeat is taken,
+/// because holding `j` is somebody moving down a list on purpose.
+///
+/// Mouse, focus and paste are read and dropped: no capture is enabled, so none
+/// of them arrives, and turning them on is TASK-dd9747e5e305's business rather
+/// than something to half-do here.
+pub fn typing(wake: Sender<Wake>) {
+    std::thread::spawn(move || loop {
+        let said = match event::read() {
+            Ok(Event::Key(key)) if key.kind != KeyEventKind::Release => Wake::Key(key),
+            Ok(Event::Resize(columns, rows)) => Wake::Resize(columns, rows),
+            Ok(_) => continue,
+            Err(e) => Wake::Broken(e.to_string()),
+        };
+        let ending = matches!(said, Wake::Broken(_));
+        if wake.send(said).is_err() || ending {
+            return;
+        }
+    });
+}

--- a/crates/ank-tui/src/text.rs
+++ b/crates/ank-tui/src/text.rs
@@ -1,38 +1,25 @@
-//! Drawing primitives: the screen control, and fitting text to a window.
+//! Fitting text to a window: the arithmetic a paged reader owes its content.
 //!
-//! **Three escape sequences, and they are the whole of what this crate emits.**
-//! They move the cursor and swap the screen buffer; none of them is colour.
-//! That is where this crate stands today, and the reason is still worth
-//! stating: the palette of §4 lives in `ank-cli`'s `style.rs`, this crate may
-//! not link `ank-cli`, and a second palette would be a second place deciding
-//! what a status looks like. With no route to the first one, monochrome was
-//! the only answer left rather than the answer that was chosen.
+//! **This is what survived the move to ratatui, and the reason it survived is
+//! that it is not drawing** (TASK-4fa385c1772d). The escape sequences that used
+//! to live here -- the alternate screen, the cursor home, the erase -- are
+//! crossterm's now, and the row-by-row painting is ratatui's. What neither of
+//! them can do for this reader is decide *how many rows a body is*: a criterion
+//! that asks for a body whole means the reader pages through it, and paging
+//! needs the count before the frame is drawn, while a key is being answered.
+//! `Paragraph`'s own wrapping happens inside the render and reports nothing, so
+//! a heading that said `41-60 of 1275` over it would be a count that agrees with
+//! nothing. The wrap is therefore done here, the rows are counted, and the slice
+//! that fits is what the widget is given.
 //!
-//! **The other route is open now, and this file has not taken it yet.**
-//! ADR-1f70ce2c3eac makes what a status means one table, held where every
-//! surface reads it and holding no escape sequence, and each surface paints
-//! that meaning its own way: two renderers are allowed and a second table is
-//! not. The reason above is the one that decision keeps; the monochrome it
-//! forced is not.
+//! [`fit`] is the other half and the same argument: ratatui clips a line that
+//! overruns its area, silently. A summary that was cut has to *say* it was cut,
+//! which is a decision about meaning rather than about pixels.
 //!
-//! TASK-4fa385c1772d is where this file is drawn again through ratatui, and
-//! TASK-6cd41d23b7d1 is where the reader paints that table and NO_COLOR
-//! reaches it. Until then nothing here is carried by colour, so what is given
-//! up is decoration and not information.
-//!
-//! The structure layer is ADR-1f70ce2c3eac's and the supersession left it
-//! word for word: the tree connectors and the marker on a held row are text,
-//! and they are the same bytes on every platform.
-
-/// The alternate screen buffer. What a full-screen reader owes the shell it was
-/// launched from: leaving restores the scrollback the session was covering.
-pub const ENTER: &str = "\x1b[?1049h";
-/// Leaving it again, on every road out of the loop.
-pub const LEAVE: &str = "\x1b[?1049l";
-/// The cursor home, then erase. Repainting the whole window rather than diffing
-/// it: a frame is at most a few kilobytes, and a differ is state that can
-/// disagree with the screen.
-pub const HOME: &str = "\x1b[H\x1b[2J";
+//! The structure layer is ADR-1f70ce2c3eac's and nothing here paints: the
+//! marker on the row the cursor is on and the marker on a held row are text,
+//! and they are the same bytes on every platform. Colour is TASK-6cd41d23b7d1's,
+//! and what is given up until then is decoration and not information.
 
 /// The marker on the row the cursor is on, in the two columns every listing in
 /// this tool already spends on its left margin (ADR-1f70ce2c3eac).

--- a/crates/ank-tui/src/view.rs
+++ b/crates/ank-tui/src/view.rs
@@ -41,10 +41,16 @@
 //! command that resolves it, passed through the way [`Failed`] carries it.
 
 use crate::ank::{Ank, Failed, Ran};
-use crate::frame::{self, fit, pad, window, wrap};
 use crate::input::{Act, Command};
+use crate::keys::{self, Editing, Press};
 use crate::model::{short_of, Detail, Queue, Row, Snapshot};
 use crate::stream::Stream;
+use crate::text::{self, fit, pad, window, wrap};
+use ratatui::buffer::Buffer;
+use ratatui::crossterm::event::KeyEvent;
+use ratatui::layout::{Constraint, Layout, Position, Rect};
+use ratatui::text::{Line, Text};
+use ratatui::widgets::{List, ListItem, Paragraph, Widget};
 
 /// # The ratification queue is a third view and not a section of the first
 ///
@@ -102,6 +108,13 @@ pub struct App {
     /// The listing an open entity was opened from, so `b` goes back where the
     /// person came from rather than always to the entities.
     origin: View,
+    /// The one-line prompt, open, with what has been typed into it so far.
+    ///
+    /// `None` is the ordinary state and it is where every key is a command. The
+    /// prompt is what a verb carrying a message, a reason, a proof or a flag is
+    /// spelled into, and what a search is typed into; it is opened by a key,
+    /// dismissed by a key, and runs nothing until Enter.
+    prompt: Option<String>,
 }
 
 impl App {
@@ -121,6 +134,7 @@ impl App {
             stream,
             queue: None,
             origin: View::List,
+            prompt: None,
         }
     }
 
@@ -262,6 +276,52 @@ impl App {
     // Acting
     // -----------------------------------------------------------------------
 
+    /// One key press. `true` means the session is over.
+    ///
+    /// **Two regimes, and which one is in force is the prompt.** With it closed
+    /// every key is a command that moves the screen, and none of them can
+    /// write: `keys::typed` has no shape in which a bare key becomes an act,
+    /// and the test beside it holds that. With it open every key is a
+    /// character, an edit or one of the two ways out, and nothing runs until
+    /// Enter -- at which point the line goes through the grammar this reader
+    /// already had, which is where the six verbs are spelled whole and where
+    /// `accept` is refused off the document and refused with a tail.
+    ///
+    /// So there is exactly one road from a key press to a spawned verb, and it
+    /// passes through a line somebody typed. That is what TASK-d4a882345837
+    /// will put the confirmation on.
+    pub fn press(&mut self, key: KeyEvent, ank: &Ank) -> bool {
+        if let Some(line) = &mut self.prompt {
+            return match keys::edit(line, key) {
+                Editing::Typing => false,
+                Editing::Cancel => {
+                    self.prompt = None;
+                    false
+                }
+                Editing::Submit => {
+                    let line = self.prompt.take().unwrap_or_default();
+                    let command = crate::input::parse(&line, self.view);
+                    self.act(command, ank)
+                }
+            };
+        }
+        match keys::typed(key, self.view) {
+            Press::Run(command) => self.act(command, ank),
+            Press::Cycle => {
+                let next = keys::next_kind(self.kind.as_deref());
+                self.act(Command::Kind(next), ank)
+            }
+            Press::Prompt(seed) => {
+                self.prompt = Some(seed.to_string());
+                false
+            }
+            // A key this screen does not answer to leaves everything where it
+            // was, note included: an unmapped arrow is not a person getting a
+            // command wrong.
+            Press::Ignored => false,
+        }
+    }
+
     /// Runs one command. `true` means the session is over.
     pub fn act(&mut self, command: Command, ank: &Ank) -> bool {
         self.note = None;
@@ -347,9 +407,8 @@ impl App {
             }
             Command::Kind(kind) => {
                 if let Some(k) = &kind {
-                    let known = ["adr", "spec", "task", "log"];
-                    if !known.contains(&k.as_str()) {
-                        self.note = Some(format!("no kind '{k}': {}", known.join(", ")));
+                    if !keys::KINDS.contains(&k.as_str()) {
+                        self.note = Some(format!("no kind '{k}': {}", keys::KINDS.join(", ")));
                         return false;
                     }
                 }
@@ -465,29 +524,121 @@ impl App {
     // Drawing
     // -----------------------------------------------------------------------
 
-    pub fn frame(&self) -> String {
-        match self.view {
-            View::List | View::Queue => self.list_frame(),
-            View::Entity => self.entity_frame(),
+    /// One frame, onto a ratatui `Frame` (TASK-4fa385c1772d).
+    ///
+    /// The caret is set only where a prompt is open, which is what makes
+    /// ratatui show a cursor at all: on every other screen this reader has
+    /// nothing to point at, and a block sitting on an arbitrary row would be a
+    /// promise that something there can be typed into.
+    pub fn draw(&self, frame: &mut ratatui::Frame) {
+        let area = frame.area();
+        self.render(area, frame.buffer_mut());
+        if let Some(at) = self.caret(area) {
+            frame.set_cursor_position(at);
         }
+    }
+
+    /// The same frame, into any buffer.
+    ///
+    /// **Separate from [`App::draw`] so that a test can have the frame without
+    /// owning a terminal.** Every assertion this crate makes about what is on
+    /// the screen goes through here, into a `Buffer` the size of a stated
+    /// window -- which is what the renderer wrote before ratatui and is the one
+    /// property of it worth keeping. What changed is that the buffer is now the
+    /// same type the terminal is painted from, so what a test reads is what a
+    /// person sees rather than a second rendering of the same state.
+    pub fn render(&self, area: Rect, buf: &mut Buffer) {
+        if area.is_empty() {
+            return;
+        }
+        match self.view {
+            View::List | View::Queue => self.render_list(area, buf),
+            View::Entity => self.render_entity(area, buf),
+        }
+    }
+
+    /// The frame as text, row by row, for a test to read.
+    pub fn frame(&self) -> String {
+        let area = self.area();
+        let mut buf = Buffer::empty(area);
+        self.render(area, &mut buf);
+        rows_of(&buf)
+    }
+
+    /// The window this reader believes it has.
+    ///
+    /// Held rather than measured, and updated by [`App::resize`] and by the
+    /// loop before every paint. Paging is answered while a key is being
+    /// handled, before any frame exists, so the arithmetic needs a window then
+    /// -- and a window read from one place and drawn into another would be two
+    /// numbers that can disagree.
+    fn area(&self) -> Rect {
+        Rect::new(0, 0, self.size.0 as u16, self.size.1 as u16)
+    }
+
+    /// The terminal was made narrower, wider, taller or shorter.
+    ///
+    /// Nothing is read and nothing is spawned: a resize is a fact about the
+    /// window and never about the corpus, so what it costs is one frame drawn
+    /// again at the new size (ADR-0bb7ea8991bc -- a screen being dragged about
+    /// renews nothing).
+    pub fn resize(&mut self, columns: u16, rows: u16) {
+        let size = (columns as usize, rows as usize);
+        // The loop reads the window before every paint, so this is asked far
+        // more often than the window moves. Answering the unchanged case here
+        // is what keeps a keystroke from re-wrapping a body that did not move.
+        if size == self.size {
+            return;
+        }
+        self.size = size;
+        // A shorter window is a smaller page, so the cursor can fall off the
+        // bottom of a listing that was fine a moment ago, and a body can be
+        // scrolled past its own end.
+        self.clamp();
+        let lines = self.pane_lines().len();
+        self.offset = self.offset.min(lines.saturating_sub(1));
     }
 
     fn width(&self) -> usize {
         self.size.0
     }
 
+    /// Where the caret goes, which is the end of the prompt or nowhere.
+    fn caret(&self, area: Rect) -> Option<Position> {
+        let line = self.prompt.as_ref()?;
+        let note = match self.view {
+            View::List | View::Queue => self.list_panes(area).note,
+            View::Entity => self.entity_panes(area).note,
+        };
+        let at = PROMPT.chars().count() + line.chars().count();
+        Some(Position::new(
+            note.x + (at as u16).min(note.width.saturating_sub(1)),
+            note.y,
+        ))
+    }
+
     /// The note, as the rows it costs.
     ///
     /// A note used to be one line, and an act's answer is not: a document has a
     /// field per line and a refusal has its sentence and the command that
-    /// resolves it. So the note is measured rather than assumed, and both frames
-    /// pay for what it actually is.
+    /// resolves it. So the note is measured rather than assumed, and both
+    /// layouts pay for what it actually is.
+    ///
+    /// **An open prompt is drawn here and hides whatever the note was saying.**
+    /// One row of the screen belongs to whatever the reader is being told or
+    /// asked, and a person typing `done commit:<sha>` needs to see the line
+    /// they are typing far more than the answer to the command before it. What
+    /// was there comes back when the prompt is dismissed, because cancelling
+    /// runs nothing and nothing clears it.
     ///
     /// Always at least one row, empty where there is nothing to say: the blank
     /// line above the key line is what keeps the trailer from moving under a
     /// reader every time a command has something to report.
     fn note_lines(&self) -> Vec<String> {
         let width = self.width();
+        if let Some(line) = &self.prompt {
+            return vec![fit(&format!("{PROMPT}{line}"), width)];
+        }
         match &self.note {
             None => vec![String::new()],
             Some(note) => note
@@ -498,15 +649,42 @@ impl App {
         }
     }
 
-    /// The rows the list has room for, once the header, the standing section
-    /// and the trailer are paid for.
-    fn list_page(&self) -> usize {
+    /// The bands of a listing, as ratatui's solver divides the window.
+    ///
+    /// **The arithmetic is the layout's and the layout is asked twice.** It is
+    /// asked here, at paint time, for where to put each widget; and it is asked
+    /// by [`App::list_page`], while a key is being answered, for how many rows
+    /// a page is. One function for both is what keeps the heading -- `41-60 of
+    /// 1275` -- agreeing with the rows underneath it, which two independent
+    /// counts would not.
+    fn list_panes(&self, area: Rect) -> Panes {
         // At least one: an empty section still costs the line that says so.
-        let standing = self.standing_lines().len().max(1);
-        // 2 header, 1 rule, 1 section heading, the section, 1 blank, 1 list
-        // heading, 1 blank, the note, 2 key lines.
-        let fixed = 2 + 1 + 1 + standing + 1 + 1 + 1 + self.note_lines().len() + 2;
-        self.size.1.saturating_sub(fixed).max(1)
+        let standing = 1 + self.standing_lines().len().max(1);
+        let [header, block, _, heading, rows, _, note, keys] = Layout::vertical([
+            // Two lines and the rule under them.
+            Constraint::Length(3),
+            Constraint::Length(standing as u16),
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Min(1),
+            Constraint::Length(1),
+            Constraint::Length(self.note_lines().len() as u16),
+            Constraint::Length(2),
+        ])
+        .areas(area);
+        Panes {
+            header,
+            block,
+            heading,
+            rows,
+            note,
+            keys,
+        }
+    }
+
+    /// The rows the list has room for.
+    fn list_page(&self) -> usize {
+        (self.list_panes(self.area()).rows.height as usize).max(1)
     }
 
     /// The block between the rule and the rows: who holds what on the
@@ -514,7 +692,7 @@ impl App {
     ///
     /// Two answers in one place because they are the same kind of thing -- a
     /// standing fact about the corpus that the rows below are read against --
-    /// and because the arithmetic above has one section to pay for either way.
+    /// and because the layout above has one band to pay for either way.
     fn standing_lines(&self) -> Vec<String> {
         match self.view {
             View::Queue => self.signer_lines(),
@@ -566,7 +744,7 @@ impl App {
         let mut out: Vec<String> = snapshot.claims[..room]
             .iter()
             .map(|c| {
-                let marker = if c.mine { frame::HELD } else { frame::PLAIN };
+                let marker = if c.mine { text::HELD } else { text::PLAIN };
                 let title = snapshot
                     .row(&c.id)
                     .map(|r| r.title.clone())
@@ -588,56 +766,65 @@ impl App {
         out
     }
 
-    fn list_frame(&self) -> String {
+    fn render_list(&self, area: Rect, buf: &mut Buffer) {
         let width = self.width();
-        let mut lines: Vec<String> = Vec::new();
         let Some(snapshot) = &self.snapshot else {
-            lines.push("ank tui".to_string());
-            lines.push(String::new());
-            lines.push(
+            // Nothing has been read yet, or the first read refused. There are
+            // no bands to divide: what the screen owes is the sentence and the
+            // way out.
+            let mut lines = vec![
+                "ank tui".to_string(),
+                String::new(),
                 self.note
                     .clone()
                     .unwrap_or_else(|| "the corpus has not been read".to_string()),
-            );
-            lines.push(KEYS.to_string());
-            lines.push(ACT_KEYS.to_string());
-            return lines.join("\n") + "\n";
+                String::new(),
+                KEYS.to_string(),
+                ACT_KEYS.to_string(),
+            ];
+            lines.iter_mut().for_each(|l| *l = fit(l, width));
+            paragraph(&lines).render(area, buf);
+            return;
         };
+        let panes = self.list_panes(area);
 
-        lines.push(fit(
-            &format!(
-                "ank tui   corpus {}   branch {} (default {})",
-                &snapshot.corpus[..12.min(snapshot.corpus.len())],
-                snapshot.branch,
-                snapshot.default_branch
+        paragraph(&[
+            fit(
+                &format!(
+                    "ank tui   corpus {}   branch {} (default {})",
+                    &snapshot.corpus[..12.min(snapshot.corpus.len())],
+                    snapshot.branch,
+                    snapshot.default_branch
+                ),
+                width,
             ),
-            width,
-        ));
-        lines.push(fit(
-            &format!(
-                "identity {}   {} claim(s) live   {}",
-                snapshot.identity,
-                snapshot.claims.len(),
-                self.route()
+            fit(
+                &format!(
+                    "identity {}   {} claim(s) live   {}",
+                    snapshot.identity,
+                    snapshot.claims.len(),
+                    self.route()
+                ),
+                width,
             ),
-            width,
-        ));
-        lines.push(frame::rule(width));
+            text::rule(width),
+        ])
+        .render(panes.header, buf);
 
         let (heading, empty) = self.standing_heading();
-        lines.push(heading);
         let standing = self.standing_lines();
+        let mut block = vec![heading];
         if standing.is_empty() {
-            lines.push(fit(empty, width));
+            block.push(fit(empty, width));
         } else {
-            lines.extend(standing);
+            block.extend(standing);
         }
-        lines.push(String::new());
+        paragraph(&block).render(panes.block, buf);
 
         let rows = self.rows();
-        let page = self.list_page();
+        let page = panes.rows.height as usize;
         let shown = page.min(rows.len().saturating_sub(self.top));
-        lines.push(fit(
+        paragraph(&[fit(
             &match self.view {
                 // The queue is answered whole: `review` carries no attention
                 // budget, so there is no "of N in the corpus" to state and
@@ -655,29 +842,15 @@ impl App {
                 ),
             },
             width,
-        ));
-        for (i, row) in rows.iter().skip(self.top).take(page).enumerate() {
-            let at = self.top + i;
-            let marker = if at == self.cursor {
-                frame::CURSOR
-            } else {
-                frame::PLAIN
-            };
-            let held = snapshot.claim_on(&row.id).is_some();
-            lines.push(fit(
-                &format!(
-                    "{marker}{:>5}  {}  {}  {}{}",
-                    at + 1,
-                    pad(&row.short(), 10),
-                    pad(&row.status, 12),
-                    row.title,
-                    if held { "  [held]" } else { "" }
-                ),
-                width,
-            ));
-        }
-        if rows.is_empty() {
-            lines.push(
+        )])
+        .render(panes.heading, buf);
+
+        // A `List` and not a paragraph, because these rows are a list: what is
+        // handed to it is exactly the window the heading above announced, so
+        // the widget scrolls nothing and there is no second offset to disagree
+        // with `self.top`.
+        let items: Vec<ListItem> = if rows.is_empty() {
+            vec![ListItem::new(
                 match (self.view, self.kind.is_some() || self.search.is_some()) {
                     // Said even where there is nothing to say, on `review`'s own
                     // reasoning: an empty queue and an unprinted queue read
@@ -687,24 +860,53 @@ impl App {
                     (View::Queue, true) => "  nothing in the queue matches this filter".to_string(),
                     _ => "  no entity matches this filter".to_string(),
                 },
-            );
-        }
+            )]
+        } else {
+            rows.iter()
+                .skip(self.top)
+                .take(page)
+                .enumerate()
+                .map(|(i, row)| {
+                    let at = self.top + i;
+                    let marker = if at == self.cursor {
+                        text::CURSOR
+                    } else {
+                        text::PLAIN
+                    };
+                    let held = snapshot.claim_on(&row.id).is_some();
+                    ListItem::new(fit(
+                        &format!(
+                            "{marker}{:>5}  {}  {}  {}{}",
+                            at + 1,
+                            pad(&row.short(), 10),
+                            pad(&row.status, 12),
+                            row.title,
+                            if held { "  [held]" } else { "" }
+                        ),
+                        width,
+                    ))
+                })
+                .collect()
+        };
+        List::new(items).render(panes.rows, buf);
 
-        lines.push(String::new());
-        lines.extend(self.note_lines());
-        lines.push(fit(KEYS, width));
-        lines.push(fit(
-            match self.view {
-                // `accept` is deliberately not offered here, and neither are the
-                // five: a ratification is typed on the document, and a trailer
-                // that offered one at a row would be making an offer the
-                // grammar turns down (TASK-84cfad83c308's rule, on this screen).
-                View::Queue => QUEUE_ACT,
-                _ => ACT_KEYS,
-            },
-            width,
-        ));
-        lines.join("\n") + "\n"
+        paragraph(&self.note_lines()).render(panes.note, buf);
+        paragraph(&[
+            fit(KEYS, width),
+            fit(
+                match self.view {
+                    // `accept` is deliberately not offered here, and neither are
+                    // the five: a ratification is typed on the document, and a
+                    // trailer that offered one at a row would be making an offer
+                    // the grammar turns down (TASK-84cfad83c308's rule, on this
+                    // screen).
+                    View::Queue => QUEUE_ACT,
+                    _ => ACT_KEYS,
+                },
+                width,
+            ),
+        ])
+        .render(panes.keys, buf);
     }
 
     /// How this screen is being kept current, in the two words a person needs.
@@ -752,7 +954,9 @@ impl App {
             // criterion asks for. A window smaller than the body is answered in
             // both directions -- paged down it, and wrapped across it, so a
             // line wider than the terminal keeps its end instead of losing it
-            // to a `~`.
+            // to a `~`. The wrap is this crate's rather than `Paragraph`'s for
+            // the reason `text.rs` gives: a widget that wraps inside its own
+            // render reports no count, and the heading over it states one.
             Pane::Body => detail
                 .content
                 .lines()
@@ -762,19 +966,38 @@ impl App {
         }
     }
 
-    fn pane_page(&self) -> usize {
-        let notes = self.note_lines().len();
-        // 4 header, 1 rule, then what differs: the body pane carries the
-        // constraint heading, the summary under it, a blank and its own heading;
-        // the constraints pane carries one heading and a blank. Both end on a
-        // blank, the note, the two key lines, and the ratification line where
-        // this document is one that could take a signature.
+    /// The bands of a document, as ratatui's solver divides the window.
+    fn entity_panes(&self, area: Rect) -> Panes {
+        // The band above the pane carries what differs between the two: the
+        // body pane heads its own section with the constraints summarised over
+        // it, and the constraints pane heads one section and nothing else.
+        let over = match self.pane {
+            Pane::Body => 1 + self.constraint_summary().len() + 1 + 1,
+            Pane::Constraints => 1 + 1,
+        };
         let ratify = usize::from(self.ratify_line().is_some());
-        let fixed = match self.pane {
-            Pane::Body => 4 + 1 + 1 + self.constraint_summary().len() + 1 + 1 + 1 + notes + 2,
-            Pane::Constraints => 4 + 1 + 1 + 1 + 1 + notes + 2,
-        } + ratify;
-        self.size.1.saturating_sub(fixed).max(1)
+        let [header, block, rows, _, note, keys] = Layout::vertical([
+            // Four lines and the rule under them.
+            Constraint::Length(5),
+            Constraint::Length(over as u16),
+            Constraint::Min(1),
+            Constraint::Length(1),
+            Constraint::Length(self.note_lines().len() as u16),
+            Constraint::Length((2 + ratify) as u16),
+        ])
+        .areas(area);
+        Panes {
+            header,
+            block,
+            heading: block,
+            rows,
+            note,
+            keys,
+        }
+    }
+
+    fn pane_page(&self) -> usize {
+        (self.entity_panes(self.area()).rows.height as usize).max(1)
     }
 
     /// The offer to ratify, where this document is one that can be ratified.
@@ -823,99 +1046,144 @@ impl App {
         out
     }
 
-    fn entity_frame(&self) -> String {
+    fn render_entity(&self, area: Rect, buf: &mut Buffer) {
         let width = self.width();
         let Some(detail) = &self.detail else {
-            return self.list_frame();
+            return self.render_list(area, buf);
         };
         let row = self.snapshot.as_ref().and_then(|s| s.row(&detail.id));
-        let mut lines: Vec<String> = Vec::new();
+        let panes = self.entity_panes(area);
 
-        lines.push(fit(
-            &format!(
-                "{}   {}   {}",
-                short_of(&detail.id),
-                row.map(|r| r.kind.clone()).unwrap_or_default(),
-                row.map(|r| r.status.clone()).unwrap_or_default()
+        paragraph(&[
+            fit(
+                &format!(
+                    "{}   {}   {}",
+                    short_of(&detail.id),
+                    row.map(|r| r.kind.clone()).unwrap_or_default(),
+                    row.map(|r| r.status.clone()).unwrap_or_default()
+                ),
+                width,
             ),
-            width,
-        ));
-        lines.push(fit(
-            &row.map(|r| r.title.clone())
-                .unwrap_or_else(|| detail.id.clone()),
-            width,
-        ));
-        lines.push(fit(
-            detail.coordination.as_deref().unwrap_or("no claim on this"),
-            width,
-        ));
-        lines.push(fit(
-            &format!("scope {}", join_or(&detail.scopes, "declared on nothing")),
-            width,
-        ));
-        lines.push(frame::rule(width));
+            fit(
+                &row.map(|r| r.title.clone())
+                    .unwrap_or_else(|| detail.id.clone()),
+                width,
+            ),
+            fit(
+                detail.coordination.as_deref().unwrap_or("no claim on this"),
+                width,
+            ),
+            fit(
+                &format!("scope {}", join_or(&detail.scopes, "declared on nothing")),
+                width,
+            ),
+            text::rule(width),
+        ])
+        .render(panes.header, buf);
 
         let pane_lines = self.pane_lines();
-        let page = self.pane_page();
+        let page = panes.rows.height as usize;
+        let counted = window(
+            self.offset,
+            page.min(pane_lines.len().saturating_sub(self.offset)),
+            pane_lines.len(),
+        );
+        let mut over = Vec::new();
         if self.pane == Pane::Body {
-            lines.push(format!(
+            over.push(format!(
                 "CONSTRAINTS ({} active, {} over this scope)",
                 active(&detail.constraints),
                 detail.constraints.len()
             ));
-            lines.extend(self.constraint_summary());
-            lines.push(String::new());
+            over.extend(self.constraint_summary());
+            over.push(String::new());
             // Rows and not lines: a body line wider than the window is several
             // rows, and calling them lines would be a count that disagrees with
             // the file.
-            lines.push(fit(
-                &format!(
-                    "BODY   rows {}",
-                    window(
-                        self.offset,
-                        page.min(pane_lines.len().saturating_sub(self.offset)),
-                        pane_lines.len()
-                    )
-                ),
-                width,
-            ));
+            over.push(fit(&format!("BODY   rows {counted}"), width));
         } else {
-            lines.push(fit(
-                &format!(
-                    "CONSTRAINTS   {}",
-                    window(
-                        self.offset,
-                        page.min(pane_lines.len().saturating_sub(self.offset)),
-                        pane_lines.len()
-                    )
-                ),
-                width,
-            ));
-            lines.push(String::new());
+            over.push(fit(&format!("CONSTRAINTS   {counted}"), width));
+            over.push(String::new());
         }
-        for line in pane_lines.iter().skip(self.offset).take(page) {
-            lines.push(fit(line, width));
-        }
+        paragraph(&over).render(panes.block, buf);
 
-        lines.push(String::new());
+        let shown: Vec<String> = pane_lines
+            .iter()
+            .skip(self.offset)
+            .take(page)
+            .map(|line| fit(line, width))
+            .collect();
+        paragraph(&shown).render(panes.rows, buf);
+
         match &self.note {
-            Some(_) => lines.extend(self.note_lines()),
-            None => lines.push(fit(
+            Some(_) => paragraph(&self.note_lines()),
+            None if self.prompt.is_some() => paragraph(&self.note_lines()),
+            None => paragraph(&[fit(
                 &detail
                     .unresolved
                     .first()
                     .map(|u| format!("a scope could not be asked about -- {u}"))
                     .unwrap_or_default(),
                 width,
-            )),
+            )]),
         }
-        lines.push(fit(ENTITY_KEYS, width));
-        lines.push(fit(ACT_KEYS, width));
+        .render(panes.note, buf);
+
+        let mut keys = vec![fit(ENTITY_KEYS, width), fit(ACT_KEYS, width)];
         if let Some(ratify) = self.ratify_line() {
-            lines.push(fit(ratify, width));
+            keys.push(fit(ratify, width));
         }
-        lines.join("\n") + "\n"
+        paragraph(&keys).render(panes.keys, buf);
     }
+}
+
+/// The bands one view divides its window into.
+///
+/// One shape for both layouts, because the two are the same screen with
+/// different content in the bands: a header, a standing block, a heading, the
+/// rows that page, whatever the reader is being told, and the keys. A document
+/// heads its rows out of the same band it summarises the constraints in, so
+/// `heading` and `block` are one there rather than a band spent on nothing.
+struct Panes {
+    header: Rect,
+    block: Rect,
+    heading: Rect,
+    rows: Rect,
+    note: Rect,
+    keys: Rect,
+}
+
+/// Lines, as a widget that clips rather than wraps.
+///
+/// Everything reaching here has been through [`fit`] or [`wrap`] already, which
+/// is where a cut is decided and announced. `Paragraph`'s own wrapping is
+/// deliberately not turned on: it would silently turn one row into two and
+/// every count on the screen would then be a count of something else.
+fn paragraph(lines: &[String]) -> Paragraph<'static> {
+    Paragraph::new(Text::from(
+        lines
+            .iter()
+            .map(|l| Line::from(l.clone()))
+            .collect::<Vec<Line>>(),
+    ))
+}
+
+/// A buffer as text, one row per line, for a test to read.
+fn rows_of(buf: &Buffer) -> String {
+    let area = *buf.area();
+    (0..area.height)
+        .map(|y| {
+            let row: String = (0..area.width)
+                .map(|x| buf.cell((x, y)).map_or(" ", |c| c.symbol()))
+                .collect();
+            row.trim_end().to_string()
+        })
+        .collect::<Vec<String>>()
+        .join("\n")
+        // The window has as many rows as it has, and the last of them is a row
+        // even where it is blank: a count taken off this text has to be the
+        // count the terminal would give.
+        + "\n"
 }
 
 /// What a verb answered, as the screen carries it.
@@ -1014,9 +1282,16 @@ fn step(at: usize, by: isize, total: usize) -> usize {
     moved.clamp(0, last as isize) as usize
 }
 
+/// The marker the prompt is drawn behind.
+///
+/// What follows it is the line the grammar will be given, byte for byte,
+/// leading slash included: a person about to press Enter is looking at exactly
+/// what will be read.
+pub const PROMPT: &str = ": ";
 pub const KEYS: &str =
-    "j/k move  n/p page  <row> or <id> select  Enter open  f <kind>  /<text>  v queue  r reload  q quit";
-pub const ENTITY_KEYS: &str = "Enter/n/p page  g top  c constraints  r reload  b back  q quit";
+    "j/k move  n/p page  Enter open  f kind  / find  v queue  r reload  a act  ? keys  q quit";
+pub const ENTITY_KEYS: &str =
+    "n/p page  g top  c constraints  r reload  b back  a act  ? keys  q quit";
 /// What the queue offers instead of the writing half.
 ///
 /// It names the one road to a ratification and no verb at all, which is the
@@ -1031,7 +1306,7 @@ pub const QUEUE_ACT: &str =
 /// trailer should be able to see at a glance which of the two they are about to
 /// do, and one line mixing them would make that a matter of remembering.
 pub const ACT_KEYS: &str =
-    "claim  log <message>  release <reason>  done <proof>  amend <flags>   (the entity on screen)";
+    "a then  claim | log <message> | release <reason> | done <proof> | amend <flags>   (the entity on screen)";
 /// The sixth act, on a line of its own, and only where the verb would take it.
 ///
 /// A third line for a third kind of offer, on the reasoning [`ACT_KEYS`] gives
@@ -1040,12 +1315,13 @@ pub const ACT_KEYS: &str =
 /// somebody about to type it should know what they are being asked for and
 /// where it has to happen.
 pub const RATIFY_KEY: &str =
-    "accept   (this document, on the default branch -- ank signs nothing, your key does)";
+    "a then  accept   (this document, on the default branch -- ank signs nothing, your key does)";
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::model::Claim;
+    use ratatui::crossterm::event::{KeyCode, KeyModifiers};
 
     fn snapshot() -> Snapshot {
         Snapshot {
@@ -1093,21 +1369,21 @@ mod tests {
     fn the_list_says_which_route_is_keeping_it_current() {
         let mut a = app();
         assert!(
-            a.list_frame().contains("stream none, r to reload"),
+            a.frame().contains("stream none, r to reload"),
             "with no stream at all:\n{}",
-            a.list_frame()
+            a.frame()
         );
         a.stream = Some(Stream::stated(false));
         assert!(
-            a.list_frame().contains("stream none, r to reload"),
+            a.frame().contains("stream none, r to reload"),
             "a stream that is not there is not a stream:\n{}",
-            a.list_frame()
+            a.frame()
         );
         a.stream = Some(Stream::stated(true));
         assert!(
-            a.list_frame().contains("stream following"),
+            a.frame().contains("stream following"),
             "and one that is:\n{}",
-            a.list_frame()
+            a.frame()
         );
     }
 
@@ -1147,7 +1423,7 @@ mod tests {
 
     #[test]
     fn the_list_names_every_kind_with_its_status_and_who_holds_what() {
-        let f = app().list_frame();
+        let f = app().frame();
         for expected in [
             "ADR-8bd7",
             "TASK-4974",
@@ -1171,7 +1447,7 @@ mod tests {
     fn no_line_of_a_frame_overflows_the_window() {
         let mut a = App::new((40, 24), None);
         a.snapshot = Some(snapshot());
-        for line in a.list_frame().lines() {
+        for line in a.frame().lines() {
             assert!(
                 line.chars().count() <= 40,
                 "{} columns in a 40 column window: {line}",
@@ -1190,7 +1466,7 @@ mod tests {
             worktree: None,
         });
         a.act(Command::Kind(Some("adr".to_string())), &ank);
-        let f = a.list_frame();
+        let f = a.frame();
         assert!(f.contains("[kind adr]"), "{f}");
         // The rows and not the whole frame: the claims section names the held
         // task whatever the filter is, which is the point of that section.
@@ -1198,7 +1474,7 @@ mod tests {
 
         a.act(Command::Kind(None), &ank);
         a.act(Command::Search(Some("cli surface".to_string())), &ank);
-        let f = a.list_frame();
+        let f = a.frame();
         assert!(f.contains("matching 'cli surface'"), "{f}");
         assert_eq!(rendered_rows(&a), ["SPEC-fe8bdb84faca"], "{f}");
     }
@@ -1214,7 +1490,7 @@ mod tests {
         });
         a.act(Command::Kind(Some("epic".to_string())), &ank);
         assert!(a.kind.is_none(), "a kind that does not exist was applied");
-        assert!(a.list_frame().contains("no kind 'epic'"));
+        assert!(a.frame().contains("no kind 'epic'"));
     }
 
     #[test]
@@ -1252,7 +1528,7 @@ mod tests {
             "the rows join back to the body byte for byte"
         );
 
-        let first = a.entity_frame();
+        let first = a.frame();
         assert!(first.contains("line 1"), "{first}");
         assert!(first.contains("claimed by claude-code/opus-5+tui-verb"));
         assert!(first.contains("ADR-8bd7"), "the constraints are on screen");
@@ -1265,7 +1541,7 @@ mod tests {
             worktree: None,
         });
         a.act(Command::Page(1), &ank);
-        let second = a.entity_frame();
+        let second = a.frame();
         assert!(!second.contains("line 1\n"), "the page turned:\n{second}");
         assert!(a.offset > 0);
 
@@ -1274,7 +1550,7 @@ mod tests {
             a.act(Command::Page(1), &ank);
         }
         assert!(a.offset < 200, "the offset stayed inside the body");
-        assert!(a.entity_frame().contains("line 200"));
+        assert!(a.frame().contains("line 200"));
 
         a.act(Command::Top, &ank);
         assert_eq!(a.offset, 0);
@@ -1307,7 +1583,7 @@ mod tests {
             unresolved: Vec::new(),
         });
         a.view = View::Entity;
-        let f = a.entity_frame();
+        let f = a.frame();
         assert!(
             f.contains("CONSTRAINTS (1 active, 2 over this scope)"),
             "{f}"
@@ -1337,7 +1613,7 @@ mod tests {
             unresolved: Vec::new(),
         });
         a.view = View::Entity;
-        assert!(a.entity_frame().contains("+26 more, c for the list"));
+        assert!(a.frame().contains("+26 more, c for the list"));
 
         let ank = Ank::new(crate::Address {
             exe: "/nonexistent/ank".into(),
@@ -1347,7 +1623,7 @@ mod tests {
         });
         a.act(Command::Constraints, &ank);
         assert_eq!(a.pane_lines().len(), 30);
-        assert!(a.entity_frame().contains("CONSTRAINTS   1-"));
+        assert!(a.frame().contains("CONSTRAINTS   1-"));
     }
 
     #[test]
@@ -1362,7 +1638,7 @@ mod tests {
             worktree: None,
         });
         assert!(!a.act(Command::Open, &ank), "a failure is not a quit");
-        let f = a.list_frame();
+        let f = a.frame();
         assert!(f.contains("cannot run `ank"), "{f}");
         assert!(f.contains("ADR-8bd7"), "the rows are still there:\n{f}");
     }
@@ -1496,7 +1772,7 @@ mod tests {
             }
             .to_string(),
         );
-        let f = a.list_frame();
+        let f = a.frame();
         assert!(f.contains("error[5]:"), "the code the table declares:\n{f}");
         assert!(
             f.contains("-> ank done TASK-4974 --proof commit:<sha>"),
@@ -1514,7 +1790,7 @@ mod tests {
                 let mut a = App::new(size, None);
                 a.snapshot = Some(snapshot());
                 a.note = note.clone();
-                let rows = a.list_frame().lines().count();
+                let rows = a.frame().lines().count();
                 assert!(rows <= size.1, "the list frame is {rows} rows in {size:?}");
 
                 a.detail = Some(detail(
@@ -1524,7 +1800,7 @@ mod tests {
                 a.view = View::Entity;
                 for pane in [Pane::Body, Pane::Constraints] {
                     a.pane = pane;
-                    let rows = a.entity_frame().lines().count();
+                    let rows = a.frame().lines().count();
                     assert!(
                         rows <= size.1,
                         "the {pane:?} pane is {rows} rows in {size:?}"
@@ -1560,7 +1836,7 @@ mod tests {
         let mut a = app();
         a.queue = Some(queued());
         a.view = View::Queue;
-        let f = a.list_frame();
+        let f = a.frame();
         for expected in [
             "QUEUE",
             "ADR-0000",
@@ -1584,7 +1860,7 @@ mod tests {
         let mut a = app();
         a.queue = Some(Queue::default());
         a.view = View::Queue;
-        let f = a.list_frame();
+        let f = a.frame();
         assert!(f.contains("nothing proposed for ratification"), "{f}");
         assert!(
             f.contains("permissions are advisory"),
@@ -1651,7 +1927,7 @@ mod tests {
             ("TASK-49746735127f", false),
         ] {
             a.detail = Some(detail(id, "body\n"));
-            let f = a.entity_frame();
+            let f = a.frame();
             assert_eq!(
                 f.contains("accept   (this document"),
                 offered,
@@ -1724,6 +2000,206 @@ mod tests {
         });
         a.act(Command::Row(99), &ank);
         assert_eq!(a.cursor, 0);
-        assert!(a.list_frame().contains("there is no row 99"));
+        assert!(a.frame().contains("there is no row 99"));
+    }
+
+    // -----------------------------------------------------------------------
+    // The keystroke engine (TASK-4fa385c1772d)
+    // -----------------------------------------------------------------------
+
+    fn stroke(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    fn tap(a: &mut App, ank: &Ank, code: KeyCode) -> bool {
+        a.press(stroke(code), ank)
+    }
+
+    fn type_in(a: &mut App, ank: &Ank, line: &str) {
+        for c in line.chars() {
+            tap(a, ank, KeyCode::Char(c));
+        }
+    }
+
+    /// One key per command, on the screen rather than in the mapping: the
+    /// cursor moves, the filter narrows, the queue opens, and none of it went
+    /// through a line.
+    #[test]
+    fn a_key_moves_the_screen_and_no_line_is_typed_to_do_it() {
+        let mut a = app();
+        let ank = nowhere();
+        assert!(!tap(&mut a, &ank, KeyCode::Char('j')));
+        assert_eq!(
+            a.selected().map(|r| r.id.clone()).as_deref(),
+            Some("TASK-49746735127f"),
+            "j moved the cursor"
+        );
+        assert!(!tap(&mut a, &ank, KeyCode::Up));
+        assert_eq!(
+            a.selected().map(|r| r.id.clone()).as_deref(),
+            Some("ADR-8bd76e8d7c4e"),
+            "and the arrow moves it back"
+        );
+        // `f` walks the registry, one kind per press, and the frame says which.
+        tap(&mut a, &ank, KeyCode::Char('f'));
+        assert!(a.frame().contains("[kind adr]"), "{}", a.frame());
+        tap(&mut a, &ank, KeyCode::Char('f'));
+        assert!(a.frame().contains("[kind spec]"), "{}", a.frame());
+        for _ in 0..3 {
+            tap(&mut a, &ank, KeyCode::Char('f'));
+        }
+        assert!(a.kind.is_none(), "and back to every kind");
+        assert!(tap(&mut a, &ank, KeyCode::Char('q')), "q ends the session");
+    }
+
+    /// The prompt is the only road from a key press to a verb that writes.
+    ///
+    /// **The negative half is the one that matters**, and it is the property the
+    /// line discipline used to give for free: every key of the alphabet is
+    /// pressed, in every view, and not one of them spawns any of the six. What
+    /// the loose keys after `a` do is fill a prompt, which runs nothing until
+    /// Enter -- and the Enter here submits a line the grammar does not know, so
+    /// still nothing is spawned.
+    #[test]
+    fn no_key_reaches_a_verb_that_writes_and_the_prompt_does() {
+        for view in [View::List, View::Queue, View::Entity] {
+            let mut a = app();
+            let ank = nowhere();
+            a.queue = Some(queued());
+            a.detail = Some(detail("SPEC-fe8bdb84faca", "body\n"));
+            a.view = view;
+            let mut said = String::new();
+            for c in 'a'..='z' {
+                tap(&mut a, &ank, KeyCode::Char(c));
+                tap(&mut a, &ank, KeyCode::Enter);
+                said.push_str(&a.note.clone().unwrap_or_default());
+            }
+            for verb in crate::ank::ACTS {
+                assert!(
+                    !said.contains(&format!("ank {verb} ")),
+                    "{view:?}: a bare key ran {verb}:\n{said}"
+                );
+            }
+        }
+
+        // And the road that does exist: `a`, the word, Enter.
+        let mut a = app();
+        let ank = nowhere();
+        tap(&mut a, &ank, KeyCode::Char(keys::ACT));
+        assert_eq!(a.prompt.as_deref(), Some(""), "the prompt opened");
+        type_in(&mut a, &ank, "claim");
+        assert!(
+            a.frame().contains(": claim"),
+            "the line is on the screen as it is typed:\n{}",
+            a.frame()
+        );
+        assert!(a.note.is_none(), "and nothing has run yet");
+        tap(&mut a, &ank, KeyCode::Enter);
+        assert!(a.prompt.is_none(), "the prompt closed");
+        let said = a.note.clone().unwrap_or_default();
+        assert!(said.contains("ank claim ADR-8bd76e8d7c4e --json"), "{said}");
+    }
+
+    /// A prompt dismissed runs nothing, whichever of the two ways out was taken.
+    #[test]
+    fn a_prompt_dismissed_runs_nothing() {
+        for out in [KeyCode::Esc, KeyCode::Backspace] {
+            let mut a = app();
+            let ank = nowhere();
+            tap(&mut a, &ank, KeyCode::Char(keys::ACT));
+            type_in(&mut a, &ank, "done");
+            // Backspace has to empty the line before it closes the prompt, which
+            // is what makes it a way out rather than an edit.
+            for _ in 0..5 {
+                tap(&mut a, &ank, out);
+            }
+            assert!(a.prompt.is_none(), "{out:?} left the prompt open");
+            assert_eq!(a.note, None, "{out:?} ran something");
+        }
+    }
+
+    /// `/` opens the same prompt on the grammar's search, seed and all.
+    #[test]
+    fn the_find_key_opens_the_prompt_on_a_search() {
+        let mut a = app();
+        let ank = nowhere();
+        tap(&mut a, &ank, KeyCode::Char(keys::FIND));
+        assert_eq!(a.prompt.as_deref(), Some("/"), "the slash is the line");
+        type_in(&mut a, &ank, "cli surface");
+        tap(&mut a, &ank, KeyCode::Enter);
+        assert_eq!(rendered_rows(&a), ["SPEC-fe8bdb84faca"]);
+        assert!(
+            a.frame().contains("matching 'cli surface'"),
+            "{}",
+            a.frame()
+        );
+    }
+
+    /// A narrower window reflows and keeps the cursor on the page.
+    ///
+    /// The second half is what a resize can silently break: a shorter terminal
+    /// is a shorter page, and a cursor left where it was would be a row the
+    /// screen no longer draws -- so the next `j` would move something nobody
+    /// can see.
+    #[test]
+    fn a_narrower_window_reflows_and_the_cursor_stays_on_the_page() {
+        let many: Vec<Row> = (1..=60)
+            .map(|n| {
+                row(
+                    &format!("TASK-{n:04}0000000f"),
+                    "task",
+                    "open",
+                    "A row with a title long enough that a narrow window has to cut it",
+                )
+            })
+            .collect();
+        let mut a = App::new((160, 50), None);
+        a.snapshot = Some(Snapshot {
+            entities: many,
+            ..snapshot()
+        });
+        let ank = nowhere();
+        for _ in 0..40 {
+            tap(&mut a, &ank, KeyCode::Char('j'));
+        }
+        assert_eq!(a.cursor, 40);
+        assert!(
+            a.frame().lines().any(|l| l.starts_with("> ")),
+            "the cursor is on the page it was moved to"
+        );
+
+        a.resize(50, 16);
+        let narrow = a.frame();
+        assert_eq!(narrow.lines().count(), 16);
+        for line in narrow.lines() {
+            assert!(line.chars().count() <= 50, "{line}");
+        }
+        assert!(
+            narrow.lines().any(|l| l.starts_with("> ")),
+            "the cursor fell off the page a resize made shorter:\n{narrow}"
+        );
+        assert!(
+            narrow.contains('~'),
+            "a title too wide for the window is cut, and the cut is announced:\n{narrow}"
+        );
+        // Wide again, and the title is whole: nothing was lost, only fitted.
+        a.resize(160, 50);
+        assert!(a.frame().contains("has to cut it"), "{}", a.frame());
+    }
+
+    /// A resize reads nothing and spawns nothing.
+    ///
+    /// The instrument is the same one every other test here uses: the binary is
+    /// not there, so any call at all leaves `cannot run` behind. A resize that
+    /// asked the corpus anything would be a window drag renewing a lease.
+    #[test]
+    fn a_resize_asks_the_corpus_nothing() {
+        let mut a = app();
+        a.detail = Some(detail("TASK-49746735127f", "body\n"));
+        a.view = View::Entity;
+        for size in [(60, 20), (200, 80), (30, 12)] {
+            a.resize(size.0, size.1);
+            assert_eq!(a.note, None, "a resize at {size:?} ran a verb");
+        }
     }
 }

--- a/crates/ank-tui/tests/dependencies.rs
+++ b/crates/ank-tui/tests/dependencies.rs
@@ -13,65 +13,129 @@
 //! crate links, and the crate's own sources answer what it reaches for -- and
 //! either one going wrong fails here rather than surviving review.
 
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
-/// The dependency graph of this crate, as cargo resolves it.
+/// The dependency graph of this crate, as the lockfile records it: every
+/// package reachable from `ank-tui`, and the lockfile itself for the message.
 ///
-/// `--target all` on purpose: a dependency that only appears on one platform is
-/// still a dependency, and a graph read for the host alone would have called
-/// this crate clean while a `git2` sat behind a `cfg(windows)`.
+/// **Read out of `Cargo.lock` and not out of `cargo tree`, and the reason is
+/// worth stating.** This used to run `cargo tree --target all --offline`, on
+/// the argument that a dependency behind a `cfg(windows)` is still a
+/// dependency and a host-only graph would have called this crate clean while a
+/// `git2` sat behind one. That argument is right and this keeps it. What
+/// stopped working is the instrument: `--target all` needs the manifest of
+/// every package on every target, `--offline` forbids fetching one, and a host
+/// build downloads only what it compiles. Before ratatui the two happened to
+/// agree; ratatui's graph reaches `bumpalo` through a `wasm32`-only edge of
+/// `time`, nothing on a CI runner ever downloads it, and the test went red
+/// asking for the network it is forbidden to use.
 ///
-/// `--offline` because a test must not reach the network. The lockfile is
-/// complete by the time anything is compiled, so there is nothing to fetch.
-fn tree() -> String {
-    let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
-    let out = Command::new(cargo)
-        .args([
-            "tree",
-            "-p",
-            "ank-tui",
-            "--edges",
-            "normal",
-            "--target",
-            "all",
-            "--offline",
-            "--prefix",
-            "none",
-        ])
-        .current_dir(manifest())
-        .output()
-        .expect("cargo must be runnable: it is what built this test");
-    assert!(
-        out.status.success(),
-        "cargo tree failed, and a graph that cannot be read is not a graph that \
-         is clean: {}",
-        String::from_utf8_lossy(&out.stderr)
-    );
-    String::from_utf8_lossy(&out.stdout).to_string()
+/// The lockfile answers the same question without asking anything: it records
+/// the resolution for every target and every optional dependency, checked in,
+/// which is *broader* than `--target all` rather than narrower. For a rule that
+/// says a name must not appear, broader is the safe direction -- a package that
+/// is locked and never compiled still fails this, and the comment below says
+/// why that is the outcome to want.
+fn graph() -> (String, Vec<String>) {
+    let text = std::fs::read_to_string(lockfile()).expect("the workspace has a lockfile");
+    let mut edges: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for block in text.split("[[package]]").skip(1) {
+        let Some(name) = field(block, "name") else {
+            continue;
+        };
+        edges.entry(name).or_default().extend(dependencies(block));
+    }
+    // Every package reachable from this crate, which is what "in ank-tui's
+    // graph" means: a crate the workspace carries for `ank-cli` alone is not
+    // this crate's business.
+    let mut seen: BTreeSet<String> = BTreeSet::new();
+    let mut walking = vec!["ank-tui".to_string()];
+    while let Some(name) = walking.pop() {
+        if !seen.insert(name.clone()) {
+            continue;
+        }
+        if let Some(deps) = edges.get(&name) {
+            walking.extend(deps.iter().cloned());
+        }
+    }
+    (text, seen.into_iter().collect())
+}
+
+fn lockfile() -> PathBuf {
+    manifest()
+        .parent()
+        .and_then(|crates| crates.parent())
+        .expect("the crate sits two directories under the workspace root")
+        .join("Cargo.lock")
+}
+
+/// One `key = "value"` of a lockfile block.
+fn field(block: &str, key: &str) -> Option<String> {
+    block
+        .lines()
+        .find_map(|line| line.strip_prefix(&format!("{key} = \"")))
+        .and_then(|rest| rest.strip_suffix('"'))
+        .map(|value| value.to_string())
+}
+
+/// The names in a block's `dependencies` list.
+///
+/// An entry is `"name"`, or `"name version"` where the lockfile carries two
+/// versions of one package. The version is dropped: what every assertion here
+/// asks about is which crates are in the graph, never which release of one.
+fn dependencies(block: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut inside = false;
+    for line in block.lines() {
+        if line.starts_with("dependencies = [") {
+            inside = true;
+            continue;
+        }
+        if !inside {
+            continue;
+        }
+        if line.starts_with(']') {
+            break;
+        }
+        if let Some(entry) = line.trim().trim_end_matches(',').strip_prefix('"') {
+            if let Some(entry) = entry.strip_suffix('"') {
+                out.push(
+                    entry
+                        .split_whitespace()
+                        .next()
+                        .unwrap_or_default()
+                        .to_string(),
+                );
+            }
+        }
+    }
+    out
 }
 
 fn manifest() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
 }
 
-/// The crate names the graph carries, one per line, without their versions.
-fn crates_of(tree: &str) -> Vec<String> {
-    tree.lines()
-        .filter_map(|line| line.split_whitespace().next())
-        .filter(|name| !name.is_empty())
-        .map(|name| name.to_string())
-        .collect()
-}
-
 #[test]
 fn the_graph_carries_neither_ank_core_nor_git() {
-    let tree = tree();
-    let names = crates_of(&tree);
+    let (tree, names) = graph();
+    // The walk starts at this crate by name, so a rename that lost it would
+    // leave an empty graph and every assertion below would pass on nothing.
     assert!(
         names.iter().any(|n| n == "ank-tui"),
-        "the graph is not this crate's:\n{tree}"
+        "the lockfile carries no ank-tui, so this graph is nobody's"
     );
+    // And the walk reaches what the manifest declares. Without this the two
+    // assertions below would pass on a graph that lost its edges: "ank-core is
+    // not in it" is worth nothing when nothing is in it.
+    for declared in ["ank-contract", "crossterm", "ratatui", "serde_yaml"] {
+        assert!(
+            names.iter().any(|n| n == declared),
+            "the walk did not reach {declared}, which the manifest declares: \
+             the lockfile was not read as a graph"
+        );
+    }
     assert!(
         !names.iter().any(|n| n == "ank-core"),
         "ank-tui links ank-core, and ADR-8bd76e8d7c4e forbids it: the reader \
@@ -102,7 +166,7 @@ fn the_graph_carries_neither_ank_core_nor_git() {
 /// and nothing this crate chose.
 #[test]
 fn the_crate_takes_nothing_the_tree_did_not_already_carry() {
-    let tree = tree();
+    let (tree, _) = graph();
     let mut direct: Vec<String> = std::fs::read_to_string(manifest().join("Cargo.toml"))
         .expect("this crate has a manifest")
         .lines()

--- a/crates/ank-tui/tests/dependencies.rs
+++ b/crates/ank-tui/tests/dependencies.rs
@@ -1,11 +1,13 @@
-//! The constraint made mechanical (ADR-8bd76e8d7c4e, TASK-49746735127f).
+//! The constraint made mechanical (ADR-8bd76e8d7c4e, ADR-0b55983421dd).
 //!
 //! ADR-8bd76e8d7c4e forbids the terminal reader from linking `ank-core`, from
 //! reading `.ank/` and from touching `refs/ank/*`, so that the refusals it shows
 //! are the refusals the CLI gave and there is no second dispatch path to keep in
-//! step. A rule that lives only in prose is a rule the second contributor breaks
-//! for a good reason, on a Tuesday, in a commit whose message explains why it is
-//! fine.
+//! step. ADR-0b55983421dd adds one of the same kind on the other side: the
+//! reader is drawn with ratatui over crossterm, and **no FFI enters this tree
+//! for any of it, on any platform**. A rule that lives only in prose is a rule
+//! the second contributor breaks for a good reason, on a Tuesday, in a commit
+//! whose message explains why it is fine.
 //!
 //! So the rule is read back out of the build. `cargo tree` answers what this
 //! crate links, and the crate's own sources answer what it reaches for -- and
@@ -95,8 +97,9 @@ fn the_graph_carries_neither_ank_core_nor_git() {
 /// The list is the manifest's argument written as an assertion. `ank-contract`
 /// is the machine contract every surface consumes (ADR-6fd69efb629c);
 /// `serde_yaml` is already in the tree four times over and is what reads the
-/// CLI's `--json`; the rest is what those two bring with them and nothing this
-/// crate chose.
+/// CLI's `--json`; `ratatui` and `crossterm` are what ADR-0b55983421dd spends
+/// and the whole of what it spends; the rest is what those four bring with them
+/// and nothing this crate chose.
 #[test]
 fn the_crate_takes_nothing_the_tree_did_not_already_carry() {
     let tree = tree();
@@ -112,11 +115,46 @@ fn the_crate_takes_nothing_the_tree_did_not_already_carry() {
     direct.sort();
     assert_eq!(
         direct,
-        ["ank-contract", "serde_yaml"],
+        ["ank-contract", "crossterm", "ratatui", "serde_yaml"],
         "a dependency arrived. It may well be the right call -- and the \
          argument for it belongs in the manifest beside the two that are \
          there, and in this list.\n{tree}"
     );
+}
+
+/// No `extern` block, on any platform (ADR-0b55983421dd).
+///
+/// **This is the assertion the whole decision rests on.** What sent the reader
+/// to a line discipline in the first place was that raw mode is `tcsetattr` on
+/// Unix and `SetConsoleMode` on Windows, each behind an `extern` this workspace
+/// does not otherwise have, and that only one of the two could be run from
+/// where the code was written. Taking crossterm is worth what it costs
+/// precisely because it answers that on all three platforms without this crate
+/// declaring a single foreign symbol -- so if one ever arrives, the trade this
+/// decision made has quietly stopped being the trade that was made.
+///
+/// Read off the sources with their prose removed, like the check below it: this
+/// file and the module headers have to be able to say the word.
+#[test]
+fn no_foreign_symbol_is_declared_in_this_tree() {
+    for (file, source) in sources() {
+        let text = code_of(&source);
+        for forbidden in ["extern \"C\"", "extern \"system\"", "#[link"] {
+            assert!(
+                !text.contains(forbidden),
+                "{file} declares {forbidden}: the reader reaches raw mode, the \
+                 window and a keystroke through crossterm, which is what \
+                 ADR-0b55983421dd bought and the only reason it was worth \
+                 buying"
+            );
+        }
+        // `unsafe` is the wider net, and it catches a foreign call reached
+        // through a dependency's own binding as well as one declared here.
+        assert!(
+            !text.contains("unsafe "),
+            "{file} is unsafe: nothing this reader does needs to be"
+        );
+    }
 }
 
 /// The other half of the constraint: what the sources reach for.


### PR DESCRIPTION
Closes TASK-4fa385c1772d, executing ADR-0b55983421dd, ratified today.

This is the **engine**: raw mode on the alternate buffer, an event loop over
keys, resize and the change stream, and every view the reader had drawn again
through ratatui. It is not the panel layout (TASK-bb43cfe2192b), not the
confirmation dialog (TASK-d4a882345837), not colour (TASK-6cd41d23b7d1) and not
mobile (TASK-dd9747e5e305). Those three are unblocked by it, each with its own
criterion.

## The seam held

`ank.rs`, `model.rs` and `stream.rs` are about reaching the corpus rather than
about drawing, and none of the three moved. `frame.rs`, `input.rs` and `view.rs`
were the presentation, and they are what changed.

- **`frame.rs` -> `text.rs`**, minus the three escape sequences crossterm owns
  now. `fit`, `wrap` and `window` survived because they are not drawing:
  `Paragraph` wraps inside its own render and reports no count, so a heading
  saying `41-60 of 1275` over a body has to have counted the rows itself, before
  the frame exists, while a key is being answered.
- **`term.rs`** is new: raw mode, the alternate screen, the crossterm event
  thread, and a `Drop` that gives the terminal back on every road out including
  a panic.
- **`keys.rs`** is new: one key per command, each with an arrow or a named key
  beside it, and no chord anywhere except Control-C, which is the way out rather
  than a command.
- **`input.rs`** keeps its grammar, for the one-line prompt `a` opens. Four of
  the six verbs that write carry a message, a reason, a proof or a flag, which
  no key has room for -- and keeping the grammar is what keeps `accept`'s two
  refusals (no tail, only on the document) and their tests alive.

**No bare key can write**, and that is asserted for every letter of the alphabet
in every view. What the line discipline used to guarantee -- a slipped finger
typed nothing, because no command was one letter -- is not fully replaced here;
that is the confirmation showing the argv, and it is TASK-d4a882345837. The
module headers say which of the two regimes the reader is in rather than
implying the stronger one.

## ADR-8bd76e8d7c4e is untouched

The reader reaches the corpus only by running the CLI with `--json`; it links
neither `ank-cli` nor `ank-core`; it writes nothing nobody asked for; it renews
no claim on its own; and `accept` stays a human act it drives and never
performs. `tests/dependencies.rs` still reads all of that back out of cargo and
out of the sources, and gains one assertion ADR-0b55983421dd asks for: **no
`extern` block and no `unsafe` in this tree, on any platform**. That is the
premise the whole decision rests on -- crossterm answers raw mode, the window
and a keystroke on all three platforms so that this workspace declares no
foreign symbol at all.

## Out of scope, and said out loud rather than done quietly

`crates/ank-cli/tests/tui.rs` is **not** in `crates/ank-tui/**` and it had to be
adapted anyway. **What it asserts did not move** -- quitting leaves no file and
no ref changed, an idle session renews no claim, an event repaints and renews
nothing, the event route and the reload route reach the same displayed state,
the frames carry no identifier the corpus does not. What moved is how it drives
and reads a session, in two ways:

1. A command is a key now, so a list of lines became a list of keystrokes.
2. **The screen is no longer the byte stream.** ratatui draws by diffing: it
   sends the cells that changed and moves the cursor over the ones that did not,
   so a space that stayed a space is never sent and `CLAIMS (1)` reaches the
   wire as `CLAIMS`, a cursor move and `(1)`. A substring search over those
   bytes would have been asserting something no longer true of them. The suite
   now applies the bytes to a grid and asserts against what a person would be
   looking at -- stricter than what it replaces, not looser, and a frame is
   compared as a frame.

One test is added there, for the criterion's own sentence: a terminal made
narrower and then wider redraws to its new size **with nothing typed**. It sets
the window on the master side and delivers `SIGWINCH` by name, because this
child was never given the slave as a controlling terminal.

`crates/ank-tui/src/lib.rs` also carried a bare `(ADR-0c8a)` -- one of the three
abbreviated citations TASK-1003ef0c5b16 is filed for. It is inside prose this
task rewrites, so it is re-pointed to ADR-1f70ce2c3eac, which carries that
sentence forward word for word. The other two sites are untouched and
TASK-1003ef0c5b16 still owns them.

## The number, since ADR-0b55983421dd wrote one

This crate compiled 15 crates before and compiles 82 now. The workspace lockfile
went from 50 entries to 200, and the two differ because a lockfile carries a
package whether or not a feature enables it -- the termion and termwiz backends,
`palette` and their trees are locked and never built. The decision priced this
at fifty-five, which is what ratatui 0.29 costs by `cargo tree`, the instrument
the decision names; 0.30 is 8 crates more compiled than that and is the current
release rather than a major this project would owe an upgrade. Default features
are off; `all-widgets` and `widget-calendar` are declined, because this reader
draws no calendar. The argument sits in the manifest.

## Verification

- `cargo test --workspace`: green (21 test binaries, including 22 in the
  pseudo-terminal suite and 87 in `ank-tui`'s own).
- `cargo fmt --check`: clean.
- `ank check`: ok. The `frame.rs` -> `text.rs` rename briefly made a done task's
  scope a fault; git's rename record lowers it to a signal once committed, which
  is ADR-3094 working as written.
- Cross-checked to compile for `x86_64-pc-windows-msvc` and
  `x86_64-apple-darwin`, and built on the declared MSRV (1.95). CLAUDE.md's
  three-platform rule is what CI settles; the Windows trap already paid for
  itself here -- `KeyEventKind::Release` must be filtered, or a Windows console
  runs every command twice and no Linux run ever shows it.

Proof: `commit:7d8717403f24931f75925ed69b8fb6611d5874a3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y357WyRXTc1eXtFe3uAz4F