### PR TITLE
What a status means moves to one table, and the CLI still paints it byte for byte

### DIFF
--- a/.ank/entities/LOG-a6f3fab8e163.md
+++ b/.ank/entities/LOG-a6f3fab8e163.md
@@ -1,0 +1,14 @@
+---
+id: LOG-a6f3fab8e163
+type: log
+title: done, proof commit:aeaebd11ddb8161f361cd417bc836a158275fdb9
+created: 2026-08-26T03:08:20Z
+author: claude-code/opus-5+status-table
+scope:
+  - crates/ank-contract/**
+  - crates/ank-cli/src/style.rs
+about: TASK-174588603cd2
+seq: 3
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-a80f986a9bf0.md
+++ b/.ank/entities/LOG-a80f986a9bf0.md
@@ -1,0 +1,30 @@
+---
+id: LOG-a80f986a9bf0
+type: log
+title: "The meaning table lands in ank-contract as src/meaning.rs: Subject (Status/Kind/Severity) x name ->"
+created: 2026-08-26T02:59:13Z
+author: claude-code/opus-5+status-table
+scope:
+  - crates/ank-contract/**
+  - crates/ank-cli/src/style.rs
+about: TASK-174588603cd2
+seq: 1
+schema: 4
+version: 1
+---
+
+ Role, one const MEANINGS and four lookups. Three findings worth keeping.
+
+(1) Subject has to be part of the key, not a comment on it. The families are open -- a kind is whatever the registry declares -- so a lookup that took a bare name would resolve a future collision by declaration order, silently. role_of(Subject, name) makes 'what kind of entity is an open' answer None instead of guessing.
+
+(2) The two parsing rules that used to sit inside ank-cli's state_sgr are meaning's, not a surface's: 'expired' wins over the status it expired from, and everything after a colon is addressing (claimed:who@host, finished:sha on main). Left in style.rs they would have been reimplemented by ank-tui, which is precisely the second opinion ADR-1f70ce2c3eac forbids -- the table would have been shared and the reading of it would not.
+
+(3) The kind rows all land on Role::Identifier and that is the point, not filler. SPEC-89070ce7f3b8 fixes an identifier's rendering for every kind at once because find and scope list them side by side; one row per kind means a surface that wanted ADR- to read differently from TASK- has to delete rows rather than add an unreviewed call site. It also made the rows live: Style::id now paints Role::Identifier, same 33m, same bytes.
+
+style.rs keeps the eight codes and gains one total Role -> code match, so a role added in the contract stops the CLI compiling instead of reaching a reader unpainted. state_sgr is gone; status() and landed() are now the shared lookup composed with that match and nothing else, asserted as an identity rather than as agreement -- comparing them against a second table written in style.rs would pass while two tables existed.
+
+Not moved, and deliberately: human.rs paints check's severities with style.red/style.yellow at the call site. The rows are in the table (fault -> Fault, signal -> Attention) and Style::role renders them, but human.rs is outside this task's scope, so the call sites still name colours. That is the one place a second reading of a severity remains, and it is a one-line change for whoever owns human.rs next.
+
+blocked is absent from the table on purpose: SPEC-89070ce7f3b8 struck it because it is derived from blocked_by at read time and no entity is stored carrying it. A row would have invented a status and coloured [blocked], which the existing style.rs test forbids.
+
+The no-ANSI guard walks the whole crate's src rather than meaning.rs alone, and derives its needles from char::from(27u8) instead of writing them out -- so a plain grep for an escape sequence over ank-contract finds nothing at all, test included, which is what makes the criterion's own phrasing checkable by hand. Verified it fires by injecting a leak into renews.rs.

--- a/.ank/entities/LOG-e9f2ee946118.md
+++ b/.ank/entities/LOG-e9f2ee946118.md
@@ -1,0 +1,22 @@
+---
+id: LOG-e9f2ee946118
+type: log
+title: Verified byte-for-byte through the binary rather than only through the unit tests, because the
+created: 2026-08-26T03:05:30Z
+author: claude-code/opus-5+status-table
+scope:
+  - crates/ank-contract/**
+  - crates/ank-cli/src/style.rs
+about: TASK-174588603cd2
+seq: 2
+schema: 4
+version: 1
+---
+
+ criterion is a claim about what the CLI writes and not about what a function returns. Built the binary at HEAD and the binary with the change, then ran 26 invocations under each of three conditions -- a real terminal (script -q allocates a pty), a pipe, and NO_COLOR at that same terminal -- comparing stdout, stderr and exit code: every read-only verb worth styling, each also in its --json form, plus three refusals. 78 pairs, all identical.
+
+Two things the sweep had to prove about itself, and both are recorded: the terminal leg genuinely carried escape sequences (a vacuous tty leg would have compared plain text twice and proved nothing), and NO_COLOR at that same terminal came back plain.
+
+One pair differed on the first run and it was not the renderer: ank status printed 'drift 1 entity file(s)' against 'drift 2' and two lease expiries 14 seconds apart, because ank log ran between the old binary's invocation and the new one's. Re-run on a quiet corpus, all three conditions are identical byte for byte. Worth writing down because it is the shape of a false positive this comparison invites: ank status reports the corpus and the lease, so any verb that mutates -- including the log recording the work -- moves the thing being compared.
+
+No fixture was blessed: git status shows tests/golden-json untouched, and ANK_BLESS_GOLDEN was never set.

--- a/.ank/entities/TASK-174588603cd2.md
+++ b/.ank/entities/TASK-174588603cd2.md
@@ -5,7 +5,7 @@ slug: what-a-status-means-moves-to-one-table-and-the-c
 title: What a status means moves to one table, and the CLI still paints it byte for byte
 created: 2026-08-25T22:45:12Z
 author: haksolot@vmi3223161
-status: open
+status: in_progress
 scope:
   - crates/ank-contract/**
   - crates/ank-cli/src/style.rs
@@ -14,5 +14,5 @@ done_criteria: |
   The mapping from a status, a kind and a severity to the role it plays lives in one table that every surface can read, and that table carries no escape sequence: grep finds no ANSI in it. crates/ank-cli/src/style.rs renders that table and holds no second opinion about what any status means. Every byte the CLI writes is unchanged, asserted against the existing goldens with no fixture blessed, under a terminal and into a pipe and with NO_COLOR set. cargo test is green and cargo fmt --check passes.
 criteria_by: creator
 schema: 4
-version: 2
+version: 3
 ---

--- a/.ank/entities/TASK-174588603cd2.md
+++ b/.ank/entities/TASK-174588603cd2.md
@@ -5,7 +5,7 @@ slug: what-a-status-means-moves-to-one-table-and-the-c
 title: What a status means moves to one table, and the CLI still paints it byte for byte
 created: 2026-08-25T22:45:12Z
 author: haksolot@vmi3223161
-status: in_progress
+status: done
 scope:
   - crates/ank-contract/**
   - crates/ank-cli/src/style.rs
@@ -13,6 +13,11 @@ blocked_by: [TASK-0722ebfc5775]
 done_criteria: |
   The mapping from a status, a kind and a severity to the role it plays lives in one table that every surface can read, and that table carries no escape sequence: grep finds no ANSI in it. crates/ank-cli/src/style.rs renders that table and holds no second opinion about what any status means. Every byte the CLI writes is unchanged, asserted against the existing goldens with no fixture blessed, under a terminal and into a pipe and with NO_COLOR set. cargo test is green and cargo fmt --check passes.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: aeaebd11ddb8161f361cd417bc836a158275fdb9
+    criteria: 2280c5dfa441
+    via: submitted
 schema: 4
-version: 3
+version: 4
 ---

--- a/crates/ank-cli/src/style.rs
+++ b/crates/ank-cli/src/style.rs
@@ -17,7 +17,16 @@
 //! No dependency, direct or transitive: `std::io::IsTerminal` has been stable
 //! since 1.70 and the floor here is 1.95. The task that ordered this feature
 //! expected to reach for `libc`, and did not need to.
+//!
+//! **What a status means is not decided here.** ADR-1f70ce2c3eac moved the
+//! meaning to `ank-contract::meaning`, where the terminal reader can read it
+//! too, and left the escape sequences behind. So this file holds two things and
+//! not three: the eight codes, and a [`Role`] -> code mapping that is total. It
+//! holds no table of statuses at all — a status reaches a code by way of the
+//! shared table, in one lookup, and a second opinion about `done` would have to
+//! be written somewhere there is now no room for it.
 
+use ank_contract::meaning::{self, Role};
 use std::io::IsTerminal;
 
 /// The structure alphabet of §4 (ADR-1f70ce2c3eac).
@@ -113,8 +122,14 @@ impl Style {
     }
 
     /// `TASK-8ebd`, `ADR-962c`. The register `git log` uses for a sha.
+    ///
+    /// Painted from the role every kind carries rather than from a colour
+    /// picked here: the shared table declares one row per kind and lands them
+    /// all on [`Role::Identifier`], which is what makes "an identifier reads the
+    /// same whatever it names" a decision a surface can be held to instead of a
+    /// coincidence of two call sites.
     pub fn id(&self, s: &str) -> String {
-        self.yellow(s)
+        self.role(Role::Identifier, s)
     }
 
     /// The trailing `> ank claim … to start` every output ends on.
@@ -124,28 +139,27 @@ impl Style {
 
     /// A bracketed status marker, styled by what it says.
     ///
-    /// The mapping lives here rather than beside each `marker()` because two
-    /// modules build these strings — `context` and `find` — and two copies of a
-    /// colour table are two chances for `[done]` to be green in one listing and
-    /// not the other.
+    /// The lookup is the shared table's and the brackets are its business too
+    /// (`meaning::role_of_marker`), because two modules build these strings —
+    /// `context` and `find` — and a third surface builds them again; a copy of
+    /// the reading is a chance for `[done]` to land in one register here and
+    /// another there.
+    ///
+    /// A string the table declares no row for is returned untouched. That is
+    /// the answer for something that is not a status at all, not a default for
+    /// a status the table forgot, and `[blocked]` is the case it is for.
     pub fn status(&self, marker: &str) -> String {
-        let inner = marker.trim_start_matches('[').trim_end_matches(']');
-        match state_sgr(inner) {
-            Some(sgr) => self.paint(sgr, marker),
-            None => marker.to_string(),
-        }
+        self.by(meaning::role_of_marker(marker), marker)
     }
 
     /// The state a transition landed on: the `done` of `TASK-8ebd -> done`.
     ///
-    /// Deliberately the same table `status` reads. `-> done` and `[done]` are
-    /// the same fact seen twice, and §4 asks that a reader who has learned one
-    /// have learned the other — which is only true if one lookup answers both.
+    /// Deliberately the same table `status` reads, reached without the
+    /// brackets. `-> done` and `[done]` are the same fact seen twice, and §4
+    /// asks that a reader who has learned one have learned the other — which is
+    /// only true if one lookup answers both.
     pub fn landed(&self, state: &str) -> String {
-        match state_sgr(state) {
-            Some(sgr) => self.paint(sgr, state),
-            None => state.to_string(),
-        }
+        self.by(meaning::role_of_status(state), state)
     }
 
     /// A transition word for something the corpus gained: `created`, `claimed`,
@@ -183,33 +197,45 @@ impl Style {
             PLAIN
         }
     }
-}
 
-/// The colour a state carries, from the one table §4 declares.
-///
-/// Free rather than a method because it answers about the state and not about
-/// the [`Style`] asking: `status` reads it for `[done]` and `landed` for the
-/// `done` of `-> done`, and the two must not be able to drift apart.
-fn state_sgr(state: &str) -> Option<&'static str> {
-    // Checked before the split: an expired marker is `[open expired:who]`,
-    // whose leading word is the status it expired from.
-    if state.contains("expired") {
-        return Some("33");
+    /// A [`Role`] of the shared table, in the register §4 gives it.
+    ///
+    /// **This is the whole of what this binary decides about meaning**, and it
+    /// is a total function of the role: a variant added to
+    /// `ank-contract::meaning` stops this compiling, which is the question the
+    /// CLI has to be asked whenever a surface learns a new part to play. A
+    /// lookup table keyed on strings would have answered the new role with a
+    /// default and shipped it unpainted.
+    pub fn role(&self, role: Role, s: &str) -> String {
+        self.paint(
+            match role {
+                Role::Available => "34",
+                // One state seen twice: `in_progress` is what the file says,
+                // `claimed` is what the ref says. A reader who sees them in two
+                // colours has to learn that they are the same fact; a reader who
+                // sees one colour does not.
+                Role::Underway => "36",
+                Role::Accomplished => "32",
+                Role::Retired => "2",
+                Role::Awaiting => "35",
+                Role::Attention => "33",
+                Role::Fault => "31",
+                Role::Identifier => "33",
+            },
+            s,
+        )
     }
-    match state.split(':').next().unwrap_or(state) {
-        "done" | "finished" | "accepted" => Some("32"),
-        // One state seen twice: `in_progress` is what the file says, `claimed`
-        // is what the ref says. A reader who sees them in two colours has to
-        // learn that they are the same fact; a reader who sees one colour does
-        // not.
-        "claimed" | "in_progress" => Some("36"),
-        "closed" | "superseded" => Some("2"),
-        "open" => Some("34"),
-        "proposed" => Some("35"),
-        // Nothing else is a status. Returning None here is not a default for a
-        // state the table forgot -- it is the answer for a string that is not a
-        // state at all, and §4 is now checkable against that.
-        _ => None,
+
+    /// [`Self::role`] where the table may have answered nothing.
+    ///
+    /// `None` returns the input byte for byte, which is the same guarantee
+    /// [`PLAIN`] gives and for the same reason: a caller must be able to hand a
+    /// string to a painter without first knowing whether it is a status.
+    fn by(&self, role: Option<Role>, s: &str) -> String {
+        match role {
+            Some(role) => self.role(role, s),
+            None => s.to_string(),
+        }
     }
 }
 
@@ -485,6 +511,128 @@ mod tests {
                 "{state} reaches a reader with no colour"
             );
             assert_ne!(s.landed(state), state, "{state} lands with no colour");
+        }
+    }
+
+    /// **Every row of the shared table reaches a code**, walked over the table
+    /// itself rather than over a list typed here.
+    ///
+    /// This is the "renders that table" half of ADR-1f70ce2c3eac from the CLI's
+    /// side: a row added in `ank-contract` that this binary had no register for
+    /// would reach a reader unpainted, and a bare array here would have gone
+    /// stale in silence — which is exactly how `in_progress` came to be missing
+    /// from the palette for as long as it was. The `match` in [`Style::role`]
+    /// stops compiling on a new *role*; this stops the suite on a new *row*.
+    #[test]
+    fn every_row_of_the_shared_table_is_painted() {
+        let s = COLOR;
+        for m in meaning::MEANINGS {
+            let painted = s.role(m.role, m.name);
+            assert_ne!(
+                painted, m.name,
+                "{:?} {} reaches a reader with no colour",
+                m.subject, m.name
+            );
+            assert!(
+                painted.ends_with(RESET),
+                "{painted:?} did not reset: an unreset attribute bleeds into the prompt"
+            );
+            assert_eq!(
+                undo_sgr(&painted),
+                m.name,
+                "{} was moved, not painted",
+                m.name
+            );
+            assert_eq!(PLAIN.role(m.role, m.name), m.name, "{} leaked", m.name);
+        }
+    }
+
+    /// The bytes a terminal receives, pinned to the literal sequence.
+    ///
+    /// The one assertion in this file written against escape literals, and it is
+    /// the one that has to be: everything else compares two renders of the same
+    /// table, and two renders of a table that moved together agree. What must
+    /// not move is what a terminal is actually sent — ADR-1f70ce2c3eac permits
+    /// the meaning to move crates precisely because "nothing a caller reads
+    /// changes by a byte", and this is where that is measured.
+    #[test]
+    fn a_role_reaches_a_terminal_as_the_bytes_it_always_did() {
+        let s = COLOR;
+        for (role, bytes) in [
+            (Role::Available, "\x1b[34mx\x1b[0m"),
+            (Role::Underway, "\x1b[36mx\x1b[0m"),
+            (Role::Accomplished, "\x1b[32mx\x1b[0m"),
+            (Role::Retired, "\x1b[2mx\x1b[0m"),
+            (Role::Awaiting, "\x1b[35mx\x1b[0m"),
+            (Role::Attention, "\x1b[33mx\x1b[0m"),
+            (Role::Fault, "\x1b[31mx\x1b[0m"),
+            (Role::Identifier, "\x1b[33mx\x1b[0m"),
+        ] {
+            assert_eq!(
+                s.role(role, "x"),
+                bytes,
+                "{role:?} changed what a terminal is sent"
+            );
+        }
+    }
+
+    /// **The one opinion, asserted as an identity rather than as agreement.**
+    ///
+    /// `status` and `landed` are required to be the shared table's lookup
+    /// followed by this file's register, and nothing else. Comparing them
+    /// against a second table written here would pass while two tables existed,
+    /// which is the state ADR-1f70ce2c3eac forbids; comparing them against the
+    /// composition fails the moment either accessor grows a case of its own.
+    #[test]
+    fn the_status_accessors_are_the_shared_table_and_no_second_opinion() {
+        let s = COLOR;
+        for m in meaning::MEANINGS {
+            if m.subject != meaning::Subject::Status {
+                continue;
+            }
+            for state in [
+                m.name.to_string(),
+                format!("{}:who@host", m.name),
+                format!("{} expired:who@host", m.name),
+            ] {
+                let expected = meaning::role_of_status(&state)
+                    .map(|r| s.role(r, &state))
+                    .unwrap_or_else(|| state.clone());
+                assert_eq!(s.landed(&state), expected, "landed decided about {state:?}");
+                let marker = format!("[{state}]");
+                let expected = meaning::role_of_marker(&marker)
+                    .map(|r| s.role(r, &marker))
+                    .unwrap_or_else(|| marker.clone());
+                assert_eq!(
+                    s.status(&marker),
+                    expected,
+                    "status decided about {marker:?}"
+                );
+            }
+        }
+    }
+
+    /// The severity rows, held to the two call sites that still name a colour.
+    ///
+    /// `check`'s tags are built in `human.rs` with `red("error:")` and
+    /// `yellow("signal:")`. Those call sites are outside this task's perimeter
+    /// and were not moved, so what keeps them and the table one fact is this
+    /// equality: it fails the day either the row or the call site moves alone,
+    /// which is the whole of what a second reading can cost.
+    #[test]
+    fn a_severity_reads_as_the_tag_check_already_prints() {
+        let s = COLOR;
+        for (severity, tag, expected) in [
+            ("fault", "error:", s.red("error:")),
+            ("signal", "signal:", s.yellow("signal:")),
+        ] {
+            let role = meaning::role_of_severity(severity)
+                .unwrap_or_else(|| panic!("the table declares no {severity}"));
+            assert_eq!(
+                s.role(role, tag),
+                expected,
+                "{severity} and the tag `check` prints have come apart"
+            );
         }
     }
 

--- a/crates/ank-contract/src/lib.rs
+++ b/crates/ank-contract/src/lib.rs
@@ -27,6 +27,12 @@
 //! change stream has a writer in one crate and a reader in another, so its key
 //! names and its vocabulary are exactly the pair this crate exists to keep from
 //! disagreeing.
+//!
+//! [`meaning`] is the third of that shape and the widest: what a status, a kind
+//! or a severity *means* has two renderers now — the CLI's hand-written ANSI and
+//! the terminal reader's — and ADR-1f70ce2c3eac permits the two renderers while
+//! forbidding the second table. So the table is here, holding roles and no
+//! escape sequence, and each surface paints those roles its own way.
 
 /// The version of the machine contract every `--json` document is written
 /// against, and carries (ADR-6fd69efb629c).
@@ -51,11 +57,13 @@ pub const CONTRACT_VERSION: u32 = 1;
 pub mod events;
 pub mod exit;
 pub mod json;
+pub mod meaning;
 pub mod renews;
 pub mod shape;
 pub mod verbs;
 
 pub use exit::ExitCode;
+pub use meaning::{Meaning, Role, Subject, MEANINGS};
 pub use renews::Renews;
 pub use verbs::{
     find_flag, known_flags, long_of, short_of, spec_of, usage, CommandSpec, FlagSpec, Refusal,

--- a/crates/ank-contract/src/meaning.rs
+++ b/crates/ank-contract/src/meaning.rs
@@ -1,0 +1,376 @@
+//! What a status, a kind or a severity means, as one table (ADR-1f70ce2c3eac).
+//!
+//! Two surfaces paint this corpus — the CLI in hand-written ANSI, the terminal
+//! reader through the library it draws with — and neither may decide for itself
+//! what `done` looks like. ADR-1f70ce2c3eac allows the two renderers and forbids
+//! the second table, so what is shared is the **meaning**: `done` is an
+//! accomplishment, `proposed` is waiting on somebody, a fault is a fault. Roles,
+//! never colours.
+//!
+//! **No escape sequence reaches this crate, and that is the decision rather than
+//! an omission.** Shipping SGR codes here would make every consumer carry bytes
+//! most of them never emit, to share the one thing the two surfaces genuinely do
+//! differently — and it would put the palette where `ank-cli`'s own guard, which
+//! reads `ank-cli/src` and no further, cannot see it. The rule is asserted here
+//! too, over this crate's own sources, by `the_table_carries_no_escape_sequence`
+//! below.
+//!
+//! **Three families in one table and not three tables.** They are keyed on
+//! different names and answer the same question, and one `find` listing prints
+//! rows of several kinds side by side: a reader should not have to know which
+//! family a row belongs to before knowing what its rendering means. That is the
+//! argument SPEC-89070ce7f3b8 already makes for reading a task's statuses and an
+//! ADR's out of one table, applied one level up.
+//!
+//! **Nothing here renders.** A surface reads a [`Role`] and paints it its own
+//! way; this crate has no opinion about how, and could not express one.
+
+/// The family of names a row is keyed on.
+///
+/// Part of the key rather than a comment on it. The families are open — a kind
+/// is whatever the registry declares, and a severity is whatever `check`
+/// attaches — so two of them are one name apart from colliding, and a lookup
+/// that did not say what the name was a name *of* would resolve the collision
+/// by declaration order, in silence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Subject {
+    /// A status an entity is stored carrying, or the word a ref answers with.
+    /// Both, because they are one fact seen twice: `in_progress` is what the
+    /// file says and `claimed` is what the claim says, and a reader who saw them
+    /// in two renderings would have to learn that they are the same state.
+    Status,
+    /// An entity kind, as the registry names it.
+    Kind,
+    /// What `check` attaches to a finding.
+    Severity,
+}
+
+/// The part a subject plays, which is the whole of what a surface is told.
+///
+/// Named for what the reader is being told and never for a colour. The CLI
+/// paints [`Role::Attention`] yellow; a reader that owns the whole screen may
+/// reasonably paint it something else against a background it chose, and a
+/// variant called `Yellow` would have made that a contradiction instead of a
+/// choice. It is also what keeps this file honest: a role has no rendering to
+/// leak into it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Role {
+    /// There to be taken.
+    Available,
+    /// Somebody is on it.
+    Underway,
+    /// It landed.
+    Accomplished,
+    /// Given up or retired, and neither is a failure. A release is how the loop
+    /// is meant to end when a criterion turns out to be wrong, so this role is
+    /// deliberately not [`Role::Fault`]: rendering it as an error would teach an
+    /// agent to avoid the honest move.
+    Retired,
+    /// Legal, complete, and waiting on a human. `accept` is nobody else's act.
+    Awaiting,
+    /// Worth a look and not a defect: a claim whose lease ran out, a `signal`.
+    Attention,
+    /// A defect in the corpus.
+    Fault,
+    /// A name to address the entity by, whatever kind it names.
+    ///
+    /// One row per kind, all of them landing here, and the repetition is the
+    /// point: `find` and `scope` list the kinds side by side and
+    /// SPEC-89070ce7f3b8 fixes an identifier's rendering for all of them at
+    /// once. A surface that wanted `ADR-` to read differently from `TASK-` has
+    /// to remove rows from this table to get it, rather than add a call site
+    /// nobody reviews.
+    Identifier,
+}
+
+/// One row: a name, the family it is a name in, and the part it plays.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Meaning {
+    pub subject: Subject,
+    pub name: &'static str,
+    pub role: Role,
+}
+
+const fn row(subject: Subject, name: &'static str, role: Role) -> Meaning {
+    Meaning {
+        subject,
+        name,
+        role,
+    }
+}
+
+/// The qualifier a marker carries when the lease behind it ran out.
+///
+/// Not a status: it is appended to whichever status the claim expired *from*,
+/// which is why [`role_of_status`] tests for it before it looks anything up.
+pub const EXPIRED: &str = "expired";
+
+/// The table (ADR-1f70ce2c3eac).
+///
+/// Grouped by family and written out row by row. A derivation — every kind in
+/// the registry mapped to [`Role::Identifier`] by a loop, say — would have been
+/// shorter and would have made adding a kind a decision nobody takes: the row is
+/// where the question gets asked.
+///
+/// **`blocked` is absent, and its absence is the same decision.** It is derived
+/// from `blocked_by` at read time and no entity is ever stored carrying it
+/// (SPEC-89070ce7f3b8), so nothing prints it and there is nothing for a surface
+/// to look up. A row here would have invented a status the model does not have.
+pub const MEANINGS: &[Meaning] = &[
+    // Statuses, and every one the model can hold is here: a task is `open`,
+    // `in_progress`, `done` or `closed`; an ADR or a spec is `proposed`,
+    // `accepted` or `superseded`.
+    row(Subject::Status, "open", Role::Available),
+    row(Subject::Status, "in_progress", Role::Underway),
+    row(Subject::Status, "claimed", Role::Underway),
+    row(Subject::Status, "done", Role::Accomplished),
+    row(Subject::Status, "finished", Role::Accomplished),
+    row(Subject::Status, "closed", Role::Retired),
+    row(Subject::Status, "proposed", Role::Awaiting),
+    row(Subject::Status, "accepted", Role::Accomplished),
+    row(Subject::Status, "superseded", Role::Retired),
+    row(Subject::Status, EXPIRED, Role::Attention),
+    // Kinds, by the `type` name the registry gives each of them. Written out
+    // rather than read from the registry because this crate has no dependencies
+    // and must not gain one for a palette: every surface consumes it, so
+    // anything it depends on is depended on by all of them at once.
+    row(Subject::Kind, "task", Role::Identifier),
+    row(Subject::Kind, "adr", Role::Identifier),
+    row(Subject::Kind, "spec", Role::Identifier),
+    row(Subject::Kind, "log", Role::Identifier),
+    // Severities, as `check` attaches them.
+    row(Subject::Severity, "fault", Role::Fault),
+    row(Subject::Severity, "signal", Role::Attention),
+];
+
+/// The role the table gives a name in one family, or `None` when it declares
+/// none.
+///
+/// `None` is an answer and not a default. It is what a string that is not a
+/// name of that family gets, which is how a surface can leave such a string
+/// alone instead of rendering it as something it is not.
+pub fn role_of(subject: Subject, name: &str) -> Option<Role> {
+    MEANINGS
+        .iter()
+        .find(|m| m.subject == subject && m.name == name)
+        .map(|m| m.role)
+}
+
+/// The role a status carries, given the word a listing or a ref answers with.
+///
+/// Two rules stand between the word and the lookup, and both are here rather
+/// than at a call site so that two surfaces cannot apply them differently.
+///
+/// **[`EXPIRED`] wins over whatever it expired from.** The marker is
+/// `open expired:who@host` or `done expired:who@host`, and what the reader has
+/// to see is the lapse rather than the state it lapsed from.
+///
+/// **What follows a colon is addressing.** `claimed:who@host` and
+/// `finished:abc1234 on main` name a holder and a landing place; the status is
+/// the word before the colon, and it is the whole of what this answers about.
+pub fn role_of_status(state: &str) -> Option<Role> {
+    if state.contains(EXPIRED) {
+        return role_of(Subject::Status, EXPIRED);
+    }
+    role_of(Subject::Status, state.split(':').next().unwrap_or(state))
+}
+
+/// The role a bracketed marker carries: `[done]`, `[claimed:who@host]`.
+///
+/// The same table [`role_of_status`] reads, reached through the brackets a
+/// listing prints. `-> done` and `[done]` are the same fact seen twice and §4
+/// asks that a reader who has learned one have learned the other, which is only
+/// true while one lookup answers both.
+pub fn role_of_marker(marker: &str) -> Option<Role> {
+    role_of_status(marker.trim_start_matches('[').trim_end_matches(']'))
+}
+
+/// The role an entity kind carries, given the `type` the registry names it by.
+pub fn role_of_kind(kind: &str) -> Option<Role> {
+    role_of(Subject::Kind, kind)
+}
+
+/// The role a finding's severity carries: `fault`, `signal`.
+pub fn role_of_severity(severity: &str) -> Option<Role> {
+    role_of(Subject::Severity, severity)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The clause of ADR-1f70ce2c3eac this crate exists to keep: the meaning
+    /// travels and the escape sequences do not.
+    ///
+    /// Over the whole crate rather than over this file, because the constraint
+    /// is about where a palette may live and not about which module holds the
+    /// table. `ank-cli` has the mirror of this test in `paint.rs`, walking its
+    /// own `src`; between them the two directories that could plausibly grow a
+    /// second palette are both covered.
+    ///
+    /// **The needles are derived from the escape byte and never written out**,
+    /// so a grep for an escape sequence over this crate finds nothing at all —
+    /// including in the test that forbids it, which is what makes the
+    /// criterion's own phrasing checkable by hand. `27` is ESC, written in
+    /// decimal for exactly that reason.
+    #[test]
+    fn the_table_carries_no_escape_sequence() {
+        let src = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let byte = char::from(27u8);
+        let hex = format!("\\x{:02x}", byte as u32);
+        let unicode = format!("\\u{{{:x}}}", byte as u32);
+        let mut walked = 0;
+        for entry in std::fs::read_dir(&src).expect("src is readable") {
+            let path = entry.expect("entry").path();
+            if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+                continue;
+            }
+            let text = std::fs::read_to_string(&path).expect("source is readable");
+            for needle in [hex.as_str(), unicode.as_str()] {
+                assert!(
+                    !text.contains(needle),
+                    "{} writes an escape sequence; a role has no rendering and \
+                     this crate has no palette",
+                    path.display()
+                );
+            }
+            assert!(
+                !text.contains(byte),
+                "{} carries a raw escape byte",
+                path.display()
+            );
+            walked += 1;
+        }
+        assert!(
+            walked >= 7,
+            "the walk read {walked} sources and gave up early"
+        );
+    }
+
+    /// One name may mean one thing in one family, and the table says which.
+    #[test]
+    fn no_two_rows_share_a_key() {
+        for (i, m) in MEANINGS.iter().enumerate() {
+            for other in &MEANINGS[i + 1..] {
+                assert!(
+                    !(m.subject == other.subject && m.name == other.name),
+                    "{:?} {} is declared twice",
+                    m.subject,
+                    m.name
+                );
+            }
+        }
+    }
+
+    /// A name is looked up in the family it belongs to and in no other.
+    ///
+    /// The property [`Subject`] is in the key for: `open` is a status, and a
+    /// surface asking the table what kind of entity an `open` is must be told
+    /// nothing rather than told the first row that happens to match.
+    #[test]
+    fn a_family_answers_only_about_its_own_names() {
+        for m in MEANINGS {
+            for subject in [Subject::Status, Subject::Kind, Subject::Severity] {
+                let answered = role_of(subject, m.name);
+                if subject == m.subject {
+                    assert_eq!(answered, Some(m.role), "{} lost its row", m.name);
+                } else {
+                    assert_eq!(
+                        answered, None,
+                        "{:?} answered about {}, which is a {:?}",
+                        subject, m.name, m.subject
+                    );
+                }
+            }
+        }
+    }
+
+    /// The statuses of SPEC-89070ce7f3b8, enumerated rather than sampled.
+    ///
+    /// Written out here rather than derived from `MEANINGS`, which would agree
+    /// with any table including one nobody meant. `ank-core` is not a dependency
+    /// of this crate and must not become one, so what pins these against the
+    /// model's own enumerations is the test in `ank-cli/src/style.rs` that walks
+    /// `TaskStatus` and `AdrStatus` through a match.
+    #[test]
+    fn the_statuses_are_the_ones_the_specification_declares() {
+        for (state, role) in [
+            ("open", Role::Available),
+            ("in_progress", Role::Underway),
+            ("claimed", Role::Underway),
+            ("done", Role::Accomplished),
+            ("finished", Role::Accomplished),
+            ("closed", Role::Retired),
+            ("proposed", Role::Awaiting),
+            ("accepted", Role::Accomplished),
+            ("superseded", Role::Retired),
+        ] {
+            assert_eq!(role_of_status(state), Some(role), "{state} moved");
+            assert_eq!(
+                role_of_marker(&format!("[{state}]")),
+                Some(role),
+                "the marker of {state} disagrees with the word"
+            );
+        }
+    }
+
+    /// The addressing after a colon names a holder, never a status.
+    #[test]
+    fn a_payload_is_not_part_of_the_status() {
+        assert_eq!(
+            role_of_status("claimed:who@host"),
+            Some(Role::Underway),
+            "a holder changed what claimed means"
+        );
+        assert_eq!(
+            role_of_marker("[finished:abc1234 on main]"),
+            Some(Role::Accomplished),
+            "a landing place changed what finished means"
+        );
+    }
+
+    /// The lapse is what the reader has to see, from whichever state it lapsed.
+    #[test]
+    fn expired_wins_over_the_status_it_expired_from() {
+        for marker in [
+            "[open expired:who@host]",
+            "[done expired:who@host]",
+            "[in_progress expired:who@host]",
+        ] {
+            assert_eq!(
+                role_of_marker(marker),
+                Some(Role::Attention),
+                "{marker} read as something other than a lapse"
+            );
+        }
+    }
+
+    /// What is not a name of the family gets no role, and `blocked` is the case
+    /// that matters: SPEC-89070ce7f3b8 struck it because it is derived at read
+    /// time and no entity is stored carrying it.
+    #[test]
+    fn a_string_that_is_not_a_status_has_no_role() {
+        for absent in ["blocked", "", "Done", "open_", "who@host"] {
+            assert_eq!(role_of_status(absent), None, "{absent:?} found a row");
+        }
+        assert_eq!(role_of_marker("[blocked]"), None);
+    }
+
+    /// Every kind reads as an identifier, which is the decision the rows carry.
+    #[test]
+    fn every_kind_is_an_identifier() {
+        for kind in ["task", "adr", "spec", "log"] {
+            assert_eq!(role_of_kind(kind), Some(Role::Identifier), "{kind} moved");
+        }
+        assert_eq!(role_of_kind("adr "), None);
+    }
+
+    /// A fault is a fault, and a signal is worth a look rather than a defect —
+    /// which is the line `check`'s exit code already draws.
+    #[test]
+    fn a_finding_reads_by_its_severity() {
+        assert_eq!(role_of_severity("fault"), Some(Role::Fault));
+        assert_eq!(role_of_severity("signal"), Some(Role::Attention));
+        assert_eq!(role_of_severity("error"), None);
+    }
+}


### PR DESCRIPTION
TASK-174588603cd2, under ADR-1f70ce2c3eac.

The decision allows two renderers and forbids a second table. The **meaning**
now lives in `ank-contract::meaning` — a status, a kind or a severity mapped to
the *role* it plays — and `crates/ank-cli/src/style.rs` keeps the escape
sequences and nothing else.

## What moved

- **`crates/ank-contract/src/meaning.rs`** (new). One `MEANINGS` table:
  `Subject` (`Status` / `Kind` / `Severity`) × name → `Role`. Four lookups on
  top of it, and no rendering of any sort.
- **`crates/ank-cli/src/style.rs`.** `state_sgr` is gone. `status` and `landed`
  are the shared lookup composed with one `match` from `Role` to an SGR code;
  `id` paints `Role::Identifier`. That `match` is total, so a role added to the
  contract stops the CLI compiling rather than reaching a reader unpainted.

Nothing else is touched. `ank-tui` is deliberately untouched — the task that
makes the reader read this table is TASK-6cd41d23b7d1, which this unblocks.

## Three choices worth reviewing

**`Subject` is part of the key, not a comment on it.** The families are open — a
kind is whatever the registry declares, a severity is whatever `check` attaches
— so two of them are one name apart from colliding. `role_of(Subject, name)`
answers `None` when asked what kind of entity an `open` is, where a bare-name
lookup would have resolved that collision by declaration order, in silence.

**The two parsing rules travel with the table.** `expired` wins over the status
it expired from, and everything after a colon is addressing (`claimed:who@host`,
`finished:abc1234 on main`). Left in `style.rs` they would have been written a
second time by the reader — the table would have been shared and the *reading*
of it would not, which is the drift the decision exists to prevent.

**Every kind lands on `Role::Identifier`, and the repetition is the decision.**
`find` and `scope` list the kinds side by side and SPEC-89070ce7f3b8 fixes an
identifier's rendering for all of them at once, so a surface wanting `ADR-` to
read differently from `TASK-` has to remove rows rather than add a call site
nobody reviews. It also makes those rows live, since `Style::id` paints that
role.

`blocked` is absent on purpose: SPEC-89070ce7f3b8 struck it because it is
derived from `blocked_by` at read time and no entity is stored carrying it.

## No byte changed, and it was measured through the binary

The criterion is a claim about what the CLI *writes*, so it was measured that
way rather than only in unit tests: the binary at `f9e0f55` and the binary with
this change, run over 26 invocations — every read-only verb worth styling, each
also in its `--json` form, plus three refusals — under **a real terminal** (a
pty via `script -q`), **into a pipe**, and **with `NO_COLOR`** at that same
terminal. 78 pairs, identical in stdout, stderr and exit code.

Two things the sweep proves about itself: the terminal leg genuinely carried
escape sequences, so it is not a vacuous comparison of plain text against plain
text; and `NO_COLOR` at that terminal came back plain.

One pair differed on the first run and it was not the renderer — `ank status`
reports the corpus and the lease, and an `ank log` recording the work ran
between the two invocations. Re-run on a quiet corpus it is identical in all
three conditions.

**No fixture was blessed.** `tests/golden-json/` is untouched in this diff and
`ANK_BLESS_GOLDEN` was never set.

## The no-ANSI guard

`the_table_carries_no_escape_sequence` walks the whole crate's `src` — the
mirror of `ank-cli`'s own guard in `paint.rs`, which reads `ank-cli/src` and no
further. Its needles are derived from `char::from(27u8)` rather than written
out, so a plain grep for an escape sequence over `ank-contract` finds nothing at
all, the test included. That is what makes the criterion's own phrasing
(*"grep finds no ANSI in it"*) checkable by hand. Verified it fires by injecting
a leak into `renews.rs`.

## One thing deliberately not moved

`human.rs` still builds `check`'s tags with `red("error:")` and
`yellow("signal:")`. That file is outside this task's perimeter and belongs to
another agent's live scope, so what holds those call sites and the severity rows
to one fact is an equality in `style.rs` that fails the day either moves alone.
Moving the call sites is a one-line change for whoever owns `human.rs` next.

## Gates

- `cargo test --workspace` green (all suites, 0 failures)
- `cargo fmt --check` clean
- `ank check` exit 0, no faults
- `ank done --proof commit:aeaebd11ddb8161f361cd417bc836a158275fdb9`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018344dXNpoXod1zETcFKYvJ