### PR TITLE
Two abbreviated citations move to the decision that carries the sentence

### DIFF
--- a/.ank/entities/LOG-77348da3f870.md
+++ b/.ank/entities/LOG-77348da3f870.md
@@ -1,0 +1,15 @@
+---
+id: LOG-77348da3f870
+type: log
+title: done, proof commit:79a677b18ef22a91db831bf32e5a0fa0dde6923b
+created: 2026-08-26T02:48:03Z
+author: claude-code/opus-5+cite-abbrev
+scope:
+  - crates/ank-tui/src/lib.rs
+  - crates/ank-cli/src/human.rs
+  - crates/ank-daemon/src/lib.rs
+about: TASK-1003ef0c5b16
+seq: 1
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-f8e6053252ad.md
+++ b/.ank/entities/LOG-f8e6053252ad.md
@@ -1,0 +1,17 @@
+---
+id: LOG-f8e6053252ad
+type: log
+title: "Two sites repaired, not three: crates/ank-tui/src/lib.rs:122 no longer carries the bare (ADR-0c8a)."
+created: 2026-08-26T02:42:23Z
+author: claude-code/opus-5+cite-abbrev
+scope:
+  - crates/ank-tui/src/lib.rs
+  - crates/ank-cli/src/human.rs
+  - crates/ank-daemon/src/lib.rs
+about: TASK-1003ef0c5b16
+seq: 0
+schema: 4
+version: 1
+---
+
+ TASK-4fa385c1772d's ratatui rewrite (7d87174) rewrote that doc comment rather than re-pointing it, and the sentence it now carries cites ADR-1f70ce2c3eac at lib.rs:144 -- the body predicted exactly that risk, and the rewrite landed the citation move on its own. grep -rn 0c8a crates/ now answers only the two remaining. Both moved rather than dropped: ADR-1f70ce2c3eac carries the structure clause of ADR-0c8ab846d262 forward word for word ('Structure ... is text, emitted identically to every reader, at a terminal or into a pipe or a file, on every platform'), which is precisely the sentence human.rs:4063 and ank-daemon/src/lib.rs:217 each state. The daemon's ADR-0c8a12b4e0a1 was never an abbreviation -- ank show answers entity not found -- but it states that split correctly, so it is a citation that resolves to nothing and moves on the same test as a real one. Cited whole, matching the twenty ADR-1f70ce2c3eac citations the whole-identifier repair left, and cited from ank-daemon though ADR-1f70's scope names only ank-cli/src/style.rs and ank-contract/**: prose names a document, it does not confer scope (ADR-1e6b, ADR-c88f99e1c16e). Both edits rewrap one line to stay inside the file's ~80 column comment width; nothing else moves.

--- a/.ank/entities/TASK-1003ef0c5b16.md
+++ b/.ank/entities/TASK-1003ef0c5b16.md
@@ -5,7 +5,7 @@ slug: three-abbreviated-citations-of-the-presentation
 title: Three abbreviated citations of the presentation decision survive the guard's reach
 created: 2026-08-25T23:27:38Z
 author: claude-code/opus-5+cite-0c8a
-status: open
+status: in_progress
 scope:
   - crates/ank-tui/src/lib.rs
   - crates/ank-cli/src/human.rs
@@ -15,7 +15,7 @@ done_criteria: |
   None of the three files names the retired presentation decision in an abbreviated form: crates/ank-tui/src/lib.rs and crates/ank-cli/src/human.rs each carry a bare (ADR-0c8a), and crates/ank-daemon/src/lib.rs carries ADR-0c8a12b4e0a1, which names no entity this corpus holds. Each site names the decision that binds it today or drops the citation, on the same test the whole-identifier repair applied: where ADR-1f70ce2c3eac carries the sentence forward the citation moves, and where it does not the citation goes rather than being re-pointed. no_superseded_document_is_cited_in_the_workspace still passes, cargo test --workspace is green and cargo fmt --check passes, and no behaviour or assertion changes beyond the identifiers themselves.
 criteria_by: creator
 schema: 4
-version: 1
+version: 2
 ---
 
 TASK-0722ebfc5775 swept `ADR-0c8ab846d262`, `0c8ab846` and `ADR-0c8a` and

--- a/.ank/entities/TASK-1003ef0c5b16.md
+++ b/.ank/entities/TASK-1003ef0c5b16.md
@@ -5,7 +5,7 @@ slug: three-abbreviated-citations-of-the-presentation
 title: Three abbreviated citations of the presentation decision survive the guard's reach
 created: 2026-08-25T23:27:38Z
 author: claude-code/opus-5+cite-0c8a
-status: in_progress
+status: done
 scope:
   - crates/ank-tui/src/lib.rs
   - crates/ank-cli/src/human.rs
@@ -14,8 +14,13 @@ blocked_by: []
 done_criteria: |
   None of the three files names the retired presentation decision in an abbreviated form: crates/ank-tui/src/lib.rs and crates/ank-cli/src/human.rs each carry a bare (ADR-0c8a), and crates/ank-daemon/src/lib.rs carries ADR-0c8a12b4e0a1, which names no entity this corpus holds. Each site names the decision that binds it today or drops the citation, on the same test the whole-identifier repair applied: where ADR-1f70ce2c3eac carries the sentence forward the citation moves, and where it does not the citation goes rather than being re-pointed. no_superseded_document_is_cited_in_the_workspace still passes, cargo test --workspace is green and cargo fmt --check passes, and no behaviour or assertion changes beyond the identifiers themselves.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 79a677b18ef22a91db831bf32e5a0fa0dde6923b
+    criteria: 5b4db14eaff2
+    via: submitted
 schema: 4
-version: 2
+version: 3
 ---
 
 TASK-0722ebfc5775 swept `ADR-0c8ab846d262`, `0c8ab846` and `ADR-0c8a` and

--- a/crates/ank-cli/src/human.rs
+++ b/crates/ank-cli/src/human.rs
@@ -4060,7 +4060,8 @@ fn render(report: &Report, inv: &Invocation, out: &mut dyn Write) {
         // The structure alphabet of §4 and nothing outside it: a note is the
         // last child of its finding, so `LAST` opens it and `CLEAR` continues
         // it. Text and never colour — it carries the command to run next, and a
-        // reader who piped this to a file must read the same bytes (ADR-0c8a).
+        // reader who piped this to a file must read the same bytes
+        // (ADR-1f70ce2c3eac).
         //
         // The breakdown comes first and the note after it, in one run of
         // children: the numbers are what the note's advice is about, and a

--- a/crates/ank-daemon/src/lib.rs
+++ b/crates/ank-daemon/src/lib.rs
@@ -214,8 +214,8 @@ pub fn run(
 
 /// What is watched, as text and only as text.
 ///
-/// No colour here at all, under ADR-0c8a12b4e0a1's split: the structure layer is
-/// emitted identically to every reader, and this process has no half that
+/// No colour here at all, under ADR-1f70ce2c3eac's split: the structure layer
+/// is emitted identically to every reader, and this process has no half that
 /// depends on who is reading -- its ordinary destination is a log file.
 fn report(declared: &Declaration, out: &mut dyn Write) {
     let watched = &declared.watch;


### PR DESCRIPTION
Closes TASK-1003ef0c5b16. Proof `commit:79a677b18ef22a91db831bf32e5a0fa0dde6923b`.

The abbreviated sweep reported three sites the `stale_citations` guard cannot
reach: it asks the corpus for the superseded ids and matches
`line.contains(id)` on the whole identifier, so a four-character form is
invisible to it.

**Two, not three.** `crates/ank-tui/src/lib.rs:122` no longer carries the bare
`(ADR-0c8a)`. TASK-4fa385c1772d's ratatui rewrite rewrote that doc comment
rather than re-pointing it, and the sentence it now carries cites
`ADR-1f70ce2c3eac` at `lib.rs:144` — the outcome the task body warned would
have to be read for rather than sed'd. `grep -rn 0c8a crates/` now answers only
the two below.

**Both move rather than go.** `ADR-1f70ce2c3eac` carries the structure clause of
the retired `ADR-0c8ab846d262` forward word for word — *"Structure … is text,
emitted identically to every reader, at a terminal or into a pipe or a file, on
every platform"* — and that is precisely the sentence each site states.

- `crates/ank-cli/src/human.rs:4063` — a bare `(ADR-0c8a)` on the note's
  structure alphabet.
- `crates/ank-daemon/src/lib.rs:217` — `ADR-0c8a12b4e0a1`, which was never an
  abbreviation of anything: `ank show` answers `entity not found`. It shares
  four characters with the retired decision and states its split correctly, so
  it is a citation resolving to nothing, and it moves on the same test as a real
  one. A defect the supersession did not create and the guard would never have
  announced.

Cited whole, matching the twenty `ADR-1f70ce2c3eac` citations the
whole-identifier repair left, and cited from `ank-daemon` though ADR-1f70's
scope names only `ank-cli/src/style.rs` and `ank-contract/**`: prose names a
document, it confers no perimeter (ADR-1e6bf6, ADR-c88f99e1c16e).

One line rewraps at each site to hold the file's comment width. No behaviour, no
assertion, nothing but the identifiers.

`cargo test --workspace` green (including
`no_superseded_document_is_cited_in_the_workspace`), `cargo fmt --check` clean,
`ank check` ok — 0 faults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjKdnEfHvVKRRQwABdoUgz