### PR TITLE
Structure is box-drawing, and ASCII where the terminal says it is dumb

### DIFF
--- a/.ank/entities/LOG-d6363b231328.md
+++ b/.ank/entities/LOG-d6363b231328.md
@@ -1,0 +1,14 @@
+---
+id: LOG-d6363b231328
+type: log
+title: done, proof commit:2849838
+created: 2026-08-26T18:21:49Z
+author: claude-code/opus-5+glyphs
+scope:
+  - crates/ank-tui/**
+  - crates/ank-cli/tests/tui.rs
+about: TASK-e900637aeac4
+seq: 2
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-e053fa8299ba.md
+++ b/.ank/entities/LOG-e053fa8299ba.md
@@ -1,0 +1,16 @@
+---
+id: LOG-e053fa8299ba
+type: log
+title: TASK-e900637aeac4 touched three files outside the division agreed for this wave, and none of them
+created: 2026-08-26T17:57:21Z
+author: claude-code/opus-5+glyphs
+scope:
+  - crates/ank-tui/**
+  - crates/ank-cli/tests/tui.rs
+about: TASK-e900637aeac4
+seq: 1
+schema: 4
+version: 1
+---
+
+ belongs to another agent's lane. crates/ank-tui/tests/phone.rs and crates/ank-tui/tests/terminal/mod.rs are assigned to nobody, and the move from ASCII borders to box-drawing reaches both mechanically: phone.rs counted '|' to decide how many rows two panels share and trimmed '|' to find a panel's content, and terminal/mod.rs hard-coded TERM=xterm-256color for every session, so a suite driving a dumb terminal had nowhere to say so (Live::dumb is the addition). The third is the #[cfg(test)] module of crates/ank-tui/src/view.rs, whose border assertions are this task's own subject: they now read the glyph out of view::Glyphs rather than carrying a copy of '=' and '-'. Nothing in ratify_line, App::actions, the key consts, keys.rs, input.rs, body_over, body_lines, pane_rows or model.rs was touched.

--- a/.ank/entities/TASK-e900637aeac4.md
+++ b/.ank/entities/TASK-e900637aeac4.md
@@ -5,7 +5,7 @@ slug: structure-is-box-drawing-and-ascii-where-colour
 title: Structure is box-drawing, and ASCII where colour is refused
 created: 2026-08-26T17:07:21Z
 author: claude-code/opus-5+reader-redesign
-status: open
+status: in_progress
 scope:
   - crates/ank-tui/**
   - crates/ank-cli/tests/tui.rs
@@ -14,5 +14,5 @@ done_criteria: |
   With TERM naming an ordinary terminal, a frame of the built binary carries the rounded corners of an unfocused panel and the heavy corners of the focused one, and no border cell carries +, - or |. With TERM=dumb it carries the ASCII rules it carries today. NO_COLOR changes neither: the frame drawn with the paint and the frame drawn without it are the same characters, which is how 'nothing is carried by colour alone' stays measurable, so the glyph choice is a second field beside the ink and never the ink itself. At every one of the three, the focused panel is told from the others by characters alone. The identifier scan in crates/ank-cli/tests/tui.rs reads a frame carrying a box-drawing glyph beside a truncated identifier without panicking at either end of its slice -- the left boundary it takes from rfind is a byte index too.
 criteria_by: creator
 schema: 4
-version: 2
+version: 3
 ---

--- a/.ank/entities/TASK-e900637aeac4.md
+++ b/.ank/entities/TASK-e900637aeac4.md
@@ -5,7 +5,7 @@ slug: structure-is-box-drawing-and-ascii-where-colour
 title: Structure is box-drawing, and ASCII where colour is refused
 created: 2026-08-26T17:07:21Z
 author: claude-code/opus-5+reader-redesign
-status: in_progress
+status: done
 scope:
   - crates/ank-tui/**
   - crates/ank-cli/tests/tui.rs
@@ -13,6 +13,11 @@ blocked_by: []
 done_criteria: |
   With TERM naming an ordinary terminal, a frame of the built binary carries the rounded corners of an unfocused panel and the heavy corners of the focused one, and no border cell carries +, - or |. With TERM=dumb it carries the ASCII rules it carries today. NO_COLOR changes neither: the frame drawn with the paint and the frame drawn without it are the same characters, which is how 'nothing is carried by colour alone' stays measurable, so the glyph choice is a second field beside the ink and never the ink itself. At every one of the three, the focused panel is told from the others by characters alone. The identifier scan in crates/ank-cli/tests/tui.rs reads a frame carrying a box-drawing glyph beside a truncated identifier without panicking at either end of its slice -- the left boundary it takes from rfind is a byte index too.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: "2849838"
+    criteria: 63a3245259e3
+    via: submitted
 schema: 4
-version: 3
+version: 4
 ---

--- a/crates/ank-cli/tests/tui.rs
+++ b/crates/ank-cli/tests/tui.rs
@@ -1143,6 +1143,80 @@ fn a_driven_session_names_the_entities_the_corpus_carries() {
     );
 }
 
+/// Every short identifier a frame carries, in the order they are drawn.
+///
+/// A short identifier is `<KIND>-xxxx`, and the kinds are the four this corpus
+/// has (ADR-c9f9d1a05b23).
+///
+/// **Both ends of the window are taken in characters and never in bytes**
+/// (ADR-c07e2694f0e1, proposed). The frames carry box-drawing glyphs now and a
+/// glyph is three bytes, so the two byte offsets this used to take are both a
+/// slice through a code point -- which is a panic and not a failure. `rfind`
+/// answers the byte index a character *starts* at, so the old `i + 1` landed
+/// inside a border drawn hard against a kind; `at + 5` landed inside one drawn
+/// hard against an identifier the reader had cut. The left boundary therefore
+/// steps over the whole character it found, and the right one counts the four
+/// characters after the hyphen rather than four bytes.
+fn identifiers_in(text: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut rest = text;
+    while let Some(at) = rest.find('-') {
+        let start = rest[..at]
+            .char_indices()
+            .rev()
+            .find(|(_, c)| !c.is_ascii_alphabetic())
+            .map_or(0, |(i, c)| i + c.len_utf8());
+        let kind = &rest[start..at];
+        let tail: String = rest[at + 1..].chars().take(4).collect();
+        if ["ADR", "SPEC", "TASK", "LOG"].contains(&kind)
+            && tail.chars().count() == 4
+            && tail.chars().all(|c| c.is_ascii_hexdigit())
+        {
+            out.push(format!("{kind}-{tail}"));
+        }
+        rest = &rest[at + 1..];
+    }
+    out
+}
+
+/// The scan reads a frame carrying a box-drawing glyph beside a truncated
+/// identifier, at either end of its slice (TASK-e900637aeac4).
+///
+/// Stated on the shapes rather than left to whichever ones a driven session
+/// happened to draw: a border pressed against a kind, a border pressed against
+/// an identifier the reader cut, and a hyphen with fewer than four characters
+/// left before the border. Each of the three panicked before the repair, and a
+/// panic in a suite is a crash with no verdict rather than a failure with one.
+///
+/// Not `#[cfg(unix)]`, unlike the session below it: this is arithmetic on a
+/// string and it is worth running on all three platforms.
+#[test]
+fn the_scan_reads_an_identifier_pressed_against_a_box_drawing_glyph() {
+    // The left boundary: the character before the kind is three bytes wide.
+    assert_eq!(
+        identifiers_in("\u{2503}TASK-4974\u{2503}"),
+        ["TASK-4974"],
+        "a border drawn hard against a kind was not read past"
+    );
+    // The right: a cut identifier, then the border that follows it.
+    assert_eq!(
+        identifiers_in("\u{2502}  ADR-8bd7~\u{2502}  LOG-e053\u{2502}"),
+        ["ADR-8bd7", "LOG-e053"]
+    );
+    // And a hyphen with less than a short identifier left after it, which is
+    // where `at + 5` used to land inside the glyph rather than past it.
+    assert_eq!(identifiers_in("SPEC-fe\u{2503}"), Vec::<String>::new());
+    assert_eq!(
+        identifiers_in("\u{256d}\u{2500}TASK-49\u{2501}"),
+        Vec::<String>::new()
+    );
+    // Nothing the corpus names is invented out of ordinary prose.
+    assert_eq!(
+        identifiers_in("claude-code/opus-5+glyphs   until 2026-08-25T04:36:32Z"),
+        Vec::<String>::new()
+    );
+}
+
 /// Every row on the screen is a row `find` answers with, and nothing else.
 ///
 /// This is the half of "every byte it shows is obtained by running the CLI"
@@ -1158,32 +1232,14 @@ fn the_frames_carry_no_identifier_the_corpus_does_not() {
         .collect();
     let seen = drive(&repo, HOLDER, &["\r", "b", "j", "\r", "b", "q"]);
 
-    let mut found = 0;
-    let text = seen.to_string();
-    let mut rest = text.as_str();
-    while let Some(at) = rest.find('-') {
-        // A short identifier is `<KIND>-xxxx`; the kinds are the four this
-        // corpus has (ADR-c9f9d1a05b23).
-        let start = rest[..at]
-            .rfind(|c: char| !c.is_ascii_alphabetic())
-            .map_or(0, |i| i + 1);
-        let kind = &rest[start..at];
-        if ["ADR", "SPEC", "TASK", "LOG"].contains(&kind) && rest.len() >= at + 5 {
-            let candidate = &rest[start..at + 5];
-            if candidate[kind.len() + 1..]
-                .chars()
-                .all(|c| c.is_ascii_hexdigit())
-            {
-                assert!(
-                    real.iter().any(|r| r == candidate),
-                    "the frames name {candidate}, which the corpus does not carry: {real:?}"
-                );
-                found += 1;
-            }
-        }
-        rest = &rest[at + 1..];
+    let named = identifiers_in(&seen.to_string());
+    for candidate in &named {
+        assert!(
+            real.iter().any(|r| r == candidate),
+            "the frames name {candidate}, which the corpus does not carry: {real:?}"
+        );
     }
-    assert!(found >= 2, "the frames named no identifier at all");
+    assert!(named.len() >= 2, "the frames named no identifier at all");
 }
 
 /// A terminal made narrower, then wider, redraws to its new size with nobody

--- a/crates/ank-tui/src/paint.rs
+++ b/crates/ank-tui/src/paint.rs
@@ -34,9 +34,17 @@
 //! is no path by which half a style reaches a cell -- and every distinction the
 //! screen makes is still on it, because the distinctions are characters:
 //! the `> ` on the row a cursor is on, the `*` on a claim its reader holds, the
-//! `=` rule and the `> ` in the title of the panel with the focus, and the
+//! heavier rule and the `> ` in the title of the panel with the focus, and the
 //! status spelled as a word in its own column. Colour repeats those; it carries
 //! none of them alone.
+//!
+//! **And the characters do not move when the paint is taken away.** That is
+//! what [`declared_dumb`] is for: the glyph set `view` draws its structure with
+//! is a second field beside the ink, and the one thing the two share is that
+//! probe. `NO_COLOR` reaches the ink alone, so the frame drawn with the paint
+//! and the frame drawn without it are the same characters -- which is the only
+//! way "nothing is carried by colour alone" can be measured at all
+//! (ADR-c07e2694f0e1, proposed).
 //!
 //! # Composing a row, and what is deliberately left alone
 //!
@@ -96,7 +104,7 @@ impl Ink {
         if std::env::var_os("NO_COLOR").is_some_and(|v| !v.is_empty()) {
             return PLAIN;
         }
-        if std::env::var_os("TERM").is_some_and(|v| v == "dumb") {
+        if declared_dumb() {
             return PLAIN;
         }
         COLOUR
@@ -155,6 +163,25 @@ impl Ink {
             None => Style::new(),
         }
     }
+}
+
+/// The terminal's own declaration that it can render nothing rich.
+///
+/// **One probe, read by two fields, which is the whole of what makes the
+/// degradation honest** (ADR-c07e2694f0e1, proposed successor to
+/// ADR-0b55983421dd). A terminal that says `dumb` is saying it can draw
+/// neither the colours [`Ink`] would paint nor the box-drawing glyphs
+/// `view`'s borders are made of, and it gets one answer to that rather than
+/// two: the plain palette *and* the ASCII rules, from this function.
+///
+/// `NO_COLOR` is deliberately not here. Refusing colour is refusing colour and
+/// nothing else, so it reaches [`Ink::detect`] above and reaches no glyph: a
+/// reader whose characters moved when the paint was taken away would make
+/// "nothing is carried by colour alone" unmeasurable, and that property is
+/// measured by drawing one corpus twice and finding the two frames identical
+/// character for character (`tests/colour.rs`).
+pub fn declared_dumb() -> bool {
+    std::env::var_os("TERM").is_some_and(|v| v == "dumb")
 }
 
 /// The role an identifier carries, read out of the kind it names.

--- a/crates/ank-tui/src/text.rs
+++ b/crates/ank-tui/src/text.rs
@@ -103,10 +103,16 @@ pub fn wrap(line: &str, width: usize) -> Vec<String> {
     out
 }
 
-/// A run of `-`, the width of the window. Text, like every other separator in
-/// this tool.
-pub fn rule(width: usize) -> String {
-    "-".repeat(width)
+/// A run of one character, the width of the window.
+///
+/// The character is the caller's, because which one it is is a decision about
+/// the terminal rather than about the arithmetic: a screen ruling its panels
+/// with box-drawing glyphs rules its chrome with the same horizontal, and one
+/// that has been told the terminal is dumb rules both with `-`
+/// (ADR-c07e2694f0e1, proposed). [`crate::view::Glyphs`] is what answers it,
+/// once, when the screen opens.
+pub fn rule(width: usize, of: &str) -> String {
+    of.repeat(width)
 }
 
 /// `a-b of n`, or `none`, for a heading that windows a list.

--- a/crates/ank-tui/src/view.rs
+++ b/crates/ank-tui/src/view.rs
@@ -61,19 +61,25 @@
 //! # Focus is where the width goes
 //!
 //! One panel has focus at a time, `Tab` and `1`..`4` move it, and the focused
-//! panel is drawn with a doubled border and the `> ` marker every listing in
+//! panel is drawn with a heavier border and the `> ` marker every listing in
 //! this tool already spends on the row a cursor is on ([`text::CURSOR`]). Both
-//! signals are characters, and both are ASCII: the screen answers "which panel
-//! am I in" with no colour at all. Colour arrived on top of that frame rather
-//! than into it (TASK-6cd41d23b7d1): what it paints is what a row *is* -- an
-//! identifier, a status -- and never where the reader is standing, so
-//! `NO_COLOR` takes away a repetition and no signal at all.
+//! signals are characters: the screen answers "which panel am I in" with no
+//! colour at all. Colour arrived on top of that frame rather than into it
+//! (TASK-6cd41d23b7d1): what it paints is what a row *is* -- an identifier, a
+//! status -- and never where the reader is standing, so `NO_COLOR` takes away
+//! a repetition and no signal at all.
 //!
-//! The borders are `-`, `|`, `+` and `=` rather than the box-drawing glyphs,
-//! deliberately. Structure in this tool is text emitted identically to every
-//! reader on every platform (ADR-1f70ce2c3eac), the markers this crate already
-//! draws are, and the terminal least likely to carry the glyphs is the one on a
-//! phone -- which is the reader TASK-dd9747e5e305 is about to serve.
+//! **The borders are box-drawing glyphs, and drop to `-`, `|`, `+` and `=` on
+//! the terminal that declares it can render neither those nor colour**
+//! (ADR-c07e2694f0e1, proposed successor to ADR-0b55983421dd). [`Glyphs`] is
+//! that choice, and it is a field of its own beside the ink rather than a part
+//! of it: the probe is the terminal's own word and never `NO_COLOR`, because
+//! refusing colour is not refusing glyphs and a frame whose characters moved
+//! when the paint went would leave "nothing is carried by colour alone" with
+//! nothing to measure it by. LOG-ed57116ba141 recorded the older answer --
+//! ASCII everywhere, for the phone that could not draw the glyphs -- and the
+//! phones people read from have overtaken it; ADR-1f70ce2c3eac's scope is the
+//! CLI's renderer and not this one.
 //!
 //! **And focus is not decoration: the focused one of the two middle panels
 //! takes four fifths of the width.** A corpus reader has exactly two things
@@ -201,7 +207,7 @@ use crate::ank::{Ank, Failed, Ran};
 use crate::input::{Act, Command};
 use crate::keys::{self, Editing, Press};
 use crate::model::{short_of, Detail, Queue, Row, Snapshot};
-use crate::paint::{role_of_id, Composed, Ink};
+use crate::paint::{self, role_of_id, Composed, Ink};
 use crate::stream::Stream;
 use crate::text::{self, fit, pad, window, wrap};
 use ank_contract::meaning::role_of_status;
@@ -305,8 +311,9 @@ impl Action {
     /// The target as it is drawn: the key, then what it does, in brackets.
     ///
     /// The brackets are the whole of what says "this is a thing to touch".
-    /// ASCII, on the reasoning the borders are (ADR-1f70ce2c3eac): the terminal
-    /// least likely to carry a box-drawing glyph is the one this is drawn for.
+    /// ASCII whatever the terminal is, unlike the borders ([`Glyphs`]): a
+    /// bracket is a character every terminal has, so there is nothing here for
+    /// a poor one to be given back.
     pub fn label(&self) -> String {
         format!("[{} {}]", named(self.key), self.does)
     }
@@ -422,6 +429,13 @@ pub struct App {
     /// under a session, and a screen that read `NO_COLOR` per paint would be a
     /// screen whose answer could differ between two rows of one frame.
     ink: Ink,
+    /// Which characters this screen draws its structure with, decided once
+    /// when it opens (ADR-c07e2694f0e1, proposed).
+    ///
+    /// **Beside the ink and never inside it.** The two are decided from one
+    /// probe and they are two fields, so taking the paint away moves no
+    /// character on this frame -- see [`Glyphs`].
+    glyphs: Glyphs,
 }
 
 impl App {
@@ -445,11 +459,14 @@ impl App {
             queue: None,
             prompt: None,
             pending: None,
-            // The one read of the environment this crate makes. A session is
-            // at a terminal by construction -- `tui` refuses where it is not
-            // -- so what is left of ADR-1f70ce2c3eac's condition is the
-            // variable, and [`Ink::detect`] is the CLI's own rule for it.
+            // The two reads of the environment this crate makes, and they
+            // ask it one thing between them. A session is at a terminal by
+            // construction -- `tui` refuses where it is not -- so what is left
+            // of ADR-1f70ce2c3eac's condition is the variable, and
+            // [`Ink::detect`] is the CLI's own rule for it. The glyph set asks
+            // only the half of that rule the terminal itself answered.
             ink: Ink::detect(),
+            glyphs: Glyphs::detect(),
         }
     }
 
@@ -461,6 +478,16 @@ impl App {
     /// cargo happened to run it in.
     pub fn inked(mut self, ink: Ink) -> App {
         self.ink = ink;
+        self
+    }
+
+    /// The same screen, drawing its structure with the set it is told to.
+    ///
+    /// [`inked`](App::inked)'s counterpart, and for the same reason: a suite
+    /// that exported `TERM` would be reporting the machine it ran on rather
+    /// than the reader.
+    pub fn drawn_with(mut self, glyphs: Glyphs) -> App {
+        self.glyphs = glyphs;
         self
     }
 
@@ -1325,7 +1352,7 @@ impl App {
                         ),
                         width,
                     ),
-                    text::rule(width),
+                    text::rule(width, self.glyphs.rule()),
                 ])
                 .render(panels.header, buf);
             }
@@ -1337,7 +1364,7 @@ impl App {
                 paragraph(&[
                     fit("ank tui", width),
                     fit("the corpus has not been read", width),
-                    text::rule(width),
+                    text::rule(width, self.glyphs.rule()),
                 ])
                 .render(panels.header, buf);
             }
@@ -1360,8 +1387,9 @@ impl App {
     /// One panel: its border, its title, and the lines it holds.
     ///
     /// **The focused one is told apart by two things and no colour.** Its
-    /// border is doubled -- `=` where the others rule with `-` -- and its title
-    /// carries the same `> ` this tool puts on the row a cursor is on. Two
+    /// border is heavier -- the thick rule where the others are rounded, or `=`
+    /// against `-` where the terminal has said it draws no glyphs -- and its
+    /// title carries the same `> ` this tool puts on the row a cursor is on. Two
     /// independent signals, because a reader looking at the middle of a panel
     /// still sees the rule under it. Colour arrived after both
     /// (TASK-6cd41d23b7d1) and took neither away: what it paints is what a row
@@ -1380,7 +1408,7 @@ impl App {
             .then(self.title_of(focus, width))
             .fitted(area.width as usize - 2);
         let block = Block::bordered()
-            .border_set(if focused { FOCUSED } else { UNFOCUSED })
+            .border_set(self.glyphs.border(focused))
             .title(title.line(self.ink));
         block.render(area, buf);
         if inside.is_empty() {
@@ -2097,14 +2125,83 @@ impl App {
     }
 }
 
-/// The border of a panel nobody is in.
+/// Which characters this reader draws its structure with.
 ///
-/// ASCII, and that is a decision rather than an omission: structure in this
-/// tool is text emitted identically to every reader on every platform
-/// (ADR-1f70ce2c3eac), the markers this crate already draws are, and the
-/// terminal least likely to carry the box-drawing glyphs is the one on a phone
-/// -- which is the reader TASK-dd9747e5e305 is about to serve.
-const UNFOCUSED: border::Set = border::Set {
+/// **A second field beside [`paint::Ink`], and never the ink itself**
+/// (ADR-c07e2694f0e1, proposed successor to ADR-0b55983421dd). The two share
+/// one probe -- [`paint::declared_dumb`], the terminal's own word that it can
+/// render nothing rich -- and nothing else: `NO_COLOR` reaches the ink and
+/// reaches no glyph. That separation is not tidiness. "Nothing on this screen
+/// is carried by colour alone" is measured by drawing one corpus with the
+/// paint and once without it and requiring the two frames to be identical
+/// character for character, and a border that moved with the ink would leave
+/// the property with no measurement at all.
+///
+/// Copied rather than referenced, and constructed in three places: [`detect`]
+/// below, and the two constants the suite uses to state both halves of the
+/// rule without an environment variable.
+///
+/// [`detect`]: Glyphs::detect
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Glyphs {
+    rich: bool,
+}
+
+/// Box-drawing. What an ordinary terminal gets.
+pub const BOXES: Glyphs = Glyphs { rich: true };
+/// `+`, `-`, `|` and `=`. What a terminal that has declared itself dumb gets,
+/// and what this reader drew everywhere before ADR-c07e2694f0e1.
+pub const ASCII: Glyphs = Glyphs { rich: false };
+
+impl Glyphs {
+    /// The glyph half of ADR-c07e2694f0e1, evaluated once when the screen
+    /// opens.
+    ///
+    /// The whole of it is [`paint::declared_dumb`]. There is deliberately no
+    /// second condition: a terminal is asked once whether it is poor, and the
+    /// palette and the border set are two answers to that one question rather
+    /// than two questions.
+    pub fn detect() -> Glyphs {
+        match paint::declared_dumb() {
+            true => ASCII,
+            false => BOXES,
+        }
+    }
+
+    /// The border of a panel, focused or not.
+    ///
+    /// **The focus is carried by the weight of the rule**, which is a
+    /// character in both sets: heavy against rounded where the terminal draws
+    /// glyphs, `=` against `-` where it does not. Every set here is one column
+    /// wide on every side, so two panels sharing a row are the same one column
+    /// of characters apart whichever of them has the focus.
+    pub const fn border(self, focused: bool) -> border::Set<'static> {
+        match (self.rich, focused) {
+            (true, false) => border::ROUNDED,
+            (true, true) => border::THICK,
+            (false, false) => ASCII_UNFOCUSED,
+            (false, true) => ASCII_FOCUSED,
+        }
+    }
+
+    /// The character a full-width rule of chrome is drawn with.
+    ///
+    /// The same horizontal the unfocused panels below it are ruled with, so
+    /// the header does not sit over a frame drawn in a different alphabet.
+    pub fn rule(self) -> &'static str {
+        self.border(false).horizontal_top
+    }
+}
+
+/// The border of a panel nobody is in, on a terminal that declared itself
+/// dumb.
+///
+/// Kept to the character, and it is what this reader drew everywhere before
+/// ADR-c07e2694f0e1: LOG-ed57116ba141's reasoning was that structure is text
+/// emitted identically to every reader on every platform, and for the terminal
+/// that has said it can render neither glyphs nor colour that reasoning still
+/// holds.
+const ASCII_UNFOCUSED: border::Set = border::Set {
     top_left: "+",
     top_right: "+",
     bottom_left: "+",
@@ -2115,13 +2212,9 @@ const UNFOCUSED: border::Set = border::Set {
     horizontal_bottom: "-",
 };
 
-/// The border of the panel with the focus: the same box, ruled twice.
-///
-/// The verticals stay `|` so that two panels sharing a row are the same one
-/// column of characters apart whichever of them has the focus. What changes is
-/// the rule above and below, which is where a title sits and where the eye
-/// goes.
-const FOCUSED: border::Set = border::Set {
+/// The border of the panel with the focus, on the same terminal: the same box,
+/// ruled twice.
+const ASCII_FOCUSED: border::Set = border::Set {
     top_left: "+",
     top_right: "+",
     bottom_left: "+",
@@ -2494,6 +2587,38 @@ mod tests {
         }
     }
 
+    /// The glyph set every screen below is pinned to, for the reason the ink
+    /// is: `App::new` reads `TERM`, and a suite that took the developer's
+    /// would be a suite that draws one frame on one machine and another on the
+    /// next. [`BOXES`] and not [`ASCII`], because an ordinary terminal is what
+    /// the reader is drawn for; the test that is about the fallback says so.
+    const SCREEN: Glyphs = BOXES;
+
+    /// How many of a line's characters are a panel's vertical border, at
+    /// either weight.
+    ///
+    /// Read off [`SCREEN`] rather than written as a character here: the border
+    /// set moved once already (ADR-c07e2694f0e1), and a suite carrying its own
+    /// copy of `|` would have gone on counting a glyph the reader no longer
+    /// draws -- which is a test that quietly stops testing rather than one that
+    /// fails.
+    fn verticals(line: &str) -> usize {
+        let of = |set: border::Set| {
+            set.vertical_left
+                .chars()
+                .next()
+                .expect("a border set has a vertical")
+        };
+        let (thin, thick) = (of(SCREEN.border(false)), of(SCREEN.border(true)));
+        line.chars().filter(|c| *c == thin || *c == thick).count()
+    }
+
+    /// A run of one panel's rule, long enough that nothing else on a frame is
+    /// it: the focused weight, or the other one.
+    fn rule_of(focused: bool) -> String {
+        SCREEN.border(focused).horizontal_top.repeat(10)
+    }
+
     /// A screen with a corpus on it, painting nothing.
     ///
     /// [`crate::paint::PLAIN`] and not whatever the environment says, so that
@@ -2502,7 +2627,9 @@ mod tests {
     /// running a different suite from one who has not. The two tests that are
     /// about the painting say which ink they mean.
     fn app() -> App {
-        let mut a = App::new((120, 40), None).inked(paint::PLAIN);
+        let mut a = App::new((120, 40), None)
+            .inked(paint::PLAIN)
+            .drawn_with(SCREEN);
         a.snapshot = Some(snapshot());
         a
     }
@@ -2600,10 +2727,7 @@ mod tests {
         // A row carrying four verticals is a row two bordered panels share,
         // which is what "side by side" is when it is measured rather than
         // described.
-        let shared = f
-            .lines()
-            .filter(|l| l.chars().filter(|c| *c == '|').count() >= 4)
-            .count();
+        let shared = f.lines().filter(|l| verticals(l) >= 4).count();
         assert!(shared >= 4, "no row of the frame carries two panels:\n{f}");
     }
 
@@ -2630,13 +2754,137 @@ mod tests {
                     "{other:?} is marked as well as {focus:?}:\n{f}"
                 );
             }
-            // And the doubled rule, which no unfocused panel is drawn with.
+            // And the heavier rule, which no unfocused panel is drawn with.
             assert!(
-                f.contains("=========="),
-                "no panel is drawn with the doubled border:\n{f}"
+                f.contains(&rule_of(true)),
+                "no panel is drawn with the focused border:\n{f}"
             );
             assert!(
-                f.contains("----------"),
+                f.contains(&rule_of(false)),
+                "every panel is drawn as the focused one:\n{f}"
+            );
+        }
+    }
+
+    /// Every cell of every panel's outline, less the top rule.
+    ///
+    /// The top rule is left out because a title is drawn into it, and a title
+    /// carries the identifier of the document a panel is showing -- so a
+    /// hyphen there is `TASK-4974`'s and not a border's. What is left is the
+    /// four corners, both verticals and the bottom rule, which is where a
+    /// character this reader chose is the only thing that can be.
+    fn outlines(a: &App) -> Vec<String> {
+        let area = a.area();
+        let mut buf = Buffer::empty(area);
+        a.render(area, &mut buf);
+        let mut out = Vec::new();
+        let mut at = |x: u16, y: u16, buf: &Buffer| {
+            if let Some(cell) = buf.cell((x, y)) {
+                out.push(cell.symbol().to_string());
+            }
+        };
+        for focus in Focus::ALL {
+            let r = a.rect_of(focus, area);
+            if r.width < 2 || r.height < 2 {
+                continue;
+            }
+            for x in r.x..r.right() {
+                at(x, r.bottom() - 1, &buf);
+            }
+            for y in r.y..r.bottom() {
+                at(r.x, y, &buf);
+                at(r.right() - 1, y, &buf);
+            }
+        }
+        out
+    }
+
+    /// Structure is box-drawing, and the ASCII rules are what a terminal that
+    /// declared itself dumb gets back (ADR-c07e2694f0e1, proposed).
+    ///
+    /// Both sets on one test, because either alone is half of it: a reader
+    /// that had gone to glyphs and taken the fallback with it would pass the
+    /// first, and one that never left ASCII would pass the second.
+    ///
+    /// What is asserted is the cells the border is drawn into, by way of
+    /// [`outlines`], rather than the frame as a string: `+`, `-` and `|` are
+    /// ordinary characters of an identity, an identifier and the line of act
+    /// forms, and a test that banned them from the whole screen would be
+    /// asserting something the reader was never supposed to do. What `ank tui`
+    /// puts on a real terminal at each of the two is `tests/panels.rs`, on the
+    /// rule CLAUDE.md states: a criterion about the binary is measured through
+    /// the binary.
+    #[test]
+    fn structure_is_box_drawing_and_ascii_where_the_terminal_says_it_is_dumb() {
+        /// [`app`], drawn with a stated set: the one thing this test varies.
+        fn screen(glyphs: Glyphs) -> App {
+            let mut a = App::new((120, 40), None)
+                .inked(paint::PLAIN)
+                .drawn_with(glyphs);
+            a.snapshot = Some(snapshot());
+            a.focus = Focus::Entities;
+            a
+        }
+
+        let boxed = screen(BOXES);
+        let outline = outlines(&boxed);
+        assert!(
+            outline.len() > 200,
+            "the outlines were not read: {outline:?}"
+        );
+        for ascii in ["+", "-", "|", "="] {
+            assert!(
+                !outline.iter().any(|cell| cell == ascii),
+                "a border cell carries {ascii}:\n{}",
+                boxed.frame()
+            );
+        }
+        // The corners say which weight a panel is drawn at, and both weights
+        // are on this frame -- which is what makes the focus a character.
+        let frame = boxed.frame();
+        for corner in ["\u{256d}", "\u{256e}", "\u{2570}", "\u{256f}"] {
+            assert!(
+                frame.contains(corner),
+                "no unfocused panel carries the rounded corner {corner}:\n{frame}"
+            );
+        }
+        for corner in ["\u{250f}", "\u{2513}", "\u{2517}", "\u{251b}"] {
+            assert!(
+                frame.contains(corner),
+                "the focused panel carries no heavy corner {corner}:\n{frame}"
+            );
+        }
+
+        // And the terminal that has said it can render nothing rich gets back
+        // exactly what this reader drew everywhere before.
+        let plain = screen(ASCII);
+        for run in ["+---", "+===", "----------", "=========="] {
+            assert!(
+                plain.frame().contains(run),
+                "the ASCII fallback is missing {run}:\n{}",
+                plain.frame()
+            );
+        }
+        for glyph in [
+            "\u{2500}", "\u{2501}", "\u{2502}", "\u{2503}", "\u{256d}", "\u{250f}",
+        ] {
+            assert!(
+                !plain.frame().contains(glyph),
+                "a terminal that declared itself dumb was sent {glyph}:\n{}",
+                plain.frame()
+            );
+        }
+
+        // The focus is told apart by characters at both, which is the half of
+        // the criterion the fallback could quietly lose.
+        for glyphs in [BOXES, ASCII] {
+            let f = screen(glyphs).frame();
+            assert!(
+                f.contains(&glyphs.border(true).horizontal_top.repeat(10)),
+                "no panel carries the focused rule:\n{f}"
+            );
+            assert!(
+                f.contains(&glyphs.border(false).horizontal_top.repeat(10)),
                 "every panel is drawn as the focused one:\n{f}"
             );
         }
@@ -2653,7 +2901,7 @@ mod tests {
     /// what the *table* is asked about, and a corpus carrying one status would
     /// have let a palette with seven arms missing pass.
     fn coloured(ink: paint::Ink) -> App {
-        let mut a = App::new((120, 40), None).inked(ink);
+        let mut a = App::new((120, 40), None).inked(ink).drawn_with(SCREEN);
         let mut snapshot = snapshot();
         snapshot.entities.push(row(
             "TASK-0000ffff0004",
@@ -2776,10 +3024,11 @@ mod tests {
         let f = a.frame();
         // The focus: the doubled rule and the marker in the title.
         assert!(f.contains("> 2 ENTITIES"), "the focus is unmarked:\n{f}");
-        assert!(f.contains("=========="), "no doubled rule:\n{f}");
+        assert!(f.contains(&rule_of(true)), "no heavier rule:\n{f}");
         // The cursor, in the two columns every listing spends on its margin.
         assert!(
-            f.lines().any(|l| l.contains("|>     1  ")),
+            f.lines()
+                .any(|l| l.contains(&format!("{}>     1  ", SCREEN.border(true).vertical_left))),
             "the row the cursor is on is unmarked:\n{f}"
         );
         // Whose claim it is, which is what `*` means in `find`.
@@ -3914,7 +4163,7 @@ mod tests {
     const PHONE: (usize, usize) = ((ONE_COLUMN - 7) as usize, 30);
 
     fn phone() -> App {
-        let mut a = App::new(PHONE, None).inked(paint::PLAIN);
+        let mut a = App::new(PHONE, None).inked(paint::PLAIN).drawn_with(SCREEN);
         a.snapshot = Some(snapshot());
         a
     }
@@ -3951,10 +4200,7 @@ mod tests {
 
     /// How many rows of a frame carry two panels, which is what a column is.
     fn shared(frame: &str) -> usize {
-        frame
-            .lines()
-            .filter(|l| l.chars().filter(|c| *c == '|').count() >= 4)
-            .count()
+        frame.lines().filter(|l| verticals(l) >= 4).count()
     }
 
     /// **Below the width the code states, the panels reflow to one column and

--- a/crates/ank-tui/tests/colour.rs
+++ b/crates/ank-tui/tests/colour.rs
@@ -55,6 +55,14 @@ use terminal::{ids_of, Live, Repo};
 /// the middle both draw rows, which is where the painted fields are.
 const WINDOW: (u16, u16) = (110, 30);
 
+/// The rule the focused panel is drawn with, read out of the reader rather
+/// than written here (ADR-c07e2694f0e1, proposed).
+///
+/// It is a *character* and that is the point of naming it in this file: the
+/// glyph set is a second field beside the ink and no `NO_COLOR` reaches it, so
+/// this rule is on the frame of every session below whether it painted or not.
+const FOCUSED_RULE: &str = ank_tui::view::BOXES.border(true).horizontal_top;
+
 /// A closed task, so that a role the table renders as an *attribute* rather
 /// than as a colour is on the screen.
 ///
@@ -220,7 +228,7 @@ fn with_no_color_set_no_sequence_the_reader_sends_paints_anything() {
 /// And the screen is still readable, because every distinction is a character.
 ///
 /// Four signals, each of a different kind and each of them on the monochrome
-/// frame: the panel names and their numbers, the doubled rule and the `> `
+/// frame: the panel names and their numbers, the heavier rule and the `> `
 /// marker that say where the focus is, the `> ` on the row a cursor is on, and
 /// the status of a row spelled as the word it is.
 #[test]
@@ -238,8 +246,8 @@ fn with_no_color_set_the_screen_still_says_everything_it_has_to_say() {
         "the focused panel is unmarked:\n{frame}"
     );
     assert!(
-        frame.contains("=========="),
-        "the focused panel has no doubled rule:\n{frame}"
+        frame.contains(&FOCUSED_RULE.repeat(10)),
+        "the focused panel has no heavier rule:\n{frame}"
     );
     assert!(
         frame.lines().any(|l| l.contains(">     1  ")),

--- a/crates/ank-tui/tests/panels.rs
+++ b/crates/ank-tui/tests/panels.rs
@@ -23,6 +23,36 @@ mod terminal;
 
 use terminal::{Live, Repo};
 
+/// The border set an ordinary terminal is drawn with, read out of the reader
+/// rather than written here (ADR-c07e2694f0e1, proposed).
+///
+/// A suite carrying its own copy of a glyph would go on asserting about a
+/// character the reader had stopped drawing, which is a test that quietly
+/// stops testing rather than one that fails.
+const BOXES: ank_tui::view::Glyphs = ank_tui::view::BOXES;
+/// And the set the terminal that declared itself dumb gets back.
+const ASCII: ank_tui::view::Glyphs = ank_tui::view::ASCII;
+
+/// How many of a line's characters are a panel's vertical border, at either
+/// weight of the set an ordinary terminal is drawn with.
+fn verticals(line: &str) -> usize {
+    let of = |focused| {
+        BOXES
+            .border(focused)
+            .vertical_left
+            .chars()
+            .next()
+            .expect("a border set has a vertical")
+    };
+    let (thin, thick) = (of(false), of(true));
+    line.chars().filter(|c| *c == thin || *c == thick).count()
+}
+
+/// A run of one panel's rule, long enough that nothing else on a frame is it.
+fn rule_of(glyphs: ank_tui::view::Glyphs, focused: bool) -> String {
+    glyphs.border(focused).horizontal_top.repeat(10)
+}
+
 // ---------------------------------------------------------------------------
 // The criterion
 // ---------------------------------------------------------------------------
@@ -106,10 +136,7 @@ fn the_panels_are_side_by_side_and_the_focused_one_is_marked_in_characters() {
         // the stated width that is what the pair in the middle does; below it
         // the four are stacked and no row carries two, which is the same fact
         // about the same function read at two windows.
-        let shared = frame
-            .lines()
-            .filter(|l| l.chars().filter(|c| *c == '|').count() >= 4)
-            .count();
+        let shared = frame.lines().filter(|l| verticals(l) >= 4).count();
         match columns >= ank_tui::view::ONE_COLUMN {
             true => assert!(
                 shared >= 4,
@@ -133,15 +160,15 @@ fn the_panels_are_side_by_side_and_the_focused_one_is_marked_in_characters() {
                 "two panels are marked at once:\n{frame}"
             );
         }
-        // And the doubled rule, which is the second signal and also a
-        // character. Both border sets are on the frame, so this is a
-        // difference and not a style everything shares.
+        // And the heavier rule, which is the second signal and also a
+        // character. Both weights of the border set are on the frame, so this
+        // is a difference and not a style everything shares.
         assert!(
-            frame.contains("=========="),
-            "no panel is drawn with the doubled border:\n{frame}"
+            frame.contains(&rule_of(BOXES, true)),
+            "no panel is drawn with the focused border:\n{frame}"
         );
         assert!(
-            frame.contains("----------"),
+            frame.contains(&rule_of(BOXES, false)),
             "every panel is drawn as the focused one:\n{frame}"
         );
 
@@ -160,6 +187,89 @@ fn the_panels_are_side_by_side_and_the_focused_one_is_marked_in_characters() {
             t.contains("> 1 CLAIMS")
         });
         live.quit();
+    }
+}
+
+/// Structure is box-drawing, and ASCII where the terminal declares itself
+/// dumb (TASK-e900637aeac4, ADR-c07e2694f0e1 proposed).
+///
+/// **Through the binary, because the probe is the environment of a process.**
+/// `src/view.rs` asserts the same property of the render function, which is
+/// where the border cells can be read one at a time; what only a spawned
+/// session can answer is whether `TERM` reached the reader at all.
+///
+/// **`NO_COLOR` is set on both children, and it is the point.** [`Live::open`]
+/// exports it, so the ordinary session below is a session that has refused
+/// colour and still draws glyphs -- which is the whole of "the probe is the
+/// terminal's own declaration and never `NO_COLOR`", measured rather than
+/// asserted in prose. What the two frames colour costs are is
+/// `tests/colour.rs`, which draws one corpus with the paint and without it and
+/// requires them identical character for character.
+#[test]
+fn the_borders_are_box_drawing_and_ascii_only_where_the_terminal_says_it_is_dumb() {
+    let repo = Repo::seeded();
+    for (columns, rows) in WINDOWS {
+        let rich = Live::open(&repo, columns, rows);
+        rich.until("the session to open", |t| t.contains("2 ENTITIES"));
+        let frame = rich.frame();
+        // The corners the criterion names: rounded on a panel nobody is in,
+        // heavy on the one with the focus.
+        for corner in ["\u{256d}", "\u{256e}", "\u{2570}", "\u{256f}"] {
+            assert!(
+                frame.contains(corner),
+                "no unfocused panel of a {columns}x{rows} frame carries the \
+                 rounded corner {corner}:\n{frame}"
+            );
+        }
+        for corner in ["\u{250f}", "\u{2513}", "\u{2517}", "\u{251b}"] {
+            assert!(
+                frame.contains(corner),
+                "the focused panel of a {columns}x{rows} frame carries no heavy \
+                 corner {corner}:\n{frame}"
+            );
+        }
+        // And nothing is ruled in ASCII any more. `-` and `|` are characters
+        // an identifier and the line of act forms carry, so what is banned is
+        // the run of four only a border was ever drawn as.
+        for ruled in ["+--", "+==", "----", "===="] {
+            assert!(
+                !frame.contains(ruled),
+                "a {columns}x{rows} frame is still ruled with {ruled}:\n{frame}"
+            );
+        }
+        rich.quit();
+
+        // The terminal that has said it can render nothing rich gets back
+        // exactly the rules this reader drew everywhere before.
+        let dumb = Live::dumb(&repo, columns, rows);
+        dumb.until("the session to open", |t| t.contains("2 ENTITIES"));
+        let plain = dumb.frame();
+        for run in [
+            &rule_of(ASCII, true),
+            &rule_of(ASCII, false),
+            &"+".to_string(),
+        ] {
+            assert!(
+                plain.contains(run.as_str()),
+                "a dumb terminal at {columns}x{rows} is missing {run}:\n{plain}"
+            );
+        }
+        for glyph in [
+            "\u{2500}", "\u{2501}", "\u{2502}", "\u{2503}", "\u{256d}", "\u{250f}",
+        ] {
+            assert!(
+                !plain.contains(glyph),
+                "a terminal that declared itself dumb was sent {glyph} at \
+                 {columns}x{rows}:\n{plain}"
+            );
+        }
+        // The focused panel is told from the others by characters here too,
+        // which is the half of the criterion a fallback could quietly lose.
+        assert!(
+            plain.contains("> 2 ENTITIES"),
+            "the focused panel of a dumb terminal is unmarked:\n{plain}"
+        );
+        dumb.quit();
     }
 }
 

--- a/crates/ank-tui/tests/phone.rs
+++ b/crates/ank-tui/tests/phone.rs
@@ -39,11 +39,37 @@ use terminal::{Live, Repo};
 /// anything. Thirty rows, because a phone is tall.
 const PHONE: (u16, u16) = (ank_tui::view::ONE_COLUMN - 7, 30);
 
+/// A panel's vertical border, at either weight, as characters
+/// (ADR-c07e2694f0e1, proposed).
+///
+/// Read out of the reader rather than written as `|` here: the border set
+/// moved once already, and a suite carrying its own copy of the character
+/// would have gone on counting a glyph the reader no longer draws -- which is
+/// a test that quietly stops testing rather than one that fails.
+fn verticals() -> [char; 2] {
+    let of = |focused| {
+        ank_tui::view::BOXES
+            .border(focused)
+            .vertical_left
+            .chars()
+            .next()
+            .expect("a border set has a vertical")
+    };
+    [of(false), of(true)]
+}
+
+/// A line with the panel border it opens with taken off, so what is left
+/// starts where the panel's own content does.
+fn inside(line: &str) -> &str {
+    line.trim_start_matches(verticals())
+}
+
 /// How many rows of a frame carry two panels side by side.
 fn shared(frame: &str) -> usize {
+    let verticals = verticals();
     frame
         .lines()
-        .filter(|l| l.chars().filter(|c| *c == '|').count() >= 4)
+        .filter(|l| l.chars().filter(|c| verticals.contains(c)).count() >= 4)
         .count()
 }
 
@@ -152,12 +178,12 @@ fn a_tap_selects_a_row_and_a_tap_on_a_target_reaches_the_action_it_names() {
     live.tap(2, *at as u16);
     live.until("the row under the finger to be selected", |t| {
         t.lines()
-            .any(|l| l.contains(&short) && l.trim_start_matches('|').starts_with("> "))
+            .any(|l| l.contains(&short) && inside(l).starts_with("> "))
     });
     let selected = live.frame();
     let marked: Vec<&str> = selected
         .lines()
-        .filter(|l| l.contains('-') && l.trim_start_matches('|').starts_with("> "))
+        .filter(|l| l.contains('-') && inside(l).starts_with("> "))
         .collect();
     assert_eq!(
         marked.len(),

--- a/crates/ank-tui/tests/terminal/mod.rs
+++ b/crates/ank-tui/tests/terminal/mod.rs
@@ -64,6 +64,15 @@ impl Drop for Repo {
 }
 
 pub const AGENT: &str = "claude-code/opus-5+panel-suite";
+
+/// The terminal every session but [`Live::dumb`] is opened on.
+///
+/// Stated rather than inherited: this suite runs under whatever the developer
+/// has exported, and a reader that reads `TERM` -- which this one does, for
+/// its palette and for its border set alike -- would otherwise draw one frame
+/// on one machine and another on the next.
+pub const TERM: &str = "xterm-256color";
+
 /// Deliberately wider than the entities panel at either window, so that a
 /// frame which overflowed rather than fitted would be visible as a row past
 /// the right edge.
@@ -581,7 +590,7 @@ impl Live {
     /// about painting wants: `NO_COLOR` makes the frames the characters they
     /// are and nothing else.
     pub fn open(repo: &Repo, columns: u16, rows: u16) -> Live {
-        Live::opened(repo, columns, rows, false)
+        Live::opened(repo, columns, rows, false, TERM)
     }
 
     /// A session that may paint (TASK-6cd41d23b7d1).
@@ -591,10 +600,22 @@ impl Live {
     /// developer running it has exported, and a test whose subject is colour
     /// must not be a test that reports the machine.
     pub fn painting(repo: &Repo, columns: u16, rows: u16) -> Live {
-        Live::opened(repo, columns, rows, true)
+        Live::opened(repo, columns, rows, true, TERM)
     }
 
-    fn opened(repo: &Repo, columns: u16, rows: u16, colour: bool) -> Live {
+    /// A session on a terminal that has declared it can render nothing rich
+    /// (ADR-c07e2694f0e1, proposed).
+    ///
+    /// `TERM=dumb` is the whole of the declaration, and it is what puts the
+    /// reader on its ASCII border set and its plain palette at once -- one
+    /// probe, two answers. `NO_COLOR` is left set as [`Live::open`] sets it,
+    /// because it is beside the point here: a terminal this poor was getting
+    /// the plain palette either way.
+    pub fn dumb(repo: &Repo, columns: u16, rows: u16) -> Live {
+        Live::opened(repo, columns, rows, false, "dumb")
+    }
+
+    fn opened(repo: &Repo, columns: u16, rows: u16, colour: bool, term: &str) -> Live {
         use std::io::Read;
 
         let (master, slave_path) = pty::open();
@@ -612,7 +633,7 @@ impl Live {
             .arg("tui")
             .current_dir(&repo.0)
             .env("ANK_AGENT", AGENT)
-            .env("TERM", "xterm-256color");
+            .env("TERM", term);
         match colour {
             true => command.env_remove("NO_COLOR"),
             false => command.env("NO_COLOR", "1"),


### PR DESCRIPTION
TASK-e900637aeac4, wave 18. Proof `commit:2849838`.

## What changed

The reader's panel borders are box-drawing glyphs: ratatui's `ROUNDED` on a
panel nobody is in, `THICK` on the one with the focus. The terminal that
declares itself dumb gets back exactly the `+`, `-`, `|` and `=` this reader
drew everywhere before. The header's full-width rule follows the same set, so
the chrome is not drawn in a different alphabet from the panels under it.

`view::Glyphs` is that choice. **It is a second field on `App` beside the ink
and never the ink itself**, and the two share one probe — `paint::declared_dumb`,
the terminal's own word that it can render nothing rich — and nothing else.
`NO_COLOR` reaches the ink and reaches no glyph.

That separation is not tidiness. `tests/colour.rs` measures "nothing is carried
by colour alone" by drawing one corpus with the paint and without it and
requiring the two frames identical character for character; a border that moved
with the ink would have left the property with nothing to measure it by. The
suites that set `NO_COLOR` on their child now see glyphs, which is the same fact
stated from the other side.

## The scan that had to be repaired

`crates/ank-cli/tests/tui.rs` sliced frames by byte at **both** ends of its
window, and a box-drawing glyph is three bytes. `rfind` answers the byte index a
character *starts* at, so `i + 1` landed inside a border drawn hard against a
kind; `at + 5` landed inside one drawn hard against a cut identifier. Either is
a slice through a code point, which is a panic and not a failure.

Both ends now count characters, and the scan is a function with a test of its
own feeding it those shapes directly rather than hoping a driven session draws
them. Three of the four cases panicked before the repair. That test is not
`#[cfg(unix)]` — it is arithmetic on a string, and it runs on all three
platforms.

## Where it is measured

| Claim | Where |
| --- | --- |
| Rounded corners unfocused, heavy focused, no border cell carries `+`, `-` or `|` | `view.rs` on the border cells one at a time; `tests/panels.rs` through the binary at both windows |
| `TERM=dumb` gets the ASCII rules back | `tests/panels.rs`, on a real pseudo-terminal (`Live::dumb`) |
| `NO_COLOR` moves no character | `tests/colour.rs`, unchanged in what it asserts |
| The probe is the terminal's word and never `NO_COLOR` | `tests/panels.rs`: `NO_COLOR` is set on the child and the glyphs are still drawn |
| The scan survives a glyph at either end | `crates/ank-cli/tests/tui.rs` |

## Citations

ADR-c07e2694f0e1 is cited as a **proposed** successor everywhere it is cited.
No citation of ADR-0b55983421dd was removed — that is TASK-fa9b436da1f4's job,
and it lands after this wave.

## Out-of-lane edits

Recorded as LOG-e053fa8299ba on the task. `tests/phone.rs` and
`tests/terminal/mod.rs` are assigned to no agent in this wave's division and the
glyph move reaches both mechanically: phone.rs counted `|` to find shared rows
and trimmed `|` to find a panel's content, and terminal/mod.rs hard-coded
`TERM=xterm-256color` for every session so a dumb-terminal suite had nowhere to
say so. Nothing in `ratify_line`, `App::actions`, the key consts, `keys.rs`,
`input.rs`, `body_over`, `body_lines`, `pane_rows` or `model.rs` was touched.

`cargo test --workspace` and `cargo fmt --check` green; `ank check` ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151gdEi8m5ZSUx2thD3H24L