### PR TITLE
The bindings are one table, and the reader reads it back

### DIFF
--- a/.ank/entities/LOG-3b0bc419c884.md
+++ b/.ank/entities/LOG-3b0bc419c884.md
@@ -1,0 +1,15 @@
+---
+id: LOG-3b0bc419c884
+type: log
+title: crates/ank-tui/tests/terminal/mod.rs is not safe to open two sessions from at once, and the defect
+created: 2026-08-26T18:37:14Z
+author: claude-code/opus-5+bindings
+scope:
+  - crates/ank-tui/**
+about: TASK-4d2eb2b4e193
+seq: 2
+schema: 4
+version: 1
+---
+
+ is pty::open's rather than any suite's. It calls posix_openpt and then ptsname(3), which answers out of a static buffer: two threads doing that together can read the same slave path, so both children attach to one terminal, whichever resize lands last wins, and the second session is a blank screen its own reader never sees. Tests in one binary run on threads, so this is reachable by any suite that opens two. It has been invisible until now because the existing suites open every session at the same window size, and a crossed path at the same size looks like a slow test rather than a wrong one. tests/bindings.rs opens one at 200x50 and one at 80x24 and tripped it under the load of a full workspace run: the wide test read an 80-column frame and the narrow one timed out on an empty one. Worked around locally with a mutex in tests/bindings.rs, because terminal/mod.rs is shared with the two suites landing beside this one in wave 18 and a change there would collide with them. The fix is ptsname_r on Linux and a lock around the four calls otherwise, in pty::open, once the wave has landed.

--- a/.ank/entities/LOG-f3a9a0fcf765.md
+++ b/.ank/entities/LOG-f3a9a0fcf765.md
@@ -1,0 +1,13 @@
+---
+id: LOG-f3a9a0fcf765
+type: log
+title: done, proof commit:c91b21fe6372c9ef7bb1b607decf6d6cd881e1b4
+created: 2026-08-26T18:40:56Z
+author: claude-code/opus-5+bindings
+scope:
+  - crates/ank-tui/**
+about: TASK-4d2eb2b4e193
+seq: 3
+schema: 4
+version: 1
+---

--- a/.ank/entities/TASK-4d2eb2b4e193.md
+++ b/.ank/entities/TASK-4d2eb2b4e193.md
@@ -5,7 +5,7 @@ slug: the-bindings-are-one-table-and-the-reader-reads
 title: The bindings are one table, and the reader reads it back
 created: 2026-08-26T17:07:10Z
 author: claude-code/opus-5+reader-redesign
-status: open
+status: in_progress
 scope:
   - crates/ank-tui/**
 blocked_by: []
@@ -13,7 +13,7 @@ done_criteria: |
   crates/ank-tui declares every binding of the reader once -- its key, its aliases, the command it runs, the word it is called by, the group it belongs to, what the screen must hold before it is offered at all, and the CLI verb it spells where it spells one -- and keys::typed, App::actions and the key list are all computed from it rather than written beside it. The list of verbs that may be spawned is NOT computed from it and stays written in ank.rs, measured against the table by a test that runs that dependency the other way round: a gate generated from the table it guards guards nothing. Every verb the table names resolves in ank_contract::verbs::COMMANDS and every flag it names to a FlagSpec of that command, and no field of the table may ever carry the value - , which the CLI reads as stdin and this reader's child does not have. Driven on a pseudo-terminal, the built binary answers ? with a list naming every binding the table declares and nothing it does not.
 criteria_by: creator
 schema: 4
-version: 3
+version: 5
 ---
 
 Seams found while designing, written here so the first holder does not pay for

--- a/.ank/entities/TASK-4d2eb2b4e193.md
+++ b/.ank/entities/TASK-4d2eb2b4e193.md
@@ -5,15 +5,20 @@ slug: the-bindings-are-one-table-and-the-reader-reads
 title: The bindings are one table, and the reader reads it back
 created: 2026-08-26T17:07:10Z
 author: claude-code/opus-5+reader-redesign
-status: in_progress
+status: done
 scope:
   - crates/ank-tui/**
 blocked_by: []
 done_criteria: |
   crates/ank-tui declares every binding of the reader once -- its key, its aliases, the command it runs, the word it is called by, the group it belongs to, what the screen must hold before it is offered at all, and the CLI verb it spells where it spells one -- and keys::typed, App::actions and the key list are all computed from it rather than written beside it. The list of verbs that may be spawned is NOT computed from it and stays written in ank.rs, measured against the table by a test that runs that dependency the other way round: a gate generated from the table it guards guards nothing. Every verb the table names resolves in ank_contract::verbs::COMMANDS and every flag it names to a FlagSpec of that command, and no field of the table may ever carry the value - , which the CLI reads as stdin and this reader's child does not have. Driven on a pseudo-terminal, the built binary answers ? with a list naming every binding the table declares and nothing it does not.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: c91b21fe6372c9ef7bb1b607decf6d6cd881e1b4
+    criteria: c54dbbf75b81
+    via: submitted
 schema: 4
-version: 5
+version: 6
 ---
 
 Seams found while designing, written here so the first holder does not pay for

--- a/crates/ank-tui/src/bindings.rs
+++ b/crates/ank-tui/src/bindings.rs
@@ -1,0 +1,1152 @@
+//! Every binding of the reader, declared once (ADR-c07e2694f0e1, proposed
+//! successor to ADR-0b55983421dd).
+//!
+//! **One table, and the surfaces are computed from it.** [`keys::typed`] reads
+//! a keystroke out of it, [`crate::view::App::actions`] draws the offer out of
+//! it, and [`listing`] is the key list `?` answers with. What was here before
+//! was five of those written beside each other -- a `match` in `keys.rs`, a
+//! `match` in `App::actions`, and three sentences in `view.rs` -- and the proof
+//! they could disagree was on the screen: the key list omitted `v`, Space,
+//! every arrow, the way out and the whole of the ring.
+//!
+//! # What a binding declares
+//!
+//! Its key and the other keys that reach it, the command it runs, the word it
+//! is called by, the group it belongs to, what the screen must hold before it
+//! is offered at all, and the CLI verb it spells where it spells one. Seven
+//! facts, in one place, because every one of them was previously stated
+//! somewhere a different surface could read a different answer.
+//!
+//! **The word is one word and it is used for both.** A target says `[c rules]`
+//! and the key list says `c rules`, and they are the same string rather than
+//! two spellings that happen to agree today.
+//!
+//! # What is deliberately not computed from this table
+//!
+//! **The spawn gate.** [`crate::ank::ACTS`] is the list of verbs this reader
+//! may run, it stays hand-written in `ank.rs`, and the dependency runs the
+//! other way round: every binding that writes is measured against the gate, and
+//! the gate reads nothing from here. A gate generated from the table it guards
+//! guards nothing -- adding a binding would widen it, silently, which is the
+//! failure the gate exists to make impossible.
+//!
+//! **The one chord.** Control-C is not in the table because it is not a
+//! command: raw mode has taken the line discipline's interrupt, and this is the
+//! way out of a program that took the terminal. `q` is the binding, and it
+//! reaches the same place with no modifier -- which is what
+//! ADR-0b55983421dd's "no command anywhere requires a modifier chord" asks for
+//! and what the table in `keys.rs` measures over every key there is.
+//!
+//! # What a verb may never be handed
+//!
+//! No field here may carry `-`. The CLI reads a lone dash as "the value is on
+//! stdin", and [`crate::ank::Ank::spawn`] gives every child `output()`'s null
+//! stdin -- so a dash reaching a composed argv would be a child waiting on a
+//! pipe that was never opened, for as long as the reader is up. Held by a test
+//! over every string field rather than by whoever writes the next row.
+
+use crate::input::Command;
+use crate::keys::{Press, ACT, CONFIRM, FIND};
+use crate::view::Focus;
+use ratatui::crossterm::event::KeyCode;
+
+/// One binding of the reader: a key, what it runs, and what it is called.
+#[derive(Debug, Clone)]
+pub struct Binding {
+    /// The key that runs it, where a key does.
+    ///
+    /// `None` for the writing half, which is still reached by spelling the verb
+    /// whole into the prompt (ADR-0b55983421dd) -- the asymmetry
+    /// TASK-1a415107fd56 spends. Nothing else about a verb's row changes when
+    /// its letter arrives, which is the point of declaring the row now.
+    pub key: Option<KeyCode>,
+    /// The other keys that reach the same thing.
+    ///
+    /// A named key beside every letter, because a person who has never read the
+    /// key line still has hands: Down for `j`, PageDown for `n`, Home for `g`,
+    /// Escape for `b`.
+    pub aliases: &'static [KeyCode],
+    /// What it runs.
+    pub runs: Runs,
+    /// The word it is called by, on a target and on the key list.
+    pub word: &'static str,
+    /// Which half of the reader it belongs to.
+    pub group: Group,
+    /// What the screen must hold before it is offered at all.
+    pub offered: Offered,
+    /// The CLI verb it spells, where it spells one.
+    pub verb: Option<Verb>,
+}
+
+/// What a binding runs.
+///
+/// Three of these are the focus arithmetic and cannot be a value: where `Tab`
+/// lands depends on where the reader already is. The rest are the commands
+/// themselves, held whole rather than named by a parallel enumeration nobody
+/// would keep in step.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Runs {
+    /// A press of the key table, the same wherever the reader is standing.
+    Press(Press),
+    /// The panel this many steps along the ring from the focused one.
+    Stepped(isize),
+    /// The panel next door, and nothing where it already has the focus: the
+    /// arrow that points at where you are is not a second way back, and `b` is.
+    Sideways(Focus),
+    /// The verb this binding spells, composed against the entity under the
+    /// cursor and shown for an answer (TASK-d4a882345837). Never spawned here.
+    Compose,
+    /// The command on the screen, run.
+    Run,
+    /// The command on the screen, dropped.
+    Dismiss,
+    /// The open line, read as a command.
+    Submit,
+    /// The open line, dropped.
+    Cancel,
+}
+
+/// Which half of the reader a binding belongs to.
+///
+/// The key list draws one line per group, and the groups are what makes those
+/// lines answerable at a glance: a person looking at the trailer needs to know
+/// whether they are about to move a screen or move a corpus, and one line
+/// mixing them would make that a matter of remembering.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Group {
+    /// Moves what is inside a panel.
+    Screen,
+    /// Moves which panel that is.
+    Panel,
+    /// Composes a verb that writes.
+    Write,
+    /// Answers what the reader is asking: a command waiting, or a line open.
+    Answer,
+}
+
+/// What the screen must hold before a binding is offered at all.
+///
+/// The offer is the short list the focused panel puts in front of a thumb, and
+/// it is shorter than the key table on purpose: the key list says what this
+/// reader *is*, and this says what there is to do *here*.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Offered {
+    /// Never drawn as a target. A key that works everywhere and is taught by
+    /// the key list rather than put in front of a finger -- movement above all,
+    /// since a tap already selects the row it lands on.
+    Never,
+    /// Every screen, whichever panel has the focus.
+    Anywhere,
+    /// Only where one of these panels has the focus.
+    Panels(&'static [Focus]),
+    /// Only over a command waiting to be answered, which is modal: nothing else
+    /// is what the rest of the keyboard does (TASK-d4a882345837).
+    Waiting,
+    /// Only over an open prompt, which is modal for the same reason.
+    Typing,
+    /// Only on a document `accept` would take: a proposal, open in the body
+    /// panel. A trailer that carried the word over every open entity would be
+    /// offering what the verb turns down.
+    Ratifiable,
+}
+
+/// The CLI verb a binding spells, and how the rest of a typed line becomes its
+/// arguments.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Verb {
+    /// The verb, as `ank` spells it. Held to `ank_contract::verbs::COMMANDS` by
+    /// a test, so a verb this reader offers is a verb the CLI has.
+    pub name: &'static str,
+    /// How the rest of the line reaches it.
+    pub tail: Tail,
+}
+
+/// How the rest of a typed line becomes a verb's arguments.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Tail {
+    /// Split into words, so flags can be typed: `claim --ttl 4h`,
+    /// `amend --scope "crates/ank tui/**"`. Empty is legitimate and the CLI
+    /// answers for what it needs.
+    Words,
+    /// The rest of the line whole, as one positional. `log <message>`, where
+    /// splitting on spaces would turn a sentence into twelve arguments.
+    ///
+    /// Required: `ank log <id>` with no message *reads* the log, which is a
+    /// different act than the one the word was typed for, and silently doing
+    /// the other one is the surprise this refuses instead.
+    Message,
+    /// The rest of the line whole, behind a flag: `done --proof <p>`,
+    /// `release --reason <r>`. Absent, the flag is not passed at all and the
+    /// CLI is left to answer for the missing one -- which is exactly the
+    /// refusal a person typing `done` on a task with no verifier needs to see.
+    ///
+    /// The flag is held to the verb's own [`ank_contract::verbs::FlagSpec`] by
+    /// a test: a form this reader offers is a form the CLI takes.
+    Behind(&'static str),
+    /// Nothing at all: the verb takes the identifier the view supplies and not
+    /// one byte more, and a line that carries a tail is refused rather than
+    /// trimmed.
+    ///
+    /// Refused and not ignored, because the two read identically on the screen
+    /// and only one of them is honest: somebody who typed `accept ADR-8bd7`
+    /// meant that identifier, and running the verb against whatever is open
+    /// while silently dropping what they wrote would be the reader choosing a
+    /// document for them. §4 gives `accept` no flags either, so there is
+    /// nothing a tail could legitimately be.
+    Nothing,
+}
+
+impl Tail {
+    /// What the key list shows after the verb, which is what a person has to
+    /// type.
+    ///
+    /// Read off the tail rather than written beside it, so a verb whose grammar
+    /// changes cannot go on advertising the old form.
+    pub fn form(self) -> String {
+        match self {
+            Tail::Words => " <flags>".to_string(),
+            Tail::Message => " <message>".to_string(),
+            Tail::Behind(flag) => format!(" <{}>", flag.trim_start_matches('-')),
+            Tail::Nothing => String::new(),
+        }
+    }
+}
+
+/// What the screen is holding, which is what decides the offer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Holding {
+    /// A composed command, waiting to be answered.
+    Waiting,
+    /// An open prompt.
+    Typing,
+    /// Neither, with this panel focused.
+    Panel(Focus),
+}
+
+/// The whole of what this reader answers to.
+///
+/// A `static` and not a `const`, and the difference is not stylistic: a `const`
+/// is inlined at every use site, so the table would be as many tables as there
+/// are readers of it and two rows for the same key could not be told apart by
+/// identity. "Declared once" is meant literally, and this is what makes it so.
+///
+/// **The order is the order the offer is drawn in**, which is why the movement
+/// keys come first and `q` comes last: the offer is this list filtered by what
+/// the screen is holding, so one order serves every panel rather than one order
+/// per panel. It is also the order the key list reads, and those two being the
+/// same order is not a coincidence to be maintained -- it is one list.
+pub static BINDINGS: &[Binding] = &[
+    // -----------------------------------------------------------------------
+    // What moves the screen (ADR-0b55983421dd: every one of them is one key)
+    // -----------------------------------------------------------------------
+    Binding {
+        key: Some(KeyCode::Char('j')),
+        aliases: &[KeyCode::Down],
+        runs: Runs::Press(Press::Run(Command::Move(1))),
+        word: "down",
+        group: Group::Screen,
+        offered: Offered::Never,
+        verb: None,
+    },
+    Binding {
+        key: Some(KeyCode::Char('k')),
+        aliases: &[KeyCode::Up],
+        runs: Runs::Press(Press::Run(Command::Move(-1))),
+        word: "up",
+        group: Group::Screen,
+        offered: Offered::Never,
+        verb: None,
+    },
+    Binding {
+        key: Some(KeyCode::Char('n')),
+        aliases: &[KeyCode::PageDown, KeyCode::Char(' ')],
+        runs: Runs::Press(Press::Run(Command::Page(1))),
+        word: "page",
+        group: Group::Screen,
+        // The body is the one panel with no rows to land on, so paging is the
+        // one movement worth a target there.
+        offered: Offered::Panels(&[Focus::Body]),
+        verb: None,
+    },
+    Binding {
+        key: Some(KeyCode::Char('p')),
+        aliases: &[KeyCode::PageUp],
+        runs: Runs::Press(Press::Run(Command::Page(-1))),
+        word: "page back",
+        group: Group::Screen,
+        offered: Offered::Never,
+        verb: None,
+    },
+    Binding {
+        key: Some(KeyCode::Char('g')),
+        aliases: &[KeyCode::Home],
+        runs: Runs::Press(Press::Run(Command::Top)),
+        word: "top",
+        group: Group::Screen,
+        offered: Offered::Never,
+        verb: None,
+    },
+    Binding {
+        key: Some(KeyCode::Enter),
+        aliases: &[],
+        runs: Runs::Press(Press::Run(Command::Open)),
+        word: "open",
+        group: Group::Screen,
+        offered: Offered::Panels(&[Focus::Claims, Focus::Entities, Focus::Queue]),
+        verb: None,
+    },
+    Binding {
+        key: Some(KeyCode::Char('c')),
+        aliases: &[],
+        runs: Runs::Press(Press::Run(Command::Constraints)),
+        word: "rules",
+        group: Group::Screen,
+        offered: Offered::Panels(&[Focus::Body]),
+        verb: None,
+    },
+    Binding {
+        key: Some(KeyCode::Char('b')),
+        aliases: &[KeyCode::Esc, KeyCode::Backspace],
+        runs: Runs::Press(Press::Run(Command::Back)),
+        word: "back",
+        group: Group::Screen,
+        offered: Offered::Panels(&[Focus::Body]),
+        verb: None,
+    },
+    Binding {
+        key: Some(KeyCode::Char(ACT)),
+        aliases: &[],
+        runs: Runs::Press(Press::Prompt("")),
+        word: "act",
+        group: Group::Screen,
+        offered: Offered::Anywhere,
+        verb: None,
+    },
+    Binding {
+        key: Some(KeyCode::Char('f')),
+        aliases: &[],
+        runs: Runs::Press(Press::Cycle),
+        word: "kind",
+        group: Group::Screen,
+        offered: Offered::Panels(&[Focus::Entities]),
+        verb: None,
+    },
+    Binding {
+        key: Some(KeyCode::Char(FIND)),
+        aliases: &[],
+        runs: Runs::Press(Press::Prompt("/")),
+        word: "find",
+        group: Group::Screen,
+        offered: Offered::Panels(&[Focus::Entities]),
+        verb: None,
+    },
+    Binding {
+        key: Some(KeyCode::Char('r')),
+        aliases: &[],
+        runs: Runs::Press(Press::Run(Command::Reload)),
+        word: "reload",
+        group: Group::Screen,
+        offered: Offered::Never,
+        verb: None,
+    },
+    Binding {
+        key: Some(KeyCode::Char('v')),
+        aliases: &[],
+        runs: Runs::Press(Press::Run(Command::Queue)),
+        word: "queue",
+        group: Group::Screen,
+        offered: Offered::Never,
+        verb: None,
+    },
+    Binding {
+        key: Some(KeyCode::Char('?')),
+        aliases: &[],
+        runs: Runs::Press(Press::Run(Command::Help)),
+        word: "keys",
+        group: Group::Screen,
+        offered: Offered::Never,
+        verb: None,
+    },
+    Binding {
+        key: Some(KeyCode::Char('q')),
+        aliases: &[],
+        runs: Runs::Press(Press::Run(Command::Quit)),
+        word: "quit",
+        group: Group::Screen,
+        offered: Offered::Anywhere,
+        verb: None,
+    },
+    // -----------------------------------------------------------------------
+    // What moves the focus (TASK-bb43cfe2192b): three ways to the same place
+    // -----------------------------------------------------------------------
+    // The ring, forward and back, and both of them declared as the panel they
+    // land on rather than as a step (TASK-dd9747e5e305). `BackTab` is what a
+    // terminal sends for Shift-Tab, and while it produced a step of its own it
+    // was the one command in this table that a bare key could not reach -- true
+    // only of the *value*, since a digit has always reached every panel, and
+    // false of anything a person could do. Naming the destination makes the two
+    // agree, so "no command requires a modifier" is a claim the whole table can
+    // be measured against instead of an argument about which steps are the same
+    // place.
+    Binding {
+        key: Some(KeyCode::Tab),
+        aliases: &[],
+        runs: Runs::Stepped(1),
+        word: "next panel",
+        group: Group::Panel,
+        offered: Offered::Never,
+        verb: None,
+    },
+    Binding {
+        key: Some(KeyCode::BackTab),
+        aliases: &[],
+        runs: Runs::Stepped(-1),
+        word: "previous panel",
+        group: Group::Panel,
+        offered: Offered::Never,
+        verb: None,
+    },
+    // A digit reaches its panel directly, which is what the number in a panel's
+    // title is for: a reader who can see `3` on the body never has to remember
+    // which key opens it. Four rows and not one rule, so the key list can name
+    // each of them by the panel it reaches.
+    Binding {
+        key: Some(KeyCode::Char('1')),
+        aliases: &[],
+        runs: Runs::Press(Press::Run(Command::Panel(Focus::Claims))),
+        word: "claims",
+        group: Group::Panel,
+        offered: Offered::Never,
+        verb: None,
+    },
+    Binding {
+        key: Some(KeyCode::Char('2')),
+        aliases: &[],
+        runs: Runs::Press(Press::Run(Command::Panel(Focus::Entities))),
+        word: "entities",
+        group: Group::Panel,
+        offered: Offered::Never,
+        verb: None,
+    },
+    Binding {
+        key: Some(KeyCode::Char('3')),
+        aliases: &[],
+        runs: Runs::Press(Press::Run(Command::Panel(Focus::Body))),
+        word: "body",
+        group: Group::Panel,
+        offered: Offered::Never,
+        verb: None,
+    },
+    Binding {
+        key: Some(KeyCode::Char('4')),
+        aliases: &[],
+        runs: Runs::Press(Press::Run(Command::Panel(Focus::Queue))),
+        word: "queue",
+        group: Group::Panel,
+        offered: Offered::Never,
+        verb: None,
+    },
+    // Left and Right reach the pair that shares a row, which is the only place
+    // on this screen where sideways means anything: a phone's arrow cluster is
+    // how a person who never read the key line moves, and going *into* what a
+    // row names is what Right means everywhere else. They are the one pair of
+    // keys that had to change meaning for panels, and `b` and Escape still go
+    // back -- which is why the arrow pointing at the panel already focused
+    // reaches nothing rather than becoming a second way out.
+    Binding {
+        key: Some(KeyCode::Right),
+        aliases: &[],
+        runs: Runs::Sideways(Focus::Body),
+        word: "body",
+        group: Group::Panel,
+        offered: Offered::Never,
+        verb: None,
+    },
+    Binding {
+        key: Some(KeyCode::Left),
+        aliases: &[],
+        runs: Runs::Sideways(Focus::Entities),
+        word: "entities",
+        group: Group::Panel,
+        offered: Offered::Never,
+        verb: None,
+    },
+    // -----------------------------------------------------------------------
+    // What moves the corpus. No key yet: the verb is spelled whole into the
+    // prompt `a` opens, and TASK-1a415107fd56 is what gives these their
+    // letters. Every other field of the row is already true of them.
+    // -----------------------------------------------------------------------
+    Binding {
+        key: None,
+        aliases: &[],
+        runs: Runs::Compose,
+        word: "claim",
+        group: Group::Write,
+        offered: Offered::Anywhere,
+        verb: Some(Verb {
+            name: "claim",
+            tail: Tail::Words,
+        }),
+    },
+    Binding {
+        key: None,
+        aliases: &[],
+        runs: Runs::Compose,
+        word: "log",
+        group: Group::Write,
+        offered: Offered::Anywhere,
+        verb: Some(Verb {
+            name: "log",
+            tail: Tail::Message,
+        }),
+    },
+    Binding {
+        key: None,
+        aliases: &[],
+        runs: Runs::Compose,
+        word: "release",
+        group: Group::Write,
+        offered: Offered::Anywhere,
+        verb: Some(Verb {
+            name: "release",
+            tail: Tail::Behind("--reason"),
+        }),
+    },
+    Binding {
+        key: None,
+        aliases: &[],
+        runs: Runs::Compose,
+        word: "done",
+        group: Group::Write,
+        offered: Offered::Anywhere,
+        verb: Some(Verb {
+            name: "done",
+            tail: Tail::Behind("--proof"),
+        }),
+    },
+    Binding {
+        key: None,
+        aliases: &[],
+        runs: Runs::Compose,
+        word: "amend",
+        group: Group::Write,
+        offered: Offered::Anywhere,
+        verb: Some(Verb {
+            name: "amend",
+            tail: Tail::Words,
+        }),
+    },
+    Binding {
+        key: None,
+        aliases: &[],
+        runs: Runs::Compose,
+        word: "accept",
+        group: Group::Write,
+        // The one act gated on what the screen is holding rather than on which
+        // panel it is (TASK-d90e94afca08): `accept` refuses a task and refuses
+        // a document already accepted, so the offer is drawn where the verb
+        // would take it and nowhere else.
+        offered: Offered::Ratifiable,
+        verb: Some(Verb {
+            name: "accept",
+            tail: Tail::Nothing,
+        }),
+    },
+    // -----------------------------------------------------------------------
+    // What answers the reader (TASK-d4a882345837). Both states are modal, and
+    // both grammars are stated over the whole keyboard in `keys.rs`: these two
+    // rows are the keys the screen *offers*, not the whole of what it reads.
+    // -----------------------------------------------------------------------
+    Binding {
+        key: Some(KeyCode::Char(CONFIRM)),
+        aliases: &[],
+        runs: Runs::Run,
+        word: "run",
+        group: Group::Answer,
+        offered: Offered::Waiting,
+        verb: None,
+    },
+    Binding {
+        key: Some(KeyCode::Esc),
+        aliases: &[],
+        runs: Runs::Dismiss,
+        word: "dismiss",
+        group: Group::Answer,
+        offered: Offered::Waiting,
+        verb: None,
+    },
+    Binding {
+        key: Some(KeyCode::Enter),
+        aliases: &[],
+        runs: Runs::Submit,
+        word: "run",
+        group: Group::Answer,
+        offered: Offered::Typing,
+        verb: None,
+    },
+    Binding {
+        key: Some(KeyCode::Esc),
+        aliases: &[],
+        runs: Runs::Cancel,
+        word: "cancel",
+        group: Group::Answer,
+        offered: Offered::Typing,
+        verb: None,
+    },
+];
+
+impl Binding {
+    /// Whether this key reaches this binding, by its own letter or by an alias.
+    pub fn answers(&self, code: KeyCode) -> bool {
+        self.key == Some(code) || self.aliases.contains(&code)
+    }
+
+    /// What pressing it asks for, once the focused panel is known.
+    ///
+    /// The focus is consulted by three rows and no others: the ring, which is
+    /// relative by nature, and the two arrows that cross between the columns,
+    /// which do nothing where they point at the panel already focused.
+    pub fn press(&self, focus: Focus) -> Press {
+        match &self.runs {
+            Runs::Press(press) => press.clone(),
+            Runs::Stepped(by) => Press::Run(Command::Panel(focus.stepped(*by))),
+            Runs::Sideways(to) if focus != *to => Press::Run(Command::Panel(*to)),
+            // The writing half has no key yet, and the two modal grammars are
+            // read by `confirming` and `edit` rather than from here.
+            _ => Press::Ignored,
+        }
+    }
+
+    /// Whether the screen holding this offers it as a target.
+    ///
+    /// A binding with no key is never a target, whatever it is offered on: a
+    /// word a finger can touch and no key to press would be an offer only half
+    /// the reader can take. That is what makes the six verbs' rows honest
+    /// today and what makes them targets on the day TASK-1a415107fd56 gives
+    /// them their letters, with nothing else here changing.
+    pub fn is_offered(&self, holding: Holding) -> bool {
+        if self.key.is_none() {
+            return false;
+        }
+        match (self.offered, holding) {
+            (Offered::Waiting, Holding::Waiting) => true,
+            (Offered::Typing, Holding::Typing) => true,
+            (Offered::Anywhere, Holding::Panel(_)) => true,
+            (Offered::Panels(panels), Holding::Panel(focus)) => panels.contains(&focus),
+            // The ratification offer is the line the trailer draws over a
+            // proposal, and it is drawn by `App::ratify_line`.
+            _ => false,
+        }
+    }
+
+    /// Every key that reaches it, as the key list spells them.
+    pub fn spelling(&self) -> String {
+        self.key
+            .into_iter()
+            .chain(self.aliases.iter().copied())
+            .map(named)
+            .collect::<Vec<String>>()
+            .join("/")
+    }
+
+    /// One entry of the key list: the keys that reach it, then what it does.
+    ///
+    /// A verb says its own name and the form a person has to type after it,
+    /// because that *is* what it does -- and a key that only moves the screen
+    /// says the word it is called by. Where a verb has a key, it carries both,
+    /// which is the shape TASK-1a415107fd56 arrives into rather than one this
+    /// has to be taught then.
+    pub fn entry(&self) -> String {
+        let does = match self.verb {
+            Some(verb) => format!("{}{}", verb.name, verb.tail.form()),
+            None => self.word.to_string(),
+        };
+        match self.key {
+            Some(_) => format!("{} {does}", self.spelling()),
+            // The writing half has no key yet: it is spelled whole into the
+            // prompt, and the word is the whole of what there is to know.
+            None => does,
+        }
+    }
+}
+
+/// The binding a key reaches, or `None` where the key reaches none.
+///
+/// Only the two groups a key press answers are searched. The writing half has
+/// no key, and the two modal grammars are the confirmation's and the prompt's
+/// -- so an `Esc` here is the one that goes back, and never the one that
+/// dismisses a command that is not on the screen.
+pub fn of_key(code: KeyCode) -> Option<&'static Binding> {
+    BINDINGS
+        .iter()
+        .filter(|b| matches!(b.group, Group::Screen | Group::Panel))
+        .find(|b| b.answers(code))
+}
+
+/// The binding that spells this verb, or `None` where none does.
+pub fn of_verb(name: &str) -> Option<&'static Binding> {
+    BINDINGS
+        .iter()
+        .find(|b| b.verb.is_some_and(|v| v.name == name))
+}
+
+/// What the screen holding this offers, in the order it is drawn.
+pub fn offered(holding: Holding) -> impl Iterator<Item = &'static Binding> {
+    BINDINGS.iter().filter(move |b| b.is_offered(holding))
+}
+
+/// What a key is called on the screen.
+///
+/// The character itself where there is one, so the offer and the mapping are
+/// the same letter rather than two spellings of it, and the terminal's own name
+/// otherwise. Space is the one character with a name instead: a key list with a
+/// bare blank in it names nothing a person can read.
+pub fn named(key: KeyCode) -> String {
+    match key {
+        KeyCode::Char(' ') => "Space".to_string(),
+        KeyCode::Char(c) => c.to_string(),
+        KeyCode::Enter => "Enter".to_string(),
+        KeyCode::Esc => "Esc".to_string(),
+        other => format!("{other:?}"),
+    }
+}
+
+/// What the key list says after the ring, about the ring.
+const PANEL_NOTE: &str = "   (the marked panel is the one keys reach)";
+/// What it says after the five, about where they land and what runs them.
+const WRITE_NOTE: &str = "   (the marked panel's entity, then";
+/// What it says after `accept`, which is a different kind of offer: the other
+/// five move a corpus, and this one asks a person for a signature ank has no
+/// way to produce.
+const RATIFY_NOTE: &str =
+    "   (this document, on the default branch -- ank signs nothing, your key does)";
+/// What it says after the confirmation's two keys.
+///
+/// "every other key" and not "these two", because that is the grammar: one key
+/// runs and the whole of the rest of the keyboard declines. The pair is what
+/// the screen *offers*; the sentence is what it does.
+const WAITING_NOTE: &str = "   (over a command waiting -- every other key dismisses it too)";
+/// What it says after the prompt's two.
+const TYPING_NOTE: &str = "   (over a line being typed)";
+
+/// One line of the key list: the bindings it names, and how they are drawn.
+///
+/// **A line is a list of rows and never a sentence with keys in it.** That is
+/// what lets the whole list be held to the table -- every binding is on exactly
+/// one line, and a line names nothing that is not a binding -- which is the
+/// claim ADR-c07e2694f0e1 found the old trailer failing.
+struct Line {
+    /// The rows it names, in the table's order.
+    bindings: Vec<&'static Binding>,
+    /// What is drawn in front of them.
+    lead: String,
+    /// What goes between them.
+    between: &'static str,
+    /// The sentence after them, which is prose about the table and never part
+    /// of it.
+    note: String,
+}
+
+impl Line {
+    fn drawn(&self) -> String {
+        let entries: Vec<String> = self.bindings.iter().map(|b| b.entry()).collect();
+        format!("{}{}{}", self.lead, entries.join(self.between), self.note)
+    }
+}
+
+/// The keys that move what is inside a panel.
+fn screen() -> Line {
+    Line {
+        bindings: of_group(Group::Screen),
+        lead: String::new(),
+        between: "  ",
+        note: String::new(),
+    }
+}
+
+/// The keys that move which panel that is, on a line of their own.
+///
+/// Separate because they are a different kind of command: the line above moves
+/// what is inside a panel, and this one moves which panel that is. A person who
+/// has lost track of where they are needs the second line and not the first.
+fn panel() -> Line {
+    Line {
+        bindings: of_group(Group::Panel),
+        lead: String::new(),
+        between: "  ",
+        note: PANEL_NOTE.to_string(),
+    }
+}
+
+/// The writing half, spelled whole.
+///
+/// Separate from the two above because it is a different kind of offer: those
+/// keys move a screen, and these move the corpus. A person reading the trailer
+/// should be able to see at a glance which of the two they are about to do,
+/// and one line mixing them would make that a matter of remembering.
+fn write() -> Line {
+    Line {
+        bindings: writing(|offered| offered != Offered::Ratifiable),
+        lead: format!("{} then  ", named(KeyCode::Char(ACT))),
+        between: " | ",
+        note: format!("{WRITE_NOTE} {})", named(KeyCode::Char(CONFIRM))),
+    }
+}
+
+/// The sixth act, on a line of its own, and only where the verb would take it.
+fn ratify() -> Line {
+    Line {
+        bindings: writing(|offered| offered == Offered::Ratifiable),
+        lead: format!("{} then  ", named(KeyCode::Char(ACT))),
+        between: " | ",
+        note: RATIFY_NOTE.to_string(),
+    }
+}
+
+/// What a command waiting to be answered offers.
+fn waiting() -> Line {
+    Line {
+        bindings: answering(Offered::Waiting),
+        lead: String::new(),
+        between: "  ",
+        note: WAITING_NOTE.to_string(),
+    }
+}
+
+/// What an open prompt offers.
+fn typing() -> Line {
+    Line {
+        bindings: answering(Offered::Typing),
+        lead: String::new(),
+        between: "  ",
+        note: TYPING_NOTE.to_string(),
+    }
+}
+
+/// The key list, line by line.
+///
+/// **Every binding of the table is on exactly one of these, and nothing else
+/// is** -- which is the property `?` is answerable for and the test below
+/// measures. Six lines because there are six kinds of offer, and the two modal
+/// ones are named rather than left to be discovered: a person who has a command
+/// waiting on the screen cannot press `?` to find out what answers it.
+fn lines() -> Vec<Line> {
+    vec![screen(), panel(), write(), ratify(), waiting(), typing()]
+}
+
+/// The keys that move what is inside a panel, as the trailer draws them.
+pub fn screen_line() -> String {
+    screen().drawn()
+}
+
+/// The writing half, as the trailer draws it.
+pub fn write_line() -> String {
+    write().drawn()
+}
+
+/// The ratification offer, as the trailer draws it over a proposal.
+pub fn ratify_line() -> String {
+    ratify().drawn()
+}
+
+/// The key list: every binding this table declares, and nothing it does not.
+///
+/// What `?` answers with, and what TASK-8a6578851244 turns into an overlay
+/// whose every line is a target. Generated from the rows above, so the list
+/// cannot go on naming a key that moved or leave out one that arrived -- which
+/// is the whole of what this table is for.
+pub fn listing() -> Vec<String> {
+    lines().iter().map(Line::drawn).collect()
+}
+
+/// Every binding of a group, in the table's order.
+fn of_group(group: Group) -> Vec<&'static Binding> {
+    BINDINGS.iter().filter(|b| b.group == group).collect()
+}
+
+/// The verbs of the writing half whose offer this line carries.
+fn writing(wanted: fn(Offered) -> bool) -> Vec<&'static Binding> {
+    BINDINGS
+        .iter()
+        .filter(|b| b.group == Group::Write && wanted(b.offered))
+        .collect()
+}
+
+/// The keys one of the two modal states offers.
+fn answering(state: Offered) -> Vec<&'static Binding> {
+    BINDINGS
+        .iter()
+        .filter(|b| b.group == Group::Answer && b.offered == state)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ank_contract::verbs;
+
+    /// **Every verb the table names is a verb the CLI has, and every flag it
+    /// names is that verb's own** (TASK-4d2eb2b4e193).
+    ///
+    /// The contract's table and not this crate's memory of it: what the reader
+    /// offers is what a person would type at the shell, and a form that had
+    /// drifted would be this reader teaching a command line the binary refuses.
+    /// `find_flag` is deliberately not used -- it also answers for the global
+    /// flags, and a verb's form has to be the verb's.
+    #[test]
+    fn every_verb_the_table_names_resolves_and_every_flag_is_that_verbs_own() {
+        let mut named = 0;
+        for binding in BINDINGS {
+            let Some(verb) = binding.verb else { continue };
+            named += 1;
+            let spec = verbs::spec_of(verb.name)
+                .unwrap_or_else(|| panic!("'{}' is no verb of the contract", verb.name));
+            if let Tail::Behind(flag) = verb.tail {
+                assert!(
+                    spec.flags.iter().any(|f| f.name == flag),
+                    "'{flag}' is no flag of 'ank {}'",
+                    verb.name
+                );
+            }
+        }
+        assert_eq!(named, 6, "the writing half is six verbs");
+    }
+
+    /// **The gate is measured against the table and never generated from it**
+    /// (TASK-4d2eb2b4e193, ADR-c07e2694f0e1).
+    ///
+    /// The dependency runs this way round on purpose. If `ank.rs` built its
+    /// list from the rows above, a row added here would widen what this reader
+    /// may spawn, silently, and the gate would be guarding the thing it is
+    /// derived from -- which is not a gate. So the rows are held to the
+    /// hand-written list, both ways so a verb added to either alone fails, and
+    /// the third assertion is the one that keeps it honest: `ank.rs` reads
+    /// nothing from here.
+    #[test]
+    fn every_binding_that_writes_is_in_the_gate_and_the_gate_reads_nothing_from_here() {
+        let spelled: Vec<&str> = BINDINGS
+            .iter()
+            .filter(|b| b.group == Group::Write)
+            .map(|b| b.verb.expect("a verb of the writing half").name)
+            .collect();
+        for verb in &spelled {
+            assert!(
+                crate::ank::ACTS.contains(verb),
+                "'{verb}' is offered and the gate would refuse it"
+            );
+        }
+        for verb in crate::ank::ACTS {
+            assert!(
+                of_verb(verb).is_some(),
+                "'{verb}' may be spawned and no binding spells it"
+            );
+        }
+        let gate = include_str!("ank.rs");
+        for read in ["crate::bindings", "BINDINGS", "bindings::"] {
+            assert!(
+                !gate.contains(read),
+                "ank.rs names {read}: a gate built from the table it guards \
+                 guards nothing"
+            );
+        }
+    }
+
+    /// **No field of the table carries `-`** (TASK-4d2eb2b4e193).
+    ///
+    /// The CLI reads a lone dash as "the value is on stdin", and this reader's
+    /// child has no stdin: `Ank::spawn` gives it `output()`'s null pipe. A dash
+    /// composed into an argv would therefore be a child waiting forever on
+    /// something nothing will ever write, and the reader waiting with it.
+    ///
+    /// Over every string a row carries rather than over the ones that look
+    /// risky, because the field that gets it wrong will be the one added next.
+    #[test]
+    fn no_field_of_the_table_is_the_dash_the_cli_reads_as_stdin() {
+        for binding in BINDINGS {
+            let mut fields = vec![binding.word];
+            if let Some(verb) = binding.verb {
+                fields.push(verb.name);
+                if let Tail::Behind(flag) = verb.tail {
+                    fields.push(flag);
+                }
+            }
+            if let Runs::Press(Press::Prompt(seed)) = &binding.runs {
+                fields.push(seed);
+            }
+            for field in fields {
+                assert_ne!(
+                    field, "-",
+                    "a field of the {} binding is the dash the CLI reads as stdin",
+                    binding.word
+                );
+            }
+        }
+    }
+
+    /// **The key list names every binding the table declares, and nothing it
+    /// does not** (TASK-4d2eb2b4e193).
+    ///
+    /// Both halves, because either alone is half a claim. A list that omitted
+    /// `v` is what ADR-c07e2694f0e1 was written against -- the reader's own
+    /// trailer taught a vocabulary the reader did not have -- and a list
+    /// carrying a key nobody bound would be worse: it reads as an offer and
+    /// behaves as nothing.
+    ///
+    /// Measured over the rows each line names rather than over the drawn text,
+    /// which is what makes "and nothing it does not" checkable at all: a
+    /// sentence about the table would otherwise be indistinguishable from an
+    /// entry of it, and the notes are sentences.
+    #[test]
+    fn the_key_list_names_every_binding_and_nothing_else() {
+        let named: Vec<&Binding> = lines().into_iter().flat_map(|l| l.bindings).collect();
+        assert_eq!(
+            named.len(),
+            BINDINGS.len(),
+            "the key list names {} of {} bindings",
+            named.len(),
+            BINDINGS.len()
+        );
+        for binding in BINDINGS {
+            assert!(
+                named.iter().any(|on| std::ptr::eq(*on, binding)),
+                "no line of the key list names '{}'",
+                binding.entry()
+            );
+        }
+        // And no entry is drawn twice. Two rows reading the same thing would be
+        // a list a person cannot act on: one of them is a key that does
+        // something else, and nothing on the screen says which.
+        let mut seen: Vec<String> = Vec::new();
+        for binding in BINDINGS {
+            let entry = binding.entry();
+            assert!(!seen.contains(&entry), "'{entry}' is on the key list twice");
+            seen.push(entry);
+        }
+        // And every entry it names is drawn, whole, on the line that names it:
+        // a row counted here and cut out of the rendering would pass the two
+        // assertions above and teach nothing.
+        for line in lines() {
+            let drawn = line.drawn();
+            for binding in line.bindings {
+                assert!(
+                    drawn.contains(&binding.entry()),
+                    "'{}' is counted on a line that does not draw it:\n{drawn}",
+                    binding.entry()
+                );
+            }
+        }
+    }
+
+    /// **The two modal grammars answer the keys the table offers**
+    /// (TASK-4d2eb2b4e193).
+    ///
+    /// [`crate::keys::confirming`] and [`crate::keys::edit`] are stated over
+    /// the whole keyboard rather than over a list -- one key runs and every
+    /// other one declines, which is a claim about every keystroke there is --
+    /// so they are not generated from rows and must not be. What *can* be held
+    /// to the rows is the key each of them answers to, and it has to be: a
+    /// screen offering `[y run]` over a confirmation that `confirming` does not
+    /// answer would be a target that reads as an offer and behaves as nothing.
+    #[test]
+    fn the_modal_grammars_answer_the_keys_the_table_offers() {
+        use crate::keys::{confirming, edit, Answer, Editing};
+        use ratatui::crossterm::event::{KeyEvent, KeyModifiers};
+
+        let bare = |code: KeyCode| KeyEvent::new(code, KeyModifiers::NONE);
+        let mut answered = 0;
+        for binding in BINDINGS.iter().filter(|b| b.group == Group::Answer) {
+            let key = bare(binding.key.expect("a key the screen offers"));
+            answered += 1;
+            match binding.runs {
+                Runs::Run => assert_eq!(confirming(key), Answer::Run, "{binding:?}"),
+                Runs::Dismiss => assert_eq!(confirming(key), Answer::Dismiss, "{binding:?}"),
+                Runs::Submit => {
+                    let mut line = String::from("done commit:2d9c847");
+                    assert_eq!(edit(&mut line, key), Editing::Submit, "{binding:?}");
+                }
+                Runs::Cancel => {
+                    let mut line = String::from("done commit:2d9c847");
+                    assert_eq!(edit(&mut line, key), Editing::Cancel, "{binding:?}");
+                }
+                ref other => panic!("{other:?} is not something a modal state answers with"),
+            }
+        }
+        assert_eq!(answered, 4, "two states, two keys each");
+    }
+
+    /// A digit reaches the panel whose title carries it, and the table and
+    /// [`Focus::of_digit`] are the same fact.
+    #[test]
+    fn the_digits_of_the_table_are_the_digits_the_panels_carry() {
+        for panel in Focus::ALL {
+            let digit = char::from_digit(panel.number() as u32, 10).expect("a digit");
+            let binding = of_key(KeyCode::Char(digit)).expect("a digit reaches a panel");
+            assert_eq!(
+                binding.press(Focus::Entities),
+                Press::Run(Command::Panel(panel)),
+                "'{digit}'"
+            );
+            assert_eq!(Focus::of_digit(digit), Some(panel));
+        }
+        // A digit no panel carries reaches nothing.
+        for c in ['0', '5', '9'] {
+            assert!(of_key(KeyCode::Char(c)).is_none(), "'{c}'");
+        }
+    }
+
+    /// No key reaches two bindings of the key table.
+    ///
+    /// [`of_key`] answers with the first row that claims a key, so a second row
+    /// claiming one would be a binding nothing can reach -- an entry on the key
+    /// list that does nothing, which is exactly the drift this table exists to
+    /// end.
+    #[test]
+    fn no_key_of_the_table_is_claimed_twice() {
+        let mut claimed: Vec<KeyCode> = Vec::new();
+        for binding in BINDINGS
+            .iter()
+            .filter(|b| matches!(b.group, Group::Screen | Group::Panel))
+        {
+            for key in binding
+                .key
+                .into_iter()
+                .chain(binding.aliases.iter().copied())
+            {
+                assert!(
+                    !claimed.contains(&key),
+                    "{key:?} is claimed twice, and the second is unreachable"
+                );
+                claimed.push(key);
+            }
+        }
+    }
+
+    /// **A key that writes runs a verb this reader may spawn, and composes it**
+    /// (TASK-4d2eb2b4e193, replacing `keys::no_bare_key_can_write`).
+    ///
+    /// The old invariant was that no key could produce a [`Command::Act`] at
+    /// all, and it was worth having because reaching a verb took a key *and* a
+    /// word: a slipped finger typed nothing. That asymmetry is what this wave
+    /// spends. What survives is narrower and still sufficient -- a key that
+    /// composes an act composes one of the six the gate allows, and an act is
+    /// [`crate::view::App::propose`]'s to show rather than [`crate::ank::Ank::act`]'s
+    /// to run. `tests/dependencies.rs` holds the second half of that, over the
+    /// crate's whole source.
+    #[test]
+    fn a_key_that_writes_composes_a_verb_the_gate_allows() {
+        for focus in Focus::ALL {
+            for binding in BINDINGS {
+                let Press::Run(Command::Act(act)) = binding.press(focus) else {
+                    continue;
+                };
+                let verb = binding.verb.expect("a binding that acts spells a verb");
+                assert_eq!(act.verb, verb.name);
+                assert!(
+                    crate::ank::ACTS.contains(&act.verb),
+                    "'{}' composes a verb the gate refuses",
+                    act.verb
+                );
+            }
+        }
+    }
+}

--- a/crates/ank-tui/src/input.rs
+++ b/crates/ank-tui/src/input.rs
@@ -42,6 +42,7 @@
 //! -- and the focused panel is the one the screen has marked, so the document a
 //! ratification lands on is the one under the reader's eyes.
 
+use crate::bindings::{self, Tail, Verb};
 use crate::view::Focus;
 
 /// What a typed line asks for.
@@ -117,51 +118,21 @@ pub struct Act {
     pub args: Vec<String>,
 }
 
-/// How the rest of a typed line becomes a verb's arguments.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Tail {
-    /// Split into words, so flags can be typed: `claim --ttl 4h`,
-    /// `amend --scope "crates/ank tui/**"`. Empty is legitimate and the CLI
-    /// answers for what it needs.
-    Words,
-    /// The rest of the line whole, as one positional. `log <message>`, where
-    /// splitting on spaces would turn a sentence into twelve arguments.
-    ///
-    /// Required: `ank log <id>` with no message *reads* the log, which is a
-    /// different act than the one the word was typed for, and silently doing
-    /// the other one is the surprise this refuses instead.
-    Message,
-    /// The rest of the line whole, behind a flag: `done --proof <p>`,
-    /// `release --reason <r>`. Absent, the flag is not passed at all and the
-    /// CLI is left to answer for the missing one -- which is exactly the
-    /// refusal a person typing `done` on a task with no verifier needs to see.
-    Behind(&'static str),
-    /// Nothing at all: the verb takes the identifier the view supplies and not
-    /// one byte more, and a line that carries a tail is refused rather than
-    /// trimmed.
-    ///
-    /// Refused and not ignored, because the two read identically on the screen
-    /// and only one of them is honest: somebody who typed `accept ADR-8bd7`
-    /// meant that identifier, and running the verb against whatever is open
-    /// while silently dropping what they wrote would be the reader choosing a
-    /// document for them. §4 gives `accept` no flags either, so there is
-    /// nothing a tail could legitimately be.
-    Nothing,
-}
-
 /// The writing half of the loop, and how each verb reads a line.
 ///
-/// The verbs here are [`crate::ank::ACTS`], and `ank.rs` refuses anything else
-/// before spawning; the test below holds the two lists to each other, so a verb
-/// added to one and forgotten in the other fails rather than half-works.
-const ACTS: &[(&str, Tail)] = &[
-    ("claim", Tail::Words),
-    ("log", Tail::Message),
-    ("release", Tail::Behind("--reason")),
-    ("done", Tail::Behind("--proof")),
-    ("amend", Tail::Words),
-    ("accept", Tail::Nothing),
-];
+/// **Not a list any more** (TASK-4d2eb2b4e193). The six verbs, their tails and
+/// the flags they spell are rows of [`crate::bindings::BINDINGS`], which is
+/// also where the keys and the key list are read from; this module looks a word
+/// up there rather than carrying a second copy of it. What used to be here was
+/// one of the five parallel tables ADR-c07e2694f0e1, proposed, was written
+/// against.
+///
+/// [`crate::ank::ACTS`] still gates the spawn and is still hand-written, and
+/// the dependency runs the other way: the bindings are measured against the
+/// gate, and the gate reads nothing from them.
+fn spelled(word: &str) -> Option<Verb> {
+    bindings::of_verb(word).and_then(|binding| binding.verb)
+}
 
 pub fn parse(line: &str, focus: Focus) -> Command {
     let line = line.trim();
@@ -193,8 +164,8 @@ pub fn parse(line: &str, focus: Focus) -> Command {
         "v" | "queue" => Command::Queue,
         "n" | "next" => Command::Page(1),
         "p" | "prev" => Command::Page(-1),
-        _ => match ACTS.iter().find(|(name, _)| *name == word) {
-            Some((verb, tail)) => act(verb, *tail, rest, focus),
+        _ => match spelled(word) {
+            Some(verb) => act(verb.name, verb.tail, rest, focus),
             None => repeated(word).unwrap_or_else(|| other(line)),
         },
     }
@@ -531,12 +502,31 @@ mod tests {
         }
     }
 
-    /// The two lists are one list, kept in two places for two jobs: this one
-    /// reads a line, `ank.rs`'s gates a spawn. They must name the same verbs.
+    /// Every verb the gate allows is a word this grammar reads, and the reverse
+    /// (TASK-4d2eb2b4e193).
+    ///
+    /// The list itself moved to [`crate::bindings`], where the keys and the key
+    /// list are read from too, and `crate::bindings` is where it is held to
+    /// `ank.rs`'s gate. What is left to say here is the thing this module is
+    /// answerable for: a line naming one of the six reaches an act rather than
+    /// falling through to [`Command::Unknown`], so the two surfaces spell the
+    /// same six words.
     #[test]
-    fn the_grammar_and_the_gate_name_the_same_verbs() {
-        let mine: Vec<&str> = ACTS.iter().map(|(name, _)| *name).collect();
-        assert_eq!(mine, crate::ank::ACTS.to_vec());
+    fn the_grammar_reads_every_verb_the_gate_allows() {
+        for verb in crate::ank::ACTS {
+            assert!(
+                spelled(verb).is_some(),
+                "'{verb}' may be spawned and this grammar does not read it"
+            );
+        }
+        for binding in crate::bindings::BINDINGS {
+            let Some(spelt) = binding.verb else { continue };
+            assert!(
+                crate::ank::ACTS.contains(&spelt.name),
+                "'{}' is read here and the gate would refuse it",
+                spelt.name
+            );
+        }
     }
 
     #[test]

--- a/crates/ank-tui/src/keys.rs
+++ b/crates/ank-tui/src/keys.rs
@@ -1,6 +1,14 @@
 //! One key per command, and the one place a line is still typed
 //! (ADR-0b55983421dd).
 //!
+//! **The keys themselves are declared in [`crate::bindings`] and not here**
+//! (TASK-4d2eb2b4e193). What this module is now is the two grammars a table
+//! cannot state -- the modifiers, and what a line editor does with a keystroke
+//! -- and the whole-domain suite at the foot of the file that measures the
+//! table over every key a terminal can report. The prose below says what the
+//! table says and is answerable to it, not the other way round: a key named
+//! here that no row declares fails the suite in `bindings.rs`.
+//!
 //! **Every command that only moves the screen is a key.** `j` and `k` move, `n`
 //! and `p` page, `g` goes to the top, Enter opens, `b` goes back, `c` shows the
 //! constraints, `v` opens the queue, `r` reads the corpus again, `f` narrows to
@@ -54,6 +62,7 @@
 //! the line a moment earlier, and a confirmation answered by the same key that
 //! opened it is a confirmation a repeated keypress walks straight through.
 
+use crate::bindings;
 use crate::input::Command;
 use crate::view::Focus;
 use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
@@ -109,58 +118,35 @@ pub fn confirming(key: KeyEvent) -> Answer {
     }
 }
 
+/// What one key asks for, read out of [`crate::bindings::BINDINGS`].
+///
+/// **The mapping is a lookup and no longer a `match`** (TASK-4d2eb2b4e193).
+/// What was here was one arm per key, written beside three other renderings of
+/// the same list, and ADR-c07e2694f0e1 -- proposed, and the successor this
+/// wave is built on -- records what that cost: a key list that
+/// omitted `v`, Space, every arrow and the whole of the ring. The table is now
+/// the single declaration and this reads it, so a key that moves moves on every
+/// surface at once.
+///
+/// The modifiers are read exactly where they were: Control alone, and the only
+/// thing it reaches is the way out. Every other way of holding a key is
+/// transparent, because the lookup is on the code -- which is what the table at
+/// the foot of this file measures over every key a terminal can report.
 pub fn typed(key: KeyEvent, focus: Focus) -> Press {
     // The one chord, and it is the way out rather than a command: raw mode has
     // taken the line discipline's interrupt, so a reader that did not answer
     // this would be a full-screen program a person cannot leave without knowing
-    // its own vocabulary.
+    // its own vocabulary. Not a row of the table, because it is not a command:
+    // `q` is the binding, and it reaches the same place with no modifier.
     if key.modifiers.contains(KeyModifiers::CONTROL) {
         return match key.code {
             KeyCode::Char('c') => Press::Run(Command::Quit),
             _ => Press::Ignored,
         };
     }
-    match key.code {
-        KeyCode::Char('q') => Press::Run(Command::Quit),
-        KeyCode::Char('j') | KeyCode::Down => Press::Run(Command::Move(1)),
-        KeyCode::Char('k') | KeyCode::Up => Press::Run(Command::Move(-1)),
-        KeyCode::Char('n') | KeyCode::PageDown | KeyCode::Char(' ') => Press::Run(Command::Page(1)),
-        KeyCode::Char('p') | KeyCode::PageUp => Press::Run(Command::Page(-1)),
-        KeyCode::Char('g') | KeyCode::Home => Press::Run(Command::Top),
-        KeyCode::Enter => Press::Run(Command::Open),
-        KeyCode::Char('b') | KeyCode::Esc | KeyCode::Backspace => Press::Run(Command::Back),
-        KeyCode::Char('c') => Press::Run(Command::Constraints),
-        KeyCode::Char('r') => Press::Run(Command::Reload),
-        KeyCode::Char('v') => Press::Run(Command::Queue),
-        KeyCode::Char('?') => Press::Run(Command::Help),
-        KeyCode::Char('f') => Press::Cycle,
-        KeyCode::Char(ACT) => Press::Prompt(""),
-        KeyCode::Char(FIND) => Press::Prompt("/"),
-        // The ring, forward and back, and both of them answered as the panel
-        // they land on rather than as a step (TASK-dd9747e5e305). `BackTab` is
-        // what a terminal sends for Shift-Tab, and while it produced a step of
-        // its own it was the one command in this table that a bare key could
-        // not reach -- true only of the *value*, since a digit has always
-        // reached every panel, and false of anything a person could do. Naming
-        // the destination here makes the two agree, so "no command requires a
-        // modifier" is a claim the whole table can be measured against instead
-        // of an argument about which steps are the same place.
-        KeyCode::Tab => Press::Run(Command::Panel(focus.stepped(1))),
-        KeyCode::BackTab => Press::Run(Command::Panel(focus.stepped(-1))),
-        // A digit reaches its panel directly, which is what the number in a
-        // panel's title is for.
-        KeyCode::Char(c) if Focus::of_digit(c).is_some() => {
-            Press::Run(Command::Panel(Focus::of_digit(c).expect("a panel")))
-        }
-        // Left and Right reach the pair that shares a row, which is the only
-        // place on this screen where sideways means anything: a phone's arrow
-        // cluster is how a person who never read the key line moves, and going
-        // *into* what a row names is what Right means everywhere else. They are
-        // the one pair of keys that had to change meaning for panels, and `b`
-        // and Escape still go back.
-        KeyCode::Right if focus != Focus::Body => Press::Run(Command::Panel(Focus::Body)),
-        KeyCode::Left if focus != Focus::Entities => Press::Run(Command::Panel(Focus::Entities)),
-        _ => Press::Ignored,
+    match bindings::of_key(key.code) {
+        Some(binding) => binding.press(focus),
+        None => Press::Ignored,
     }
 }
 
@@ -291,22 +277,37 @@ mod tests {
         }
     }
 
-    /// A key that writes does not exist: the six are spelled into the prompt,
-    /// and the prompt is where the grammar refuses them.
+    /// **A key that writes reaches the confirmation, and never the spawn**
+    /// (TASK-4d2eb2b4e193).
+    ///
+    /// This replaces `no_bare_key_can_write`, which said that no key could
+    /// produce a [`Command::Act`] at all. That was worth having because
+    /// reaching a verb took a key *and* a word -- a slipped finger typed
+    /// nothing, because there was no `d` -- and the asymmetry is what
+    /// ADR-c07e2694f0e1 spends: TASK-1a415107fd56 gives the six their letters,
+    /// and the old assertion would then be a rule against the decision rather
+    /// than a rule the decision keeps.
+    ///
+    /// What survives is narrower and still sufficient, and it is stated over
+    /// the whole key table rather than over the letters: whatever an act a key
+    /// composes turns out to be, it is one of the six [`crate::ank::ACTS`]
+    /// allows, and it arrives as a [`Command::Act`] -- which
+    /// [`crate::view::App`] answers by composing an argv and showing it.
+    /// `tests/dependencies.rs` holds the other half over the crate's whole
+    /// source: one function spawns a verb that writes, and the confirmation is
+    /// in front of it.
     #[test]
-    fn no_bare_key_can_write() {
+    fn a_key_that_writes_composes_one_of_the_six_and_spawns_nothing() {
         for view in Focus::ALL {
-            for c in 'a'..='z' {
+            for code in table::every_key() {
+                let Press::Run(Command::Act(act)) = typed(key(code), view) else {
+                    continue;
+                };
                 assert!(
-                    !matches!(press(c, view), Press::Run(Command::Act(_))),
-                    "'{c}' writes in {view:?}"
+                    crate::ank::ACTS.contains(&act.verb),
+                    "{code:?} composes '{}' in {view:?}, and the gate refuses it",
+                    act.verb
                 );
-            }
-            for named in [KeyCode::Enter, KeyCode::Esc, KeyCode::Down, KeyCode::Home] {
-                assert!(!matches!(
-                    typed(key(named), view),
-                    Press::Run(Command::Act(_))
-                ));
             }
         }
     }

--- a/crates/ank-tui/src/lib.rs
+++ b/crates/ank-tui/src/lib.rs
@@ -187,6 +187,7 @@ use std::io::IsTerminal;
 use std::path::PathBuf;
 
 pub mod ank;
+pub mod bindings;
 pub mod input;
 pub mod keys;
 pub mod model;

--- a/crates/ank-tui/src/view.rs
+++ b/crates/ank-tui/src/view.rs
@@ -198,6 +198,7 @@
 //! it.
 
 use crate::ank::{Ank, Failed, Ran};
+use crate::bindings::{self, Holding};
 use crate::input::{Act, Command};
 use crate::keys::{self, Editing, Press};
 use crate::model::{short_of, Detail, Queue, Row, Snapshot};
@@ -312,19 +313,14 @@ impl Action {
     }
 }
 
-/// What a key is called on the screen.
+/// What a key is called on the screen, which is what the key list calls it
+/// (TASK-4d2eb2b4e193).
 ///
-/// The character itself where there is one, so the offer and the mapping are
-/// the same letter rather than two spellings of it, and the terminal's own name
-/// otherwise.
-fn named(key: KeyCode) -> String {
-    match key {
-        KeyCode::Char(c) => c.to_string(),
-        KeyCode::Enter => "Enter".to_string(),
-        KeyCode::Esc => "Esc".to_string(),
-        other => format!("{other:?}"),
-    }
-}
+/// [`bindings::named`] and not a second spelling of the same keys: a target
+/// reading `Esc` beside a key list reading `Escape` would be one vocabulary
+/// pretending to be two, and the whole of what the table is for is that there
+/// is one.
+pub use crate::bindings::named;
 
 /// One action, and where on the band it was laid out.
 struct Target {
@@ -915,7 +911,7 @@ impl App {
             }
             Command::Act(act) => self.propose(act, ank),
             Command::Malformed(said) => self.note = Some(said),
-            Command::Help => self.note = Some(format!("{KEYS}\n{PANEL_KEYS}\n{ACT_KEYS}")),
+            Command::Help => self.note = Some(bindings::listing().join("\n")),
             Command::Nothing => {}
             Command::Unknown(word) => {
                 self.note = Some(format!("no command '{word}'; ? for the list"))
@@ -1350,9 +1346,12 @@ impl App {
         paragraph(&self.note_lines()).render(panels.note, buf);
         paragraph(&self.action_lines()).render(panels.actions, buf);
 
-        let mut keys = vec![fit(KEYS, width), fit(ACT_KEYS, width)];
+        let mut keys = vec![
+            fit(&bindings::screen_line(), width),
+            fit(&bindings::write_line(), width),
+        ];
         if let Some(ratify) = self.ratify_line() {
-            keys.push(fit(ratify, width));
+            keys.push(fit(&ratify, width));
         }
         paragraph(&keys).render(panels.keys, buf);
     }
@@ -1760,11 +1759,11 @@ impl App {
     /// snapshot does not carry the row -- `find` answers within a budget -- no
     /// line is drawn, which errs towards saying nothing rather than towards
     /// offering something.
-    fn ratify_line(&self) -> Option<&'static str> {
+    fn ratify_line(&self) -> Option<String> {
         let detail = self.detail.as_ref()?;
         let row = self.snapshot.as_ref()?.row(&detail.id)?;
         let ratifiable = row.status == "proposed" && matches!(row.kind.as_str(), "adr" | "spec");
-        ratifiable.then_some(RATIFY_KEY)
+        ratifiable.then(bindings::ratify_line)
     }
 
     /// The frame as text, row by row, for a test to read.
@@ -1913,87 +1912,44 @@ impl App {
     /// them would be a target for the thing the screen is already answering.
     /// The body has no rows to land on, so paging is the one movement offered.
     ///
-    /// **Two states come before the focus and both are modal.** A command
-    /// waiting to be answered offers the key that runs it and the key that
-    /// drops it and nothing else, because nothing else is what the rest of the
-    /// keyboard does (TASK-d4a882345837); and an open prompt offers the two
-    /// ways out of a line. Anything else drawn under either would be an offer
-    /// the reader would refuse.
+    /// **Which of them is drawn is declared beside the key rather than here**
+    /// (TASK-4d2eb2b4e193). Every row of [`bindings::BINDINGS`] carries what
+    /// the screen must hold before it is offered at all, so this is a filter
+    /// over that table in its own order rather than a second list per panel --
+    /// and the word a target says is the word the key list says, because it is
+    /// the same string.
+    ///
+    /// A binding with no key is never a target, whatever it is offered on: the
+    /// six verbs are still spelled into the prompt, and a word a finger could
+    /// touch with no key to press would be an offer only half the reader can
+    /// take.
     pub fn actions(&self) -> Vec<Action> {
+        bindings::offered(self.holding())
+            .map(|binding| Action {
+                key: binding
+                    .key
+                    .expect("a binding with no key is never offered as a target"),
+                does: binding.word,
+            })
+            .collect()
+    }
+
+    /// What the screen is holding, which is what decides the offer.
+    ///
+    /// The two modal states come before the focus and both of them are modal in
+    /// the same direction: a command waiting to be answered offers the key that
+    /// runs it and the key that drops it and nothing else, because nothing else
+    /// is what the rest of the keyboard does (TASK-d4a882345837); and an open
+    /// prompt offers the two ways out of a line. Anything else drawn under
+    /// either would be an offer the reader would refuse.
+    fn holding(&self) -> Holding {
         if self.pending.is_some() {
-            return vec![
-                Action {
-                    key: KeyCode::Char(keys::CONFIRM),
-                    does: "run",
-                },
-                Action {
-                    key: KeyCode::Esc,
-                    does: "dismiss",
-                },
-            ];
+            return Holding::Waiting;
         }
         if self.prompt.is_some() {
-            return vec![
-                Action {
-                    key: KeyCode::Enter,
-                    does: "run",
-                },
-                Action {
-                    key: KeyCode::Esc,
-                    does: "cancel",
-                },
-            ];
+            return Holding::Typing;
         }
-        let quit = Action {
-            key: KeyCode::Char('q'),
-            does: "quit",
-        };
-        let act = Action {
-            key: KeyCode::Char(keys::ACT),
-            does: "act",
-        };
-        match self.focus {
-            Focus::Body => vec![
-                Action {
-                    key: KeyCode::Char('n'),
-                    does: "page",
-                },
-                Action {
-                    key: KeyCode::Char('c'),
-                    does: "rules",
-                },
-                Action {
-                    key: KeyCode::Char('b'),
-                    does: "back",
-                },
-                act,
-                quit,
-            ],
-            Focus::Entities => vec![
-                Action {
-                    key: KeyCode::Enter,
-                    does: "open",
-                },
-                act,
-                Action {
-                    key: KeyCode::Char('f'),
-                    does: "kind",
-                },
-                Action {
-                    key: KeyCode::Char(keys::FIND),
-                    does: "find",
-                },
-                quit,
-            ],
-            _ => vec![
-                Action {
-                    key: KeyCode::Enter,
-                    does: "open",
-                },
-                act,
-                quit,
-            ],
-        }
+        Holding::Panel(self.focus)
     }
 
     /// The offer laid out on the band it is drawn in.
@@ -2405,33 +2361,16 @@ fn step(at: usize, by: isize, total: usize) -> usize {
 /// leading slash included: a person about to press Enter is looking at exactly
 /// what will be read.
 pub const PROMPT: &str = ": ";
-/// The keys that move the screen.
-pub const KEYS: &str =
-    "j/k move  n/p page  g top  Enter open  b back  c constraints  f kind  / find  r reload  a act  ? keys  q quit";
-/// The keys that move the focus, on a line of their own.
-///
-/// Separate because they are a different kind of command: the line above moves
-/// what is inside a panel, and this one moves which panel that is. A person who
-/// has lost track of where they are needs the second line and not the first.
-pub const PANEL_KEYS: &str =
-    "Tab next panel  1 claims  2 entities  3 body  4 queue  Left/Right the pair in the middle   (the marked panel is the one keys reach)";
-/// The writing half, on its own line and spelled whole.
-///
-/// Separate from the other two because it is a different kind of offer: those
-/// keys move a screen, and these five move the corpus. A person reading the
-/// trailer should be able to see at a glance which of the two they are about to
-/// do, and one line mixing them would make that a matter of remembering.
-pub const ACT_KEYS: &str =
-    "a then  claim | log <message> | release <reason> | done <proof> | amend <flags>   (the marked panel's entity, then y)";
-/// The sixth act, on a line of its own, and only where the verb would take it.
-///
-/// A third line for a third kind of offer, on the reasoning [`ACT_KEYS`] gives
-/// for being a second one: those five move the corpus, and this one asks a
-/// person for a signature that ank has no way to produce. It says so, because
-/// somebody about to type it should know what they are being asked for and
-/// where it has to happen.
-pub const RATIFY_KEY: &str =
-    "a then  accept   (this document, on the default branch -- ank signs nothing, your key does)";
+// `KEYS`, `PANEL_KEYS`, `ACT_KEYS` and `RATIFY_KEY` stood here
+// (TASK-4d2eb2b4e193). Four sentences about a key table, written beside two
+// other renderings of the same table, and ADR-c07e2694f0e1 -- proposed --
+// records what they
+// cost: the trailer taught a vocabulary the reader did not have, and left out
+// `v`, Space, every arrow and the whole of the ring. The trailer now draws
+// `bindings::screen_line` and `bindings::write_line`, over
+// `bindings::ratify_line` where the document takes it, and `?` answers with
+// `bindings::listing` -- all of them generated from the rows they describe, so
+// what the reader teaches is what the reader answers to.
 
 /// What the confirmation says above the command line it is showing
 /// (TASK-d4a882345837).

--- a/crates/ank-tui/tests/bindings.rs
+++ b/crates/ank-tui/tests/bindings.rs
@@ -1,0 +1,197 @@
+//! The key list, through the binary, on a real terminal (TASK-4d2eb2b4e193).
+//!
+//! CLAUDE.md leaves no choice about where this is measured, and the criterion
+//! says the same thing in its own words: *driven on a pseudo-terminal, the
+//! built binary answers `?` with a list naming every binding the table declares
+//! and nothing it does not*. Every part of that is about a process. A unit test
+//! can prove [`ank_tui::bindings::listing`] is complete -- and one does, beside
+//! the table -- but completeness of a function is not the claim. The claim is
+//! that the thing a person presses `?` on shows it, and between those two
+//! there is a dispatch, a note band, a wrap, a `fit` and a terminal.
+//!
+//! **Twice, that being the whole of the point.** ADR-c07e2694f0e1, the
+//! proposed successor this wave is built on, was written
+//! because the reader's own trailer taught a vocabulary the reader did not have
+//! -- `?` omitted `v`, Space, every arrow, the way out and the whole of the
+//! ring -- and a suite that asserted the list contains `q quit` would have
+//! passed on that screen. So this reads the drawn rows back and holds them to
+//! the table both ways: nothing the table declares is missing, and nothing that
+//! is drawn is absent from the table.
+//!
+//! The window is wide on purpose. `fit` cuts a line that does not fit with `~`,
+//! which is a real behaviour and not this suite's subject: what is measured
+//! here is what the reader has to say, and a suite that read it through a
+//! truncation would be measuring the truncation.
+//!
+//! `#[cfg(unix)]` for the reason the other suites give: a pseudo-terminal on
+//! Windows is ConPTY, and reaching it means the console API this workspace does
+//! not otherwise call. The table itself is platform-free and its own tests run
+//! on all three.
+
+#![cfg(unix)]
+
+mod terminal;
+
+use ank_tui::bindings::{self, BINDINGS};
+use std::sync::Mutex;
+use terminal::{Live, Repo};
+
+/// One pseudo-terminal open at a time, in this suite.
+///
+/// **Not a slow test being polite: `ptsname(3)` answers out of a static
+/// buffer.** `terminal::pty::open` calls `posix_openpt` and then asks
+/// `ptsname` for the slave's path, and two threads doing that at once can both
+/// read the same answer -- so two sessions attach to one terminal, one of them
+/// resizes it to the other's window, and the second child is left writing down
+/// a pipe nobody is draining. That is what this suite tripped: it is the first
+/// to open two sessions at *different* sizes, which is what makes a crossed
+/// path visible rather than merely wrong.
+///
+/// The defect is the harness's and the fix belongs there (`ptsname_r`, or a
+/// lock around the four calls); LOG-3b0bc419c884 records it. This is the local
+/// answer -- the two tests below take it in turn -- and it costs a second.
+static ONE_AT_A_TIME: Mutex<()> = Mutex::new(());
+
+/// A window the key list fits on whole.
+///
+/// Two hundred columns because the longest line the table generates is under
+/// that with room to spare, and fifty rows because the note band grows to hold
+/// what it is given and the panels have to survive it.
+const WIDE: (u16, u16) = (200, 50);
+
+/// **The binary answers `?` with every binding the table declares, and with
+/// nothing it does not** (TASK-4d2eb2b4e193).
+#[test]
+fn the_key_the_list_is_named_after_draws_every_binding_and_no_other() {
+    let _one = ONE_AT_A_TIME
+        .lock()
+        .unwrap_or_else(|held| held.into_inner());
+    let repo = Repo::seeded();
+    let mut live = Live::open(&repo, WIDE.0, WIDE.1);
+    live.until("the session to open", |t| t.contains("2 ENTITIES"));
+    // Not on the screen before it is asked for: the ring is on no other line,
+    // so this also says the wait below is waiting for something.
+    assert!(
+        !live.frame().contains("Tab next panel"),
+        "the key list is on the screen before anybody asked for it"
+    );
+    live.send("?");
+    live.until("the key list to be drawn", |t| t.contains("Tab next panel"));
+    let frame = live.frame();
+    let rows: Vec<&str> = frame.lines().collect();
+
+    // The band the list was drawn on, read off the frame: the row the first
+    // line landed on, and the rows under it. The note band is above the
+    // trailer, so this is the answer to `?` and not the chrome that quotes two
+    // of its lines at rest.
+    let list = bindings::listing();
+    let at = rows
+        .iter()
+        .position(|row| *row == list[0])
+        .unwrap_or_else(|| panic!("the key list is not on the frame:\n{frame}"));
+    let band: Vec<&str> = rows
+        .iter()
+        .skip(at)
+        .take(list.len())
+        .copied()
+        .collect::<Vec<&str>>();
+
+    // Line for line, whole and uncut. Equality and not `contains`, because a
+    // list that arrived cut would be a reader teaching half a vocabulary --
+    // which is the failure this task ends, rather than a smaller version of it.
+    assert_eq!(
+        band,
+        list.iter().map(String::as_str).collect::<Vec<&str>>(),
+        "the band `?` drew is not the list the table generates:\n{frame}"
+    );
+
+    // Every binding, named. Stated over the rows of the table rather than over
+    // a list written here, because a suite carrying its own copy of the keys
+    // would agree with a table that moved.
+    for binding in BINDINGS {
+        let entry = binding.entry();
+        assert!(
+            band.iter().any(|row| row.contains(&entry)),
+            "'{entry}' is a binding of this reader and `?` does not name it:\n{frame}"
+        );
+    }
+
+    // And nothing it does not. The band is read back entry by entry, and every
+    // one of them is a row of the table: a key list offering a letter nobody
+    // bound reads as an offer and behaves as nothing, which is worse than an
+    // omission and is what "and nothing it does not" is there to catch.
+    for entry in drawn(&band) {
+        assert!(
+            BINDINGS.iter().any(|b| b.entry() == entry),
+            "`?` names '{entry}' and no binding declares it:\n{frame}"
+        );
+    }
+    live.quit();
+}
+
+/// The entries the reader drew, read back off the rows it drew them on.
+///
+/// What is stripped from each row is its lead and its note -- the sentence a
+/// line ends with is prose about the table and never an entry of it -- and what
+/// is left is split the two ways a line joins entries.
+fn drawn(band: &[&str]) -> Vec<String> {
+    band.iter()
+        .flat_map(|line| {
+            let body = match line.find("   (") {
+                Some(at) => &line[..at],
+                None => line,
+            };
+            let body = match body.split_once(" then  ") {
+                Some((_, verbs)) => verbs,
+                None => body,
+            };
+            body.split("  ")
+                .flat_map(|entry| entry.split(" | "))
+                .map(|entry| entry.trim().to_string())
+                .filter(|entry| !entry.is_empty())
+                .collect::<Vec<String>>()
+        })
+        .collect()
+}
+
+/// The window ADR-c07e2694f0e1 measures this reader's frame on.
+const EIGHTY: (u16, u16) = (80, 24);
+
+/// **The key list fits the window it is asked for on** (TASK-4d2eb2b4e193).
+///
+/// The list is longer than the three sentences it replaces, and it has to be:
+/// naming every binding is the criterion, and the omissions of the old one are
+/// what ADR-c07e2694f0e1 was written against. What it must not do is break the
+/// screen it is drawn on. So the note band grows to hold what it is given, the
+/// panels give way to it, and the frame is still the window's own size, row for
+/// row and column for column.
+///
+/// The rows it costs are real and this task does not buy them back:
+/// TASK-8a6578851244 does, by making the list an overlay drawn over the frame
+/// rather than a note the layout has to find room for.
+#[test]
+fn the_key_list_fits_the_window_it_is_asked_for_on() {
+    let _one = ONE_AT_A_TIME
+        .lock()
+        .unwrap_or_else(|held| held.into_inner());
+    let repo = Repo::seeded();
+    let mut live = Live::open(&repo, EIGHTY.0, EIGHTY.1);
+    live.until("the session to open", |t| t.contains("2 ENTITIES"));
+    live.send("?");
+    live.until("the key list to be drawn", |t| t.contains("next panel"));
+    let frame = live.frame();
+    assert_eq!(
+        frame.lines().count(),
+        EIGHTY.1 as usize,
+        "the key list changed how many rows the frame is:\n{frame}"
+    );
+    for line in frame.lines() {
+        assert!(
+            line.chars().count() <= EIGHTY.0 as usize,
+            "{} columns in an {}-column window: {line}\n{frame}",
+            line.chars().count(),
+            EIGHTY.0
+        );
+    }
+    live.quit();
+}

--- a/crates/ank-tui/tests/dependencies.rs
+++ b/crates/ank-tui/tests/dependencies.rs
@@ -297,6 +297,58 @@ fn one_function_in_this_crate_spawns_a_verb_that_writes() {
     );
 }
 
+/// **An act reaches the confirmation, and there is one arm that answers one**
+/// (TASK-4d2eb2b4e193, TASK-d4a882345837).
+///
+/// This is the half of `keys::no_bare_key_can_write` that survives the wave.
+/// That test said no bare key could produce a [`ank_tui::input::Command::Act`]
+/// at all, and it was worth having because reaching a verb took a key *and* a
+/// word. ADR-c07e2694f0e1, proposed, spends that asymmetry:
+/// TASK-1a415107fd56 gives the
+/// six their own letters, and the rule that has to hold afterwards is not that
+/// an act is unreachable by a key -- it is that *however* an act is reached, it
+/// is composed and shown rather than run.
+///
+/// So it is stated over the dispatch instead of over the keyboard. Exactly one
+/// arm in this crate answers a `Command::Act`, it is in `view.rs`, and what it
+/// does is `propose` -- which composes the argv, draws it, and spawns nothing.
+/// Together with the count above of one `ank.act(` in `src/`, that is what the
+/// old asymmetry bought: there is one road from an act to a spawn, and the
+/// confirmation is on it.
+#[test]
+fn one_arm_answers_an_act_and_what_it_does_is_show_it() {
+    let arms: Vec<String> = sources()
+        .into_iter()
+        .flat_map(|(file, source)| {
+            code_of(&source)
+                .lines()
+                .filter(|line| line.contains("Command::Act(") && line.contains("=>"))
+                .map(|line| format!("{file}  {}", line.trim()))
+                .collect::<Vec<String>>()
+        })
+        .collect();
+    assert_eq!(
+        arms.len(),
+        1,
+        "an act is answered in {} places, and only one of them can have the \
+         confirmation on it:\n{}",
+        arms.len(),
+        arms.join("\n")
+    );
+    assert!(
+        arms[0].starts_with("view.rs"),
+        "the answer to an act moved out of the view, where the confirmation \
+         is: {}",
+        arms[0]
+    );
+    assert!(
+        arms[0].contains("propose"),
+        "an act is answered by something other than composing it and showing \
+         it: {}",
+        arms[0]
+    );
+}
+
 /// A source with its comments removed.
 ///
 /// The prose is allowed to name `.ank/` and `refs/ank/*` -- it has to, since


### PR DESCRIPTION
Closes TASK-4d2eb2b4e193. First of wave 18, under ADR-c07e2694f0e1 (**proposed**, successor to ADR-0b55983421dd -- it is cited here as a proposed successor and nothing in this branch removes a citation of ADR-0b55983421dd; TASK-fa9b436da1f4 lands those).

## What this changes

`crates/ank-tui` declared its key mapping in five places: a `match` in `keys::typed`, a `match` per panel in `App::actions`, a verb list in `input.rs`, and three sentences in `view.rs` that the trailer drew and `?` answered with. The ADR records the proof they could disagree, and it was on the screen: `?` omitted `v`, Space, every arrow, the way out and the whole of the ring.

`crates/ank-tui/src/bindings.rs` is now the one declaration. A row carries its key, the other keys that reach it, the command it runs, the word it is called by, the group it belongs to, what the screen must hold before it is offered at all, and the CLI verb it spells where it spells one.

- `keys::typed` is a lookup into it.
- `App::actions` is that table filtered by what the screen is holding, in the table's own order -- so one order serves every panel instead of one list per panel, and a target says the word the key list says because it is the same string.
- The key list is generated, and `?` answers with it.

**The letters do not move.** This is a pure refactor of where they are written down; moving them is TASK-1a415107fd56, which this unblocks along with TASK-8a6578851244.

## What is deliberately *not* computed from the table

`ank::ACTS` -- the list of verbs this reader may spawn -- stays hand-written in `ank.rs`. The dependency runs the other way round: the bindings are measured against the gate, and a test asserts `ank.rs` reads nothing from the table. A gate generated from the thing it guards guards nothing.

Control-C is also not a row. It is not a command -- it is the way out of a program that took the terminal -- and `q` reaches the same place with no modifier, which is what `keys.rs`'s whole-domain suite measures.

## Held rather than described

- every verb the table names resolves in `ank_contract::verbs::COMMANDS`, and every flag it names is that verb's own `FlagSpec` rather than a global;
- no field carries `-`, which the CLI reads as "the value is on stdin" and this reader's child has not got;
- the key list names every binding and nothing else, measured over the rows each line names rather than over the drawn text;
- driven on a pseudo-terminal, the built binary's answer to `?` is read back off the frame and held to the table both ways (`crates/ank-tui/tests/bindings.rs`).

`keys::no_bare_key_can_write` is **replaced, not deleted**. It said no key could produce a `Command::Act` at all, which was worth having while reaching a verb took a key *and* a word -- the asymmetry ADR-c07e2694f0e1 spends. What survives is narrower and still sufficient: a key that composes an act composes one of the six the gate allows, and `tests/dependencies.rs` holds the other half over the crate's whole source -- one arm answers an act, it is in the view, and what it does is show it.

## Two things worth a reviewer's eye

**The trailer and `?` now say more, and that costs rows.** Naming every binding is the criterion, so the list is longer than the three sentences it replaces: at eighty columns the note band it grows to is around eleven rows rather than six. `tests/bindings.rs` holds the frame to its window at 80x24 so nothing breaks, and TASK-8a6578851244 buys the rows back by making the list an overlay. The frame's *layout* is unchanged -- the trailer is still two lines over an optional ratification line.

**A latent harness defect surfaced.** `tests/terminal/mod.rs`'s `pty::open` calls `ptsname(3)`, which answers out of a static buffer, so two sessions opened from two threads can attach to one terminal. This suite is the first to open two at *different* window sizes, which is what makes a crossed path visible; it is worked around locally with a mutex rather than by editing a file the two sibling branches in this wave also build on. LOG-3b0bc419c884 records the defect and the fix.

## Verification

`cargo test --workspace` green (26 test binaries), `cargo fmt --check` green, `ank check` ok. Proof `commit:c91b21fe6372c9ef7bb1b607decf6d6cd881e1b4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017dEiRNdwmATCuD2m9sKJym