### PR TITLE
Ratify ADR-c07e2694f0e1, and move the workspace's citations with it

### DIFF
--- a/.ank/entities/ADR-0b55983421dd.md
+++ b/.ank/entities/ADR-0b55983421dd.md
@@ -5,7 +5,7 @@ slug: the-reader-is-a-terminal-application-built-on-ra
 title: The reader is a terminal application built on ratatui and crossterm
 created: 2026-08-25T22:44:33Z
 author: haksolot@vmi3223161
-status: accepted
+status: superseded
 scope:
   - crates/ank-tui/**
 constraint: |
@@ -21,7 +21,7 @@ verified:
   - by: haksolot@vmi3223161
     at: 2026-08-25T23:13:06Z
 schema: 4
-version: 2
+version: 3
 ---
 
 The reader shipped in TASK-49746735127f, gained the writing half in

--- a/.ank/entities/ADR-c07e2694f0e1.md
+++ b/.ank/entities/ADR-c07e2694f0e1.md
@@ -5,7 +5,7 @@ slug: the-reader-spends-its-screen-on-the-corpus-and-i
 title: The reader spends its screen on the corpus, and its keys on the verbs
 created: 2026-08-26T17:06:58Z
 author: claude-code/opus-5+reader-redesign
-status: proposed
+status: accepted
 scope:
   - crates/ank-tui/**
 constraint: |
@@ -21,8 +21,12 @@ constraint: |
   
   What ADR-8bd76e8d7c4e fixed is untouched and this decision restates none of it: the reader reaches the corpus only by running the CLI with --json, it writes nothing the person at the keyboard did not ask for, it renews no claim on its own, and accept stays a signed human act it may drive and never perform. No browser reader, nothing under a viewer/ directory, no HTML page: a reader that a phone can drive is a terminal application reached from a phone, and never a step toward one that is not.
 supersedes: ADR-0b55983421dd
+ratified: 11192fbfc9dc
+verified:
+  - by: haksolot@vmi3223161
+    at: 2026-08-26T19:46:25Z
 schema: 4
-version: 2
+version: 3
 ---
 
 ADR-0b55983421dd is kept in three of its five paragraphs and rewritten in the

--- a/.ank/entities/LOG-064f798841db.md
+++ b/.ank/entities/LOG-064f798841db.md
@@ -1,0 +1,13 @@
+---
+id: LOG-064f798841db
+type: log
+title: done, proof commit:1e1e19c0309c32b9ec850bab4f89d2f9f165ffca
+created: 2026-08-26T20:13:02Z
+author: claude-code/opus-5+sweep
+scope:
+  - crates/**
+about: TASK-fa9b436da1f4
+seq: 3
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-c848740fdee2.md
+++ b/.ank/entities/LOG-c848740fdee2.md
@@ -1,0 +1,16 @@
+---
+id: LOG-c848740fdee2
+type: log
+title: "-blocked_by TASK-1a415107fd56, -blocked_by TASK-9a402a54886f, -blocked_by TASK-e900637aeac4,"
+created: 2026-08-26T19:50:11Z
+author: claude-code/opus-5+sweep
+scope:
+  - crates/**
+about: TASK-fa9b436da1f4
+seq: 1
+records: edit
+schema: 4
+version: 1
+---
+
+ -blocked_by TASK-d832452630d2, -blocked_by TASK-b08d090f699c, -blocked_by TASK-e8da6a00564a (version 2 to 3, replaced 59c9a0de2975, produced f2d014b780ae)

--- a/.ank/entities/LOG-d8b0bb760b9c.md
+++ b/.ank/entities/LOG-d8b0bb760b9c.md
@@ -1,0 +1,14 @@
+---
+id: LOG-d8b0bb760b9c
+type: log
+title: body (version 3 to 4, replaced 17030d0d004b, produced a9bdf2169f65)
+created: 2026-08-26T19:50:23Z
+author: claude-code/opus-5+sweep
+scope:
+  - crates/**
+about: TASK-fa9b436da1f4
+seq: 2
+records: edit
+schema: 4
+version: 1
+---

--- a/.ank/entities/TASK-fa9b436da1f4.md
+++ b/.ank/entities/TASK-fa9b436da1f4.md
@@ -5,15 +5,20 @@ slug: the-workspace-cites-the-successor-and-no-comment
 title: The workspace cites the successor, and no comment sources a claim it does not make
 created: 2026-08-26T17:07:37Z
 author: claude-code/opus-5+reader-redesign
-status: in_progress
+status: done
 scope:
   - crates/**
 blocked_by: []
 done_criteria: |
   No tracked file outside a .ank/ directory names ADR-0b55983421dd, in that form or abbreviated. Every citation that moved names the successor only where the successor carries that rule forward; where the supersession made the sentence false, the sentence is rewritten or gone with the code it described, and no comment cites the successor in support of a claim it does not make. cargo test --workspace is green on all three platforms and ank check reports no fault.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 1e1e19c0309c32b9ec850bab4f89d2f9f165ffca
+    criteria: 9cfe413d950e
+    via: submitted
 schema: 4
-version: 5
+version: 6
 ---
 
 The ordering this task carried was written on one assumption: that the

--- a/.ank/entities/TASK-fa9b436da1f4.md
+++ b/.ank/entities/TASK-fa9b436da1f4.md
@@ -5,13 +5,32 @@ slug: the-workspace-cites-the-successor-and-no-comment
 title: The workspace cites the successor, and no comment sources a claim it does not make
 created: 2026-08-26T17:07:37Z
 author: claude-code/opus-5+reader-redesign
-status: open
+status: in_progress
 scope:
   - crates/**
-blocked_by: [TASK-1a415107fd56, TASK-9a402a54886f, TASK-e900637aeac4, TASK-d832452630d2, TASK-b08d090f699c, TASK-e8da6a00564a]
+blocked_by: []
 done_criteria: |
   No tracked file outside a .ank/ directory names ADR-0b55983421dd, in that form or abbreviated. Every citation that moved names the successor only where the successor carries that rule forward; where the supersession made the sentence false, the sentence is rewritten or gone with the code it described, and no comment cites the successor in support of a claim it does not make. cargo test --workspace is green on all three platforms and ank check reports no fault.
 criteria_by: creator
 schema: 4
-version: 2
+version: 5
 ---
+
+The ordering this task carried was written on one assumption: that the
+signature would come last, so a sweep done early would be a sweep done twice
+over files the wave was still rewriting. The signature came first instead --
+`ank accept` warned where ADR-3b6ba766a42e says it refuses, so nothing stopped
+it -- and the assumption inverted with it.
+
+Sweeping now is the cheaper half, not the more expensive one. A citation
+re-pointed at ADR-c07e2694f0e1 stays re-pointed when a later task edits the
+file around it, and from this task onward every agent in the wave writes its
+citations against a document that is **accepted** rather than one that is
+merely proposed. What the old ordering was protecting against was doing the
+judgement pass twice; what it did not price is that the judgement pass gets
+harder, not easier, once four more tasks have rewritten the comments it has to
+judge.
+
+The six blockers are dropped for that reason and no other. The dependency
+between the *work* of those tasks and this one never existed; what existed was
+a dependency on the signature, and it has fired.

--- a/crates/ank-cli/tests/tui.rs
+++ b/crates/ank-cli/tests/tui.rs
@@ -1,5 +1,5 @@
 //! `ank tui` through the binary (TASK-49746735127f, ADR-8bd76e8d7c4e,
-//! ADR-0b55983421dd).
+//! ADR-c07e2694f0e1).
 //!
 //! CLAUDE.md leaves no choice about where this suite lives: a criterion that
 //! talks about the binary is tested through the binary, and twice in this
@@ -24,7 +24,7 @@
 //! the engine whole.
 //!
 //! **How the session is driven did move, twice.** A command is a key now
-//! (ADR-0b55983421dd), so a list of lines became a list of keystrokes, with the
+//! (ADR-c07e2694f0e1), so a list of lines became a list of keystrokes, with the
 //! four verbs that carry a message, a reason, a proof or a flag spelled into
 //! the prompt that `a` opens -- see [`on_a_terminal`] for what an entry of one
 //! of those lists is.
@@ -355,7 +355,7 @@ fn json_does_not_exempt_a_caller_from_the_terminal() {
 /// nothing is added to the link line either.
 ///
 /// **The window is set here and it has to be.** The reader asks the terminal
-/// how big it is (ADR-0b55983421dd), and a pseudo-terminal nobody sized is nought
+/// how big it is (ADR-c07e2694f0e1), and a pseudo-terminal nobody sized is nought
 /// by nought -- so a suite that skipped this would be asserting what a reader
 /// draws into no window at all. It is also what makes the resize measurable:
 /// setting it again while a session is running is exactly what a person
@@ -817,9 +817,11 @@ fn drive(repo: &Repo, agent: &str, keys: &[&str]) -> Seen {
 /// **What an entry of `keys` is.** Anything beginning with `:` is a line typed
 /// into the prompt: the key that opens it, the rest of the entry, and Enter.
 /// Anything else is the keys themselves, byte for byte -- `"q"`, `"j"`, `"\r"`
-/// for Enter. That is the shape of the reader now (ADR-0b55983421dd): every
-/// command that only moves the screen is one key, and the four verbs that carry
-/// a message, a reason, a proof or a flag are spelled into a prompt.
+/// for Enter. Every command that only moves the screen is one key
+/// (ADR-c07e2694f0e1), and the four verbs that carry a message, a reason, a
+/// proof or a flag are spelled into a prompt -- which is the shape of the
+/// reader today and not a shape the decision asks for: TASK-1a415107fd56 is
+/// where the writing verbs take letters of their own.
 ///
 /// A line that spells one of the six verbs that write composes a command and
 /// shows it rather than running it, so an entry that spells one is followed by
@@ -1149,9 +1151,9 @@ fn a_driven_session_names_the_entities_the_corpus_carries() {
 /// has (ADR-c9f9d1a05b23).
 ///
 /// **Both ends of the window are taken in characters and never in bytes**
-/// (ADR-c07e2694f0e1, proposed). The frames carry box-drawing glyphs now and a
-/// glyph is three bytes, so the two byte offsets this used to take are both a
-/// slice through a code point -- which is a panic and not a failure. `rfind`
+/// (ADR-c07e2694f0e1). The frames carry box-drawing glyphs now and a glyph is
+/// three bytes, so the two byte offsets this used to take are both a slice
+/// through a code point -- which is a panic and not a failure. `rfind`
 /// answers the byte index a character *starts* at, so the old `i + 1` landed
 /// inside a border drawn hard against a kind; `at + 5` landed inside one drawn
 /// hard against an identifier the reader had cut. The left boundary therefore
@@ -1243,7 +1245,7 @@ fn the_frames_carry_no_identifier_the_corpus_does_not() {
 }
 
 /// A terminal made narrower, then wider, redraws to its new size with nobody
-/// typing (TASK-4fa385c1772d, ADR-0b55983421dd).
+/// typing (TASK-4fa385c1772d, ADR-c07e2694f0e1).
 ///
 /// **The whole of the assertion is that no key was pressed.** The window is
 /// changed on the master side, exactly as a terminal emulator changes it, and

--- a/crates/ank-tui/Cargo.toml
+++ b/crates/ank-tui/Cargo.toml
@@ -13,20 +13,20 @@ license = "Apache-2.0"
 description = "The Ank terminal reader: it draws what the CLI prints, and reaches the corpus only by running it."
 
 # **The dependency list is the constraint made mechanical** (ADR-8bd76e8d7c4e,
-# ADR-0b55983421dd). `ank-core` is absent and must stay absent, and so is every
+# ADR-c07e2694f0e1). `ank-core` is absent and must stay absent, and so is every
 # git library: this crate reaches the corpus by running `ank ... --json` and by
 # nothing else, so the refusals it shows are the refusals the binary gave and
 # there is no second dispatch path to keep in step. `tests/dependencies.rs`
 # reads the graph back out of cargo and fails when either arrives, holds this
 # list to what is declared below, and reads the sources for the `extern` block
-# ADR-0b55983421dd forbids on any platform.
+# ADR-c07e2694f0e1 forbids on any platform.
 [dependencies]
 # The exit codes, read out of the contract rather than typed as numbers
 # (ADR-6fd69efb629c). This is what `ank-daemon` takes from it and for the same
 # reason: this crate dispatches no verb, so the verb table is not its business.
 ank-contract = { path = "../ank-contract" }
 # **The two the decision spends, and the whole of what they buy**
-# (ADR-0b55983421dd). The reader is a full-screen application: raw mode, the
+# (ADR-c07e2694f0e1). The reader is a full-screen application: raw mode, the
 # alternate buffer, a keystroke, a resize, and a layout with panels to come.
 # Every one of those is two implementations of one behaviour -- `tcsetattr` and
 # `SetConsoleMode`, an `ioctl` and a console call, a byte and a key record --
@@ -40,9 +40,10 @@ ank-contract = { path = "../ank-contract" }
 # lockfile went from 50 entries to 200, and the two counts differ because a
 # lockfile carries a package whether or not a feature enables it: the termion
 # and termwiz backends, `palette` and their trees are locked and never built.
-# ADR-0b55983421dd priced this at fifty-five, which is what ratatui 0.29 costs
-# by the same instrument; 0.30 is 8 crates more compiled than that, and it is
-# the current release rather than a major this project would owe an upgrade.
+# Fifty-five is what this was priced at when the two were taken, and it is what
+# ratatui 0.29 costs by the same instrument; 0.30 is 8 crates more compiled than
+# that, and it is the current release rather than a major this project would owe
+# an upgrade.
 #
 # The default features are off and four are named. `all-widgets` and
 # `widget-calendar` are what they buy back: this reader draws no calendar, and

--- a/crates/ank-tui/src/bindings.rs
+++ b/crates/ank-tui/src/bindings.rs
@@ -1,5 +1,4 @@
-//! Every binding of the reader, declared once (ADR-c07e2694f0e1, proposed
-//! successor to ADR-0b55983421dd).
+//! Every binding of the reader, declared once (ADR-c07e2694f0e1).
 //!
 //! **One table, and the surfaces are computed from it.** [`keys::typed`] reads
 //! a keystroke out of it, [`crate::view::App::actions`] draws the offer out of
@@ -34,7 +33,7 @@
 //! command: raw mode has taken the line discipline's interrupt, and this is the
 //! way out of a program that took the terminal. `q` is the binding, and it
 //! reaches the same place with no modifier -- which is what
-//! ADR-0b55983421dd's "no command anywhere requires a modifier chord" asks for
+//! ADR-c07e2694f0e1's "no command anywhere requires a modifier chord" asks for
 //! and what the table in `keys.rs` measures over every key there is.
 //!
 //! # What a verb may never be handed
@@ -56,9 +55,11 @@ pub struct Binding {
     /// The key that runs it, where a key does.
     ///
     /// `None` for the writing half, which is still reached by spelling the verb
-    /// whole into the prompt (ADR-0b55983421dd) -- the asymmetry
-    /// TASK-1a415107fd56 spends. Nothing else about a verb's row changes when
-    /// its letter arrives, which is the point of declaring the row now.
+    /// whole into the prompt. That is a state and no longer a decision:
+    /// ADR-c07e2694f0e1 says a key is the verb it runs and that the reader
+    /// binds the CLI's own initial for it, and TASK-1a415107fd56 is the
+    /// asymmetry being spent. Nothing else about a verb's row changes when its
+    /// letter arrives, which is the point of declaring the row now.
     pub key: Option<KeyCode>,
     /// The other keys that reach the same thing.
     ///
@@ -237,7 +238,7 @@ pub enum Holding {
 /// same order is not a coincidence to be maintained -- it is one list.
 pub static BINDINGS: &[Binding] = &[
     // -----------------------------------------------------------------------
-    // What moves the screen (ADR-0b55983421dd: every one of them is one key)
+    // What moves the screen (ADR-c07e2694f0e1: every one of them is one key)
     // -----------------------------------------------------------------------
     Binding {
         key: Some(KeyCode::Char('j')),

--- a/crates/ank-tui/src/input.rs
+++ b/crates/ank-tui/src/input.rs
@@ -1,28 +1,34 @@
 //! The grammar of the one-line prompt: a verb spelled whole, and its tail.
 //!
-//! **This is no longer how the screen is moved, and that is the whole of what
-//! ADR-0b55983421dd changed here.** Every command that only moves the screen is
-//! a key now, and `keys.rs` is where those live. What is left for a line is
-//! what a key cannot carry: `log <what you learned>`, `done --proof <p>`,
-//! `release <reason>`, `amend <flags>` -- four of the six verbs that write take
-//! something a keystroke has no room for, so `a` opens a prompt and this reads
-//! what is typed into it. `/` opens the same prompt on a search.
+//! **This is no longer how the screen is moved** (ADR-c07e2694f0e1). Every
+//! command that only moves the screen is a key now, and `keys.rs` is where
+//! those live. What is left for a line is what a key cannot carry: `log <what
+//! you learned>`, `done --proof <p>`, `release <reason>`, `amend <flags>` --
+//! four of the six verbs that write take something a keystroke has no room
+//! for, so `a` opens a prompt and this reads what is typed into it. `/` opens
+//! the same prompt on a search.
 //!
 //! The reading commands stay in the grammar, spelled whole, and that is not
 //! vestigial: `q`, `open`, `top` and the rest cost nothing to keep, a row
 //! number and an identifier are lines by nature, and a person who reaches the
 //! prompt and types the word they know gets what they meant.
 //!
-//! # A verb that writes is spelled whole, and none of the six is a key
+//! # A verb that writes is spelled whole here, and that is a state not a rule
 //!
-//! The six are `claim`, `log`, `release`, `done`, `amend` and `accept`, with no
-//! abbreviation and no letter of their own. Under the line discipline that
-//! asymmetry *was* the guarantee -- a slipped finger typed nothing, because
-//! there was no `d`. It is still worth having and it is no longer the whole of
-//! it: what a verb read here produces is a [`Command::Act`], and an act is a
-//! command *composed* rather than a command run. It reaches the screen spelled
-//! as a shell would spell it and waits for one key (TASK-d4a882345837,
-//! ADR-0b55983421dd). `keys.rs` and `view.rs` are where that half lives.
+//! The six are `claim`, `log`, `release`, `done`, `amend` and `accept`, and
+//! today none of them has an abbreviation or a letter of its own. Under the
+//! line discipline that asymmetry *was* the guarantee -- a slipped finger typed
+//! nothing, because there was no `d` -- and it stopped being the guarantee when
+//! the reader took keystrokes. ADR-c07e2694f0e1 ends the asymmetry outright: a
+//! key is the verb it runs, the reader binds the initial the CLI already
+//! spells, and TASK-1a415107fd56 is where those letters arrive here.
+//!
+//! What survives that is this module's actual half of the guarantee, which
+//! never depended on the road the verb was reached by. What a verb read here
+//! produces is a [`Command::Act`], and an act is a command *composed* rather
+//! than a command run. It reaches the screen spelled as a shell would spell it
+//! and waits for one key (TASK-d4a882345837, ADR-c07e2694f0e1). `keys.rs` and
+//! `view.rs` are where that half lives.
 //!
 //! # What `accept` costs on top of that, and why
 //!
@@ -124,8 +130,7 @@ pub struct Act {
 /// the flags they spell are rows of [`crate::bindings::BINDINGS`], which is
 /// also where the keys and the key list are read from; this module looks a word
 /// up there rather than carrying a second copy of it. What used to be here was
-/// one of the five parallel tables ADR-c07e2694f0e1, proposed, was written
-/// against.
+/// one of the five parallel tables ADR-c07e2694f0e1 was written against.
 ///
 /// [`crate::ank::ACTS`] still gates the spawn and is still hand-written, and
 /// the dependency runs the other way: the bindings are measured against the

--- a/crates/ank-tui/src/keys.rs
+++ b/crates/ank-tui/src/keys.rs
@@ -1,5 +1,5 @@
 //! One key per command, and the one place a line is still typed
-//! (ADR-0b55983421dd).
+//! (ADR-c07e2694f0e1).
 //!
 //! **The keys themselves are declared in [`crate::bindings`] and not here**
 //! (TASK-4d2eb2b4e193). What this module is now is the two grammars a table
@@ -24,7 +24,7 @@
 //! for with nothing read at all; and `Tab` is what a person who has used one of
 //! these before will press first.
 //!
-//! **No command requires a modifier chord**, which ADR-0b55983421dd asks for and
+//! **No command requires a modifier chord**, which ADR-c07e2694f0e1 asks for and
 //! a phone makes literal: a terminal keyboard on a phone has no comfortable
 //! Control. Control-C is the one exception and it is not a command -- it is the
 //! way out of a program that has taken the terminal, which raw mode has stopped
@@ -57,7 +57,7 @@
 //! keystroke that dismisses the confirmation runs anything" is true of the
 //! whole keyboard rather than of a list somebody has to keep complete.
 //!
-//! `y` is a letter and not a chord, which ADR-0b55983421dd requires and a
+//! `y` is a letter and not a chord, which ADR-c07e2694f0e1 requires and a
 //! phone makes literal, and it is not Enter: Enter is the key that submitted
 //! the line a moment earlier, and a confirmation answered by the same key that
 //! opened it is a confirmation a repeated keypress walks straight through.
@@ -108,7 +108,7 @@ pub enum Answer {
 ///
 /// The modifiers are read and not ignored, in the strict direction: a `y` with
 /// anything held is not the `y` this asks for. So no chord runs a verb, which
-/// is ADR-0b55983421dd's rule applied to the one keystroke in this reader that
+/// is ADR-c07e2694f0e1's rule applied to the one keystroke in this reader that
 /// can move a corpus, and Control-C over a confirmation dismisses it rather
 /// than doing the thing the person was interrupting.
 pub fn confirming(key: KeyEvent) -> Answer {
@@ -122,9 +122,9 @@ pub fn confirming(key: KeyEvent) -> Answer {
 ///
 /// **The mapping is a lookup and no longer a `match`** (TASK-4d2eb2b4e193).
 /// What was here was one arm per key, written beside three other renderings of
-/// the same list, and ADR-c07e2694f0e1 -- proposed, and the successor this
-/// wave is built on -- records what that cost: a key list that
-/// omitted `v`, Space, every arrow and the whole of the ring. The table is now
+/// the same list, and ADR-c07e2694f0e1 -- the decision this wave is built on --
+/// records what that cost: a key list that omitted `v`, Space, every arrow and
+/// the whole of the ring. The table is now
 /// the single declaration and this reads it, so a key that moves moves on every
 /// surface at once.
 ///
@@ -231,7 +231,7 @@ mod tests {
     }
 
     /// Every command that only moves the screen is one key, in every panel
-    /// (ADR-0b55983421dd).
+    /// (ADR-c07e2694f0e1).
     #[test]
     fn a_reading_command_is_one_key_and_the_named_keys_agree_with_the_letters() {
         for view in Focus::ALL {
@@ -261,7 +261,7 @@ mod tests {
     }
 
     /// No command is a chord, and the one that is is the way out rather than a
-    /// command (ADR-0b55983421dd: no command anywhere requires a modifier).
+    /// command (ADR-c07e2694f0e1: no command anywhere requires a modifier).
     #[test]
     fn nothing_but_the_way_out_is_reached_with_a_modifier() {
         for view in Focus::ALL {
@@ -347,7 +347,7 @@ mod tests {
     }
 
     /// Focus moves by key, three ways, and none of the three is a chord
-    /// (TASK-bb43cfe2192b, ADR-0b55983421dd).
+    /// (TASK-bb43cfe2192b, ADR-c07e2694f0e1).
     #[test]
     fn focus_moves_by_key_in_a_ring_by_digit_and_across_the_columns() {
         // The ring, forward from every panel and back again.
@@ -470,7 +470,7 @@ mod tests {
     }
 
     /// And no chord runs one either: the key that writes is the bare letter
-    /// (ADR-0b55983421dd, which forbids a command requiring a modifier -- and
+    /// (ADR-c07e2694f0e1, which forbids a command requiring a modifier -- and
     /// this is the one command that moves a corpus).
     #[test]
     fn no_modifier_held_over_the_confirming_key_still_runs_it() {
@@ -510,7 +510,7 @@ mod tests {
 /// The whole key table, stated as a domain rather than as a list of the likely
 /// keys (TASK-dd9747e5e305).
 ///
-/// ADR-0b55983421dd's rule is that **no command anywhere requires a modifier
+/// ADR-c07e2694f0e1's rule is that **no command anywhere requires a modifier
 /// chord**, and a phone makes it literal: a terminal keyboard on a phone has no
 /// comfortable Control, and a command reachable only with one is a command that
 /// reader cannot run at all. What was here before was that rule checked by
@@ -703,7 +703,7 @@ mod table {
         assert!(every_modifier().contains(&KeyModifiers::NONE));
     }
 
-    /// **No command anywhere requires a modifier chord** (ADR-0b55983421dd),
+    /// **No command anywhere requires a modifier chord** (ADR-c07e2694f0e1),
     /// over the whole table.
     ///
     /// Every key, every way of holding it, every panel: whatever a chord

--- a/crates/ank-tui/src/lib.rs
+++ b/crates/ank-tui/src/lib.rs
@@ -1,5 +1,5 @@
 //! The `tui` verb: a full-screen reader over one corpus (ADR-8bd76e8d7c4e, §4),
-//! drawn with ratatui over crossterm (ADR-0b55983421dd).
+//! drawn with ratatui over crossterm (ADR-c07e2694f0e1).
 //!
 //! **It reaches the corpus by running the CLI, and by nothing else.** Every row
 //! of corpus data on the screen arrives as a `--json` document written by
@@ -68,20 +68,26 @@
 //!
 //! Every command that only moves the screen is one key ([`keys`]), focus
 //! included: `Tab` walks the panels, `1` to `4` name one, and Left and Right
-//! cross the columns. Four of the six verbs that write carry something a key
-//! has no room for -- a message, a reason, a proof, a flag -- so `a` opens a
-//! one-line prompt and what is typed there goes through [`input`], which is the
-//! grammar that spells the six whole. `/` opens the same prompt on a search.
+//! cross the columns. The verbs that write have no letter of their own here
+//! yet: `a` opens a one-line prompt and what is typed there goes through
+//! [`input`], which is the grammar that spells them whole. That is where the
+//! reader stands and no longer where it is going -- ADR-c07e2694f0e1 decides
+//! that a key is the verb it runs, and TASK-1a415107fd56 is where the letters
+//! arrive. The prompt outlives them rather than being replaced by them: four
+//! of the six carry something a key has no room for -- a message, a reason, a
+//! proof, a flag. `/` opens the same prompt on a search.
 //!
 //! **What the line discipline used to guarantee is replaced, and this is what
 //! replaced it.** Under a line reader a slipped finger typed nothing, because a
 //! command was a word and Enter and no word was one letter. Under a keystroke
 //! reader the guarantee is the confirmation that shows the argv before anything
-//! is spawned, which ADR-0b55983421dd requires and TASK-d4a882345837 built: a
+//! is spawned, which ADR-c07e2694f0e1 requires and TASK-d4a882345837 built: a
 //! submitted line composes the command and shows it spelled as a shell would
 //! have to spell it, `y` runs that command, and every other key on the keyboard
-//! dismisses it. So no key writes, no line writes, and what writes is a person
-//! reading an argv and saying yes to it.
+//! dismisses it. What writes is a person reading an argv and saying yes to it,
+//! and that stays true when the verbs take their letters, because the
+//! guarantee is stated over the verbs that write rather than over the road
+//! they were reached by.
 //!
 //! # The layout
 //!
@@ -128,7 +134,7 @@
 //! a keyboard cannot: [`view::App::actions`] draws what the focused panel
 //! offers with the key beside the word, so the two roads carry one vocabulary.
 //!
-//! **No command anywhere requires a modifier chord** (ADR-0b55983421dd), and
+//! **No command anywhere requires a modifier chord** (ADR-c07e2694f0e1), and
 //! that is now measured rather than reviewed: `keys`'s own table walks every
 //! key a terminal can report against every way a modifier can be held and holds
 //! this reader to it. It is what turned `Tab` and Shift-`Tab` into the panel
@@ -553,7 +559,7 @@ mod tests {
     }
 
     /// A terminal made narrower redraws to its new size, with nobody typing
-    /// (TASK-4fa385c1772d, ADR-0b55983421dd).
+    /// (TASK-4fa385c1772d, ADR-c07e2694f0e1).
     ///
     /// The only wake in the session is the resize, so a second frame existing at
     /// all is the reader answering the window rather than a command. What is

--- a/crates/ank-tui/src/paint.rs
+++ b/crates/ank-tui/src/paint.rs
@@ -44,7 +44,7 @@
 //! probe. `NO_COLOR` reaches the ink alone, so the frame drawn with the paint
 //! and the frame drawn without it are the same characters -- which is the only
 //! way "nothing is carried by colour alone" can be measured at all
-//! (ADR-c07e2694f0e1, proposed).
+//! (ADR-c07e2694f0e1).
 //!
 //! # Composing a row, and what is deliberately left alone
 //!
@@ -168,11 +168,11 @@ impl Ink {
 /// The terminal's own declaration that it can render nothing rich.
 ///
 /// **One probe, read by two fields, which is the whole of what makes the
-/// degradation honest** (ADR-c07e2694f0e1, proposed successor to
-/// ADR-0b55983421dd). A terminal that says `dumb` is saying it can draw
-/// neither the colours [`Ink`] would paint nor the box-drawing glyphs
-/// `view`'s borders are made of, and it gets one answer to that rather than
-/// two: the plain palette *and* the ASCII rules, from this function.
+/// degradation honest** (ADR-c07e2694f0e1). A terminal that says `dumb` is
+/// saying it can draw neither the colours [`Ink`] would paint nor the
+/// box-drawing glyphs `view`'s borders are made of, and it gets one answer to
+/// that rather than two: the plain palette *and* the ASCII rules, from this
+/// function.
 ///
 /// `NO_COLOR` is deliberately not here. Refusing colour is refusing colour and
 /// nothing else, so it reaches [`Ink::detect`] above and reaches no glyph: a

--- a/crates/ank-tui/src/term.rs
+++ b/crates/ank-tui/src/term.rs
@@ -1,5 +1,5 @@
 //! The engine: raw mode, the alternate screen, and the three things that wake a
-//! drawn screen (ADR-0b55983421dd).
+//! drawn screen (ADR-c07e2694f0e1).
 //!
 //! **No `extern` block enters this workspace for any of it, and that is the
 //! whole of why this file may exist at all.** Raw mode is `tcsetattr` on Unix

--- a/crates/ank-tui/src/text.rs
+++ b/crates/ank-tui/src/text.rs
@@ -109,7 +109,7 @@ pub fn wrap(line: &str, width: usize) -> Vec<String> {
 /// the terminal rather than about the arithmetic: a screen ruling its panels
 /// with box-drawing glyphs rules its chrome with the same horizontal, and one
 /// that has been told the terminal is dumb rules both with `-`
-/// (ADR-c07e2694f0e1, proposed). [`crate::view::Glyphs`] is what answers it,
+/// (ADR-c07e2694f0e1). [`crate::view::Glyphs`] is what answers it,
 /// once, when the screen opens.
 pub fn rule(width: usize, of: &str) -> String {
     of.repeat(width)

--- a/crates/ank-tui/src/view.rs
+++ b/crates/ank-tui/src/view.rs
@@ -72,15 +72,15 @@
 //!
 //! **The borders are box-drawing glyphs, and drop to `-`, `|`, `+` and `=` on
 //! the terminal that declares it can render neither those nor colour**
-//! (ADR-c07e2694f0e1, proposed successor to ADR-0b55983421dd). [`Glyphs`] is
-//! that choice, and it is a field of its own beside the ink rather than a part
-//! of it: the probe is the terminal's own word and never `NO_COLOR`, because
-//! refusing colour is not refusing glyphs and a frame whose characters moved
-//! when the paint went would leave "nothing is carried by colour alone" with
-//! nothing to measure it by. LOG-ed57116ba141 recorded the older answer --
-//! ASCII everywhere, for the phone that could not draw the glyphs -- and the
-//! phones people read from have overtaken it; ADR-1f70ce2c3eac's scope is the
-//! CLI's renderer and not this one.
+//! (ADR-c07e2694f0e1). [`Glyphs`] is that choice, and it is a field of its own
+//! beside the ink rather than a part of it: the probe is the terminal's own
+//! word and never `NO_COLOR`, because refusing colour is not refusing glyphs
+//! and a frame whose characters moved when the paint went would leave "nothing
+//! is carried by colour alone" with nothing to measure it by.
+//! LOG-ed57116ba141 recorded the older answer -- ASCII everywhere, for the
+//! phone that could not draw the glyphs -- and the phones people read from
+//! have overtaken it; ADR-1f70ce2c3eac's scope is the CLI's renderer and not
+//! this one.
 //!
 //! **And focus is not decoration: the focused one of the two middle panels
 //! takes four fifths of the width.** A corpus reader has exactly two things
@@ -142,7 +142,7 @@
 //! # The confirmation, which is the fourth act
 //!
 //! **No verb that writes is spawned without the exact command line having been
-//! on the screen first** (TASK-d4a882345837, ADR-0b55983421dd). What
+//! on the screen first** (TASK-d4a882345837, ADR-c07e2694f0e1). What
 //! [`App::propose`] leaves behind is a `Pending`: the verb, the argv, and the
 //! line spelled as a shell would have to spell it. The band under the panels
 //! shows that line, `y` runs it and every other key on the keyboard drops it
@@ -313,7 +313,7 @@ impl Focus {
 /// person with a keyboard reads the letter, a person with a thumb touches the
 /// word, and neither is using a feature the other has not got.
 ///
-/// None of the keys named here is a chord, which is ADR-0b55983421dd's rule
+/// None of the keys named here is a chord, which is ADR-c07e2694f0e1's rule
 /// showing on the screen rather than only in `keys`: a target offering
 /// Control-something would be an offer a phone cannot take.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -444,7 +444,7 @@ pub struct App {
     /// screen whose answer could differ between two rows of one frame.
     ink: Ink,
     /// Which characters this screen draws its structure with, decided once
-    /// when it opens (ADR-c07e2694f0e1, proposed).
+    /// when it opens (ADR-c07e2694f0e1).
     ///
     /// **Beside the ink and never inside it.** The two are decided from one
     /// probe and they are two fields, so taking the paint away moves no
@@ -1805,10 +1805,9 @@ impl App {
     ///
     /// **What the block buys is the screen this panel was spending on text a
     /// person had to read as YAML.** That is the ground ADR-c07e2694f0e1 stands
-    /// on -- the reader spends its screen on the corpus -- which is proposed and
-    /// not ratified: a successor to ADR-0b55983421dd rather than a decision this
-    /// code may yet lean on. What binds here is still ADR-0b55983421dd, and
-    /// nothing above needs the successor to be true.
+    /// on -- the reader spends its screen on the corpus -- and it is ratified,
+    /// so the argument this block was built on and the decision that binds it
+    /// are one document rather than two that happened to agree.
     fn block(&self, width: usize) -> Vec<(Composed, Option<String>)> {
         let Some(detail) = &self.detail else {
             return Vec::new();
@@ -2224,14 +2223,14 @@ impl App {
 /// Which characters this reader draws its structure with.
 ///
 /// **A second field beside [`paint::Ink`], and never the ink itself**
-/// (ADR-c07e2694f0e1, proposed successor to ADR-0b55983421dd). The two share
-/// one probe -- [`paint::declared_dumb`], the terminal's own word that it can
-/// render nothing rich -- and nothing else: `NO_COLOR` reaches the ink and
-/// reaches no glyph. That separation is not tidiness. "Nothing on this screen
-/// is carried by colour alone" is measured by drawing one corpus with the
-/// paint and once without it and requiring the two frames to be identical
-/// character for character, and a border that moved with the ink would leave
-/// the property with no measurement at all.
+/// (ADR-c07e2694f0e1). The two share one probe -- [`paint::declared_dumb`],
+/// the terminal's own word that it can render nothing rich -- and nothing
+/// else: `NO_COLOR` reaches the ink and reaches no glyph. That separation is
+/// not tidiness. "Nothing on this screen is carried by colour alone" is
+/// measured by drawing one corpus with the paint and once without it and
+/// requiring the two frames to be identical character for character, and a
+/// border that moved with the ink would leave the property with no measurement
+/// at all.
 ///
 /// Copied rather than referenced, and constructed in three places: [`detect`]
 /// below, and the two constants the suite uses to state both halves of the
@@ -2704,8 +2703,7 @@ fn step(at: usize, by: isize, total: usize) -> usize {
 pub const PROMPT: &str = ": ";
 // `KEYS`, `PANEL_KEYS`, `ACT_KEYS` and `RATIFY_KEY` stood here
 // (TASK-4d2eb2b4e193). Four sentences about a key table, written beside two
-// other renderings of the same table, and ADR-c07e2694f0e1 -- proposed --
-// records what they
+// other renderings of the same table, and ADR-c07e2694f0e1 records what they
 // cost: the trailer taught a vocabulary the reader did not have, and left out
 // `v`, Space, every arrow and the whole of the ring. The trailer now draws
 // `bindings::screen_line` and `bindings::write_line`, over
@@ -2987,7 +2985,7 @@ mod tests {
     }
 
     /// Structure is box-drawing, and the ASCII rules are what a terminal that
-    /// declared itself dumb gets back (ADR-c07e2694f0e1, proposed).
+    /// declared itself dumb gets back (ADR-c07e2694f0e1).
     ///
     /// Both sets on one test, because either alone is half of it: a reader
     /// that had gone to glyphs and taken the fallback with it would pass the

--- a/crates/ank-tui/tests/bindings.rs
+++ b/crates/ank-tui/tests/bindings.rs
@@ -10,8 +10,8 @@
 //! there is a dispatch, a note band, a wrap, a `fit` and a terminal.
 //!
 //! **Twice, that being the whole of the point.** ADR-c07e2694f0e1, the
-//! proposed successor this wave is built on, was written
-//! because the reader's own trailer taught a vocabulary the reader did not have
+//! decision this wave is built on, was written because the reader's own
+//! trailer taught a vocabulary the reader did not have
 //! -- `?` omitted `v`, Space, every arrow, the way out and the whole of the
 //! ring -- and a suite that asserted the list contains `q quit` would have
 //! passed on that screen. So this reads the drawn rows back and holds them to

--- a/crates/ank-tui/tests/colour.rs
+++ b/crates/ank-tui/tests/colour.rs
@@ -56,7 +56,7 @@ use terminal::{ids_of, Live, Repo};
 const WINDOW: (u16, u16) = (110, 30);
 
 /// The rule the focused panel is drawn with, read out of the reader rather
-/// than written here (ADR-c07e2694f0e1, proposed).
+/// than written here (ADR-c07e2694f0e1).
 ///
 /// It is a *character* and that is the point of naming it in this file: the
 /// glyph set is a second field beside the ink and no `NO_COLOR` reaches it, so

--- a/crates/ank-tui/tests/dependencies.rs
+++ b/crates/ank-tui/tests/dependencies.rs
@@ -1,9 +1,9 @@
-//! The constraint made mechanical (ADR-8bd76e8d7c4e, ADR-0b55983421dd).
+//! The constraint made mechanical (ADR-8bd76e8d7c4e, ADR-c07e2694f0e1).
 //!
 //! ADR-8bd76e8d7c4e forbids the terminal reader from linking `ank-core`, from
 //! reading `.ank/` and from touching `refs/ank/*`, so that the refusals it shows
 //! are the refusals the CLI gave and there is no second dispatch path to keep in
-//! step. ADR-0b55983421dd adds one of the same kind on the other side: the
+//! step. ADR-c07e2694f0e1 adds one of the same kind on the other side: the
 //! reader is drawn with ratatui over crossterm, and **no FFI enters this tree
 //! for any of it, on any platform**. A rule that lives only in prose is a rule
 //! the second contributor breaks for a good reason, on a Tuesday, in a commit
@@ -161,7 +161,7 @@ fn the_graph_carries_neither_ank_core_nor_git() {
 /// The list is the manifest's argument written as an assertion. `ank-contract`
 /// is the machine contract every surface consumes (ADR-6fd69efb629c);
 /// `serde_yaml` is already in the tree four times over and is what reads the
-/// CLI's `--json`; `ratatui` and `crossterm` are what ADR-0b55983421dd spends
+/// CLI's `--json`; `ratatui` and `crossterm` are what ADR-c07e2694f0e1 spends
 /// and the whole of what it spends; the rest is what those four bring with them
 /// and nothing this crate chose.
 #[test]
@@ -186,7 +186,7 @@ fn the_crate_takes_nothing_the_tree_did_not_already_carry() {
     );
 }
 
-/// No `extern` block, on any platform (ADR-0b55983421dd).
+/// No `extern` block, on any platform (ADR-c07e2694f0e1).
 ///
 /// **This is the assertion the whole decision rests on.** What sent the reader
 /// to a line discipline in the first place was that raw mode is `tcsetattr` on
@@ -208,7 +208,7 @@ fn no_foreign_symbol_is_declared_in_this_tree() {
                 !text.contains(forbidden),
                 "{file} declares {forbidden}: the reader reaches raw mode, the \
                  window and a keystroke through crossterm, which is what \
-                 ADR-0b55983421dd bought and the only reason it was worth \
+                 ADR-c07e2694f0e1 bought and the only reason it was worth \
                  buying"
             );
         }
@@ -303,8 +303,7 @@ fn one_function_in_this_crate_spawns_a_verb_that_writes() {
 /// This is the half of `keys::no_bare_key_can_write` that survives the wave.
 /// That test said no bare key could produce a [`ank_tui::input::Command::Act`]
 /// at all, and it was worth having because reaching a verb took a key *and* a
-/// word. ADR-c07e2694f0e1, proposed, spends that asymmetry:
-/// TASK-1a415107fd56 gives the
+/// word. ADR-c07e2694f0e1 spends that asymmetry: TASK-1a415107fd56 gives the
 /// six their own letters, and the rule that has to hold afterwards is not that
 /// an act is unreachable by a key -- it is that *however* an act is reached, it
 /// is composed and shown rather than run.

--- a/crates/ank-tui/tests/panels.rs
+++ b/crates/ank-tui/tests/panels.rs
@@ -24,7 +24,7 @@ mod terminal;
 use terminal::{Live, Repo};
 
 /// The border set an ordinary terminal is drawn with, read out of the reader
-/// rather than written here (ADR-c07e2694f0e1, proposed).
+/// rather than written here (ADR-c07e2694f0e1).
 ///
 /// A suite carrying its own copy of a glyph would go on asserting about a
 /// character the reader had stopped drawing, which is a test that quietly
@@ -191,7 +191,7 @@ fn the_panels_are_side_by_side_and_the_focused_one_is_marked_in_characters() {
 }
 
 /// Structure is box-drawing, and ASCII where the terminal declares itself
-/// dumb (TASK-e900637aeac4, ADR-c07e2694f0e1 proposed).
+/// dumb (TASK-e900637aeac4, ADR-c07e2694f0e1).
 ///
 /// **Through the binary, because the probe is the environment of a process.**
 /// `src/view.rs` asserts the same property of the render function, which is

--- a/crates/ank-tui/tests/phone.rs
+++ b/crates/ank-tui/tests/phone.rs
@@ -40,7 +40,7 @@ use terminal::{Live, Repo};
 const PHONE: (u16, u16) = (ank_tui::view::ONE_COLUMN - 7, 30);
 
 /// A panel's vertical border, at either weight, as characters
-/// (ADR-c07e2694f0e1, proposed).
+/// (ADR-c07e2694f0e1).
 ///
 /// Read out of the reader rather than written as `|` here: the border set
 /// moved once already, and a suite carrying its own copy of the character

--- a/crates/ank-tui/tests/terminal/mod.rs
+++ b/crates/ank-tui/tests/terminal/mod.rs
@@ -5,7 +5,7 @@
 //! crate, so two of them share nothing that is not in a library -- and a
 //! pseudo-terminal in `ank-tui`'s own `src/` is not an option:
 //! `tests/dependencies.rs` forbids this crate a foreign symbol and forbids it
-//! `unsafe`, which is the whole of what ADR-0b55983421dd bought by taking
+//! `unsafe`, which is the whole of what ADR-c07e2694f0e1 bought by taking
 //! crossterm. A test may name what the crate may not, and that file's
 //! `sources()` reads only `src/`, which is exactly the exemption it is written
 //! to give. So the smallest terminal that can answer these questions lives in a
@@ -604,7 +604,7 @@ impl Live {
     }
 
     /// A session on a terminal that has declared it can render nothing rich
-    /// (ADR-c07e2694f0e1, proposed).
+    /// (ADR-c07e2694f0e1).
     ///
     /// `TERM=dumb` is the whole of the declaration, and it is what puts the
     /// reader on its ASCII border set and its plain palette at once -- one


### PR DESCRIPTION
Carries the ratification and the repair together, on purpose: `ank accept`
warns where ADR-3b6ba766a42e refuses, so a branch that merged the signature
alone would put a red commit on `main` — 43 citations of a document the same
commit retired, and `no_superseded_document_is_cited_in_the_workspace`
walking every crate to find them.

## What is here

* `7ab64af` — the ratification, signed. ADR-c07e2694f0e1 accepted,
  ADR-0b55983421dd superseded. Untouched, in place, never rebased.
* `1e1e19c` — the sweep. 43 citations across 11 tracked files → 0.
* `18397c9` — `ank done TASK-fa9b436da1f4 --proof commit:1e1e19c`.

## Why it is a judgement pass and not a `sed`

The citations do not all move the same way. ADR-c07e2694f0e1 keeps three of
its predecessor's paragraphs word for word and rewrites the one the screen
overtook, so re-pointing every identifier mechanically would have produced
comments that cite the accepted document in support of claims it does not
make — sourced-looking, wrong, and invisible to any later grep.

**Re-pointed**, where the successor carries the sentence forward verbatim:
the ratatui/crossterm spend and the no-FFI-on-any-platform rule
(`Cargo.toml`, `tests/dependencies.rs`, `term.rs`, `tests/terminal/mod.rs`);
all ten chord and one-key-per-screen-command citations in `keys.rs`, and
their counterparts in `lib.rs`, `view.rs` and `bindings.rs`; the
confirmation that shows the argv; the resize.

**Rewritten**, where the ratification made the sentence false:

* The fifty-five-crate price is stated only in the *old* body. `Cargo.toml`
  now states the number without sourcing it to a document that never says
  it.
* `bindings.rs`, `input.rs`, `lib.rs` and `crates/ank-cli/tests/tui.rs`
  read "a writing verb has no letter of its own" as a decision. The
  successor decides the opposite — *a key is the verb it runs* — so that is
  now written as the state the reader is in, with TASK-1a415107fd56 named
  as where the letters arrive, and the write guarantee restated over the
  verbs that write rather than over the road they were reached by.
* `view::App::block` said the successor was proposed and that this code
  may not yet lean on it. It is ratified.

**Also corrected**: thirteen comments calling ADR-c07e2694f0e1 "proposed".
The guard cannot see those — they cite the living document — but the same
commit falsified them, so they are fixed in the same pass.

## Verification

* `cargo test --workspace` — green.
* `cargo fmt --check` — green.
* `ank check` — `check: ok`, exit 0, signals only, no fault.
* `git grep 0b55983421dd -- . ':!.ank/'` — 0, confirmed 43 before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y36P977xERU4A5788J35HQ