### PR TITLE
The chrome collapses to a header and the panels

### DIFF
--- a/.ank/entities/LOG-1afc1b09f95b.md
+++ b/.ank/entities/LOG-1afc1b09f95b.md
@@ -1,0 +1,31 @@
+---
+id: LOG-1afc1b09f95b
+type: log
+title: The chrome is a header and the panels, and what the band of targets bought is now one cell of the
+created: 2026-08-27T02:53:58Z
+author: claude-code/opus-5+chrome
+scope:
+  - crates/ank-tui/**
+about: TASK-9a402a54886f
+seq: 2
+schema: 4
+version: 1
+---
+
+ header.
+
+WHAT THE FRAME SPENDS, at 80x24 with no claim held and the queue never asked for: three rows of header and one of note band. Four, against ADR-c07e2694f0e1's measured thirteen. The trailer's two rows and the target band's two are gone; the note band keeps its single row for the reason it always had one minus the one that died with the trailer -- the panels' bottom border no longer moves under a reader every time a command reports something.
+
+THE TWO TRAPS THE TASK RECORDED WERE NOT REDISCOVERED. arrange() still sizes from counts: the two bands it measures, note_lines and targets, read the width and nothing else and neither reaches page(). And the Length/Max ranking is untouched -- the panels are Max in both arrangements, the two bands are Length, and the confirmation's argv still wraps whole at 20x24 (the unit test that caught it is green).
+
+Panels.keys is gone from the struct rather than left as a zero-height rectangle: a band nothing renders into is a field the next reader has to work out. Panels.actions stays and is zero rows except while a command is waiting -- targets() returns empty when self.pending is None, so drawing the band and hitting it are one arithmetic and there is no rectangle that is empty for the eye and occupied for the finger.
+
+THE OFFER HAD TO GO SOMEWHERE OR THE ADR WOULD HAVE BEEN BROKEN BY THE REMOVAL. The clause asks for 'one permanently visible target that opens the key list', and there was none: TASK-8a6578851244 made ? open an overlay and made every line of it a target, but nothing on the frame opened it by touch, and the band I was deleting was the whole of the phone's way in. So the header's first row is padded and carries [?] on its right edge, three cells, and App::pointed resolves a press there to the key the table binds Command::Help to -- read through bindings::of_command, not written as a character here, because a bracketed letter in view.rs would be a sixth parallel key table one character long. It is resolved AFTER the pending and prompt checks, so a touch under a confirmation still dismisses it: the modal rule is not something a new target gets an exception from.
+
+A SECOND PRESS ON THE SELECTED ROW OPENS IT, and it is the second and never the first because the first is what makes a row the selected one -- a tap that moved the cursor and opened what it landed on is a screen where nobody can look before they choose. It is also the panel already focused: a touch that crosses panels is a person changing where they are.
+
+WHERE ratify_line WENT. It was the trailer's third line and the trailer is forbidden. It is not a key table, though -- it is a sentence about the document somebody has open -- so it moved into the row note_lines already keeps blank, behind the unresolved-scope sentence that was already using that slot the same way. Zero rows, and a person reading a proposal is still told what accept costs.
+
+MEASURED THROUGH THE BINARY as CLAUDE.md and the criterion both demand: crates/ank-tui/tests/chrome.rs drives ank on a pseudo-terminal at 80x24, 40x24, 80x40, 40x12 and 120x40. A row is a panel's own content when its first character is a box edge read out of view::BOXES -- the header's rule is a horizontal and never a corner, the note band is a sentence or a blank -- and the desk frame has four such rows against a budget of five. The second test says the same thing in the shape it would break in: the last panel closes on the window's second-last row at every one of the five, the last row is the blank note band, and the only bracketed thing outside the panels is [?]. Asked outside the panels on purpose: a listing marks a held claim with [held], which is a field of a row and not a target.
+
+WHAT I CHANGED IN TESTS I DO NOT OWN. crates/ank-cli/tests/tui.rs asserted the trailer was on the last row and counted rows with lines(). Screen::text joins the grid with newlines, so a blank last row makes the string end in one and lines() drops the empty piece -- a frame reads one row short of its window. Three assertions there now use split, and the resize test reads the bottom off the last panel's border instead of off a trailer. tests/panels.rs and tests/overlay.rs took the same change for the same reason. bindings::screen_line and write_line are deleted: nothing rendered them once the trailer went, and two suites were the only thing keeping them compiling.

--- a/.ank/entities/LOG-37d1ac393251.md
+++ b/.ank/entities/LOG-37d1ac393251.md
@@ -1,0 +1,13 @@
+---
+id: LOG-37d1ac393251
+type: log
+title: done, proof commit:370d116
+created: 2026-08-27T02:54:19Z
+author: claude-code/opus-5+chrome
+scope:
+  - crates/ank-tui/**
+about: TASK-9a402a54886f
+seq: 3
+schema: 4
+version: 1
+---

--- a/.ank/entities/TASK-9a402a54886f.md
+++ b/.ank/entities/TASK-9a402a54886f.md
@@ -5,15 +5,20 @@ slug: the-chrome-collapses-to-a-header-and-the-panels
 title: The chrome collapses to a header and the panels
 created: 2026-08-26T17:07:21Z
 author: claude-code/opus-5+reader-redesign
-status: in_progress
+status: done
 scope:
   - crates/ank-tui/**
 blocked_by: [TASK-8a6578851244]
 done_criteria: |
   At eighty columns by twenty-four, with no claim held and the queue never asked for, the built binary draws at most five rows that are not a panel's own content. No frame carries the key trailer or the band of targets. A press on the row already selected opens it in the body panel, and a press on any other row selects that row without opening it. The frame is still exactly the window's rows, with no row past its right edge, at 80x24, 40x24, 80x40, 40x12 and 120x40.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 370d116
+    criteria: 55d2ace007e0
+    via: submitted
 schema: 4
-version: 4
+version: 5
 ---
 
 **Keep `Panels.actions` as a band that is zero rows except while a command is

--- a/.ank/entities/TASK-9a402a54886f.md
+++ b/.ank/entities/TASK-9a402a54886f.md
@@ -5,7 +5,7 @@ slug: the-chrome-collapses-to-a-header-and-the-panels
 title: The chrome collapses to a header and the panels
 created: 2026-08-26T17:07:21Z
 author: claude-code/opus-5+reader-redesign
-status: open
+status: in_progress
 scope:
   - crates/ank-tui/**
 blocked_by: [TASK-8a6578851244]
@@ -13,7 +13,7 @@ done_criteria: |
   At eighty columns by twenty-four, with no claim held and the queue never asked for, the built binary draws at most five rows that are not a panel's own content. No frame carries the key trailer or the band of targets. A press on the row already selected opens it in the body panel, and a press on any other row selects that row without opening it. The frame is still exactly the window's rows, with no row past its right edge, at 80x24, 40x24, 80x40, 40x12 and 120x40.
 criteria_by: creator
 schema: 4
-version: 3
+version: 4
 ---
 
 **Keep `Panels.actions` as a band that is zero rows except while a command is

--- a/crates/ank-cli/tests/tui.rs
+++ b/crates/ank-cli/tests/tui.rs
@@ -1314,7 +1314,9 @@ fn a_terminal_resized_redraws_to_its_new_size_with_nothing_typed() {
         s.contains(LONG)
     });
     let wide = live.frame();
-    assert_eq!(wide.lines().count(), WINDOW.1 as usize, "{wide}");
+    // `split` and not `lines`, for the reason given further down: the last row
+    // of every frame is the note band, and it is blank at rest.
+    assert_eq!(wide.split('\n').count(), WINDOW.1 as usize, "{wide}");
 
     live.resize(60, 20);
     live.until_screen("the narrow frame", |s| {
@@ -1332,28 +1334,31 @@ fn a_terminal_resized_redraws_to_its_new_size_with_nothing_typed() {
         narrow.contains('~'),
         "nothing was cut, so nothing was fitted to the narrower window:\n{narrow}"
     );
-    // The trailer is on the last row there is, which is what says the layout
-    // used the new height rather than the old one.
-    let rows: Vec<&str> = narrow.lines().collect();
+    // The bottom of the window is reached, which is what says the layout used
+    // the new height rather than the old one.
+    //
+    // **Read off the last panel's own bottom border since TASK-9a402a54886f.**
+    // It was read off the trailer, which was the last row and was never blank;
+    // the trailer is gone and what is there now is the note band -- one row,
+    // blank where there is nothing to say. So the count is taken with `split`,
+    // which keeps the empty piece a trailing separator leaves behind, and the
+    // bottom is the second-last row.
+    let rows: Vec<&str> = narrow.split('\n').collect();
     assert_eq!(rows.len(), 20, "{narrow}");
-    // The trailer's own first entry, read out of the reader rather than spelled
-    // here: it was `a then` for as long as a verb was spelled into a prompt,
-    // and TASK-1a415107fd56 made it the first verb's letter.
-    let trailer = ank_tui::bindings::write_line();
-    let first = trailer
-        .split("  ")
-        .next()
-        .expect("the trailer names a verb");
     assert!(
-        rows[19].starts_with(first),
-        "the key line is not on the last row of the new window:\n{narrow}"
+        rows[19].trim().is_empty(),
+        "something other than the note band is on the last row:\n{narrow}"
+    );
+    assert!(
+        !rows[18].trim().is_empty(),
+        "the layout did not reach the bottom of the new window:\n{narrow}"
     );
 
     // Wider again, and nothing was lost: the title is whole.
     live.resize(140, 44);
     live.until_screen("the wide frame again", |s| s.contains(LONG));
     let again = live.frame();
-    assert_eq!(again.lines().count(), 44, "{again}");
+    assert_eq!(again.split('\n').count(), 44, "{again}");
     assert!(again.contains("ENTITIES"), "{again}");
 
     // And a window being dragged about reads nothing and writes nothing: a

--- a/crates/ank-tui/src/bindings.rs
+++ b/crates/ank-tui/src/bindings.rs
@@ -777,6 +777,18 @@ pub fn offered(holding: Holding) -> impl Iterator<Item = &'static Binding> {
     BINDINGS.iter().filter(move |b| b.is_offered(holding))
 }
 
+/// The binding one command is reached by, or `None` where no row runs it.
+///
+/// The reverse of [`Binding::press`], and it exists for the two callers that
+/// have a command and need the key: a sentence that names a letter, and a
+/// drawn target that has to hand [`crate::view::App::press`] the very key a
+/// keyboard would have sent (ADR-c07e2694f0e1).
+pub fn of_command(command: &Command) -> Option<&'static Binding> {
+    BINDINGS
+        .iter()
+        .find(|b| b.runs == Runs::Press(Press::Run(command.clone())))
+}
+
 /// What one command is spelled with, for a sentence that has to name a key.
 ///
 /// **Read out of the table rather than written into the sentence.** The header
@@ -788,9 +800,7 @@ pub fn offered(holding: Holding) -> impl Iterator<Item = &'static Binding> {
 /// The empty string where no binding runs it, which no caller has: a sentence
 /// naming a key that does not exist would be worse than one naming none.
 pub fn spelling_of(command: &Command) -> String {
-    BINDINGS
-        .iter()
-        .find(|b| b.runs == Runs::Press(Press::Run(command.clone())))
+    of_command(command)
         .map(|b| named(b.key))
         .unwrap_or_default()
 }
@@ -992,17 +1002,18 @@ fn lines() -> Vec<Line> {
     vec![screen(), panel(), write(), ratify(), waiting(), typing()]
 }
 
-/// The keys that move what is inside a panel, as the trailer draws them.
-pub fn screen_line() -> String {
-    screen().drawn()
-}
+// `screen_line` and `write_line` stood here (TASK-9a402a54886f). They were the
+// two lines of the trailer, drawn under every frame at every window, and
+// ADR-c07e2694f0e1 records what they cost the reader they were meant to serve.
+// The rows they named are on the key list, whole, one to a row, and nothing
+// else renders them now.
 
-/// The writing half, as the trailer draws it.
-pub fn write_line() -> String {
-    write().drawn()
-}
-
-/// The ratification offer, as the trailer draws it over a proposal.
+/// The ratification offer, as the note band draws it over a proposal.
+///
+/// The last of the three lines the trailer used to carry, and the one that
+/// survived it: it is a sentence about the document somebody has open rather
+/// than a table of keys, so it moved into the band that says what the reader is
+/// being told, where it costs a row that is drawn blank either way.
 pub fn ratify_line() -> String {
     ratify().drawn()
 }

--- a/crates/ank-tui/src/view.rs
+++ b/crates/ank-tui/src/view.rs
@@ -116,12 +116,22 @@
 //! row it landed on is that panel's own window arithmetic read the other way.
 //! There is no second layout for a finger to disagree with.
 //!
-//! **And what a panel offers is drawn where a finger can reach it.**
-//! [`App::actions`] is what the focused panel can do, drawn as targets that each
-//! carry the key that runs them, and touching one hands [`App::press`] that very
-//! key. So there is one vocabulary on this screen: a person with a keyboard
-//! reads the letter, a person with a thumb touches the word, and the offer is
-//! checkable against the mapping instead of against somebody's memory of it.
+//! **And what a panel offers is reachable by a finger without being drawn at
+//! rest** (TASK-9a402a54886f, ADR-c07e2694f0e1). It was a band of targets under
+//! the panels, on every frame and at every window, and the window it cost the
+//! most on was the phone the clause exists to protect: four rows of twenty-four
+//! spent teaching keys, plus two more of trailer under them. What stands there
+//! now is one cell of the header ([`App::help_line`]), and behind it the key
+//! list, every row of which is the key it names. The chrome is a header and the
+//! panels; the two bands under them are the note, which is a row, and the
+//! offer, which is zero rows until a command is waiting to be answered.
+//!
+//! The vocabulary is unchanged and that is the point: a target hands
+//! [`App::press`] the very key a keyboard would have sent, so a person with a
+//! keyboard reads the letter, a person with a thumb touches the word, and the
+//! offer is checkable against the mapping instead of against somebody's memory
+//! of it. A thumb reaches the commonest act of all with no target whatever --
+//! touching the row already selected opens it ([`App::tapped`]).
 //!
 //! # A failure is a line on the screen and never the end of the session
 //!
@@ -826,8 +836,17 @@ impl App {
                 if self.prompt.is_some() {
                     return false;
                 }
-                self.tapped(at, ank);
-                false
+                // The one target the frame always carries, and it is resolved
+                // here rather than above the two modal states on purpose: what
+                // a touch does while a command is waiting is dismiss it, and a
+                // target that opened a list from under a confirmation would be
+                // the second road ADR-c07e2694f0e1 forbids.
+                if self.help_rect(self.area()).contains(at) {
+                    if let Some(binding) = bindings::of_command(&Command::Help) {
+                        return self.press(KeyEvent::new(binding.key, KeyModifiers::NONE), ank);
+                    }
+                }
+                self.tapped(at, ank)
             }
             // A swipe, which is what a phone sends for a scroll. It moves the
             // cursor of whatever has the focus, which is what `j` and `k` do:
@@ -899,7 +918,7 @@ impl App {
     }
 
     /// A tap that landed on a panel: that panel focused, and the row under the
-    /// finger selected.
+    /// finger selected -- or opened, where it was already the selected one.
     ///
     /// **The row is resolved before the focus moves and applied after**, and
     /// that ordering is the whole of the correctness. Focus decides the
@@ -908,15 +927,30 @@ impl App {
     /// old focus drew. Resolving after moving would select the row that has
     /// since slid under the finger, which is the same defect the confirmation
     /// avoids by freezing its argv.
-    fn tapped(&mut self, at: Position, ank: &Ank) {
+    ///
+    /// **Touching the row already selected opens it** (ADR-c07e2694f0e1,
+    /// TASK-9a402a54886f), and that is the commonest act on a phone reaching
+    /// the screen with no button at all: select, look, touch again. It is the
+    /// second touch and never the first, because the first is what *makes* a
+    /// row the selected one -- a tap that both moved the cursor and opened
+    /// whatever it landed on would be a screen where a person cannot look
+    /// before they choose. And it is the panel already focused: a touch that
+    /// crosses from one panel into another is a person changing where they
+    /// are, and the row it lands on is where they arrive rather than what they
+    /// asked for.
+    fn tapped(&mut self, at: Position, ank: &Ank) -> bool {
         let area = self.area();
         let Some(focus) = Focus::ALL
             .into_iter()
             .find(|f| self.rect_of(*f, area).contains(at))
         else {
-            return;
+            return false;
         };
         let landed = self.row_at(focus, at);
+        let again = self.focus == focus
+            && landed.is_some_and(|row| {
+                row < self.count(focus) && row == self.cursors[focus.number() - 1].at
+            });
         self.focus_on(focus, ank);
         if let Some(row) = landed {
             if row < self.count(focus) {
@@ -924,6 +958,7 @@ impl App {
                 self.clamp(focus);
             }
         }
+        again && self.act(Command::Open, ank)
     }
 
     /// Which row of a listing a point is on, in the panel as it is drawn now.
@@ -1299,23 +1334,28 @@ impl App {
             // The proposals, over the one row the regime is always on.
             Some(_) => self.count(Focus::Queue).max(1) + 1,
         };
-        let keys = 2 + u16::from(self.ratify_line().is_some());
         // The two bands under the panels, measured rather than assumed, and
         // both of them from the width alone: `note_lines` wraps what the reader
         // is being told and `targets` wraps the offer under it, and neither
         // reaches `page` -- which is what keeps this function out of the
         // recursion the counts above are avoiding.
+        //
+        // The third band that stood here is gone (TASK-9a402a54886f): the
+        // trailer taught the keys on every frame, and ADR-c07e2694f0e1 priced
+        // what that cost the reader it was meant to serve. `?` teaches them
+        // now, over the frame rather than out of it, and `offered` is zero on
+        // every screen but the confirmation.
         let note = self.note_lines().len() as u16;
         let offered = self.target_rows() as u16;
         if area.width < ONE_COLUMN {
-            return self.stacked(area, HEADER + note + offered + keys, note, offered, keys);
+            return self.stacked(area, HEADER + note + offered, note, offered);
         }
         // `Max` on the two full-width panels and `Min` on the row between them:
         // where the window is too short for all three, what gives way is a
         // listing that is glanced at rather than the pair somebody is working
-        // in, and the trailer keeps its rows either way because a `Length`
-        // outranks both.
-        let [header, claims, band, queue, note, actions, trailer] = Layout::vertical([
+        // in, and the two bands under them keep their rows either way because a
+        // `Length` outranks both.
+        let [header, claims, band, queue, note, actions] = Layout::vertical([
             // Two lines and the rule under them.
             Constraint::Length(HEADER),
             Constraint::Max(bordered(holding)),
@@ -1323,7 +1363,6 @@ impl App {
             Constraint::Max(bordered(waiting)),
             Constraint::Length(note),
             Constraint::Length(offered),
-            Constraint::Length(keys),
         ])
         .areas(area);
         let (left_width, right_width) = share(band.width, self.focus != Focus::Body);
@@ -1340,7 +1379,6 @@ impl App {
             body,
             note,
             actions,
-            keys: trailer,
         }
     }
 
@@ -1359,7 +1397,7 @@ impl App {
     /// the lines a panel draws are windowed to the room it has, so asking for
     /// them here would be asking the layout for the answer it is being computed
     /// to give.
-    fn stacked(&self, area: Rect, chrome: u16, note: u16, offered: u16, keys: u16) -> Panels {
+    fn stacked(&self, area: Rect, chrome: u16, note: u16, offered: u16) -> Panels {
         let room = area.height.saturating_sub(chrome);
         let open = room.saturating_sub(SHUT * 3).max(SHUT);
         // `Max` and never `Length`, for the reason the wide arrangement gives:
@@ -1372,7 +1410,7 @@ impl App {
             true => Constraint::Max(open),
             false => Constraint::Max(SHUT),
         };
-        let [header, claims, entities, body, queue, note, actions, trailer] = Layout::vertical([
+        let [header, claims, entities, body, queue, note, actions] = Layout::vertical([
             Constraint::Length(HEADER),
             height(Focus::Claims),
             height(Focus::Entities),
@@ -1380,7 +1418,6 @@ impl App {
             height(Focus::Queue),
             Constraint::Length(note),
             Constraint::Length(offered),
-            Constraint::Length(keys),
         ])
         .areas(area);
         Panels {
@@ -1391,7 +1428,6 @@ impl App {
             body,
             note,
             actions,
-            keys: trailer,
         }
     }
 
@@ -1468,44 +1504,36 @@ impl App {
         let width = area.width as usize;
         let panels = self.arrange(area);
 
-        match &self.snapshot {
-            Some(snapshot) => {
-                paragraph(&[
-                    fit(
-                        &format!(
-                            "ank tui   corpus {}   branch {} (default {})",
-                            &snapshot.corpus[..12.min(snapshot.corpus.len())],
-                            snapshot.branch,
-                            snapshot.default_branch
-                        ),
-                        width,
-                    ),
-                    fit(
-                        &format!(
-                            "identity {}   {} claim(s) live   {}",
-                            snapshot.identity,
-                            snapshot.claims.len(),
-                            self.route()
-                        ),
-                        width,
-                    ),
-                    text::rule(width, self.glyphs.rule()),
-                ])
-                .render(panels.header, buf);
-            }
-            None => {
-                // Nothing has been read yet, or the first read refused. The
-                // panels below still draw -- empty, and saying so -- because a
-                // reader that showed a different screen on a failed first read
-                // would be two layouts to keep in step.
-                paragraph(&[
-                    fit("ank tui", width),
-                    fit("the corpus has not been read", width),
-                    text::rule(width, self.glyphs.rule()),
-                ])
-                .render(panels.header, buf);
-            }
-        }
+        let (corpus, identity) = match &self.snapshot {
+            Some(snapshot) => (
+                format!(
+                    "ank tui   corpus {}   branch {} (default {})",
+                    &snapshot.corpus[..12.min(snapshot.corpus.len())],
+                    snapshot.branch,
+                    snapshot.default_branch
+                ),
+                format!(
+                    "identity {}   {} claim(s) live   {}",
+                    snapshot.identity,
+                    snapshot.claims.len(),
+                    self.route()
+                ),
+            ),
+            // Nothing has been read yet, or the first read refused. The panels
+            // below still draw -- empty, and saying so -- because a reader that
+            // showed a different screen on a failed first read would be two
+            // layouts to keep in step.
+            None => (
+                "ank tui".to_string(),
+                "the corpus has not been read".to_string(),
+            ),
+        };
+        paragraph(&[
+            self.help_line(&corpus, width),
+            fit(&identity, width),
+            text::rule(width, self.glyphs.rule()),
+        ])
+        .render(panels.header, buf);
 
         for focus in Focus::ALL {
             self.panel(focus, self.rect_of(focus, area), buf);
@@ -1513,15 +1541,6 @@ impl App {
 
         paragraph(&self.note_lines()).render(panels.note, buf);
         paragraph(&self.action_lines()).render(panels.actions, buf);
-
-        let mut keys = vec![
-            fit(&bindings::screen_line(), width),
-            fit(&bindings::write_line(), width),
-        ];
-        if let Some(ratify) = self.ratify_line() {
-            keys.push(fit(&ratify, width));
-        }
-        paragraph(&keys).render(panels.keys, buf);
 
         // Last, and over everything the header does not carry: the key list is
         // an overlay (TASK-8a6578851244), so it is painted after the frame it
@@ -2161,7 +2180,19 @@ impl App {
                     &format!("a scope could not be asked about -- {u}"),
                     width,
                 )],
-                None => vec![String::new()],
+                // The ratification offer lands in the row this band keeps
+                // empty (TASK-9a402a54886f). It was the trailer's third line
+                // and the trailer is gone; it is a sentence about the document
+                // somebody has open rather than a key table, which is what this
+                // band is for, and putting it here costs nothing -- the row is
+                // drawn blank either way. The unresolved scope wins where both
+                // are true, because a reader told that something could not be
+                // asked about is being told the screen is incomplete, and that
+                // outranks an offer.
+                None => match self.ratify_line() {
+                    Some(offer) => vec![fit(&offer, width)],
+                    None => vec![String::new()],
+                },
             },
             Some(note) => note
                 .lines()
@@ -2238,7 +2269,25 @@ impl App {
     /// Wrapped rather than cut, because a target cut in half is a target whose
     /// key nobody can read. It reads the width and nothing else -- no page, no
     /// rectangle -- so [`App::arrange`] may ask it for its height.
+    ///
+    /// **And it is empty unless a command is waiting** (TASK-9a402a54886f).
+    /// The band was drawn at rest on every frame and at every window, and
+    /// ADR-c07e2694f0e1 priced it: four rows of the twenty-four the reader it
+    /// was written for has. What replaced it is the key list behind one
+    /// permanently visible target ([`App::help_line`]), which costs a cell
+    /// rather than a band. The confirmation keeps its two, and that is the one
+    /// screen where knowing the key is not optional: a person being asked
+    /// whether to run something must be able to say no without having learnt a
+    /// letter first.
+    ///
+    /// The gate is here rather than in [`App::actions`] so that drawing the
+    /// band and hitting it stay one arithmetic: [`App::target_at`] resolves
+    /// against these very rectangles, and a band that was empty for the eye and
+    /// occupied for the finger would answer a touch nobody aimed at anything.
     fn targets(&self) -> Vec<Target> {
+        if self.pending.is_none() {
+            return Vec::new();
+        }
         let width = self.width();
         let mut out: Vec<Target> = Vec::new();
         let (mut row, mut at) = (0usize, 0usize);
@@ -2298,6 +2347,42 @@ impl App {
             .into_iter()
             .find(|t| t.row == row && column >= t.at && column < t.at + t.label.chars().count())
             .map(|t| t.key)
+    }
+
+    // -----------------------------------------------------------------------
+    // The one target that is always there (ADR-c07e2694f0e1)
+    // -----------------------------------------------------------------------
+
+    /// The header's first row, with the key list's own target on the end of it.
+    ///
+    /// **This is what the band of targets was traded for** (TASK-9a402a54886f).
+    /// ADR-c07e2694f0e1 asks for one permanently visible target that opens the
+    /// key list, and it costs a cell of a row the header was drawing anyway --
+    /// against four rows of twenty-four, on the window the clause was written
+    /// to protect. The corpus line is padded rather than fitted so the target
+    /// lands on the right edge at every width, and where the window is too
+    /// narrow to hold it at all the line is fitted as it always was: a target
+    /// half drawn would be a target whose key nobody can read.
+    fn help_line(&self, said: &str, width: usize) -> String {
+        let label = help_target();
+        let wide = label.chars().count();
+        match width > wide {
+            true => format!("{}{label}", pad(said, width - wide)),
+            false => fit(said, width),
+        }
+    }
+
+    /// Where that target is, which is [`App::help_line`] read backwards.
+    ///
+    /// Empty where the header has no room for it, so a press cannot resolve to
+    /// a target the frame is not drawing.
+    fn help_rect(&self, area: Rect) -> Rect {
+        let header = self.arrange(area).header;
+        let wide = help_target().chars().count() as u16;
+        if header.height == 0 || header.width <= wide {
+            return Rect::new(header.x, header.y, 0, 0);
+        }
+        Rect::new(header.x + header.width - wide, header.y, wide, 1)
     }
 
     // -----------------------------------------------------------------------
@@ -2589,8 +2674,14 @@ struct Panels {
     note: Rect,
     /// The band the offer is drawn in, and the one band on this screen a finger
     /// is aimed at rather than an eye (TASK-dd9747e5e305).
+    ///
+    /// **Zero rows on every frame but one** (TASK-9a402a54886f). It is drawn
+    /// while a command is waiting to be answered and never otherwise, because
+    /// that is the one screen ADR-c07e2694f0e1 still requires an offer on: a
+    /// person deciding whether to run something must not have to know a letter
+    /// to say no. Everywhere else the offer is the key list, which costs
+    /// nothing until it is asked for.
     actions: Rect,
-    keys: Rect,
 }
 
 /// The corpus line, the identity line, and the rule under them.
@@ -2680,6 +2771,23 @@ fn share(width: u16, left: bool) -> (u16, u16) {
 /// screen, and forty claims is a scroll rather than a screen.
 fn bordered(rows: usize) -> u16 {
     (rows as u16).clamp(1, 6) + 2
+}
+
+/// The label of the one target drawn on every frame: the key that opens the
+/// key list, in the brackets every target on this screen wears
+/// (ADR-c07e2694f0e1).
+///
+/// **The letter is the table's and not this file's.** It is `?` today and the
+/// whole of what TASK-4d2eb2b4e193 bought is that a key which moved would move
+/// here too; a bracketed character written into this function would be a sixth
+/// parallel key table, one character long. The empty string where no row runs
+/// the command, which cannot happen from the table as it stands and draws
+/// nothing rather than a bracket around nothing if it ever does.
+fn help_target() -> String {
+    match bindings::of_command(&Command::Help) {
+        Some(binding) => format!("[{}]", named(binding.key)),
+        None => String::new(),
+    }
 }
 
 /// The rectangle inside a panel's borders, which is what `Block` calls its
@@ -2964,11 +3072,11 @@ pub const PROMPT: &str = ": ";
 // (TASK-4d2eb2b4e193). Four sentences about a key table, written beside two
 // other renderings of the same table, and ADR-c07e2694f0e1 records what they
 // cost: the trailer taught a vocabulary the reader did not have, and left out
-// `v`, Space, every arrow and the whole of the ring. The trailer now draws
-// `bindings::screen_line` and `bindings::write_line`, over
-// `bindings::ratify_line` where the document takes it, and `?` answers with
-// `bindings::listing` -- all of them generated from the rows they describe, so
-// what the reader teaches is what the reader answers to.
+// `v`, Space, every arrow and the whole of the ring. The trailer itself went
+// with them (TASK-9a402a54886f): `?` answers with `bindings::listing`, and
+// `bindings::ratify_line` is the one sentence of it the note band kept -- both
+// generated from the rows they describe, so what the reader teaches is what the
+// reader answers to.
 
 /// What the confirmation says above the command line it is showing
 /// (TASK-d4a882345837).
@@ -5087,20 +5195,10 @@ mod tests {
         assert_eq!(a.note, None);
     }
 
-    /// **The actions available on the focused panel are drawn as visible
-    /// targets carrying the key that also triggers them**
-    /// (TASK-dd9747e5e305).
-    ///
-    /// Both halves, over every panel and over both modal states: the target is
-    /// on the frame where a person can read it, and touching it does exactly
-    /// what pressing the key it names does. Compared as states rather than
-    /// asserted one by one -- two screens driven from the same start, one by a
-    /// finger and one by the key the finger's target names -- so a target that
-    /// reached the right place by a different road would still fail.
-    #[test]
-    fn every_target_is_on_the_screen_and_is_the_key_it_carries() {
-        let ank = nowhere();
-        let states: [fn(&mut App); 6] = [
+    /// The states the offer is asked about at, which is every panel, both
+    /// modal grammars, and nothing else.
+    fn offering() -> [fn(&mut App); 6] {
+        [
             |a| a.focus = Focus::Claims,
             |a| a.focus = Focus::Entities,
             |a| a.focus = Focus::Queue,
@@ -5116,12 +5214,48 @@ mod tests {
                     shown: "ank log TASK-49746735127f 'a message' --json".to_string(),
                 })
             },
-        ];
-        for state in states {
+        ]
+    }
+
+    /// **The band of targets is zero rows on every screen but the
+    /// confirmation, and there it draws its own two**
+    /// (TASK-9a402a54886f, ADR-c07e2694f0e1).
+    ///
+    /// The clause it used to answer -- every action of the focused pane drawn
+    /// as a visible target at rest -- is the one ADR-c07e2694f0e1 replaced, and
+    /// it names what the band cost: four rows of the twenty-four the reader it
+    /// was written for has. The confirmation is what stayed, because a person
+    /// being asked whether to run something must be able to say no without
+    /// having learnt a letter first.
+    ///
+    /// Both halves of what is left, as before: the target is on the frame where
+    /// a person can read it, and touching it does exactly what pressing the key
+    /// it names does. Compared as states rather than asserted one by one -- two
+    /// screens driven from the same start, one by a finger and one by the key
+    /// the finger's target names -- so a target that reached the right place by
+    /// a different road would still fail.
+    #[test]
+    fn the_confirmation_draws_its_two_targets_and_no_other_screen_draws_any() {
+        let ank = nowhere();
+        for state in offering() {
             let mut start = phone();
             state(&mut start);
+            if start.pending.is_none() {
+                assert!(
+                    start.targets().is_empty(),
+                    "a screen with no command waiting is drawing targets:\n{}",
+                    start.frame()
+                );
+                assert_eq!(
+                    start.arrange(start.area()).actions.height,
+                    0,
+                    "the band is costing rows with nothing in it:\n{}",
+                    start.frame()
+                );
+                continue;
+            }
             let actions = start.actions();
-            assert!(!actions.is_empty(), "a screen with nothing to do on it");
+            assert_eq!(actions.len(), 2, "the confirmation offers two keys");
             for action in actions {
                 // Drawn, whole, where a person can read it.
                 let label = action.label();
@@ -5152,6 +5286,68 @@ mod tests {
                     pressed.frame(),
                     "touching {label} is not pressing {:?}",
                     action.key
+                );
+            }
+        }
+    }
+
+    /// **The key list is one touch away on every frame**
+    /// (TASK-9a402a54886f, ADR-c07e2694f0e1).
+    ///
+    /// This is what the band of targets was traded for, and it is what makes
+    /// the trade honest: the offer is complete and free at rest rather than
+    /// four rows drawn on every window. So the target is asserted on every
+    /// screen the offer was asserted on before, at the phone's window and at
+    /// the desk's, and touching it is pressing the key the table names.
+    ///
+    /// The two modal states are the exception and they are asserted as one: a
+    /// touch there answers the thing that is waiting, which is the modal rule
+    /// this reader holds everywhere. A target that opened a list from under a
+    /// confirmation would be the second road ADR-c07e2694f0e1 forbids.
+    #[test]
+    fn the_key_list_is_one_touch_away_on_every_frame() {
+        let ank = nowhere();
+        let key = bindings::of_command(&Command::Help)
+            .expect("a row of the table opens the key list")
+            .key;
+        for window in [PHONE, (80, 24), (120, 40)] {
+            let at = |a: &App| {
+                let rect = a.help_rect(a.area());
+                Position::new(rect.x, rect.y)
+            };
+            let made = |state: fn(&mut App)| {
+                let mut a = App::new(window, None)
+                    .inked(paint::PLAIN)
+                    .drawn_with(SCREEN);
+                a.snapshot = Some(snapshot());
+                state(&mut a);
+                a
+            };
+            for state in offering() {
+                let start = made(state);
+                let label = help_target();
+                assert!(
+                    start.frame().lines().next().unwrap().ends_with(&label),
+                    "{label} is not on the header at {window:?}:\n{}",
+                    start.frame()
+                );
+                let modal = start.pending.is_some() || start.prompt.is_some();
+                let mut touched = made(state);
+                touch(&mut touched, &ank, at(&start));
+                assert_eq!(
+                    touched.overlay.is_some(),
+                    !modal,
+                    "the list at {window:?} is not what a touch on {label} leaves"
+                );
+                if modal {
+                    continue;
+                }
+                let mut pressed = made(state);
+                pressed.press(KeyEvent::new(key, KeyModifiers::NONE), &ank);
+                assert_eq!(
+                    touched.frame(),
+                    pressed.frame(),
+                    "touching {label} is not pressing {key:?} at {window:?}"
                 );
             }
         }

--- a/crates/ank-tui/tests/chrome.rs
+++ b/crates/ank-tui/tests/chrome.rs
@@ -1,0 +1,205 @@
+//! What the frame spends on furniture, through the binary, at the five windows
+//! the criterion names (TASK-9a402a54886f).
+//!
+//! ADR-c07e2694f0e1 was written against a measurement and this suite is that
+//! measurement, kept: at eighty columns and twenty-four rows the reader spent
+//! three rows on a header, one on a note band, one on a band of touch targets
+//! and two on key lines cut with `~` before they finished -- and the two lines
+//! teaching the keys did not fit on the screen they were taught from. The
+//! decision's answer was to take the offer out of the frame and put it behind
+//! one permanently visible target, and the number it has to hold to afterwards
+//! is [`CHROME`].
+//!
+//! **Counted through the binary, on a pseudo-terminal, at every window the
+//! criterion states.** CLAUDE.md leaves no choice about that: a criterion that
+//! talks about the binary is tested through the binary, and a row count is a
+//! claim about a process reading a real terminal's size. `src/view.rs` asserts
+//! what the layout function answers; this asserts what a person sees.
+//!
+//! **The terminal, the corpus and the driven session are `terminal/mod.rs`**,
+//! which `tests/panels.rs` explains and three other suites here declare.
+
+#![cfg(unix)]
+
+mod terminal;
+
+use terminal::{Live, Repo};
+
+/// The windows the criterion names: the desk, the phone, a tall desk, a phone
+/// with almost nothing left, and a wide one.
+///
+/// The short one is the one worth having. At forty by twelve there are eight
+/// rows for four panels once the chrome is paid for, which is two apiece and no
+/// more -- a window where an arrangement that had not been asked to give way
+/// would be drawing rows the terminal does not have.
+const WINDOWS: [(u16, u16); 5] = [(80, 24), (40, 24), (80, 40), (40, 12), (120, 40)];
+
+/// The desk the criterion counts rows on.
+const DESK: (u16, u16) = WINDOWS[0];
+
+/// What the frame may spend on anything that is not a panel's own content.
+///
+/// Four is what it actually spends -- the header's two lines and the rule under
+/// them, and the note band's single row -- and the criterion allows five, which
+/// is one row of slack for a note that has two things to say. The trailer alone
+/// was two rows and the band of targets was one more at this window, so a frame
+/// that had kept either could not pass this.
+const CHROME: usize = 5;
+
+/// Every character the reader draws the left or right edge of a box with, at
+/// either weight: the two verticals and the four corners.
+///
+/// Read out of the reader rather than written as glyphs, for the reason
+/// `tests/phone.rs` and `tests/overlay.rs` both give: the border set moved once
+/// already, and a suite carrying its own copy would go on counting a character
+/// nothing draws.
+fn edges() -> Vec<char> {
+    let mut out = Vec::new();
+    for focused in [false, true] {
+        let set = ank_tui::view::BOXES.border(focused);
+        for piece in [
+            set.vertical_left,
+            set.top_left,
+            set.bottom_left,
+            set.vertical_right,
+            set.top_right,
+            set.bottom_right,
+        ] {
+            out.extend(piece.chars());
+        }
+    }
+    out
+}
+
+/// Whether a row of the frame is a panel's own content.
+///
+/// **Read off the left edge, which is where a panel starts at every window this
+/// suite drives.** The two full-width panels open at column zero, and the pair
+/// in the middle is the entities panel there -- side by side above
+/// [`ank_tui::view::ONE_COLUMN`] and stacked below it, but always with a border
+/// on the first column either way. The header's rule is a horizontal and never
+/// a corner, so it is not mistaken for one; the note band is a sentence or a
+/// blank, and neither is either.
+fn panelled(line: &str, edges: &[char]) -> bool {
+    line.chars().next().is_some_and(|c| edges.contains(&c))
+}
+
+/// The frame as the grid it is: exactly the window's rows, blank ones included.
+///
+/// `split` and never `lines`, because the last row of every frame is the note
+/// band and it is blank at rest -- and `lines` drops the empty piece a trailing
+/// separator leaves behind, which reads as a frame one row short of its window.
+fn grid(frame: &str) -> Vec<&str> {
+    frame.split('\n').collect()
+}
+
+/// **At eighty by twenty-four, with no claim held and the queue never asked
+/// for, at most five rows are not a panel's own content**
+/// (TASK-9a402a54886f, ADR-c07e2694f0e1).
+///
+/// The corpus is the seeded one, which holds no claim and is opened on a
+/// session that never presses the key that asks for the queue -- so what is
+/// counted is the screen the criterion states and not a busier one that would
+/// flatter it.
+#[test]
+fn the_chrome_at_the_desk_is_a_header_and_a_row() {
+    let repo = Repo::seeded();
+    let live = Live::open(&repo, DESK.0, DESK.1);
+    live.until("the session to open", |t| t.contains("2 ENTITIES"));
+    let frame = live.frame();
+    let edges = edges();
+    let furniture: Vec<(usize, &str)> = grid(&frame)
+        .into_iter()
+        .enumerate()
+        .filter(|(_, line)| !panelled(line, &edges))
+        .collect();
+    assert!(
+        furniture.len() <= CHROME,
+        "{} rows of {DESK:?} are not a panel's own content, and {CHROME} is the \
+         budget:\n{:#?}\n{frame}",
+        furniture.len(),
+        furniture
+    );
+    // And the corpus is the one the criterion describes: nothing is held, and
+    // nothing has asked the CLI for the ratification queue.
+    assert!(frame.contains("nothing is held"), "{frame}");
+    assert!(frame.contains("(not asked)"), "{frame}");
+    live.quit();
+}
+
+/// **No frame carries the key trailer or the band of targets, at any of the
+/// five windows** (TASK-9a402a54886f).
+///
+/// Two things are asserted and they are different failures. The trailer was
+/// rows of key entries under the panels, so it is caught by the row budget
+/// above and by the shape of what is left here: everything below the last panel
+/// is one row. The band of targets was bracketed labels, and it is caught by
+/// the brackets -- the one bracketed thing on a frame at rest is the header's
+/// own target, which is what the band was traded for.
+///
+/// The label is read out of the reader rather than written here, so a key that
+/// moved moves this with it.
+#[test]
+fn no_frame_carries_the_trailer_or_the_band_at_any_window() {
+    let repo = Repo::seeded();
+    for window in WINDOWS {
+        let live = Live::open(&repo, window.0, window.1);
+        live.until("the session to open", |t| t.contains("ank tui"));
+        let frame = live.frame();
+        let rows = grid(&frame);
+        assert_eq!(
+            rows.len(),
+            window.1 as usize,
+            "the frame is not the window's rows at {window:?}:\n{frame}"
+        );
+        for line in &rows {
+            assert!(
+                line.chars().count() <= window.0 as usize,
+                "{} columns in a {} column window: {line}\n{frame}",
+                line.chars().count(),
+                window.0
+            );
+        }
+        // Under the last panel there is one row and it is the note band, blank
+        // because nothing has been said. Two rows of key lines would be here.
+        let edges = edges();
+        let last = rows
+            .iter()
+            .rposition(|line| panelled(line, &edges))
+            .unwrap_or_else(|| panic!("no panel is drawn at {window:?}:\n{frame}"));
+        assert_eq!(
+            last,
+            rows.len() - 2,
+            "the chrome under the panels is not one row at {window:?}:\n{frame}"
+        );
+        assert!(
+            rows[rows.len() - 1].trim().is_empty(),
+            "the last row of {window:?} is not the blank note band:\n{frame}"
+        );
+        // And the only target drawn at rest is the one that opens the key list.
+        // Asked of the chrome and not of the panels: a listing marks a claim
+        // the reader holds with `[held]`, which is a field of a row rather than
+        // anything a finger is aimed at.
+        let target = help_target();
+        for line in rows.iter().filter(|line| !panelled(line, &edges)) {
+            assert!(
+                !line.contains('[') || line.contains(&target),
+                "a target is drawn at rest at {window:?}: {line}\n{frame}"
+            );
+        }
+        assert!(
+            rows[0].ends_with(&target),
+            "the key list's target is not on the header at {window:?}:\n{frame}"
+        );
+        live.quit();
+    }
+}
+
+/// The target the reader opens its key list with, out of the table that binds
+/// the key it names.
+fn help_target() -> String {
+    let key = ank_tui::bindings::of_command(&ank_tui::input::Command::Help)
+        .expect("a row of the table opens the key list")
+        .key;
+    format!("[{}]", ank_tui::bindings::named(key))
+}

--- a/crates/ank-tui/tests/overlay.rs
+++ b/crates/ank-tui/tests/overlay.rs
@@ -119,9 +119,15 @@ fn drawn_at(frame: &str, needle: &str) -> Option<(u16, u16)> {
 
 /// **The frame is the window and nothing is past its right edge**, which the
 /// criterion asks for over every screen this suite draws.
+///
+/// Counted with `split` and not `lines` since TASK-9a402a54886f: the trailer
+/// was the last row of every frame and was never blank, and what is there now
+/// is the note band -- one row, blank where there is nothing to say. `lines`
+/// drops the empty piece the trailing separator leaves behind, which would read
+/// as a frame one row short of its window.
 fn fits(frame: &str, window: (u16, u16), said: &str) {
     assert_eq!(
-        frame.lines().count(),
+        frame.split('\n').count(),
         window.1 as usize,
         "{said}: the frame is not the window's rows at {window:?}:\n{frame}"
     );

--- a/crates/ank-tui/tests/panels.rs
+++ b/crates/ank-tui/tests/panels.rs
@@ -73,9 +73,16 @@ const FIND: char = ank_tui::keys::FIND;
 ///
 /// Both directions, because a frame overflows in two ways and only one of them
 /// is visible in a screenshot: a row wider than the window, and more rows than
-/// the window has. The trailer being on the last row is the third half of it --
-/// it is what says the layout used the size the terminal gave rather than a
-/// default it was born with.
+/// the window has.
+///
+/// **The third half of it is that the bottom of the window is reached**, which
+/// is what says the layout used the size the terminal gave rather than a
+/// default it was born with. It used to be read off the trailer, which was the
+/// last row and was never blank; TASK-9a402a54886f took the trailer away, and
+/// the last row of every frame is now the note band -- one row, blank where
+/// there is nothing to say. So the assertion moved one row up, onto the last
+/// panel's own bottom border, and says the same thing about the same layout:
+/// the chrome under the panels is exactly one row, and it is the window's last.
 #[test]
 fn no_frame_overflows_the_window_at_eighty_columns_or_at_forty() {
     let repo = Repo::seeded();
@@ -83,31 +90,36 @@ fn no_frame_overflows_the_window_at_eighty_columns_or_at_forty() {
         let live = Live::open(&repo, columns, rows);
         live.until("the session to open", |t| t.contains("ank tui"));
         let frame = live.frame();
-        let lines: Vec<&str> = frame.lines().collect();
+        // `split` and not `lines`, because the grid's last row is blank now and
+        // `lines` drops the empty piece a trailing separator leaves behind.
+        let grid: Vec<&str> = frame.split('\n').collect();
         assert_eq!(
-            lines.len(),
+            grid.len(),
             rows as usize,
             "the frame is {} rows in a {columns}x{rows} window:\n{frame}",
-            lines.len()
+            grid.len()
         );
-        for line in &lines {
+        for line in &grid {
             assert!(
                 line.chars().count() <= columns as usize,
                 "{} columns in a {columns} column window: {line}\n{frame}",
                 line.chars().count()
             );
         }
-        // The trailer's own first entry, read out of the reader rather than
-        // spelled here: it was `a then` for as long as a verb was spelled into
-        // a prompt, and TASK-1a415107fd56 made it the first verb's letter.
-        let trailer = ank_tui::bindings::write_line();
-        let first = trailer
-            .split("  ")
-            .next()
-            .expect("the trailer names a verb");
+        let last = grid
+            .iter()
+            .rposition(|line| !line.trim().is_empty())
+            .expect("a frame with something on it");
+        assert_eq!(
+            last,
+            rows as usize - 2,
+            "the last panel does not close on the window's second-last row \
+             of a {columns}x{rows} window:\n{frame}"
+        );
         assert!(
-            lines[rows as usize - 1].starts_with(first),
-            "the key line is not on the last row of a {columns}x{rows} window:\n{frame}"
+            grid[rows as usize - 1].trim().is_empty(),
+            "something other than the note band is on the last row of a \
+             {columns}x{rows} window:\n{frame}"
         );
         live.quit();
     }

--- a/crates/ank-tui/tests/phone.rs
+++ b/crates/ank-tui/tests/phone.rs
@@ -160,17 +160,24 @@ fn at_a_phone_sized_window_the_panels_are_one_column_and_all_four_are_reachable(
     live.quit();
 }
 
-/// **A row is selected by a mouse press, and the actions on the focused panel
-/// are targets that carry the key that also triggers them**
-/// (TASK-dd9747e5e305), through the binary at a phone-sized window.
+/// **A press on a row selects it, and a press on the row already selected
+/// opens it** (TASK-dd9747e5e305, TASK-9a402a54886f, ADR-c07e2694f0e1),
+/// through the binary at a phone-sized window.
 ///
 /// The criterion's own sentence, driven: a tap lands on a row of the listing
-/// and the frame afterwards shows the mark on *that* row and on no other; a tap
-/// lands on the target reading `[Enter open]` and the frame afterwards shows
-/// that entity open in the body panel. Both halves are read off the grid, so
-/// what is asserted is what a person would have been looking at.
+/// and the frame afterwards shows the mark on *that* row and on no other; a
+/// second tap on that same row and the frame afterwards shows that entity open
+/// in the body panel. Both halves are read off the grid, so what is asserted is
+/// what a person would have been looking at.
+///
+/// **The second half used to be a tap on the target reading `[Enter open]`**,
+/// and that band is gone (TASK-9a402a54886f): ADR-c07e2694f0e1 priced four rows
+/// of standing targets on the twenty-four-row screen the clause was written to
+/// protect, and what it asks for instead is exactly this -- the commonest act
+/// on a phone, read this document, reached with no button to press. So the
+/// suite asks for it the way the decision states it.
 #[test]
-fn a_tap_selects_a_row_and_a_tap_on_a_target_reaches_the_action_it_names() {
+fn a_tap_selects_a_row_and_a_second_tap_on_it_opens_it() {
     let repo = Repo::seeded();
     let mut live = Live::open(&repo, PHONE.0, PHONE.1);
     live.until("the session to open", |t| t.contains("2 ENTITIES"));
@@ -215,10 +222,13 @@ fn a_tap_selects_a_row_and_a_tap_on_a_target_reaches_the_action_it_names() {
         "the press selected a row other than the one under it:\n{selected}"
     );
 
-    // The action: the target that says what Enter does, touched rather than
-    // typed.
-    let (column, row) = drawn_at(&selected, "[Enter open]");
-    live.tap(column + 1, row);
+    // The second press, on the very row the first one marked: the row already
+    // selected opens, and no target was touched to do it.
+    let (again, _) = listed(&selected)
+        .into_iter()
+        .find(|(_, l)| l.contains(&short))
+        .expect("the marked row is still on the frame");
+    live.tap(2, again as u16);
     live.until(
         "the entity the tap selected to open in the body panel",
         |t| t.contains("> 3 BODY") && t.contains(&short),


### PR DESCRIPTION
Closes TASK-9a402a54886f.

## What the frame spends now

At 80x24, with no claim held and the queue never asked for, four rows are not a panel's own content: the header's two lines and the rule under them, and the note band's single row. ADR-c07e2694f0e1 measured thirteen when it was written, and the two lines teaching the keys did not fit on the screen they were taught from.

The trailer is gone. The band of touch targets is zero rows except while a command is waiting to be answered — the confirmation keeps its own two, which is the one screen where knowing the key is not optional.

## What the offer was traded for

Removing the band would have broken the ADR's own clause on the way out: it asks for *one permanently visible target that opens the key list*, and there was none. `?` opened an overlay (TASK-8a6578851244) but nothing on the frame opened it by touch, and the band was the phone's only way in.

So the header's first row carries `[?]` on its right edge, and a press there is the key the table binds `Command::Help` to — read through `bindings::of_command`, never written as a character in `view.rs`. It is resolved *after* the pending and prompt checks, so a touch under a confirmation still dismisses it: a new target gets no exception from the modal rule.

And the commonest act on a phone now needs no button at all — **a press on the row already selected opens it**, a press on any other row selects it without opening. Second press and never the first: the first is what makes a row the selected one.

## The two recorded traps, not rediscovered

- `arrange()` still sizes from counts. The two bands it measures read the width and nothing else, and neither reaches `page()` — so `page → arrange → page` stays impossible.
- `Length` still outranks `Max`, and the panels are still `Max` in both arrangements. The confirmation's argv wraps whole at 20x24; the unit test that caught this the hard way is green.

`Panels.keys` is removed from the struct rather than left as a zero-height rectangle. `Panels.actions` stays, and `targets()` returns empty when nothing is pending — so drawing the band and hitting it remain one arithmetic, with no rectangle that is empty for the eye and occupied for the finger.

`bindings::ratify_line` was the trailer's third line and is not a key table but a sentence about the open document, so it moved into the row `note_lines` already keeps blank. Zero rows, and a person reading a proposal is still told what `accept` costs.

## Measured through the binary

`crates/ank-tui/tests/chrome.rs` drives the built `ank` on a pseudo-terminal at 80x24, 40x24, 80x40, 40x12 and 120x40. A row is a panel's own content when its first character is a box edge read out of `view::BOXES`. The desk frame has four such rows against a budget of five; at every window the last panel closes on the second-last row, the last row is the blank note band, no row runs past the right edge, and the only bracketed thing outside the panels is `[?]`.

## Tests outside this crate that had to move

`Screen::text` joins the grid with newlines, so a blank last row makes the string end in one and `lines()` drops the empty piece — a frame reads one row short of its window. `crates/ank-cli/tests/tui.rs`, `tests/panels.rs` and `tests/overlay.rs` count with `split` now, and the resize test reads the bottom off the last panel's border rather than off a trailer. `bindings::screen_line` and `write_line` are deleted; nothing rendered them once the trailer went.

`cargo test --workspace` green, `cargo fmt --check` clean, `ank check` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017LCneNdveVdZTRRGhJFgpZ