### PR TITLE
The reader is panels with focus, in the shape lazygit gave the idea

### DIFF
--- a/.ank/entities/LOG-1b033a3b018b.md
+++ b/.ank/entities/LOG-1b033a3b018b.md
@@ -1,0 +1,13 @@
+---
+id: LOG-1b033a3b018b
+type: log
+title: done, proof commit:c6d7e02
+created: 2026-08-26T04:59:24Z
+author: claude-code/opus-5+reader-panels
+scope:
+  - crates/ank-tui/**
+about: TASK-bb43cfe2192b
+seq: 2
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-ed57116ba141.md
+++ b/.ank/entities/LOG-ed57116ba141.md
@@ -1,0 +1,29 @@
+---
+id: LOG-ed57116ba141
+type: log
+title: Settled the panel set and the focus model, and wrote both down in crates/ank-tui/src/view.rs so the
+created: 2026-08-26T04:58:57Z
+author: claude-code/opus-5+reader-panels
+scope:
+  - crates/ank-tui/**
+about: TASK-bb43cfe2192b
+seq: 1
+schema: 4
+version: 1
+---
+
+ two tasks that build on this have one seam each.
+
+THE SET, four panels: 1 CLAIMS (full width, top), 2 ENTITIES | 3 BODY (side by side, middle), 4 QUEUE (full width, bottom). The rule that decides which is which: a panel whose row is one LINE gets the full width, a panel whose rows are a LIST that is read against another panel shares a row. A claim row carries an identity of thirty characters and the queue carries the seventy-character sentence naming the advisory regime of section 8 -- a column cuts both, and a cut identity is the one field that answers 'held by whom'. The entities and the body are the pair genuinely read against each other: you move down a list in order to open something and want the list still there when you have.
+
+THE FOCUS MODEL: one focused at a time, Tab walks the ring, 1-4 name a panel directly (the digit is in the panel's own title), Left/Right reach the pair in the middle. No chord is required; BackTab is an alias, never the only road. Focus is drawn in two ASCII signals and no colour: the border rules with '=' instead of '-', and the title carries the '> ' this crate already spends on the row a cursor is on. rows_of() reads symbols and never styles, so 'distinguishable without colour' is a property the suite can state rather than a claim.
+
+FOCUS IS WHERE THE WIDTH GOES, which is the load-bearing decision. The focused one of the middle pair takes four fifths; the other stays a reminder. Eighty columns will not hold both a list of sentences and a body of prose, and splitting the difference serves neither. Enter therefore opens a document AND hands it the screen. This also removed the one arrangement that could not work: with a fixed split the entities panel is never wide enough for a real title at 120 columns.
+
+WHAT THE BODY PANEL DELIBERATELY DOES NOT DO: preview whatever the entities cursor is on. A preview is an 'ank show' per 'j', and 'show' renews the lease on a task you hold (ADR-0bb7ea8991bc) -- so a body that followed a cursor would renew a claim by being scrolled. Same reasoning as repaint(). The queue is likewise loaded only when its panel is focused: 'ank review' inspects the whole corpus, and a panel drawn is not a panel paid for.
+
+SEAMS I LEFT ON PURPOSE. For TASK-d4a882345837 (confirmation before every write): App::run is the single place an argv is composed, and there is exactly one road from a key to a spawned verb (a prompt somebody opened and a word spelled whole). One function to intercept. For TASK-dd9747e5e305 (one column on a phone, mouse selection): App::arrange decides every rectangle from the window and the focus and nothing else -- one column is a branch there, and hit-testing a tap is that same function read backwards. Panel numbers and per-panel cursors are already what a tap has to resolve to.
+
+TWO THINGS FOUND THE HARD WAY, both worth knowing. (1) arrange() must size panels from COUNTS, never from the lines they will draw: line-building calls page(), page() calls arrange(), and that recursion is a stack overflow rather than a wrong number. (2) The borders are ASCII rather than box-drawing glyphs. Beyond ADR-1f70ce2c3eac's 'structure is text on every platform' and the phone terminals dd97 targets, there is a mechanical reason: ank-cli/tests/tui.rs scans frames for KIND-hhhh identifiers by BYTE slicing, and a truncated id followed immediately by a three-byte glyph panics that scan on a char boundary. ASCII borders make that class of failure unreachable.
+
+Measured through the binary as CLAUDE.md requires: crates/ank-tui/tests/panels.rs drives the built ank on a real pseudo-terminal at eighty columns and at forty -- exactly the window's rows, no row past its right edge, the trailer on the last row, four panel titles, two panels sharing rows, the mark on one panel only and moving with Tab, and the body reached whole by paging. The harness is duplicated from ank-cli's rather than shared because an integration test is its own crate and this crate's own src/ may not carry unsafe (tests/dependencies.rs); the binary is found beside the test executable because CARGO_BIN_EXE_ank exists only for ank-cli.

--- a/.ank/entities/TASK-bb43cfe2192b.md
+++ b/.ank/entities/TASK-bb43cfe2192b.md
@@ -5,13 +5,18 @@ slug: the-reader-is-panels-with-focus-in-the-shape-laz
 title: The reader is panels with focus, in the shape lazygit gave the idea
 created: 2026-08-25T22:45:27Z
 author: haksolot@vmi3223161
-status: in_progress
+status: done
 scope:
   - crates/ank-tui/**
 blocked_by: [TASK-4fa385c1772d]
 done_criteria: |
   The screen is panels drawn side by side with one focused at a time, focus moves by key, and the focused panel is distinguishable without colour. What a panel holds and how the set is arranged is the design this task settles, and the body of a selected entity is still served whole rather than cut. A frame never overflows the window it was given at any size the suite states, asserted at eighty columns and at forty. The reader still reaches the corpus only by running the CLI. cargo test is green and cargo fmt --check passes.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: c6d7e02
+    criteria: a698e9f6a523
+    via: submitted
 schema: 4
-version: 3
+version: 4
 ---

--- a/.ank/entities/TASK-bb43cfe2192b.md
+++ b/.ank/entities/TASK-bb43cfe2192b.md
@@ -5,7 +5,7 @@ slug: the-reader-is-panels-with-focus-in-the-shape-laz
 title: The reader is panels with focus, in the shape lazygit gave the idea
 created: 2026-08-25T22:45:27Z
 author: haksolot@vmi3223161
-status: open
+status: in_progress
 scope:
   - crates/ank-tui/**
 blocked_by: [TASK-4fa385c1772d]
@@ -13,5 +13,5 @@ done_criteria: |
   The screen is panels drawn side by side with one focused at a time, focus moves by key, and the focused panel is distinguishable without colour. What a panel holds and how the set is arranged is the design this task settles, and the body of a selected entity is still served whole rather than cut. A frame never overflows the window it was given at any size the suite states, asserted at eighty columns and at forty. The reader still reaches the corpus only by running the CLI. cargo test is green and cargo fmt --check passes.
 criteria_by: creator
 schema: 4
-version: 2
+version: 3
 ---

--- a/crates/ank-tui/src/input.rs
+++ b/crates/ank-tui/src/input.rs
@@ -34,12 +34,14 @@
 //! identifier the view puts in front -- "nothing beyond the single document",
 //! held by there being no shape in which a second argument could travel.
 //!
-//! **It is only a command where the document is open.** In the list it is
+//! **It is only a command where the body panel has focus.** At a row it is
 //! refused, naming the way in: a proposal binds nobody until somebody reads it,
 //! and a queue that could be ratified from a row is a queue nobody reads. That
-//! is why [`parse`] takes a view, and it is now the only reason it takes one.
+//! is why [`parse`] takes the focus, and it is now the only reason it takes it
+//! -- and the focused panel is the one the screen has marked, so the document a
+//! ratification lands on is the one under the reader's eyes.
 
-use crate::view::View;
+use crate::view::Focus;
 
 /// What a typed line asks for.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -57,8 +59,13 @@ pub enum Command {
     Top,
     /// Open the row under the cursor.
     Open,
-    /// Back to the list.
+    /// Back to the listing a session opens on.
     Back,
+    /// Focus one named panel (TASK-bb43cfe2192b). A digit names one, and a
+    /// digit is what the panel's own title carries.
+    Panel(Focus),
+    /// Focus the panel this many steps along the ring, wrapping.
+    NextPanel(isize),
     /// An identifier, whole or abbreviated.
     Select(String),
     /// A row number, as the list prints them: one-based.
@@ -70,7 +77,7 @@ pub enum Command {
     Search(Option<String>),
     /// Show the constraints binding the open entity, or hide them for the body.
     Constraints,
-    /// The ratification queue: what is proposed, and who may sign it
+    /// Focus the ratification queue, and ask `review` for it
     /// (TASK-d90e94afca08). A read and nothing else -- `ank review` writes no
     /// file, takes no ref and renews no lease (§4).
     Queue,
@@ -155,7 +162,7 @@ const ACTS: &[(&str, Tail)] = &[
     ("accept", Tail::Nothing),
 ];
 
-pub fn parse(line: &str, view: View) -> Command {
+pub fn parse(line: &str, focus: Focus) -> Command {
     let line = line.trim();
     // A prompt opened and submitted empty asked for nothing, and answering it
     // with the obvious next thing would be the reader choosing a command for
@@ -186,7 +193,7 @@ pub fn parse(line: &str, view: View) -> Command {
         "n" | "next" => Command::Page(1),
         "p" | "prev" => Command::Page(-1),
         _ => match ACTS.iter().find(|(name, _)| *name == word) {
-            Some((verb, tail)) => act(verb, *tail, rest, view),
+            Some((verb, tail)) => act(verb, *tail, rest, focus),
             None => repeated(word).unwrap_or_else(|| other(line)),
         },
     }
@@ -194,12 +201,12 @@ pub fn parse(line: &str, view: View) -> Command {
 
 /// One act, with the rest of the line read the way its verb reads one.
 ///
-/// The view is consulted for exactly one verb, and the module header says why:
+/// The focus is consulted for exactly one verb, and the module header says why:
 /// a ratification is typed on the document, not at a row that names it.
-fn act(verb: &'static str, tail: Tail, rest: &str, view: View) -> Command {
-    if verb == "accept" && view != View::Entity {
+fn act(verb: &'static str, tail: Tail, rest: &str, focus: Focus) -> Command {
+    if verb == "accept" && focus != Focus::Body {
         return Command::Malformed(
-            "'accept' is typed on the document itself: open it first, and read it              (Enter opens the row under the cursor)"
+            "'accept' is typed on the document itself: open it first, and read it in              the body panel (Enter opens the row under the cursor)"
                 .to_string(),
         );
     }
@@ -310,17 +317,17 @@ mod tests {
     use super::*;
 
     fn list(line: &str) -> Command {
-        parse(line, View::List)
+        parse(line, Focus::Entities)
     }
 
-    /// A prompt submitted empty runs nothing, in every view. Enter is a key and
-    /// opening a row is what it does; a line that says nothing must not be
-    /// turned into a command nobody typed.
+    /// A prompt submitted empty runs nothing, whichever panel is focused. Enter
+    /// is a key and opening a row is what it does; a line that says nothing must
+    /// not be turned into a command nobody typed.
     #[test]
-    fn an_empty_line_asks_for_nothing_in_every_view() {
-        for view in [View::List, View::Queue, View::Entity] {
-            assert_eq!(parse("", view), Command::Nothing, "{view:?}");
-            assert_eq!(parse("   ", view), Command::Nothing, "{view:?}");
+    fn an_empty_line_asks_for_nothing_in_any_panel() {
+        for focus in Focus::ALL {
+            assert_eq!(parse("", focus), Command::Nothing, "{focus:?}");
+            assert_eq!(parse("   ", focus), Command::Nothing, "{focus:?}");
         }
     }
 
@@ -378,7 +385,7 @@ mod tests {
                 verb: "claim",
                 args: Vec::new()
             }),
-            "the identifier is the view's, not the parse's"
+            "the identifier is the panel's, not the parse's"
         );
         assert_eq!(
             list("claim --ttl 4h"),
@@ -458,26 +465,26 @@ mod tests {
     /// is a letter no mapping can quietly turn into one.
     #[test]
     fn no_single_letter_line_can_write() {
-        for view in [View::List, View::Queue, View::Entity] {
+        for focus in Focus::ALL {
             for c in 'a'..='z' {
                 let line = c.to_string();
                 assert!(
-                    !matches!(parse(&line, view), Command::Act(_)),
-                    "'{line}' writes in {view:?}, and one letter must not"
+                    !matches!(parse(&line, focus), Command::Act(_)),
+                    "'{line}' writes in {focus:?}, and one letter must not"
                 );
             }
             // Nor does a near miss on one of the six.
             for line in ["d", "cl", "clai", "don", "rel", "am", "acce", "close"] {
                 assert!(
-                    !matches!(parse(line, view), Command::Act(_)),
-                    "'{line}' writes in {view:?}"
+                    !matches!(parse(line, focus), Command::Act(_)),
+                    "'{line}' writes in {focus:?}"
                 );
             }
         }
     }
 
-    /// `accept` is a command where the document is open, and a refusal
-    /// everywhere else (TASK-d90e94afca08).
+    /// `accept` is a command in the body panel, and a refusal in every other
+    /// (TASK-d90e94afca08).
     ///
     /// The refusal is the reader's own and names the way in, because the person
     /// who typed it wants to ratify and the answer is "read it first" rather
@@ -485,19 +492,19 @@ mod tests {
     #[test]
     fn accept_is_typed_on_the_document_and_nowhere_else() {
         assert_eq!(
-            parse("accept", View::Entity),
+            parse("accept", Focus::Body),
             Command::Act(Act {
                 verb: "accept",
                 args: Vec::new()
             }),
-            "the identifier is the view's, and there is nothing else to pass"
+            "the identifier is the panel's, and there is nothing else to pass"
         );
-        for view in [View::List, View::Queue] {
-            match parse("accept", view) {
+        for focus in Focus::ALL.into_iter().filter(|f| *f != Focus::Body) {
+            match parse("accept", focus) {
                 Command::Malformed(said) => {
-                    assert!(said.contains("open it first"), "{view:?}: {said}");
+                    assert!(said.contains("open it first"), "{focus:?}: {said}");
                 }
-                other => panic!("{view:?} took an accept off a row: {other:?}"),
+                other => panic!("{focus:?} took an accept off a row: {other:?}"),
             }
         }
     }
@@ -510,7 +517,7 @@ mod tests {
     #[test]
     fn accept_takes_no_tail_and_says_so_rather_than_dropping_it() {
         for line in ["accept ADR-8bd7", "accept --force", "accept  everything"] {
-            match parse(line, View::Entity) {
+            match parse(line, Focus::Body) {
                 Command::Malformed(said) => {
                     assert!(said.contains("takes nothing after it"), "{line}: {said}");
                     assert!(

--- a/crates/ank-tui/src/keys.rs
+++ b/crates/ank-tui/src/keys.rs
@@ -8,6 +8,14 @@
 //! a named key beside it -- Down for `j`, PageDown for `n`, Home for `g`, Escape
 //! for `b` -- because a person who has never read the key line still has hands.
 //!
+//! **And focus is a key too** (TASK-bb43cfe2192b). `Tab` walks the four panels
+//! in a ring, `1` to `4` reach one directly, and Left and Right cross between
+//! the two columns. Three ways to the same place, deliberately: the digit is
+//! what the panel's own title carries, so a reader who can see `3` on the queue
+//! never has to remember which key opens it; the arrows are what a hand reaches
+//! for with nothing read at all; and `Tab` is what a person who has used one of
+//! these before will press first.
+//!
 //! **No command requires a modifier chord**, which ADR-0b55983421dd asks for and
 //! a phone makes literal: a terminal keyboard on a phone has no comfortable
 //! Control. Control-C is the one exception and it is not a command -- it is the
@@ -35,16 +43,16 @@
 //! looking at.
 
 use crate::input::Command;
-use crate::view::View;
+use crate::view::Focus;
 use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
-/// What a key press asks for, once the view is known.
+/// What a key press asks for, once the focused panel is known.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Press {
     /// A command of the grammar, ready to run.
     Run(Command),
     /// `f`: narrow to the next kind, which needs the one in force and is
-    /// therefore the view's to compute rather than this module's.
+    /// therefore the screen's to compute rather than this module's.
     Cycle,
     /// Open the one-line prompt, seeded with this much of a line.
     Prompt(&'static str),
@@ -60,7 +68,7 @@ pub const ACT: char = 'a';
 /// The key that opens it seeded with the grammar's search.
 pub const FIND: char = '/';
 
-pub fn typed(key: KeyEvent, view: View) -> Press {
+pub fn typed(key: KeyEvent, focus: Focus) -> Press {
     // The one chord, and it is the way out rather than a command: raw mode has
     // taken the line discipline's interrupt, so a reader that did not answer
     // this would be a full-screen program a person cannot leave without knowing
@@ -79,9 +87,7 @@ pub fn typed(key: KeyEvent, view: View) -> Press {
         KeyCode::Char('p') | KeyCode::PageUp => Press::Run(Command::Page(-1)),
         KeyCode::Char('g') | KeyCode::Home => Press::Run(Command::Top),
         KeyCode::Enter => Press::Run(Command::Open),
-        KeyCode::Char('b') | KeyCode::Esc | KeyCode::Backspace | KeyCode::Left => {
-            Press::Run(Command::Back)
-        }
+        KeyCode::Char('b') | KeyCode::Esc | KeyCode::Backspace => Press::Run(Command::Back),
         KeyCode::Char('c') => Press::Run(Command::Constraints),
         KeyCode::Char('r') => Press::Run(Command::Reload),
         KeyCode::Char('v') => Press::Run(Command::Queue),
@@ -89,11 +95,25 @@ pub fn typed(key: KeyEvent, view: View) -> Press {
         KeyCode::Char('f') => Press::Cycle,
         KeyCode::Char(ACT) => Press::Prompt(""),
         KeyCode::Char(FIND) => Press::Prompt("/"),
-        // Right opens, on the listings only: a phone's arrow cluster is how a
-        // person who never read the key line moves, and going *into* a row is
-        // what right means everywhere else. On a document there is nothing to
-        // the right, so it is left alone rather than given a second meaning.
-        KeyCode::Right if view != View::Entity => Press::Run(Command::Open),
+        // The ring, forward and back. `BackTab` is what a terminal sends for
+        // Shift-Tab and it is an alias rather than a command: `Tab` alone
+        // reaches all four panels, so nothing here *requires* the modifier
+        // ADR-0b55983421dd forbids requiring.
+        KeyCode::Tab => Press::Run(Command::NextPanel(1)),
+        KeyCode::BackTab => Press::Run(Command::NextPanel(-1)),
+        // A digit reaches its panel directly, which is what the number in a
+        // panel's title is for.
+        KeyCode::Char(c) if Focus::of_digit(c).is_some() => {
+            Press::Run(Command::Panel(Focus::of_digit(c).expect("a panel")))
+        }
+        // Left and Right reach the pair that shares a row, which is the only
+        // place on this screen where sideways means anything: a phone's arrow
+        // cluster is how a person who never read the key line moves, and going
+        // *into* what a row names is what Right means everywhere else. They are
+        // the one pair of keys that had to change meaning for panels, and `b`
+        // and Escape still go back.
+        KeyCode::Right if focus != Focus::Body => Press::Run(Command::Panel(Focus::Body)),
+        KeyCode::Left if focus != Focus::Entities => Press::Run(Command::Panel(Focus::Entities)),
         _ => Press::Ignored,
     }
 }
@@ -174,15 +194,15 @@ mod tests {
         KeyEvent::new(code, KeyModifiers::NONE)
     }
 
-    fn press(c: char, view: View) -> Press {
-        typed(key(KeyCode::Char(c)), view)
+    fn press(c: char, focus: Focus) -> Press {
+        typed(key(KeyCode::Char(c)), focus)
     }
 
-    /// Every command that only moves the screen is one key, in every view
+    /// Every command that only moves the screen is one key, in every panel
     /// (ADR-0b55983421dd).
     #[test]
     fn a_reading_command_is_one_key_and_the_named_keys_agree_with_the_letters() {
-        for view in [View::List, View::Queue, View::Entity] {
+        for view in Focus::ALL {
             for (letter, named, expected) in [
                 ('j', KeyCode::Down, Command::Move(1)),
                 ('k', KeyCode::Up, Command::Move(-1)),
@@ -212,7 +232,7 @@ mod tests {
     /// command (ADR-0b55983421dd: no command anywhere requires a modifier).
     #[test]
     fn nothing_but_the_way_out_is_reached_with_a_modifier() {
-        for view in [View::List, View::Queue, View::Entity] {
+        for view in Focus::ALL {
             for c in 'a'..='z' {
                 let held = KeyEvent::new(KeyCode::Char(c), KeyModifiers::CONTROL);
                 let press = typed(held, view);
@@ -229,7 +249,7 @@ mod tests {
     /// and the prompt is where the grammar refuses them.
     #[test]
     fn no_bare_key_can_write() {
-        for view in [View::List, View::Queue, View::Entity] {
+        for view in Focus::ALL {
             for c in 'a'..='z' {
                 assert!(
                     !matches!(press(c, view), Press::Run(Command::Act(_))),
@@ -247,19 +267,19 @@ mod tests {
 
     #[test]
     fn the_two_prompt_keys_seed_the_grammar_they_open() {
-        assert_eq!(press(ACT, View::List), Press::Prompt(""));
-        assert_eq!(press(FIND, View::List), Press::Prompt("/"));
+        assert_eq!(press(ACT, Focus::Entities), Press::Prompt(""));
+        assert_eq!(press(FIND, Focus::Entities), Press::Prompt("/"));
         // And what they seed is what the grammar reads: a bare line is a verb,
         // a slashed one is a search.
         assert_eq!(
-            crate::input::parse("claim", View::List),
+            crate::input::parse("claim", Focus::Entities),
             Command::Act(Act {
                 verb: "claim",
                 args: Vec::new()
             })
         );
         assert_eq!(
-            crate::input::parse("/a needle", View::List),
+            crate::input::parse("/a needle", Focus::Entities),
             Command::Search(Some("a needle".to_string()))
         );
     }
@@ -267,14 +287,63 @@ mod tests {
     #[test]
     fn an_unmapped_key_is_ignored_rather_than_named() {
         for code in [KeyCode::F(5), KeyCode::Insert, KeyCode::Char('z')] {
-            assert_eq!(typed(key(code), View::List), Press::Ignored, "{code:?}");
+            assert_eq!(
+                typed(key(code), Focus::Entities),
+                Press::Ignored,
+                "{code:?}"
+            );
         }
-        // Right opens a row and means nothing on a document.
+        // A digit no panel carries is not a panel.
+        for c in ['0', '5', '9'] {
+            assert_eq!(press(c, Focus::Entities), Press::Ignored, "'{c}'");
+        }
+    }
+
+    /// Focus moves by key, three ways, and none of the three is a chord
+    /// (TASK-bb43cfe2192b, ADR-0b55983421dd).
+    #[test]
+    fn focus_moves_by_key_in_a_ring_by_digit_and_across_the_columns() {
+        // The ring, forward from every panel and back again.
+        for focus in Focus::ALL {
+            assert_eq!(
+                typed(key(KeyCode::Tab), focus),
+                Press::Run(Command::NextPanel(1))
+            );
+            assert_eq!(
+                typed(key(KeyCode::BackTab), focus),
+                Press::Run(Command::NextPanel(-1))
+            );
+        }
+        // A digit reaches the panel whose title carries it.
+        for panel in Focus::ALL {
+            let digit = char::from_digit(panel.number() as u32, 10).expect("a digit");
+            assert_eq!(
+                press(digit, Focus::Entities),
+                Press::Run(Command::Panel(panel)),
+                "'{digit}'"
+            );
+        }
+        // Left and Right reach the pair that shares a row, from anywhere.
+        for (focus, sideways, arrived) in [
+            (Focus::Claims, KeyCode::Right, Focus::Body),
+            (Focus::Entities, KeyCode::Right, Focus::Body),
+            (Focus::Queue, KeyCode::Left, Focus::Entities),
+            (Focus::Body, KeyCode::Left, Focus::Entities),
+        ] {
+            assert_eq!(
+                typed(key(sideways), focus),
+                Press::Run(Command::Panel(arrived)),
+                "{focus:?} {sideways:?}"
+            );
+        }
+        // And the arrow that points at the panel already focused does nothing,
+        // rather than becoming a second way back: `b` and Escape are that.
+        assert_eq!(typed(key(KeyCode::Left), Focus::Entities), Press::Ignored);
+        assert_eq!(typed(key(KeyCode::Right), Focus::Body), Press::Ignored);
         assert_eq!(
-            typed(key(KeyCode::Right), View::List),
-            Press::Run(Command::Open)
+            typed(key(KeyCode::Esc), Focus::Body),
+            Press::Run(Command::Back)
         );
-        assert_eq!(typed(key(KeyCode::Right), View::Entity), Press::Ignored);
     }
 
     /// `f` walks the registry and comes back to every kind, so a person who

--- a/crates/ank-tui/src/lib.rs
+++ b/crates/ank-tui/src/lib.rs
@@ -65,11 +65,12 @@
 //!
 //! # Input is a key, and the one line that is left
 //!
-//! Every command that only moves the screen is one key ([`keys`]). Four of the
-//! six that write carry something a key has no room for -- a message, a reason,
-//! a proof, a flag -- so `a` opens a one-line prompt and what is typed there
-//! goes through [`input`], which is the grammar that spells the six whole. `/`
-//! opens the same prompt on a search.
+//! Every command that only moves the screen is one key ([`keys`]), focus
+//! included: `Tab` walks the panels, `1` to `4` name one, and Left and Right
+//! cross the columns. Four of the six verbs that write carry something a key
+//! has no room for -- a message, a reason, a proof, a flag -- so `a` opens a
+//! one-line prompt and what is typed there goes through [`input`], which is the
+//! grammar that spells the six whole. `/` opens the same prompt on a search.
 //!
 //! **What the line discipline used to guarantee is not yet replaced, and this
 //! is the honest state of it.** Under a line reader a slipped finger typed
@@ -82,19 +83,29 @@
 //!
 //! # The layout
 //!
-//! Three views, one screen each, because a criterion that asks for a body
-//! *whole* and a list of every kind on one screen asks for two screens, and the
-//! ratification queue asks a different question from either. Panels with focus
-//! are TASK-bb43cfe2192b, and this is the engine they will be drawn on.
+//! Four panels on one screen, two columns of two, one of them focused
+//! (TASK-bb43cfe2192b). What used to be three views one at a time is now four
+//! places at once, and the reason is that a corpus reader is read across rather
+//! than down: what binds this, who holds it, what is waiting, and what does it
+//! say are four questions a person carries together.
 //!
-//! * [`view::View::List`] -- who holds what, then every entity of every kind
-//!   with its status, windowed and filterable.
-//! * [`view::View::Queue`] -- what is proposed and waiting for a signature, and
-//!   who may give one: `ank review`, asked when its person presses `v` and never
-//!   on the reader's own initiative.
-//! * [`view::View::Entity`] -- one entity: what holds it, the constraints
+//! * [`view::Focus::Claims`] -- who holds what, the caller's own marked.
+//! * [`view::Focus::Entities`] -- every entity of every kind with its status,
+//!   windowed and filterable. Where a session opens.
+//! * [`view::Focus::Queue`] -- what is proposed and waiting for a signature,
+//!   and which regime the corpus is in: `ank review`, run when its person
+//!   focuses the panel and never on the reader's own initiative.
+//! * [`view::Focus::Body`] -- one entity: what holds it, the constraints
 //!   binding its declared scope, and its body, paged rather than cut. This is
-//!   the only screen `accept` can be typed on.
+//!   the only panel `accept` can be typed in.
+//!
+//! Focus moves by key and is drawn in characters -- a heavy border and the
+//! `> ` marker -- so the screen says where a reader is with no colour at all.
+//! It also decides the width: the focused column takes four fifths of it, which
+//! is what lets a list of sentences and a body of prose share eighty columns
+//! without both being too narrow. [`view::App::arrange`] is where all of that
+//! is decided, and it is the one function TASK-dd9747e5e305 has to extend for a
+//! phone.
 //!
 //! # Ratification, and the two words that are not the same
 //!
@@ -106,7 +117,8 @@
 //! prompt, or moving more than one document at a time -- and none of the three
 //! is reachable from here. No key is `accept` and no key is any of the six, so
 //! a held key repeats a movement and nothing else; the queue is never accepted
-//! in bulk because the grammar has no shape for it; no secret can reach git
+//! in bulk because the grammar has no shape for it and because the word is
+//! refused anywhere but the body panel; no secret can reach git
 //! through this process because the child is given no stdin; and a screen left
 //! open all night still runs nothing at all, because `accept` is on the acting
 //! list and a repaint only ever reads.

--- a/crates/ank-tui/src/view.rs
+++ b/crates/ank-tui/src/view.rs
@@ -1,33 +1,122 @@
-//! The three views and the state between them.
+//! Four panels, one of them focused, and the state between them
+//! (TASK-bb43cfe2192b).
 //!
-//! [`App`] holds what was read, where the cursor is, and what is filtered. It
-//! reads by calling [`Ank`] and by nothing else, and it renders by returning a
-//! `String` rather than writing: a frame that is a value is a frame a test can
-//! read, which is what lets the suite assert that the screen names entities the
-//! corpus actually carries without also owning a terminal.
+//! [`App`] holds what was read, where each cursor is, what is filtered and
+//! which panel has focus. It reads by calling [`Ank`] and by nothing else, and
+//! it renders by returning a `String` rather than writing: a frame that is a
+//! value is a frame a test can read, which is what lets the suite assert that
+//! the screen names entities the corpus actually carries without also owning a
+//! terminal.
 //!
-//! **A failure is a line on the screen and never the end of the session.** The
-//! CLI refuses on state, and a reader that exited on the first refusal would
-//! throw away the twelve hundred rows it already has because one entity could
-//! not be shown. So [`App::note`] carries what the CLI said, in the CLI's own
-//! bytes, and the frame keeps its shape.
+//! # The panel set, and why they are arranged this way
+//!
+//! Four panels, one focused, in the shape lazygit gave the idea. Two of them
+//! sit side by side and two run the width of the screen, and which is which is
+//! decided by one question: whether a row of the panel is a *line* or a *list*.
+//!
+//! ```text
+//! ank tui   corpus ...   branch ...                          <- chrome
+//! +-  1 CLAIMS (2) ------------------------------------+
+//! |  * TASK-4974  claude-code/opus-5+wave14  until ...  |
+//! +-----------------------------------------------------+
+//! +=> 2 ENTITIES 1-9 of 41 ====++-  3 BODY ------------+
+//! |>     1  ADR-8bd7  accepted ||   nothing is open    |
+//! +============================++----------------------+
+//! +-  4 QUEUE all 2 -----------------------------------+
+//! |   ADR-2b7c  adr  A decision waiting for a person    |
+//! +-----------------------------------------------------+
+//! whatever the reader is being told, or the prompt            <- chrome
+//! the keys, and the five verbs that write                     <- chrome
+//! ```
+//!
+//! * **1 CLAIMS** -- who holds what, the caller's own marked. Full width,
+//!   because a row of it is one line: an identifier, an identity, an instant
+//!   and a title, and an identity alone is thirty characters. A column would
+//!   cut the one field that answers "held by whom".
+//! * **2 ENTITIES** -- every entity of every kind with its status, filtered by
+//!   `f` and `/`, windowed. Where a session opens, because it is the question a
+//!   reader arrives with.
+//! * **3 BODY** -- the entity somebody opened, whole: what holds it, what binds
+//!   its declared scope, and its body paged rather than cut. `c` swaps it for
+//!   the constraints, listed whole.
+//! * **4 QUEUE** -- what is proposed and waiting for a signature, and which
+//!   regime the corpus is in. Full width for the same reason the claims are:
+//!   the sentence saying a corpus has declared no ratification key is
+//!   seventy-odd characters and means nothing cut in half. Asked for rather
+//!   than kept current: `ank review` inspects the whole corpus and costs what a
+//!   `check` costs, so it is run when somebody focuses this panel and never on
+//!   a repaint nobody asked for.
+//!
+//! **The two in the middle are the pair that is genuinely read against each
+//! other**, and that is why they are the pair that shares a row: a person moves
+//! down a list *in order to* open something, and wants the list still there
+//! when they have.
+//!
+//! **The chrome is not a panel and cannot be focused.** The three bands that
+//! stay full width and unbordered -- the corpus line, whatever the reader is
+//! being told, and the keys -- hold sentences rather than rows. A refusal the
+//! CLI gave is the clearest case: it carries a code and the command that
+//! resolves it, and a border would cost it two columns for nothing.
+//!
+//! # Focus is where the width goes
+//!
+//! One panel has focus at a time, `Tab` and `1`..`4` move it, and the focused
+//! panel is drawn with a doubled border and the `> ` marker every listing in
+//! this tool already spends on the row a cursor is on ([`text::CURSOR`]). Both
+//! signals are characters, and both are ASCII: the screen answers "which panel
+//! am I in" with no colour at all -- which matters twice over: `NO_COLOR` is
+//! honoured (ADR-1f70ce2c3eac), and colour is TASK-6cd41d23b7d1's to add on top
+//! of a frame that already reads without it.
+//!
+//! The borders are `-`, `|`, `+` and `=` rather than the box-drawing glyphs,
+//! deliberately. Structure in this tool is text emitted identically to every
+//! reader on every platform (ADR-1f70ce2c3eac), the markers this crate already
+//! draws are, and the terminal least likely to carry the glyphs is the one on a
+//! phone -- which is the reader TASK-dd9747e5e305 is about to serve.
+//!
+//! **And focus is not decoration: the focused one of the two middle panels
+//! takes four fifths of the width.** A corpus reader has exactly two things
+//! worth being wide -- a list whose titles are sentences, and a body that is
+//! prose -- and they cannot both be wide at once in eighty columns. So the
+//! answer is the one lazygit gives: the panel being worked in is the one that
+//! gets the room, and the other stays as a reminder of what is there. Pressing
+//! Enter on a row therefore opens the document *and* hands it the screen, which
+//! is what opening something means.
+//!
+//! Below the width where two panels side by side are worth having at all, they
+//! reflow to one -- that is TASK-dd9747e5e305, and [`App::arrange`] is the one
+//! function it has to change: every rectangle on the screen is decided there,
+//! from the window and the focus and nothing else, so a second arrangement is a
+//! second branch in one place rather than a rewrite. The same function is what
+//! a tap has to be resolved against, since a mouse event carries a column and a
+//! row and needs to be told which panel that is.
+//!
+//! # A failure is a line on the screen and never the end of the session
+//!
+//! The CLI refuses on state, and a reader that exited on the first refusal
+//! would throw away the twelve hundred rows it already has because one entity
+//! could not be shown. So [`App::note`] carries what the CLI said, in the CLI's
+//! own bytes, and the frame keeps its shape.
 //!
 //! # Acting, and where the words come from
 //!
-//! [`App::run`] is the writing half: it puts the selected identifier in front of
-//! what was typed and hands the whole to [`Ank::act`], which spawns the verb.
-//! Nothing else here writes, and nothing runs without a line having been typed
-//! -- there is no timer in this crate, and [`App::frame`] is a pure function of
-//! what the last command left behind.
+//! [`App::run`] is the writing half and the only road to a spawned verb: it
+//! puts the identifier the focused panel names in front of what was typed and
+//! hands the whole to [`Ank::act`]. Nothing else here writes, and nothing runs
+//! without a line having been typed -- there is no timer in this crate, and
+//! [`App::frame`] is a pure function of what the last command left behind. One
+//! choke point, deliberately, because TASK-d4a882345837 puts a confirmation in
+//! front of it: the argv every write is about to run is composed in exactly one
+//! function, so the dialog that shows it has one thing to intercept.
 //!
 //! **`accept` runs through that same function, and the difference is what it is
 //! *not* allowed to be** (TASK-d90e94afca08). It is one more verb spawned
-//! against one selected identifier, which is the point: a ratification taken
-//! from this screen is the ratification a shell takes, because it *is* the
-//! command a shell runs. What the reader adds is subtraction. The grammar takes
-//! no tail after the word and takes the word only where the document is open,
-//! so the entity a ratification lands on is always one somebody put on the
-//! screen and read; [`App::ratify_line`] offers the word only where the verb
+//! against one identifier, which is the point: a ratification taken from this
+//! screen is the ratification a shell takes, because it *is* the command a
+//! shell runs. What the reader adds is subtraction. The grammar takes no tail
+//! after the word and takes the word only where the body panel has focus, so
+//! the entity a ratification lands on is always the document somebody opened
+//! and is looking at; [`App::ratify_line`] offers the word only where the verb
 //! would accept it; and the child is spawned with no stdin, so nothing in this
 //! process can answer a passphrase prompt on a person's behalf. Every refusal
 //! that follows -- the wrong branch, a document already ratified, a signature
@@ -35,10 +124,11 @@
 //!
 //! **The split on what reaches the screen is the crate header's, applied to an
 //! answer.** The chrome is this crate's own -- the line naming the command that
-//! ran, the two columns of gutter -- and every value under it is the document's,
-//! rendered by [`answered`] without a word added. A refusal is not rendered at
-//! all: it is the CLI's stderr, which already carries `error[N]:` and the
-//! command that resolves it, passed through the way [`Failed`] carries it.
+//! ran, the markers, the panel titles -- and every value under it is the
+//! document's, rendered by [`answered`] without a word added. A refusal is not
+//! rendered at all: it is the CLI's stderr, which already carries `error[N]:`
+//! and the command that resolves it, passed through the way [`Failed`] carries
+//! it.
 
 use crate::ank::{Ank, Failed, Ran};
 use crate::input::{Act, Command};
@@ -49,65 +139,117 @@ use crate::text::{self, fit, pad, window, wrap};
 use ratatui::buffer::Buffer;
 use ratatui::crossterm::event::KeyEvent;
 use ratatui::layout::{Constraint, Layout, Position, Rect};
+use ratatui::symbols::border;
 use ratatui::text::{Line, Text};
-use ratatui::widgets::{List, ListItem, Paragraph, Widget};
+use ratatui::widgets::{Block, Paragraph, Widget};
 
-/// # The ratification queue is a third view and not a section of the first
+/// Which panel has focus.
 ///
-/// It could have been a block above the entities, the way the claims are, and
-/// that was the first shape (TASK-d90e94afca08). Two facts sent it to a view of
-/// its own. `ank review` runs a whole inspection of the corpus and costs
-/// seconds where the other four verbs cost tenths, so a queue in the list frame
-/// is a queue paid for on every repaint, including the ones a watcher's news
-/// causes -- and this crate spent a wave making an idle screen cost nothing.
-/// And the queue answers a different question with a different second half:
-/// what is waiting, and *who may sign it*, which is a fact about the repository
-/// that has no place among rows about work.
-///
-/// So it is asked for, by `v`, and it shares everything the list already has:
-/// [`App::rows`] answers with the queue's rows there, so the cursor, the row
-/// numbers, `j`/`k` and Enter are the same code and behave the same way. Enter
-/// opens the document, which is where `accept` is typed.
+/// The order is the order `Tab` walks, the order the digits name, and the order
+/// the screen reads: claims across the top, then the two that share a row, then
+/// the queue across the bottom. A number on a panel is not decoration either --
+/// it is the whole of what "focus moves by key" costs a person to learn, since
+/// a reader who can see `4` on the queue never has to remember which key opens
+/// it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum View {
-    List,
+pub enum Focus {
+    Claims,
+    Entities,
+    Body,
     Queue,
-    Entity,
 }
 
-/// What the entity view is paging through.
+impl Focus {
+    /// Every panel, in the order `Tab` walks them.
+    pub const ALL: [Focus; 4] = [Focus::Claims, Focus::Entities, Focus::Body, Focus::Queue];
+
+    /// The digit that names this panel, which is the key that focuses it.
+    pub fn number(self) -> usize {
+        match self {
+            Focus::Claims => 1,
+            Focus::Entities => 2,
+            Focus::Body => 3,
+            Focus::Queue => 4,
+        }
+    }
+
+    /// The panel a digit names, or `None` where the digit names none.
+    pub fn of_digit(c: char) -> Option<Focus> {
+        let n = c.to_digit(10)? as usize;
+        Focus::ALL.into_iter().find(|f| f.number() == n)
+    }
+
+    /// The panel `by` steps along, wrapping.
+    ///
+    /// Wrapping and not clamping, unlike a cursor: four panels are a ring a
+    /// person walks with one key, and a `Tab` that stopped on the last of them
+    /// would be a key that does nothing every fourth press.
+    pub fn stepped(self, by: isize) -> Focus {
+        let len = Focus::ALL.len() as isize;
+        let at = (self.number() as isize - 1 + by).rem_euclid(len);
+        Focus::ALL[at as usize]
+    }
+
+    /// Whether this panel holds rows a cursor moves through.
+    ///
+    /// Three of the four do. The body is the one that does not: what moves
+    /// there is an offset into lines, because a document has no rows to select
+    /// and paging it is what "whole rather than cut" means.
+    pub fn holds_rows(self) -> bool {
+        self != Focus::Body
+    }
+
+    /// The name in the panel's own title.
+    fn name(self) -> &'static str {
+        match self {
+            Focus::Claims => "CLAIMS",
+            Focus::Entities => "ENTITIES",
+            Focus::Body => "BODY",
+            Focus::Queue => "QUEUE",
+        }
+    }
+}
+
+/// What the body panel is paging through.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Pane {
     Body,
     Constraints,
 }
 
+/// Where one listing is, and what of it is on the screen.
+///
+/// One per listing rather than one shared, which is what makes a panel a place
+/// rather than a mode: leaving the entities to look at the queue and coming
+/// back finds the row that was under the cursor, because it was never moved.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct Cursor {
+    at: usize,
+    top: usize,
+}
+
 pub struct App {
     size: (usize, usize),
-    view: View,
+    focus: Focus,
     pane: Pane,
     snapshot: Option<Snapshot>,
     detail: Option<Detail>,
     note: Option<String>,
-    /// The cursor, into the filtered rows.
-    cursor: usize,
-    /// The first filtered row on screen.
-    top: usize,
+    /// One cursor per panel, indexed by [`Focus::number`] less one. The body's
+    /// slot is never read: what moves there is `offset`.
+    cursors: [Cursor; 4],
     kind: Option<String>,
     search: Option<String>,
-    /// The first line of the pane on screen.
+    /// The first line of the body panel on screen.
     offset: usize,
     /// The change stream this reader is following, or `None` where there is
     /// nothing to follow. Read at every paint rather than stored as a word,
     /// because a watcher started after the session opened makes one appear.
     stream: Option<Stream>,
-    /// The ratification queue, once somebody has asked for it, and `None`
+    /// The ratification queue, once somebody has focused its panel, and `None`
     /// before that. Never loaded on the reader's own initiative: `review` is
-    /// the one read here that costs a full inspection of the corpus.
+    /// the one read here that inspects the whole corpus.
     queue: Option<Queue>,
-    /// The listing an open entity was opened from, so `b` goes back where the
-    /// person came from rather than always to the entities.
-    origin: View,
     /// The one-line prompt, open, with what has been typed into it so far.
     ///
     /// `None` is the ordinary state and it is where every key is a command. The
@@ -121,64 +263,70 @@ impl App {
     pub fn new(size: (usize, usize), stream: Option<Stream>) -> App {
         App {
             size,
-            view: View::List,
+            // Where a session opens, and it is the question a reader arrives
+            // with: what is in this corpus. The claims panel above it answers a
+            // narrower one and the body beside it is empty until something is
+            // opened.
+            focus: Focus::Entities,
             pane: Pane::Body,
             snapshot: None,
             detail: None,
             note: None,
-            cursor: 0,
-            top: 0,
+            cursors: [Cursor::default(); 4],
             kind: None,
             search: None,
             offset: 0,
             stream,
             queue: None,
-            origin: View::List,
             prompt: None,
         }
     }
 
-    pub fn view(&self) -> View {
-        self.view
+    pub fn focus(&self) -> Focus {
+        self.focus
     }
 
     pub fn note(&mut self, message: String) {
         self.note = Some(message);
     }
 
-    /// Ask the CLI for the corpus again, keeping the cursor where it can be
+    /// Ask the CLI for the corpus again, keeping every cursor where it can be
     /// kept: a reload that jumped to the top would lose the reader's place
     /// every time an entity was written next door.
     pub fn reload(&mut self, ank: &Ank) {
-        let held = self.selected().map(|r| r.id.clone());
+        let held = self.selected_id(Focus::Entities);
         match Snapshot::load(ank) {
             Ok(snapshot) => {
                 self.snapshot = Some(snapshot);
                 self.note = None;
                 self.requeue(ank);
                 if let Some(id) = held {
-                    if let Some(at) = self.rows().iter().position(|r| r.id == id) {
-                        self.cursor = at;
+                    if let Some(at) = self.entity_rows().iter().position(|r| r.id == id) {
+                        self.cursors[Focus::Entities.number() - 1].at = at;
                     }
                 }
-                self.clamp();
+                self.clamp_all();
             }
             Err(failed) => self.fail(failed),
         }
     }
 
-    /// Asks `review` again, but only where the queue is what somebody is
-    /// looking at.
+    /// Asks `review` again, but only where the queue panel has focus.
     ///
     /// **The condition is the whole of the design.** `review` inspects the
     /// corpus and costs what a `check` costs, so running it on every reload
     /// would put that price on every event a watcher sends and undo what
-    /// TASK-2f7777a1fdff bought. A queue nobody has opened is not stale, and one
-    /// that is open has to be current -- a ratification queue showing a document
-    /// somebody else ratified a minute ago is the one row a person would act on
-    /// wrongly.
+    /// TASK-2f7777a1fdff bought. A queue nobody is looking at is not stale, and
+    /// one that is focused has to be current -- a ratification queue showing a
+    /// document somebody else ratified a minute ago is the one row a person
+    /// would act on wrongly.
+    ///
+    /// A panel drawn is not a panel focused, and that distinction is what lets
+    /// the queue be on the screen at all times without being paid for at all
+    /// times: unfocused and never asked, it says so in the words that name the
+    /// price.
     fn requeue(&mut self, ank: &Ank) {
-        if self.view != View::Queue {
+        if self.focus != Focus::Queue {
             return;
         }
         match Queue::load(ank) {
@@ -195,17 +343,19 @@ impl App {
     /// caller holds (ADR-0bb7ea8991bc, and TASK-49746735127f found it the hard
     /// way), so re-reading the open entity here would be a watcher's news
     /// renewing somebody's claim -- a claim renewed by reporting rather than by
-    /// working, which is what that decision refuses and what
-    /// TASK-b50b340c0bb1 forbade a session to do by sitting still. So `reload`
-    /// and nothing else: the list and the claims come back current, and the body
-    /// on screen stays as it was until its person asks for it with `r`.
+    /// working, which is what that decision refuses and what TASK-b50b340c0bb1
+    /// forbade a session to do by sitting still. So `reload` and nothing else:
+    /// the listings come back current, and the body panel stays as it was until
+    /// its person asks for it with `r`.
     ///
-    /// That is a decision and not an omission. The alternative -- refreshing the
-    /// open entity too -- is one line, and it is the line that would make an
-    /// unattended screen keep a lease alive.
+    /// That is a decision and not an omission. The alternative -- refreshing
+    /// the open entity too -- is one line, and it is the line that would make
+    /// an unattended screen keep a lease alive. It is also why the body panel
+    /// does not preview whatever the entities cursor is on: a preview is an
+    /// `ank show` per `j`, and scrolling past the task you hold would renew it.
     ///
-    /// **The note survives.** An event arriving a second after a `done` must not
-    /// wipe what the CLI answered, which is the one thing on the screen the
+    /// **The note survives.** An event arriving a second after a `done` must
+    /// not wipe what the CLI answered, which is the one thing on the screen the
     /// person cannot get back.
     pub fn repaint(&mut self, ank: &Ank) {
         let said = self.note.take();
@@ -220,27 +370,30 @@ impl App {
     }
 
     // -----------------------------------------------------------------------
-    // The rows a filter leaves
+    // What each listing holds
     // -----------------------------------------------------------------------
 
-    /// The rows the current listing offers, filtered.
+    /// The entity rows, filtered by the kind and the search in force.
+    fn entity_rows(&self) -> Vec<&Row> {
+        match &self.snapshot {
+            Some(snapshot) => self.filtered(&snapshot.entities),
+            None => Vec::new(),
+        }
+    }
+
+    /// The proposals, filtered the same way.
     ///
-    /// One function for both listings rather than two, which is what makes the
-    /// cursor, the row numbers, `j`/`k` and Enter behave identically in the
-    /// queue without a line of their own. The filters apply there too: a queue
-    /// of two hundred proposals is a list like any other, and `f adr` narrows
-    /// it the way it narrows everything else.
-    fn rows(&self) -> Vec<&Row> {
-        let all: &[Row] = match self.view {
-            View::Queue => match &self.queue {
-                Some(queue) => &queue.proposed,
-                None => &[],
-            },
-            _ => match &self.snapshot {
-                Some(snapshot) => &snapshot.entities,
-                None => return Vec::new(),
-            },
-        };
+    /// The filters reach here too: a queue of two hundred proposals is a list
+    /// like any other, and `f adr` narrows it the way it narrows everything
+    /// else.
+    fn queue_rows(&self) -> Vec<&Row> {
+        match &self.queue {
+            Some(queue) => self.filtered(&queue.proposed),
+            None => Vec::new(),
+        }
+    }
+
+    fn filtered<'a>(&self, all: &'a [Row]) -> Vec<&'a Row> {
         let needle = self.search.as_ref().map(|s| s.to_ascii_lowercase());
         all.iter()
             .filter(|r| self.kind.as_ref().is_none_or(|k| &r.kind == k))
@@ -253,22 +406,49 @@ impl App {
             .collect()
     }
 
-    fn selected(&self) -> Option<&Row> {
-        self.rows().get(self.cursor).copied()
+    /// How many rows a listing holds.
+    fn count(&self, focus: Focus) -> usize {
+        match focus {
+            Focus::Claims => self.snapshot.as_ref().map_or(0, |s| s.claims.len()),
+            Focus::Entities => self.entity_rows().len(),
+            Focus::Queue => self.queue_rows().len(),
+            Focus::Body => 0,
+        }
     }
 
-    fn clamp(&mut self) {
-        let total = self.rows().len();
-        self.cursor = self.cursor.min(total.saturating_sub(1));
-        let page = self.list_page();
-        if self.cursor < self.top {
-            self.top = self.cursor;
+    /// The identifier the row under a listing's cursor names.
+    fn selected_id(&self, focus: Focus) -> Option<String> {
+        let at = self.cursors[focus.number() - 1].at;
+        match focus {
+            Focus::Claims => self.snapshot.as_ref()?.claims.get(at).map(|c| c.id.clone()),
+            Focus::Entities => self.entity_rows().get(at).map(|r| r.id.clone()),
+            Focus::Queue => self.queue_rows().get(at).map(|r| r.id.clone()),
+            Focus::Body => None,
         }
-        if page > 0 && self.cursor >= self.top + page {
-            self.top = self.cursor + 1 - page;
+    }
+
+    fn clamp_all(&mut self) {
+        for focus in Focus::ALL {
+            self.clamp(focus);
         }
-        if self.top >= total {
-            self.top = total.saturating_sub(1).min(self.top);
+    }
+
+    fn clamp(&mut self, focus: Focus) {
+        if !focus.holds_rows() {
+            return;
+        }
+        let total = self.count(focus);
+        let page = self.page(focus);
+        let c = &mut self.cursors[focus.number() - 1];
+        c.at = c.at.min(total.saturating_sub(1));
+        if c.at < c.top {
+            c.top = c.at;
+        }
+        if page > 0 && c.at >= c.top + page {
+            c.top = c.at + 1 - page;
+        }
+        if c.top >= total {
+            c.top = total.saturating_sub(1).min(c.top);
         }
     }
 
@@ -285,7 +465,7 @@ impl App {
     /// character, an edit or one of the two ways out, and nothing runs until
     /// Enter -- at which point the line goes through the grammar this reader
     /// already had, which is where the six verbs are spelled whole and where
-    /// `accept` is refused off the document and refused with a tail.
+    /// `accept` is refused off the body panel.
     ///
     /// So there is exactly one road from a key press to a spawned verb, and it
     /// passes through a line somebody typed. That is what TASK-d4a882345837
@@ -300,12 +480,12 @@ impl App {
                 }
                 Editing::Submit => {
                     let line = self.prompt.take().unwrap_or_default();
-                    let command = crate::input::parse(&line, self.view);
+                    let command = crate::input::parse(&line, self.focus);
                     self.act(command, ank)
                 }
             };
         }
-        match keys::typed(key, self.view) {
+        match keys::typed(key, self.focus) {
             Press::Run(command) => self.act(command, ank),
             Press::Cycle => {
                 let next = keys::next_kind(self.kind.as_deref());
@@ -329,80 +509,85 @@ impl App {
             Command::Quit => return true,
             Command::Reload => {
                 self.reload(ank);
-                if self.view == View::Entity {
-                    self.open_selected(ank);
+                if self.detail.is_some() {
+                    self.reopen(ank);
                 }
             }
-            Command::Move(by) => {
-                self.cursor = step(self.cursor, by, self.rows().len());
-                self.clamp();
+            Command::Panel(focus) => self.focus_on(focus, ank),
+            Command::NextPanel(by) => {
+                let next = self.focus.stepped(by);
+                self.focus_on(next, ank);
             }
-            Command::Page(by) => match self.view {
-                View::List | View::Queue => {
-                    let page = self.list_page().max(1) as isize;
-                    self.cursor = step(self.cursor, by * page, self.rows().len());
-                    self.clamp();
+            Command::Move(by) => match self.focus {
+                Focus::Body => {
+                    self.offset = step(self.offset, by, self.pane_lines().len());
                 }
-                View::Entity => {
-                    let page = self.pane_page().max(1);
+                listing => {
+                    let total = self.count(listing);
+                    let c = &mut self.cursors[listing.number() - 1];
+                    c.at = step(c.at, by, total);
+                    self.clamp(listing);
+                }
+            },
+            Command::Page(by) => match self.focus {
+                Focus::Body => {
+                    let page = self.page(Focus::Body).max(1);
                     let lines = self.pane_lines().len();
                     self.offset = match by {
                         b if b < 0 => self.offset.saturating_sub(page),
                         _ => (self.offset + page).min(lines.saturating_sub(1)),
                     };
                 }
-            },
-            Command::Top => match self.view {
-                View::List | View::Queue => {
-                    self.cursor = 0;
-                    self.top = 0;
+                listing => {
+                    let page = self.page(listing).max(1) as isize;
+                    let total = self.count(listing);
+                    let c = &mut self.cursors[listing.number() - 1];
+                    c.at = step(c.at, by * page, total);
+                    self.clamp(listing);
                 }
-                View::Entity => self.offset = 0,
+            },
+            Command::Top => match self.focus {
+                Focus::Body => self.offset = 0,
+                listing => self.cursors[listing.number() - 1] = Cursor::default(),
             },
             Command::Open => self.open_selected(ank),
-            Command::Queue => {
-                // The person asked, so the price is theirs to spend: this is
-                // the one read here that inspects the whole corpus.
-                self.view = View::Queue;
-                self.cursor = 0;
-                self.top = 0;
-                self.requeue(ank);
-                self.clamp();
-            }
-            Command::Back => {
-                self.view = match self.view {
-                    // Back out of a document to the listing it was opened
-                    // from, and out of the queue to the entities.
-                    View::Entity => self.origin,
-                    _ => View::List,
-                };
-                self.detail = None;
-                self.pane = Pane::Body;
-                self.offset = 0;
-                self.clamp();
-            }
-            Command::Select(needle) => match self.rows().iter().position(|r| {
-                r.id.to_ascii_uppercase()
-                    .starts_with(&needle.to_ascii_uppercase())
-            }) {
-                Some(at) => {
-                    self.cursor = at;
-                    self.clamp();
-                    self.open_selected(ank);
+            Command::Queue => self.focus_on(Focus::Queue, ank),
+            // Out of wherever a person went, back to the listing a session
+            // opens on. The body panel keeps the document it was given: a panel
+            // that emptied itself when focus left it would be a panel nobody
+            // could look away from.
+            Command::Back => self.focus_on(Focus::Entities, ank),
+            Command::Select(needle) => {
+                match self.entity_rows().iter().position(|r| {
+                    r.id.to_ascii_uppercase()
+                        .starts_with(&needle.to_ascii_uppercase())
+                }) {
+                    Some(at) => {
+                        self.focus = Focus::Entities;
+                        self.cursors[Focus::Entities.number() - 1].at = at;
+                        self.clamp(Focus::Entities);
+                        self.open_selected(ank);
+                    }
+                    None => {
+                        self.note = Some(format!(
+                            "no entity here matches '{needle}' (a filter is on: f, /)"
+                        ))
+                    }
                 }
-                None => {
-                    self.note = Some(format!(
-                        "no entity here matches '{needle}' (a filter is on: f, /)"
-                    ))
-                }
-            },
+            }
             Command::Row(n) => {
-                let total = self.rows().len();
+                if !self.focus.holds_rows() {
+                    self.note = Some(format!(
+                        "the body panel has no row {n}: a document is paged, not selected"
+                    ));
+                    return false;
+                }
+                let total = self.count(self.focus);
                 if n == 0 || n > total {
-                    self.note = Some(format!("there is no row {n}: the list holds {total}"));
+                    self.note = Some(format!("there is no row {n}: the panel holds {total}"));
                 } else {
-                    self.cursor = n - 1;
-                    self.clamp();
+                    self.cursors[self.focus.number() - 1].at = n - 1;
+                    self.clamp(self.focus);
                 }
             }
             Command::Kind(kind) => {
@@ -413,13 +598,13 @@ impl App {
                     }
                 }
                 self.kind = kind;
-                self.cursor = 0;
-                self.top = 0;
+                self.cursors[Focus::Entities.number() - 1] = Cursor::default();
+                self.cursors[Focus::Queue.number() - 1] = Cursor::default();
             }
             Command::Search(text) => {
                 self.search = text;
-                self.cursor = 0;
-                self.top = 0;
+                self.cursors[Focus::Entities.number() - 1] = Cursor::default();
+                self.cursors[Focus::Queue.number() - 1] = Cursor::default();
             }
             Command::Constraints => {
                 self.pane = match self.pane {
@@ -427,10 +612,12 @@ impl App {
                     Pane::Constraints => Pane::Body,
                 };
                 self.offset = 0;
+                // The pane that was asked for is the pane to be looking at.
+                self.focus = Focus::Body;
             }
             Command::Act(act) => self.run(act, ank),
             Command::Malformed(said) => self.note = Some(said),
-            Command::Help => self.note = Some(format!("{KEYS}\n{ENTITY_KEYS}\n{ACT_KEYS}")),
+            Command::Help => self.note = Some(format!("{KEYS}\n{PANEL_KEYS}\n{ACT_KEYS}")),
             Command::Nothing => {}
             Command::Unknown(word) => {
                 self.note = Some(format!("no command '{word}'; ? for the list"))
@@ -439,35 +626,54 @@ impl App {
         false
     }
 
-    /// The entity a typed act is about.
+    /// Move focus, and pay whatever the panel arriving costs.
     ///
-    /// The one that is open when one is open, and the row under the cursor
-    /// otherwise. Not the cursor in both cases: an entity opened by identifier
-    /// from a filtered list is the entity on the screen, and acting on whatever
-    /// the cursor drifted onto instead would be the reader choosing a different
-    /// task than the one being read.
-    fn target(&self) -> Option<String> {
-        match self.view {
-            View::Entity => self.detail.as_ref().map(|d| d.id.clone()),
-            View::List | View::Queue => self.selected().map(|r| r.id.clone()),
+    /// The queue is the only one that costs anything, and it is charged here
+    /// rather than at every repaint: focusing it is a person asking for
+    /// `ank review`, which is a whole inspection of the corpus.
+    fn focus_on(&mut self, focus: Focus, ank: &Ank) {
+        self.focus = focus;
+        if focus == Focus::Queue {
+            self.requeue(ank);
+            self.clamp(Focus::Queue);
         }
     }
 
-    /// Runs one verb of the writing half against the selected entity.
+    /// The entity a typed act is about.
+    ///
+    /// The body panel's document when that panel has focus, and the row under
+    /// the focused listing's cursor otherwise. Never both, and never a mixture:
+    /// an act is about the panel the person is in, which is the panel the
+    /// screen has already marked.
+    fn target(&self) -> Option<String> {
+        match self.focus {
+            Focus::Body => self.detail.as_ref().map(|d| d.id.clone()),
+            listing => self.selected_id(listing),
+        }
+    }
+
+    /// Runs one verb of the writing half against the entity the focused panel
+    /// names.
     ///
     /// The identifier goes in front of what was typed, because `<id>` is the
-    /// first positional of all five verbs and the person at the keyboard already
-    /// said which entity they meant by having it on the screen. Everything after
-    /// it is theirs, untouched.
+    /// first positional of all six verbs and the person at the keyboard already
+    /// said which entity they meant by being in the panel that names it.
+    /// Everything after it is theirs, untouched.
+    ///
+    /// **This is the one place an argv is composed**, which is what
+    /// TASK-d4a882345837 needs: a confirmation that shows the exact command
+    /// before anything is spawned has exactly one function to sit in front of.
     ///
     /// **The reread afterwards is part of the same keystroke.** A `claim` moves
     /// a ref and a `done` moves a status, so the frame still on the screen is
     /// stale the instant the verb answers; leaving it would be the reader
-    /// showing a task as open that it has just finished. This is not a timer and
-    /// there is none: nothing here runs unless a line was typed.
+    /// showing a task as open that it has just finished. This is not a timer
+    /// and there is none: nothing here runs unless a line was typed.
     fn run(&mut self, act: Act, ank: &Ank) {
         let Some(id) = self.target() else {
-            self.note = Some("no entity is selected: move onto a row, or open one".to_string());
+            self.note = Some(
+                "no entity is named here: move onto a row, or open one into the body".to_string(),
+            );
             return;
         };
         let verb = act.verb;
@@ -481,13 +687,13 @@ impl App {
             Err(failed) => failed.to_string(),
         };
         self.reload(ank);
-        if self.view == View::Entity {
-            self.open_selected(ank);
+        if self.detail.is_some() {
+            self.reopen(ank);
         }
-        // A ratification leaves the queue, so a queue somebody opened before
+        // A ratification leaves the queue, so a queue somebody loaded before
         // typing the word is wrong the moment it lands. Asked again here and
-        // nowhere else: `reload` refreshes it only where it is on the screen,
-        // and after an `accept` the screen is the document.
+        // nowhere else: `reload` refreshes it only where it is focused, and
+        // after an `accept` the focus is the body panel.
         if verb == "accept" && self.queue.is_some() {
             if let Ok(queue) = Queue::load(ank) {
                 self.queue = Some(queue);
@@ -502,22 +708,147 @@ impl App {
         });
     }
 
+    /// Opens the row the focused listing names into the body panel, and hands
+    /// the panel the focus and the width with it.
     fn open_selected(&mut self, ank: &Ank) {
-        let Some(id) = self.selected().map(|r| r.id.clone()) else {
+        if !self.focus.holds_rows() {
+            return;
+        }
+        let Some(id) = self.selected_id(self.focus) else {
             self.note = Some("no row to open".to_string());
             return;
         };
-        match Detail::load(ank, &id) {
+        self.show(ank, &id);
+    }
+
+    /// Asks `show` for whatever the body panel is already holding, leaving the
+    /// focus where it was.
+    fn reopen(&mut self, ank: &Ank) {
+        let Some(id) = self.detail.as_ref().map(|d| d.id.clone()) else {
+            return;
+        };
+        let was = self.focus;
+        self.show(ank, &id);
+        self.focus = was;
+    }
+
+    fn show(&mut self, ank: &Ank, id: &str) {
+        match Detail::load(ank, id) {
             Ok(detail) => {
+                let same = self.detail.as_ref().is_some_and(|d| d.id == detail.id);
                 self.detail = Some(detail);
-                if self.view != View::Entity {
-                    self.origin = self.view;
+                if !same {
+                    self.offset = 0;
                 }
-                self.view = View::Entity;
-                self.offset = 0;
+                self.focus = Focus::Body;
             }
             Err(failed) => self.fail(failed),
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // The arrangement
+    // -----------------------------------------------------------------------
+
+    /// Every rectangle on the screen, from the window and the focus.
+    ///
+    /// **The arithmetic is the layout's and the layout is asked twice.** It is
+    /// asked at paint time for where to put each widget, and it is asked by
+    /// [`App::page`] while a key is being answered, for how many rows a page
+    /// is. One function for both is what keeps a heading -- `41-60 of 1275` --
+    /// agreeing with the rows underneath it, which two independent counts would
+    /// not.
+    ///
+    /// It is also the seam TASK-dd9747e5e305 extends in both of its halves: one
+    /// column below a stated width is a branch here, and resolving a tap to a
+    /// panel is this function run backwards.
+    fn arrange(&self, area: Rect) -> Panels {
+        // **The two full-width panels are sized from counts and never from the
+        // lines they will draw.** What a panel draws is windowed to the room it
+        // has, so asking for the lines here would be asking the layout for the
+        // answer the layout is being computed to give.
+        let holding = self.count(Focus::Claims).max(1);
+        let waiting = match &self.queue {
+            // Not asked for: the sentence naming the price, and one line above
+            // it saying so.
+            None => 2,
+            // The proposals, over the one row the regime is always on.
+            Some(_) => self.count(Focus::Queue).max(1) + 1,
+        };
+        let keys = 2 + u16::from(self.ratify_line().is_some());
+        // `Max` on the two full-width panels and `Min` on the row between them:
+        // where the window is too short for all three, what gives way is a
+        // listing that is glanced at rather than the pair somebody is working
+        // in, and the trailer keeps its rows either way because a `Length`
+        // outranks both.
+        let [header, claims, band, queue, note, trailer] = Layout::vertical([
+            // Two lines and the rule under them.
+            Constraint::Length(3),
+            Constraint::Max(bordered(holding)),
+            Constraint::Min(5),
+            Constraint::Max(bordered(waiting)),
+            Constraint::Length(self.note_lines().len() as u16),
+            Constraint::Length(keys),
+        ])
+        .areas(area);
+        let (left_width, right_width) = share(band.width, self.focus != Focus::Body);
+        let [entities, body] = Layout::horizontal([
+            Constraint::Length(left_width),
+            Constraint::Length(right_width),
+        ])
+        .areas(band);
+        Panels {
+            header,
+            claims,
+            entities,
+            queue,
+            body,
+            note,
+            keys: trailer,
+        }
+    }
+
+    /// The rectangle one panel was given.
+    fn rect_of(&self, focus: Focus, area: Rect) -> Rect {
+        let panels = self.arrange(area);
+        match focus {
+            Focus::Claims => panels.claims,
+            Focus::Entities => panels.entities,
+            Focus::Body => panels.body,
+            Focus::Queue => panels.queue,
+        }
+    }
+
+    /// The rows a panel has room for, which is what a page is worth.
+    ///
+    /// A panel's own standing lines are taken off first, and that is not a
+    /// detail: a page the size of the panel would step the body past whatever
+    /// its heading was covering, and the rows nobody saw would be the ones
+    /// between two presses of `n`.
+    fn page(&self, focus: Focus) -> usize {
+        let inside = inside(self.rect_of(focus, self.area()));
+        let taken = match focus {
+            // The regime line sits on the panel's last row: which regime a
+            // corpus is in is a fact about every proposal above it.
+            Focus::Queue => 1,
+            Focus::Body => self.body_over(inside.width as usize),
+            _ => 0,
+        };
+        (inside.height as usize).saturating_sub(taken).max(1)
+    }
+
+    /// How many rows the body panel spends before the document itself: what
+    /// holds it, what binds it, and the blank under them.
+    ///
+    /// Zero on the constraints pane, which heads its list in the panel's title
+    /// and needs no block of its own.
+    fn body_over(&self, width: usize) -> usize {
+        if self.pane != Pane::Body || self.detail.is_none() {
+            return 0;
+        }
+        // The title, the coordination, the scope, the constraints heading,
+        // whatever the summary is, and the blank line under it.
+        4 + self.constraint_summary(width).len() + 1
     }
 
     // -----------------------------------------------------------------------
@@ -543,18 +874,463 @@ impl App {
     /// **Separate from [`App::draw`] so that a test can have the frame without
     /// owning a terminal.** Every assertion this crate makes about what is on
     /// the screen goes through here, into a `Buffer` the size of a stated
-    /// window -- which is what the renderer wrote before ratatui and is the one
-    /// property of it worth keeping. What changed is that the buffer is now the
-    /// same type the terminal is painted from, so what a test reads is what a
-    /// person sees rather than a second rendering of the same state.
+    /// window -- and the buffer is the same type the terminal is painted from,
+    /// so what a test reads is what a person sees rather than a second
+    /// rendering of the same state.
+    ///
+    /// **What it reads is symbols and never styles**, which is what makes "the
+    /// focused panel is distinguishable without colour" a property a test can
+    /// state: [`rows_of`] takes the character out of every cell and nothing
+    /// else, so a frame that told a reader where they are only by painting it
+    /// would come back from here saying nothing at all.
     pub fn render(&self, area: Rect, buf: &mut Buffer) {
         if area.is_empty() {
             return;
         }
-        match self.view {
-            View::List | View::Queue => self.render_list(area, buf),
-            View::Entity => self.render_entity(area, buf),
+        let width = area.width as usize;
+        let panels = self.arrange(area);
+
+        match &self.snapshot {
+            Some(snapshot) => {
+                paragraph(&[
+                    fit(
+                        &format!(
+                            "ank tui   corpus {}   branch {} (default {})",
+                            &snapshot.corpus[..12.min(snapshot.corpus.len())],
+                            snapshot.branch,
+                            snapshot.default_branch
+                        ),
+                        width,
+                    ),
+                    fit(
+                        &format!(
+                            "identity {}   {} claim(s) live   {}",
+                            snapshot.identity,
+                            snapshot.claims.len(),
+                            self.route()
+                        ),
+                        width,
+                    ),
+                    text::rule(width),
+                ])
+                .render(panels.header, buf);
+            }
+            None => {
+                // Nothing has been read yet, or the first read refused. The
+                // panels below still draw -- empty, and saying so -- because a
+                // reader that showed a different screen on a failed first read
+                // would be two layouts to keep in step.
+                paragraph(&[
+                    fit("ank tui", width),
+                    fit("the corpus has not been read", width),
+                    text::rule(width),
+                ])
+                .render(panels.header, buf);
+            }
         }
+
+        for focus in Focus::ALL {
+            self.panel(focus, self.rect_of(focus, area), buf);
+        }
+
+        paragraph(&self.note_lines()).render(panels.note, buf);
+
+        let mut keys = vec![fit(KEYS, width), fit(ACT_KEYS, width)];
+        if let Some(ratify) = self.ratify_line() {
+            keys.push(fit(ratify, width));
+        }
+        paragraph(&keys).render(panels.keys, buf);
+    }
+
+    /// One panel: its border, its title, and the lines it holds.
+    ///
+    /// **The focused one is told apart by two things and no colour.** Its
+    /// border is doubled -- `=` where the others rule with `-` -- and its title
+    /// carries the same `> ` this tool puts on the row a cursor is on. Two
+    /// independent signals, because a reader looking at the middle of a panel
+    /// still sees the rule under it.
+    fn panel(&self, focus: Focus, area: Rect, buf: &mut Buffer) {
+        if area.width < 2 || area.height < 2 {
+            return;
+        }
+        let focused = self.focus == focus;
+        let inside = inside(area);
+        let width = inside.width as usize;
+        let marker = if focused { text::CURSOR } else { text::PLAIN };
+        let title = fit(
+            &format!("{marker}{} {}", focus.number(), self.title_of(focus, width)),
+            area.width as usize - 2,
+        );
+        let block = Block::bordered()
+            .border_set(if focused { FOCUSED } else { UNFOCUSED })
+            .title(Line::from(title));
+        block.render(area, buf);
+        if inside.is_empty() {
+            return;
+        }
+        let lines = match focus {
+            Focus::Claims => self.claim_lines(width),
+            Focus::Entities => self.entity_lines(width, inside.height as usize),
+            Focus::Queue => self.queue_lines(width),
+            Focus::Body => self.body_lines(width, inside.height as usize),
+        };
+        paragraph(&lines).render(inside, buf);
+    }
+
+    /// What a panel's title says after its number: its name, and the state of
+    /// what it holds.
+    ///
+    /// The name is [`Focus::name`] and never a string written here, so the
+    /// title a person reads and the title a test looks for are one constant.
+    fn title_of(&self, focus: Focus, width: usize) -> String {
+        let name = focus.name();
+        match focus {
+            Focus::Claims => format!("{name} ({})", self.count(Focus::Claims)),
+            Focus::Entities => {
+                let total = self.snapshot.as_ref().map_or(0, |s| s.total);
+                let rows = self.count(Focus::Entities);
+                let c = self.cursors[Focus::Entities.number() - 1];
+                let shown = self.page(Focus::Entities).min(rows.saturating_sub(c.top));
+                format!(
+                    "{name} {}{}   ({total} in the corpus)",
+                    window(c.top, shown, rows),
+                    self.filter_note()
+                )
+            }
+            Focus::Queue => match &self.queue {
+                None => format!("{name}   (not asked)"),
+                Some(_) => {
+                    let rows = self.count(Focus::Queue);
+                    let c = self.cursors[Focus::Queue.number() - 1];
+                    let shown = self.page(Focus::Queue).min(rows.saturating_sub(c.top));
+                    format!(
+                        "{name} {}{}   (waiting for a person)",
+                        window(c.top, shown, rows),
+                        self.filter_note()
+                    )
+                }
+            },
+            Focus::Body => {
+                let Some(detail) = &self.detail else {
+                    return name.to_string();
+                };
+                let row = self.snapshot.as_ref().and_then(|s| s.row(&detail.id));
+                let counted = self.counted(width);
+                match self.pane {
+                    Pane::Body => format!(
+                        "{name}   {}  {}  {}   rows {counted}",
+                        short_of(&detail.id),
+                        row.map(|r| r.kind.clone()).unwrap_or_default(),
+                        row.map(|r| r.status.clone()).unwrap_or_default(),
+                    ),
+                    // The one title that is not the panel's name: the panel is
+                    // showing the other thing it can show, and saying `BODY`
+                    // over a list of decisions would be a heading that lies.
+                    Pane::Constraints => {
+                        format!("CONSTRAINTS   {}   {counted}", short_of(&detail.id))
+                    }
+                }
+            }
+        }
+    }
+
+    /// The window the body panel is showing, as `a-b of n`.
+    ///
+    /// Rows and not lines: a body line wider than the panel is several rows,
+    /// and calling them lines would be a count that disagrees with the file.
+    fn counted(&self, width: usize) -> String {
+        let lines = self.pane_rows(width);
+        let page = self.page(Focus::Body);
+        window(
+            self.offset,
+            page.min(lines.len().saturating_sub(self.offset)),
+            lines.len(),
+        )
+    }
+
+    /// The claims, one per row, the caller's own marked.
+    ///
+    /// Two markers and not one: the first two columns say where the cursor is,
+    /// the next two say whose claim it is. `*` is what `find` prints on a row
+    /// the caller holds, and it stays against the identifier rather than moving
+    /// to make room for a cursor that arrived later.
+    fn claim_lines(&self, width: usize) -> Vec<String> {
+        let Some(snapshot) = &self.snapshot else {
+            return vec![fit("  the corpus has not been read", width)];
+        };
+        if snapshot.claims.is_empty() {
+            return vec![fit("  nothing is held", width)];
+        }
+        let c = self.cursors[Focus::Claims.number() - 1];
+        let page = self.page(Focus::Claims);
+        snapshot
+            .claims
+            .iter()
+            .enumerate()
+            .skip(c.top)
+            .take(page)
+            .map(|(at, claim)| {
+                let here = if at == c.at && self.focus == Focus::Claims {
+                    text::CURSOR
+                } else {
+                    text::PLAIN
+                };
+                let whose = if claim.mine { text::HELD } else { text::PLAIN };
+                let title = snapshot
+                    .row(&claim.id)
+                    .map(|r| r.title.clone())
+                    .unwrap_or_default();
+                fit(
+                    &format!(
+                        "{here}{whose}{}  {}  until {}  {title}",
+                        pad(&short_of(&claim.id), 10),
+                        claim.holder,
+                        claim.expires
+                    ),
+                    width,
+                )
+            })
+            .collect()
+    }
+
+    /// The entity rows the panel has room for.
+    fn entity_lines(&self, width: usize, height: usize) -> Vec<String> {
+        let rows = self.entity_rows();
+        if rows.is_empty() {
+            return vec![fit("  no entity matches this filter", width)];
+        }
+        let c = self.cursors[Focus::Entities.number() - 1];
+        let held = |id: &str| {
+            self.snapshot
+                .as_ref()
+                .is_some_and(|s| s.claim_on(id).is_some())
+        };
+        rows.iter()
+            .enumerate()
+            .skip(c.top)
+            .take(height)
+            .map(|(at, row)| {
+                let here = if at == c.at && self.focus == Focus::Entities {
+                    text::CURSOR
+                } else {
+                    text::PLAIN
+                };
+                fit(
+                    &format!(
+                        "{here}{:>5}  {}  {}  {}{}",
+                        at + 1,
+                        pad(&row.short(), 10),
+                        pad(&row.status, 12),
+                        row.title,
+                        if held(&row.id) { "  [held]" } else { "" }
+                    ),
+                    width,
+                )
+            })
+            .collect()
+    }
+
+    /// The proposals, over the one line that says which regime the corpus is
+    /// in.
+    ///
+    /// **The regime is on the panel's last row and never omitted.** `review`
+    /// insists on the distinction and this screen is where it has an answer: a
+    /// corpus that declares no ratification key is in the advisory mode of §8,
+    /// which is a different fact from "nobody may sign", and a panel that drew
+    /// nothing where the signers go would let a person mistake one for the
+    /// other.
+    fn queue_lines(&self, width: usize) -> Vec<String> {
+        let regime = fit(
+            &match &self.queue {
+                None => "  4 or v runs 'ank review', which inspects the whole corpus".to_string(),
+                Some(queue) if queue.signers.is_empty() => {
+                    "  no ratification key declared: permissions are advisory, not enforced (§8)"
+                        .to_string()
+                }
+                Some(queue) => format!("  may ratify: {}", queue.signers.join("; ")),
+            },
+            width,
+        );
+        if self.queue.is_none() {
+            return vec![fit("  nothing asked for yet", width), regime];
+        }
+        let rows = self.queue_rows();
+        let mut out: Vec<String> = if rows.is_empty() {
+            // Said even where there is nothing to say, on `review`'s own
+            // reasoning: an empty queue and an unprinted queue read
+            // identically, and this panel is where the question has an answer.
+            let said = match self.kind.is_some() || self.search.is_some() {
+                true => "  nothing in the queue matches this filter",
+                false => "  nothing proposed for ratification",
+            };
+            vec![fit(said, width)]
+        } else {
+            let c = self.cursors[Focus::Queue.number() - 1];
+            let page = self.page(Focus::Queue);
+            rows.iter()
+                .enumerate()
+                .skip(c.top)
+                .take(page)
+                .map(|(at, row)| {
+                    let here = if at == c.at && self.focus == Focus::Queue {
+                        text::CURSOR
+                    } else {
+                        text::PLAIN
+                    };
+                    // No status column: everything in a ratification queue is
+                    // proposed, and a word repeated on every row is a column
+                    // spent saying nothing. The kind is not -- an ADR and a
+                    // specification are signed for different reasons.
+                    fit(
+                        &format!(
+                            "{here}{}  {}  {}",
+                            pad(&row.short(), 10),
+                            pad(&row.kind, 5),
+                            row.title
+                        ),
+                        width,
+                    )
+                })
+                .collect()
+        };
+        out.push(regime);
+        out
+    }
+
+    /// The open document: what holds it, what binds it, and its body.
+    fn body_lines(&self, width: usize, height: usize) -> Vec<String> {
+        let Some(detail) = &self.detail else {
+            return vec![
+                fit("  nothing is open here", width),
+                fit(
+                    "  Enter opens the row a listing's cursor is on, and hands this panel the",
+                    width,
+                ),
+                fit(
+                    "  width. Nothing is previewed: 'show' renews the lease on a task you hold,",
+                    width,
+                ),
+                fit(
+                    "  so a body that followed a cursor would renew a claim by being scrolled.",
+                    width,
+                ),
+            ];
+        };
+        let row = self.snapshot.as_ref().and_then(|s| s.row(&detail.id));
+        let mut out = Vec::new();
+        if self.pane == Pane::Body {
+            out.push(fit(
+                &row.map(|r| r.title.clone())
+                    .unwrap_or_else(|| detail.id.clone()),
+                width,
+            ));
+            out.push(fit(
+                detail.coordination.as_deref().unwrap_or("no claim on this"),
+                width,
+            ));
+            out.push(fit(
+                &format!("scope {}", join_or(&detail.scopes, "declared on nothing")),
+                width,
+            ));
+            out.push(fit(
+                &format!(
+                    "CONSTRAINTS ({} active, {} over this scope)",
+                    active(&detail.constraints),
+                    detail.constraints.len()
+                ),
+                width,
+            ));
+            out.extend(self.constraint_summary(width));
+            out.push(String::new());
+        }
+        let over = out.len();
+        let rows = self.pane_rows(width);
+        out.extend(
+            rows.iter()
+                .skip(self.offset)
+                .take(height.saturating_sub(over))
+                .map(|line| fit(line, width)),
+        );
+        out
+    }
+
+    /// The lines the body panel is paging through, at a stated width.
+    ///
+    /// Never trimmed and never elided: `content` is the entity as `show`
+    /// printed it, and "the body of a selected entity whole" is what the
+    /// criterion asks for. A panel narrower than the body is answered in both
+    /// directions -- paged down it, and wrapped across it, so a line wider than
+    /// the panel keeps its end instead of losing it to a `~`. The wrap is this
+    /// crate's rather than `Paragraph`'s for the reason `text.rs` gives: a
+    /// widget that wraps inside its own render reports no count, and the title
+    /// over it states one.
+    fn pane_rows(&self, width: usize) -> Vec<String> {
+        let Some(detail) = &self.detail else {
+            return Vec::new();
+        };
+        match self.pane {
+            Pane::Body => detail
+                .content
+                .lines()
+                .flat_map(|l| wrap(l, width.max(1)))
+                .collect(),
+            Pane::Constraints => detail.constraints.iter().map(constraint_row).collect(),
+        }
+    }
+
+    /// The same, at whatever width the body panel has now.
+    fn pane_lines(&self) -> Vec<String> {
+        let width = inside(self.rect_of(Focus::Body, self.area())).width as usize;
+        self.pane_rows(width)
+    }
+
+    /// The first few constraints, so the body panel still answers "what binds
+    /// this" without a command. `c` gives the list whole.
+    fn constraint_summary(&self, width: usize) -> Vec<String> {
+        let Some(detail) = &self.detail else {
+            return Vec::new();
+        };
+        let room = 3.min(detail.constraints.len());
+        let mut out: Vec<String> = detail.constraints[..room]
+            .iter()
+            .map(|c| fit(&constraint_row(c), width))
+            .collect();
+        if detail.constraints.len() > room {
+            out.push(fit(
+                &format!(
+                    "  +{} more, c for the list",
+                    detail.constraints.len() - room
+                ),
+                width,
+            ));
+        }
+        if detail.constraints.is_empty() {
+            out.push(fit("  nothing binds this scope", width));
+        }
+        out
+    }
+
+    /// The offer to ratify, where the body panel holds a document that can be
+    /// ratified.
+    ///
+    /// **Shown on a proposed ADR or spec and on nothing else.** `accept`
+    /// refuses a task, and it refuses a document already accepted, so a trailer
+    /// that carried the word over every open entity would be offering what the
+    /// verb turns down -- the defect TASK-84cfad83c308 named on `help`, which
+    /// is the same defect wherever an interface makes a promise the dispatch
+    /// does not keep. A person reading a task therefore never sees the word at
+    /// all, and one reading a proposal sees what it costs: their signature, on
+    /// the default branch, on this document.
+    ///
+    /// The status is the snapshot's and not this crate's judgement. Where the
+    /// snapshot does not carry the row -- `find` answers within a budget -- no
+    /// line is drawn, which errs towards saying nothing rather than towards
+    /// offering something.
+    fn ratify_line(&self) -> Option<&'static str> {
+        let detail = self.detail.as_ref()?;
+        let row = self.snapshot.as_ref()?.row(&detail.id)?;
+        let ratifiable = row.status == "proposed" && matches!(row.kind.as_str(), "adr" | "spec");
+        ratifiable.then_some(RATIFY_KEY)
     }
 
     /// The frame as text, row by row, for a test to read.
@@ -591,10 +1367,10 @@ impl App {
             return;
         }
         self.size = size;
-        // A shorter window is a smaller page, so the cursor can fall off the
-        // bottom of a listing that was fine a moment ago, and a body can be
-        // scrolled past its own end.
-        self.clamp();
+        // A shorter window is a smaller page, so a cursor can fall off the
+        // bottom of a listing that was fine a moment ago, and a narrower one
+        // rewraps a body under an offset that was inside it.
+        self.clamp_all();
         let lines = self.pane_lines().len();
         self.offset = self.offset.min(lines.saturating_sub(1));
     }
@@ -606,10 +1382,7 @@ impl App {
     /// Where the caret goes, which is the end of the prompt or nowhere.
     fn caret(&self, area: Rect) -> Option<Position> {
         let line = self.prompt.as_ref()?;
-        let note = match self.view {
-            View::List | View::Queue => self.list_panes(area).note,
-            View::Entity => self.entity_panes(area).note,
-        };
+        let note = self.arrange(area).note;
         let at = PROMPT.chars().count() + line.chars().count();
         Some(Position::new(
             note.x + (at as u16).min(note.width.saturating_sub(1)),
@@ -619,13 +1392,13 @@ impl App {
 
     /// The note, as the rows it costs.
     ///
-    /// A note used to be one line, and an act's answer is not: a document has a
-    /// field per line and a refusal has its sentence and the command that
-    /// resolves it. So the note is measured rather than assumed, and both
-    /// layouts pay for what it actually is.
+    /// A note is not one line: a document has a field per line and a refusal
+    /// has its sentence and the command that resolves it. So the note is
+    /// measured rather than assumed, and the layout pays for what it actually
+    /// is.
     ///
     /// **An open prompt is drawn here and hides whatever the note was saying.**
-    /// One row of the screen belongs to whatever the reader is being told or
+    /// One band of the screen belongs to whatever the reader is being told or
     /// asked, and a person typing `done commit:<sha>` needs to see the line
     /// they are typing far more than the answer to the command before it. What
     /// was there comes back when the prompt is dismissed, because cancelling
@@ -640,7 +1413,18 @@ impl App {
             return vec![fit(&format!("{PROMPT}{line}"), width)];
         }
         match &self.note {
-            None => vec![String::new()],
+            None => match self
+                .detail
+                .as_ref()
+                .and_then(|d| d.unresolved.first())
+                .filter(|_| self.focus == Focus::Body)
+            {
+                Some(u) => vec![fit(
+                    &format!("a scope could not be asked about -- {u}"),
+                    width,
+                )],
+                None => vec![String::new()],
+            },
             Some(note) => note
                 .lines()
                 .flat_map(|l| wrap(l, width))
@@ -649,276 +1433,11 @@ impl App {
         }
     }
 
-    /// The bands of a listing, as ratatui's solver divides the window.
-    ///
-    /// **The arithmetic is the layout's and the layout is asked twice.** It is
-    /// asked here, at paint time, for where to put each widget; and it is asked
-    /// by [`App::list_page`], while a key is being answered, for how many rows
-    /// a page is. One function for both is what keeps the heading -- `41-60 of
-    /// 1275` -- agreeing with the rows underneath it, which two independent
-    /// counts would not.
-    fn list_panes(&self, area: Rect) -> Panes {
-        // At least one: an empty section still costs the line that says so.
-        let standing = 1 + self.standing_lines().len().max(1);
-        let [header, block, _, heading, rows, _, note, keys] = Layout::vertical([
-            // Two lines and the rule under them.
-            Constraint::Length(3),
-            Constraint::Length(standing as u16),
-            Constraint::Length(1),
-            Constraint::Length(1),
-            Constraint::Min(1),
-            Constraint::Length(1),
-            Constraint::Length(self.note_lines().len() as u16),
-            Constraint::Length(2),
-        ])
-        .areas(area);
-        Panes {
-            header,
-            block,
-            heading,
-            rows,
-            note,
-            keys,
-        }
-    }
-
-    /// The rows the list has room for.
-    fn list_page(&self) -> usize {
-        (self.list_panes(self.area()).rows.height as usize).max(1)
-    }
-
-    /// The block between the rule and the rows: who holds what on the
-    /// entities, who may sign on the queue.
-    ///
-    /// Two answers in one place because they are the same kind of thing -- a
-    /// standing fact about the corpus that the rows below are read against --
-    /// and because the layout above has one band to pay for either way.
-    fn standing_lines(&self) -> Vec<String> {
-        match self.view {
-            View::Queue => self.signer_lines(),
-            _ => self.claim_lines(),
-        }
-    }
-
-    /// The heading over that block, and the sentence for an empty one.
-    ///
-    /// The empty queue sentence is §8's own, carried through from `review`
-    /// rather than written again here: an empty signer list is not "declared,
-    /// and nobody yet" -- it is the advisory regime, and a reader that rendered
-    /// a section with no rows would let a person mistake one for the other.
-    fn standing_heading(&self) -> (String, &'static str) {
-        match self.view {
-            View::Queue => (
-                format!("MAY RATIFY ({})", self.signer_lines().len()),
-                "  no ratification key declared: permissions are advisory, not enforced (§8)",
-            ),
-            _ => (
-                format!(
-                    "CLAIMS ({})",
-                    self.snapshot.as_ref().map_or(0, |s| s.claims.len())
-                ),
-                "  nothing is held",
-            ),
-        }
-    }
-
-    /// The principals `.ank/allowed_signers` declares, as `review` reads them.
-    fn signer_lines(&self) -> Vec<String> {
-        let width = self.width();
-        match &self.queue {
-            None => Vec::new(),
-            Some(queue) => queue
-                .signers
-                .iter()
-                .map(|s| fit(&format!("  {s}"), width))
-                .collect(),
-        }
-    }
-
-    fn claim_lines(&self) -> Vec<String> {
-        let Some(snapshot) = &self.snapshot else {
-            return Vec::new();
-        };
-        let width = self.width();
-        let room = 4.min(snapshot.claims.len());
-        let mut out: Vec<String> = snapshot.claims[..room]
-            .iter()
-            .map(|c| {
-                let marker = if c.mine { text::HELD } else { text::PLAIN };
-                let title = snapshot
-                    .row(&c.id)
-                    .map(|r| r.title.clone())
-                    .unwrap_or_default();
-                fit(
-                    &format!(
-                        "{marker}{}  {}  until {}  {title}",
-                        pad(&short_of(&c.id), 10),
-                        pad(&c.holder, 32),
-                        c.expires
-                    ),
-                    width,
-                )
-            })
-            .collect();
-        if snapshot.claims.len() > room {
-            out.push(format!("  +{} more", snapshot.claims.len() - room));
-        }
-        out
-    }
-
-    fn render_list(&self, area: Rect, buf: &mut Buffer) {
-        let width = self.width();
-        let Some(snapshot) = &self.snapshot else {
-            // Nothing has been read yet, or the first read refused. There are
-            // no bands to divide: what the screen owes is the sentence and the
-            // way out.
-            let mut lines = vec![
-                "ank tui".to_string(),
-                String::new(),
-                self.note
-                    .clone()
-                    .unwrap_or_else(|| "the corpus has not been read".to_string()),
-                String::new(),
-                KEYS.to_string(),
-                ACT_KEYS.to_string(),
-            ];
-            lines.iter_mut().for_each(|l| *l = fit(l, width));
-            paragraph(&lines).render(area, buf);
-            return;
-        };
-        let panes = self.list_panes(area);
-
-        paragraph(&[
-            fit(
-                &format!(
-                    "ank tui   corpus {}   branch {} (default {})",
-                    &snapshot.corpus[..12.min(snapshot.corpus.len())],
-                    snapshot.branch,
-                    snapshot.default_branch
-                ),
-                width,
-            ),
-            fit(
-                &format!(
-                    "identity {}   {} claim(s) live   {}",
-                    snapshot.identity,
-                    snapshot.claims.len(),
-                    self.route()
-                ),
-                width,
-            ),
-            text::rule(width),
-        ])
-        .render(panes.header, buf);
-
-        let (heading, empty) = self.standing_heading();
-        let standing = self.standing_lines();
-        let mut block = vec![heading];
-        if standing.is_empty() {
-            block.push(fit(empty, width));
-        } else {
-            block.extend(standing);
-        }
-        paragraph(&block).render(panes.block, buf);
-
-        let rows = self.rows();
-        let page = panes.rows.height as usize;
-        let shown = page.min(rows.len().saturating_sub(self.top));
-        paragraph(&[fit(
-            &match self.view {
-                // The queue is answered whole: `review` carries no attention
-                // budget, so there is no "of N in the corpus" to state and
-                // stating one would imply a withholding that did not happen.
-                View::Queue => format!(
-                    "QUEUE {}{}   (proposed, and waiting for a person)",
-                    window(self.top, shown, rows.len()),
-                    self.filter_note()
-                ),
-                _ => format!(
-                    "ENTITIES {}{}   (of {} in the corpus)",
-                    window(self.top, shown, rows.len()),
-                    self.filter_note(),
-                    snapshot.total
-                ),
-            },
-            width,
-        )])
-        .render(panes.heading, buf);
-
-        // A `List` and not a paragraph, because these rows are a list: what is
-        // handed to it is exactly the window the heading above announced, so
-        // the widget scrolls nothing and there is no second offset to disagree
-        // with `self.top`.
-        let items: Vec<ListItem> = if rows.is_empty() {
-            vec![ListItem::new(
-                match (self.view, self.kind.is_some() || self.search.is_some()) {
-                    // Said even where there is nothing to say, on `review`'s own
-                    // reasoning: an empty queue and an unprinted queue read
-                    // identically, and this screen is where the question has an
-                    // answer.
-                    (View::Queue, false) => "  nothing proposed for ratification".to_string(),
-                    (View::Queue, true) => "  nothing in the queue matches this filter".to_string(),
-                    _ => "  no entity matches this filter".to_string(),
-                },
-            )]
-        } else {
-            rows.iter()
-                .skip(self.top)
-                .take(page)
-                .enumerate()
-                .map(|(i, row)| {
-                    let at = self.top + i;
-                    let marker = if at == self.cursor {
-                        text::CURSOR
-                    } else {
-                        text::PLAIN
-                    };
-                    let held = snapshot.claim_on(&row.id).is_some();
-                    ListItem::new(fit(
-                        &format!(
-                            "{marker}{:>5}  {}  {}  {}{}",
-                            at + 1,
-                            pad(&row.short(), 10),
-                            pad(&row.status, 12),
-                            row.title,
-                            if held { "  [held]" } else { "" }
-                        ),
-                        width,
-                    ))
-                })
-                .collect()
-        };
-        List::new(items).render(panes.rows, buf);
-
-        paragraph(&self.note_lines()).render(panes.note, buf);
-        paragraph(&[
-            fit(KEYS, width),
-            fit(
-                match self.view {
-                    // `accept` is deliberately not offered here, and neither are
-                    // the five: a ratification is typed on the document, and a
-                    // trailer that offered one at a row would be making an offer
-                    // the grammar turns down (TASK-84cfad83c308's rule, on this
-                    // screen).
-                    View::Queue => QUEUE_ACT,
-                    _ => ACT_KEYS,
-                },
-                width,
-            ),
-        ])
-        .render(panes.keys, buf);
-    }
-
     /// How this screen is being kept current, in the two words a person needs.
     ///
     /// It says a stream exists, never that a watcher is running: nothing here
     /// can honestly say the second without polling something, and polling
     /// something is what the stream exists to remove.
-    ///
-    /// **On the list and not on an entity**, deliberately. An event refreshes
-    /// the list and leaves the open body where it was, for the reason
-    /// [`App::repaint`] gives, so a line promising a live screen over a body
-    /// that is not one would be the reader overstating what it does.
     fn route(&self) -> &'static str {
         match &self.stream {
             Some(s) if s.following() => "stream following",
@@ -941,216 +1460,106 @@ impl App {
             }
         }
     }
+}
 
-    /// The lines the entity view is paging through: the body whole, or the
-    /// constraints whole, according to the pane.
-    fn pane_lines(&self) -> Vec<String> {
-        let Some(detail) = &self.detail else {
-            return Vec::new();
-        };
-        match self.pane {
-            // Never trimmed and never elided: `content` is the entity as `show`
-            // printed it, and "the body of a selected entity whole" is what the
-            // criterion asks for. A window smaller than the body is answered in
-            // both directions -- paged down it, and wrapped across it, so a
-            // line wider than the terminal keeps its end instead of losing it
-            // to a `~`. The wrap is this crate's rather than `Paragraph`'s for
-            // the reason `text.rs` gives: a widget that wraps inside its own
-            // render reports no count, and the heading over it states one.
-            Pane::Body => detail
-                .content
-                .lines()
-                .flat_map(|l| wrap(l, self.width()))
-                .collect(),
-            Pane::Constraints => detail.constraints.iter().map(constraint_row).collect(),
-        }
-    }
+/// The border of a panel nobody is in.
+///
+/// ASCII, and that is a decision rather than an omission: structure in this
+/// tool is text emitted identically to every reader on every platform
+/// (ADR-1f70ce2c3eac), the markers this crate already draws are, and the
+/// terminal least likely to carry the box-drawing glyphs is the one on a phone
+/// -- which is the reader TASK-dd9747e5e305 is about to serve.
+const UNFOCUSED: border::Set = border::Set {
+    top_left: "+",
+    top_right: "+",
+    bottom_left: "+",
+    bottom_right: "+",
+    vertical_left: "|",
+    vertical_right: "|",
+    horizontal_top: "-",
+    horizontal_bottom: "-",
+};
 
-    /// The bands of a document, as ratatui's solver divides the window.
-    fn entity_panes(&self, area: Rect) -> Panes {
-        // The band above the pane carries what differs between the two: the
-        // body pane heads its own section with the constraints summarised over
-        // it, and the constraints pane heads one section and nothing else.
-        let over = match self.pane {
-            Pane::Body => 1 + self.constraint_summary().len() + 1 + 1,
-            Pane::Constraints => 1 + 1,
-        };
-        let ratify = usize::from(self.ratify_line().is_some());
-        let [header, block, rows, _, note, keys] = Layout::vertical([
-            // Four lines and the rule under them.
-            Constraint::Length(5),
-            Constraint::Length(over as u16),
-            Constraint::Min(1),
-            Constraint::Length(1),
-            Constraint::Length(self.note_lines().len() as u16),
-            Constraint::Length((2 + ratify) as u16),
-        ])
-        .areas(area);
-        Panes {
-            header,
-            block,
-            heading: block,
-            rows,
-            note,
-            keys,
-        }
-    }
+/// The border of the panel with the focus: the same box, ruled twice.
+///
+/// The verticals stay `|` so that two panels sharing a row are the same one
+/// column of characters apart whichever of them has the focus. What changes is
+/// the rule above and below, which is where a title sits and where the eye
+/// goes.
+const FOCUSED: border::Set = border::Set {
+    top_left: "+",
+    top_right: "+",
+    bottom_left: "+",
+    bottom_right: "+",
+    vertical_left: "|",
+    vertical_right: "|",
+    horizontal_top: "=",
+    horizontal_bottom: "=",
+};
 
-    fn pane_page(&self) -> usize {
-        (self.entity_panes(self.area()).rows.height as usize).max(1)
-    }
+/// The rectangles one frame is divided into.
+struct Panels {
+    header: Rect,
+    claims: Rect,
+    entities: Rect,
+    queue: Rect,
+    body: Rect,
+    note: Rect,
+    keys: Rect,
+}
 
-    /// The offer to ratify, where this document is one that can be ratified.
-    ///
-    /// **Shown on a proposed ADR or spec and on nothing else.** `accept` refuses
-    /// a task, and it refuses a document already accepted, so a trailer that
-    /// carried the word over every open entity would be offering what the verb
-    /// turns down -- the defect TASK-84cfad83c308 named on `help`, which is the
-    /// same defect wherever an interface makes a promise the dispatch does not
-    /// keep. A person reading a task therefore never sees the word at all, and
-    /// one reading a proposal sees what it costs: their signature, on the
-    /// default branch, on this document.
-    ///
-    /// The status is the snapshot's and not this crate's judgement. Where the
-    /// snapshot does not carry the row -- `find` answers within a budget -- no
-    /// line is drawn, which errs towards saying nothing rather than towards
-    /// offering something.
-    fn ratify_line(&self) -> Option<&'static str> {
-        let detail = self.detail.as_ref()?;
-        let row = self.snapshot.as_ref()?.row(&detail.id)?;
-        let ratifiable = row.status == "proposed" && matches!(row.kind.as_str(), "adr" | "spec");
-        ratifiable.then_some(RATIFY_KEY)
-    }
-
-    /// The first few constraints, so the body view still answers "what binds
-    /// this" without a command. `c` gives the list whole.
-    fn constraint_summary(&self) -> Vec<String> {
-        let Some(detail) = &self.detail else {
-            return Vec::new();
-        };
-        let width = self.width();
-        let room = 4.min(detail.constraints.len());
-        let mut out: Vec<String> = detail.constraints[..room]
-            .iter()
-            .map(|c| fit(&constraint_row(c), width))
-            .collect();
-        if detail.constraints.len() > room {
-            out.push(format!(
-                "  +{} more, c for the list",
-                detail.constraints.len() - room
-            ));
-        }
-        if detail.constraints.is_empty() {
-            out.push("  nothing binds this scope".to_string());
-        }
-        out
-    }
-
-    fn render_entity(&self, area: Rect, buf: &mut Buffer) {
-        let width = self.width();
-        let Some(detail) = &self.detail else {
-            return self.render_list(area, buf);
-        };
-        let row = self.snapshot.as_ref().and_then(|s| s.row(&detail.id));
-        let panes = self.entity_panes(area);
-
-        paragraph(&[
-            fit(
-                &format!(
-                    "{}   {}   {}",
-                    short_of(&detail.id),
-                    row.map(|r| r.kind.clone()).unwrap_or_default(),
-                    row.map(|r| r.status.clone()).unwrap_or_default()
-                ),
-                width,
-            ),
-            fit(
-                &row.map(|r| r.title.clone())
-                    .unwrap_or_else(|| detail.id.clone()),
-                width,
-            ),
-            fit(
-                detail.coordination.as_deref().unwrap_or("no claim on this"),
-                width,
-            ),
-            fit(
-                &format!("scope {}", join_or(&detail.scopes, "declared on nothing")),
-                width,
-            ),
-            text::rule(width),
-        ])
-        .render(panes.header, buf);
-
-        let pane_lines = self.pane_lines();
-        let page = panes.rows.height as usize;
-        let counted = window(
-            self.offset,
-            page.min(pane_lines.len().saturating_sub(self.offset)),
-            pane_lines.len(),
-        );
-        let mut over = Vec::new();
-        if self.pane == Pane::Body {
-            over.push(format!(
-                "CONSTRAINTS ({} active, {} over this scope)",
-                active(&detail.constraints),
-                detail.constraints.len()
-            ));
-            over.extend(self.constraint_summary());
-            over.push(String::new());
-            // Rows and not lines: a body line wider than the window is several
-            // rows, and calling them lines would be a count that disagrees with
-            // the file.
-            over.push(fit(&format!("BODY   rows {counted}"), width));
+/// How the two panels that share a row divide it, and which of them the focus
+/// is in.
+///
+/// **Four fifths to the one being worked in.** A corpus reader has two things
+/// worth being wide -- a listing whose titles are sentences, and a body that is
+/// prose -- and eighty columns will not hold both. Splitting the difference
+/// gives two panels that are each slightly too narrow, which is the arrangement
+/// that serves neither question; giving the room to the panel somebody is in
+/// serves whichever one they are asking, and the other stays as a reminder of
+/// what is there.
+///
+/// The share the other one keeps has a floor, because a column of four
+/// characters is a border and nothing else. Below twice that floor there is no
+/// arrangement that honours it, and the row is halved -- the width at which
+/// TASK-dd9747e5e305's single column is the honest answer.
+fn share(width: u16, left: bool) -> (u16, u16) {
+    const FLOOR: u16 = 12;
+    if width < FLOOR * 2 {
+        let half = width / 2;
+        return if left {
+            (width - half, half)
         } else {
-            over.push(fit(&format!("CONSTRAINTS   {counted}"), width));
-            over.push(String::new());
-        }
-        paragraph(&over).render(panes.block, buf);
-
-        let shown: Vec<String> = pane_lines
-            .iter()
-            .skip(self.offset)
-            .take(page)
-            .map(|line| fit(line, width))
-            .collect();
-        paragraph(&shown).render(panes.rows, buf);
-
-        match &self.note {
-            Some(_) => paragraph(&self.note_lines()),
-            None if self.prompt.is_some() => paragraph(&self.note_lines()),
-            None => paragraph(&[fit(
-                &detail
-                    .unresolved
-                    .first()
-                    .map(|u| format!("a scope could not be asked about -- {u}"))
-                    .unwrap_or_default(),
-                width,
-            )]),
-        }
-        .render(panes.note, buf);
-
-        let mut keys = vec![fit(ENTITY_KEYS, width), fit(ACT_KEYS, width)];
-        if let Some(ratify) = self.ratify_line() {
-            keys.push(fit(ratify, width));
-        }
-        paragraph(&keys).render(panes.keys, buf);
+            (half, width - half)
+        };
+    }
+    let wide = (width * 4 / 5).clamp(FLOOR, width - FLOOR);
+    if left {
+        (wide, width - wide)
+    } else {
+        (width - wide, wide)
     }
 }
 
-/// The bands one view divides its window into.
+/// How many rows a full-width panel asks for: what it holds, plus its two
+/// borders, and never more than six rows of content.
 ///
-/// One shape for both layouts, because the two are the same screen with
-/// different content in the bands: a header, a standing block, a heading, the
-/// rows that page, whatever the reader is being told, and the keys. A document
-/// heads its rows out of the same band it summarises the constraints in, so
-/// `heading` and `block` are one there rather than a band spent on nothing.
-struct Panes {
-    header: Rect,
-    block: Rect,
-    heading: Rect,
-    rows: Rect,
-    note: Rect,
-    keys: Rect,
+/// Capped because both of them are listings a reader glances at: a corpus with
+/// forty live claims would otherwise push the pair in the middle off the
+/// screen, and forty claims is a scroll rather than a screen.
+fn bordered(rows: usize) -> u16 {
+    (rows as u16).clamp(1, 6) + 2
+}
+
+/// The rectangle inside a panel's borders, which is what `Block` calls its
+/// inner area.
+fn inside(rect: Rect) -> Rect {
+    Rect {
+        x: rect.x.saturating_add(1),
+        y: rect.y.saturating_add(1),
+        width: rect.width.saturating_sub(2),
+        height: rect.height.saturating_sub(2),
+    }
 }
 
 /// Lines, as a widget that clips rather than wraps.
@@ -1169,6 +1578,11 @@ fn paragraph(lines: &[String]) -> Paragraph<'static> {
 }
 
 /// A buffer as text, one row per line, for a test to read.
+///
+/// The symbol out of every cell and nothing else: no colour, no attribute, no
+/// style. That is deliberate and it is what makes the focus assertions mean
+/// something -- a frame that said where the focus was only in a colour would
+/// come back from here identical to one that had it somewhere else.
 fn rows_of(buf: &Buffer) -> String {
     let area = *buf.area();
     (0..area.height)
@@ -1273,6 +1687,9 @@ fn join_or(items: &[String], empty: &str) -> String {
 
 /// A cursor move, clamped rather than wrapped: a list that jumped from the last
 /// row to the first would lose a reader who typed one `j` too many.
+///
+/// Panels are the one thing here that wraps instead, and [`Focus::stepped`]
+/// says why.
 fn step(at: usize, by: isize, total: usize) -> usize {
     if total == 0 {
         return 0;
@@ -1288,25 +1705,24 @@ fn step(at: usize, by: isize, total: usize) -> usize {
 /// leading slash included: a person about to press Enter is looking at exactly
 /// what will be read.
 pub const PROMPT: &str = ": ";
+/// The keys that move the screen.
 pub const KEYS: &str =
-    "j/k move  n/p page  Enter open  f kind  / find  v queue  r reload  a act  ? keys  q quit";
-pub const ENTITY_KEYS: &str =
-    "n/p page  g top  c constraints  r reload  b back  a act  ? keys  q quit";
-/// What the queue offers instead of the writing half.
+    "j/k move  n/p page  g top  Enter open  b back  c constraints  f kind  / find  r reload  a act  ? keys  q quit";
+/// The keys that move the focus, on a line of their own.
 ///
-/// It names the one road to a ratification and no verb at all, which is the
-/// honest shape of this screen: nothing here can be signed, and the way to sign
-/// is to read the document first.
-pub const QUEUE_ACT: &str =
-    "Enter opens a document   (accept is typed there, on the body -- the signature stays yours)";
+/// Separate because they are a different kind of command: the line above moves
+/// what is inside a panel, and this one moves which panel that is. A person who
+/// has lost track of where they are needs the second line and not the first.
+pub const PANEL_KEYS: &str =
+    "Tab next panel  1 claims  2 entities  3 body  4 queue  Left/Right the pair in the middle   (the marked panel is the one keys reach)";
 /// The writing half, on its own line and spelled whole.
 ///
-/// Separate from the other two because it is a different kind of offer: the keys
-/// above move a screen, and these five move the corpus. A person reading the
+/// Separate from the other two because it is a different kind of offer: those
+/// keys move a screen, and these five move the corpus. A person reading the
 /// trailer should be able to see at a glance which of the two they are about to
 /// do, and one line mixing them would make that a matter of remembering.
 pub const ACT_KEYS: &str =
-    "a then  claim | log <message> | release <reason> | done <proof> | amend <flags>   (the entity on screen)";
+    "a then  claim | log <message> | release <reason> | done <proof> | amend <flags>   (the entity the marked panel names)";
 /// The sixth act, on a line of its own, and only where the verb would take it.
 ///
 /// A third line for a third kind of offer, on the reasoning [`ACT_KEYS`] gives
@@ -1354,37 +1770,9 @@ mod tests {
     }
 
     fn app() -> App {
-        let mut a = App::new((100, 30), None);
+        let mut a = App::new((120, 40), None);
         a.snapshot = Some(snapshot());
         a
-    }
-
-    /// The list says how the screen is being kept current, and it says the
-    /// truth in all three states (TASK-2f7777a1fdff).
-    ///
-    /// The word matters to a person deciding whether to type `r`, and the three
-    /// cases are genuinely different: a stream being followed, a stream that is
-    /// not there yet, and a reader with nowhere to look for one.
-    #[test]
-    fn the_list_says_which_route_is_keeping_it_current() {
-        let mut a = app();
-        assert!(
-            a.frame().contains("stream none, r to reload"),
-            "with no stream at all:\n{}",
-            a.frame()
-        );
-        a.stream = Some(Stream::stated(false));
-        assert!(
-            a.frame().contains("stream none, r to reload"),
-            "a stream that is not there is not a stream:\n{}",
-            a.frame()
-        );
-        a.stream = Some(Stream::stated(true));
-        assert!(
-            a.frame().contains("stream following"),
-            "and one that is:\n{}",
-            a.frame()
-        );
     }
 
     /// The CLI, addressed where there is none: every call fails to spawn and
@@ -1416,9 +1804,245 @@ mod tests {
         }
     }
 
+    fn tap(a: &mut App, ank: &Ank, code: KeyCode) -> bool {
+        a.press(KeyEvent::new(code, KeyModifiers::NONE), ank)
+    }
+
     /// The identifiers the entity rows carry, which is what a filter narrows.
     fn rendered_rows(a: &App) -> Vec<String> {
-        a.rows().iter().map(|r| r.id.clone()).collect()
+        a.entity_rows().iter().map(|r| r.id.clone()).collect()
+    }
+
+    fn queued() -> Queue {
+        Queue {
+            proposed: vec![
+                row("ADR-0000ffff0002", "adr", "proposed", "A decision waiting"),
+                row(
+                    "SPEC-0000ffff0003",
+                    "spec",
+                    "proposed",
+                    "A specification waiting",
+                ),
+            ],
+            signers: vec!["marie@laptop  ssh-ed25519".to_string()],
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // The panels, and the focus (TASK-bb43cfe2192b)
+    // -----------------------------------------------------------------------
+
+    /// Four panels, two of them drawn side by side, on one frame.
+    #[test]
+    fn the_frame_draws_four_panels_and_two_of_them_share_a_row() {
+        let f = app().frame();
+        for panel in ["1 CLAIMS", "2 ENTITIES", "3 BODY", "4 QUEUE"] {
+            assert!(f.contains(panel), "{panel} is not on the frame:\n{f}");
+        }
+        // A row carrying four verticals is a row two bordered panels share,
+        // which is what "side by side" is when it is measured rather than
+        // described.
+        let shared = f
+            .lines()
+            .filter(|l| l.chars().filter(|c| *c == '|').count() >= 4)
+            .count();
+        assert!(shared >= 4, "no row of the frame carries two panels:\n{f}");
+    }
+
+    /// The focused panel is told apart with no colour at all.
+    ///
+    /// The frame under test is [`rows_of`], which takes the symbol out of every
+    /// cell and no style, so anything this test can see is a character a
+    /// monochrome terminal draws. Two signals are asserted, because a marker in
+    /// a title and a rule under a panel fail differently.
+    #[test]
+    fn the_focused_panel_is_marked_in_characters_and_never_in_colour() {
+        let mut a = app();
+        for focus in Focus::ALL {
+            a.focus = focus;
+            let f = a.frame();
+            let marked = format!("> {} {}", focus.number(), focus.name());
+            assert!(
+                f.contains(&marked),
+                "the focused panel carries no marker:\n{f}"
+            );
+            for other in Focus::ALL.into_iter().filter(|o| *o != focus) {
+                assert!(
+                    !f.contains(&format!("> {} {}", other.number(), other.name())),
+                    "{other:?} is marked as well as {focus:?}:\n{f}"
+                );
+            }
+            // And the doubled rule, which no unfocused panel is drawn with.
+            assert!(
+                f.contains("=========="),
+                "no panel is drawn with the doubled border:\n{f}"
+            );
+            assert!(
+                f.contains("----------"),
+                "every panel is drawn as the focused one:\n{f}"
+            );
+        }
+    }
+
+    /// Focus moves by key, in both of the two ways a person reaches for.
+    #[test]
+    fn focus_moves_by_key_and_wraps() {
+        let mut a = app();
+        let ank = nowhere();
+        assert_eq!(a.focus(), Focus::Entities, "a session opens on the list");
+        for expected in [Focus::Body, Focus::Queue, Focus::Claims, Focus::Entities] {
+            tap(&mut a, &ank, KeyCode::Tab);
+            assert_eq!(a.focus(), expected);
+        }
+        // And a digit reaches one directly, which is what a number on a panel
+        // is for.
+        for focus in Focus::ALL {
+            let digit = char::from_digit(focus.number() as u32, 10).expect("a digit");
+            tap(&mut a, &ank, KeyCode::Char(digit));
+            assert_eq!(a.focus(), focus, "'{digit}' did not reach {focus:?}");
+        }
+        // Back the way it came.
+        a.focus = Focus::Claims;
+        tap(&mut a, &ank, KeyCode::BackTab);
+        assert_eq!(a.focus(), Focus::Queue, "the ring turns both ways");
+    }
+
+    /// Focus is where the width goes, and that is the whole of the accordion.
+    #[test]
+    fn the_focused_panel_of_the_pair_takes_the_width() {
+        let mut a = app();
+        a.focus = Focus::Entities;
+        let listing = inside(a.rect_of(Focus::Entities, a.area())).width;
+        a.focus = Focus::Body;
+        let document = inside(a.rect_of(Focus::Body, a.area())).width;
+        let squeezed = inside(a.rect_of(Focus::Entities, a.area())).width;
+        assert!(
+            listing > squeezed * 2,
+            "the listing kept its width while the body was focused: {listing} then {squeezed}"
+        );
+        assert_eq!(
+            listing, document,
+            "the two are not the same size when each is the focused one"
+        );
+        // And the two of them still add up to the window, borders included.
+        assert_eq!(document + squeezed + 4, a.area().width);
+    }
+
+    /// Each listing keeps its own place, which is what makes a panel a place.
+    #[test]
+    fn every_listing_remembers_where_its_cursor_was() {
+        let mut a = app();
+        let ank = nowhere();
+        tap(&mut a, &ank, KeyCode::Char('j'));
+        tap(&mut a, &ank, KeyCode::Char('j'));
+        assert_eq!(a.cursors[Focus::Entities.number() - 1].at, 2);
+        tap(&mut a, &ank, KeyCode::Char('1'));
+        tap(&mut a, &ank, KeyCode::Char('j'));
+        assert_eq!(
+            a.cursors[Focus::Entities.number() - 1].at,
+            2,
+            "moving in the claims moved the entities cursor"
+        );
+        tap(&mut a, &ank, KeyCode::Char('2'));
+        assert_eq!(
+            a.cursors[Focus::Entities.number() - 1].at,
+            2,
+            "coming back lost the row that was under the cursor"
+        );
+    }
+
+    /// The queue costs `ank review`, and it is paid when somebody focuses it.
+    ///
+    /// The instrument is the binary not being there: any call at all leaves
+    /// `cannot run` and the argv behind, so which verb was reached for is on
+    /// the screen and can be read.
+    #[test]
+    fn the_queue_is_asked_for_when_it_is_focused_and_never_before() {
+        let mut a = app();
+        let ank = nowhere();
+        // A reload, an event and a handful of keys that are not `4`: none of
+        // them is a person asking, so `review` is never reached.
+        a.reload(&ank);
+        a.repaint(&ank);
+        for c in ['j', 'k', 'r', 'f', 'b'] {
+            tap(&mut a, &ank, KeyCode::Char(c));
+        }
+        assert!(
+            a.queue.is_none(),
+            "review was run while nobody was looking at the queue"
+        );
+        assert!(
+            !a.note.clone().unwrap_or_default().contains("ank review"),
+            "review was reached for: {:?}",
+            a.note
+        );
+        // And the panel says so rather than looking empty, which is a
+        // different fact.
+        a.focus = Focus::Queue;
+        assert!(
+            a.frame().contains("not asked"),
+            "the panel does not say what it has not done:\n{}",
+            a.frame()
+        );
+
+        a.focus = Focus::Entities;
+        tap(&mut a, &ank, KeyCode::Char('4'));
+        assert_eq!(a.focus(), Focus::Queue);
+        assert!(
+            a.note.clone().unwrap_or_default().contains("ank review"),
+            "focusing the queue did not run review at all: {:?}",
+            a.note
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // The window, at the two sizes the criterion states
+    // -----------------------------------------------------------------------
+
+    /// A frame never overflows the window it was given, in either direction.
+    ///
+    /// Eighty columns and forty are the two the criterion names, and every
+    /// state a panel can be in is driven through both: nothing read, a corpus
+    /// read, a document open, the constraints listed, a long answer on the
+    /// note band, and each of the four panels focused in turn.
+    #[test]
+    fn a_frame_never_outgrows_the_window_at_eighty_columns_or_at_forty() {
+        let long: String = (1..=6).map(|n| format!("a note line {n}\n")).collect();
+        for size in [(80, 24), (40, 24), (80, 40), (40, 12), (120, 40)] {
+            for note in [None, Some(long.clone())] {
+                for focus in Focus::ALL {
+                    let mut a = App::new(size, None);
+                    a.focus = focus;
+                    a.note = note.clone();
+                    a.queue = Some(queued());
+                    for read in [false, true] {
+                        if read {
+                            a.snapshot = Some(snapshot());
+                            a.detail = Some(detail(
+                                "TASK-49746735127f",
+                                &(1..=200).map(|n| format!("line {n}\n")).collect::<String>(),
+                            ));
+                        }
+                        for pane in [Pane::Body, Pane::Constraints] {
+                            a.pane = pane;
+                            let frame = a.frame();
+                            let rows = frame.lines().count();
+                            assert_eq!(
+                                rows, size.1,
+                                "{rows} rows in a {size:?} window, {focus:?}, {pane:?}:\n{frame}"
+                            );
+                            for line in frame.lines() {
+                                assert!(
+                                    line.chars().count() <= size.0,
+                                    "{} columns in a {size:?} window, {focus:?}: {line}\n{frame}",
+                                    line.chars().count()
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 
     #[test]
@@ -1443,54 +2067,50 @@ mod tests {
         assert!(f.contains("> "), "the cursor is drawn:\n{f}");
     }
 
+    /// The list says how the screen is being kept current, and it says the
+    /// truth in all three states (TASK-2f7777a1fdff).
     #[test]
-    fn no_line_of_a_frame_overflows_the_window() {
-        let mut a = App::new((40, 24), None);
-        a.snapshot = Some(snapshot());
-        for line in a.frame().lines() {
-            assert!(
-                line.chars().count() <= 40,
-                "{} columns in a 40 column window: {line}",
-                line.chars().count()
-            );
-        }
+    fn the_list_says_which_route_is_keeping_it_current() {
+        let mut a = app();
+        assert!(
+            a.frame().contains("stream none, r to reload"),
+            "with no stream at all:\n{}",
+            a.frame()
+        );
+        a.stream = Some(Stream::stated(false));
+        assert!(
+            a.frame().contains("stream none, r to reload"),
+            "a stream that is not there is not a stream:\n{}",
+            a.frame()
+        );
+        a.stream = Some(Stream::stated(true));
+        assert!(
+            a.frame().contains("stream following"),
+            "and one that is:\n{}",
+            a.frame()
+        );
     }
 
     #[test]
     fn a_filter_narrows_the_rows_and_says_so() {
         let mut a = app();
-        let ank = Ank::new(crate::Address {
-            exe: "/nonexistent/ank".into(),
-            cwd: ".".into(),
-            repo: None,
-            worktree: None,
-        });
-        a.act(Command::Kind(Some("adr".to_string())), &ank);
-        let f = a.frame();
-        assert!(f.contains("[kind adr]"), "{f}");
-        // The rows and not the whole frame: the claims section names the held
-        // task whatever the filter is, which is the point of that section.
-        assert_eq!(rendered_rows(&a), ["ADR-8bd76e8d7c4e"], "{f}");
+        let ank = nowhere();
+        a.act(Command::Kind(Some("task".to_string())), &ank);
+        assert_eq!(rendered_rows(&a), ["TASK-49746735127f"]);
+        assert!(a.frame().contains("[kind task]"), "{}", a.frame());
 
         a.act(Command::Kind(None), &ank);
-        a.act(Command::Search(Some("cli surface".to_string())), &ank);
-        let f = a.frame();
-        assert!(f.contains("matching 'cli surface'"), "{f}");
-        assert_eq!(rendered_rows(&a), ["SPEC-fe8bdb84faca"], "{f}");
+        a.act(Command::Search(Some("terminal".to_string())), &ank);
+        assert_eq!(rendered_rows(&a), ["ADR-8bd76e8d7c4e"]);
+        assert!(a.frame().contains("matching 'terminal'"), "{}", a.frame());
     }
 
     #[test]
     fn an_unknown_kind_is_named_and_the_filter_does_not_move() {
         let mut a = app();
-        let ank = Ank::new(crate::Address {
-            exe: "/nonexistent/ank".into(),
-            cwd: ".".into(),
-            repo: None,
-            worktree: None,
-        });
-        a.act(Command::Kind(Some("epic".to_string())), &ank);
-        assert!(a.kind.is_none(), "a kind that does not exist was applied");
-        assert!(a.frame().contains("no kind 'epic'"));
+        a.act(Command::Kind(Some("epic".to_string())), &nowhere());
+        assert_eq!(a.kind, None);
+        assert!(a.note.unwrap().contains("no kind 'epic'"));
     }
 
     #[test]
@@ -1501,26 +2121,17 @@ mod tests {
         assert_eq!(step(0, 1, 0), 0, "an empty list has nowhere to move");
     }
 
+    /// The body is served whole: paged down it, and joining the rows back gives
+    /// the file.
     #[test]
     fn the_body_is_paged_and_never_cut() {
         let body: String = (1..=200).map(|n| format!("line {n}\n")).collect();
         let mut a = app();
         a.detail = Some(Detail {
-            id: "TASK-49746735127f".to_string(),
-            coordination: Some("claimed by claude-code/opus-5+tui-verb".to_string()),
             content: body,
-            scopes: vec!["crates/ank-tui/**".to_string()],
-            constraints: vec![row(
-                "ADR-8bd76e8d7c4e",
-                "adr",
-                "accepted",
-                "A terminal reader",
-            )],
-            blocked_by: Vec::new(),
-            unblocks: Vec::new(),
-            unresolved: Vec::new(),
+            ..detail("TASK-49746735127f", "")
         });
-        a.view = View::Entity;
+        a.focus = Focus::Body;
         assert_eq!(a.pane_lines().len(), 200, "the body is carried whole");
         assert_eq!(
             a.pane_lines().join("\n") + "\n",
@@ -1534,12 +2145,7 @@ mod tests {
         assert!(first.contains("ADR-8bd7"), "the constraints are on screen");
         assert!(first.contains("crates/ank-tui/**"), "the scope is named");
 
-        let ank = Ank::new(crate::Address {
-            exe: "/nonexistent/ank".into(),
-            cwd: ".".into(),
-            repo: None,
-            worktree: None,
-        });
+        let ank = nowhere();
         a.act(Command::Page(1), &ank);
         let second = a.frame();
         assert!(!second.contains("line 1\n"), "the page turned:\n{second}");
@@ -1556,16 +2162,55 @@ mod tests {
         assert_eq!(a.offset, 0);
     }
 
+    /// A body line wider than the panel keeps its end, at both stated widths.
+    ///
+    /// **Whole means two things and both are asserted.** Across: a line wider
+    /// than the panel becomes as many rows as it needs and carries exactly the
+    /// characters the file does, so nothing is lost at the right edge. Down:
+    /// what does not fit on one frame is reached by paging, in a bounded number
+    /// of presses, so nothing is lost at the bottom either.
+    #[test]
+    fn a_body_line_wider_than_the_panel_keeps_its_end() {
+        const TAIL: &str = "TAIL-9f31";
+        let content = format!(
+            "---\ndone_criteria: |\n  A sentence longer than any panel this reader draws, so that a \
+             reader which cut it at the right edge would lose {TAIL} off its end.\n---\n"
+        );
+        let ank = nowhere();
+        for size in [(80, 24), (40, 24)] {
+            let mut a = App::new(size, None);
+            a.snapshot = Some(snapshot());
+            a.detail = Some(Detail {
+                content: content.clone(),
+                ..detail("TASK-49746735127f", "")
+            });
+            a.focus = Focus::Body;
+            // Nothing lost and nothing invented: the rows carry exactly the
+            // characters the file does, a wrap having added no separator of its
+            // own.
+            assert_eq!(
+                a.pane_lines().concat(),
+                content.lines().collect::<String>(),
+                "the rows are not the body's own characters at {size:?}"
+            );
+            let mut on_screen = a.frame().contains(TAIL);
+            for _ in 0..8 {
+                if on_screen {
+                    break;
+                }
+                a.act(Command::Page(1), &ank);
+                on_screen = a.frame().contains(TAIL);
+            }
+            assert!(on_screen, "the body was cut at {size:?}:\n{}", a.frame());
+        }
+    }
+
     /// `ank scope` answers with every ADR whose glob matches, superseded ones
     /// included, and forty rules over a scope are not forty rules binding it.
     #[test]
     fn a_superseded_constraint_is_shown_with_its_status_and_never_counted_active() {
         let mut a = app();
         a.detail = Some(Detail {
-            id: "TASK-49746735127f".to_string(),
-            coordination: None,
-            content: "---\nid: TASK-49746735127f\n---\n\nbody\n".to_string(),
-            scopes: vec!["crates/ank-tui/**".to_string()],
             constraints: vec![
                 row("ADR-8bd76e8d7c4e", "adr", "accepted", "A terminal reader"),
                 // Zero-prefixed, which is what a fixture identifier is in this
@@ -1578,11 +2223,12 @@ mod tests {
                     "The reader lives outside",
                 ),
             ],
-            blocked_by: Vec::new(),
-            unblocks: Vec::new(),
-            unresolved: Vec::new(),
+            ..detail(
+                "TASK-49746735127f",
+                "---\nid: TASK-49746735127f\n---\n\nbody\n",
+            )
         });
-        a.view = View::Entity;
+        a.focus = Focus::Body;
         let f = a.frame();
         assert!(
             f.contains("CONSTRAINTS (1 active, 2 over this scope)"),
@@ -1603,544 +2249,362 @@ mod tests {
             .collect();
         let mut a = app();
         a.detail = Some(Detail {
-            id: "TASK-49746735127f".to_string(),
-            coordination: None,
-            content: "---\nid: TASK-49746735127f\n---\n\nbody\n".to_string(),
-            scopes: vec!["crates/ank-tui/**".to_string()],
             constraints: many,
-            blocked_by: Vec::new(),
-            unblocks: Vec::new(),
-            unresolved: Vec::new(),
+            ..detail(
+                "TASK-49746735127f",
+                "---\nid: TASK-49746735127f\n---\n\nbody\n",
+            )
         });
-        a.view = View::Entity;
-        assert!(a.frame().contains("+26 more, c for the list"));
+        a.focus = Focus::Body;
+        assert!(a.frame().contains("+27 more, c for the list"));
 
-        let ank = Ank::new(crate::Address {
-            exe: "/nonexistent/ank".into(),
-            cwd: ".".into(),
-            repo: None,
-            worktree: None,
-        });
-        a.act(Command::Constraints, &ank);
+        a.act(Command::Constraints, &nowhere());
         assert_eq!(a.pane_lines().len(), 30);
-        assert!(a.frame().contains("CONSTRAINTS   1-"));
+        assert_eq!(a.focus(), Focus::Body, "the pane asked for is the pane in");
+        assert!(a.frame().contains("3 CONSTRAINTS"), "{}", a.frame());
     }
 
     #[test]
     fn a_refusal_is_a_line_and_not_the_end_of_the_session() {
         let mut a = app();
-        // The binary is not there, so every call fails. The session survives it
-        // and says what happened.
-        let ank = Ank::new(crate::Address {
-            exe: "/nonexistent/ank".into(),
-            cwd: ".".into(),
-            repo: None,
-            worktree: None,
-        });
-        assert!(!a.act(Command::Open, &ank), "a failure is not a quit");
+        let ank = nowhere();
+        a.act(Command::Open, &ank);
         let f = a.frame();
-        assert!(f.contains("cannot run `ank"), "{f}");
-        assert!(f.contains("ADR-8bd7"), "the rows are still there:\n{f}");
+        assert!(
+            f.contains("cannot run"),
+            "the refusal is on the screen:\n{f}"
+        );
+        assert!(
+            f.contains("2 ENTITIES"),
+            "and the panels are still here:\n{f}"
+        );
     }
 
-    /// The identifier the reader puts in front is the selected one, and what
-    /// follows it is what was typed.
-    ///
-    /// Read off the failure, which is the one place a spawn that never happened
-    /// still states its own command line: the binary is not there, so `Failed`
-    /// carries the whole `argv` and the assertion is on the call that would have
-    /// been made.
     #[test]
     fn an_act_runs_the_verb_with_the_selected_identifier_in_front() {
         let mut a = app();
-        let ank = nowhere();
-        a.act(Command::Kind(Some("task".to_string())), &ank);
         a.act(
             Command::Act(Act {
-                verb: "done",
-                args: vec!["--proof".to_string(), "commit:2d9c847".to_string()],
+                verb: "claim",
+                args: Vec::new(),
             }),
-            &ank,
+            &nowhere(),
         );
         let said = a.note.clone().unwrap_or_default();
         assert!(
-            said.contains("ank done TASK-49746735127f --proof commit:2d9c847 --json"),
-            "{said}"
+            said.contains("ADR-8bd76e8d7c4e"),
+            "the row under the cursor is the entity acted on:\n{said}"
         );
+        assert!(said.contains("claim"), "{said}");
     }
 
-    /// The entity on the screen and not the row the cursor drifted onto.
     #[test]
-    fn an_act_in_the_entity_view_is_about_the_entity_that_is_open() {
+    fn an_act_in_the_body_panel_is_about_the_document_that_is_open() {
         let mut a = app();
-        let ank = nowhere();
-        a.detail = Some(detail("SPEC-fe8bdb84faca", "body\n"));
-        a.view = View::Entity;
-        // The cursor is still on the first row of the list, which is the ADR.
-        assert_eq!(
-            a.selected().map(|r| r.id.clone()).as_deref(),
-            Some("ADR-8bd76e8d7c4e")
-        );
+        a.detail = Some(detail("TASK-49746735127f", "body\n"));
+        a.focus = Focus::Body;
+        // The cursor in the entities is somewhere else entirely.
+        a.cursors[Focus::Entities.number() - 1].at = 0;
         a.act(
             Command::Act(Act {
-                verb: "claim",
-                args: Vec::new(),
+                verb: "log",
+                args: vec!["something".to_string()],
             }),
-            &ank,
+            &nowhere(),
         );
         let said = a.note.clone().unwrap_or_default();
         assert!(
-            said.contains("ank claim SPEC-fe8bdb84faca --json"),
-            "{said}"
+            said.contains("TASK-49746735127f"),
+            "the open document is what the act was about:\n{said}"
         );
     }
 
     #[test]
-    fn an_act_with_nothing_selected_names_that_and_runs_nothing() {
-        let mut a = App::new((100, 30), None);
-        let ank = nowhere();
+    fn an_act_with_nothing_named_runs_nothing_and_says_so() {
+        let mut a = App::new((80, 24), None);
         a.act(
             Command::Act(Act {
                 verb: "claim",
                 args: Vec::new(),
             }),
-            &ank,
+            &nowhere(),
         );
-        let said = a.note.clone().unwrap_or_default();
-        assert!(said.contains("no entity is selected"), "{said}");
-        assert!(!said.contains("cannot run"), "nothing was spawned: {said}");
+        assert!(
+            a.note.unwrap().contains("no entity is named here"),
+            "the reader's own refusal, not the CLI's"
+        );
     }
 
-    /// The chrome is one line and the rest is the document, field for field.
     #[test]
     fn an_answer_is_the_documents_own_fields_under_the_command_that_ran() {
         let ran = Ran {
-            shown: "ank claim TASK-49746735127f --json".to_string(),
+            shown: "ank claim TASK-49746735127f".to_string(),
             answered: serde_yaml::from_str(
-                r#"{"contract":1,"task":"TASK-49746735127f","holder":"claude-code/opus-5","expires":"2026-08-25T10:00:00Z","warnings":["a constraint moved"]}"#,
+                "{contract: 4, id: TASK-49746735127f, expires: 2026-08-25T04:36:32Z, warnings: []}",
             )
-            .unwrap(),
+            .expect("a document"),
         };
         let said = answered(&ran);
-        let lines: Vec<&str> = said.lines().collect();
-        assert_eq!(lines[0], "ank claim TASK-49746735127f --json");
-        assert!(
-            !said.contains("contract"),
-            "the one field that says nothing about the act: {said}"
-        );
-        for expected in [
-            "task",
-            "TASK-49746735127f",
-            "holder",
-            "claude-code/opus-5",
-            "expires",
-            "2026-08-25T10:00:00Z",
-            "warnings",
-            "a constraint moved",
-        ] {
-            assert!(said.contains(expected), "{expected} missing from:\n{said}");
-        }
+        assert!(said.starts_with("ank claim TASK-49746735127f"));
+        assert!(said.contains("expires"), "{said}");
+        assert!(said.contains("warnings"), "{said}");
+        assert!(said.contains("(none)"), "an empty list is said:\n{said}");
+        assert!(!said.contains("contract"), "{said}");
     }
 
-    /// A field the reader was never taught about still reaches the screen, and
-    /// an empty list says so rather than showing as a field with nothing after
-    /// it (ADR-6fd69efb629c).
     #[test]
     fn a_field_this_reader_never_heard_of_is_shown_rather_than_dropped() {
         let ran = Ran {
-            shown: "ank amend TASK-0001 --json".to_string(),
-            answered: serde_yaml::from_str(
-                r#"{"contract":1,"entity":"TASK-0001","amended":[],"invented_later":{"deep":[1,2]}}"#,
-            )
-            .unwrap(),
+            shown: "ank done TASK-49746735127f".to_string(),
+            answered: serde_yaml::from_str("{invented_later: {a: 1, b: [x, y]}}")
+                .expect("a document"),
         };
         let said = answered(&ran);
-        assert!(said.contains("(none)"), "an empty list is named: {said}");
         assert!(said.contains("invented_later"), "{said}");
-        assert!(said.contains("deep=1, 2"), "{said}");
+        assert!(said.contains("a=1"), "{said}");
+        assert!(said.contains("b=x, y"), "{said}");
     }
 
-    /// A refusal reaches the screen whole, `error[N]:` and the way out both.
     #[test]
     fn a_refusal_keeps_its_code_and_its_way_out_on_the_screen() {
         let mut a = app();
-        a.note = Some(
-            Failed::Refused {
-                args: "done TASK-49746735127f".to_string(),
-                code: 5,
-                stderr: "error[5]: TASK-4974 declares no verifier, so done needs a proof\n  -> ank done TASK-4974 --proof commit:<sha>\n".to_string(),
-            }
-            .to_string(),
-        );
+        a.note =
+            Some("error[5]: 'done' needs a proof\n> ank done <id> --proof commit:<sha>".into());
         let f = a.frame();
-        assert!(f.contains("error[5]:"), "the code the table declares:\n{f}");
-        assert!(
-            f.contains("-> ank done TASK-4974 --proof commit:<sha>"),
-            "and the command the CLI named as the way out:\n{f}"
-        );
-    }
-
-    /// A note of several lines costs the rows it takes, and the frame still
-    /// fits the window.
-    #[test]
-    fn a_frame_never_outgrows_the_window_it_was_given() {
-        let long: String = (1..=6).map(|n| format!("a note line {n}\n")).collect();
-        for size in [(100, 40), (80, 24), (60, 20)] {
-            for note in [None, Some(long.clone())] {
-                let mut a = App::new(size, None);
-                a.snapshot = Some(snapshot());
-                a.note = note.clone();
-                let rows = a.frame().lines().count();
-                assert!(rows <= size.1, "the list frame is {rows} rows in {size:?}");
-
-                a.detail = Some(detail(
-                    "TASK-49746735127f",
-                    &(1..=200).map(|n| format!("line {n}\n")).collect::<String>(),
-                ));
-                a.view = View::Entity;
-                for pane in [Pane::Body, Pane::Constraints] {
-                    a.pane = pane;
-                    let rows = a.frame().lines().count();
-                    assert!(
-                        rows <= size.1,
-                        "the {pane:?} pane is {rows} rows in {size:?}"
-                    );
-                }
-            }
-        }
+        assert!(f.contains("error[5]:"), "{f}");
+        assert!(f.contains("--proof"), "{f}");
     }
 
     // -----------------------------------------------------------------------
     // The ratification queue (TASK-d90e94afca08)
     // -----------------------------------------------------------------------
 
-    fn queued() -> Queue {
-        Queue {
-            proposed: vec![
-                row("ADR-0000ffff0002", "adr", "proposed", "A decision waiting"),
-                row(
-                    "SPEC-0000ffff0003",
-                    "spec",
-                    "proposed",
-                    "A specification waiting",
-                ),
-            ],
-            signers: vec!["marie@laptop  ssh-ed25519".to_string()],
-        }
-    }
-
-    /// The queue names what is waiting and who may sign it, and both halves are
-    /// `review`'s own answer.
     #[test]
     fn the_queue_names_what_is_waiting_and_who_may_ratify() {
         let mut a = app();
         a.queue = Some(queued());
-        a.view = View::Queue;
+        a.focus = Focus::Queue;
         let f = a.frame();
         for expected in [
-            "QUEUE",
+            "4 QUEUE",
             "ADR-0000",
-            "SPEC-0000",
             "A decision waiting",
-            "MAY RATIFY (1)",
-            "marie@laptop",
+            "SPEC-0000",
+            "may ratify: marie@laptop",
         ] {
             assert!(f.contains(expected), "{expected} missing from:\n{f}");
         }
+        // A task is not waiting for a signature and has no business in this
+        // panel. Asked of the rows rather than of the frame, because the claims
+        // panel above it names a task quite legitimately.
         assert!(
-            !f.contains("CLAIMS"),
-            "the queue answers a different question:\n{f}"
+            a.queue_rows().iter().all(|r| r.kind != "task"),
+            "a task is in the ratification queue"
         );
     }
 
-    /// An empty queue says so, and a corpus declaring no key says which regime
-    /// it is in rather than showing an empty section.
     #[test]
     fn an_empty_queue_and_an_undeclared_key_are_both_stated() {
         let mut a = app();
-        a.queue = Some(Queue::default());
-        a.view = View::Queue;
+        a.queue = Some(Queue {
+            proposed: Vec::new(),
+            signers: Vec::new(),
+        });
+        a.focus = Focus::Queue;
         let f = a.frame();
         assert!(f.contains("nothing proposed for ratification"), "{f}");
-        assert!(
-            f.contains("permissions are advisory"),
-            "the advisory regime is a state, not an empty list:\n{f}"
-        );
+        assert!(f.contains("permissions are advisory"), "{f}");
     }
 
-    /// The queue's rows are the list's rows: one cursor, one set of keys, one
-    /// road to the document.
     #[test]
-    fn the_queue_moves_and_opens_the_way_the_list_does() {
+    fn the_queue_moves_and_opens_the_way_the_entities_do() {
         let mut a = app();
+        a.queue = Some(queued());
+        a.focus = Focus::Queue;
         let ank = nowhere();
-        a.queue = Some(queued());
-        a.act(Command::Queue, &ank);
-        // `Command::Queue` asked `review`, which cannot be spawned here, so the
-        // frame carries the refusal -- and the rows already in hand stay.
-        a.queue = Some(queued());
-        assert_eq!(a.view, View::Queue);
-        assert_eq!(rendered_rows(&a), ["ADR-0000ffff0002", "SPEC-0000ffff0003"]);
-        a.act(Command::Move(1), &ank);
         assert_eq!(
-            a.selected().map(|r| r.id.clone()).as_deref(),
-            Some("SPEC-0000ffff0003"),
-            "j moves in the queue"
+            a.selected_id(Focus::Queue).as_deref(),
+            Some("ADR-0000ffff0002")
         );
-        a.act(Command::Row(1), &ank);
-        assert_eq!(a.cursor, 0, "a row number selects in the queue");
+        tap(&mut a, &ank, KeyCode::Char('j'));
+        assert_eq!(
+            a.selected_id(Focus::Queue).as_deref(),
+            Some("SPEC-0000ffff0003")
+        );
+        // Enter reaches for `show` on the row, which is the same road the
+        // entities take.
+        tap(&mut a, &ank, KeyCode::Enter);
+        assert!(
+            a.note
+                .clone()
+                .unwrap_or_default()
+                .contains("SPEC-0000ffff0003"),
+            "{:?}",
+            a.note
+        );
     }
 
-    /// `b` out of a document goes back to the listing it was opened from.
     #[test]
-    fn back_out_of_a_document_returns_to_the_listing_it_was_opened_from() {
+    fn back_returns_to_the_listing_a_session_opens_on() {
         let mut a = app();
         let ank = nowhere();
-        a.queue = Some(queued());
-        a.view = View::Queue;
-        a.detail = Some(detail("ADR-0000ffff0002", "body\n"));
-        a.origin = View::Queue;
-        a.view = View::Entity;
-        a.act(Command::Back, &ank);
-        assert_eq!(a.view, View::Queue, "the queue is where the person was");
-        a.act(Command::Back, &ank);
-        assert_eq!(a.view, View::List, "and out of the queue is the entities");
+        a.focus = Focus::Body;
+        tap(&mut a, &ank, KeyCode::Char('b'));
+        assert_eq!(a.focus(), Focus::Entities);
+        a.focus = Focus::Queue;
+        tap(&mut a, &ank, KeyCode::Esc);
+        assert_eq!(a.focus(), Focus::Entities);
     }
 
-    /// The word is offered on a document that could take it, and on nothing
-    /// else (TASK-84cfad83c308's rule: no offer the verb turns down).
     #[test]
     fn the_ratification_line_is_drawn_only_where_accept_would_take_it() {
-        let mut a = App::new((100, 30), None);
+        let mut a = app();
         a.snapshot = Some(Snapshot {
             entities: vec![
                 row("ADR-0000ffff0002", "adr", "proposed", "A decision waiting"),
+                row("TASK-49746735127f", "task", "in_progress", "ank tui opens"),
                 row("ADR-8bd76e8d7c4e", "adr", "accepted", "A terminal reader"),
-                row("TASK-49746735127f", "task", "open", "A task"),
             ],
             ..snapshot()
         });
-        a.view = View::Entity;
         for (id, offered) in [
             ("ADR-0000ffff0002", true),
-            ("ADR-8bd76e8d7c4e", false),
             ("TASK-49746735127f", false),
+            ("ADR-8bd76e8d7c4e", false),
         ] {
             a.detail = Some(detail(id, "body\n"));
-            let f = a.frame();
+            a.focus = Focus::Body;
             assert_eq!(
-                f.contains("accept   (this document"),
+                a.ratify_line().is_some(),
                 offered,
-                "{id} was offered {}:\n{f}",
-                f.contains("accept   (this document")
+                "the offer on {id} is wrong"
             );
+            assert_eq!(a.frame().contains("ank signs nothing"), offered, "{id}");
         }
     }
 
-    /// A ratification is one verb, one identifier, and nothing else on the
-    /// command line.
-    ///
-    /// Read off the failure, the way the other acts are: the binary is not
-    /// there, so `Failed` carries the whole `argv` that would have been spawned.
     #[test]
     fn a_ratification_runs_accept_with_the_open_document_and_nothing_else() {
         let mut a = app();
-        let ank = nowhere();
         a.detail = Some(detail("ADR-8bd76e8d7c4e", "body\n"));
-        a.view = View::Entity;
+        a.focus = Focus::Body;
         a.act(
             Command::Act(Act {
                 verb: "accept",
                 args: Vec::new(),
             }),
-            &ank,
+            &nowhere(),
         );
         let said = a.note.clone().unwrap_or_default();
-        assert!(
-            said.contains("ank accept ADR-8bd76e8d7c4e --json"),
-            "{said}"
-        );
-    }
-
-    /// The queue is never asked for on the reader's own initiative.
-    ///
-    /// `review` inspects the whole corpus, and this is the property that keeps
-    /// an event cheap: a repaint refreshes the queue where it is on the screen
-    /// and leaves it alone where it is not.
-    #[test]
-    fn a_repaint_asks_review_only_where_the_queue_is_on_the_screen() {
-        let mut a = app();
-        let ank = nowhere();
-        a.queue = Some(queued());
-        // The binary is not there, so a call that is made says so and a call
-        // that is not made leaves the note alone. That is the whole
-        // instrument, and it reads in both directions.
-        a.requeue(&ank);
-        assert_eq!(
-            a.note, None,
-            "a repaint of the entities asked review for the queue"
-        );
-        a.view = View::Queue;
-        a.requeue(&ank);
-        let said = a.note.clone().unwrap_or_default();
-        assert!(
-            said.contains("review"),
-            "a repaint of the queue did not ask review: {said}"
-        );
+        assert!(said.contains("accept"), "{said}");
+        assert!(said.contains("ADR-8bd76e8d7c4e"), "{said}");
     }
 
     #[test]
     fn a_row_number_out_of_range_is_named_rather_than_clamped_silently() {
         let mut a = app();
-        let ank = Ank::new(crate::Address {
-            exe: "/nonexistent/ank".into(),
-            cwd: ".".into(),
-            repo: None,
-            worktree: None,
-        });
+        let ank = nowhere();
         a.act(Command::Row(99), &ank);
-        assert_eq!(a.cursor, 0);
-        assert!(a.frame().contains("there is no row 99"));
+        assert!(a.note.clone().unwrap().contains("there is no row 99"));
+        a.act(Command::Row(2), &ank);
+        assert_eq!(a.cursors[Focus::Entities.number() - 1].at, 1);
+        a.focus = Focus::Body;
+        a.act(Command::Row(1), &ank);
+        assert!(
+            a.note.unwrap().contains("the body panel has no row 1"),
+            "a document is paged, not selected"
+        );
     }
 
-    // -----------------------------------------------------------------------
-    // The keystroke engine (TASK-4fa385c1772d)
-    // -----------------------------------------------------------------------
-
-    fn stroke(code: KeyCode) -> KeyEvent {
-        KeyEvent::new(code, KeyModifiers::NONE)
-    }
-
-    fn tap(a: &mut App, ank: &Ank, code: KeyCode) -> bool {
-        a.press(stroke(code), ank)
-    }
-
-    fn type_in(a: &mut App, ank: &Ank, line: &str) {
-        for c in line.chars() {
-            tap(a, ank, KeyCode::Char(c));
-        }
-    }
-
-    /// One key per command, on the screen rather than in the mapping: the
-    /// cursor moves, the filter narrows, the queue opens, and none of it went
-    /// through a line.
     #[test]
     fn a_key_moves_the_screen_and_no_line_is_typed_to_do_it() {
         let mut a = app();
         let ank = nowhere();
-        assert!(!tap(&mut a, &ank, KeyCode::Char('j')));
-        assert_eq!(
-            a.selected().map(|r| r.id.clone()).as_deref(),
-            Some("TASK-49746735127f"),
-            "j moved the cursor"
-        );
-        assert!(!tap(&mut a, &ank, KeyCode::Up));
-        assert_eq!(
-            a.selected().map(|r| r.id.clone()).as_deref(),
-            Some("ADR-8bd76e8d7c4e"),
-            "and the arrow moves it back"
-        );
-        // `f` walks the registry, one kind per press, and the frame says which.
+        tap(&mut a, &ank, KeyCode::Char('j'));
+        assert_eq!(a.cursors[Focus::Entities.number() - 1].at, 1);
+        tap(&mut a, &ank, KeyCode::Char('k'));
+        assert_eq!(a.cursors[Focus::Entities.number() - 1].at, 0);
         tap(&mut a, &ank, KeyCode::Char('f'));
-        assert!(a.frame().contains("[kind adr]"), "{}", a.frame());
-        tap(&mut a, &ank, KeyCode::Char('f'));
-        assert!(a.frame().contains("[kind spec]"), "{}", a.frame());
-        for _ in 0..3 {
-            tap(&mut a, &ank, KeyCode::Char('f'));
-        }
-        assert!(a.kind.is_none(), "and back to every kind");
+        assert_eq!(a.kind.as_deref(), Some("adr"));
         assert!(tap(&mut a, &ank, KeyCode::Char('q')), "q ends the session");
     }
 
-    /// The prompt is the only road from a key press to a verb that writes.
+    /// No bare key spawns a verb that writes, and the prompt does.
     ///
-    /// **The negative half is the one that matters**, and it is the property the
-    /// line discipline used to give for free: every key of the alphabet is
-    /// pressed, in every view, and not one of them spawns any of the six. What
-    /// the loose keys after `a` do is fill a prompt, which runs nothing until
-    /// Enter -- and the Enter here submits a line the grammar does not know, so
-    /// still nothing is spawned.
+    /// The instrument is the binary not being there: every call leaves
+    /// `cannot run` and the argv behind, so the command the reader *would* have
+    /// run is on the screen and can be read. Keys that only read are expected
+    /// to appear there -- `r` is a `status` and a `find` -- and what is
+    /// asserted is that none of the six ever does.
     #[test]
     fn no_key_reaches_a_verb_that_writes_and_the_prompt_does() {
-        for view in [View::List, View::Queue, View::Entity] {
-            let mut a = app();
-            let ank = nowhere();
-            a.queue = Some(queued());
-            a.detail = Some(detail("SPEC-fe8bdb84faca", "body\n"));
-            a.view = view;
-            let mut said = String::new();
+        const WRITES: [&str; 6] = ["claim", "log", "release", "done", "amend", "accept"];
+        let mut a = app();
+        let ank = nowhere();
+        a.detail = Some(detail("TASK-49746735127f", "body\n"));
+        for panel in Focus::ALL {
             for c in 'a'..='z' {
+                a.focus = panel;
+                a.note = None;
                 tap(&mut a, &ank, KeyCode::Char(c));
-                tap(&mut a, &ank, KeyCode::Enter);
-                said.push_str(&a.note.clone().unwrap_or_default());
-            }
-            for verb in crate::ank::ACTS {
-                assert!(
-                    !said.contains(&format!("ank {verb} ")),
-                    "{view:?}: a bare key ran {verb}:\n{said}"
-                );
+                a.prompt = None;
+                let said = a.note.clone().unwrap_or_default();
+                for verb in WRITES {
+                    assert!(
+                        !said.contains(&format!("ank {verb}")),
+                        "'{c}' spawned {verb} in {panel:?}: {said}"
+                    );
+                }
             }
         }
+        // And the prompt does: `a`, the word, Enter. The filter the loop above
+        // left cycling is cleared first, so the panel names a row to act on.
+        a.focus = Focus::Entities;
+        a.kind = None;
+        a.search = None;
+        a.cursors = [Cursor::default(); 4];
+        a.note = None;
+        tap(&mut a, &ank, KeyCode::Char(keys::ACT));
+        for c in "claim".chars() {
+            tap(&mut a, &ank, KeyCode::Char(c));
+        }
+        tap(&mut a, &ank, KeyCode::Enter);
+        assert!(
+            a.note.clone().unwrap_or_default().contains("ank claim"),
+            "the prompt did not reach the verb: {:?}",
+            a.note
+        );
+    }
 
-        // And the road that does exist: `a`, the word, Enter.
+    #[test]
+    fn a_prompt_dismissed_runs_nothing() {
         let mut a = app();
         let ank = nowhere();
         tap(&mut a, &ank, KeyCode::Char(keys::ACT));
-        assert_eq!(a.prompt.as_deref(), Some(""), "the prompt opened");
-        type_in(&mut a, &ank, "claim");
-        assert!(
-            a.frame().contains(": claim"),
-            "the line is on the screen as it is typed:\n{}",
-            a.frame()
-        );
-        assert!(a.note.is_none(), "and nothing has run yet");
-        tap(&mut a, &ank, KeyCode::Enter);
-        assert!(a.prompt.is_none(), "the prompt closed");
-        let said = a.note.clone().unwrap_or_default();
-        assert!(said.contains("ank claim ADR-8bd76e8d7c4e --json"), "{said}");
-    }
-
-    /// A prompt dismissed runs nothing, whichever of the two ways out was taken.
-    #[test]
-    fn a_prompt_dismissed_runs_nothing() {
-        for out in [KeyCode::Esc, KeyCode::Backspace] {
-            let mut a = app();
-            let ank = nowhere();
-            tap(&mut a, &ank, KeyCode::Char(keys::ACT));
-            type_in(&mut a, &ank, "done");
-            // Backspace has to empty the line before it closes the prompt, which
-            // is what makes it a way out rather than an edit.
-            for _ in 0..5 {
-                tap(&mut a, &ank, out);
-            }
-            assert!(a.prompt.is_none(), "{out:?} left the prompt open");
-            assert_eq!(a.note, None, "{out:?} ran something");
+        for c in "claim".chars() {
+            tap(&mut a, &ank, KeyCode::Char(c));
         }
+        tap(&mut a, &ank, KeyCode::Esc);
+        assert_eq!(a.prompt, None);
+        assert_eq!(a.note, None, "a dismissed prompt ran something");
     }
 
-    /// `/` opens the same prompt on the grammar's search, seed and all.
     #[test]
     fn the_find_key_opens_the_prompt_on_a_search() {
         let mut a = app();
         let ank = nowhere();
         tap(&mut a, &ank, KeyCode::Char(keys::FIND));
-        assert_eq!(a.prompt.as_deref(), Some("/"), "the slash is the line");
-        type_in(&mut a, &ank, "cli surface");
+        assert_eq!(a.prompt.as_deref(), Some("/"));
+        for c in "terminal".chars() {
+            tap(&mut a, &ank, KeyCode::Char(c));
+        }
+        assert!(a.frame().contains(": /terminal"), "{}", a.frame());
         tap(&mut a, &ank, KeyCode::Enter);
-        assert_eq!(rendered_rows(&a), ["SPEC-fe8bdb84faca"]);
-        assert!(
-            a.frame().contains("matching 'cli surface'"),
-            "{}",
-            a.frame()
-        );
+        assert_eq!(rendered_rows(&a), ["ADR-8bd76e8d7c4e"]);
     }
 
-    /// A narrower window reflows and keeps the cursor on the page.
-    ///
-    /// The second half is what a resize can silently break: a shorter terminal
-    /// is a shorter page, and a cursor left where it was would be a row the
-    /// screen no longer draws -- so the next `j` would move something nobody
-    /// can see.
+    /// A narrower window reflows, and the cursor stays on a page the screen
+    /// still draws.
     #[test]
     fn a_narrower_window_reflows_and_the_cursor_stays_on_the_page() {
         let many: Vec<Row> = (1..=60)
@@ -2162,9 +2626,9 @@ mod tests {
         for _ in 0..40 {
             tap(&mut a, &ank, KeyCode::Char('j'));
         }
-        assert_eq!(a.cursor, 40);
+        assert_eq!(a.cursors[Focus::Entities.number() - 1].at, 40);
         assert!(
-            a.frame().lines().any(|l| l.starts_with("> ")),
+            a.frame().contains("> "),
             "the cursor is on the page it was moved to"
         );
 
@@ -2174,8 +2638,9 @@ mod tests {
         for line in narrow.lines() {
             assert!(line.chars().count() <= 50, "{line}");
         }
+        let c = a.cursors[Focus::Entities.number() - 1];
         assert!(
-            narrow.lines().any(|l| l.starts_with("> ")),
+            c.at >= c.top && c.at < c.top + a.page(Focus::Entities),
             "the cursor fell off the page a resize made shorter:\n{narrow}"
         );
         assert!(
@@ -2188,15 +2653,11 @@ mod tests {
     }
 
     /// A resize reads nothing and spawns nothing.
-    ///
-    /// The instrument is the same one every other test here uses: the binary is
-    /// not there, so any call at all leaves `cannot run` behind. A resize that
-    /// asked the corpus anything would be a window drag renewing a lease.
     #[test]
     fn a_resize_asks_the_corpus_nothing() {
         let mut a = app();
         a.detail = Some(detail("TASK-49746735127f", "body\n"));
-        a.view = View::Entity;
+        a.focus = Focus::Body;
         for size in [(60, 20), (200, 80), (30, 12)] {
             a.resize(size.0, size.1);
             assert_eq!(a.note, None, "a resize at {size:?} ran a verb");

--- a/crates/ank-tui/tests/panels.rs
+++ b/crates/ank-tui/tests/panels.rs
@@ -1,0 +1,750 @@
+//! The panels, through the binary, at the two widths the criterion names
+//! (TASK-bb43cfe2192b).
+//!
+//! CLAUDE.md leaves no choice about where the measurement happens: a criterion
+//! that talks about the binary is tested through the binary, and "a frame never
+//! overflows the window at eighty columns and at forty" is a claim about a
+//! process reading a real terminal's size. `src/view.rs` asserts the same
+//! property of the layout function, at more sizes and on every platform; this
+//! asserts it of `ank tui`, on a pseudo-terminal, with the window stated the
+//! way a terminal emulator states one.
+//!
+//! **Why the harness is here and not shared.** `crates/ank-cli/tests/tui.rs`
+//! drives a session the same way, and this file cannot call into it: a Rust
+//! integration test is its own crate, and two of them share nothing that is not
+//! in a library. Putting a pseudo-terminal in `ank-tui`'s own `src/` is not an
+//! option either -- `tests/dependencies.rs` forbids this crate a foreign symbol
+//! and forbids it `unsafe`, which is the whole of what ADR-0b55983421dd bought
+//! by taking crossterm. A test may name what the crate may not, and that is
+//! exactly the exemption `sources()` there is written to give. So what is
+//! duplicated is the smallest terminal that can answer this question, and
+//! nothing above it.
+//!
+//! **Why the binary is found rather than named.** `CARGO_BIN_EXE_ank` is
+//! defined only for the package that declares the binary, and that is
+//! `ank-cli`. So it is looked for beside the test executable, which is where
+//! cargo puts it, and the assertion when it is missing names the command that
+//! builds it rather than passing on nothing.
+//!
+//! The driven session is `#[cfg(unix)]`, for the reason `ank-cli`'s suite
+//! gives: a pseudo-terminal on Windows is ConPTY, and reaching it means the
+//! console API this workspace does not otherwise call. What runs on all three
+//! platforms is the layout, the keystroke mapping and the render, in
+//! `src/view.rs`.
+
+#![cfg(unix)]
+
+use std::path::PathBuf;
+use std::process::{Command, Output};
+
+// ---------------------------------------------------------------------------
+// The binary, and a corpus for it to read
+// ---------------------------------------------------------------------------
+
+/// The `ank` this workspace just built.
+///
+/// Beside the test executable's own directory: cargo puts an integration test
+/// in `<target>/<profile>/deps/` and a binary in `<target>/<profile>/`.
+fn ank() -> PathBuf {
+    let mut at = std::env::current_exe().expect("a test executable has a path");
+    at.pop();
+    if at.file_name().is_some_and(|n| n == "deps") {
+        at.pop();
+    }
+    let binary = at.join("ank");
+    assert!(
+        binary.is_file(),
+        "the ank binary is not at {}: this suite drives the process, so build it \
+         first (cargo test --workspace, or cargo build -p ank-cli)",
+        binary.display()
+    );
+    binary
+}
+
+/// A scratch repository nothing else uses, removed when the test ends.
+struct Repo(PathBuf);
+
+impl Drop for Repo {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+const AGENT: &str = "claude-code/opus-5+panel-suite";
+/// Deliberately wider than the entities panel at either window, so that a
+/// frame which overflowed rather than fitted would be visible as a row past
+/// the right edge.
+const TASK_TITLE: &str =
+    "A task whose title is wider than any panel this reader draws at forty columns";
+
+impl Repo {
+    fn seeded() -> Repo {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static SEQ: AtomicU64 = AtomicU64::new(0);
+        let root = std::env::temp_dir().join(format!(
+            "ank-tui-panels-{}-{}",
+            std::process::id(),
+            SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        let repo = Repo(root);
+        repo.git(&["init", "--initial-branch=main"]);
+        repo.git(&["config", "user.email", "suite@example.invalid"]);
+        repo.git(&["config", "user.name", "The Suite"]);
+        // Signing off: a throwaway corpus inherits whatever the machine has
+        // globally otherwise, and a suite whose commits are signed on one
+        // machine and not the next is a suite that reports the machine.
+        repo.git(&["config", "commit.gpgsign", "false"]);
+        std::fs::create_dir_all(repo.0.join("src")).unwrap();
+        std::fs::write(repo.0.join("src/lib.rs"), "// code\n").unwrap();
+        repo.ank(&["init"]);
+        repo.ank(&[
+            "new",
+            "adr",
+            "--title",
+            "Every byte shown is a byte the CLI printed",
+            "--scope",
+            "src/**",
+            "--constraint",
+            "The reader reaches the corpus by running the CLI.",
+        ]);
+        repo.ank(&[
+            "new",
+            "task",
+            "--title",
+            TASK_TITLE,
+            "--scope",
+            "src/**",
+            "--criteria",
+            "The frame names this entity and the body arrives whole.",
+        ]);
+        repo
+    }
+
+    fn git(&self, args: &[&str]) -> Output {
+        let out = Command::new("git")
+            .args(args)
+            .current_dir(&self.0)
+            .output()
+            .expect("git must be on PATH for this suite");
+        assert!(
+            out.status.success(),
+            "git {args:?}: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        out
+    }
+
+    /// The short form of the task this corpus carries, which is what a listing
+    /// prints and what the prompt takes.
+    fn task(&self) -> String {
+        let doc = String::from_utf8_lossy(&self.ank(&["find", "--type", "task", "--json"]).stdout)
+            .to_string();
+        let at = doc.find("\"id\":\"").expect("the corpus carries a task") + 6;
+        let rest = &doc[at..];
+        let id = &rest[..rest.find('"').expect("an id is a closed string")];
+        let (kind, hex) = id.split_once('-').expect("an identifier has a kind");
+        format!("{kind}-{}", &hex[..4])
+    }
+
+    fn ank(&self, args: &[&str]) -> Output {
+        let out = Command::new(ank())
+            .args(args)
+            .current_dir(&self.0)
+            .env("ANK_AGENT", AGENT)
+            .env("NO_COLOR", "1")
+            .output()
+            .expect("the binary must have been built");
+        assert!(
+            out.status.success(),
+            "ank {args:?}: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        out
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The terminal
+// ---------------------------------------------------------------------------
+
+mod pty {
+    use std::ffi::CStr;
+    use std::fs::File;
+    use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd};
+    use std::os::raw::{c_char, c_int, c_ulong};
+    use std::path::{Path, PathBuf};
+
+    extern "C" {
+        fn posix_openpt(flags: c_int) -> c_int;
+        fn grantpt(fd: c_int) -> c_int;
+        fn unlockpt(fd: c_int) -> c_int;
+        fn ptsname(fd: c_int) -> *mut c_char;
+        fn ioctl(fd: c_int, request: c_ulong, ...) -> c_int;
+    }
+
+    const O_RDWR: c_int = 2;
+
+    /// Not POSIX, and spelled per platform because it is per platform: an
+    /// `ioctl` number encodes the direction and the size of its argument, and
+    /// the two kernels encode them differently.
+    #[cfg(target_os = "linux")]
+    const TIOCSWINSZ: c_ulong = 0x5414;
+    #[cfg(not(target_os = "linux"))]
+    const TIOCSWINSZ: c_ulong = 0x8008_7467;
+
+    #[repr(C)]
+    struct WinSize {
+        rows: u16,
+        columns: u16,
+        x_pixels: u16,
+        y_pixels: u16,
+    }
+
+    pub fn open() -> (File, PathBuf) {
+        // SAFETY: the four calls are the POSIX pseudo-terminal sequence, in
+        // order, and every return is checked before the next is made. The
+        // pointer `ptsname` answers with is owned by the C library and is
+        // copied out before anything else can invalidate it.
+        unsafe {
+            let master = posix_openpt(O_RDWR);
+            assert!(master >= 0, "posix_openpt failed");
+            assert_eq!(grantpt(master), 0, "grantpt failed");
+            assert_eq!(unlockpt(master), 0, "unlockpt failed");
+            let name = ptsname(master);
+            assert!(!name.is_null(), "ptsname answered nothing");
+            let path = PathBuf::from(
+                CStr::from_ptr(name)
+                    .to_str()
+                    .expect("a device path is UTF-8")
+                    .to_string(),
+            );
+            (File::from_raw_fd(master), path)
+        }
+    }
+
+    /// The window, stated on the slave side.
+    ///
+    /// On the slave and never on the master: macOS answers `-1` to a general
+    /// tty ioctl on the cloning device, and a window size is a property of the
+    /// terminal the program is looking at anyway.
+    pub fn resize(slave_path: &Path, columns: u16, rows: u16) {
+        let tty = slave(slave_path);
+        let size = WinSize {
+            rows,
+            columns,
+            x_pixels: 0,
+            y_pixels: 0,
+        };
+        // SAFETY: the descriptor is open and owned by `tty`, and the third
+        // argument is a pointer to a `winsize`, which is what TIOCSWINSZ reads.
+        let set = unsafe { ioctl(tty.as_raw_fd(), TIOCSWINSZ, &size) };
+        assert_eq!(
+            set,
+            0,
+            "the window could not be set: {}",
+            std::io::Error::last_os_error()
+        );
+    }
+
+    pub fn slave(path: &Path) -> File {
+        std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(path)
+            .expect("the slave side of a pseudo-terminal must open")
+    }
+
+    pub fn stdio(file: File) -> std::process::Stdio {
+        // SAFETY: the descriptor is owned by `file`, which gives it up here, so
+        // exactly one owner reaches the child.
+        unsafe { std::process::Stdio::from_raw_fd(file.into_raw_fd()) }
+    }
+}
+
+/// A terminal, as far as this suite needs one.
+///
+/// The reader draws by diffing: ratatui writes the cells that changed and moves
+/// the cursor over the ones that did not, so `2 ENTITIES` reaches the wire as
+/// `2 ENTIT`, a cursor move and `IES`. A substring search over the bytes would
+/// be asserting something untrue of them, so they are applied to a grid and
+/// every assertion here is made against what a person would be looking at.
+///
+/// The smallest emulator that is honest about this stream: cursor position, the
+/// two erases, and text. Everything else a CSI can say -- colour, attributes,
+/// the alternate buffer, the cursor's visibility -- moves no character, so it
+/// is consumed and dropped rather than half understood.
+struct Screen {
+    grid: Vec<Vec<char>>,
+    columns: usize,
+    rows: usize,
+    x: usize,
+    y: usize,
+    /// Bytes of a sequence whose end has not arrived yet: a terminal hands over
+    /// a frame in whatever pieces it likes, and half a `MoveTo` is not a
+    /// character.
+    pending: Vec<u8>,
+}
+
+impl Screen {
+    fn new(columns: u16, rows: u16) -> Screen {
+        Screen {
+            grid: vec![vec![' '; columns as usize]; rows as usize],
+            columns: columns as usize,
+            rows: rows as usize,
+            x: 0,
+            y: 0,
+            pending: Vec::new(),
+        }
+    }
+
+    fn feed(&mut self, bytes: &[u8]) {
+        self.pending.extend_from_slice(bytes);
+        let taken = self.apply();
+        self.pending.drain(..taken);
+    }
+
+    fn apply(&mut self) -> usize {
+        let bytes = std::mem::take(&mut self.pending);
+        let mut at = 0;
+        while at < bytes.len() {
+            match bytes[at] {
+                0x1b => match escape(&bytes[at..]) {
+                    // Not all here yet: stop, and keep it for the next read.
+                    None => break,
+                    Some((len, csi)) => {
+                        if let Some((params, final_byte, private)) = csi {
+                            self.csi(&params, final_byte, private);
+                        }
+                        at += len;
+                    }
+                },
+                b'\r' => {
+                    self.x = 0;
+                    at += 1;
+                }
+                b'\n' => {
+                    self.y = (self.y + 1).min(self.rows.saturating_sub(1));
+                    at += 1;
+                }
+                first => {
+                    let width = utf8_width(first);
+                    if at + width > bytes.len() {
+                        break;
+                    }
+                    if let Ok(s) = std::str::from_utf8(&bytes[at..at + width]) {
+                        for c in s.chars() {
+                            self.put(c);
+                        }
+                    }
+                    at += width;
+                }
+            }
+        }
+        self.pending = bytes;
+        at
+    }
+
+    fn put(&mut self, c: char) {
+        if self.y < self.rows && self.x < self.columns {
+            self.grid[self.y][self.x] = c;
+        }
+        self.x += 1;
+        if self.x >= self.columns {
+            self.x = 0;
+            self.y = (self.y + 1).min(self.rows.saturating_sub(1));
+        }
+    }
+
+    fn csi(&mut self, params: &[usize], final_byte: u8, private: bool) {
+        if private {
+            return;
+        }
+        let at = |i: usize, default: usize| params.get(i).copied().unwrap_or(default);
+        match final_byte {
+            b'H' | b'f' => {
+                self.y = at(0, 1).saturating_sub(1).min(self.rows.saturating_sub(1));
+                self.x = at(1, 1)
+                    .saturating_sub(1)
+                    .min(self.columns.saturating_sub(1));
+            }
+            b'J' => match at(0, 0) {
+                0 => {
+                    for x in self.x..self.columns {
+                        self.grid[self.y][x] = ' ';
+                    }
+                    for y in self.y + 1..self.rows {
+                        self.grid[y] = vec![' '; self.columns];
+                    }
+                }
+                1 => {
+                    for y in 0..self.y {
+                        self.grid[y] = vec![' '; self.columns];
+                    }
+                    for x in 0..=self.x.min(self.columns - 1) {
+                        self.grid[self.y][x] = ' ';
+                    }
+                }
+                _ => self.grid = vec![vec![' '; self.columns]; self.rows],
+            },
+            b'K' => match at(0, 0) {
+                0 => {
+                    for x in self.x..self.columns {
+                        self.grid[self.y][x] = ' ';
+                    }
+                }
+                1 => {
+                    for x in 0..=self.x.min(self.columns - 1) {
+                        self.grid[self.y][x] = ' ';
+                    }
+                }
+                _ => self.grid[self.y] = vec![' '; self.columns],
+            },
+            // Colour, attributes, scroll regions, anything else: no character
+            // moves, so nothing here does either.
+            _ => {}
+        }
+    }
+
+    /// What is on the screen now, one row per line, trailing space cut.
+    fn text(&self) -> String {
+        self.grid
+            .iter()
+            .map(|row| row.iter().collect::<String>().trim_end().to_string())
+            .collect::<Vec<String>>()
+            .join("\n")
+    }
+}
+
+/// One escape sequence at the head of `bytes`: how long it is, and the CSI it
+/// was if it was one. `None` means it is not all here yet.
+#[allow(clippy::type_complexity)]
+fn escape(bytes: &[u8]) -> Option<(usize, Option<(Vec<usize>, u8, bool)>)> {
+    match bytes.get(1)? {
+        b'[' => {
+            let private = bytes.get(2).is_some_and(|b| b"<=>?".contains(b));
+            let from = 2 + usize::from(private);
+            let mut at = from;
+            while bytes
+                .get(at)
+                .is_some_and(|b| b.is_ascii_digit() || *b == b';')
+            {
+                at += 1;
+            }
+            let final_byte = *bytes.get(at)?;
+            let params = bytes[from..at]
+                .split(|b| *b == b';')
+                .filter_map(|p| std::str::from_utf8(p).ok()?.parse().ok())
+                .collect();
+            Some((at + 1, Some((params, final_byte, private))))
+        }
+        // An operating-system command runs to a bell or a string terminator.
+        b']' => {
+            let mut at = 2;
+            while at < bytes.len() {
+                if bytes[at] == 0x07 {
+                    return Some((at + 1, None));
+                }
+                if bytes[at] == 0x1b && bytes.get(at + 1) == Some(&b'\\') {
+                    return Some((at + 2, None));
+                }
+                at += 1;
+            }
+            None
+        }
+        // Anything else is two bytes: `ESC c`, `ESC (B` is three but is not on
+        // this stream, and a byte consumed wrongly would show up as a character
+        // nobody wrote.
+        _ => Some((2, None)),
+    }
+}
+
+fn utf8_width(first: u8) -> usize {
+    match first {
+        b if b < 0x80 => 1,
+        b if b >> 5 == 0b110 => 2,
+        b if b >> 4 == 0b1110 => 3,
+        b if b >> 3 == 0b11110 => 4,
+        _ => 1,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// A driven session
+// ---------------------------------------------------------------------------
+
+/// `ank tui` on a real terminal of a stated size, drivable while it runs.
+struct Live {
+    child: std::process::Child,
+    writer: std::fs::File,
+    screen: std::sync::Arc<std::sync::Mutex<Screen>>,
+    drain: Option<std::thread::JoinHandle<()>>,
+}
+
+impl Live {
+    fn open(repo: &Repo, columns: u16, rows: u16) -> Live {
+        use std::io::Read;
+
+        let (master, slave_path) = pty::open();
+        // The child's streams are opened before the window is set: a
+        // pseudo-terminal whose last slave descriptor closes is one that hung
+        // up, and how permanently depends on the platform.
+        let (stdin, stdout, stderr) = (
+            pty::slave(&slave_path),
+            pty::slave(&slave_path),
+            pty::slave(&slave_path),
+        );
+        pty::resize(&slave_path, columns, rows);
+        let child = Command::new(ank())
+            .arg("tui")
+            .current_dir(&repo.0)
+            .env("ANK_AGENT", AGENT)
+            .env("NO_COLOR", "1")
+            .stdin(pty::stdio(stdin))
+            .stdout(pty::stdio(stdout))
+            .stderr(pty::stdio(stderr))
+            .spawn()
+            .expect("the binary must have been built");
+
+        let screen = std::sync::Arc::new(std::sync::Mutex::new(Screen::new(columns, rows)));
+        let into = std::sync::Arc::clone(&screen);
+        let mut reader = master.try_clone().expect("the master side clones");
+        // Drained on a thread of its own: a session that painted more than the
+        // pseudo-terminal's buffer holds while nobody was reading would
+        // deadlock, and a deadlock in a suite is a timeout with no message.
+        let drain = std::thread::spawn(move || {
+            let mut buf = [0u8; 4096];
+            loop {
+                match reader.read(&mut buf) {
+                    // Linux answers EIO once the last slave is closed; macOS
+                    // answers zero. Both mean the session is over.
+                    Ok(0) | Err(_) => return,
+                    Ok(n) => into.lock().unwrap().feed(&buf[..n]),
+                }
+            }
+        });
+        Live {
+            child,
+            writer: master,
+            screen,
+            drain: Some(drain),
+        }
+    }
+
+    fn until(&self, what: &str, done: impl Fn(&str) -> bool) {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        while std::time::Instant::now() < deadline {
+            if done(&self.screen.lock().unwrap().text()) {
+                return;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(25));
+        }
+        panic!(
+            "timed out waiting for {what}:\n{}",
+            self.screen.lock().unwrap().text()
+        );
+    }
+
+    /// The screen as it is, once it has stopped moving.
+    ///
+    /// Settled first, because a screen read the instant a needle appeared is
+    /// half a screen: the reader writes a frame in one call but a terminal
+    /// hands it over in whatever pieces it likes.
+    fn frame(&self) -> String {
+        let mut last = String::new();
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        while std::time::Instant::now() < deadline {
+            let now = self.screen.lock().unwrap().text();
+            if !now.trim().is_empty() && now == last {
+                return now;
+            }
+            last = now;
+            std::thread::sleep(std::time::Duration::from_millis(200));
+        }
+        panic!("the screen never stopped moving:\n{last}");
+    }
+
+    fn send(&mut self, bytes: &str) {
+        use std::io::Write;
+        self.writer
+            .write_all(bytes.as_bytes())
+            .expect("the terminal must accept a keystroke");
+        self.writer.flush().unwrap();
+    }
+
+    fn quit(mut self) {
+        self.send("q");
+        let status = self.child.wait().expect("the session must end");
+        assert!(status.success(), "a reader that quits answers 0: {status}");
+        drop(self.writer);
+        if let Some(drain) = self.drain.take() {
+            drain.join().expect("the drain must not panic");
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The criterion
+// ---------------------------------------------------------------------------
+
+/// The two windows the criterion names.
+const WINDOWS: [(u16, u16); 2] = [(80, 24), (40, 24)];
+
+/// The key that opens the prompt, read out of the reader rather than typed as a
+/// letter here: it is the one key this suite has to know, and a suite carrying
+/// its own copy of it would agree with a mapping that moved.
+const ACT: char = ank_tui::keys::ACT;
+
+/// A frame never overflows the window the terminal reported, at eighty columns
+/// and at forty (TASK-bb43cfe2192b).
+///
+/// Both directions, because a frame overflows in two ways and only one of them
+/// is visible in a screenshot: a row wider than the window, and more rows than
+/// the window has. The trailer being on the last row is the third half of it --
+/// it is what says the layout used the size the terminal gave rather than a
+/// default it was born with.
+#[test]
+fn no_frame_overflows_the_window_at_eighty_columns_or_at_forty() {
+    let repo = Repo::seeded();
+    for (columns, rows) in WINDOWS {
+        let live = Live::open(&repo, columns, rows);
+        live.until("the session to open", |t| t.contains("ank tui"));
+        let frame = live.frame();
+        let lines: Vec<&str> = frame.lines().collect();
+        assert_eq!(
+            lines.len(),
+            rows as usize,
+            "the frame is {} rows in a {columns}x{rows} window:\n{frame}",
+            lines.len()
+        );
+        for line in &lines {
+            assert!(
+                line.chars().count() <= columns as usize,
+                "{} columns in a {columns} column window: {line}\n{frame}",
+                line.chars().count()
+            );
+        }
+        assert!(
+            lines[rows as usize - 1].starts_with("a then"),
+            "the key line is not on the last row of a {columns}x{rows} window:\n{frame}"
+        );
+        live.quit();
+    }
+}
+
+/// The screen is panels drawn side by side, one of them focused, and the
+/// focused one is told apart with no colour (TASK-bb43cfe2192b).
+///
+/// `NO_COLOR` is set on the child, so what reaches the terminal carries no
+/// palette at all and every difference this test can see is a character. That
+/// is the criterion's "without colour", measured where it is true or not: on
+/// the wire.
+#[test]
+fn the_panels_are_side_by_side_and_the_focused_one_is_marked_in_characters() {
+    let repo = Repo::seeded();
+    for (columns, rows) in WINDOWS {
+        let mut live = Live::open(&repo, columns, rows);
+        live.until("the session to open", |t| t.contains("2 ENTITIES"));
+        let frame = live.frame();
+        for panel in ["1 CLAIMS", "2 ENTITIES", "3 BODY", "4 QUEUE"] {
+            assert!(
+                frame.contains(panel),
+                "{panel} is not on a {columns}x{rows} frame:\n{frame}"
+            );
+        }
+        // A row carrying two vertical borders is a row two panels share.
+        let shared = frame
+            .lines()
+            .filter(|l| l.chars().filter(|c| *c == '|').count() >= 4)
+            .count();
+        assert!(
+            shared >= 4,
+            "no row of a {columns}x{rows} frame carries two panels:\n{frame}"
+        );
+        // The session opens on the entities, and the mark is there and nowhere
+        // else.
+        assert!(
+            frame.contains("> 2 ENTITIES"),
+            "the focused panel is not marked:\n{frame}"
+        );
+        for other in ["> 1 CLAIMS", "> 3 BODY", "> 4 QUEUE"] {
+            assert!(
+                !frame.contains(other),
+                "two panels are marked at once:\n{frame}"
+            );
+        }
+        // And the doubled rule, which is the second signal and also a
+        // character. Both border sets are on the frame, so this is a
+        // difference and not a style everything shares.
+        assert!(
+            frame.contains("=========="),
+            "no panel is drawn with the doubled border:\n{frame}"
+        );
+        assert!(
+            frame.contains("----------"),
+            "every panel is drawn as the focused one:\n{frame}"
+        );
+
+        // Focus moves by key, and the mark moves with it.
+        live.send("\t");
+        live.until("the focus to move to the body", |t| t.contains("> 3 BODY"));
+        let moved = live.frame();
+        assert!(
+            !moved.contains("> 2 ENTITIES"),
+            "the mark stayed where it was:\n{moved}"
+        );
+        // A digit reaches one directly, which is what the number in a title is
+        // for.
+        live.send("1");
+        live.until("the focus to reach the claims", |t| {
+            t.contains("> 1 CLAIMS")
+        });
+        live.quit();
+    }
+}
+
+/// The body of a selected entity is served whole rather than cut, at either
+/// window (TASK-bb43cfe2192b).
+///
+/// Opened by pressing Enter on the row a session opens on, which is what a
+/// person does. What is asserted is the end of a criterion wider than the
+/// panel: it reaches the screen only if the reader wrapped rather than cut.
+#[test]
+fn the_body_of_a_selected_entity_is_served_whole() {
+    let repo = Repo::seeded();
+    let task = repo.task();
+    for (columns, rows) in WINDOWS {
+        let mut live = Live::open(&repo, columns, rows);
+        live.until("the session to open", |t| t.contains("2 ENTITIES"));
+        // Opened by identifier rather than by counting rows: an identifier is a
+        // line by nature and the prompt is where the grammar reads one, so this
+        // says which entity is meant instead of depending on where `find`
+        // happens to have put it.
+        live.send(&format!("{ACT}{task}\r"));
+        live.until("the document to open in the body panel", |t| {
+            t.contains("> 3 BODY")
+        });
+        // Paged until the criterion's end arrives, which is what "whole" means
+        // on a panel shorter than the document.
+        let mut found = false;
+        for _ in 0..12 {
+            if live.frame().contains("arrives whole") {
+                found = true;
+                break;
+            }
+            live.send("n");
+        }
+        let frame = live.frame();
+        assert!(found, "the body was cut at {columns}x{rows}:\n{frame}");
+        // And it is still a frame that fits the window it was given.
+        for line in frame.lines() {
+            assert!(
+                line.chars().count() <= columns as usize,
+                "{} columns in a {columns} column window: {line}\n{frame}",
+                line.chars().count()
+            );
+        }
+        live.quit();
+    }
+}


### PR DESCRIPTION
Settles TASK-bb43cfe2192b: the terminal reader stops being three screens shown one at a time and becomes four panels with focus.

## The panel set

```
ank tui   corpus ...   branch ...                        <- chrome
+-  1 CLAIMS (2) -----------------------------------+
|  * TASK-4974  claude-code/opus-5+wave14  until ... |
+----------------------------------------------------+
+=> 2 ENTITIES 1-9 of 41 ====++-  3 BODY ------------+
|>     1  ADR-8bd7  accepted ||   nothing is open    |
+============================++----------------------+
+-  4 QUEUE all 2 ----------------------------------+
|   ADR-2b7c  adr  A decision waiting for a person   |
+----------------------------------------------------+
whatever the reader is being told, or the prompt          <- chrome
the keys, and the five verbs that write                   <- chrome
```

Which panel gets the full width and which shares a row is decided by one question: whether a row of it is a **line** or a **list**. A claim carries an identity thirty characters long; the queue carries the seventy-character sentence naming §8's advisory regime. A column cuts both, and a cut identity is the one field that answers "held by whom". The entities and the body are the pair genuinely read against each other — you move down a list *in order to* open something — so they are the pair that shares a row.

## Focus

`Tab` walks the ring, `1`–`4` name a panel directly (the digit is in the panel's own title), Left and Right reach the pair in the middle. No command requires a chord.

The focused panel is told apart by two ASCII signals and no colour: its border rules with `=` where the others rule with `-`, and its title carries the `> ` this crate already spends on the row a cursor is on. The test harness reads symbols and never styles, so "distinguishable without colour" is a property the suite states rather than a claim it makes.

**Focus is not decoration: the focused one of the middle pair takes four fifths of the width.** Eighty columns will not hold both a list whose titles are sentences and a body that is prose, and splitting the difference serves neither question. Pressing Enter therefore opens a document *and* hands it the screen.

## What the body panel deliberately does not do

Preview whatever the entities cursor is on. A preview is an `ank show` per `j`, and `show` renews the lease on a task you hold (ADR-0bb7ea8991bc) — so a body that followed a cursor would renew a claim by being scrolled. The queue is likewise loaded only when its panel is focused, because `ank review` inspects the whole corpus.

## Seams left open on purpose

- **TASK-d4a882345837** (a confirmation in front of every write): `App::run` is the one place an argv is composed, and there is exactly one road from a key press to a spawned verb. One function to intercept.
- **TASK-dd9747e5e305** (one column for a phone, mouse selection): `App::arrange` decides every rectangle from the window and the focus and nothing else. One column is a branch there; hit-testing a tap is that same function read backwards.

## Measured through the binary

`crates/ank-tui/tests/panels.rs` drives the built `ank` on a real pseudo-terminal at **eighty columns and at forty**: exactly the window's rows, no row past its right edge, the trailer on the last row, four panel titles, two panels sharing rows, one panel marked and the mark moving with `Tab`, and the body reached whole by paging. `src/view.rs` asserts the same window property of the layout at five sizes on every platform.

The borders are ASCII rather than box-drawing glyphs: structure in this tool is text emitted identically on every platform (ADR-1f70ce2c3eac), it is what a phone terminal is likeliest to render, and it keeps `ank-cli/tests/tui.rs`'s byte-wise identifier scan off a char boundary.

`cargo test --workspace` green (all 22 of the existing `ank-cli` PTY tests included, unmodified), `cargo fmt --check` clean, `ank check` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RarMjpP3fqpUB7EeVAssaw