### PR TITLE
The key list is an overlay, and every line of it is a target

### DIFF
--- a/.ank/entities/LOG-27216f511c91.md
+++ b/.ank/entities/LOG-27216f511c91.md
@@ -1,0 +1,13 @@
+---
+id: LOG-27216f511c91
+type: log
+title: done, proof commit:e14078f
+created: 2026-08-26T22:48:10Z
+author: claude-code/opus-5+overlay
+scope:
+  - crates/ank-tui/**
+about: TASK-8a6578851244
+seq: 2
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-7887dc4f2b4c.md
+++ b/.ank/entities/LOG-7887dc4f2b4c.md
@@ -1,0 +1,25 @@
+---
+id: LOG-7887dc4f2b4c
+type: log
+title: The key list is an overlay drawn over everything below the header, and arrange() does not know it
+created: 2026-08-26T22:41:16Z
+author: claude-code/opus-5+overlay
+scope:
+  - crates/ank-tui/**
+about: TASK-8a6578851244
+seq: 1
+schema: 4
+version: 1
+---
+
+ exists. That is the whole of why Esc gives the frame back character for character: nothing moved to make room, so nothing has to move back. The note band still reserves its one row underneath, unchanged.
+
+ONE ROW PER BINDING, GENERATED FROM THE LINE THE TRAILER ALREADY DRAWS. bindings::listing() now returns Vec<Item> -- text plus the binding a press runs -- built from the same lines() the trailer's screen_line/write_line/ratify_line come from, so there is still one list and the unit test that holds every binding to exactly one line still states it. What the trailer's lead and note become is a heading, and a heading is the one row of the overlay that runs nothing. A line of six entries joined by two spaces could not be a target; a row can.
+
+A KEYLESS VERB IS REACHED THROUGH input::parse AND NOT AROUND IT. The writing half has no letter until TASK-1a415107fd56, so a press on the row reading 'claim' composes the verb the way a typed line does: parse(verb.name, focus) -> Command::Act -> propose. Tail::Message and Tail::Behind cannot be composed with nothing, so those rows seed the prompt instead. dependencies.rs is untouched by this -- there is still one 'Command::Act(' arm and one 'ank.act(' in src/.
+
+THE OVERLAY'S GRAMMAR IS COMMANDS, NEVER LETTERS. App::over_list reads keys::typed and answers Move/Page/Top by scrolling and Help/Back by closing; everything else closes the list and goes on to do what it does. So Esc closes it because Esc is an alias of back, and there is no fifth key table.
+
+THE PTY FLAKE THAT COST ME A RED WORKSPACE RUN, AND IT IS THE SUITE'S AND NOT THE READER'S. Live::frame() settles the screen -- it returns once two reads 200ms apart agree -- and a settled screen is NOT a screen that has answered the keystroke just sent to it. Under load the reader was still getting to the 'n' that scrolls, frame() returned the page that was already there, and the row located on it was pressed against a list that had since moved: the press landed on '? keys' instead of 'claim', which reopens the list at the top and looks exactly like a scroll that never happened. The fix is to synchronise on something the reader prints: the overlay's own count line, 'KEYS 20-38 of 40', waited for with until() after every page.
+
+TWO MORE TRAPS IN terminal/mod.rs FOR WHOEVER WRITES THE NEXT SUITE. until(|t| t.contains("2 ENTITIES")) waits for nothing at all -- a panel title carries the panel's NUMBER and its name and is on the very first frame, before the reader has asked the CLI anything; wait for a row of the corpus ('TASK-') instead. And live.quit() over a waiting confirmation hangs for ever: quit() sends 'q', and 'q' over a confirmation dismisses the command rather than ending the session, so child.wait() never returns. Decline it first.

--- a/.ank/entities/TASK-8a6578851244.md
+++ b/.ank/entities/TASK-8a6578851244.md
@@ -5,7 +5,7 @@ slug: the-key-list-is-an-overlay-and-every-line-of-it
 title: The key list is an overlay, and every line of it is a target
 created: 2026-08-26T17:07:21Z
 author: claude-code/opus-5+reader-redesign
-status: open
+status: in_progress
 scope:
   - crates/ank-tui/**
 blocked_by: [TASK-4d2eb2b4e193]
@@ -13,5 +13,5 @@ done_criteria: |
   At eighty columns by twenty-four and at forty by thirty, the built binary answers ? with a bordered list drawn over the panels rather than a note written under them. A press sent as SGR on the line reading claim raises the claim confirmation, so a line of the list is the key it names. Esc closes the list and leaves the frame the one it was. A press while a command waits dismisses that command and opens no list, and the frame is still exactly the window's rows with no row past its right edge at both windows.
 criteria_by: creator
 schema: 4
-version: 2
+version: 3
 ---

--- a/.ank/entities/TASK-8a6578851244.md
+++ b/.ank/entities/TASK-8a6578851244.md
@@ -5,13 +5,18 @@ slug: the-key-list-is-an-overlay-and-every-line-of-it
 title: The key list is an overlay, and every line of it is a target
 created: 2026-08-26T17:07:21Z
 author: claude-code/opus-5+reader-redesign
-status: in_progress
+status: done
 scope:
   - crates/ank-tui/**
 blocked_by: [TASK-4d2eb2b4e193]
 done_criteria: |
   At eighty columns by twenty-four and at forty by thirty, the built binary answers ? with a bordered list drawn over the panels rather than a note written under them. A press sent as SGR on the line reading claim raises the claim confirmation, so a line of the list is the key it names. Esc closes the list and leaves the frame the one it was. A press while a command waits dismisses that command and opens no list, and the frame is still exactly the window's rows with no row past its right edge at both windows.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: e14078f
+    criteria: 0b8a75cc24e4
+    via: submitted
 schema: 4
-version: 3
+version: 4
 ---

--- a/crates/ank-tui/src/bindings.rs
+++ b/crates/ank-tui/src/bindings.rs
@@ -737,6 +737,12 @@ const TYPING_NOTE: &str = "   (over a line being typed)";
 /// one line, and a line names nothing that is not a binding -- which is the
 /// claim ADR-c07e2694f0e1 found the old trailer failing.
 struct Line {
+    /// What the key list calls the rows under it, on the heading over them.
+    ///
+    /// Two words at most, because it stands over the rows rather than
+    /// explaining them: the sentence that does the explaining is `note`, and it
+    /// is the same sentence the trailer ends its own line with.
+    title: &'static str,
     /// The rows it names, in the table's order.
     bindings: Vec<&'static Binding>,
     /// What is drawn in front of them.
@@ -753,11 +759,48 @@ impl Line {
         let entries: Vec<String> = self.bindings.iter().map(|b| b.entry()).collect();
         format!("{}{}{}", self.lead, entries.join(self.between), self.note)
     }
+
+    /// What stands over this line's rows on the key list
+    /// (TASK-8a6578851244).
+    ///
+    /// **Prose, and never an entry.** The title, the lead the trailer draws in
+    /// front of its entries, and the sentence it ends with are all three about
+    /// the rows beneath rather than one of them -- which is what keeps "every
+    /// line of the list is the key it names" a claim about rows a person can
+    /// press, and leaves a heading as the one line on the overlay that runs
+    /// nothing.
+    fn heading(&self) -> String {
+        let lead = self.lead.trim_end();
+        match lead.is_empty() {
+            true => format!("{}{}", self.title, self.note),
+            false => format!("{}   {lead}{}", self.title, self.note),
+        }
+    }
+}
+
+/// One row of the key list, and the binding a press on it runs
+/// (TASK-8a6578851244).
+///
+/// **The row and its binding are one value**, which is the whole of why the
+/// list is generated as this rather than as strings: a screen that drew the
+/// rows from one function and resolved a press with another would be two
+/// orderings agreeing by luck, and the ADR asks for a list every line of which
+/// *is* the key it names.
+///
+/// `binding` is `None` on a heading, which is prose about the rows under it --
+/// see [`Line::heading`].
+#[derive(Debug, Clone)]
+pub struct Item {
+    /// What the row reads.
+    pub text: String,
+    /// What pressing it runs, where it names one.
+    pub binding: Option<&'static Binding>,
 }
 
 /// The keys that move what is inside a panel.
 fn screen() -> Line {
     Line {
+        title: "screen",
         bindings: of_group(Group::Screen),
         lead: String::new(),
         between: "  ",
@@ -772,6 +815,7 @@ fn screen() -> Line {
 /// has lost track of where they are needs the second line and not the first.
 fn panel() -> Line {
     Line {
+        title: "panels",
         bindings: of_group(Group::Panel),
         lead: String::new(),
         between: "  ",
@@ -787,6 +831,7 @@ fn panel() -> Line {
 /// and one line mixing them would make that a matter of remembering.
 fn write() -> Line {
     Line {
+        title: "corpus",
         bindings: writing(|offered| offered != Offered::Ratifiable),
         lead: format!("{} then  ", named(KeyCode::Char(ACT))),
         between: " | ",
@@ -797,6 +842,7 @@ fn write() -> Line {
 /// The sixth act, on a line of its own, and only where the verb would take it.
 fn ratify() -> Line {
     Line {
+        title: "signature",
         bindings: writing(|offered| offered == Offered::Ratifiable),
         lead: format!("{} then  ", named(KeyCode::Char(ACT))),
         between: " | ",
@@ -807,6 +853,7 @@ fn ratify() -> Line {
 /// What a command waiting to be answered offers.
 fn waiting() -> Line {
     Line {
+        title: "waiting",
         bindings: answering(Offered::Waiting),
         lead: String::new(),
         between: "  ",
@@ -817,6 +864,7 @@ fn waiting() -> Line {
 /// What an open prompt offers.
 fn typing() -> Line {
     Line {
+        title: "typing",
         bindings: answering(Offered::Typing),
         lead: String::new(),
         between: "  ",
@@ -852,12 +900,37 @@ pub fn ratify_line() -> String {
 
 /// The key list: every binding this table declares, and nothing it does not.
 ///
-/// What `?` answers with, and what TASK-8a6578851244 turns into an overlay
-/// whose every line is a target. Generated from the rows above, so the list
-/// cannot go on naming a key that moved or leave out one that arrived -- which
-/// is the whole of what this table is for.
-pub fn listing() -> Vec<String> {
-    lines().iter().map(Line::drawn).collect()
+/// What `?` answers with, drawn as an overlay over the panels every row of
+/// which is the key it names (TASK-8a6578851244). Generated from the rows
+/// above, so the list cannot go on naming a key that moved or leave out one
+/// that arrived -- which is the whole of what this table is for.
+///
+/// **One row per binding, and that is what the overlay bought.** Under the
+/// trailer a line was six entries joined by two spaces, because a band with
+/// three rows to spend had no other way to carry thirty-three of them; a person
+/// with a thumb could read `claim <flags>` there and had nowhere to put it. A
+/// row of its own is a rectangle a finger fits in, and [`Item`] carries the
+/// binding beside the text so the rectangle and the verb are one fact.
+///
+/// The headings are what the trailer's leads and notes become: prose over the
+/// rows rather than beside them, and the one kind of row that runs nothing.
+pub fn listing() -> Vec<Item> {
+    let mut out = Vec::new();
+    for line in lines() {
+        out.push(Item {
+            text: line.heading(),
+            binding: None,
+        });
+        for binding in line.bindings {
+            out.push(Item {
+                // Indented under the heading it belongs to, which is the whole
+                // of what says a row is an entry and not a sentence about them.
+                text: format!("  {}", binding.entry()),
+                binding: Some(binding),
+            });
+        }
+    }
+    out
 }
 
 /// Every binding of a group, in the table's order.
@@ -1036,6 +1109,41 @@ mod tests {
                 );
             }
         }
+        // And the list a person presses is that same list, row for row
+        // (TASK-8a6578851244). Every binding on exactly one row that draws it,
+        // every other row a heading, and no third kind -- which is what turns
+        // "every line of the list is the key it names" into something a screen
+        // can be held to rather than something to remember.
+        let listed = listing();
+        for binding in BINDINGS {
+            let on: Vec<&Item> = listed
+                .iter()
+                .filter(|item| item.binding.is_some_and(|b| std::ptr::eq(b, binding)))
+                .collect();
+            assert_eq!(
+                on.len(),
+                1,
+                "'{}' is on {} rows of the key list",
+                binding.entry(),
+                on.len()
+            );
+            assert!(
+                on[0].text.contains(&binding.entry()),
+                "a row of the key list names '{}' and does not draw it: {}",
+                binding.entry(),
+                on[0].text
+            );
+        }
+        assert_eq!(
+            listed.iter().filter(|item| item.binding.is_none()).count(),
+            lines().len(),
+            "the key list draws one heading per line of the table"
+        );
+        assert_eq!(
+            listed.len(),
+            BINDINGS.len() + lines().len(),
+            "the key list carries a row that is neither a binding nor a heading"
+        );
     }
 
     /// **The two modal grammars answer the keys the table offers**

--- a/crates/ank-tui/src/view.rs
+++ b/crates/ank-tui/src/view.rs
@@ -213,7 +213,7 @@
 //! it.
 
 use crate::ank::{Ank, Failed, Ran};
-use crate::bindings::{self, Holding};
+use crate::bindings::{self, Binding, Holding, Tail, Verb};
 use crate::input::{Act, Command};
 use crate::keys::{self, Editing, Press};
 use crate::model::{self, short_of, Detail, Queue, Row, Snapshot};
@@ -226,7 +226,7 @@ use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseEvent, Mou
 use ratatui::layout::{Constraint, Layout, Position, Rect};
 use ratatui::symbols::border;
 use ratatui::text::{Line, Text};
-use ratatui::widgets::{Block, Paragraph, Widget};
+use ratatui::widgets::{Block, Clear, Paragraph, Widget};
 
 /// Which panel has focus.
 ///
@@ -396,6 +396,16 @@ struct Cursor {
     top: usize,
 }
 
+/// What the key list did with a key pressed over it (TASK-8a6578851244).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Listed {
+    /// The list answered it: it scrolled, went back to the top, or closed.
+    Answered,
+    /// The list has no answer for it. It closes, and the key goes on to the
+    /// reader as if the list had not been there.
+    Through,
+}
+
 pub struct App {
     size: (usize, usize),
     focus: Focus,
@@ -450,6 +460,21 @@ pub struct App {
     /// probe and they are two fields, so taking the paint away moves no
     /// character on this frame -- see [`Glyphs`].
     glyphs: Glyphs,
+    /// The key list, open, with the row of it the overlay starts at
+    /// (TASK-8a6578851244).
+    ///
+    /// `None` is the ordinary state, and it is the whole of what the list costs
+    /// at rest: nothing. Open, it is drawn *over* the panels rather than into
+    /// the band under them, so the arrangement beneath it does not move and
+    /// closing it gives back the frame that was there -- which is what a note
+    /// carrying thirty-three entries could not do at eighty by twenty-four,
+    /// where the panels were squeezed to make room for it.
+    ///
+    /// A row and not a flag, because the list is longer than the window at both
+    /// of the windows ADR-c07e2694f0e1 measures this reader on. The alternative
+    /// to scrolling it is cutting it, and a key list that stops at the bottom of
+    /// the screen is the omission that decision was written against.
+    overlay: Option<usize>,
 }
 
 impl App {
@@ -481,6 +506,7 @@ impl App {
             // only the half of that rule the terminal itself answered.
             ink: Ink::detect(),
             glyphs: Glyphs::detect(),
+            overlay: None,
         }
     }
 
@@ -722,6 +748,16 @@ impl App {
                 }
             };
         }
+        if self.overlay.is_some() {
+            match self.over_list(key) {
+                Listed::Answered => return false,
+                // The list closes on a key it has no answer for, and that key
+                // goes on to do what it does: a person who pressed `4` on the
+                // key list asked for the queue, and a reader that swallowed the
+                // press to close a window would be one press behind them.
+                Listed::Through => self.overlay = None,
+            }
+        }
         match keys::typed(key, self.focus) {
             Press::Run(command) => self.act(command, ank),
             Press::Cycle => {
@@ -767,6 +803,15 @@ impl App {
         let at = Position::new(event.column, event.row);
         match event.kind {
             MouseEventKind::Down(_) => {
+                // The list is over the panels and over the bands, so it is what
+                // a press lands on while it is open: one row, one binding, and
+                // no second road to whatever is drawn underneath it.
+                if self.overlay.is_some() {
+                    return match self.list_at(at) {
+                        Some(binding) => self.ran(binding, ank),
+                        None => false,
+                    };
+                }
                 if let Some(key) = self.target_at(at) {
                     return self.press(KeyEvent::new(key, KeyModifiers::NONE), ank);
                 }
@@ -798,7 +843,56 @@ impl App {
         if self.pending.is_some() || self.prompt.is_some() {
             return false;
         }
+        // A swipe over the key list scrolls the key list, which is the same
+        // rule: what a scroll moves is what the finger is on.
+        if self.overlay.is_some() {
+            self.scroll_list(by);
+            return false;
+        }
         self.act(Command::Move(by), ank)
+    }
+
+    /// What one key does to the key list that is open under it
+    /// (TASK-8a6578851244).
+    ///
+    /// **Read as commands and never as letters**, which is what keeps the
+    /// overlay's own grammar from being a fifth key table. What the list
+    /// answers to is what a person means by it: the movement commands scroll
+    /// the rows, `top` goes back to the first of them, and the two commands
+    /// that mean "out of this" -- the key the list is named after, and `back`,
+    /// which is where `Esc` lands -- close it. Every other key is the reader's
+    /// as usual.
+    ///
+    /// It is not modal, and deliberately: the confirmation is modal because
+    /// what a person says yes to must not move underneath them, and a list of
+    /// keys has nothing to say yes to.
+    fn over_list(&mut self, key: KeyEvent) -> Listed {
+        let Press::Run(command) = keys::typed(key, self.focus) else {
+            return Listed::Through;
+        };
+        match command {
+            Command::Move(by) => self.scroll_list(by),
+            Command::Page(by) => {
+                let page = self.list_rows().max(1) as isize;
+                self.scroll_list(by * page)
+            }
+            Command::Top => self.overlay = Some(0),
+            Command::Help | Command::Back => self.overlay = None,
+            _ => return Listed::Through,
+        }
+        Listed::Answered
+    }
+
+    /// The key list, moved by this many rows, and never past either end.
+    ///
+    /// Clamped against the rows the overlay can actually draw rather than
+    /// against the list's length: a window that scrolled past its last row
+    /// would answer `j` with a screen that did not move, which reads as a
+    /// reader that has stopped listening.
+    fn scroll_list(&mut self, by: isize) {
+        let last = self.list_lines().len().saturating_sub(self.list_rows());
+        let top = self.overlay.unwrap_or(0) as isize + by;
+        self.overlay = Some(top.clamp(0, last as isize) as usize);
     }
 
     /// A tap that landed on a panel: that panel focused, and the row under the
@@ -969,7 +1063,10 @@ impl App {
             }
             Command::Act(act) => self.propose(act, ank),
             Command::Malformed(said) => self.note = Some(said),
-            Command::Help => self.note = Some(bindings::listing().join("\n")),
+            // Opened and never toggled here: a `?` pressed *on* the list is
+            // read by `press` before the dispatch is reached, so this arm only
+            // ever runs on a screen that has none.
+            Command::Help => self.overlay = Some(0),
             Command::Nothing => {}
             Command::Unknown(word) => {
                 self.note = Some(format!("no command '{word}'; ? for the list"))
@@ -1415,6 +1512,11 @@ impl App {
             keys.push(fit(&ratify, width));
         }
         paragraph(&keys).render(panels.keys, buf);
+
+        // Last, and over everything the header does not carry: the key list is
+        // an overlay (TASK-8a6578851244), so it is painted after the frame it
+        // covers rather than into a band the frame had to give up rows for.
+        self.list(area, buf);
     }
 
     /// One panel: its border, its title, and the lines it holds.
@@ -2189,6 +2291,176 @@ impl App {
             .into_iter()
             .find(|t| t.row == row && column >= t.at && column < t.at + t.label.chars().count())
             .map(|t| t.key)
+    }
+
+    // -----------------------------------------------------------------------
+    // The key list, and where a finger lands on it (TASK-8a6578851244)
+    // -----------------------------------------------------------------------
+
+    /// The rectangle the key list is drawn in: everything under the header.
+    ///
+    /// **Over the panels and over the bands under them, and never a rectangle
+    /// the layout was asked for.** [`App::arrange`] does not know this exists,
+    /// which is the whole of why closing the list gives back the frame that was
+    /// there: nothing moved to make room for it, so nothing has to move back.
+    ///
+    /// The header is left alone because it is where a person is told which
+    /// corpus and which branch they are on, and a list of keys is not a reason
+    /// to stop saying so.
+    fn list_rect(&self, area: Rect) -> Rect {
+        let header = self.arrange(area).header;
+        Rect {
+            x: area.x,
+            y: area.y + header.height,
+            width: area.width,
+            height: area.height.saturating_sub(header.height),
+        }
+    }
+
+    /// The rows of the key list, wrapped to the width the overlay draws them
+    /// at, each with the binding a press on it runs.
+    ///
+    /// **One function for drawing them and for hitting them**, which is the
+    /// reason [`App::targets`] gives for itself: a row a person can see and a
+    /// row a press resolves to are the same row or they are two, and two is a
+    /// screen that answers somewhere other than where it was touched.
+    ///
+    /// Wrapped rather than cut, because a heading is a sentence and the
+    /// sentences are what the trailer used to lose to a `~` before they
+    /// finished. Every row of a wrapped entry carries the same binding, so a
+    /// press anywhere on it reaches the key it names.
+    fn list_lines(&self) -> Vec<(String, Option<&'static Binding>)> {
+        let width = inside(self.list_rect(self.area())).width as usize;
+        bindings::listing()
+            .into_iter()
+            .flat_map(|item| {
+                let binding = item.binding;
+                wrap(&item.text, width.max(1))
+                    .into_iter()
+                    .map(move |line| (line, binding))
+            })
+            .collect()
+    }
+
+    /// How many of those rows the overlay has room for, which is what a page of
+    /// it is worth.
+    fn list_rows(&self) -> usize {
+        inside(self.list_rect(self.area())).height as usize
+    }
+
+    /// The binding a press on the key list reached.
+    ///
+    /// `None` on a heading, which is prose about the rows under it; on the
+    /// border; and on a row past the end of a list shorter than its window. A
+    /// press that named no binding does nothing at all rather than closing the
+    /// list -- a finger that missed is a finger that missed, and a reader that
+    /// took the list away for it would be answering a question nobody asked.
+    fn list_at(&self, at: Position) -> Option<&'static Binding> {
+        let top = self.overlay?;
+        let inside = inside(self.list_rect(self.area()));
+        if !inside.contains(at) {
+            return None;
+        }
+        let row = top + (at.y - inside.y) as usize;
+        self.list_lines().get(row).and_then(|(_, binding)| *binding)
+    }
+
+    /// One row of the key list, pressed. `true` means the session is over.
+    ///
+    /// **A row is the key it names, and it reaches it by pressing it**
+    /// (ADR-c07e2694f0e1). The same reasoning [`Action`] carries: a tap on a
+    /// word hands [`App::press`] the very [`KeyEvent`] that word names, so
+    /// there is one vocabulary on this screen rather than a second road that
+    /// happens to agree.
+    ///
+    /// The writing half has no key yet -- TASK-1a415107fd56 is what gives the
+    /// six their letters -- and until it does, a row of it reaches the verb the
+    /// way a typed line reaches it: through [`crate::input::parse`], which is
+    /// the reader's one reading of a verb's grammar. So a press on `claim`
+    /// composes a claim and shows it, and none of this is a road around the
+    /// confirmation: what it produces is a [`Command`], and the arm that
+    /// answers an act still only proposes one.
+    ///
+    /// The list closes on the press, whatever it reached. A person who has
+    /// asked for a verb is being shown the verb, and a key list still over the
+    /// screen would be covering the command they are about to answer for.
+    fn ran(&mut self, binding: &'static Binding, ank: &Ank) -> bool {
+        self.overlay = None;
+        match binding.key {
+            Some(code) => self.press(KeyEvent::new(code, KeyModifiers::NONE), ank),
+            None => match binding.verb {
+                Some(verb) => self.spell(verb, ank),
+                None => false,
+            },
+        }
+    }
+
+    /// A verb of the writing half, reached from the list rather than typed.
+    ///
+    /// The two grammars are the verb's own and read off its tail rather than
+    /// decided here: a verb that takes only the identifier the focused panel
+    /// names is composed and shown, and one that needs a message, a reason or a
+    /// proof opens the prompt with its word already in it -- because the reader
+    /// cannot invent the sentence a person has not written, and a `log` composed
+    /// with an empty message would be a confirmation for a command the CLI
+    /// refuses.
+    fn spell(&mut self, verb: Verb, ank: &Ank) -> bool {
+        match verb.tail {
+            Tail::Message | Tail::Behind(_) => {
+                self.prompt = Some(format!("{} ", verb.name));
+                false
+            }
+            Tail::Words | Tail::Nothing => {
+                self.act(crate::input::parse(verb.name, self.focus), ank)
+            }
+        }
+    }
+
+    /// The key list, drawn over the frame it was asked for from.
+    ///
+    /// Cleared first, because a `Block` paints a border and a `Paragraph` paints
+    /// the rows it was given: the cells between the last row and the bottom
+    /// border would otherwise still be carrying whatever panel is underneath,
+    /// which is a list with somebody else's rows showing through it.
+    fn list(&self, area: Rect, buf: &mut Buffer) {
+        let Some(top) = self.overlay else {
+            return;
+        };
+        let rect = self.list_rect(area);
+        if rect.width < 2 || rect.height < 2 {
+            return;
+        }
+        let lines = self.list_lines();
+        let inside = inside(rect);
+        let room = inside.height as usize;
+        let shown = lines.len().min(top + room);
+        // What is on the screen and what there is of it, because the list is
+        // longer than the window at both of the windows this reader is measured
+        // on: a person who cannot see that row nine of thirty-seven is under
+        // their thumb has no reason to scroll.
+        let heading = format!(
+            "KEYS {}-{} of {}   {} closes",
+            (top + 1).min(shown),
+            shown,
+            lines.len(),
+            named(KeyCode::Esc)
+        );
+        let title = Composed::new()
+            .plain(text::CURSOR)
+            .plain(&heading)
+            .fitted(rect.width as usize - 2);
+        Clear.render(rect, buf);
+        Block::bordered()
+            .border_set(self.glyphs.border(true))
+            .title(title.line(self.ink))
+            .render(rect, buf);
+        let rows: Vec<String> = lines
+            .iter()
+            .skip(top)
+            .take(room)
+            .map(|(line, _)| fit(line, inside.width as usize))
+            .collect();
+        paragraph(&rows).render(inside, buf);
     }
 
     /// How this screen is being kept current, in the two words a person needs.
@@ -4965,6 +5237,215 @@ mod tests {
                 &ank,
             );
             assert_eq!(a.cursors[Focus::Entities.number() - 1].at, expected);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // The key list as an overlay (TASK-8a6578851244)
+    // -----------------------------------------------------------------------
+
+    /// A screen of a stated window with the corpus on it.
+    ///
+    /// The suite drives the built binary at the two windows the criterion
+    /// names; what is here is the same properties at more of them and on every
+    /// platform, which is where the layout and the hit test belong.
+    fn windowed(window: (usize, usize)) -> App {
+        let mut a = App::new(window, None)
+            .inked(paint::PLAIN)
+            .drawn_with(SCREEN);
+        a.snapshot = Some(snapshot());
+        a
+    }
+
+    /// The row of the list that names one verb, as the table spells it.
+    fn row_reading(verb: &str) -> String {
+        format!(
+            "  {}",
+            bindings::of_verb(verb)
+                .unwrap_or_else(|| panic!("the table spells {verb}"))
+                .entry()
+        )
+    }
+
+    /// The list scrolled so that one row of it is on the screen, and where on
+    /// the screen that row landed.
+    fn scrolled_to(a: &mut App, row: usize) -> Position {
+        let lines = a.list_lines();
+        let top = row.min(lines.len().saturating_sub(a.list_rows()));
+        a.overlay = Some(top);
+        let inside = inside(a.list_rect(a.area()));
+        Position::new(inside.x, inside.y + (row - top) as u16)
+    }
+
+    /// **The key list is drawn over the panels, and closing it gives the frame
+    /// back character for character** (TASK-8a6578851244).
+    ///
+    /// The second half is the one the overlay exists for. A list the layout had
+    /// to find rows for cost the panels those rows -- thirteen of twenty-four
+    /// on furniture is what ADR-c07e2694f0e1 measured -- and giving them back
+    /// afterwards is a second arrangement that has to agree with the first.
+    /// Nothing moved to make room, so nothing has to move back, and the
+    /// cheapest way to say so is that the two frames are the same characters.
+    #[test]
+    fn the_key_list_covers_the_panels_and_gives_the_frame_back_when_it_closes() {
+        for window in [(80, 24), (40, 30), (120, 40), (200, 50)] {
+            let ank = nowhere();
+            let mut a = windowed(window);
+            let before = a.frame();
+            assert!(
+                before.contains(Focus::Entities.name()),
+                "{window:?}: the screen drew no panel to cover:\n{before}"
+            );
+
+            tap(&mut a, &ank, KeyCode::Char('?'));
+            let frame = a.frame();
+            assert_eq!(
+                frame.lines().count(),
+                window.1,
+                "{window:?}: the list changed how many rows the frame is:\n{frame}"
+            );
+            for line in frame.lines() {
+                assert!(
+                    line.chars().count() <= window.0,
+                    "{window:?}: a row is past the right edge: {line}\n{frame}"
+                );
+            }
+            assert!(
+                !frame.contains(Focus::Entities.name()),
+                "{window:?}: the list left the panels showing rather than \
+                 covering them:\n{frame}"
+            );
+
+            tap(&mut a, &ank, KeyCode::Esc);
+            assert!(a.overlay.is_none(), "{window:?}: Esc left the list open");
+            assert_eq!(
+                a.frame(),
+                before,
+                "{window:?}: the key list did not give the frame back"
+            );
+        }
+    }
+
+    /// **Every row of the list that names a binding is reached by a press on
+    /// it, and every row that names none reaches nothing**
+    /// (TASK-8a6578851244, ADR-c07e2694f0e1).
+    ///
+    /// Over every row rather than over the one the criterion names, because
+    /// "every line of that list is a target" is a claim about all of them: a
+    /// hit test off by one would answer the row above for thirty-odd of these
+    /// and still pass a test that only pressed `claim`. The headings are in
+    /// here for the same reason from the other side -- a sentence about the
+    /// rows under it is the one row of this list that must run nothing.
+    #[test]
+    fn every_row_of_the_key_list_is_the_binding_it_names_and_a_heading_is_none() {
+        for window in [(80, 24), (40, 30), (120, 40)] {
+            let ank = nowhere();
+            let mut a = windowed(window);
+            tap(&mut a, &ank, KeyCode::Char('?'));
+            let lines = a.list_lines();
+            assert!(
+                lines.len() > a.list_rows(),
+                "{window:?}: the list is not longer than its window, so this \
+                 asserts nothing about scrolling it"
+            );
+            for row in 0..lines.len() {
+                let (text, binding) = lines[row].clone();
+                let at = scrolled_to(&mut a, row);
+                assert_eq!(
+                    a.list_at(at).map(|b| b.entry()),
+                    binding.map(|b| b.entry()),
+                    "{window:?}: a press on row {row} did not reach '{text}'"
+                );
+            }
+        }
+    }
+
+    /// **A press on the row reading `claim` composes a claim and shows it**
+    /// (TASK-8a6578851244, TASK-d4a882345837).
+    ///
+    /// A row is a road to a verb, and there is one road from a verb to a spawn
+    /// with the confirmation on it. So what a press reaches is the composed
+    /// command, waiting: the list closes -- a person answering for a command is
+    /// not reading a key list drawn over it -- and nothing has run.
+    #[test]
+    fn a_press_on_the_row_reading_claim_composes_a_claim_and_shows_it() {
+        for window in [(80, 24), (40, 30), (120, 40)] {
+            let ank = nowhere();
+            let mut a = windowed(window);
+            tap(&mut a, &ank, KeyCode::Char('?'));
+            let entry = row_reading("claim");
+            let row = a
+                .list_lines()
+                .iter()
+                .position(|(text, _)| *text == entry)
+                .unwrap_or_else(|| panic!("{window:?}: no row of the list reads '{entry}'"));
+            let at = scrolled_to(&mut a, row);
+            touch(&mut a, &ank, at);
+
+            assert!(
+                a.overlay.is_none(),
+                "{window:?}: the list stayed over the command it raised"
+            );
+            let pending = a
+                .pending
+                .as_ref()
+                .unwrap_or_else(|| panic!("{window:?}: no command is waiting"));
+            assert_eq!(pending.verb, "claim");
+            assert!(
+                pending.shown.starts_with("ank claim "),
+                "{window:?}: {}",
+                pending.shown
+            );
+        }
+    }
+
+    /// **A press while a command waits dismisses that command and opens no
+    /// list** (TASK-8a6578851244, TASK-d4a882345837).
+    ///
+    /// The confirmation is modal for a finger exactly as it is for a key, and
+    /// the key list is where a second road to one would appear: it is reachable
+    /// by a press, and a press is what the confirmation answers. Both roads are
+    /// stated -- the key the list is named after, and a touch on the screen --
+    /// because either alone would leave the other open.
+    #[test]
+    fn a_press_while_a_command_waits_dismisses_it_and_opens_no_list() {
+        for window in [(80, 24), (40, 30)] {
+            let ank = nowhere();
+            for by_key in [true, false] {
+                let mut a = windowed(window);
+                a.pending = Some(Pending {
+                    verb: "claim",
+                    args: vec!["TASK-4d2eb2b4e193".to_string()],
+                    shown: "ank claim TASK-4d2eb2b4e193 --json".to_string(),
+                });
+                match by_key {
+                    true => {
+                        tap(&mut a, &ank, KeyCode::Char('?'));
+                    }
+                    false => {
+                        let at = Position::new(1, (window.1 / 2) as u16);
+                        touch(&mut a, &ank, at);
+                    }
+                }
+                assert!(
+                    a.overlay.is_none(),
+                    "{window:?}: a press over a waiting command opened the key list"
+                );
+                assert!(
+                    a.pending.is_none(),
+                    "{window:?}: a press over a waiting command left it waiting"
+                );
+                assert!(
+                    a.note
+                        .as_deref()
+                        .is_some_and(|note| note.starts_with(DISMISSED)),
+                    "{window:?}: the reader did not say the command was declined"
+                );
+                assert!(
+                    !a.frame().contains("KEYS"),
+                    "{window:?}: the key list is on the frame"
+                );
+            }
         }
     }
 }

--- a/crates/ank-tui/tests/bindings.rs
+++ b/crates/ank-tui/tests/bindings.rs
@@ -36,6 +36,31 @@ use ank_tui::bindings::{self, BINDINGS};
 use std::sync::Mutex;
 use terminal::{Live, Repo};
 
+/// A panel's vertical border, at either weight, as characters.
+///
+/// Read out of the reader rather than written as a glyph here, for the reason
+/// `tests/phone.rs` gives: the border set has moved once already, and a suite
+/// carrying its own copy of the character would go on counting one the reader
+/// no longer draws.
+fn verticals() -> [char; 2] {
+    let of = |focused| {
+        ank_tui::view::BOXES
+            .border(focused)
+            .vertical_left
+            .chars()
+            .next()
+            .expect("a border set has a vertical")
+    };
+    [of(false), of(true)]
+}
+
+/// One row of the overlay with the border it is drawn inside taken off.
+fn peeled(line: &str) -> String {
+    line.trim_matches(|c| verticals().contains(&c))
+        .trim_end()
+        .to_string()
+}
+
 /// One pseudo-terminal open at a time, in this suite.
 ///
 /// **Not a slow test being polite: `ptsname(3)` answers out of a static
@@ -80,78 +105,65 @@ fn the_key_the_list_is_named_after_draws_every_binding_and_no_other() {
     let frame = live.frame();
     let rows: Vec<&str> = frame.lines().collect();
 
-    // The band the list was drawn on, read off the frame: the row the first
-    // line landed on, and the rows under it. The note band is above the
-    // trailer, so this is the answer to `?` and not the chrome that quotes two
-    // of its lines at rest.
+    // The overlay the list was drawn in, read off the frame: the row the first
+    // item landed on, and the rows under it, each with the border it is drawn
+    // inside taken off (TASK-8a6578851244). The window is wide and tall enough
+    // to hold the whole list, so what is read back here is the list and not a
+    // window over it.
     let list = bindings::listing();
     let at = rows
         .iter()
-        .position(|row| *row == list[0])
+        .position(|row| peeled(row) == list[0].text)
         .unwrap_or_else(|| panic!("the key list is not on the frame:\n{frame}"));
-    let band: Vec<&str> = rows
+    let band: Vec<String> = rows
         .iter()
         .skip(at)
         .take(list.len())
-        .copied()
-        .collect::<Vec<&str>>();
+        .map(|r| peeled(r))
+        .collect();
 
-    // Line for line, whole and uncut. Equality and not `contains`, because a
+    // Row for row, whole and uncut. Equality and not `contains`, because a
     // list that arrived cut would be a reader teaching half a vocabulary --
     // which is the failure this task ends, rather than a smaller version of it.
     assert_eq!(
         band,
-        list.iter().map(String::as_str).collect::<Vec<&str>>(),
-        "the band `?` drew is not the list the table generates:\n{frame}"
+        list.iter()
+            .map(|item| item.text.clone())
+            .collect::<Vec<String>>(),
+        "the overlay `?` drew is not the list the table generates:\n{frame}"
     );
 
-    // Every binding, named. Stated over the rows of the table rather than over
-    // a list written here, because a suite carrying its own copy of the keys
-    // would agree with a table that moved.
+    // Every binding, named, on a row of its own. Stated over the rows of the
+    // table rather than over a list written here, because a suite carrying its
+    // own copy of the keys would agree with a table that moved.
     for binding in BINDINGS {
         let entry = binding.entry();
-        assert!(
-            band.iter().any(|row| row.contains(&entry)),
-            "'{entry}' is a binding of this reader and `?` does not name it:\n{frame}"
+        assert_eq!(
+            band.iter().filter(|row| row.trim() == entry).count(),
+            1,
+            "'{entry}' is a binding of this reader and `?` does not draw it on a \
+             row of its own:\n{frame}"
         );
     }
 
-    // And nothing it does not. The band is read back entry by entry, and every
-    // one of them is a row of the table: a key list offering a letter nobody
-    // bound reads as an offer and behaves as nothing, which is worse than an
-    // omission and is what "and nothing it does not" is there to catch.
-    for entry in drawn(&band) {
+    // And nothing it does not. Every row is read back and is either an entry of
+    // the table or a heading the table generated: a key list offering a letter
+    // nobody bound reads as an offer and behaves as nothing, which is worse
+    // than an omission and is what "and nothing it does not" is there to catch.
+    let headings: Vec<&String> = list
+        .iter()
+        .filter(|item| item.binding.is_none())
+        .map(|item| &item.text)
+        .collect();
+    for row in &band {
+        let entry = row.trim();
         assert!(
-            BINDINGS.iter().any(|b| b.entry() == entry),
-            "`?` names '{entry}' and no binding declares it:\n{frame}"
+            BINDINGS.iter().any(|b| b.entry() == entry)
+                || headings.iter().any(|h| h.trim() == entry),
+            "`?` draws '{entry}' and no binding or heading declares it:\n{frame}"
         );
     }
     live.quit();
-}
-
-/// The entries the reader drew, read back off the rows it drew them on.
-///
-/// What is stripped from each row is its lead and its note -- the sentence a
-/// line ends with is prose about the table and never an entry of it -- and what
-/// is left is split the two ways a line joins entries.
-fn drawn(band: &[&str]) -> Vec<String> {
-    band.iter()
-        .flat_map(|line| {
-            let body = match line.find("   (") {
-                Some(at) => &line[..at],
-                None => line,
-            };
-            let body = match body.split_once(" then  ") {
-                Some((_, verbs)) => verbs,
-                None => body,
-            };
-            body.split("  ")
-                .flat_map(|entry| entry.split(" | "))
-                .map(|entry| entry.trim().to_string())
-                .filter(|entry| !entry.is_empty())
-                .collect::<Vec<String>>()
-        })
-        .collect()
 }
 
 /// The window ADR-c07e2694f0e1 measures this reader's frame on.
@@ -166,9 +178,12 @@ const EIGHTY: (u16, u16) = (80, 24);
 /// panels give way to it, and the frame is still the window's own size, row for
 /// row and column for column.
 ///
-/// The rows it costs are real and this task does not buy them back:
-/// TASK-8a6578851244 does, by making the list an overlay drawn over the frame
-/// rather than a note the layout has to find room for.
+/// The rows it costs used to be real: the list was a note the layout had to
+/// find room for, and the panels were squeezed to give it. TASK-8a6578851244
+/// bought them back by drawing the list over the frame instead -- so what this
+/// still holds is the half that never depended on which of the two it was: the
+/// frame is the window's own size, row for row and column for column, with the
+/// list on it. `tests/overlay.rs` states what the overlay itself is.
 #[test]
 fn the_key_list_fits_the_window_it_is_asked_for_on() {
     let _one = ONE_AT_A_TIME

--- a/crates/ank-tui/tests/overlay.rs
+++ b/crates/ank-tui/tests/overlay.rs
@@ -1,0 +1,425 @@
+//! The key list as an overlay, through the binary, on a real terminal
+//! (TASK-8a6578851244).
+//!
+//! CLAUDE.md leaves no choice about where this is measured and the criterion
+//! names the two windows itself: *at eighty columns by twenty-four and at forty
+//! by thirty, the built binary answers `?` with a bordered list drawn over the
+//! panels rather than a note written under them*. Every clause of that is about
+//! a process at a size. A unit test can hand `App` a `MouseEvent` and read a
+//! `Buffer` back -- and `src/view.rs` does, at more sizes and on every platform
+//! -- but what is claimed here is that a *terminal* sending SGR bytes at a
+//! *window* reaches the verb the row names, and between those two there is a
+//! layout, a hit test, a dispatch and a confirmation.
+//!
+//! **Both windows, every time.** The two are not two runs of one test: eighty
+//! by twenty-four is the desk ADR-c07e2694f0e1 measured the old chrome on and
+//! found it spending thirteen rows of twenty-four on furniture, and forty by
+//! thirty is the phone the decision was written for. The list is longer than
+//! either of them, which is why it scrolls, and the row reading `claim` is
+//! below the fold at both -- so a suite that only pressed at the top would be
+//! asserting on the one part of the list a window happens to hold.
+//!
+//! `#[cfg(unix)]` for the reason the other suites give: a pseudo-terminal on
+//! Windows is ConPTY, and reaching it means the console API this workspace does
+//! not otherwise call.
+
+#![cfg(unix)]
+
+mod terminal;
+
+use ank_tui::bindings;
+use std::sync::Mutex;
+use terminal::{Live, Repo};
+
+/// One pseudo-terminal open at a time, in this suite.
+///
+/// `ptsname(3)` answers out of a static buffer, so two sessions opened at once
+/// can both read the same slave path -- and this suite is one of the two that
+/// opens sessions at *different* sizes, which is what makes a crossed path
+/// visible rather than merely wrong. LOG-3b0bc419c884 records the defect and
+/// `tests/bindings.rs` carries the same lock for the same reason.
+static ONE_AT_A_TIME: Mutex<()> = Mutex::new(());
+
+/// The desk ADR-c07e2694f0e1 measures this reader's frame on, and the phone it
+/// was written for.
+const WINDOWS: [(u16, u16); 2] = [(80, 24), (40, 30)];
+
+/// What the confirmation says above the command line, and what it says once
+/// somebody has declined one. Read out of the reader rather than written here:
+/// a suite carrying its own copy would agree with a sentence that moved.
+const ABOUT: &str = ank_tui::view::ABOUT;
+const DISMISSED: &str = ank_tui::view::DISMISSED;
+
+/// The row of the list that names `claim`, as the table spells it.
+///
+/// Out of the table and never `"claim"` written here, for the reason every
+/// suite in this crate gives: the whole of what the table is for is that the
+/// screen and the mapping are one fact, and a needle typed by hand would go on
+/// looking for a row the reader had stopped drawing.
+fn claim_entry() -> String {
+    bindings::of_verb("claim")
+        .expect("the table spells claim")
+        .entry()
+}
+
+/// Every character the reader draws the left or right edge of a box with, at
+/// either weight: the two verticals and the four corners.
+///
+/// Read out of the reader rather than written as glyphs, for the reason
+/// `tests/phone.rs` gives: the border set moved once already, and a suite
+/// carrying its own copy would go on counting a character nothing draws.
+fn edges() -> Vec<char> {
+    let mut out = Vec::new();
+    for focused in [false, true] {
+        let set = ank_tui::view::BOXES.border(focused);
+        for piece in [
+            set.vertical_left,
+            set.vertical_right,
+            set.top_left,
+            set.top_right,
+            set.bottom_left,
+            set.bottom_right,
+        ] {
+            out.extend(piece.chars());
+        }
+    }
+    out
+}
+
+/// Where a piece of text is drawn, as a column and a row a finger can be aimed
+/// at, or `None` where it is not on the frame.
+fn drawn_at(frame: &str, needle: &str) -> Option<(u16, u16)> {
+    frame
+        .lines()
+        .enumerate()
+        .find_map(|(row, line)| line.find(needle).map(|column| (column as u16, row as u16)))
+}
+
+/// **The frame is the window and nothing is past its right edge**, which the
+/// criterion asks for over every screen this suite draws.
+fn fits(frame: &str, window: (u16, u16), said: &str) {
+    assert_eq!(
+        frame.lines().count(),
+        window.1 as usize,
+        "{said}: the frame is not the window's rows at {window:?}:\n{frame}"
+    );
+    for line in frame.lines() {
+        assert!(
+            line.chars().count() <= window.0 as usize,
+            "{said}: {} columns in a {} column window: {line}\n{frame}",
+            line.chars().count(),
+            window.0
+        );
+    }
+}
+
+/// A session with the corpus on it, at one window.
+///
+/// Waited for on a row of the corpus and not on a panel title: the titles carry
+/// the panel's number and its name and are on the very first frame, before the
+/// reader has asked the CLI anything -- so a suite that waited for one would be
+/// reading a screen whose listing had not arrived.
+fn opened(repo: &Repo, window: (u16, u16)) -> Live {
+    let live = Live::open(repo, window.0, window.1);
+    live.until("the corpus to reach the screen", |t| t.contains("TASK-"));
+    live
+}
+
+/// What the key list says it is showing: the first row on the screen, the last,
+/// and how many there are of it.
+///
+/// Read off the line the reader draws rather than computed here, and that is
+/// what makes it worth having -- see [`list_at_claim`].
+fn shown(frame: &str) -> (usize, usize, usize) {
+    let said = frame
+        .lines()
+        .find_map(|line| line.split_once("KEYS "))
+        .map(|(_, rest)| rest)
+        .unwrap_or_else(|| panic!("the key list is not on the frame:\n{frame}"));
+    let (span, tail) = said
+        .split_once(" of ")
+        .unwrap_or_else(|| panic!("the key list does not say how much of it there is: {said}"));
+    let (from, to) = span
+        .split_once('-')
+        .unwrap_or_else(|| panic!("the key list does not say what it is showing: {said}"));
+    let number = |s: &str| {
+        s.trim()
+            .parse::<usize>()
+            .unwrap_or_else(|_| panic!("'{s}' is not a count: {said}"))
+    };
+    (
+        number(from),
+        number(to),
+        number(tail.split_whitespace().next().unwrap_or_default()),
+    )
+}
+
+/// The list, opened, and scrolled until the row reading `claim` is on the
+/// screen.
+///
+/// **Scrolled and never assumed**, because the list is longer than both windows
+/// and where a given row lands depends on how the headings above it wrapped.
+/// `n` is the key the table binds to a page, so what this does is what a person
+/// with a keyboard does; a thumb swipes, and `src/view.rs` states that the two
+/// reach the same arithmetic.
+///
+/// **Each page is waited for on the list's own count line, and that is the
+/// load-bearing part.** `Live::frame` settles the screen -- it returns once two
+/// reads agree -- and a settled screen is not a screen that has answered the
+/// keystroke just sent to it: under a loaded machine the reader can still be
+/// getting to the `n`, and the frame that comes back is the one that was there.
+/// A row located on that frame is then pressed against a list that has since
+/// moved, which is a press on whatever slid under it. So the scroll is
+/// synchronised on the count the reader prints -- `KEYS 20-38 of 40` -- and the
+/// row is only located once the screen has said it is showing that page.
+fn list_at_claim(live: &mut Live) -> (u16, u16) {
+    let entry = claim_entry();
+    live.send("?");
+    live.until("the key list to be drawn", |t| t.contains("KEYS "));
+    for _ in 0..12 {
+        let frame = live.frame();
+        if let Some(at) = drawn_at(&frame, &entry) {
+            return at;
+        }
+        let (from, to, total) = shown(&frame);
+        let page = (to + 1).saturating_sub(from);
+        let next = (from + page).min((total + 1).saturating_sub(page));
+        assert!(
+            next > from,
+            "the key list will not scroll any further and '{entry}' is not on \
+             it:\n{frame}"
+        );
+        live.send("n");
+        live.until("the key list to scroll", |t| {
+            t.contains(&format!("KEYS {next}-"))
+        });
+    }
+    panic!("'{entry}' never reached the screen:\n{}", live.frame());
+}
+
+/// **`?` draws a bordered list over the panels, and never a note under them**
+/// (TASK-8a6578851244, ADR-c07e2694f0e1), at both windows.
+///
+/// The negative is the half that matters and it is why the panels are read
+/// first. A list drawn *into* the note band is what this replaces: it was on
+/// the screen too, and it was on it by squeezing the panels to find the rows.
+/// So what is asserted is that the panels the reader was drawing are no longer
+/// on the frame at all -- covered, not resized -- while the frame itself is
+/// still exactly the window it was.
+#[test]
+fn the_key_list_is_a_bordered_overlay_over_the_panels_at_both_windows() {
+    let _one = ONE_AT_A_TIME
+        .lock()
+        .unwrap_or_else(|held| held.into_inner());
+    for window in WINDOWS {
+        let repo = Repo::seeded();
+        let mut live = opened(&repo, window);
+        let before = live.frame();
+        fits(&before, window, "at rest");
+        assert!(
+            !before.contains("KEYS"),
+            "the key list is on the screen before anybody asked for it at \
+             {window:?}:\n{before}"
+        );
+
+        live.send("?");
+        live.until("the key list to be drawn", |t| t.contains("KEYS"));
+        let frame = live.frame();
+        fits(&frame, window, "with the list open");
+
+        // Over the panels: the listing that was on the frame is not on it any
+        // more, and it did not move -- it is underneath.
+        assert!(
+            before.contains("2 ENTITIES"),
+            "the session drew no panels to cover at {window:?}:\n{before}"
+        );
+        assert!(
+            !frame.contains("2 ENTITIES"),
+            "the key list left the panels showing rather than covering them at \
+             {window:?}:\n{frame}"
+        );
+
+        // Bordered: the row the list is named on carries the reader's own
+        // border, and so does the row under it.
+        let (_, title) = drawn_at(&frame, "KEYS").expect("the list says what it is");
+        let edges = edges();
+        let rows: Vec<&str> = frame.lines().collect();
+        assert!(
+            (title as usize) + 2 < rows.len(),
+            "the key list has no rows under its title at {window:?}:\n{frame}"
+        );
+        for row in &rows[title as usize..] {
+            let ends = row.trim_end();
+            let (first, last) = (
+                ends.chars().next().expect("a drawn row has characters"),
+                ends.chars().last().expect("a drawn row has characters"),
+            );
+            assert!(
+                edges.contains(&first) && edges.contains(&last),
+                "a row of the key list is not inside a border at {window:?}: \
+                 {row}\n{frame}"
+            );
+        }
+        live.quit();
+    }
+}
+
+/// **A press on the row reading `claim` raises the claim confirmation**
+/// (TASK-8a6578851244, ADR-c07e2694f0e1), at both windows.
+///
+/// This is the whole of "a line of the list is the key it names", and it is
+/// stated through the wire because that is the only place it can be: whether a
+/// terminal reports a press at all is decided by whether this reader asked it
+/// to, and `Live::tap` writes the SGR bytes `?1006` turns on rather than
+/// constructing an event a suite already believes in.
+///
+/// What it must reach is the *confirmation* and not a claim. The row is a road
+/// to a verb and there is one road from a verb to a spawn, with the
+/// confirmation on it (TASK-d4a882345837): so the assertion is the command
+/// line, drawn, with the key that would run it -- and nothing run.
+#[test]
+fn a_press_on_the_row_reading_claim_raises_the_claim_confirmation_at_both_windows() {
+    let _one = ONE_AT_A_TIME
+        .lock()
+        .unwrap_or_else(|held| held.into_inner());
+    for window in WINDOWS {
+        let repo = Repo::seeded();
+        repo.warm();
+        let refs = repo.refs();
+        let corpus = repo.corpus();
+        let mut live = opened(&repo, window);
+
+        let (column, row) = list_at_claim(&mut live);
+        live.tap(column, row);
+        live.until("the claim confirmation", |t| flat(t).contains(ABOUT));
+        let frame = live.frame();
+        fits(&frame, window, "with the confirmation up");
+        assert!(
+            flat(&frame).contains("ank claim "),
+            "the press on '{}' did not compose a claim at {window:?}:\n{frame}",
+            claim_entry()
+        );
+        // And the list is gone: a person answering for a command is not reading
+        // a key list drawn over it.
+        assert!(
+            !frame.contains("KEYS"),
+            "the key list is still over the command it raised at \
+             {window:?}:\n{frame}"
+        );
+
+        // Declined before the session is asked to end, because a confirmation
+        // is modal: `q` over one drops the command rather than quitting, and a
+        // suite that sent it and then waited for the child would wait for ever.
+        live.send("\u{1b}");
+        live.until("the command to be declined", |t| {
+            flat(t).contains(DISMISSED)
+        });
+        live.quit();
+        assert_eq!(corpus, repo.corpus(), "a shown claim moved a file");
+        assert_eq!(refs, repo.refs(), "a shown claim moved a ref");
+    }
+}
+
+/// **The key that closes the list leaves the frame the one it was**
+/// (TASK-8a6578851244), at both windows.
+///
+/// Equality on the whole frame and not on a needle, because that is the claim
+/// the overlay is *for*: a list the layout had to find rows for cost the panels
+/// those rows, and giving them back afterwards is a second arrangement that has
+/// to agree with the first. Drawn over, nothing moved, so nothing has to move
+/// back -- and the cheapest way to say so is that the two frames are the same
+/// characters.
+#[test]
+fn esc_closes_the_list_and_leaves_the_frame_the_one_it_was_at_both_windows() {
+    let _one = ONE_AT_A_TIME
+        .lock()
+        .unwrap_or_else(|held| held.into_inner());
+    for window in WINDOWS {
+        let repo = Repo::seeded();
+        let mut live = opened(&repo, window);
+        let before = live.frame();
+
+        live.send("?");
+        live.until("the key list to be drawn", |t| t.contains("KEYS"));
+        // Scrolled first, so what is being given back is a list somebody used
+        // rather than one that was opened and never touched.
+        live.send("n");
+        live.send("\u{1b}");
+        live.until("the key list to close", |t| !t.contains("KEYS"));
+
+        let after = live.frame();
+        fits(&after, window, "with the list closed again");
+        assert_eq!(
+            before, after,
+            "the key list did not give the frame back at {window:?}"
+        );
+        live.quit();
+    }
+}
+
+/// **A press while a command waits dismisses that command and opens no list**
+/// (TASK-8a6578851244, TASK-d4a882345837), at both windows.
+///
+/// The confirmation is modal for a finger exactly as it is for a key, and this
+/// is that rule read against the surface this task adds: the list is reachable
+/// by a press, so a press over a waiting command is exactly where a second road
+/// to one would appear. What it does instead is what every other touch does --
+/// it declines, through `keys::confirming`, and the screen it leaves is the
+/// reader and not a key list.
+#[test]
+fn a_press_while_a_command_waits_dismisses_it_and_opens_no_list_at_both_windows() {
+    let _one = ONE_AT_A_TIME
+        .lock()
+        .unwrap_or_else(|held| held.into_inner());
+    for window in WINDOWS {
+        let repo = Repo::seeded();
+        repo.warm();
+        let refs = repo.refs();
+        let corpus = repo.corpus();
+        let mut live = opened(&repo, window);
+
+        let (column, row) = list_at_claim(&mut live);
+        live.tap(column, row);
+        live.until("the claim confirmation", |t| flat(t).contains(ABOUT));
+
+        // On a row of the listing, which is where a press with nothing waiting
+        // would select that row and focus that panel: over a waiting command it
+        // declines instead, which is what makes this the modal claim rather
+        // than a press on a part of the screen that was never a control.
+        let waiting = live.frame();
+        let (on_row, at_row) = drawn_at(&waiting, "TASK-")
+            .unwrap_or_else(|| panic!("no row names a task:\n{waiting}"));
+        live.tap(on_row, at_row);
+        live.until("the command to be declined", |t| {
+            flat(t).contains(DISMISSED)
+        });
+        let frame = live.frame();
+        fits(&frame, window, "after the command was declined");
+        assert!(
+            !frame.contains("KEYS"),
+            "a press over a waiting command opened the key list at \
+             {window:?}:\n{frame}"
+        );
+        assert!(
+            frame.contains("2 ENTITIES"),
+            "the reader is not drawing its panels again at {window:?}:\n{frame}"
+        );
+
+        live.quit();
+        assert_eq!(corpus, repo.corpus(), "a declined claim moved a file");
+        assert_eq!(refs, repo.refs(), "a declined claim moved a ref");
+    }
+}
+
+/// The screen flattened to one line, so an assertion about a command line
+/// survives the row it happens to have wrapped onto.
+fn flat(frame: &str) -> String {
+    frame
+        .lines()
+        .map(|l| l.trim())
+        .collect::<Vec<&str>>()
+        .join(" ")
+        .split_whitespace()
+        .collect::<Vec<&str>>()
+        .join(" ")
+}


### PR DESCRIPTION
TASK-8a6578851244, under ADR-c07e2694f0e1.

`?` drew the key list into the note band, so the layout had to find thirty-odd
rows for it: at eighty by twenty-four the panels were squeezed to make room, and
the list was cut anyway. It is now drawn over everything below the header, and
`App::arrange` does not know it exists — which is the whole of why closing it
gives the frame back character for character.

**One row per binding, so a row is a rectangle a finger fits in.**
`bindings::listing` returns the rows and the binding each one runs, built from
the same `lines()` the trailer draws — so there is still one list, and the test
holding every binding to exactly one line still states it. What the trailer's
lead and note become is a heading, and a heading is the one row of the overlay
that runs nothing.

**A press on a row is the key it names, pressed.** The writing half has no letter
until TASK-1a415107fd56, so a press on the row reading `claim` composes the verb
the way a typed line does, through `input::parse`: one `Command::Act` arm in the
crate, one `ank.act(`, and the confirmation still on the only road between them.

**The list's grammar is commands and never letters.** `over_list` reads
`keys::typed` and scrolls on `Move`/`Page`, goes back to the top on `Top`, and
closes on `Help` or `Back` — which is where `Esc` lands. Every other key closes
it and goes on to do what it does.

## Measured

`crates/ank-tui/tests/overlay.rs` drives the built binary on a pseudo-terminal at
eighty by twenty-four and at forty by thirty, sends the press as SGR, and reads
the grid back: the list is bordered and covers the panels, a press on the row
reading `claim` raises the claim confirmation with nothing written, `Esc` gives
the frame back character for character, and a press over a waiting command
declines it and opens no list. `src/view.rs` states the layout and the hit test
at more windows and on every platform, including that *every* row is the binding
it names rather than only the one the criterion presses.

`cargo test --workspace` green, `cargo fmt --check` clean, `ank check` exit 0.

Proof: `commit:e14078f`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AS3fFoFKUQVvefiVHexcya