### PR TITLE
The reader paints the shared table, and NO_COLOR reaches it

### DIFF
--- a/.ank/entities/LOG-20e6bad90d06.md
+++ b/.ank/entities/LOG-20e6bad90d06.md
@@ -1,0 +1,31 @@
+---
+id: LOG-20e6bad90d06
+type: log
+title: Settled where colour is allowed to exist in this crate, and put the whole of it in
+created: 2026-08-26T06:37:14Z
+author: claude-code/opus-5+paints-table
+scope:
+  - crates/ank-tui/**
+about: TASK-6cd41d23b7d1
+seq: 1
+schema: 4
+version: 1
+---
+
+ crates/ank-tui/src/paint.rs so TASK-dd9747e5e305 has one rule to obey and no palette to think about.
+
+ONE RENDER, NAMED Ink::role. It is a total match on ank_contract::meaning::Role and carries no string at all: a name reaches a colour only through meaning::role_of_status / role_of_marker / role_of_kind, so there is nowhere left for a second opinion about 'done' to be written. The registers are ank-cli's on purpose -- blue/cyan/green/dim/magenta/yellow/red/yellow -- because ADR-1f70ce2c3eac lets each surface paint a role its own way but not disagree about which things are alike, and both surfaces draw into the same terminal palette. MADE MECHANICAL rather than asserted: paint.rs's own suite walks src/ and fails if any file but paint.rs names Color::, Modifier::, .fg(, .bg( or add_modifier, AND fails if paint.rs's shipped code contains any name MEANINGS declares. Comments and #[cfg(test)] are cut before the scan, which is the same exemption tests/dependencies.rs gives by reading only src/. That pair is the criterion's grep, run by cargo.
+
+HOW A ROW CARRIES A COLOUR: paint::Composed. A line is still built as the characters it always was, with (from,to,Role) marks recorded beside it in CHARACTERS not bytes. That was the load-bearing choice: fit(), pad(), wrap() and every window count in this reader are arithmetic on chars, and a list of styled spans would have made each of them a second implementation. rows_of() is UNTOUCHED and still reads symbols only, so bb43's property -- the focused panel is distinguishable without colour -- is still a thing the suite can state. Composed::fitted clips a mark to the cut so the '~' announcing it is never the tail of a painted identifier.
+
+THE RULE, and it is the one dd97 has to keep: THIS READER PAINTS THE ROWS IT COMPOSES AND NOTHING ELSE. A field carries a meaning -- the status column of a listing, the identifier a row is addressed by, the state in the body panel's title -- and a field is something this crate put there. A document's body, a refusal the CLI wrote, and the fields of an answer are drawn as they arrived. Not squeamishness: 'done', 'accepted' and 'proposed' are ordinary English and an ADR's prose is full of them, so a reader that painted every occurrence would be telling its person that a sentence is a state. view.rs asserts exactly that with a body containing the word 'closed', a status no row of the fixture carries.
+
+SEAM FOR TASK-dd9747e5e305, and it cost nothing. App::arrange is UNTOUCHED: no rectangle moved, no panel added, no band. Colour is per line inside App::panel, which means the one-column branch inherits it for free and a tap resolves against the same rectangles it always did. The ONE thing to watch: rows reach the screen through painted(&[Composed], self.ink) and the three chrome bands through paragraph(&[String]). A one-column layout that built its rows as Strings and rendered them with paragraph() would be the single place in this crate that draws an unpainted listing, and nothing would fail -- so build rows as Composed. bb43's two traps are untouched and still true: arrange() sizes from counts (page() calls arrange(), so the recursion is a stack overflow), and the borders stay ASCII.
+
+WHERE NO_COLOR IS READ: Ink::detect(), once, in App::new, held on the App -- ank-cli's opted_out to the letter (non-empty NO_COLOR, or TERM=dumb). The terminal half of the CLI's condition is absent because 'tui' already refuses without one. App::inked(ink) exists for the suite so no test depends on the environment of the machine running it, and app() in view.rs's tests is explicitly PLAIN for the same reason.
+
+THE TRAP THAT WOULD HAVE MADE THE WHOLE TEST VACUOUS. crossterm 0.29 reads NO_COLOR ITSELF and silently drops the colour half of an SGR -- and drops nothing else: an attribute like Dim goes out on the wire whatever the variable says. So a reader that had left NO_COLOR to its dependency would have passed a naive pty assertion. That is why Role::Retired is DIM rather than a colour and why tests/colour.rs closes a task in its corpus before every drive: 'closed' is Retired, dim is the one register crossterm does not suppress, and its absence under NO_COLOR is therefore this crate's decision rather than crossterm's manners. Verified non-vacuous by disabling Ink::detect's NO_COLOR branch and watching the suite go red. Second crossterm fact worth knowing: it spells every NAMED colour in the extended form, so ratatui's Color::Yellow reaches the wire as ESC[38;5;3m, not ESC[33m -- a byte-level assertion written against 30-37 finds nothing.
+
+MEASURED THROUGH THE BINARY as CLAUDE.md demands: crates/ank-tui/tests/colour.rs drives the built ank on a pty at 110x30 through all four panels, once with NO_COLOR=1 and once with it removed from the child's environment, and asserts on the RAW BYTES -- no SGR sets anything in the first, something does in the second, what it sets is only an attribute or one of the terminal's own sixteen foregrounds and never a background, and the two GRIDS are identical character for character. That last one is the criterion's 'stays readable' stated the strongest way there is: anything colour carried alone would be a difference between those two frames. tests/terminal/mod.rs gained Screen.raw, Live::painting and Live::raw; Live::open still sets NO_COLOR=1, so panels.rs and confirmation.rs are unaffected.
+
+NOTHING OUTSIDE crates/ank-tui/** CHANGED. crates/ank-cli/tests/tui.rs needed NO edit and I want that on the record, because it was the expected cost: its emulator applies a CSI ending in 'm' as 'no character moves', so the grid it byte-slices for KIND-hhhh ids is the same grid it always was.

--- a/.ank/entities/LOG-3b548b0d0c9b.md
+++ b/.ank/entities/LOG-3b548b0d0c9b.md
@@ -1,0 +1,13 @@
+---
+id: LOG-3b548b0d0c9b
+type: log
+title: done, proof commit:6cfc8ea
+created: 2026-08-26T06:37:39Z
+author: claude-code/opus-5+paints-table
+scope:
+  - crates/ank-tui/**
+about: TASK-6cd41d23b7d1
+seq: 2
+schema: 4
+version: 1
+---

--- a/.ank/entities/TASK-6cd41d23b7d1.md
+++ b/.ank/entities/TASK-6cd41d23b7d1.md
@@ -5,7 +5,7 @@ slug: the-reader-paints-the-shared-table-and-no-color
 title: The reader paints the shared table, and NO_COLOR reaches it
 created: 2026-08-25T22:45:39Z
 author: haksolot@vmi3223161
-status: open
+status: in_progress
 scope:
   - crates/ank-tui/**
 blocked_by: [TASK-4fa385c1772d, TASK-174588603cd2]
@@ -13,5 +13,5 @@ done_criteria: |
   Every colour the reader draws comes from the one table of ADR-1f70ce2c3eac, and the crate holds no second opinion about what a status means: grep finds no status name mapped to a colour anywhere in crates/ank-tui outside the render of that table. With NO_COLOR set the reader draws no colour at all and stays readable, which a test asserts by showing that every distinction it makes is still carried by text. cargo test is green and cargo fmt --check passes.
 criteria_by: creator
 schema: 4
-version: 2
+version: 3
 ---

--- a/.ank/entities/TASK-6cd41d23b7d1.md
+++ b/.ank/entities/TASK-6cd41d23b7d1.md
@@ -5,13 +5,18 @@ slug: the-reader-paints-the-shared-table-and-no-color
 title: The reader paints the shared table, and NO_COLOR reaches it
 created: 2026-08-25T22:45:39Z
 author: haksolot@vmi3223161
-status: in_progress
+status: done
 scope:
   - crates/ank-tui/**
 blocked_by: [TASK-4fa385c1772d, TASK-174588603cd2]
 done_criteria: |
   Every colour the reader draws comes from the one table of ADR-1f70ce2c3eac, and the crate holds no second opinion about what a status means: grep finds no status name mapped to a colour anywhere in crates/ank-tui outside the render of that table. With NO_COLOR set the reader draws no colour at all and stays readable, which a test asserts by showing that every distinction it makes is still carried by text. cargo test is green and cargo fmt --check passes.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 6cfc8ea
+    criteria: e93f8e2ad73b
+    via: submitted
 schema: 4
-version: 3
+version: 4
 ---

--- a/crates/ank-tui/src/lib.rs
+++ b/crates/ank-tui/src/lib.rs
@@ -109,6 +109,28 @@
 //! is decided, and it is the one function TASK-dd9747e5e305 has to extend for a
 //! phone.
 //!
+//! # The painting, and what `NO_COLOR` takes away
+//!
+//! **What a status means is one table, and this is one of the two surfaces
+//! that paint it** (ADR-1f70ce2c3eac, TASK-6cd41d23b7d1). The meaning lives in
+//! `ank_contract::meaning` -- `done` is an accomplishment, `proposed` is
+//! waiting on somebody -- and [`paint::Ink::role`] is this crate's render of
+//! it, through ratatui rather than in the hand-written ANSI `ank-cli` uses.
+//! Two renderers are allowed and a second table is not, so no source here
+//! names a colour but that one and no name reaches a colour except through the
+//! shared lookup: `src/paint.rs` walks the crate and fails if either stops
+//! being true.
+//!
+//! **`NO_COLOR` reaches this reader and takes nothing away.** The variable is
+//! read once when the screen opens, by the CLI's own rule, and what it turns
+//! off is a repetition: every distinction on this screen is already a
+//! character. Where the focus is, is `=` and `> `; where the cursor is, is
+//! `> `; whose claim a row is, is `*`; what state an entity is in, is the word
+//! spelled in its own column. `crates/ank-tui/tests/colour.rs` drives the
+//! binary on a pseudo-terminal with the variable set and with it unset, and
+//! compares the two screens character for character -- anything colour carried
+//! alone would be a difference, and there is none.
+//!
 //! # Ratification, and the two words that are not the same
 //!
 //! ADR-8bd76e8d7c4e lets this reader *drive* `ank accept` and forbids it
@@ -141,6 +163,7 @@ pub mod ank;
 pub mod input;
 pub mod keys;
 pub mod model;
+pub mod paint;
 pub mod stream;
 pub mod term;
 pub mod text;

--- a/crates/ank-tui/src/paint.rs
+++ b/crates/ank-tui/src/paint.rs
@@ -1,0 +1,617 @@
+//! What this reader paints, and the whole of it (ADR-1f70ce2c3eac,
+//! TASK-6cd41d23b7d1).
+//!
+//! **One table, two renderers, and this is the second one.** What a status, a
+//! kind or a severity *means* is `ank_contract::meaning`: `done` is an
+//! accomplishment, `proposed` is waiting on somebody, a fault is a fault --
+//! roles, never colours. `ank-cli` renders those roles in hand-written ANSI in
+//! its own `style.rs`; this file renders the same roles through ratatui, which
+//! is what a library that owns the screen has to be allowed to do. Neither
+//! knows how the other paints, and neither carries a second opinion about what
+//! `done` is.
+//!
+//! **[`Ink::role`] is that render, and it is the only place in this crate where
+//! a colour is named at all.** It is a total function of [`Role`], so a variant
+//! added to the shared table stops this crate compiling rather than shipping a
+//! part the reader silently draws in nothing. There is no string in it: a name
+//! reaches a colour by way of the table's own lookup, in one hop, and the test
+//! at the bottom of this file walks `src/` and fails if any other source names
+//! a colour or if this one names a status. That is the criterion of
+//! TASK-6cd41d23b7d1 -- "grep finds no status name mapped to a colour outside
+//! the render of that table" -- made mechanical instead of asserted in prose.
+//!
+//! # `NO_COLOR` reaches the reader
+//!
+//! The CLI paints on two conditions: stdout is a terminal, and `NO_COLOR` is
+//! unset. A full-screen reader is at a terminal by construction -- `ank tui`
+//! refuses outright where it is not -- so the first condition is vacuous here
+//! and the second is not. [`Ink::detect`] is the CLI's `opted_out` and nothing
+//! else, which is what makes "honoured the same way" true rather than
+//! approximately true.
+//!
+//! **[`PLAIN`] is a guarantee and not a setting.** A [`Composed`] line asked
+//! for its rendering under [`PLAIN`] comes back as one unstyled span, so there
+//! is no path by which half a style reaches a cell -- and every distinction the
+//! screen makes is still on it, because the distinctions are characters:
+//! the `> ` on the row a cursor is on, the `*` on a claim its reader holds, the
+//! `=` rule and the `> ` in the title of the panel with the focus, and the
+//! status spelled as a word in its own column. Colour repeats those; it carries
+//! none of them alone.
+//!
+//! # Composing a row, and what is deliberately left alone
+//!
+//! [`Composed`] is a line built as text with the pieces the table has something
+//! to say about recorded beside it. Text first, on purpose: every count, cut
+//! and pad in this reader is arithmetic on characters, and a list of styled
+//! spans would have made each of them a second implementation of `fit`.
+//!
+//! **This reader paints the rows it composes, and nothing else.** A document's
+//! body, a refusal the CLI wrote and the fields of an answer arrive as bytes
+//! from the child and are drawn as they arrived. That line is not squeamishness
+//! about somebody else's output: `done`, `accepted` and `proposed` are ordinary
+//! English words and an ADR's prose is full of them, so a reader that painted
+//! every occurrence would be telling its person that a sentence is a status.
+//! What carries a meaning is a *field* -- the status column of a listing, the
+//! identifier a row is addressed by -- and a field is something this crate put
+//! there.
+
+use crate::text;
+use ank_contract::meaning::{self, Role};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+
+/// Whether this reader may paint, and the palette if it may.
+///
+/// Copied rather than referenced, and constructed in exactly two places:
+/// [`Ink::detect`], and the two constants below that the suite uses to state
+/// both halves of the rule without an environment variable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Ink {
+    on: bool,
+}
+
+/// No colour. What `NO_COLOR` produces, and the default everywhere an answer
+/// has not been established -- so a forgotten wiring draws plain text rather
+/// than leaking a style.
+pub const PLAIN: Ink = Ink { on: false };
+/// Colour. What a terminal with no opt-out produces.
+pub const COLOUR: Ink = Ink { on: true };
+
+impl Ink {
+    /// The rule of ADR-1f70ce2c3eac, evaluated once when the screen opens.
+    ///
+    /// `NO_COLOR` set to anything non-empty, or a terminal that says it cannot
+    /// render. The empty value is deliberately not an opt-out: `NO_COLOR=` is
+    /// how a shell spells "unset this for the child", and reading it as
+    /// "disable" would make the variable impossible to turn back off. Both
+    /// halves are `ank-cli`'s `style::opted_out`, to the letter.
+    ///
+    /// The terminal test the CLI makes first is absent because it is answered
+    /// already: `ank tui` refuses without a terminal on stdin *and* stdout
+    /// before a screen is ever opened, so by the time anything here is asked
+    /// there is one. Windows is answered a rung down too -- crossterm's
+    /// `windows` feature is what puts that console into virtual-terminal mode,
+    /// and it is the same code path ratatui draws through.
+    pub fn detect() -> Ink {
+        if std::env::var_os("NO_COLOR").is_some_and(|v| !v.is_empty()) {
+            return PLAIN;
+        }
+        if std::env::var_os("TERM").is_some_and(|v| v == "dumb") {
+            return PLAIN;
+        }
+        COLOUR
+    }
+
+    pub fn enabled(self) -> bool {
+        self.on
+    }
+
+    /// A [`Role`] of the shared table, in the register this surface gives it.
+    ///
+    /// **The whole of what this crate decides about meaning**, and a total
+    /// function of the role rather than a lookup keyed on strings: a lookup
+    /// would have answered a role it had never heard of with a default and
+    /// drawn it unpainted, where this stops compiling and asks.
+    ///
+    /// The registers are the CLI's, and agreeing is a choice rather than an
+    /// obligation. ADR-1f70ce2c3eac lets each surface paint a role its own way
+    /// and the reader could reasonably paint `Attention` something else against
+    /// a background it chose; what it must not do is disagree about *which*
+    /// things are alike. Since this reader draws on the same terminal palette
+    /// the CLI writes into, the least surprising answer is the one a person has
+    /// already learned from `ank find`.
+    pub fn role(self, role: Role) -> Style {
+        if !self.on {
+            return Style::new();
+        }
+        match role {
+            Role::Available => Style::new().fg(Color::Blue),
+            // One state seen twice: `in_progress` is what the file says and
+            // `claimed` is what the ref says. A reader who sees them in two
+            // colours has to learn that they are the same fact.
+            Role::Underway => Style::new().fg(Color::Cyan),
+            Role::Accomplished => Style::new().fg(Color::Green),
+            // Dim and never red: nothing here failed. A release is how the loop
+            // is meant to end when a criterion turns out to be wrong, and
+            // painting it as an error would teach an agent to avoid the honest
+            // move.
+            Role::Retired => Style::new().add_modifier(Modifier::DIM),
+            Role::Awaiting => Style::new().fg(Color::Magenta),
+            Role::Attention => Style::new().fg(Color::Yellow),
+            Role::Fault => Style::new().fg(Color::Red),
+            Role::Identifier => Style::new().fg(Color::Yellow),
+        }
+    }
+
+    /// [`Ink::role`] where the table may have answered nothing.
+    ///
+    /// `None` is an answer: a string that is not a name of its family is left
+    /// alone rather than painted as something it is not. That is what lets a
+    /// composer hand a value to this without first knowing whether the table
+    /// declares it -- `[blocked]` being the case it exists for.
+    pub fn of(self, role: Option<Role>) -> Style {
+        match role {
+            Some(role) => self.role(role),
+            None => Style::new(),
+        }
+    }
+}
+
+/// The role an identifier carries, read out of the kind it names.
+///
+/// `TASK-4974` is a `task` in the table's spelling, so the kind is lowered
+/// before the lookup and the table answers about the family it is a name in.
+/// Every kind lands on [`Role::Identifier`] and the repetition is the shared
+/// table's decision, not this crate's: a surface wanting `ADR-` to read
+/// differently from `TASK-` would have to remove rows there to get it.
+pub fn role_of_id(id: &str) -> Option<Role> {
+    let kind = id.split_once('-').map_or(id, |(kind, _)| kind);
+    meaning::role_of_kind(&kind.to_ascii_lowercase())
+}
+
+/// Where the shared table had something to say, in characters of the line.
+///
+/// Characters and not bytes, because [`text::fit`], [`text::pad`] and every
+/// window count in this reader are counted in characters: a byte range would
+/// disagree with all of them on the first title that is not ASCII.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Mark {
+    from: usize,
+    to: usize,
+    role: Role,
+}
+
+/// A line this crate composed, and the pieces of it the table names.
+///
+/// Built by consuming: a row reads as the sequence of columns it is, and the
+/// alternative -- a mutable builder threaded through six statements -- hides
+/// the shape of the row it is building.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Composed {
+    text: String,
+    marks: Vec<Mark>,
+}
+
+impl Composed {
+    pub fn new() -> Composed {
+        Composed::default()
+    }
+
+    /// A line with nothing for the table to say about it.
+    ///
+    /// What every band of chrome, every sentence and every row of a document's
+    /// own body becomes: text, and text is what it stays.
+    pub fn of(s: &str) -> Composed {
+        Composed {
+            text: s.to_string(),
+            marks: Vec::new(),
+        }
+    }
+
+    /// The characters of the line, which is what a frame is read as.
+    pub fn text(&self) -> &str {
+        &self.text
+    }
+
+    fn len(&self) -> usize {
+        self.text.chars().count()
+    }
+
+    /// More text, carrying no meaning.
+    pub fn plain(self, s: &str) -> Composed {
+        self.named(s, None)
+    }
+
+    /// More text, and the role the table gives it.
+    pub fn named(mut self, s: &str, role: Option<Role>) -> Composed {
+        let from = self.len();
+        self.text.push_str(s);
+        let to = self.len();
+        if let Some(role) = role {
+            if to > from {
+                self.marks.push(Mark { from, to, role });
+            }
+        }
+        self
+    }
+
+    /// A column of a listing: the value fitted to a width, then padded out.
+    ///
+    /// The padding is deliberately outside the mark. Nothing shows on a space
+    /// painted with a foreground colour, but a mark that covered the gap
+    /// between two columns would be a claim that the gap means something, and
+    /// the next person to add a background would find out that it did.
+    pub fn column(self, s: &str, width: usize, role: Option<Role>) -> Composed {
+        let fitted = text::fit(s, width);
+        let spent = fitted.chars().count();
+        self.named(&fitted, role)
+            .plain(&" ".repeat(width.saturating_sub(spent)))
+    }
+
+    /// Another composed line, appended with its marks moved along.
+    pub fn then(mut self, other: Composed) -> Composed {
+        let from = self.len();
+        self.text.push_str(&other.text);
+        self.marks.extend(other.marks.iter().map(|m| Mark {
+            from: m.from + from,
+            to: m.to + from,
+            role: m.role,
+        }));
+        self
+    }
+
+    /// The line, clamped to a width, with the cut announced ([`text::fit`]).
+    ///
+    /// A mark past the cut is dropped and a mark across it is shortened, so the
+    /// `~` that says "there is more of this" is this crate's own character and
+    /// never the tail of a painted identifier.
+    pub fn fitted(mut self, width: usize) -> Composed {
+        let before = self.len();
+        self.text = text::fit(&self.text, width);
+        let after = self.len();
+        if after >= before {
+            return self;
+        }
+        let keep = after.saturating_sub(1);
+        self.marks.retain(|m| m.from < keep);
+        for mark in &mut self.marks {
+            mark.to = mark.to.min(keep);
+        }
+        self
+    }
+
+    /// The line as ratatui draws it.
+    ///
+    /// **Under [`PLAIN`] this is one unstyled span, always.** Not a styled span
+    /// carrying a style that happens to be empty: the guarantee `NO_COLOR` buys
+    /// is that no style reaches a cell at all, and it is worth more as a
+    /// property of this function than as a property of eight match arms.
+    pub fn line(&self, ink: Ink) -> Line<'static> {
+        if !ink.enabled() || self.marks.is_empty() {
+            return Line::from(self.text.clone());
+        }
+        let chars: Vec<char> = self.text.chars().collect();
+        let take = |from: usize, to: usize| chars[from..to].iter().collect::<String>();
+        let mut spans: Vec<Span<'static>> = Vec::new();
+        let mut at = 0;
+        for mark in &self.marks {
+            let from = mark.from.max(at);
+            if from > at {
+                spans.push(Span::raw(take(at, from)));
+            }
+            if mark.to > from {
+                spans.push(Span::styled(take(from, mark.to), ink.role(mark.role)));
+                at = mark.to;
+            }
+        }
+        if at < chars.len() {
+            spans.push(Span::raw(take(at, chars.len())));
+        }
+        Line::from(spans)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ank_contract::meaning::MEANINGS;
+    use std::path::{Path, PathBuf};
+
+    fn manifest() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+    }
+
+    /// A source with its prose and its own suite removed.
+    ///
+    /// The comments are allowed to name a colour and to name a status -- they
+    /// have to, since what they are explaining is where the one is allowed to
+    /// meet the other -- and the code is not. Same reader
+    /// `tests/dependencies.rs` uses, and for the same reason.
+    ///
+    /// **The `#[cfg(test)]` module is cut off with them, and that exemption is
+    /// the same one** `tests/dependencies.rs` gives by reading only `src/`: a
+    /// test may name what the crate may not, and the assertions below have to
+    /// be able to write `done` and `accepted` in order to state that nothing
+    /// else does. What ships is what is above the marker.
+    fn code_of(source: &str) -> String {
+        let shipped = match source.find("#[cfg(test)]") {
+            Some(at) => &source[..at],
+            None => source,
+        };
+        shipped
+            .lines()
+            .filter(|line| !line.trim_start().starts_with("//"))
+            .map(|line| match line.find("//") {
+                Some(at) if !line[..at].contains('"') => &line[..at],
+                _ => line,
+            })
+            .collect::<Vec<&str>>()
+            .join("\n")
+    }
+
+    fn sources() -> Vec<(String, String)> {
+        let mut out = Vec::new();
+        walk(&manifest().join("src"), &mut out);
+        out
+    }
+
+    fn walk(dir: &Path, out: &mut Vec<(String, String)>) {
+        for entry in std::fs::read_dir(dir).expect("the source directory must be readable") {
+            let path = entry.unwrap().path();
+            if path.is_dir() {
+                walk(&path, out);
+            } else if path.extension().is_some_and(|e| e == "rs") {
+                out.push((
+                    path.file_name().unwrap().to_string_lossy().to_string(),
+                    std::fs::read_to_string(&path).unwrap(),
+                ));
+            }
+        }
+    }
+
+    /// The criterion of TASK-6cd41d23b7d1, made mechanical.
+    ///
+    /// Two halves, and neither is worth anything without the other. **No source
+    /// but this one names a colour**, so every colour the reader draws is
+    /// drawn by [`Ink::role`]; and **this one names no status**, so the way a
+    /// name reaches a colour is the shared table's lookup and there is nowhere
+    /// left for a second opinion about `done` to be written.
+    ///
+    /// It walks the whole of `src/` rather than the files somebody remembers
+    /// drawing in: a palette added to `model.rs` next year is the exact failure
+    /// this is for, and it is the one nobody would think to look for.
+    #[test]
+    fn the_render_of_the_table_is_the_only_place_a_colour_is_named() {
+        let sources = sources();
+        assert!(
+            sources.len() >= 10,
+            "the walk read {} sources and gave up early",
+            sources.len()
+        );
+        assert!(
+            sources.iter().any(|(name, _)| name == "paint.rs"),
+            "the walk never reached this file, so it asserted nothing"
+        );
+        for (name, source) in &sources {
+            let code = code_of(source);
+            for needle in ["Color::", "Modifier::", ".fg(", ".bg(", "add_modifier"] {
+                assert!(
+                    name == "paint.rs" || !code.contains(needle),
+                    "{name} names {needle}: every colour this reader draws comes \
+                     from the one render of the shared table, in paint.rs \
+                     (ADR-1f70ce2c3eac)"
+                );
+            }
+            if name != "paint.rs" {
+                continue;
+            }
+            for meaning in MEANINGS {
+                assert!(
+                    !code.contains(&format!("\"{}\"", meaning.name)),
+                    "paint.rs writes {:?}, which is a name the shared table \
+                     already declares: a status reaches a colour through \
+                     meaning::role_of_*, or this file is the second table \
+                     ADR-1f70ce2c3eac forbids",
+                    meaning.name
+                );
+            }
+        }
+    }
+
+    /// Off returns no style at all, which is the guarantee and not a setting.
+    #[test]
+    fn plain_carries_no_style_for_any_role() {
+        for meaning in MEANINGS {
+            assert_eq!(
+                PLAIN.role(meaning.role),
+                Style::new(),
+                "{} was painted with colour off",
+                meaning.name
+            );
+        }
+        assert_eq!(PLAIN.of(None), Style::new());
+        assert!(!PLAIN.enabled());
+        assert!(COLOUR.enabled());
+    }
+
+    /// And on, every role the table declares is painted as something.
+    ///
+    /// Over `MEANINGS` rather than over a list written here, so a row added to
+    /// the shared table is asserted about the day it lands.
+    #[test]
+    fn every_role_the_table_declares_is_painted() {
+        for meaning in MEANINGS {
+            assert_ne!(
+                COLOUR.role(meaning.role),
+                Style::new(),
+                "{} reached the screen unpainted",
+                meaning.name
+            );
+        }
+        // A string the table declares nothing for is left alone, which is what
+        // lets a composer hand a value over without knowing what it is.
+        assert_eq!(COLOUR.of(meaning::role_of_status("blocked")), Style::new());
+    }
+
+    /// One state seen twice reads as one state.
+    #[test]
+    fn a_name_and_its_marker_are_painted_the_same() {
+        for state in ["open", "in_progress", "done", "closed", "proposed"] {
+            assert_eq!(
+                COLOUR.of(meaning::role_of_status(state)),
+                COLOUR.of(meaning::role_of_marker(&format!("[{state}]"))),
+                "{state} is painted one way as a word and another in brackets"
+            );
+        }
+        assert_eq!(
+            COLOUR.of(meaning::role_of_status("in_progress")),
+            COLOUR.of(meaning::role_of_status("claimed:who@host")),
+            "the file's word and the ref's word are one state"
+        );
+    }
+
+    /// An identifier is painted by the kind it names, and every kind alike.
+    #[test]
+    fn an_identifier_reads_the_same_whatever_it_names() {
+        let task = role_of_id("TASK-6cd41d23b7d1");
+        assert_eq!(task, Some(Role::Identifier));
+        for id in ["ADR-1f70ce2c3eac", "SPEC-89070ce7f3b8", "LOG-ed57116ba141"] {
+            assert_eq!(role_of_id(id), task, "{id} is painted apart");
+        }
+        // Not an identifier at all: no kind the registry declares, so nothing
+        // is painted rather than something being guessed.
+        for other in ["until", "2026-08-26T04:58:57Z", "claude-code/opus-5", ""] {
+            assert_eq!(role_of_id(other), None, "{other:?} was taken for an id");
+        }
+    }
+
+    /// A composed row is the string it always was, whatever the ink.
+    #[test]
+    fn composing_a_row_changes_none_of_its_characters() {
+        let row = Composed::new()
+            .plain("> ")
+            .column("TASK-6cd4", 10, role_of_id("TASK-6cd41d23b7d1"))
+            .plain("  ")
+            .column("in_progress", 12, meaning::role_of_status("in_progress"))
+            .plain("  ")
+            .plain("The reader paints the shared table");
+        assert_eq!(
+            row.text(),
+            "> TASK-6cd4   in_progress   The reader paints the shared table"
+        );
+        for ink in [PLAIN, COLOUR] {
+            let drawn: String = row
+                .line(ink)
+                .spans
+                .iter()
+                .map(|s| s.content.as_ref())
+                .collect();
+            assert_eq!(drawn, row.text(), "the ink moved a character");
+        }
+    }
+
+    /// With colour off the line is one span and it carries nothing.
+    #[test]
+    fn no_style_reaches_a_cell_with_colour_off() {
+        let row = Composed::new()
+            .column("ADR-1f70", 10, role_of_id("ADR-1f70ce2c3eac"))
+            .column("accepted", 12, meaning::role_of_status("accepted"));
+        let line = row.line(PLAIN);
+        assert_eq!(line.spans.len(), 1, "a plain line is one span");
+        assert_eq!(line.spans[0].style, Style::new());
+    }
+
+    /// With colour on, exactly the marked pieces carry a style, and the style
+    /// each carries is the one the table's role renders to.
+    #[test]
+    fn only_what_the_table_named_is_painted() {
+        let row = Composed::new()
+            .plain("  ")
+            .column("ADR-1f70", 10, role_of_id("ADR-1f70ce2c3eac"))
+            .plain("  ")
+            .column("superseded", 12, meaning::role_of_status("superseded"))
+            .plain("  ")
+            .plain("a title that says done and accepted in prose");
+        let painted: Vec<(String, Style)> = row
+            .line(COLOUR)
+            .spans
+            .iter()
+            .filter(|s| s.style != Style::new())
+            .map(|s| (s.content.to_string(), s.style))
+            .collect();
+        assert_eq!(
+            painted,
+            [
+                ("ADR-1f70".to_string(), COLOUR.role(Role::Identifier)),
+                ("superseded".to_string(), COLOUR.role(Role::Retired)),
+            ],
+            "the prose was painted, or the columns were not"
+        );
+    }
+
+    /// A cut takes the mark with it, so the `~` is never part of an identifier.
+    #[test]
+    fn a_cut_line_keeps_its_marks_inside_the_window() {
+        let row = Composed::new()
+            .column("TASK-6cd4", 10, role_of_id("TASK-6cd41d23b7d1"))
+            .plain("  ")
+            .column("in_progress", 12, meaning::role_of_status("in_progress"));
+        let cut = row.clone().fitted(6);
+        assert_eq!(cut.text(), "TASK-~");
+        let spans = cut.line(COLOUR).spans;
+        let styled: Vec<String> = spans
+            .iter()
+            .filter(|s| s.style != Style::new())
+            .map(|s| s.content.to_string())
+            .collect();
+        assert_eq!(styled, ["TASK-"], "the announcement of the cut was painted");
+        // Nothing survives a window narrower than the first column.
+        let gone = row.fitted(1);
+        assert_eq!(gone.text(), "~");
+        assert_eq!(gone.line(COLOUR).spans.len(), 1);
+        assert_eq!(gone.line(COLOUR).spans[0].style, Style::new());
+    }
+
+    /// Two composed pieces joined keep both sets of marks, in place.
+    #[test]
+    fn joining_two_composed_pieces_moves_the_marks_along() {
+        let left = Composed::new().named("TASK-6cd4", Some(Role::Identifier));
+        let right = Composed::new()
+            .plain("   ")
+            .named("done", meaning::role_of_status("done"));
+        let joined = left.then(right);
+        assert_eq!(joined.text(), "TASK-6cd4   done");
+        let styled: Vec<(String, Style)> = joined
+            .line(COLOUR)
+            .spans
+            .iter()
+            .filter(|s| s.style != Style::new())
+            .map(|s| (s.content.to_string(), s.style))
+            .collect();
+        assert_eq!(
+            styled,
+            [
+                ("TASK-6cd4".to_string(), COLOUR.role(Role::Identifier)),
+                ("done".to_string(), COLOUR.role(Role::Accomplished)),
+            ]
+        );
+    }
+
+    /// A title outside ASCII is marked in characters, so a column is not cut
+    /// through a code point and a mark does not slide off its value.
+    #[test]
+    fn a_mark_is_counted_in_characters_and_not_in_bytes() {
+        let row = Composed::new()
+            .plain("crit\u{e8}re gel\u{e9} \u{4e2d}\u{6587} -- ")
+            .named("done", meaning::role_of_status("done"))
+            .plain(" \u{4e2d}\u{6587}");
+        let styled: Vec<String> = row
+            .line(COLOUR)
+            .spans
+            .iter()
+            .filter(|s| s.style != Style::new())
+            .map(|s| s.content.to_string())
+            .collect();
+        assert_eq!(styled, ["done"]);
+    }
+}

--- a/crates/ank-tui/src/text.rs
+++ b/crates/ank-tui/src/text.rs
@@ -18,8 +18,11 @@
 //!
 //! The structure layer is ADR-1f70ce2c3eac's and nothing here paints: the
 //! marker on the row the cursor is on and the marker on a held row are text,
-//! and they are the same bytes on every platform. Colour is TASK-6cd41d23b7d1's,
-//! and what is given up until then is decoration and not information.
+//! and they are the same bytes on every platform. Colour arrived after them
+//! (TASK-6cd41d23b7d1) and lives in [`crate::paint`], where the shared table
+//! has one render and this crate has no other -- so what is measured here is
+//! still characters, and a window narrowed to nothing costs a reader
+//! decoration rather than information.
 
 /// The marker on the row the cursor is on, in the two columns every listing in
 /// this tool already spends on its left margin (ADR-1f70ce2c3eac).

--- a/crates/ank-tui/src/view.rs
+++ b/crates/ank-tui/src/view.rs
@@ -64,9 +64,10 @@
 //! panel is drawn with a doubled border and the `> ` marker every listing in
 //! this tool already spends on the row a cursor is on ([`text::CURSOR`]). Both
 //! signals are characters, and both are ASCII: the screen answers "which panel
-//! am I in" with no colour at all -- which matters twice over: `NO_COLOR` is
-//! honoured (ADR-1f70ce2c3eac), and colour is TASK-6cd41d23b7d1's to add on top
-//! of a frame that already reads without it.
+//! am I in" with no colour at all. Colour arrived on top of that frame rather
+//! than into it (TASK-6cd41d23b7d1): what it paints is what a row *is* -- an
+//! identifier, a status -- and never where the reader is standing, so
+//! `NO_COLOR` takes away a repetition and no signal at all.
 //!
 //! The borders are `-`, `|`, `+` and `=` rather than the box-drawing glyphs,
 //! deliberately. Structure in this tool is text emitted identically to every
@@ -143,6 +144,27 @@
 //! wrong branch, a document already ratified, a signature git would not make --
 //! is the CLI's, shown in the CLI's own bytes.
 //!
+//! # What is painted, and what is deliberately not
+//!
+//! **Every colour on this screen is the render of a role the shared table
+//! declares** (ADR-1f70ce2c3eac, TASK-6cd41d23b7d1). [`crate::paint::Ink::role`]
+//! is that render and the only place in this crate where a colour is named;
+//! what reaches it is `ank_contract::meaning`'s own lookup, so `done` has one
+//! meaning here and in `ank find` and there is nowhere for a second opinion to
+//! be written. [`crate::paint::Composed`] is how a row carries that: the line is
+//! built as the characters it always was, with the pieces the table named
+//! recorded beside them, which is what keeps [`fit`], [`pad`] and every window
+//! count arithmetic on characters and lets [`rows_of`] still read a frame as
+//! text.
+//!
+//! **This reader paints the rows it composes.** A field carries a meaning -- the
+//! status column of a listing, the identifier a row is addressed by, the state
+//! in the body panel's title -- and a field is something this crate put there. A
+//! document's own body, a refusal the CLI wrote and the fields of an answer are
+//! drawn as they arrived: `done` and `accepted` are ordinary English words, an
+//! ADR's prose is full of them, and a reader that painted every occurrence would
+//! be telling its person that a sentence is a state.
+//!
 //! **The split on what reaches the screen is the crate header's, applied to an
 //! answer.** The chrome is this crate's own -- the line naming the command that
 //! ran, the markers, the panel titles -- and every value under it is the
@@ -155,8 +177,10 @@ use crate::ank::{Ank, Failed, Ran};
 use crate::input::{Act, Command};
 use crate::keys::{self, Editing, Press};
 use crate::model::{short_of, Detail, Queue, Row, Snapshot};
+use crate::paint::{role_of_id, Composed, Ink};
 use crate::stream::Stream;
 use crate::text::{self, fit, pad, window, wrap};
+use ank_contract::meaning::role_of_status;
 use ratatui::buffer::Buffer;
 use ratatui::crossterm::event::KeyEvent;
 use ratatui::layout::{Constraint, Layout, Position, Rect};
@@ -309,6 +333,14 @@ pub struct App {
     /// but the one immediately after a writing verb was spelled. While it is
     /// `Some`, no key does anything but run that command or drop it.
     pending: Option<Pending>,
+    /// Whether this screen may paint, decided once when it opens
+    /// (TASK-6cd41d23b7d1, ADR-1f70ce2c3eac).
+    ///
+    /// Held rather than asked for at every frame, on the reasoning `ank-cli`
+    /// gives for detecting once in `main`: the environment does not change
+    /// under a session, and a screen that read `NO_COLOR` per paint would be a
+    /// screen whose answer could differ between two rows of one frame.
+    ink: Ink,
 }
 
 impl App {
@@ -332,7 +364,23 @@ impl App {
             queue: None,
             prompt: None,
             pending: None,
+            // The one read of the environment this crate makes. A session is
+            // at a terminal by construction -- `tui` refuses where it is not
+            // -- so what is left of ADR-1f70ce2c3eac's condition is the
+            // variable, and [`Ink::detect`] is the CLI's own rule for it.
+            ink: Ink::detect(),
         }
+    }
+
+    /// The same screen, painting the way it is told to.
+    ///
+    /// For the suite, which has to be able to state both halves of the rule
+    /// without setting a variable on the process running it: a test that
+    /// exported `NO_COLOR` would be a test whose answer depended on the order
+    /// cargo happened to run it in.
+    pub fn inked(mut self, ink: Ink) -> App {
+        self.ink = ink;
+        self
     }
 
     pub fn focus(&self) -> Focus {
@@ -1051,7 +1099,9 @@ impl App {
     /// border is doubled -- `=` where the others rule with `-` -- and its title
     /// carries the same `> ` this tool puts on the row a cursor is on. Two
     /// independent signals, because a reader looking at the middle of a panel
-    /// still sees the rule under it.
+    /// still sees the rule under it. Colour arrived after both
+    /// (TASK-6cd41d23b7d1) and took neither away: what it paints is what a row
+    /// *is* -- an identifier, a status -- and never where the reader is.
     fn panel(&self, focus: Focus, area: Rect, buf: &mut Buffer) {
         if area.width < 2 || area.height < 2 {
             return;
@@ -1060,13 +1110,14 @@ impl App {
         let inside = inside(area);
         let width = inside.width as usize;
         let marker = if focused { text::CURSOR } else { text::PLAIN };
-        let title = fit(
-            &format!("{marker}{} {}", focus.number(), self.title_of(focus, width)),
-            area.width as usize - 2,
-        );
+        let title = Composed::new()
+            .plain(marker)
+            .plain(&format!("{} ", focus.number()))
+            .then(self.title_of(focus, width))
+            .fitted(area.width as usize - 2);
         let block = Block::bordered()
             .border_set(if focused { FOCUSED } else { UNFOCUSED })
-            .title(Line::from(title));
+            .title(title.line(self.ink));
         block.render(area, buf);
         if inside.is_empty() {
             return;
@@ -1077,7 +1128,7 @@ impl App {
             Focus::Queue => self.queue_lines(width),
             Focus::Body => self.body_lines(width, inside.height as usize),
         };
-        paragraph(&lines).render(inside, buf);
+        painted(&lines, self.ink).render(inside, buf);
     }
 
     /// What a panel's title says after its number: its name, and the state of
@@ -1085,53 +1136,66 @@ impl App {
     ///
     /// The name is [`Focus::name`] and never a string written here, so the
     /// title a person reads and the title a test looks for are one constant.
-    fn title_of(&self, focus: Focus, width: usize) -> String {
+    ///
+    /// The body panel's title is the one that carries fields rather than a
+    /// count -- the identifier of the document and the status it is in -- so it
+    /// is the one composed piece by piece; the other three are sentences about
+    /// a window and there is nothing in them for the table to say.
+    fn title_of(&self, focus: Focus, width: usize) -> Composed {
         let name = focus.name();
         match focus {
-            Focus::Claims => format!("{name} ({})", self.count(Focus::Claims)),
+            Focus::Claims => Composed::of(&format!("{name} ({})", self.count(Focus::Claims))),
             Focus::Entities => {
                 let total = self.snapshot.as_ref().map_or(0, |s| s.total);
                 let rows = self.count(Focus::Entities);
                 let c = self.cursors[Focus::Entities.number() - 1];
                 let shown = self.page(Focus::Entities).min(rows.saturating_sub(c.top));
-                format!(
+                Composed::of(&format!(
                     "{name} {}{}   ({total} in the corpus)",
                     window(c.top, shown, rows),
                     self.filter_note()
-                )
+                ))
             }
             Focus::Queue => match &self.queue {
-                None => format!("{name}   (not asked)"),
+                None => Composed::of(&format!("{name}   (not asked)")),
                 Some(_) => {
                     let rows = self.count(Focus::Queue);
                     let c = self.cursors[Focus::Queue.number() - 1];
                     let shown = self.page(Focus::Queue).min(rows.saturating_sub(c.top));
-                    format!(
+                    Composed::of(&format!(
                         "{name} {}{}   (waiting for a person)",
                         window(c.top, shown, rows),
                         self.filter_note()
-                    )
+                    ))
                 }
             },
             Focus::Body => {
                 let Some(detail) = &self.detail else {
-                    return name.to_string();
+                    return Composed::of(name);
                 };
                 let row = self.snapshot.as_ref().and_then(|s| s.row(&detail.id));
                 let counted = self.counted(width);
+                let short = short_of(&detail.id);
                 match self.pane {
-                    Pane::Body => format!(
-                        "{name}   {}  {}  {}   rows {counted}",
-                        short_of(&detail.id),
-                        row.map(|r| r.kind.clone()).unwrap_or_default(),
-                        row.map(|r| r.status.clone()).unwrap_or_default(),
-                    ),
+                    Pane::Body => {
+                        let status = row.map(|r| r.status.clone()).unwrap_or_default();
+                        Composed::new()
+                            .plain(&format!("{name}   "))
+                            .named(&short, role_of_id(&detail.id))
+                            .plain(&format!(
+                                "  {}  ",
+                                row.map(|r| r.kind.clone()).unwrap_or_default()
+                            ))
+                            .named(&status, role_of_status(&status))
+                            .plain(&format!("   rows {counted}"))
+                    }
                     // The one title that is not the panel's name: the panel is
                     // showing the other thing it can show, and saying `BODY`
                     // over a list of decisions would be a heading that lies.
-                    Pane::Constraints => {
-                        format!("CONSTRAINTS   {}   {counted}", short_of(&detail.id))
-                    }
+                    Pane::Constraints => Composed::new()
+                        .plain("CONSTRAINTS   ")
+                        .named(&short, role_of_id(&detail.id))
+                        .plain(&format!("   {counted}")),
                 }
             }
         }
@@ -1157,12 +1221,12 @@ impl App {
     /// the next two say whose claim it is. `*` is what `find` prints on a row
     /// the caller holds, and it stays against the identifier rather than moving
     /// to make room for a cursor that arrived later.
-    fn claim_lines(&self, width: usize) -> Vec<String> {
+    fn claim_lines(&self, width: usize) -> Vec<Composed> {
         let Some(snapshot) = &self.snapshot else {
-            return vec![fit("  the corpus has not been read", width)];
+            return vec![Composed::of("  the corpus has not been read").fitted(width)];
         };
         if snapshot.claims.is_empty() {
-            return vec![fit("  nothing is held", width)];
+            return vec![Composed::of("  nothing is held").fitted(width)];
         }
         let c = self.cursors[Focus::Claims.number() - 1];
         let page = self.page(Focus::Claims);
@@ -1183,24 +1247,24 @@ impl App {
                     .row(&claim.id)
                     .map(|r| r.title.clone())
                     .unwrap_or_default();
-                fit(
-                    &format!(
-                        "{here}{whose}{}  {}  until {}  {title}",
-                        pad(&short_of(&claim.id), 10),
-                        claim.holder,
-                        claim.expires
-                    ),
-                    width,
-                )
+                Composed::new()
+                    .plain(here)
+                    .plain(whose)
+                    .column(&short_of(&claim.id), 10, role_of_id(&claim.id))
+                    .plain(&format!(
+                        "  {}  until {}  {title}",
+                        claim.holder, claim.expires
+                    ))
+                    .fitted(width)
             })
             .collect()
     }
 
     /// The entity rows the panel has room for.
-    fn entity_lines(&self, width: usize, height: usize) -> Vec<String> {
+    fn entity_lines(&self, width: usize, height: usize) -> Vec<Composed> {
         let rows = self.entity_rows();
         if rows.is_empty() {
-            return vec![fit("  no entity matches this filter", width)];
+            return vec![Composed::of("  no entity matches this filter").fitted(width)];
         }
         let c = self.cursors[Focus::Entities.number() - 1];
         let held = |id: &str| {
@@ -1218,17 +1282,16 @@ impl App {
                 } else {
                     text::PLAIN
                 };
-                fit(
-                    &format!(
-                        "{here}{:>5}  {}  {}  {}{}",
-                        at + 1,
-                        pad(&row.short(), 10),
-                        pad(&row.status, 12),
-                        row.title,
-                        if held(&row.id) { "  [held]" } else { "" }
-                    ),
-                    width,
-                )
+                Composed::new()
+                    .plain(here)
+                    .plain(&format!("{:>5}  ", at + 1))
+                    .column(&row.short(), 10, role_of_id(&row.id))
+                    .plain("  ")
+                    .column(&row.status, 12, role_of_status(&row.status))
+                    .plain("  ")
+                    .plain(&row.title)
+                    .plain(if held(&row.id) { "  [held]" } else { "" })
+                    .fitted(width)
             })
             .collect()
     }
@@ -1242,23 +1305,24 @@ impl App {
     /// which is a different fact from "nobody may sign", and a panel that drew
     /// nothing where the signers go would let a person mistake one for the
     /// other.
-    fn queue_lines(&self, width: usize) -> Vec<String> {
-        let regime = fit(
-            &match &self.queue {
-                None => "  4 or v runs 'ank review', which inspects the whole corpus".to_string(),
-                Some(queue) if queue.signers.is_empty() => {
-                    "  no ratification key declared: permissions are advisory, not enforced (§8)"
-                        .to_string()
-                }
-                Some(queue) => format!("  may ratify: {}", queue.signers.join("; ")),
-            },
-            width,
-        );
+    fn queue_lines(&self, width: usize) -> Vec<Composed> {
+        let regime = Composed::of(&match &self.queue {
+            None => "  4 or v runs 'ank review', which inspects the whole corpus".to_string(),
+            Some(queue) if queue.signers.is_empty() => {
+                "  no ratification key declared: permissions are advisory, not enforced (§8)"
+                    .to_string()
+            }
+            Some(queue) => format!("  may ratify: {}", queue.signers.join("; ")),
+        })
+        .fitted(width);
         if self.queue.is_none() {
-            return vec![fit("  nothing asked for yet", width), regime];
+            return vec![
+                Composed::of("  nothing asked for yet").fitted(width),
+                regime,
+            ];
         }
         let rows = self.queue_rows();
-        let mut out: Vec<String> = if rows.is_empty() {
+        let mut out: Vec<Composed> = if rows.is_empty() {
             // Said even where there is nothing to say, on `review`'s own
             // reasoning: an empty queue and an unprinted queue read
             // identically, and this panel is where the question has an answer.
@@ -1266,7 +1330,7 @@ impl App {
                 true => "  nothing in the queue matches this filter",
                 false => "  nothing proposed for ratification",
             };
-            vec![fit(said, width)]
+            vec![Composed::of(said).fitted(width)]
         } else {
             let c = self.cursors[Focus::Queue.number() - 1];
             let page = self.page(Focus::Queue);
@@ -1284,15 +1348,11 @@ impl App {
                     // proposed, and a word repeated on every row is a column
                     // spent saying nothing. The kind is not -- an ADR and a
                     // specification are signed for different reasons.
-                    fit(
-                        &format!(
-                            "{here}{}  {}  {}",
-                            pad(&row.short(), 10),
-                            pad(&row.kind, 5),
-                            row.title
-                        ),
-                        width,
-                    )
+                    Composed::new()
+                        .plain(here)
+                        .column(&row.short(), 10, role_of_id(&row.id))
+                        .plain(&format!("  {}  {}", pad(&row.kind, 5), row.title))
+                        .fitted(width)
                 })
                 .collect()
         };
@@ -1301,58 +1361,57 @@ impl App {
     }
 
     /// The open document: what holds it, what binds it, and its body.
-    fn body_lines(&self, width: usize, height: usize) -> Vec<String> {
+    fn body_lines(&self, width: usize, height: usize) -> Vec<Composed> {
         let Some(detail) = &self.detail else {
-            return vec![
-                fit("  nothing is open here", width),
-                fit(
-                    "  Enter opens the row a listing's cursor is on, and hands this panel the",
-                    width,
-                ),
-                fit(
-                    "  width. Nothing is previewed: 'show' renews the lease on a task you hold,",
-                    width,
-                ),
-                fit(
-                    "  so a body that followed a cursor would renew a claim by being scrolled.",
-                    width,
-                ),
-            ];
+            return [
+                "  nothing is open here",
+                "  Enter opens the row a listing's cursor is on, and hands this panel the",
+                "  width. Nothing is previewed: 'show' renews the lease on a task you hold,",
+                "  so a body that followed a cursor would renew a claim by being scrolled.",
+            ]
+            .iter()
+            .map(|l| Composed::of(l).fitted(width))
+            .collect();
         };
         let row = self.snapshot.as_ref().and_then(|s| s.row(&detail.id));
         let mut out = Vec::new();
         if self.pane == Pane::Body {
-            out.push(fit(
-                &row.map(|r| r.title.clone())
-                    .unwrap_or_else(|| detail.id.clone()),
-                width,
-            ));
-            out.push(fit(
-                detail.coordination.as_deref().unwrap_or("no claim on this"),
-                width,
-            ));
-            out.push(fit(
-                &format!("scope {}", join_or(&detail.scopes, "declared on nothing")),
-                width,
-            ));
-            out.push(fit(
-                &format!(
+            out.push(
+                Composed::of(
+                    &row.map(|r| r.title.clone())
+                        .unwrap_or_else(|| detail.id.clone()),
+                )
+                .fitted(width),
+            );
+            out.push(
+                Composed::of(detail.coordination.as_deref().unwrap_or("no claim on this"))
+                    .fitted(width),
+            );
+            out.push(
+                Composed::of(&format!(
+                    "scope {}",
+                    join_or(&detail.scopes, "declared on nothing")
+                ))
+                .fitted(width),
+            );
+            out.push(
+                Composed::of(&format!(
                     "CONSTRAINTS ({} active, {} over this scope)",
                     active(&detail.constraints),
                     detail.constraints.len()
-                ),
-                width,
-            ));
+                ))
+                .fitted(width),
+            );
             out.extend(self.constraint_summary(width));
-            out.push(String::new());
+            out.push(Composed::new());
         }
         let over = out.len();
         let rows = self.pane_rows(width);
         out.extend(
-            rows.iter()
+            rows.into_iter()
                 .skip(self.offset)
                 .take(height.saturating_sub(over))
-                .map(|line| fit(line, width)),
+                .map(|line| line.fitted(width)),
         );
         out
     }
@@ -1367,7 +1426,14 @@ impl App {
     /// crate's rather than `Paragraph`'s for the reason `text.rs` gives: a
     /// widget that wraps inside its own render reports no count, and the title
     /// over it states one.
-    fn pane_rows(&self, width: usize) -> Vec<String> {
+    /// **The document's own body is not painted, and the constraints beside it
+    /// are** (TASK-6cd41d23b7d1). A row of the constraint list is a row this
+    /// crate composed out of fields -- an identifier, a status, a title -- and
+    /// the table has something to say about two of them. `content` is the
+    /// entity as `show` printed it: prose, in which `done` and `accepted` are
+    /// English words, and a reader that painted every occurrence of one would
+    /// be telling its person that a sentence is a status.
+    fn pane_rows(&self, width: usize) -> Vec<Composed> {
         let Some(detail) = &self.detail else {
             return Vec::new();
         };
@@ -1376,39 +1442,40 @@ impl App {
                 .content
                 .lines()
                 .flat_map(|l| wrap(l, width.max(1)))
+                .map(|l| Composed::of(&l))
                 .collect(),
             Pane::Constraints => detail.constraints.iter().map(constraint_row).collect(),
         }
     }
 
     /// The same, at whatever width the body panel has now.
-    fn pane_lines(&self) -> Vec<String> {
+    fn pane_lines(&self) -> Vec<Composed> {
         let width = inside(self.rect_of(Focus::Body, self.area())).width as usize;
         self.pane_rows(width)
     }
 
     /// The first few constraints, so the body panel still answers "what binds
     /// this" without a command. `c` gives the list whole.
-    fn constraint_summary(&self, width: usize) -> Vec<String> {
+    fn constraint_summary(&self, width: usize) -> Vec<Composed> {
         let Some(detail) = &self.detail else {
             return Vec::new();
         };
         let room = 3.min(detail.constraints.len());
-        let mut out: Vec<String> = detail.constraints[..room]
+        let mut out: Vec<Composed> = detail.constraints[..room]
             .iter()
-            .map(|c| fit(&constraint_row(c), width))
+            .map(|c| constraint_row(c).fitted(width))
             .collect();
         if detail.constraints.len() > room {
-            out.push(fit(
-                &format!(
+            out.push(
+                Composed::of(&format!(
                     "  +{} more, c for the list",
                     detail.constraints.len() - room
-                ),
-                width,
-            ));
+                ))
+                .fitted(width),
+            );
         }
         if detail.constraints.is_empty() {
-            out.push(fit("  nothing binds this scope", width));
+            out.push(Composed::of("  nothing binds this scope").fitted(width));
         }
         out
     }
@@ -1706,6 +1773,21 @@ fn paragraph(lines: &[String]) -> Paragraph<'static> {
     ))
 }
 
+/// The same, for the rows this crate composed rather than the bands of chrome
+/// it writes as sentences (TASK-6cd41d23b7d1).
+///
+/// The one place a [`Composed`] line becomes something ratatui can draw, so
+/// "every colour on this screen came out of `Ink::role`" is a claim about one
+/// call rather than about however many render sites there happen to be. Under
+/// `NO_COLOR` the [`Ink`] is [`crate::paint::PLAIN`] and every line comes back
+/// as one unstyled span, which is the same `Line` [`paragraph`] would have
+/// built.
+fn painted(lines: &[Composed], ink: Ink) -> Paragraph<'static> {
+    Paragraph::new(Text::from(
+        lines.iter().map(|l| l.line(ink)).collect::<Vec<Line>>(),
+    ))
+}
+
 /// A buffer as text, one row per line, for a test to read.
 ///
 /// The symbol out of every cell and nothing else: no colour, no attribute, no
@@ -1789,13 +1871,14 @@ fn flat(value: &crate::ank::Value) -> String {
 /// filtered out either -- a superseded decision is where the reasoning of the
 /// live one came from, and hiding it would be answering a different question
 /// than the CLI was asked.
-fn constraint_row(c: &Row) -> String {
-    format!(
-        "  {}  {}  {}",
-        pad(&c.short(), 10),
-        pad(&c.status, 12),
-        c.title
-    )
+fn constraint_row(c: &Row) -> Composed {
+    Composed::new()
+        .plain("  ")
+        .column(&c.short(), 10, role_of_id(&c.id))
+        .plain("  ")
+        .column(&c.status, 12, role_of_status(&c.status))
+        .plain("  ")
+        .plain(&c.title)
 }
 
 /// How many of them are accepted, which is what `context` calls active.
@@ -1888,7 +1971,10 @@ pub const DISMISSED: &str = "dismissed, and nothing was run:";
 mod tests {
     use super::*;
     use crate::model::Claim;
+    use crate::paint;
+    use ank_contract::meaning::{Role, MEANINGS};
     use ratatui::crossterm::event::{KeyCode, KeyModifiers};
+    use ratatui::style::Style;
 
     fn snapshot() -> Snapshot {
         Snapshot {
@@ -1920,8 +2006,15 @@ mod tests {
         }
     }
 
+    /// A screen with a corpus on it, painting nothing.
+    ///
+    /// [`crate::paint::PLAIN`] and not whatever the environment says, so that
+    /// no assertion below reports the machine it ran on: `App::new` reads
+    /// `NO_COLOR` and a developer who has it exported would otherwise be
+    /// running a different suite from one who has not. The two tests that are
+    /// about the painting say which ink they mean.
     fn app() -> App {
-        let mut a = App::new((120, 40), None);
+        let mut a = App::new((120, 40), None).inked(paint::PLAIN);
         a.snapshot = Some(snapshot());
         a
     }
@@ -1975,6 +2068,14 @@ mod tests {
 
     fn tap(a: &mut App, ank: &Ank, code: KeyCode) -> bool {
         a.press(KeyEvent::new(code, KeyModifiers::NONE), ank)
+    }
+
+    /// The characters of a list of composed lines, which is what every
+    /// assertion about a body is about: a `Composed` is a string with the
+    /// pieces the shared table named recorded beside it, and what a person
+    /// reads is the string.
+    fn texts(lines: &[Composed]) -> Vec<String> {
+        lines.iter().map(|l| l.text().to_string()).collect()
     }
 
     /// The identifiers the entity rows carry, which is what a filter narrows.
@@ -2051,6 +2152,264 @@ mod tests {
                 "every panel is drawn as the focused one:\n{f}"
             );
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // The painting (TASK-6cd41d23b7d1, ADR-1f70ce2c3eac)
+    // -----------------------------------------------------------------------
+
+    /// A screen with something of every family on it: rows in four statuses,
+    /// a claim, a queue of proposals and an open document.
+    ///
+    /// Written out rather than reused from [`app`] because the question here is
+    /// what the *table* is asked about, and a corpus carrying one status would
+    /// have let a palette with seven arms missing pass.
+    fn coloured(ink: paint::Ink) -> App {
+        let mut a = App::new((120, 40), None).inked(ink);
+        let mut snapshot = snapshot();
+        snapshot.entities.push(row(
+            "TASK-0000ffff0004",
+            "task",
+            "done",
+            "A task that landed",
+        ));
+        snapshot.entities.push(row(
+            "TASK-0000ffff0005",
+            "task",
+            "open",
+            "A task there to be taken",
+        ));
+        snapshot.entities.push(row(
+            "ADR-0000ffff0006",
+            "adr",
+            "superseded",
+            "A decision retired",
+        ));
+        snapshot.total = snapshot.entities.len() as u64;
+        a.snapshot = Some(snapshot);
+        a.queue = Some(queued());
+        a.detail = Some(detail("TASK-49746735127f", "a body, in prose\n"));
+        a
+    }
+
+    /// The style a cell nobody painted carries.
+    ///
+    /// Taken off an untouched buffer rather than written out: ratatui's empty
+    /// cell is `Reset` in three fields where `Style::default()` is `None` in
+    /// all of them, and a test that compared against the wrong one of those
+    /// would call an unpainted screen painted. Asking the buffer means this
+    /// stays true of whatever ratatui calls empty next.
+    fn blank() -> Style {
+        Buffer::empty(Rect::new(0, 0, 1, 1))
+            .cell((0, 0))
+            .expect("a one-cell buffer has a cell")
+            .style()
+    }
+
+    /// Every style on the frame, with the cells that carry it.
+    fn styles(a: &App) -> Vec<(Style, String)> {
+        let area = a.area();
+        let mut buf = Buffer::empty(area);
+        a.render(area, &mut buf);
+        let mut out: Vec<(Style, String)> = Vec::new();
+        for y in 0..area.height {
+            for x in 0..area.width {
+                let Some(cell) = buf.cell((x, y)) else {
+                    continue;
+                };
+                let style = cell.style();
+                match out.iter_mut().find(|(s, _)| *s == style) {
+                    Some((_, seen)) => seen.push_str(cell.symbol()),
+                    None => out.push((style, cell.symbol().to_string())),
+                }
+            }
+        }
+        out
+    }
+
+    /// With `NO_COLOR` set the reader draws no colour at all
+    /// (ADR-1f70ce2c3eac).
+    ///
+    /// Asserted on the cells and not on the code that filled them: every cell
+    /// of a full screen -- four panels, their borders, their titles, the three
+    /// bands of chrome -- carries the default style, so there is no row, no
+    /// column and no corner where half a style got through.
+    #[test]
+    fn with_no_colour_not_one_cell_of_the_frame_carries_a_style() {
+        let seen = styles(&coloured(paint::PLAIN));
+        assert_eq!(
+            seen.len(),
+            1,
+            "the frame carries {} styles with colour off",
+            seen.len()
+        );
+        assert_eq!(seen[0].0, blank());
+        assert!(
+            seen[0].1.contains("TASK-4974"),
+            "the frame was empty, so this asserted nothing"
+        );
+    }
+
+    /// And every distinction it makes is still carried by text.
+    ///
+    /// The whole of the claim, stated the strongest way there is: the frame a
+    /// painting reader draws and the frame a monochrome one draws are the same
+    /// characters, at every focus and in both panes. Anything a colour said
+    /// that a character did not would show up here as a difference.
+    #[test]
+    fn a_painted_frame_and_a_plain_one_are_the_same_characters() {
+        for focus in Focus::ALL {
+            for pane in [Pane::Body, Pane::Constraints] {
+                let (mut painted, mut plain) = (coloured(paint::COLOUR), coloured(paint::PLAIN));
+                painted.focus = focus;
+                plain.focus = focus;
+                painted.pane = pane;
+                plain.pane = pane;
+                assert_eq!(
+                    painted.frame(),
+                    plain.frame(),
+                    "the painted frame says something the plain one does not, \
+                     at {focus:?} in {pane:?}"
+                );
+            }
+        }
+    }
+
+    /// And the distinctions are named, one by one, on the monochrome frame.
+    ///
+    /// The frame above says the two agree; this says what they agree *on*, so
+    /// that two equally blank screens could not pass. Four signals, each of a
+    /// different kind: where the focus is, where the cursor is, whose claim a
+    /// row is, and what state an entity is in.
+    #[test]
+    fn every_distinction_the_plain_frame_makes_is_a_character_on_it() {
+        let mut a = coloured(paint::PLAIN);
+        a.focus = Focus::Entities;
+        let f = a.frame();
+        // The focus: the doubled rule and the marker in the title.
+        assert!(f.contains("> 2 ENTITIES"), "the focus is unmarked:\n{f}");
+        assert!(f.contains("=========="), "no doubled rule:\n{f}");
+        // The cursor, in the two columns every listing spends on its margin.
+        assert!(
+            f.lines().any(|l| l.contains("|>     1  ")),
+            "the row the cursor is on is unmarked:\n{f}"
+        );
+        // Whose claim it is, which is what `*` means in `find`.
+        assert!(
+            f.contains("* TASK-4974"),
+            "the caller's own claim is unmarked:\n{f}"
+        );
+        // And the status, spelled as the word it is rather than shown as a hue.
+        for state in ["in_progress", "accepted", "done", "open", "superseded"] {
+            assert!(f.contains(state), "{state} is on no row of:\n{f}");
+        }
+    }
+
+    /// Every colour the reader draws comes from the one table.
+    ///
+    /// Not "a colour appears" -- the set of styles on a full frame is collected
+    /// and each one is required to be the render of a [`Role`] the shared table
+    /// declares. A palette added anywhere in this crate would show up here as a
+    /// style nothing in `MEANINGS` accounts for, whatever file it was written
+    /// in.
+    #[test]
+    fn every_colour_on_the_frame_is_the_render_of_a_role_the_table_declares() {
+        let allowed: Vec<Style> = MEANINGS
+            .iter()
+            .map(|m| blank().patch(paint::COLOUR.role(m.role)))
+            .chain([blank()])
+            .collect();
+        let seen = styles(&coloured(paint::COLOUR));
+        for (style, cells) in &seen {
+            assert!(
+                allowed.contains(style),
+                "{style:?} is on the frame over {cells:?}, and the shared table \
+                 renders to none of {allowed:?}"
+            );
+        }
+        assert!(
+            seen.len() > 1,
+            "nothing on the frame was painted at all, so this asserted nothing"
+        );
+    }
+
+    /// What is painted is a field and never a sentence.
+    ///
+    /// The row of a listing carries an identifier and a status in columns of
+    /// their own, and a title after them; a title reading "A task that landed"
+    /// contains no status, but an ADR's body is full of `done` and `accepted`
+    /// as ordinary English, and this is the rule that keeps the reader from
+    /// telling a person that a sentence is a state.
+    #[test]
+    fn a_status_written_in_prose_is_not_painted_as_a_status() {
+        let mut a = coloured(paint::COLOUR);
+        a.focus = Focus::Body;
+        // `closed` is a status the table declares and no row of this corpus
+        // carries, so every occurrence of it on the frame is the one in the
+        // body -- which is what lets "it was not painted" be asserted over the
+        // whole screen rather than over a rectangle.
+        a.detail = Some(Detail {
+            content: "the word closed is prose here, and it is prose in an ADR too\n".to_string(),
+            ..detail("TASK-49746735127f", "")
+        });
+        let seen = styles(&a);
+        for (style, cells) in &seen {
+            if *style == blank() {
+                continue;
+            }
+            assert!(
+                !cells.contains("closed"),
+                "a word of the document's own body was painted: {cells:?}"
+            );
+        }
+        let unpainted: String = seen
+            .iter()
+            .filter(|(s, _)| *s == blank())
+            .map(|(_, cells)| cells.clone())
+            .collect();
+        assert!(
+            unpainted.contains("closed"),
+            "the body never reached the screen, so this asserted nothing"
+        );
+        // And the row of the listing, which is a field and not a sentence, was.
+        let painted: String = seen
+            .iter()
+            .filter(|(s, _)| *s == blank().patch(paint::COLOUR.role(Role::Underway)))
+            .map(|(_, cells)| cells.clone())
+            .collect();
+        assert!(
+            painted.contains("in_progress"),
+            "the status column was not painted at all: {painted:?}"
+        );
+    }
+
+    /// The focus is drawn in characters, and colour did not quietly take that
+    /// over (TASK-bb43cfe2192b).
+    ///
+    /// The panel with the focus and a panel without it are asked for their
+    /// styles separately: if focus had become a colour, moving it would change
+    /// which cells are painted. It does not, because what the table names is
+    /// what a row *is* and never where a reader is standing.
+    #[test]
+    fn moving_the_focus_paints_nothing_differently() {
+        let mut here = coloured(paint::COLOUR);
+        here.focus = Focus::Claims;
+        let mut there = coloured(paint::COLOUR);
+        there.focus = Focus::Queue;
+        let painted = |a: &App| -> Vec<Style> {
+            let mut styles: Vec<Style> = styles(a)
+                .into_iter()
+                .filter(|(s, _)| *s != blank())
+                .map(|(s, _)| s)
+                .collect();
+            styles.sort_by_key(|s| format!("{s:?}"));
+            styles
+        };
+        assert_eq!(
+            painted(&here),
+            painted(&there),
+            "the focus changed the palette, so it is being drawn in colour"
+        );
     }
 
     /// Focus moves by key, in both of the two ways a person reaches for.
@@ -2303,7 +2662,7 @@ mod tests {
         a.focus = Focus::Body;
         assert_eq!(a.pane_lines().len(), 200, "the body is carried whole");
         assert_eq!(
-            a.pane_lines().join("\n") + "\n",
+            texts(&a.pane_lines()).join("\n") + "\n",
             a.detail.as_ref().unwrap().content,
             "the rows join back to the body byte for byte"
         );
@@ -2358,7 +2717,7 @@ mod tests {
             // characters the file does, a wrap having added no separator of its
             // own.
             assert_eq!(
-                a.pane_lines().concat(),
+                texts(&a.pane_lines()).concat(),
                 content.lines().collect::<String>(),
                 "the rows are not the body's own characters at {size:?}"
             );

--- a/crates/ank-tui/tests/colour.rs
+++ b/crates/ank-tui/tests/colour.rs
@@ -1,0 +1,327 @@
+//! `NO_COLOR` through the binary, on a real terminal (TASK-6cd41d23b7d1,
+//! ADR-1f70ce2c3eac).
+//!
+//! CLAUDE.md leaves no choice about where this is measured. "With `NO_COLOR`
+//! set the reader draws no colour at all" is a claim about a process and its
+//! environment: about which bytes reach a terminal when a variable is exported
+//! and when it is not. A function that answers `PLAIN` proves nothing about
+//! that -- twice in this repository green unit tests covered code that was
+//! right on a path the binary never reached -- so `ank tui` is spawned on a
+//! pseudo-terminal with the variable set, and the assertion is made on the
+//! wire.
+//!
+//! **The grid cannot answer this question, and that is why the raw bytes are
+//! kept.** An emulator's whole job is to consume escape sequences and show what
+//! is left, so a screen painted red and a screen painted nothing read
+//! identically off `terminal::Live::frame`. Every other assertion in this crate
+//! is deliberately made against that grid, because every other question is
+//! about what a person would be looking at. This one is about what was sent.
+//!
+//! # The reason this is not measuring crossterm's manners
+//!
+//! **crossterm 0.29 reads `NO_COLOR` itself** and drops the *colour* half of an
+//! SGR when it is set -- and it drops nothing else. A `Dim`, a `Bold` or an
+//! `Underline` goes out on the wire whatever the variable says, because those
+//! are attributes rather than colours to it.
+//!
+//! That is exactly why the shared table's `Retired` role is on the screen of
+//! every session driven below: [`with_a_retired_row`] closes a task, and a
+//! closed task is what this reader draws dim. So a reader that had left the
+//! variable to its dependency would fail here on `ESC[2m`, and what passes is a
+//! reader that decided. Honouring a variable is deciding; inheriting somebody
+//! else's decision about it is a coincidence that holds until they change their
+//! mind.
+//!
+//! # What is asserted where
+//!
+//! The palette is asserted where a palette can be: `src/view.rs` collects every
+//! style on a full frame and requires each to be the render of a
+//! [`Role`](ank_contract::meaning::Role) the shared table declares, and
+//! `src/paint.rs` walks the crate's sources and fails if any file but the one
+//! holding that render names a colour at all. What is left for a terminal to
+//! answer is the environment, and it is what this file answers.
+//!
+//! `#[cfg(unix)]` for the reason the other two suites give: a pseudo-terminal
+//! on Windows is ConPTY, and reaching it means the console API this workspace
+//! does not otherwise call.
+
+#![cfg(unix)]
+
+mod terminal;
+
+use terminal::{ids_of, Live, Repo};
+
+/// The window every session here opens on. Wide enough that the two panels in
+/// the middle both draw rows, which is where the painted fields are.
+const WINDOW: (u16, u16) = (110, 30);
+
+/// A closed task, so that a role the table renders as an *attribute* rather
+/// than as a colour is on the screen.
+///
+/// `closed` is `Role::Retired`, which this reader draws dim -- and dim is the
+/// one register crossterm's own `NO_COLOR` handling does not suppress. Without
+/// a row in it, the assertion below would be measuring a dependency's manners
+/// instead of this crate's decision. See the header.
+fn with_a_retired_row(repo: &Repo) {
+    let made = repo.stdout(&[
+        "new",
+        "task",
+        "--title",
+        "A task that will never be done",
+        "--scope",
+        "src/**",
+        "--criteria",
+        "Nothing: this one is closed, and it is here to be drawn.",
+        "--json",
+    ]);
+    let ids = ids_of(&made);
+    assert_eq!(ids.len(), 1, "one task was written: {made}");
+    repo.ank(&[
+        "close",
+        &ids[0],
+        "--reason",
+        "it is here so that a retired row reaches the screen",
+    ]);
+}
+
+/// One `ESC [ ... m` of a byte stream, as its parameters.
+///
+/// Only the SGR sequences: everything else a CSI can say -- the alternate
+/// buffer, a cursor move, an erase -- is structure, and structure is what this
+/// reader is *supposed* to be sending on every platform. A sequence with no
+/// parameters at all is `ESC [ m`, which the standard spells `0`, and it is
+/// read that way here so a bare reset is not mistaken for a paint.
+fn sgr(bytes: &[u8]) -> Vec<Vec<usize>> {
+    let mut out = Vec::new();
+    let mut at = 0;
+    while at + 1 < bytes.len() {
+        if bytes[at] != 0x1b || bytes[at + 1] != b'[' {
+            at += 1;
+            continue;
+        }
+        let from = at + 2;
+        let mut end = from;
+        while end < bytes.len() && (bytes[end].is_ascii_digit() || bytes[end] == b';') {
+            end += 1;
+        }
+        if end < bytes.len() && bytes[end] == b'm' {
+            out.push(
+                bytes[from..end]
+                    .split(|b| *b == b';')
+                    .map(|p| {
+                        std::str::from_utf8(p)
+                            .ok()
+                            .and_then(|p| p.parse().ok())
+                            .unwrap_or(0)
+                    })
+                    .collect(),
+            );
+        }
+        at = end.max(at + 1);
+    }
+    out
+}
+
+/// What one SGR sequence turns on, as the parameters that did it.
+///
+/// Empty where the sequence only turns things off. The four that turn things
+/// off are what ratatui's backend writes at the end of every frame it draws,
+/// unconditionally and whatever the styles were: `0` all attributes, `39` the
+/// default foreground, `49` the default background, `59` the default underline
+/// colour. They are the reason this asks "does any sequence *set* anything"
+/// rather than "is there any sequence at all" -- a reader that painted nothing
+/// still sends those four, and a test that forbade them would be a test nothing
+/// could pass.
+///
+/// `38`, `48` and `58` introduce a colour spelled in the extended form, which
+/// is how crossterm writes every named colour: `38;5;3` is the terminal's own
+/// third palette entry. The whole run is answered as one parameter so that the
+/// `5` and the index are never read as attributes of their own.
+fn sets(params: &[usize]) -> Vec<Vec<usize>> {
+    let mut out = Vec::new();
+    let mut at = 0;
+    while at < params.len() {
+        match params[at] {
+            0 | 39 | 49 | 59 => at += 1,
+            38 | 48 | 58 => {
+                // `38;5;n` is one index, `38;2;r;g;b` is a literal colour.
+                let len = match params.get(at + 1) {
+                    Some(5) => 3,
+                    Some(2) => 5,
+                    _ => 1,
+                };
+                out.push(params[at..(at + len).min(params.len())].to_vec());
+                at += len;
+            }
+            other => {
+                out.push(vec![other]);
+                at += 1;
+            }
+        }
+    }
+    out
+}
+
+/// A session driven across the screens that carry painted fields.
+///
+/// The listing a session opens on, a document opened and given the width, the
+/// constraints beside it, and the ratification queue: the four panels, and
+/// every place this reader puts an identifier or a status.
+fn driven(mut live: Live) -> (String, Vec<u8>) {
+    live.until("the session to open", |t| t.contains("2 ENTITIES"));
+    for key in ["\r", "c", "b", "4"] {
+        live.send(key);
+        // Settled between keys and not only at the end: what is asserted is
+        // every frame the session drew, and a screen read while one was still
+        // arriving would be half of it.
+        let _ = live.frame();
+    }
+    let frame = live.frame();
+    let raw = live.raw();
+    live.quit();
+    (frame, raw)
+}
+
+/// The parameters a session set, over every sequence it sent.
+fn painted(raw: &[u8]) -> Vec<Vec<usize>> {
+    sgr(raw).iter().flat_map(|params| sets(params)).collect()
+}
+
+/// With `NO_COLOR` set the reader draws no colour at all (ADR-1f70ce2c3eac).
+///
+/// Over every byte of the session and not over one frame: a reader that painted
+/// only the panel a key had just reached would pass an assertion made on the
+/// opening screen, and the four keys the drive presses walk it through all of
+/// them. The corpus carries a closed task, which is what makes this a test of
+/// this crate rather than of crossterm -- see the header.
+#[test]
+fn with_no_color_set_no_sequence_the_reader_sends_paints_anything() {
+    let repo = Repo::seeded();
+    with_a_retired_row(&repo);
+    let (frame, raw) = driven(Live::open(&repo, WINDOW.0, WINDOW.1));
+    assert!(
+        !sgr(&raw).is_empty(),
+        "the session sent no SGR at all, so this asserted nothing: ratatui \
+         resets the terminal at the end of every frame it draws"
+    );
+    assert!(
+        frame.contains("closed"),
+        "the retired row never reached the screen, so the one register \
+         crossterm would not have suppressed was never drawn:\n{frame}"
+    );
+    let set = painted(&raw);
+    assert!(
+        set.is_empty(),
+        "the reader set {set:?} with NO_COLOR in its environment, and every \
+         colour it draws is supposed to be off (ADR-1f70ce2c3eac):\n{frame}"
+    );
+}
+
+/// And the screen is still readable, because every distinction is a character.
+///
+/// Four signals, each of a different kind and each of them on the monochrome
+/// frame: the panel names and their numbers, the doubled rule and the `> `
+/// marker that say where the focus is, the `> ` on the row a cursor is on, and
+/// the status of a row spelled as the word it is.
+#[test]
+fn with_no_color_set_the_screen_still_says_everything_it_has_to_say() {
+    let repo = Repo::seeded();
+    with_a_retired_row(&repo);
+    let live = Live::open(&repo, WINDOW.0, WINDOW.1);
+    live.until("the session to open", |t| t.contains("2 ENTITIES"));
+    let frame = live.frame();
+    for panel in ["1 CLAIMS", "2 ENTITIES", "3 BODY", "4 QUEUE"] {
+        assert!(frame.contains(panel), "{panel} is not named:\n{frame}");
+    }
+    assert!(
+        frame.contains("> 2 ENTITIES"),
+        "the focused panel is unmarked:\n{frame}"
+    );
+    assert!(
+        frame.contains("=========="),
+        "the focused panel has no doubled rule:\n{frame}"
+    );
+    assert!(
+        frame.lines().any(|l| l.contains(">     1  ")),
+        "the row the cursor is on is unmarked:\n{frame}"
+    );
+    // The state of a row, as a word rather than as a hue. Three of the eight
+    // roles are on this listing and each of them is spelled out.
+    for state in ["open", "proposed", "closed"] {
+        assert!(
+            frame.contains(state),
+            "no row spells its status {state}:\n{frame}"
+        );
+    }
+    live.quit();
+}
+
+/// Without it the reader paints -- which is what makes the assertion above mean
+/// something -- and the two screens are still the same characters.
+///
+/// Three claims in one drive, because they are one fact seen from three sides.
+/// The painting session sets something, so the plain one setting nothing is a
+/// difference rather than a reader that cannot paint at all. What it sets is a
+/// foreground of the terminal's own sixteen or an attribute, and never a
+/// background: the shared table says what a status *is*, and a surface
+/// answering that with a filled cell would be deciding for the whole screen
+/// what somebody's terminal theme already decided. And what it drew is
+/// character for character what the plain session drew, which is the criterion's
+/// "stays readable" -- a distinction carried by a colour alone would be a
+/// difference between these two frames, and there is none.
+///
+/// One corpus for both sessions, deliberately. A second `Repo::seeded()` would
+/// mint different identifiers and the frames would differ for a reason that has
+/// nothing to do with colour.
+#[test]
+fn without_no_color_it_paints_and_the_two_screens_are_the_same_characters() {
+    let repo = Repo::seeded();
+    with_a_retired_row(&repo);
+    // Warmed first: `.ank/index.db` is written by the first search of a corpus,
+    // and only one of two sessions can be the one that built it.
+    repo.warm();
+    let (plain, plain_raw) = driven(Live::open(&repo, WINDOW.0, WINDOW.1));
+    let (frame, raw) = driven(Live::painting(&repo, WINDOW.0, WINDOW.1));
+
+    let set = painted(&raw);
+    assert!(
+        !set.is_empty(),
+        "the reader painted nothing with NO_COLOR unset, so the assertion that \
+         it paints nothing with NO_COLOR set is vacuous:\n{frame}"
+    );
+    for params in &set {
+        match params.as_slice() {
+            // An attribute: `2` is dim, which is what a retired row is drawn
+            // with, and `22` is the backend taking it off again.
+            [attribute] if *attribute < 30 => {}
+            // A foreground, spelled the way crossterm spells a named colour,
+            // and one of the sixteen the terminal itself defines.
+            [38, 5, index] if *index <= 15 => {}
+            other => panic!(
+                "the reader sent ESC[{}m: this surface paints an attribute or \
+                 one of the terminal's own foregrounds, and nothing else\n{frame}",
+                other
+                    .iter()
+                    .map(|p| p.to_string())
+                    .collect::<Vec<String>>()
+                    .join(";")
+            ),
+        }
+    }
+    // The register crossterm would have let through under NO_COLOR is one the
+    // reader genuinely uses, so its absence up there was a decision.
+    assert!(
+        set.iter().any(|p| p.as_slice() == [2]),
+        "no row was drawn dim, so the retired role is painted as a colour and \
+         the NO_COLOR assertion is crossterm's rather than this crate's: {set:?}"
+    );
+    assert!(
+        painted(&plain_raw).is_empty(),
+        "the plain half of this comparison painted something"
+    );
+    assert_eq!(
+        frame, plain,
+        "the painted screen and the plain one are not the same characters, so \
+         something on it is carried by colour alone"
+    );
+}

--- a/crates/ank-tui/tests/terminal/mod.rs
+++ b/crates/ank-tui/tests/terminal/mod.rs
@@ -369,6 +369,14 @@ struct Screen {
     /// a frame in whatever pieces it likes, and half a `MoveTo` is not a
     /// character.
     pending: Vec<u8>,
+    /// Everything the session wrote, kept alongside the grid.
+    ///
+    /// The grid is what a person would have been looking at and it is what
+    /// almost every assertion is about. `NO_COLOR` is the exception and it is
+    /// exactly the other question: whether an escape sequence was on the wire
+    /// at all. A grid cannot answer that, because an emulator's whole job is to
+    /// consume the sequences and show what is left.
+    raw: Vec<u8>,
 }
 
 impl Screen {
@@ -380,10 +388,12 @@ impl Screen {
             x: 0,
             y: 0,
             pending: Vec::new(),
+            raw: Vec::new(),
         }
     }
 
     fn feed(&mut self, bytes: &[u8]) {
+        self.raw.extend_from_slice(bytes);
         self.pending.extend_from_slice(bytes);
         let taken = self.apply();
         self.pending.drain(..taken);
@@ -567,7 +577,24 @@ pub struct Live {
 }
 
 impl Live {
+    /// A session that may not paint, which is what every suite but the one
+    /// about painting wants: `NO_COLOR` makes the frames the characters they
+    /// are and nothing else.
     pub fn open(repo: &Repo, columns: u16, rows: u16) -> Live {
+        Live::opened(repo, columns, rows, false)
+    }
+
+    /// A session that may paint (TASK-6cd41d23b7d1).
+    ///
+    /// `NO_COLOR` is *removed* from the child's environment rather than left
+    /// unset here, and `TERM` is stated: this suite inherits whatever the
+    /// developer running it has exported, and a test whose subject is colour
+    /// must not be a test that reports the machine.
+    pub fn painting(repo: &Repo, columns: u16, rows: u16) -> Live {
+        Live::opened(repo, columns, rows, true)
+    }
+
+    fn opened(repo: &Repo, columns: u16, rows: u16, colour: bool) -> Live {
         use std::io::Read;
 
         let (master, slave_path) = pty::open();
@@ -580,11 +607,17 @@ impl Live {
             pty::slave(&slave_path),
         );
         pty::resize(&slave_path, columns, rows);
-        let child = Command::new(ank())
+        let mut command = Command::new(ank());
+        command
             .arg("tui")
             .current_dir(&repo.0)
             .env("ANK_AGENT", AGENT)
-            .env("NO_COLOR", "1")
+            .env("TERM", "xterm-256color");
+        match colour {
+            true => command.env_remove("NO_COLOR"),
+            false => command.env("NO_COLOR", "1"),
+        };
+        let child = command
             .stdin(pty::stdio(stdin))
             .stdout(pty::stdio(stdout))
             .stderr(pty::stdio(stderr))
@@ -655,6 +688,11 @@ impl Live {
             .write_all(bytes.as_bytes())
             .expect("the terminal must accept a keystroke");
         self.writer.flush().unwrap();
+    }
+
+    /// Every byte the session wrote, sequences included.
+    pub fn raw(&self) -> Vec<u8> {
+        self.screen.lock().unwrap().raw.clone()
     }
 
     pub fn quit(mut self) {


### PR DESCRIPTION
Closes TASK-6cd41d23b7d1. Proof `commit:6cfc8ea`.

## One render, and nowhere for a second one

`crates/ank-tui/src/paint.rs` is new and it is the whole of what this crate
decides about colour. `Ink::role` is a total match on
`ank_contract::meaning::Role` with no string in it: a status, a kind or a
severity reaches a colour only through the shared table's own lookup
(`role_of_status`, `role_of_marker`, `role_of_kind`), so the second opinion
ADR-1f70ce2c3eac forbids has nowhere to be written. The registers are
`ank-cli`'s, because the decision lets each surface paint a role its own way
but not disagree about which things are alike.

The criterion's grep is run by cargo. `paint.rs`'s own suite walks `src/` and
fails if any file but that one names `Color::`, `Modifier::`, `.fg(`, `.bg(` or
`add_modifier`, and fails if `paint.rs`'s shipped code contains any name
`MEANINGS` declares. Comments and `#[cfg(test)]` are cut before the scan, which
is the exemption `tests/dependencies.rs` already gives by reading only `src/`.

## How a row carries it

`paint::Composed`: the line is still built as the characters it always was,
with the pieces the table named recorded beside them **in characters, not
bytes**. `fit()`, `pad()`, `wrap()` and every window count in this reader are
arithmetic on chars, and a list of styled spans would have made each of them a
second implementation. `rows_of()` is untouched and still reads symbols only,
so TASK-bb43cfe2192b's property — the focused panel is distinguishable without
colour — remains something the suite can state.

**This reader paints the rows it composes and nothing else.** A field carries a
meaning; a document's body, a refusal the CLI wrote and the fields of an answer
are drawn as they arrived. `done` and `accepted` are ordinary English, an ADR's
prose is full of them, and painting every occurrence would tell a reader that a
sentence is a state.

`App::arrange` is untouched: no rectangle moved, no panel added. The one-column
branch TASK-dd9747e5e305 adds inherits the painting for free.

## NO_COLOR, measured through the binary

`Ink::detect()` is `ank-cli`'s `opted_out` to the letter, read once when the
screen opens. `crates/ank-tui/tests/colour.rs` drives the built binary on a
pseudo-terminal at 110x30 through all four panels — once with `NO_COLOR=1`,
once with it removed from the child's environment — and asserts on the **raw
bytes**: no SGR sets anything in the first, something does in the second, what
it sets is only an attribute or one of the terminal's own sixteen foregrounds
and never a background, and the two grids are identical character for
character. That last one is "stays readable" stated the strongest way there is.

The corpus carries a **closed** task before every drive on purpose. crossterm
0.29 reads `NO_COLOR` itself and drops the colour half of an SGR — and drops
nothing else, so an attribute goes out whatever the variable says. `Retired` is
drawn dim, which means its absence under `NO_COLOR` is this crate's decision
rather than its dependency's manners. Verified non-vacuous by disabling
`Ink::detect`'s `NO_COLOR` branch and watching the suite go red.

## Scope

Nothing outside `crates/ank-tui/**` changed. `crates/ank-cli/tests/tui.rs`
needed no edit: its emulator applies a CSI ending in `m` as "no character
moves", so the grid it byte-slices for `KIND-hhhh` ids is the grid it always
was.

`cargo test --workspace` green, `cargo fmt --check` clean, `ank check` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRJ1B6shqg56YVLKWbrV8H