### PR TITLE
The reader makes an entity

### DIFF
--- a/.ank/entities/LOG-d342e71f08b9.md
+++ b/.ank/entities/LOG-d342e71f08b9.md
@@ -1,0 +1,13 @@
+---
+id: LOG-d342e71f08b9
+type: log
+title: done, proof commit:6c619ef
+created: 2026-08-27T03:47:10Z
+author: claude-code/opus-5+entity
+scope:
+  - crates/ank-tui/**
+about: TASK-d832452630d2
+seq: 3
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-f455c09157bc.md
+++ b/.ank/entities/LOG-f455c09157bc.md
@@ -1,0 +1,31 @@
+---
+id: LOG-f455c09157bc
+type: log
+title: The form reads its fields out of the contract, and the editor is unreachable by type rather than by
+created: 2026-08-27T03:44:16Z
+author: claude-code/opus-5+entity
+scope:
+  - crates/ank-tui/**
+about: TASK-d832452630d2
+seq: 2
+schema: 4
+version: 1
+---
+
+ care.
+
+WHERE THE FIELDS COME FROM, AND THE ONE FACT THE CONTRACT DOES NOT CARRY. `ank help --json` declares flags per verb and not per subcommand: `spec_of("new").flags` is nine names, and `new` makes three kinds out of that one set. So the form's rows are that list for every kind, read out of ank_contract::verbs exactly as bindings::further already reads it, and the kind itself comes from the verb's own `subcommands` and is drawn on the heading rather than as a field -- it is `ank new`'s first positional, not a flag. What differs per kind is which of those flags the CLI refuses without, and that is commands.rs's `mandatory_flags`, which reaches no document at all. `form::REQUIRED` is therefore the one thing in that file written down rather than read, and it is measured instead of trusted: tests/entity.rs leaves each of its names out in turn, drives the binary, and requires a refusal on the screen. The per-kind foreign-flag refusals -- --verify on an ADR, --constraint on a spec -- stay the CLI's, like every refusal in this crate.
+
+THE EDITOR IS UNREACHABLE BY TYPE. `Form::composed` is the one road from a form to an Act and it answers a Result; `required(kind)` is non-empty for every kind and a test says so; so an argv this form produces always carries a mandatory flag with a value, and `is_interactive`'s `all` can never be true of it. That is the whole guarantee -- not a check somewhere that could be forgotten, but a state the type cannot hold. The sentinel says the same thing from outside, and it is proved to work FIRST, from a shell, on the very call the form must never compose: a negative measured with an instrument nobody checked is not a measurement. The lone dash is refused by the same function, for the reason bindings.rs already states over its own fields.
+
+THE PSEUDO-TERMINAL CAUGHT WHAT NINE UNIT TESTS DID NOT. `Form::press` turned down every keystroke with a modifier held, copying keys::typed's rule -- and a terminal reports a capital as Char('A') with Shift. The first title driven through the form arrived as "task the reader made", its A eaten, and every unit test was green. The rule `typed` enforces exists because six letters write; a field is the opposite case and belongs with keys::edit, where Control is the only modifier that means anything else. Shift-Tab was broken by the same line and is fixed by the same fix. CLAUDE.md's rule earned its keep here exactly as written.
+
+AN ACT GAINED A SUBJECT RATHER THAN propose GAINING AN ARM. All six of the writing half take <id> first and the view supplies it; `ank new` takes a kind, which no panel names, so a reader that put the row's identifier in front would compose `ank new TASK-... task`. The question is asked of the act (`Subject::Selected` or `Subject::Given`) and never of the verb's name, so App::propose stays one function, `Command::Act` stays one match arm -- tests/dependencies.rs counts it -- and Ank::act keeps its single caller behind the confirmation.
+
+THE GATE WIDENED BY ONE AND IS STILL HAND-WRITTEN. ACTS carries `new`. bindings.rs's test that every spelled verb is in the gate had been filtering on Group::Write, so a new group would have walked past it; it filters on `verb.is_some()` now. `new` is Group::Create and not Group::Write because the key list's corpus line ends "(the marked panel's entity, then y)", which is false of a verb whose first positional is a kind -- a note true of six rows and false of the seventh is prose the table cannot be held to. The list has a `make` line of its own and the listing test still counts every binding on exactly one row.
+
+NO ROW OF CHROME WAS SPENT. The form is an overlay on list_rect like the key list: arrange() does not know it exists, so the four non-panel rows LOG-1afc1b09f95b measured are what they still are, and closing the form gives the frame back character for character -- asserted at 80x24, 40x30, 120x40 and 40x12. Two things moved for the short windows. The sentence naming the refused field is drawn OVER the rows rather than under them, so a window too short for thirteen rows cannot scroll the refusal off the bottom exactly when it is needed; and the row window follows the cursor, because a person typing into --body at 40x12 would otherwise be typing at a screen where nothing moves. For the same reason the focused row shows the END of its value where every other row announces its cut with `~`.
+
+WHAT I CHANGED IN A TEST I DO NOT OWN. crates/ank-cli/tests/tui.rs sent `["v", <open>, "n", "n", "c", "b", "v", "q"]` at the reader: the two `n`s paged a body when that line was written, stopped paging it when TASK-1a415107fd56 spent the letter, and open a form now -- so every key after them went into a title, `q` included, and the session never ended. `cargo test --workspace` did not fail, it hung, which is the shape this defect always takes: the whole point of the criterion is that a key which reaches an editor is a hang and not an error, and the same is true one layer up of a key that reaches a text field. Space, which is the paging key, and the rest of the sequence untouched. Worth knowing for the next wave that moves a letter: `grep '"<letter>"' crates/*/tests` before pressing it, because a suite that types a letter somewhere else in the workspace will not say so at compile time.
+
+WHAT I DID NOT TOUCH, AND WHY. ank_contract's note on the `tui` verb still reads "claim, log, release, done, amend and accept act on the entity the focused panel names" and does not mention the seventh; crates/ank-contract is outside this task's scope and amending it here would be widening a perimeter rather than working one. view.rs's header diagram still draws "the keys, and the six verbs that write" as a band of chrome, which TASK-9a402a54886f deleted -- also stale, also not this task's.

--- a/.ank/entities/TASK-d832452630d2.md
+++ b/.ank/entities/TASK-d832452630d2.md
@@ -5,7 +5,7 @@ slug: the-reader-makes-an-entity
 title: The reader makes an entity
 created: 2026-08-26T17:07:37Z
 author: claude-code/opus-5+reader-redesign
-status: open
+status: in_progress
 scope:
   - crates/ank-tui/**
 blocked_by: [TASK-1a415107fd56, TASK-8a6578851244]
@@ -13,5 +13,5 @@ done_criteria: |
   The built binary raises, on n, a form for task, adr and spec, whose fields are the flags ank help --json declares for that kind and no others. The form refuses to compose while a mandatory field is empty, and names the field: ank new opens $EDITOR precisely when every mandatory flag is absent, and an editor spawned into a raw-mode alternate screen by a child with no stdin is a hang and not an error, so the form must never be able to submit one. A composed form raises the confirmation spelling ank new <kind> --title ... --scope ... exactly as a shell would have to spell it. Dismissing it leaves every byte under .ank/ and every ref under refs/ank/ unchanged. Confirming it creates the entity, and ank find then answers with the identifier the reader was given. Measured with $EDITOR pointed at a script that writes a sentinel the test then finds absent.
 criteria_by: creator
 schema: 4
-version: 3
+version: 4
 ---

--- a/.ank/entities/TASK-d832452630d2.md
+++ b/.ank/entities/TASK-d832452630d2.md
@@ -5,13 +5,18 @@ slug: the-reader-makes-an-entity
 title: The reader makes an entity
 created: 2026-08-26T17:07:37Z
 author: claude-code/opus-5+reader-redesign
-status: in_progress
+status: done
 scope:
   - crates/ank-tui/**
 blocked_by: [TASK-1a415107fd56, TASK-8a6578851244]
 done_criteria: |
   The built binary raises, on n, a form for task, adr and spec, whose fields are the flags ank help --json declares for that kind and no others. The form refuses to compose while a mandatory field is empty, and names the field: ank new opens $EDITOR precisely when every mandatory flag is absent, and an editor spawned into a raw-mode alternate screen by a child with no stdin is a hang and not an error, so the form must never be able to submit one. A composed form raises the confirmation spelling ank new <kind> --title ... --scope ... exactly as a shell would have to spell it. Dismissing it leaves every byte under .ank/ and every ref under refs/ank/ unchanged. Confirming it creates the entity, and ank find then answers with the identifier the reader was given. Measured with $EDITOR pointed at a script that writes a sentinel the test then finds absent.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 6c619ef
+    criteria: ac769fbc6695
+    via: submitted
 schema: 4
-version: 4
+version: 5
 ---

--- a/crates/ank-cli/tests/tui.rs
+++ b/crates/ank-cli/tests/tui.rs
@@ -2571,10 +2571,16 @@ fn with_the_word_withheld_nothing_in_the_queue_changes_state() {
         .trim()
         .to_string();
 
+    // Space and not `n` (TASK-d832452630d2). `n` paged this body when the line
+    // was written, stopped paging it when TASK-1a415107fd56 spent the letter on
+    // the verbs, and is `ank new` now -- so the two presses opened a form and
+    // every key after them went into a title, `q` included, and this session
+    // never ended. The paging key is Space, which is what a reader who has used
+    // `less` presses first; the rest of the sequence is untouched.
     let seen = drive(
         &repo,
         READER,
-        &["v", &open(&waiting), "n", "n", "c", "b", "v", "q"],
+        &["v", &open(&waiting), " ", " ", "c", "b", "v", "q"],
     );
     assert!(
         seen.contains(&short_of(&waiting)),

--- a/crates/ank-tui/src/ank.rs
+++ b/crates/ank-tui/src/ank.rs
@@ -90,8 +90,18 @@ const FINDINGS_ARE_AN_ANSWER: &[&str] = &["review"];
 /// takes it only where the document is open on the screen; and the child is
 /// given no stdin, so no prompt of git's can be answered from this process.
 ///
+/// **`new` is the seventh, and it arrived the same way** (TASK-d832452630d2).
+/// It is the one verb here that moves no entity and names none: what it takes
+/// first is a kind, and what follows is the flags the contract declares, filled
+/// in on a form. It is here because a reader that could not make a task is a
+/// reader half the loop is missing from, and what keeps the act deliberate is
+/// the confirmation every other row goes through -- the form composes and never
+/// spawns, `App::confirmed` is still the one caller of [`Ank::act`], and the
+/// form itself cannot compose the flagless call that would open `$EDITOR` into
+/// a child with no stdin.
+///
 /// `close`, `check`, `attest` and `init` are not here and must not arrive.
-pub const ACTS: &[&str] = &["claim", "log", "release", "done", "amend", "accept"];
+pub const ACTS: &[&str] = &["claim", "log", "release", "done", "amend", "accept", "new"];
 
 /// A call that did not produce a document, in the three ways it can fail.
 ///

--- a/crates/ank-tui/src/bindings.rs
+++ b/crates/ank-tui/src/bindings.rs
@@ -68,7 +68,7 @@
 //! pipe that was never opened, for as long as the reader is up. Held by a test
 //! over every string field rather than by whoever writes the next row.
 
-use crate::input::{Act, Command};
+use crate::input::{Act, Command, Subject};
 use crate::keys::{Press, CONFIRM, FIND};
 use crate::view::Focus;
 use ratatui::crossterm::event::KeyCode;
@@ -127,9 +127,20 @@ pub enum Runs {
     ///
     /// It carries no arguments beyond the identifier the view puts in front,
     /// because there is nothing left to carry them: the line a tail used to be
-    /// typed on is gone (TASK-1a415107fd56), and the form that gives them back
-    /// is TASK-d832452630d2's and TASK-e8da6a00564a's.
+    /// typed on is gone (TASK-1a415107fd56). A form is what gives one back and
+    /// the shape of it is settled -- [`crate::form`] arrived with `ank new`
+    /// (TASK-d832452630d2) -- but these six still compose the identifier and
+    /// nothing else, and TASK-e8da6a00564a is where their tails come back.
     Compose,
+    /// The form `ank new` is filled in on, opened (TASK-d832452630d2).
+    ///
+    /// Not [`Runs::Compose`], and the difference is the verb's first
+    /// positional: the six compose against the entity the focused panel names,
+    /// and `ank new <kind>` names a kind no panel holds. So this opens a form
+    /// and composes nothing, and what the form composes goes through the same
+    /// confirmation the other seven rows do -- `crate::form::Form::composed` is
+    /// the one road out of it, and `App::propose` is where it lands.
+    Form,
     /// The command on the screen, run.
     Run,
     /// The command on the screen, dropped.
@@ -154,6 +165,15 @@ pub enum Group {
     Panel,
     /// Composes a verb that writes.
     Write,
+    /// Makes an entity that does not exist yet (TASK-d832452630d2).
+    ///
+    /// Its own group and not [`Group::Write`], because the key list's line for
+    /// the writing half says what those keys land on -- the marked panel's
+    /// entity -- and `ank new` lands on nothing: it is the one verb here whose
+    /// first positional is a kind rather than a row. A note that was true of
+    /// six rows and false of the seventh would be prose the table cannot be
+    /// held to.
+    Create,
     /// Answers what the reader is asking: a command waiting, or a line open.
     Answer,
 }
@@ -198,13 +218,17 @@ pub struct Verb {
 /// The tail a verb takes at the shell, and how a line would become it.
 ///
 /// **Nothing types one into this reader any more** (TASK-1a415107fd56). The
-/// prompt a verb was spelled into is gone, so a press composes the verb and the
-/// identifier and not one byte more, and the form that gives the tails back is
-/// TASK-d832452630d2's and TASK-e8da6a00564a's. What the field is for in the
-/// meantime is the fact itself: `release` takes `--reason` and `done` takes
-/// `--proof`, declared once beside the verb and held to
-/// [`ank_contract::verbs::FlagSpec`] by the test at the foot of this file, so
-/// the row is already true on the day a form reads it.
+/// prompt a verb was spelled into is gone, so a press of one of the six
+/// composes the verb and the identifier and not one byte more, and
+/// TASK-e8da6a00564a is where their tails come back. [`Tail::Form`] is the one
+/// that has arrived, on `ank new` (TASK-d832452630d2): what it means is that
+/// the tail is the flags the contract declares, read by [`crate::form`] rather
+/// than named on this row.
+///
+/// What the field is for on the other six in the meantime is the fact itself:
+/// `release` takes `--reason` and `done` takes `--proof`, declared once beside
+/// the verb and held to [`ank_contract::verbs::FlagSpec`] by the test at the
+/// foot of this file, so the row is already true on the day a form reads it.
 ///
 /// It is deliberately not drawn. [`Binding::entry`] names the verb and its key
 /// and stops there: a key list advertising `done <proof>` where no line takes
@@ -227,6 +251,12 @@ pub enum Tail {
     /// The flag is held to the verb's own [`ank_contract::verbs::FlagSpec`] by
     /// a test: a form this reader offers is a form the CLI takes.
     Behind(&'static str),
+    /// The flags the verb declares, filled in on a form (TASK-d832452630d2).
+    ///
+    /// `ank new` takes nine of them and no line was ever going to carry that;
+    /// what reads them is [`crate::form`], out of the contract's own table, so
+    /// there is nothing for this row to declare beyond which shape the tail is.
+    Form,
     /// Nothing at all: the verb takes the identifier the view supplies and not
     /// one byte more.
     ///
@@ -607,6 +637,31 @@ pub static BINDINGS: &[Binding] = &[
         }),
     },
     // -----------------------------------------------------------------------
+    // What makes an entity (TASK-d832452630d2)
+    //
+    // `n` is `new`'s own initial, which is ADR-c07e2694f0e1's rule and the same
+    // reason the six above have theirs -- and the letter was free: paging went
+    // to Space and the two named keys when TASK-1a415107fd56 priced `n` and `p`
+    // out of movement, so the verb takes a key nothing else wanted.
+    //
+    // A press opens a form and composes nothing. What the form composes is an
+    // act like any other, and it reaches the same confirmation: there is no
+    // second road to `Ank::act` here, and `crates/ank-tui/tests/entity.rs`
+    // drives the binary to say so.
+    // -----------------------------------------------------------------------
+    Binding {
+        key: KeyCode::Char('n'),
+        aliases: &[],
+        runs: Runs::Form,
+        word: "new",
+        group: Group::Create,
+        offered: Offered::Anywhere,
+        verb: Some(Verb {
+            name: crate::form::VERB,
+            tail: Tail::Form,
+        }),
+    },
+    // -----------------------------------------------------------------------
     // What answers the reader (TASK-d4a882345837). Both states are modal, and
     // both grammars are stated over the whole keyboard in `keys.rs`: these two
     // rows are the keys the screen *offers*, not the whole of what it reads.
@@ -666,6 +721,7 @@ impl Binding {
             Runs::Press(press) => press.clone(),
             Runs::Stepped(by) => Press::Run(Command::Panel(focus.stepped(*by))),
             Runs::Sideways(to) if focus != *to => Press::Run(Command::Panel(*to)),
+            Runs::Form => Press::Run(Command::Form),
             Runs::Compose => match self.verb {
                 Some(verb) => composed(verb, focus),
                 // Unreachable from this table -- a composing row spells a verb,
@@ -741,6 +797,9 @@ fn composed(verb: Verb, focus: Focus) -> Press {
     let act = Act {
         verb: verb.name,
         args: Vec::new(),
+        // All six take `<id>` first, and the view is what knows which entity
+        // the person meant.
+        subject: Subject::Selected,
     };
     Press::Run(Command::Act(act))
 }
@@ -761,7 +820,12 @@ pub const OFF_THE_DOCUMENT: &str =
 pub fn of_key(code: KeyCode) -> Option<&'static Binding> {
     BINDINGS
         .iter()
-        .filter(|b| matches!(b.group, Group::Screen | Group::Panel | Group::Write))
+        .filter(|b| {
+            matches!(
+                b.group,
+                Group::Screen | Group::Panel | Group::Write | Group::Create
+            )
+        })
         .find(|b| b.answers(code))
 }
 
@@ -835,6 +899,10 @@ const WRITE_NOTE: &str = "   (the marked panel's entity, then";
 const FURTHER: &[&str] = &["close", "attest", "read"];
 /// What `x` says under them, which is the fact that makes the list honest.
 const FURTHER_NOTE: &str = "   (a shell runs these: this reader does not, yet)";
+/// What it says after the verb that makes one: the fields are the flags the CLI
+/// declares, and nothing on that form is typed at a corpus until it has been
+/// through the confirmation the other seven rows go through.
+const CREATE_NOTE: &str = "   (a form of the flags ank new takes, then";
 /// What it says after `accept`, which is a different kind of offer: the other
 /// five move a corpus, and this one asks a person for a signature ank has no
 /// way to produce.
@@ -958,6 +1026,22 @@ fn write() -> Line {
     }
 }
 
+/// The verb that makes an entity, on a line of its own (TASK-d832452630d2).
+///
+/// Separate from the writing half above for the reason [`Group::Create`] gives:
+/// those keys land on the marked panel's entity and this one lands on nothing,
+/// so one line carrying both would end on a sentence that is false of one of
+/// its rows.
+fn create() -> Line {
+    Line {
+        title: "make",
+        bindings: of_group(Group::Create),
+        lead: String::new(),
+        between: "  ",
+        note: format!("{CREATE_NOTE} {})", named(KeyCode::Char(CONFIRM))),
+    }
+}
+
 /// The sixth act, on a line of its own, and only where the verb would take it.
 fn ratify() -> Line {
     Line {
@@ -999,7 +1083,15 @@ fn typing() -> Line {
 /// ones are named rather than left to be discovered: a person who has a command
 /// waiting on the screen cannot press `?` to find out what answers it.
 fn lines() -> Vec<Line> {
-    vec![screen(), panel(), write(), ratify(), waiting(), typing()]
+    vec![
+        screen(),
+        panel(),
+        write(),
+        create(),
+        ratify(),
+        waiting(),
+        typing(),
+    ]
 }
 
 // `screen_line` and `write_line` stood here (TASK-9a402a54886f). They were the
@@ -1142,7 +1234,11 @@ mod tests {
                 );
             }
         }
-        assert_eq!(named, 6, "the writing half is six verbs");
+        assert_eq!(
+            named, 7,
+            "the verbs this reader spells are the six that move an entity and \
+             the one that makes one (TASK-d832452630d2)"
+        );
     }
 
     /// **The gate is measured against the table and never generated from it**
@@ -1159,8 +1255,8 @@ mod tests {
     fn every_binding_that_writes_is_in_the_gate_and_the_gate_reads_nothing_from_here() {
         let spelled: Vec<&str> = BINDINGS
             .iter()
-            .filter(|b| b.group == Group::Write)
-            .map(|b| b.verb.expect("a verb of the writing half").name)
+            .filter_map(|b| b.verb)
+            .map(|verb| verb.name)
             .collect();
         for verb in &spelled {
             assert!(
@@ -1371,10 +1467,12 @@ mod tests {
     #[test]
     fn no_key_of_the_table_is_claimed_twice() {
         let mut claimed: Vec<KeyCode> = Vec::new();
-        for binding in BINDINGS
-            .iter()
-            .filter(|b| matches!(b.group, Group::Screen | Group::Panel | Group::Write))
-        {
+        for binding in BINDINGS.iter().filter(|b| {
+            matches!(
+                b.group,
+                Group::Screen | Group::Panel | Group::Write | Group::Create
+            )
+        }) {
             for key in std::iter::once(binding.key).chain(binding.aliases.iter().copied()) {
                 assert!(
                     !claimed.contains(&key),

--- a/crates/ank-tui/src/form.rs
+++ b/crates/ank-tui/src/form.rs
@@ -1,0 +1,1006 @@
+//! The form `ank new` is filled in on, and the whole of why it cannot open an
+//! editor (TASK-d832452630d2, ADR-c07e2694f0e1).
+//!
+//! **The fields are the contract's and not this file's.** `ank help --json`
+//! declares what `ank new` takes, [`ank_contract::verbs`] is where that
+//! declaration lives, and [`Form::fields`] is that list read in its own order.
+//! Nothing here writes a flag name down: this crate has already been burned
+//! once by five parallel key tables (ADR-c07e2694f0e1 records what they cost),
+//! and a parallel flag table would be the same mistake one surface further
+//! along. A flag `new` gains is a row of this form the day it is declared, and
+//! a flag it loses is a row that goes.
+//!
+//! The kinds are read the same way, out of the verb's own `subcommands`: `ank
+//! new <task|adr|spec>` is what the contract's usage line says, and the three
+//! words are its list rather than three arms of a `match` here.
+//!
+//! # The editor, and why this form is a `Result`
+//!
+//! `ank new` opens `$EDITOR` **precisely when every mandatory flag is absent**
+//! -- that is the CLI's `is_interactive`, and it is `all` and not `any`: `ank
+//! new task --title x` still refuses on the missing scope, and `ank new task`
+//! alone opens an editor. The reader's child is spawned with `output()`'s null
+//! stdin, into a process that has taken the terminal into raw mode on the
+//! alternate screen. An editor reached from here is therefore not an error that
+//! shows up on the screen; it is a full-screen program drawing into a captured
+//! pipe, reading from nothing, for as long as the reader is up.
+//!
+//! So the form is not *unlikely* to compose one, it is structurally incapable
+//! of it. [`Form::composed`] is the one road from a form to an [`Act`], it
+//! answers `Err` while a mandatory field is blank, and [`REQUIRED`] gives every
+//! kind at least one -- which is what makes "every mandatory flag absent"
+//! unreachable rather than merely unusual. The suite measures it the way the
+//! criterion asks: `$EDITOR` points at a script that writes a sentinel, and the
+//! sentinel is not there afterwards.
+//!
+//! # Where the mandatory list comes from, and why it is here
+//!
+//! It is the one fact this form needs that the contract does not carry.
+//! `ank help --json` declares the flags of the *verb* `new`, and `new` makes
+//! three kinds out of one flag set; which of them a kind cannot do without is
+//! the CLI's own `mandatory_flags`, and it reaches no document. So [`REQUIRED`]
+//! is written below -- and it is *measured* rather than trusted: `tests/
+//! entity.rs` runs the built binary once per name in it with that flag left
+//! out and finds a refusal, and once with the whole set and finds an entity. A
+//! list that drifted from the CLI fails there rather than surviving review.
+//!
+//! Every name in it is held to the contract's own flags by the suite at the
+//! foot of this file, so the two halves cannot disagree either.
+
+use crate::input::{Act, Subject};
+use crate::text::fit;
+use ank_contract::verbs::{self, CommandSpec, FlagSpec};
+use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+/// The verb this form spells, named once so the binding, the gate and the
+/// composed argv are the same string.
+pub const VERB: &str = "new";
+
+/// The flags `ank new` will not make an entity of this kind without.
+///
+/// **Not read from the contract, because the contract does not carry it** --
+/// see the module header for what is declared where, and `tests/entity.rs` for
+/// how this is held to the binary rather than to a memory of it.
+///
+/// A kind the contract declares and this list does not name falls to
+/// [`BASE`], which is what all three kinds share: a title and a scope. That is
+/// the conservative direction -- it can only ask for more than the CLI needs,
+/// never less -- and asking for more is a refusal on this side of the pipe,
+/// where asking for less would be the editor.
+const REQUIRED: &[(&str, &[&str])] = &[
+    // An ADR is a rule, and a rule with no sentence in it binds nothing.
+    ("adr", &["--title", "--scope", "--constraint"]),
+];
+
+/// What every kind needs: a title, and the scope that attaches it to something.
+///
+/// "a scope is mandatory: an entity attached to nothing is invisible" is the
+/// verb's own note, and it is the sentence this form refuses on.
+const BASE: &[&str] = &["--title", "--scope"];
+
+/// The mandatory flags of one kind.
+pub fn required(kind: &str) -> &'static [&'static str] {
+    REQUIRED
+        .iter()
+        .find(|(named, _)| *named == kind)
+        .map(|(_, flags)| *flags)
+        .unwrap_or(BASE)
+}
+
+/// The verb's own declaration, or `None` where this build's contract has no
+/// `new` at all.
+///
+/// `None` rather than a panic, for [`crate::bindings::further`]'s reason: a
+/// reader must not die because a verb moved, and a form with no contract behind
+/// it is a form that refuses rather than one that invents a flag set.
+pub fn spec() -> Option<&'static CommandSpec> {
+    verbs::spec_of(VERB)
+}
+
+/// What one field of the form holds.
+///
+/// Two shapes because the contract declares two: a flag that takes a value, and
+/// a switch that is present or absent. `ank new` declares no switch today and
+/// the form is generated, so the day one arrives it is a row of this form and
+/// not a panic.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Entry {
+    /// A flag that takes a value: what has been typed for it. Blank is absent,
+    /// and an absent flag is not passed at all -- the CLI is left to answer for
+    /// the ones it needs, which is the refusal a person needs to see.
+    Typed(String),
+    /// A flag that takes none. Space turns it over; off is absent.
+    Set(bool),
+}
+
+impl Entry {
+    /// Whether this field says nothing, which is what "absent" means to the
+    /// composed argv and what a mandatory field may not be.
+    pub fn blank(&self) -> bool {
+        match self {
+            Entry::Typed(text) => text.trim().is_empty(),
+            Entry::Set(on) => !on,
+        }
+    }
+
+    /// What the row draws after the flag.
+    pub fn drawn(&self) -> String {
+        match self {
+            Entry::Typed(text) => text.clone(),
+            Entry::Set(true) => "yes".to_string(),
+            Entry::Set(false) => String::new(),
+        }
+    }
+}
+
+/// One field: the flag the contract declared, and what has been put in it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Field {
+    /// The flag, as `ank` spells it. Copied from [`FlagSpec::name`] and never
+    /// written here.
+    pub flag: &'static str,
+    /// Whether the CLI takes a repeat of it. Drawn as a fact about the flag,
+    /// and not acted on: this form offers a repeatable flag once, which is a
+    /// subset of what a shell can say and never a form the CLI refuses.
+    pub repeatable: bool,
+    pub entry: Entry,
+}
+
+/// What one key did to an open form.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Filled {
+    /// The form changed, or the key meant nothing here. It stays open and
+    /// nothing is composed.
+    Filling,
+    /// Enter: the form is asking for what it holds to be composed.
+    Compose,
+    /// Escape, or the one chord: the form closes and nothing was composed.
+    Close,
+}
+
+/// A field that has to be filled in before this form can compose anything.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Missing {
+    /// The row it is on, so the form can put the cursor where the answer goes.
+    pub at: usize,
+    /// What the form says about it, naming the flag.
+    pub said: String,
+}
+
+/// The form, open.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Form {
+    /// Which of the verb's own subcommands this form is for, as an index into
+    /// [`Form::kinds`]: the kind is the first positional of `ank new` and never
+    /// a field, so it is drawn on the heading rather than in the rows.
+    kind: usize,
+    fields: Vec<Field>,
+    /// The row the cursor is on.
+    at: usize,
+    /// What the form is telling the person filling it in -- which field is
+    /// still empty, above all.
+    ///
+    /// Carried by the form rather than left to [`crate::view::App::note`]
+    /// because the form is drawn over the band that note lives in: a refusal
+    /// nobody can see is a refusal that did not happen.
+    said: Option<String>,
+}
+
+impl Form {
+    /// A form for the first kind the contract declares, with every field empty.
+    ///
+    /// `None` where this build's contract declares no `new`, or declares it
+    /// with no subcommands: a form with no kind has nothing to compose.
+    pub fn open() -> Option<Form> {
+        let spec = spec()?;
+        if spec.subcommands.is_empty() {
+            return None;
+        }
+        Some(Form {
+            kind: 0,
+            fields: spec.flags.iter().filter(|f| f.listed).map(field).collect(),
+            at: 0,
+            said: None,
+        })
+    }
+
+    /// The kinds this form can be for, in the contract's own order.
+    pub fn kinds(&self) -> &'static [&'static str] {
+        spec().map(|s| s.subcommands).unwrap_or_default()
+    }
+
+    /// The kind it is for now.
+    pub fn kind(&self) -> &'static str {
+        self.kinds().get(self.kind).copied().unwrap_or_default()
+    }
+
+    pub fn fields(&self) -> &[Field] {
+        &self.fields
+    }
+
+    pub fn at(&self) -> usize {
+        self.at
+    }
+
+    pub fn said(&self) -> Option<&str> {
+        self.said.as_deref()
+    }
+
+    /// Whether this flag is one the kind cannot do without.
+    pub fn needed(&self, flag: &str) -> bool {
+        required(self.kind()).contains(&flag)
+    }
+
+    /// The kind after this one, and back to the first after the last.
+    fn cycle(&mut self, by: isize) {
+        let count = self.kinds().len();
+        if count == 0 {
+            return;
+        }
+        let at = self.kind as isize + by;
+        self.kind = at.rem_euclid(count as isize) as usize;
+        self.said = None;
+    }
+
+    fn step(&mut self, by: isize) {
+        let count = self.fields.len();
+        if count == 0 {
+            return;
+        }
+        let at = self.at as isize + by;
+        self.at = at.rem_euclid(count as isize) as usize;
+    }
+
+    /// One key, answered against the form.
+    ///
+    /// **Modal, and every letter is a letter.** A form is where a person types
+    /// words, so no printable character is a command here: the movement is on
+    /// the named keys a terminal sends for arrows and tabs, the kind is on the
+    /// two arrows that cross, Enter composes and Escape closes. That is the
+    /// same shape the confirmation and the prompt have -- a state where the
+    /// keyboard means something else -- and the reason is the one
+    /// [`crate::keys::edit`] gives: a line being typed into cannot also be a
+    /// key table.
+    ///
+    /// **No command here is a chord** (ADR-c07e2694f0e1). Control-C is the way
+    /// out of a program that took the terminal and it closes the form, and
+    /// Control-U clears the field, which is what the prompt does with it.
+    ///
+    /// **And the modifiers are read the way [`crate::keys::edit`] reads them
+    /// and not the way [`crate::keys::typed`] does**, which is the one place
+    /// this grammar had to part company with the key table. The table refuses a
+    /// modifier held, because six letters write and a Shift still down from the
+    /// character before must not compose a claim. A field is the opposite case:
+    /// a terminal reports a capital as `Char('A')` *with Shift held*, so a form
+    /// that turned a held modifier down would be a form nobody can put a
+    /// capital letter in -- which is every title in this corpus. It cost a
+    /// title its first letter before the pseudo-terminal caught it. Control is
+    /// the only modifier that means anything else here, exactly as at the
+    /// prompt, and nothing under it types.
+    pub fn press(&mut self, key: KeyEvent) -> Filled {
+        if key.modifiers.contains(KeyModifiers::CONTROL) {
+            return match key.code {
+                KeyCode::Char('c') => Filled::Close,
+                KeyCode::Char('u') => {
+                    self.clear();
+                    Filled::Filling
+                }
+                _ => Filled::Filling,
+            };
+        }
+        match key.code {
+            KeyCode::Esc => Filled::Close,
+            KeyCode::Enter => Filled::Compose,
+            KeyCode::Tab | KeyCode::Down => {
+                self.step(1);
+                Filled::Filling
+            }
+            KeyCode::BackTab | KeyCode::Up => {
+                self.step(-1);
+                Filled::Filling
+            }
+            KeyCode::Right => {
+                self.cycle(1);
+                Filled::Filling
+            }
+            KeyCode::Left => {
+                self.cycle(-1);
+                Filled::Filling
+            }
+            KeyCode::Backspace => {
+                self.backspace();
+                Filled::Filling
+            }
+            KeyCode::Char(c) => {
+                self.typed(c);
+                Filled::Filling
+            }
+            _ => Filled::Filling,
+        }
+    }
+
+    /// The row a press landed on, selected. A tap reaches a field exactly as
+    /// the arrows do.
+    pub fn select(&mut self, at: usize) {
+        if at < self.fields.len() {
+            self.at = at;
+        }
+    }
+
+    fn clear(&mut self) {
+        if let Some(field) = self.fields.get_mut(self.at) {
+            match &mut field.entry {
+                Entry::Typed(text) => text.clear(),
+                Entry::Set(on) => *on = false,
+            }
+        }
+        self.said = None;
+    }
+
+    fn backspace(&mut self) {
+        // Backspacing an empty field does not close the form, which is where
+        // this and the prompt part company: a prompt is one line and emptying
+        // it is a person saying they did not mean to be there, and a form is
+        // nine fields somebody has been typing into.
+        if let Some(field) = self.fields.get_mut(self.at) {
+            match &mut field.entry {
+                Entry::Typed(text) => {
+                    text.pop();
+                }
+                Entry::Set(on) => *on = false,
+            }
+        }
+        self.said = None;
+    }
+
+    fn typed(&mut self, c: char) {
+        if let Some(field) = self.fields.get_mut(self.at) {
+            match &mut field.entry {
+                Entry::Typed(text) => text.push(c),
+                // A switch has no text to carry, so the one printable key that
+                // means anything on it is the one that turns it over.
+                Entry::Set(on) if c == ' ' => *on = !*on,
+                Entry::Set(_) => {}
+            }
+        }
+        self.said = None;
+    }
+
+    /// The act this form composes, or the field that is still empty.
+    ///
+    /// **This is the one road from a form to an argv**, and it is a `Result`
+    /// for the reason the module header gives: `ank new` with every mandatory
+    /// flag absent opens `$EDITOR`, and an editor spawned by a child with no
+    /// stdin into a raw-mode alternate screen is a hang. Every kind has at
+    /// least one flag it refuses without ([`required`], held non-empty by the
+    /// suite below), so an argv this answers `Ok` to always carries one -- and
+    /// "every mandatory flag absent" is a state this cannot produce rather than
+    /// a state it is careful about.
+    ///
+    /// The kind goes in front because it is `ank new`'s first positional, and
+    /// the flags follow in the contract's own order, a blank field passing
+    /// nothing at all.
+    pub fn composed(&self) -> Result<Act, Missing> {
+        for (at, field) in self.fields.iter().enumerate() {
+            if self.needed(field.flag) && field.entry.blank() {
+                return Err(Missing {
+                    at,
+                    said: format!(
+                        "{} is empty, and 'ank {VERB} {}' will not make one without it",
+                        field.flag,
+                        self.kind()
+                    ),
+                });
+            }
+            // The lone dash is the CLI's "the value is on stdin", and this
+            // reader's child has none: `Ank::spawn` gives it `output()`'s null
+            // pipe, so a dash reaching a composed argv would be a child waiting
+            // on a thing nothing will ever write. Refused here, where the person
+            // who typed it can read why, rather than left to hang.
+            if let Entry::Typed(text) = &field.entry {
+                if text.trim() == "-" {
+                    return Err(Missing {
+                        at,
+                        said: format!(
+                            "{} is a lone dash, which asks the CLI to read it from a pipe this \
+                             reader has not got",
+                            field.flag
+                        ),
+                    });
+                }
+            }
+        }
+        let mut args = vec![self.kind().to_string()];
+        for field in &self.fields {
+            match &field.entry {
+                Entry::Typed(text) if !text.trim().is_empty() => {
+                    args.push(field.flag.to_string());
+                    args.push(text.trim().to_string());
+                }
+                Entry::Set(true) => args.push(field.flag.to_string()),
+                _ => {}
+            }
+        }
+        Ok(Act {
+            verb: VERB,
+            args,
+            // `ank new <kind>` names a kind and not an entity, so there is no
+            // row for the view to put in front of it.
+            subject: Subject::Given,
+        })
+    }
+
+    /// The act, with the cursor moved onto whatever is missing where there is
+    /// nothing to compose.
+    ///
+    /// What the screen calls: a form that said no puts the person on the field
+    /// that has to be answered, and says which it is.
+    pub fn submit(&mut self) -> Option<Act> {
+        match self.composed() {
+            Ok(act) => Some(act),
+            Err(missing) => {
+                self.at = missing.at;
+                self.said = Some(missing.said);
+                None
+            }
+        }
+    }
+
+    /// The rows of the form, each with the field a press on it selects.
+    ///
+    /// **One function for drawing them and for hitting them**, which is what
+    /// [`crate::view::App::list_lines`] and [`crate::view::App::targets`] both
+    /// say for themselves: a row a person can see and a row a press resolves to
+    /// are the same row, or they are two and the screen answers somewhere other
+    /// than where it was touched.
+    ///
+    /// The heading and the sentence under it carry no field: they are prose
+    /// about the rows, which is the one kind of row that selects nothing.
+    pub fn rows(&self, width: usize) -> Vec<(String, Option<usize>)> {
+        let mut out: Vec<(String, Option<usize>)> = Vec::new();
+        out.push((fit(&self.heading(), width), None));
+        // Over the rows rather than under them, which is where it was first
+        // put: what this says is either how the form works or which field it
+        // refused on, and a window too short for the whole form would have
+        // scrolled the second one off the bottom exactly when it was needed.
+        for line in crate::text::wrap(self.said.as_deref().unwrap_or(REQUIRED_NOTE), width.max(1)) {
+            out.push((fit(&line, width), None));
+        }
+        out.push((String::new(), None));
+        for (at, field) in self.fields.iter().enumerate() {
+            let marker = match at == self.at {
+                true => crate::text::CURSOR,
+                false => crate::text::PLAIN,
+            };
+            let needed = match self.needed(field.flag) {
+                true => '*',
+                false => ' ',
+            };
+            let repeat = match field.repeatable {
+                true => "...",
+                false => "",
+            };
+            let name = format!("{}{repeat}", field.flag);
+            let gap = " ".repeat(FLAG_COLUMN.saturating_sub(name.chars().count()));
+            let lead = format!("{marker}{needed} {name}{gap}");
+            let room = width.saturating_sub(lead.chars().count());
+            out.push((
+                fit(
+                    &format!("{lead}{}", shown(&field.entry, room, at == self.at)),
+                    width,
+                ),
+                Some(at),
+            ));
+        }
+        out
+    }
+
+    /// The row of the form the cursor is on, so a window too short for the
+    /// whole of it can keep the field being typed into on the screen.
+    pub fn row_of_cursor(&self, width: usize) -> usize {
+        self.rows(width)
+            .iter()
+            .position(|(_, field)| *field == Some(self.at))
+            .unwrap_or(0)
+    }
+
+    /// What stands over the rows: which kind is being made, and how to reach
+    /// the other two.
+    fn heading(&self) -> String {
+        let others: Vec<&str> = self
+            .kinds()
+            .iter()
+            .copied()
+            .filter(|k| *k != self.kind())
+            .collect();
+        match others.is_empty() {
+            true => format!("ank {VERB} {}", self.kind()),
+            false => format!(
+                "ank {VERB} {}   (Left/Right for {})",
+                self.kind(),
+                others.join(", ")
+            ),
+        }
+    }
+}
+
+/// What the form says under the rows while it has nothing else to say.
+const REQUIRED_NOTE: &str =
+    "* is a flag ank new will not make one without: Enter composes, Esc closes";
+
+/// The column the values line up in, which is wide enough for the longest flag
+/// `ank new` declares and its repeat marker.
+const FLAG_COLUMN: usize = 16;
+
+/// What a value looks like in the room its row has left.
+///
+/// **The end of it on the row being typed into, and the beginning everywhere
+/// else.** A cut announced with `~` is the right answer for a value somebody is
+/// reading -- there is more of this, and the row above says which flag it is --
+/// and the wrong one for the value under the cursor: a person typing a title at
+/// forty columns would be typing past the right edge with nothing on the screen
+/// moving, which is a text field that has stopped saying what it holds. So the
+/// focused row shows its tail, which is where the next character lands.
+fn shown(entry: &Entry, room: usize, focused: bool) -> String {
+    let text = entry.drawn();
+    let over = text.chars().count().saturating_sub(room);
+    if !focused || over == 0 || room == 0 {
+        return text;
+    }
+    // One column of the room goes to saying that the beginning is off the left,
+    // for the reason `fit` spends one on the other end: a window with no edge
+    // drawn reads as the whole of what is there.
+    text.chars().skip(over + 1).collect::<String>()
+}
+
+/// One field, from the flag the contract declared.
+fn field(spec: &FlagSpec) -> Field {
+    Field {
+        flag: spec.name,
+        repeatable: spec.repeatable,
+        entry: match spec.takes_value {
+            true => Entry::Typed(String::new()),
+            false => Entry::Set(false),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn form() -> Form {
+        Form::open().expect("this build's contract declares 'ank new'")
+    }
+
+    fn filled(form: &mut Form, flag: &str, value: &str) {
+        let at = form
+            .fields
+            .iter()
+            .position(|f| f.flag == flag)
+            .unwrap_or_else(|| panic!("'{flag}' is a field of this form"));
+        form.fields[at].entry = Entry::Typed(value.to_string());
+    }
+
+    fn on(form: &mut Form, kind: &str) {
+        let at = form
+            .kinds()
+            .iter()
+            .position(|k| *k == kind)
+            .unwrap_or_else(|| panic!("'{kind}' is a kind of ank new"));
+        form.kind = at;
+    }
+
+    /// **The fields are the flags the contract declares and no others**
+    /// (TASK-d832452630d2, ADR-c07e2694f0e1).
+    ///
+    /// Both halves, over every kind. A form short of a flag is a form that
+    /// cannot say what the shell can, and a form carrying one the verb does not
+    /// declare is this reader teaching a command line the binary refuses --
+    /// which is the drift ADR-c07e2694f0e1 was written against, one surface
+    /// along from the key tables it names.
+    ///
+    /// The contract declares one flag set for `ank new` and not one per
+    /// subcommand, so the three kinds carry the same rows; which of them a kind
+    /// cannot do without is what differs, and it is [`required`].
+    #[test]
+    fn the_fields_are_the_flags_the_contract_declares_for_new_and_no_others() {
+        let spec = spec().expect("'new' is a verb of the contract");
+        let declared: Vec<&str> = spec
+            .flags
+            .iter()
+            .filter(|f| f.listed)
+            .map(|f| f.name)
+            .collect();
+        assert!(!declared.is_empty(), "'ank new' declares flags");
+        let mut form = form();
+        for kind in form.kinds() {
+            on(&mut form, kind);
+            let named: Vec<&str> = form.fields().iter().map(|f| f.flag).collect();
+            assert_eq!(named, declared, "the form for '{kind}'");
+        }
+        // And the shape of a field is the flag's own, so a switch the verb
+        // gains is a switch here rather than a line to type into.
+        for field in form.fields() {
+            let flag = spec
+                .flags
+                .iter()
+                .find(|f| f.name == field.flag)
+                .expect("a field's flag is declared");
+            assert_eq!(field.repeatable, flag.repeatable, "{}", field.flag);
+            assert_eq!(
+                matches!(field.entry, Entry::Typed(_)),
+                flag.takes_value,
+                "{}",
+                field.flag
+            );
+        }
+    }
+
+    /// The kinds are the verb's own subcommands, in its order.
+    #[test]
+    fn the_kinds_are_the_subcommands_the_contract_declares() {
+        let spec = spec().expect("'new' is a verb of the contract");
+        assert_eq!(form().kinds(), spec.subcommands);
+        assert!(!spec.subcommands.is_empty(), "ank new makes something");
+    }
+
+    /// **Every kind has a flag this form will not compose without, and every
+    /// name in that list is a flag the verb declares.**
+    ///
+    /// The first half is the whole of the editor guarantee: `ank new` opens
+    /// `$EDITOR` when *every* mandatory flag is absent, so a kind with nothing
+    /// mandatory would be a kind this form could compose an editor for. The
+    /// second is what keeps the list from drifting into flags the CLI would
+    /// refuse.
+    #[test]
+    fn every_kind_refuses_without_a_flag_the_contract_declares() {
+        let spec = spec().expect("'new' is a verb of the contract");
+        let form = form();
+        for kind in form.kinds() {
+            let needed = required(kind);
+            assert!(
+                !needed.is_empty(),
+                "'{kind}' needs nothing, so a form for it could compose an editor"
+            );
+            for flag in needed {
+                assert!(
+                    spec.flags.iter().any(|f| f.name == *flag && f.listed),
+                    "'{flag}' is mandatory for '{kind}' and is no flag of 'ank {VERB}'"
+                );
+            }
+        }
+        // A kind the contract has not got falls to the base, which is what all
+        // three share rather than nothing at all.
+        assert_eq!(required("a kind nobody declared"), BASE);
+    }
+
+    /// **A form with a mandatory field empty composes nothing, and says which**
+    /// (TASK-d832452630d2).
+    ///
+    /// Stated over every kind and every one of its mandatory flags, one left
+    /// out at a time: the field that gets it wrong next is the one added next,
+    /// and a test over `--title` alone would not see it.
+    #[test]
+    fn a_mandatory_field_left_empty_refuses_and_names_itself() {
+        let mut form = form();
+        for kind in form.kinds() {
+            for left_out in required(kind) {
+                let mut form = Form::open().expect("a form");
+                on(&mut form, kind);
+                for flag in required(kind) {
+                    if flag != left_out {
+                        filled(&mut form, flag, "something");
+                    }
+                }
+                let missing = form
+                    .composed()
+                    .expect_err("a mandatory field is empty and this composed anyway");
+                assert!(
+                    missing.said.contains(left_out),
+                    "'{kind}' without {left_out} said: {}",
+                    missing.said
+                );
+                assert_eq!(
+                    form.fields()[missing.at].flag,
+                    *left_out,
+                    "the cursor was sent to the wrong field"
+                );
+            }
+            // Whitespace is not an answer: the CLI reads a blank `--title` as
+            // absent, so a form that let one through would be a form composing
+            // the editor.
+            let mut blank = Form::open().expect("a form");
+            on(&mut blank, kind);
+            for flag in required(kind) {
+                filled(&mut blank, flag, "   ");
+            }
+            assert!(blank.composed().is_err(), "'{kind}' composed on whitespace");
+        }
+        form.at = 0;
+    }
+
+    /// And a form whose mandatory fields are answered composes the command a
+    /// shell would spell.
+    #[test]
+    fn a_filled_form_composes_the_kind_and_the_flags_that_were_answered() {
+        let mut form = form();
+        on(&mut form, "task");
+        filled(&mut form, "--title", "The reader makes an entity");
+        filled(&mut form, "--scope", "crates/ank-tui/**");
+        let act = form.composed().expect("a filled form composes");
+        assert_eq!(act.verb, VERB);
+        assert_eq!(act.subject, Subject::Given);
+        assert_eq!(
+            act.args,
+            [
+                "task",
+                "--title",
+                "The reader makes an entity",
+                "--scope",
+                "crates/ank-tui/**"
+            ]
+        );
+        // A blank field passes nothing at all: the CLI is left to answer for
+        // what it needs rather than being handed an empty flag.
+        assert!(
+            !act.args.iter().any(|a| a == "--criteria"),
+            "an empty field reached the argv: {:?}",
+            act.args
+        );
+    }
+
+    /// The lone dash never reaches an argv (ADR-c07e2694f0e1's null stdin).
+    #[test]
+    fn a_lone_dash_is_refused_rather_than_handed_to_a_child_with_no_stdin() {
+        let mut form = form();
+        on(&mut form, "task");
+        filled(&mut form, "--title", "A title");
+        filled(&mut form, "--scope", "src/**");
+        filled(&mut form, "--body", "-");
+        let missing = form.composed().expect_err("a dash composed");
+        assert!(missing.said.contains("--body"), "{}", missing.said);
+        // And a body that merely starts with one is a body.
+        filled(&mut form, "--body", "-- not a pipe");
+        assert!(form.composed().is_ok());
+    }
+
+    /// The kind cycles both ways and comes back to where it started, and the
+    /// fields it carries do not move with it.
+    #[test]
+    fn the_kind_cycles_and_the_fields_stay_what_the_contract_declared() {
+        let mut form = form();
+        let kinds = form.kinds().to_vec();
+        let named: Vec<&str> = form.fields().iter().map(|f| f.flag).collect();
+        for expected in kinds.iter().cycle().skip(1).take(kinds.len()) {
+            form.cycle(1);
+            assert_eq!(form.kind(), *expected);
+            let now: Vec<&str> = form.fields().iter().map(|f| f.flag).collect();
+            assert_eq!(now, named, "the fields moved with the kind");
+        }
+        form.cycle(-1);
+        assert_eq!(form.kind(), kinds[kinds.len() - 1]);
+    }
+
+    /// **Every printable key is a character here and no printable key is a
+    /// command** (TASK-1a415107fd56, ADR-c07e2694f0e1).
+    ///
+    /// A form is where words are typed, so a letter that closed it or composed
+    /// it would be a letter nobody could put in a title. The whole of the
+    /// grammar is on the named keys, and the two chords are the ones the prompt
+    /// already answers.
+    #[test]
+    fn no_printable_key_is_a_command_of_the_form() {
+        let bare = |code| KeyEvent::new(code, KeyModifiers::NONE);
+        for c in ' '..='~' {
+            let mut form = form();
+            assert_eq!(
+                form.press(bare(KeyCode::Char(c))),
+                Filled::Filling,
+                "'{c}' is a command of the form"
+            );
+        }
+        let mut form = form();
+        for c in "a title".chars() {
+            form.press(bare(KeyCode::Char(c)));
+        }
+        assert_eq!(form.fields()[0].entry, Entry::Typed("a title".to_string()));
+        assert_eq!(form.press(bare(KeyCode::Enter)), Filled::Compose);
+        assert_eq!(form.press(bare(KeyCode::Esc)), Filled::Close);
+        // Backspacing an empty field is not a way out: a form is not a prompt.
+        let mut empty = Form::open().expect("a form");
+        assert_eq!(empty.press(bare(KeyCode::Backspace)), Filled::Filling);
+        assert!(empty.fields()[0].entry.blank());
+    }
+
+    /// **A capital letter is a letter** (TASK-d832452630d2).
+    ///
+    /// A terminal reports one as `Char('A')` with Shift held, and this form
+    /// turned every held modifier down when it was written -- so the first
+    /// title driven through it on a pseudo-terminal arrived as
+    /// `task the reader made`, its capital eaten. Stated over the whole
+    /// alphabet rather than over the one letter that caught it, and over
+    /// Shift-Tab too, which is the other keystroke a terminal only ever sends
+    /// with a modifier on it.
+    #[test]
+    fn a_capital_is_a_letter_and_shift_tab_still_steps_back() {
+        let held = KeyEvent::new;
+        let mut form = form();
+        for c in 'A'..='Z' {
+            form.press(held(KeyCode::Char(c), KeyModifiers::SHIFT));
+        }
+        assert_eq!(
+            form.fields()[0].entry,
+            Entry::Typed(('A'..='Z').collect::<String>()),
+            "a capital was eaten"
+        );
+        let at = form.at();
+        form.press(held(KeyCode::BackTab, KeyModifiers::SHIFT));
+        assert_eq!(
+            form.at(),
+            (at + form.fields().len() - 1) % form.fields().len()
+        );
+    }
+
+    /// Control is the one modifier that means something else, and it is the way
+    /// out and the clear -- the two the prompt already answers
+    /// ([`crate::keys::edit`]).
+    #[test]
+    fn control_is_the_way_out_and_the_clear_and_nothing_under_it_types() {
+        let held = KeyEvent::new;
+        let mut form = form();
+        for c in 'a'..='z' {
+            let answered = form.press(held(KeyCode::Char(c), KeyModifiers::CONTROL));
+            let expected = match c {
+                'c' => Filled::Close,
+                _ => Filled::Filling,
+            };
+            assert_eq!(answered, expected, "Control-{c}");
+            assert!(
+                form.fields()[0].entry.blank(),
+                "Control-{c} typed something"
+            );
+        }
+        for c in "cleared".chars() {
+            form.press(held(KeyCode::Char(c), KeyModifiers::NONE));
+        }
+        assert!(!form.fields()[0].entry.blank());
+        form.press(held(KeyCode::Char('u'), KeyModifiers::CONTROL));
+        assert!(form.fields()[0].entry.blank(), "Control-U left the field");
+    }
+
+    /// The cursor walks the fields and wraps, and a tap reaches the same rows.
+    #[test]
+    fn the_cursor_walks_the_fields_and_a_row_is_where_a_tap_lands() {
+        let bare = |code| KeyEvent::new(code, KeyModifiers::NONE);
+        let mut form = form();
+        let count = form.fields().len();
+        for expected in 1..count {
+            form.press(bare(KeyCode::Tab));
+            assert_eq!(form.at(), expected);
+        }
+        form.press(bare(KeyCode::Tab));
+        assert_eq!(form.at(), 0, "the last field steps back to the first");
+        form.press(bare(KeyCode::Up));
+        assert_eq!(form.at(), count - 1);
+        // Every row that names a field selects it, and the prose selects
+        // nothing.
+        let rows = form.rows(100);
+        let named: Vec<usize> = rows.iter().filter_map(|(_, at)| *at).collect();
+        assert_eq!(named, (0..count).collect::<Vec<usize>>());
+        for (text, at) in &rows {
+            if let Some(at) = at {
+                assert!(
+                    text.contains(form.fields()[*at].flag),
+                    "a row names field {at} and does not draw it: {text}"
+                );
+            }
+        }
+    }
+
+    /// **The row being typed into shows where the next character lands**
+    /// (TASK-d832452630d2).
+    ///
+    /// A value longer than the room its row has left is cut with `~` on every
+    /// row but the one under the cursor, where the cut would be at the wrong
+    /// end: a person typing a title into forty columns would be typing past the
+    /// right edge with nothing on the screen moving.
+    #[test]
+    fn the_field_being_typed_into_shows_its_end_and_the_others_show_their_start() {
+        let mut form = form();
+        let long: String = ('a'..='z').cycle().take(80).collect();
+        filled(&mut form, "--title", &long);
+        filled(&mut form, "--criteria", &long);
+        let rows = form.rows(40);
+        let at = |flag: &str| {
+            form.fields()
+                .iter()
+                .position(|f| f.flag == flag)
+                .expect("a field")
+        };
+        let title = rows
+            .iter()
+            .find(|(_, field)| *field == Some(at("--title")))
+            .expect("a title row");
+        assert!(
+            title.0.ends_with(&long[long.len() - 4..]),
+            "the row being typed into does not show its end: {}",
+            title.0
+        );
+        let criteria = rows
+            .iter()
+            .find(|(_, field)| *field == Some(at("--criteria")))
+            .expect("a criteria row");
+        assert!(
+            criteria.0.ends_with('~'),
+            "a row nobody is typing into did not announce its cut: {}",
+            criteria.0
+        );
+        for (text, _) in &rows {
+            assert!(
+                text.chars().count() <= 40,
+                "a row outgrew the window: {text}"
+            );
+        }
+    }
+
+    /// Every mandatory field is marked on the rows, so what the form refuses on
+    /// is on the screen before it refuses.
+    #[test]
+    fn the_rows_mark_what_the_kind_will_not_do_without() {
+        let mut form = form();
+        for kind in form.kinds().to_vec() {
+            on(&mut form, kind);
+            for (text, at) in form.rows(100) {
+                let Some(at) = at else { continue };
+                let field = &form.fields()[at];
+                assert_eq!(
+                    text.contains('*'),
+                    required(kind).contains(&field.flag),
+                    "'{kind}' marked {} as {}",
+                    field.flag,
+                    text
+                );
+            }
+            assert!(
+                form.rows(100)[0].0.contains(kind),
+                "the heading does not say which kind is being made"
+            );
+        }
+    }
+
+    /// A refused submit puts the cursor on the field it named and says so on
+    /// the form, where the person filling it in can read it.
+    #[test]
+    fn a_refused_submit_moves_the_cursor_and_says_why_on_the_form() {
+        let mut form = form();
+        on(&mut form, "task");
+        filled(&mut form, "--scope", "src/**");
+        assert!(form.submit().is_none());
+        assert_eq!(form.fields()[form.at()].flag, "--title");
+        let said = form.said().expect("the form says which field").to_string();
+        assert!(said.contains("--title"), "{said}");
+        assert!(
+            form.rows(120).iter().any(|(text, field)| field.is_none()
+                && text.contains("--title")
+                && text.contains("empty")),
+            "the form does not draw what it refused on"
+        );
+        // And it draws it over the fields, so a window too short for the whole
+        // form cannot scroll the refusal off the bottom.
+        let rows = form.rows(120);
+        let said = rows
+            .iter()
+            .position(|(text, _)| text.contains("empty"))
+            .expect("the refusal is drawn");
+        let first_field = rows
+            .iter()
+            .position(|(_, field)| field.is_some())
+            .expect("the form has fields");
+        assert!(said < first_field, "the refusal is drawn under the rows");
+        // And typing into it clears the refusal: what is being said is about the
+        // form as it is, not about the form as it was.
+        form.press(KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE));
+        assert_eq!(form.said(), None);
+    }
+}

--- a/crates/ank-tui/src/input.rs
+++ b/crates/ank-tui/src/input.rs
@@ -114,6 +114,13 @@ pub enum Command {
     /// what it opens is a list of what this reader does not run, so there is
     /// nothing for a person to have typed.
     Further,
+    /// The form `ank new` is filled in on (TASK-d832452630d2).
+    ///
+    /// A key and no word, like [`Command::Further`]: what it opens is a form
+    /// whose fields are read out of the contract, and a line that spelled the
+    /// verb would be the second road to a write ADR-c07e2694f0e1 closed. It
+    /// carries nothing, because what the form holds is the form's.
+    Form,
     /// A line that asked for nothing: an empty prompt, or one carrying only
     /// whitespace.
     Nothing,
@@ -127,18 +134,41 @@ pub enum Command {
 /// is named rather than swallowed.
 const IDENTIFIER_KINDS: &[&str] = &["task", "adr", "spec", "log"];
 
-/// One verb of the writing half, with the arguments a typed line gave it.
+/// One verb of the writing half, with the arguments the key or the form gave
+/// it.
 ///
-/// `args` is the verb's own tail and never carries the identifier: the view
-/// puts that in front, because `<id>` is the first positional of all six and
-/// the view is what knows which entity is selected. It is empty on every act
-/// this reader composes today -- there is no longer a line to type a tail on --
-/// and it is a `Vec` rather than nothing because the form that fills it is
-/// TASK-d832452630d2's and TASK-e8da6a00564a's.
+/// `args` is what follows the verb, and [`Act::subject`] says whether the view
+/// still has to put an identifier in front of it.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Act {
     pub verb: &'static str,
     pub args: Vec<String>,
+    /// What the verb's first positional is, which is the one thing the view has
+    /// to know before it can compose an argv.
+    pub subject: Subject,
+}
+
+/// Where a verb's first positional comes from.
+///
+/// **Two answers, because there are two shapes of act and there always were.**
+/// The six that move an entity take `<id>` first, and the identifier is the
+/// view's to supply: the person at the keyboard said which entity they meant by
+/// being in the panel that names it, and a key press does not carry it. `ank
+/// new` takes a kind first, which is nothing the panels name at all -- so the
+/// act arrives carrying its own front, and the view must not put a row's
+/// identifier in front of it (TASK-d832452630d2).
+///
+/// Stated on the act rather than decided from the verb's name, so a second verb
+/// of this shape is a field on its row and never an arm somewhere that has to
+/// be remembered.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Subject {
+    /// The entity the focused panel names goes in front. What all six of the
+    /// writing half take.
+    Selected,
+    /// The act already carries its own first positional, and nothing is put in
+    /// front of it.
+    Given,
 }
 
 pub fn parse(line: &str) -> Command {

--- a/crates/ank-tui/src/keys.rs
+++ b/crates/ank-tui/src/keys.rs
@@ -57,7 +57,12 @@
 //! [`crate::input::parse`]; no word that grammar reads writes anything, and the
 //! prompt a verb used to be spelled into is gone with the key that opened it.
 //! What the six carried in a tail -- a message, a reason, a proof, a flag --
-//! comes back as a form, which is TASK-d832452630d2's and TASK-e8da6a00564a's.
+//! comes back as a form, and TASK-e8da6a00564a is where. The form itself
+//! arrived with TASK-d832452630d2, on the seventh verb: `n` opens
+//! [`crate::form`], whose fields are the flags the contract declares for `ank
+//! new` and which is modal, so no letter typed into it is a command and no
+//! word typed into it reaches a verb -- what reaches one is Enter, and what
+//! Enter reaches is the confirmation.
 //!
 //! # The guarantee, now that the letter is one keystroke
 //!
@@ -246,7 +251,7 @@ pub fn edit(line: &mut String, key: KeyEvent) -> Editing {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::input::Act;
+    use crate::input::{Act, Subject};
 
     fn key(code: KeyCode) -> KeyEvent {
         KeyEvent::new(code, KeyModifiers::NONE)
@@ -311,7 +316,8 @@ mod tests {
                     press(letter, view),
                     Press::Run(Command::Act(Act {
                         verb,
-                        args: Vec::new()
+                        args: Vec::new(),
+                        subject: Subject::Selected,
                     })),
                     "'{letter}' in {view:?}"
                 );
@@ -322,7 +328,8 @@ mod tests {
             press('a', Focus::Body),
             Press::Run(Command::Act(Act {
                 verb: "accept",
-                args: Vec::new()
+                args: Vec::new(),
+                subject: Subject::Selected,
             }))
         );
         for view in Focus::ALL.into_iter().filter(|f| *f != Focus::Body) {
@@ -339,13 +346,18 @@ mod tests {
     ///
     /// The price ADR-c07e2694f0e1 puts on the letters, stated as what it is: a
     /// person pressing `l` for "right" or `n` for "next page" gets no movement,
-    /// and `l` gets the log confirmation instead. Three of the four reach
-    /// nothing at all, which is the honest answer -- a key that quietly did
+    /// and `l` gets the log confirmation instead. What the four do *instead* is
+    /// what the verbs made of them, and the claim this holds is about movement:
+    /// none of them steps a cursor, pages a body or crosses a panel.
+    ///
+    /// `n` stopped being one of the three that reach nothing at all
+    /// (TASK-d832452630d2): it is `new`'s own initial, and what it opens is the
+    /// form. `h` and `p` are still the honest answer -- a key that quietly did
     /// something else would be worse than one that does nothing.
     #[test]
     fn the_four_letters_the_verbs_cost_move_nothing() {
         for view in Focus::ALL {
-            for c in ['h', 'n', 'p'] {
+            for c in ['h', 'p'] {
                 assert_eq!(press(c, view), Press::Ignored, "'{c}' in {view:?}");
             }
             // `l` is `log`, which composes a verb and moves no cursor.
@@ -354,6 +366,12 @@ mod tests {
                 panic!("'l' in {view:?} is {reached:?}");
             };
             assert_eq!(act.verb, "log");
+            // `n` is `new`, which opens a form and moves no cursor either.
+            assert_eq!(
+                press('n', view),
+                Press::Run(Command::Form),
+                "'n' in {view:?}"
+            );
         }
     }
 

--- a/crates/ank-tui/src/lib.rs
+++ b/crates/ank-tui/src/lib.rs
@@ -64,18 +64,25 @@
 //! a reader whose screen is wrong for as long as its person is reading rather
 //! than acting.
 //!
-//! # Input is a key, and the one line that is left
+//! # Input is a key, and the two places a word is still typed
 //!
 //! Every command that only moves the screen is one key ([`keys`]), focus
 //! included: `Tab` walks the panels, `1` to `4` name one, and Left and Right
-//! cross the columns. The verbs that write have no letter of their own here
-//! yet: `a` opens a one-line prompt and what is typed there goes through
-//! [`input`], which is the grammar that spells them whole. That is where the
-//! reader stands and no longer where it is going -- ADR-c07e2694f0e1 decides
-//! that a key is the verb it runs, and TASK-1a415107fd56 is where the letters
-//! arrive. The prompt outlives them rather than being replaced by them: four
-//! of the six carry something a key has no room for -- a message, a reason, a
-//! proof, a flag. `/` opens the same prompt on a search.
+//! cross the columns. **And so is every verb that writes**
+//! (TASK-1a415107fd56, ADR-c07e2694f0e1: a key *is* the verb it runs): `c`
+//! claims, `l` logs, `d` finishes, `r` releases, `m` amends, `a` ratifies, and
+//! `n` makes one. What each of them is bound to is [`bindings`], declared once,
+//! and every surface -- the mapping, the offer, the key list -- is computed
+//! from it.
+//!
+//! What is left of the typed word is two places, and neither of them reaches a
+//! verb by being read. `/` opens the one-line prompt on a search, and
+//! [`input`]'s grammar carries no verb at all. `n` opens the form
+//! (TASK-d832452630d2), whose fields are the flags `ank help --json` declares
+//! for `ank new` and which is modal: a letter typed into it is a letter, and
+//! what reaches the verb is Enter, and what Enter reaches is the confirmation.
+//! What the other six carried in a tail comes back the same way, and
+//! TASK-e8da6a00564a is where.
 //!
 //! **What the line discipline used to guarantee is replaced, and this is what
 //! replaced it.** Under a line reader a slipped finger typed nothing, because a
@@ -194,6 +201,7 @@ use std::path::PathBuf;
 
 pub mod ank;
 pub mod bindings;
+pub mod form;
 pub mod input;
 pub mod keys;
 pub mod model;

--- a/crates/ank-tui/src/view.rs
+++ b/crates/ank-tui/src/view.rs
@@ -229,7 +229,8 @@
 
 use crate::ank::{Ank, Failed, Ran};
 use crate::bindings::{self, Binding, Holding};
-use crate::input::{Act, Command};
+use crate::form::{self, Filled, Form};
+use crate::input::{Act, Command, Subject};
 use crate::keys::{self, Editing, Press};
 use crate::model::{self, short_of, Detail, Queue, Row, Snapshot};
 use crate::paint::{self, role_of_id, Composed, Ink};
@@ -490,6 +491,19 @@ pub struct App {
     /// to scrolling it is cutting it, and a key list that stops at the bottom of
     /// the screen is the omission that decision was written against.
     overlay: Option<usize>,
+    /// The form `ank new` is filled in on, open (TASK-d832452630d2).
+    ///
+    /// `None` is the ordinary state and it costs nothing at rest, for the key
+    /// list's reason: it is drawn *over* the panels rather than into a band the
+    /// layout gave rows up for, so [`App::arrange`] does not know it exists and
+    /// closing it gives back exactly the frame that was there. The five-row
+    /// budget TASK-9a402a54886f spent is untouched by it.
+    ///
+    /// Modal while it is open. A form is where words are typed, so no letter is
+    /// a command over one -- [`crate::form::Form::press`] is the whole of the
+    /// grammar, and what it composes reaches the confirmation like every other
+    /// act.
+    form: Option<Form>,
 }
 
 impl App {
@@ -522,6 +536,7 @@ impl App {
             ink: Ink::detect(),
             glyphs: Glyphs::detect(),
             overlay: None,
+            form: None,
         }
     }
 
@@ -761,6 +776,12 @@ impl App {
                 }
             };
         }
+        // After the two states that are asking a question and before the key
+        // list, which is not modal: a form is where words are typed, so a `?`
+        // over one is a question mark in a title.
+        if self.form.is_some() {
+            return self.filling(key, ank);
+        }
         if self.overlay.is_some() {
             match self.over_list(key) {
                 Listed::Answered => return false,
@@ -819,6 +840,19 @@ impl App {
                 // The list is over the panels and over the bands, so it is what
                 // a press lands on while it is open: one row, one binding, and
                 // no second road to whatever is drawn underneath it.
+                // The form is over the panels and over the bands, exactly as
+                // the key list is, and it is modal besides: while one is open
+                // the only touch that does anything is a touch on one of its
+                // rows, which selects that field. A thumb reaches the same
+                // fields the arrows reach and nothing underneath.
+                if self.form.is_some() {
+                    if let Some(field) = self.field_at(at) {
+                        if let Some(form) = &mut self.form {
+                            form.select(field);
+                        }
+                    }
+                    return false;
+                }
                 if self.overlay.is_some() {
                     return match self.list_at(at) {
                         Some(binding) => self.ran(binding, ank),
@@ -863,6 +897,16 @@ impl App {
     /// confirmation nothing moves, which is the modal rule again.
     fn moved(&mut self, by: isize, ank: &Ank) -> bool {
         if self.pending.is_some() || self.prompt.is_some() {
+            return false;
+        }
+        // A swipe over the form walks its fields, which is what the arrows do:
+        // what a scroll moves is what the finger is on.
+        if let Some(form) = &mut self.form {
+            let key = match by < 0 {
+                true => KeyCode::Up,
+                false => KeyCode::Down,
+            };
+            form.press(KeyEvent::new(key, KeyModifiers::NONE));
             return false;
         }
         // A swipe over the key list scrolls the key list, which is the same
@@ -1112,6 +1156,22 @@ impl App {
             // so drawing them there would be the one thing that list must never
             // carry.
             Command::Further => self.note = Some(bindings::further().join("\n")),
+            // The form, opened. Nothing is composed here and nothing is
+            // spawned: what a person fills in reaches `propose` through
+            // `App::filling`, and the confirmation is on that road like every
+            // other (TASK-d832452630d2).
+            Command::Form => match Form::open() {
+                Some(form) => self.form = Some(form),
+                // A build whose contract declares no `new` at all. Said rather
+                // than drawn as an empty form: a form with no fields is a
+                // screen that reads as a defect of the reader.
+                None => {
+                    self.note = Some(format!(
+                        "this build of ank declares no '{}' to make one with",
+                        form::VERB
+                    ))
+                }
+            },
             Command::Nothing => {}
             Command::Unknown(word) => {
                 self.note = Some(format!("no command '{word}'; ? for the list"))
@@ -1167,14 +1227,24 @@ impl App {
     /// `ank claim  --json` to say no to would be offering a command that could
     /// never run.
     fn propose(&mut self, act: Act, ank: &Ank) {
-        let Some(id) = self.target() else {
-            self.note = Some(
-                "no entity is named here: move onto a row, or open one into the body".to_string(),
-            );
-            return;
-        };
+        let mut args = Vec::new();
+        // **Only where the act says its first positional is a row's**
+        // (TASK-d832452630d2). `ank new <kind>` carries its own, and a reader
+        // that put an identifier in front of it would compose
+        // `ank new TASK-... task`, which is a command line nobody could have
+        // typed. The question is asked of the act rather than of its verb's
+        // name, so a second verb of that shape declares itself.
+        if act.subject == Subject::Selected {
+            let Some(id) = self.target() else {
+                self.note = Some(
+                    "no entity is named here: move onto a row, or open one into the body"
+                        .to_string(),
+                );
+                return;
+            };
+            args.push(id);
+        }
         let verb = act.verb;
-        let mut args = vec![id];
         args.extend(act.args);
         let shown = ank.spelling(verb, &args);
         self.pending = Some(Pending { verb, args, shown });
@@ -1195,6 +1265,38 @@ impl App {
                 // reassuring to somebody who can see what did not.
                 let dropped = self.pending.take();
                 self.note = dropped.map(|p| format!("{DISMISSED}\n{}", p.shown));
+            }
+        }
+        false
+    }
+
+    /// One key, answered against the form that is open (TASK-d832452630d2).
+    ///
+    /// Three outcomes and no fourth, and the one that matters is the middle
+    /// one: a form that composed goes to [`App::propose`], which puts the argv
+    /// on the screen and spawns nothing. There is no road from here to
+    /// [`Ank::act`] that does not pass the confirmation, which is the same
+    /// sentence every other act in this reader is answerable to.
+    ///
+    /// A form that could not compose stays open with the cursor on the field it
+    /// refused about and the reason drawn on itself -- not in the note band,
+    /// which the form is covering. The session never ends here: `q` is a
+    /// letter in a title.
+    fn filling(&mut self, key: KeyEvent, ank: &Ank) -> bool {
+        let Some(form) = &mut self.form else {
+            return false;
+        };
+        match form.press(key) {
+            Filled::Filling => {}
+            Filled::Close => {
+                self.form = None;
+                self.note = None;
+            }
+            Filled::Compose => {
+                if let Some(act) = form.submit() {
+                    self.form = None;
+                    self.propose(act, ank);
+                }
             }
         }
         false
@@ -1545,7 +1647,11 @@ impl App {
         // Last, and over everything the header does not carry: the key list is
         // an overlay (TASK-8a6578851244), so it is painted after the frame it
         // covers rather than into a band the frame had to give up rows for.
+        // The form is the second of that shape and takes the same rectangle
+        // (TASK-d832452630d2); the two are never both open, because `n` is a
+        // key the list passes through and opening the form closes it.
         self.list(area, buf);
+        self.form(area, buf);
     }
 
     /// One panel: its border, its title, and the lines it holds.
@@ -2523,6 +2629,103 @@ impl App {
         let rows: Vec<String> = lines
             .iter()
             .skip(top)
+            .take(room)
+            .map(|(line, _)| fit(line, inside.width as usize))
+            .collect();
+        paragraph(&rows).render(inside, buf);
+    }
+
+    // -----------------------------------------------------------------------
+    // The form, and where a finger lands on it (TASK-d832452630d2)
+    // -----------------------------------------------------------------------
+
+    /// The rows of the form, wrapped to the width the overlay draws them at,
+    /// each with the field a press on it selects.
+    ///
+    /// [`crate::form::Form::rows`] and never a second rendering of the same
+    /// fields: a row a person can see and a row a press resolves to are the
+    /// same row, or they are two and the screen answers somewhere other than
+    /// where it was touched.
+    fn form_lines(&self) -> Vec<(String, Option<usize>)> {
+        let Some(form) = &self.form else {
+            return Vec::new();
+        };
+        form.rows(inside(self.list_rect(self.area())).width as usize)
+    }
+
+    /// The first row of the form on the screen.
+    ///
+    /// Zero while the whole form fits, which is every window this reader is
+    /// measured on and nearly every window there is. Where it does not, the
+    /// window follows the cursor: a field being typed into that had scrolled
+    /// off the bottom would be a text field that has stopped saying what it
+    /// holds. The heading and the sentence over the rows go first, which is why
+    /// they are over them -- what that sentence says on a refusal is which
+    /// field the form would not compose without, and it is drawn beside the
+    /// row the cursor has just been sent to.
+    fn form_top(&self, room: usize) -> usize {
+        let Some(form) = &self.form else {
+            return 0;
+        };
+        let lines = self.form_lines();
+        if lines.len() <= room || room == 0 {
+            return 0;
+        }
+        let at = form.row_of_cursor(inside(self.list_rect(self.area())).width as usize);
+        at.saturating_sub(room - 1).min(lines.len() - room)
+    }
+
+    /// The field a press on the form reached.
+    ///
+    /// `None` on the heading, on the sentence under the rows, on the border,
+    /// and on a row past the end of a form shorter than its window. A press
+    /// that named no field does nothing at all: a finger that missed is a
+    /// finger that missed, and a reader that closed the form for it would throw
+    /// away everything typed into it.
+    fn field_at(&self, at: Position) -> Option<usize> {
+        self.form.as_ref()?;
+        let inside = inside(self.list_rect(self.area()));
+        if !inside.contains(at) {
+            return None;
+        }
+        let row = self.form_top(inside.height as usize) + (at.y - inside.y) as usize;
+        self.form_lines().get(row).and_then(|(_, field)| *field)
+    }
+
+    /// The form, drawn over the frame it was asked for from.
+    ///
+    /// Cleared first for the key list's reason: a `Block` paints a border and a
+    /// `Paragraph` paints the rows it was given, so the cells between the last
+    /// row and the bottom border would otherwise still carry whatever panel is
+    /// underneath.
+    fn form(&self, area: Rect, buf: &mut Buffer) {
+        let Some(form) = &self.form else {
+            return;
+        };
+        let rect = self.list_rect(area);
+        if rect.width < 2 || rect.height < 2 {
+            return;
+        }
+        let inside = inside(rect);
+        let heading = format!(
+            "NEW {}   {} closes",
+            form.kind().to_ascii_uppercase(),
+            named(KeyCode::Esc)
+        );
+        let title = Composed::new()
+            .plain(text::CURSOR)
+            .plain(&heading)
+            .fitted(rect.width as usize - 2);
+        Clear.render(rect, buf);
+        Block::bordered()
+            .border_set(self.glyphs.border(true))
+            .title(title.line(self.ink))
+            .render(rect, buf);
+        let room = inside.height as usize;
+        let rows: Vec<String> = self
+            .form_lines()
+            .iter()
+            .skip(self.form_top(room))
             .take(room)
             .map(|(line, _)| fit(line, inside.width as usize))
             .collect();
@@ -4339,6 +4542,7 @@ mod tests {
             Command::Act(Act {
                 verb: "claim",
                 args: Vec::new(),
+                subject: Subject::Selected,
             }),
             &ank,
         );
@@ -4368,6 +4572,7 @@ mod tests {
             Command::Act(Act {
                 verb: "log",
                 args: vec!["something".to_string()],
+                subject: Subject::Selected,
             }),
             &ank,
         );
@@ -4386,6 +4591,7 @@ mod tests {
             Command::Act(Act {
                 verb: "claim",
                 args: Vec::new(),
+                subject: Subject::Selected,
             }),
             &nowhere(),
         );
@@ -4557,6 +4763,7 @@ mod tests {
             Command::Act(Act {
                 verb: "accept",
                 args: Vec::new(),
+                subject: Subject::Selected,
             }),
             &ank,
         );
@@ -4628,9 +4835,13 @@ mod tests {
                 a.note = None;
                 tap(&mut a, &ank, KeyCode::Char(c));
                 // Whatever the key left waiting or open is dropped rather than
-                // answered: what is being measured is the keystroke alone.
+                // answered: what is being measured is the keystroke alone. The
+                // form is one of those states now (TASK-d832452630d2), and
+                // leaving it open would send the rest of the alphabet into a
+                // title instead of into the reader.
                 a.prompt = None;
                 a.pending = None;
+                a.form = None;
                 let said = a.note.clone().unwrap_or_default();
                 for verb in WRITES {
                     assert!(
@@ -5505,6 +5716,87 @@ mod tests {
                 "{window:?}: the key list did not give the frame back"
             );
         }
+    }
+
+    /// **The form is drawn over the panels, and closing it gives the frame back
+    /// character for character** (TASK-d832452630d2).
+    ///
+    /// The key list's own claim, applied to the second overlay: nothing moved
+    /// to make room for it, so nothing has to move back, and the five rows of
+    /// chrome TASK-9a402a54886f left the reader are untouched by a form being
+    /// open. Measured at the windows ADR-c07e2694f0e1 measures this reader on
+    /// and at one too short for the form, which is where an overlay the layout
+    /// had been asked for would have shown.
+    #[test]
+    fn the_form_covers_the_panels_and_gives_the_frame_back_when_it_closes() {
+        for window in [(80, 24), (40, 30), (120, 40), (40, 12)] {
+            let ank = nowhere();
+            let mut a = windowed(window);
+            let before = a.frame();
+
+            tap(&mut a, &ank, form_key());
+            assert!(a.form.is_some(), "{window:?}: the key opened no form");
+            let frame = a.frame();
+            assert_eq!(
+                frame.lines().count(),
+                window.1,
+                "{window:?}: the form changed how many rows the frame is:\n{frame}"
+            );
+            for line in frame.lines() {
+                assert!(
+                    line.chars().count() <= window.0,
+                    "{window:?}: a row is past the right edge: {line}\n{frame}"
+                );
+            }
+
+            tap(&mut a, &ank, KeyCode::Esc);
+            assert!(a.form.is_none(), "{window:?}: Esc left the form open");
+            assert_eq!(
+                a.frame(),
+                before,
+                "{window:?}: the form did not give the frame back"
+            );
+        }
+    }
+
+    /// **The field being typed into is on the screen at every window**
+    /// (TASK-d832452630d2).
+    ///
+    /// The form is thirteen rows and a window can be shorter than that. A
+    /// reader that drew the first thirteen and stopped would put a person
+    /// typing into `--body` in front of a screen where nothing moves, which is
+    /// a text field that has stopped saying what it holds. So the window
+    /// follows the cursor, and the sentence that says which field the form
+    /// refused on is drawn over the rows rather than under them so it cannot
+    /// scroll off the end.
+    #[test]
+    fn the_field_being_typed_into_is_on_the_screen_however_short_the_window_is() {
+        for window in [(80, 24), (40, 12), (60, 9)] {
+            let ank = nowhere();
+            let mut a = windowed(window);
+            tap(&mut a, &ank, form_key());
+            let count = a.form.as_ref().expect("a form").fields().len();
+            for _ in 0..count {
+                let at = a.form.as_ref().expect("a form").at();
+                let flag = a.form.as_ref().expect("a form").fields()[at].flag;
+                let frame = a.frame();
+                assert!(
+                    frame
+                        .lines()
+                        .any(|line| line.contains("> ") && line.contains(flag)),
+                    "{window:?}: the cursor is on {flag} and it is not on the \
+                     screen:\n{frame}"
+                );
+                tap(&mut a, &ank, KeyCode::Tab);
+            }
+        }
+    }
+
+    /// The key the form is opened with, out of the table.
+    fn form_key() -> KeyCode {
+        bindings::of_verb(crate::form::VERB)
+            .expect("a key opens the form")
+            .key
     }
 
     /// **Every row of the list that names a binding is reached by a press on

--- a/crates/ank-tui/tests/entity.rs
+++ b/crates/ank-tui/tests/entity.rs
@@ -1,0 +1,625 @@
+//! The form, through the binary, on a real terminal (TASK-d832452630d2).
+//!
+//! CLAUDE.md leaves no choice about where this is measured and the criterion
+//! names the instrument outright: "$EDITOR pointed at a script that writes a
+//! sentinel the test then finds absent". A unit test can say that
+//! `Form::composed` answers `Err` on an empty title; it cannot say that a
+//! process which took a terminal into raw mode on the alternate screen, and
+//! which spawns its children with no stdin, never once reached an editor.
+//!
+//! **The sentinel is proved to work before it is used as a negative.** The
+//! first thing this suite does is run `ank new task` from a shell with the same
+//! `$EDITOR` and find the sentinel *there* -- so "the sentinel is absent"
+//! afterwards is a fact about the reader rather than about a script that never
+//! ran. A negative measured with an instrument nobody checked is not a
+//! measurement.
+//!
+//! **And the fields are compared with what the binary declares**, not with a
+//! list written here: `ank help new` says which flags are the verb's own and
+//! `ank help new --json` says the same thing as a document, and the rows the
+//! form draws are held to both. A suite carrying its own copy of the flag set
+//! would agree with a form that had drifted, which is the whole failure
+//! ADR-c07e2694f0e1 was written against.
+//!
+//! The terminal, the corpus and the driven session are `terminal/mod.rs`, which
+//! `tests/confirmation.rs` declares too.
+
+#![cfg(unix)]
+
+mod terminal;
+
+use std::path::PathBuf;
+use terminal::{Live, Repo};
+
+/// What the confirmation says above the command line, and what it says after a
+/// person has declined one. Read out of the reader, never spelled here.
+const ABOUT: &str = ank_tui::view::ABOUT;
+const DISMISSED: &str = ank_tui::view::DISMISSED;
+const CONFIRM: char = ank_tui::keys::CONFIRM;
+
+/// Wide enough that a composed `ank new task --title ... --scope ...` fits one
+/// row, so an assertion on the command line is an assertion on a line and not
+/// on a reflow.
+const WINDOW: (u16, u16) = (120, 34);
+
+/// The key the form is opened with, out of the reader's own table.
+///
+/// Never `n` written here. The point of the wave is that a key *is* the verb,
+/// and a suite that typed the letter `new` happens to be bound to today would
+/// go on passing against a table that moved it.
+fn key_of_new() -> String {
+    let binding = ank_tui::bindings::of_verb(ank_tui::form::VERB)
+        .expect("the reader binds a key to 'ank new'");
+    let letter = ank_tui::bindings::named(binding.key);
+    assert_eq!(
+        letter.chars().count(),
+        1,
+        "the key is named '{letter}', which is not one keystroke to send"
+    );
+    letter
+}
+
+/// The kinds `ank new` makes, in the order the form cycles them.
+fn kinds() -> Vec<&'static str> {
+    ank_tui::form::Form::open()
+        .expect("this build declares 'ank new'")
+        .kinds()
+        .to_vec()
+}
+
+/// The mandatory flags of one kind, as the reader has them.
+fn required(kind: &str) -> &'static [&'static str] {
+    ank_tui::form::required(kind)
+}
+
+// ---------------------------------------------------------------------------
+// The editor, and the sentinel that says it ran
+// ---------------------------------------------------------------------------
+
+/// An `$EDITOR` that writes a file and exits.
+///
+/// It writes and does not edit, deliberately: what is being measured is whether
+/// the editor was *reached*, and a script that filled the template in would
+/// make the reader's failure look like a success.
+struct Editor {
+    script: PathBuf,
+    sentinel: PathBuf,
+}
+
+impl Editor {
+    fn beside(repo: &Repo) -> Editor {
+        use std::os::unix::fs::PermissionsExt;
+        let script = repo.0.join("editor.sh");
+        let sentinel = repo.0.join("the-editor-ran");
+        std::fs::write(
+            &script,
+            format!(
+                "#!/bin/sh\nprintf 'the editor ran on %s\\n' \"$1\" > {}\n",
+                sentinel.display()
+            ),
+        )
+        .expect("the script must be writable");
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755))
+            .expect("the script must be executable");
+        Editor { script, sentinel }
+    }
+
+    fn env(&self) -> Vec<(&str, &str)> {
+        vec![("EDITOR", self.script.to_str().expect("a UTF-8 path"))]
+    }
+
+    fn ran(&self) -> bool {
+        self.sentinel.is_file()
+    }
+
+    fn forget(&self) {
+        let _ = std::fs::remove_file(&self.sentinel);
+    }
+
+    /// The assertion this whole suite turns on, made wherever it is worth
+    /// making: the reader never reached an editor.
+    fn never_ran(&self, when: &str) {
+        assert!(
+            !self.ran(),
+            "the reader opened $EDITOR {when}, into a child with no stdin and a \
+             terminal in raw mode on the alternate screen: {}",
+            self.sentinel.display()
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// What the binary says the verb takes
+// ---------------------------------------------------------------------------
+
+/// The flags `ank new` declares as its own, read off the binary's own page.
+///
+/// The page and not the document, for the one reason the document cannot
+/// answer: `--json` merges a verb's flags with the global ones every verb
+/// carries, and `--repo`, `--worktree`, `--json` and `--quiet` are the reader's
+/// own address and its own call -- a form offering them would be offering to
+/// re-address the corpus it is already looking at. The human page separates the
+/// two, and [`declared_as_json`] holds the page to the document so neither can
+/// drift.
+fn declared(repo: &Repo) -> Vec<String> {
+    let page = String::from_utf8_lossy(&repo.ank(&["help", "new"]).stdout).to_string();
+    let mut out = Vec::new();
+    let mut inside = false;
+    for line in page.lines() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("flags:") {
+            inside = true;
+        } else if !trimmed.starts_with('-') && trimmed.contains(':') {
+            inside = false;
+        }
+        if !inside {
+            continue;
+        }
+        for word in trimmed.split_whitespace() {
+            let word = word.trim_end_matches(',').trim_end_matches("...");
+            if word.starts_with("--") {
+                out.push(word.to_string());
+            }
+        }
+    }
+    assert!(!out.is_empty(), "'ank help new' declared no flags:\n{page}");
+    out
+}
+
+/// The same names, out of `ank help new --json`, which is what the criterion
+/// names.
+fn declared_as_json(repo: &Repo) -> Vec<String> {
+    let doc = repo.stdout(&["help", "new", "--json"]);
+    let mut out = Vec::new();
+    let mut rest = doc.as_str();
+    while let Some(at) = rest.find("\"name\":\"--") {
+        rest = &rest[at + "\"name\":\"".len()..];
+        let end = rest.find('"').expect("a name is a closed string");
+        out.push(rest[..end].to_string());
+        rest = &rest[end..];
+    }
+    assert!(
+        !out.is_empty(),
+        "'ank help new --json' declared no flags:\n{doc}"
+    );
+    out
+}
+
+/// The flags one frame of the form is drawing, in the order they are on it.
+///
+/// One per row, which is what a form is: the first `--` word of a line is its
+/// flag, and everything after it is what has been typed into it.
+fn fields_on(frame: &str) -> Vec<String> {
+    frame
+        .lines()
+        .filter_map(|line| {
+            line.split_whitespace()
+                .find(|word| word.starts_with("--"))
+                .map(|word| word.trim_end_matches("...").to_string())
+        })
+        .collect()
+}
+
+/// A value with a space in it, so what the confirmation shows is a command line
+/// a shell would have had to quote.
+fn sentence(flag: &str) -> String {
+    format!("v for {}", flag.trim_start_matches("--"))
+}
+
+/// The screen, flattened to one line, so an assertion about a command line
+/// survives the row it happens to have wrapped onto.
+fn flat(frame: &str) -> String {
+    frame
+        .lines()
+        .map(|l| l.trim())
+        .collect::<Vec<&str>>()
+        .join(" ")
+        .split_whitespace()
+        .collect::<Vec<&str>>()
+        .join(" ")
+}
+
+// ---------------------------------------------------------------------------
+// Driving the form
+// ---------------------------------------------------------------------------
+
+/// Opens the form and waits until it is on the screen.
+fn open_form(live: &mut Live) {
+    live.send(&key_of_new());
+    live.until("the form to open", |t| t.contains(&heading(kinds()[0])));
+}
+
+/// What the form's own border says while it is making one kind.
+fn heading(kind: &str) -> String {
+    format!("NEW {}", kind.to_ascii_uppercase())
+}
+
+/// Walks the form's kind round to the one asked for, by the arrow that crosses.
+fn to_kind(live: &mut Live, kind: &str) {
+    let at = kinds()
+        .iter()
+        .position(|k| *k == kind)
+        .expect("a kind of ank new");
+    for _ in 0..at {
+        live.send("\u{1b}[C");
+    }
+    live.until(&format!("the form to be making a {kind}"), |t| {
+        t.contains(&heading(kind))
+    });
+}
+
+/// Fills the fields one kind cannot do without, leaving one of them out.
+///
+/// The cursor walks down from the field the form opens on, which is the first
+/// one, and the flags are visited in the order the contract declares them: a
+/// walk that assumed where the cursor already was would be a suite driving a
+/// form it had not looked at.
+fn fill_required(live: &mut Live, kind: &str, value_of: impl Fn(&str) -> Option<String>) {
+    let form = ank_tui::form::Form::open().expect("a form");
+    let mut wanted: Vec<(usize, &str, String)> = Vec::new();
+    for flag in required(kind) {
+        let Some(value) = value_of(flag) else {
+            continue;
+        };
+        let at = form
+            .fields()
+            .iter()
+            .position(|f| f.flag == *flag)
+            .unwrap_or_else(|| panic!("'{flag}' is a field of the form"));
+        wanted.push((at, flag, value));
+    }
+    wanted.sort_by_key(|(at, _, _)| *at);
+    // A form opens on its first field, and `to_kind` moves the kind and never
+    // the cursor.
+    let mut at = 0usize;
+    for (row, flag, value) in wanted {
+        while at < row {
+            live.send("\t");
+            at += 1;
+        }
+        live.until(&format!("the cursor to reach {flag}"), |t| {
+            on_field(t, flag)
+        });
+        live.send(&value);
+        live.until(&format!("'{value}' to be typed into {flag}"), |t| {
+            t.lines()
+                .any(|line| named_on(line, flag) && line.contains(&value))
+        });
+    }
+}
+
+/// Whether the cursor is on the row this flag names.
+fn on_field(frame: &str, flag: &str) -> bool {
+    frame
+        .lines()
+        .any(|line| line.contains("> ") && named_on(line, flag))
+}
+
+/// Whether a drawn row is this flag's, repeat marker and all.
+fn named_on(line: &str, flag: &str) -> bool {
+    line.split_whitespace()
+        .any(|word| word.trim_end_matches("...") == flag)
+}
+
+/// The identifier of one kind, read off the `id` field of the document the
+/// reader drew after the verb ran.
+///
+/// The field and not the first match on the frame: a reload has redrawn the
+/// listings by then, and every one of them carries identifiers of its own.
+fn identifier_on(frame: &str, kind: &str) -> String {
+    let head = format!("{}-", kind.to_ascii_uppercase());
+    for line in frame.lines() {
+        let Some(rest) = line.trim().strip_prefix("id ") else {
+            continue;
+        };
+        let value = rest.trim();
+        if value.starts_with(&head) {
+            return value
+                .split_whitespace()
+                .next()
+                .unwrap_or_default()
+                .to_string();
+        }
+    }
+    panic!("no {head} identifier on the answer the reader drew:\n{frame}");
+}
+
+// ---------------------------------------------------------------------------
+// The tests
+// ---------------------------------------------------------------------------
+
+/// **The form's fields are the flags `ank help --json` declares for `ank new`
+/// and no others**, for every kind it makes (TASK-d832452630d2).
+///
+/// Read off the binary twice -- the page, which separates a verb's own flags
+/// from the global ones, and the document, which the criterion names -- and
+/// compared with the rows on the screen. A form short of a flag cannot say what
+/// a shell can; a form carrying one the verb does not declare is this reader
+/// teaching a command line the binary refuses.
+///
+/// The contract declares one flag set for `ank new` and not one per
+/// subcommand, so the three kinds draw the same rows. What differs between them
+/// is which of those rows the form will not compose without, and that is the
+/// next test.
+#[test]
+fn the_forms_fields_are_the_flags_the_binary_declares_for_new_and_no_others() {
+    let repo = Repo::seeded();
+    repo.warm();
+    let editor = Editor::beside(&repo);
+    let wanted = declared(&repo);
+    // The page and the document name the same flags, so "the flags ank help
+    // --json declares" and "the flags of the verb" are one list rather than
+    // two.
+    let as_json = declared_as_json(&repo);
+    for flag in &wanted {
+        assert!(
+            as_json.contains(flag),
+            "'ank help new' declares {flag} and 'ank help new --json' does not: {as_json:?}"
+        );
+    }
+
+    let mut live = Live::with(&repo, WINDOW.0, WINDOW.1, &editor.env());
+    live.until("the session to open", |t| t.contains("2 ENTITIES"));
+
+    for kind in kinds() {
+        // Opened afresh for each, because `to_kind` counts its steps from the
+        // kind a form opens on: a walk that started wherever the last one
+        // stopped would be a suite asserting about a different screen.
+        open_form(&mut live);
+        to_kind(&mut live, kind);
+        let frame = live.frame();
+        assert_eq!(
+            fields_on(&frame),
+            wanted,
+            "the form for '{kind}' draws fields the verb does not declare, or \
+             is short of one:\n{frame}"
+        );
+        // And every flag the kind cannot do without is marked on its own row,
+        // so what the form will refuse on is readable before it refuses.
+        for flag in required(kind) {
+            let row = frame
+                .lines()
+                .find(|line| {
+                    line.split_whitespace()
+                        .any(|w| w.trim_end_matches("...") == *flag)
+                })
+                .unwrap_or_else(|| panic!("no row for {flag}:\n{frame}"));
+            assert!(row.contains('*'), "{flag} is not marked mandatory: {row}");
+        }
+        live.send("\u{1b}");
+        live.until("the form to close", |t| !t.contains(&heading(kind)));
+    }
+
+    live.quit();
+    editor.never_ran("while its fields were being read");
+}
+
+/// **The form refuses to compose while a mandatory field is empty, it names the
+/// field, and no keystroke of it reaches `$EDITOR`** (TASK-d832452630d2).
+///
+/// This is the criterion's dangerous half and it is measured the way the
+/// criterion asks. `ank new` opens `$EDITOR` precisely when *every* mandatory
+/// flag is absent, and this reader's child is spawned with `output()`'s null
+/// stdin from a process holding the terminal in raw mode on the alternate
+/// screen -- so an editor reached from here is a hang and not an error on the
+/// screen.
+///
+/// The sentinel is proved first, from a shell, so its absence afterwards means
+/// something. Then every mandatory flag of every kind is left out in turn, the
+/// form is asked to compose, and what has to be true each time is three things
+/// at once: it named the flag, no confirmation appeared, and the sentinel is
+/// still not there.
+#[test]
+fn a_form_with_a_mandatory_field_empty_names_it_and_opens_no_editor() {
+    let repo = Repo::seeded();
+    let editor = Editor::beside(&repo);
+
+    // The instrument, checked. `ank new task` with no flags at all is exactly
+    // the call the form must never compose, and from a shell it reaches the
+    // editor -- which is what makes the absence below a measurement.
+    let tried = repo.tried(&["new", "task"], &editor.env());
+    assert!(
+        editor.ran(),
+        "the sentinel never appeared even from a shell, so this suite would \
+         measure nothing: {}",
+        String::from_utf8_lossy(&tried.stderr)
+    );
+    editor.forget();
+
+    repo.warm();
+    let before = repo.corpus();
+    let refs = repo.refs();
+    assert!(!before.is_empty(), "the corpus has files to compare");
+
+    let mut live = Live::with(&repo, WINDOW.0, WINDOW.1, &editor.env());
+    live.until("the session to open", |t| t.contains("2 ENTITIES"));
+
+    for kind in kinds() {
+        for left_out in required(kind) {
+            open_form(&mut live);
+            to_kind(&mut live, kind);
+            fill_required(&mut live, kind, |flag| {
+                (flag != *left_out).then(|| "something".to_string())
+            });
+            // Enter, on a form with a mandatory field still empty.
+            live.send("\r");
+            live.until(
+                &format!("the form to refuse '{kind}' without {left_out}"),
+                |t| flat(t).contains(&format!("{left_out} is empty")),
+            );
+            let said = live.frame();
+            assert!(
+                !flat(&said).contains(ABOUT),
+                "'{kind}' without {left_out} composed a command:\n{said}"
+            );
+            assert!(
+                said.contains(&heading(kind)),
+                "the form closed on a refusal, and everything typed with it:\n{said}"
+            );
+            editor.never_ran(&format!("on '{kind}' with {left_out} empty"));
+
+            live.send("\u{1b}");
+            live.until("the form to close", |t| !t.contains(&heading(kind)));
+        }
+    }
+
+    live.quit();
+    editor.never_ran("during the session");
+    assert_eq!(
+        before,
+        repo.corpus(),
+        "a file under .ank/ moved, and every form was refused"
+    );
+    assert_eq!(
+        refs,
+        repo.refs(),
+        "a ref under refs/ank/ moved, and every form was refused"
+    );
+}
+
+/// **A composed form raises the confirmation, and dismissing it leaves every
+/// byte under `.ank/` and every ref under `refs/ank/` where it was**
+/// (TASK-d832452630d2).
+///
+/// The command line is asserted whole, spelled as a shell would have to spell
+/// it: the kind is `ank new`'s first positional and the flags follow it, quoted
+/// where a shell would need them quoted. A confirmation showing something other
+/// than what would run is the one failure this whole road exists to prevent.
+#[test]
+fn a_composed_form_is_shown_first_and_dismissing_it_writes_nothing() {
+    let repo = Repo::seeded();
+    let editor = Editor::beside(&repo);
+    repo.warm();
+    let before = repo.corpus();
+    let refs = repo.refs();
+
+    let mut live = Live::with(&repo, WINDOW.0, WINDOW.1, &editor.env());
+    live.until("the session to open", |t| t.contains("2 ENTITIES"));
+
+    for kind in kinds() {
+        open_form(&mut live);
+        to_kind(&mut live, kind);
+        let mut spelled = format!("ank new {kind}");
+        for flag in required(kind) {
+            spelled.push_str(&format!(" {flag} '{}'", sentence(flag)));
+        }
+        spelled.push_str(" --json");
+        fill_required(&mut live, kind, |flag| Some(sentence(flag)));
+
+        live.send("\r");
+        live.until(&format!("the confirmation for a new {kind}"), |t| {
+            flat(t).contains(&spelled)
+        });
+        let asking = live.frame();
+        let asked = flat(&asking);
+        assert!(
+            asked.contains(ABOUT),
+            "a new {kind} was not asked about:\n{asking}"
+        );
+        assert!(
+            asked.contains(&format!("{CONFIRM} runs it")),
+            "a new {kind} offered no key to run it with:\n{asking}"
+        );
+        // The form is gone: what is being answered for is the command line, and
+        // a form still on the screen would be a second thing to read.
+        assert!(
+            !asking.contains(&heading(kind)),
+            "the form is still drawn over the command it composed:\n{asking}"
+        );
+
+        live.send("\u{1b}");
+        live.until("the command to be dismissed", |t| {
+            flat(t).contains(DISMISSED)
+        });
+        let after = live.frame();
+        assert!(
+            flat(&after).contains(&spelled),
+            "the dismissal did not say what it had not done:\n{after}"
+        );
+        assert!(
+            !after.contains("error["),
+            "a dismissed form reached the CLI:\n{after}"
+        );
+    }
+
+    live.quit();
+    editor.never_ran("while a form was being composed and dismissed");
+    assert_eq!(
+        before,
+        repo.corpus(),
+        "a file under .ank/ moved, and every composed form was dismissed"
+    );
+    assert_eq!(
+        refs,
+        repo.refs(),
+        "a ref under refs/ank/ moved, and every composed form was dismissed"
+    );
+}
+
+/// **Confirming one makes the entity, and `ank find` answers with the
+/// identifier the reader was given** (TASK-d832452630d2).
+///
+/// The half that keeps the three above from being vacuous: a form that refused
+/// everything would pass every assertion in them and be a reader nobody can
+/// make a task with. What is compared is the identifier on the screen with the
+/// identifier in the corpus, because there is no second dispatch path -- the
+/// reader spawned `ank new`, and what it drew is the document that verb
+/// answered with.
+#[test]
+fn a_confirmed_form_makes_the_entity_and_find_answers_with_its_identifier() {
+    let repo = Repo::seeded();
+    let editor = Editor::beside(&repo);
+    repo.warm();
+
+    let mut live = Live::with(&repo, WINDOW.0, WINDOW.1, &editor.env());
+    live.until("the session to open", |t| t.contains("2 ENTITIES"));
+
+    let mut made: Vec<(String, String)> = Vec::new();
+    for kind in kinds() {
+        open_form(&mut live);
+        to_kind(&mut live, kind);
+        fill_required(&mut live, kind, |flag| {
+            Some(match flag {
+                "--scope" => "src/**".to_string(),
+                "--title" => format!("A {kind} the reader made"),
+                other => sentence(other),
+            })
+        });
+        live.send("\r");
+        live.until(&format!("the confirmation for a new {kind}"), |t| {
+            flat(t).contains(&format!("ank new {kind}"))
+        });
+        live.send(&CONFIRM.to_string());
+        live.until(&format!("the {kind} to be made"), |t| {
+            flat(t).contains(&format!("kind {kind}"))
+        });
+        let answered = live.frame();
+        assert!(
+            !answered.contains("error["),
+            "the confirmed form was refused:\n{answered}"
+        );
+        made.push((kind.to_string(), identifier_on(&answered, kind)));
+    }
+
+    live.quit();
+    editor.never_ran("while three entities were made");
+
+    for (kind, id) in &made {
+        let doc = repo.stdout(&["find", id, "--json"]);
+        assert!(
+            terminal::ids_of(&doc).iter().any(|found| found == id),
+            "'ank find {id}' does not answer with the identifier the reader was \
+             given:\n{doc}"
+        );
+        assert!(
+            doc.contains(&format!("\"kind\":\"{kind}\"")),
+            "the entity the reader made is not a {kind}:\n{doc}"
+        );
+    }
+    // Three kinds, three entities, and they are three: a form that made the
+    // same one three times would satisfy every assertion above.
+    let mut ids: Vec<&String> = made.iter().map(|(_, id)| id).collect();
+    ids.sort();
+    ids.dedup();
+    assert_eq!(ids.len(), kinds().len(), "the reader made {ids:?}");
+}

--- a/crates/ank-tui/tests/terminal/mod.rs
+++ b/crates/ank-tui/tests/terminal/mod.rs
@@ -223,19 +223,33 @@ impl Repo {
     }
 
     pub fn ank(&self, args: &[&str]) -> Output {
-        let out = Command::new(ank())
-            .args(args)
-            .current_dir(&self.0)
-            .env("ANK_AGENT", AGENT)
-            .env("NO_COLOR", "1")
-            .output()
-            .expect("the binary must have been built");
+        let out = self.tried(args, &[]);
         assert!(
             out.status.success(),
             "ank {args:?}: {}",
             String::from_utf8_lossy(&out.stderr)
         );
         out
+    }
+
+    /// One call, with whatever else the caller wants in the environment, and no
+    /// assertion about how it went.
+    ///
+    /// Separate from [`Repo::ank`] because the suites that need it are asking
+    /// about a refusal: `ank new adr --title x --scope y` is *supposed* to exit
+    /// non-zero, and that is the fact being measured rather than a failure to
+    /// report (TASK-d832452630d2).
+    pub fn tried(&self, args: &[&str], env: &[(&str, &str)]) -> Output {
+        let mut command = Command::new(ank());
+        command
+            .args(args)
+            .current_dir(&self.0)
+            .env("ANK_AGENT", AGENT)
+            .env("NO_COLOR", "1");
+        for (name, value) in env {
+            command.env(name, value);
+        }
+        command.output().expect("the binary must have been built")
     }
 }
 
@@ -590,7 +604,7 @@ impl Live {
     /// about painting wants: `NO_COLOR` makes the frames the characters they
     /// are and nothing else.
     pub fn open(repo: &Repo, columns: u16, rows: u16) -> Live {
-        Live::opened(repo, columns, rows, false, TERM)
+        Live::opened(repo, columns, rows, false, TERM, &[])
     }
 
     /// A session that may paint (TASK-6cd41d23b7d1).
@@ -600,7 +614,7 @@ impl Live {
     /// developer running it has exported, and a test whose subject is colour
     /// must not be a test that reports the machine.
     pub fn painting(repo: &Repo, columns: u16, rows: u16) -> Live {
-        Live::opened(repo, columns, rows, true, TERM)
+        Live::opened(repo, columns, rows, true, TERM, &[])
     }
 
     /// A session on a terminal that has declared it can render nothing rich
@@ -612,10 +626,26 @@ impl Live {
     /// because it is beside the point here: a terminal this poor was getting
     /// the plain palette either way.
     pub fn dumb(repo: &Repo, columns: u16, rows: u16) -> Live {
-        Live::opened(repo, columns, rows, false, "dumb")
+        Live::opened(repo, columns, rows, false, "dumb", &[])
     }
 
-    fn opened(repo: &Repo, columns: u16, rows: u16, colour: bool, term: &str) -> Live {
+    /// A session with something else in its environment (TASK-d832452630d2).
+    ///
+    /// `$EDITOR` above all: the criterion for the form is measured by pointing
+    /// it at a script that writes a sentinel and finding the sentinel absent,
+    /// and a variable the harness could not set would leave that unmeasurable.
+    pub fn with(repo: &Repo, columns: u16, rows: u16, env: &[(&str, &str)]) -> Live {
+        Live::opened(repo, columns, rows, false, TERM, env)
+    }
+
+    fn opened(
+        repo: &Repo,
+        columns: u16,
+        rows: u16,
+        colour: bool,
+        term: &str,
+        env: &[(&str, &str)],
+    ) -> Live {
         use std::io::Read;
 
         let (master, slave_path) = pty::open();
@@ -638,6 +668,9 @@ impl Live {
             true => command.env_remove("NO_COLOR"),
             false => command.env("NO_COLOR", "1"),
         };
+        for (name, value) in env {
+            command.env(name, value);
+        }
         let child = command
             .stdin(pty::stdio(stdin))
             .stdout(pty::stdio(stdout))

--- a/crates/ank-tui/tests/verbs.rs
+++ b/crates/ank-tui/tests/verbs.rs
@@ -241,7 +241,7 @@ fn the_four_letters_the_verbs_cost_move_nothing_on_the_screen() {
         "the listing draws two rows:\n{standing}"
     );
 
-    for c in ['h', 'n', 'p'] {
+    for c in ['h', 'p'] {
         live.send(&c.to_string());
         let after = live.frame();
         assert_eq!(
@@ -249,6 +249,20 @@ fn the_four_letters_the_verbs_cost_move_nothing_on_the_screen() {
             "'{c}' moved something, and it is one of the letters the verbs cost"
         );
     }
+
+    // `n` is `new` (TASK-d832452630d2): it opens a form over the panels and
+    // moves nothing under it. Closing it gives back the frame that was there,
+    // character for character, which is what an overlay is and what a band of
+    // rows the layout had to find room for would not have been.
+    live.send("n");
+    live.until("the form to open", |t| t.contains("NEW TASK"));
+    live.send("\u{1b}");
+    live.until("the form to close", |t| !t.contains("NEW TASK"));
+    assert_eq!(
+        live.frame(),
+        standing,
+        "'n' moved the frame under the form it opened"
+    );
 
     // `l` is `log`: it composes, and the listing under it is where it was.
     live.send("l");


### PR DESCRIPTION
Closes TASK-d832452630d2.

`n` opens a form for `task`, `adr` and `spec`, whose fields are the flags `ank help --json` declares for `ank new` — read out of `ank_contract::verbs`, never transcribed. This crate has been burned once by five parallel key tables (ADR-c07e2694f0e1 records what they cost); a parallel flag table would be the same mistake one surface along.

## The editor

`ank new` opens `$EDITOR` **precisely when every mandatory flag is absent**, and this reader spawns its children with `output()`'s null stdin from a process holding the terminal in raw mode on the alternate screen. An editor reached from here is a hang, not an error on the screen.

`Form::composed` is the one road from a form to an argv and it answers a `Result`; `required(kind)` is non-empty for every kind and a test says so; so an argv this form produces always carries a mandatory flag with a value, and `is_interactive`'s `all` can never be true of it. That is a state the form cannot produce, not a state it is careful about.

Measured the way the criterion asks: `crates/ank-tui/tests/entity.rs` drives the built binary on a pseudo-terminal with `$EDITOR` pointed at a script that writes a sentinel — **proved to work first, from a shell, on the very call the form must never compose**, then found absent throughout. A negative measured with an instrument nobody checked is not a measurement.

## The rest of the criterion

- The form refuses to compose while a mandatory field is empty and names the field, on the form itself (the note band is under the overlay).
- A composed form raises the confirmation spelling `ank new <kind> --title '…' --scope '…' --json`, quoted as a shell would have to quote it.
- Dismissing leaves every byte under `.ank/` and every ref under `refs/ank/` unchanged — compared before and after, by name and by object.
- Confirming makes the entity, and `ank find` answers with the identifier the reader was given, for all three kinds.

## Where the mandatory list comes from

The contract declares flags per *verb*, not per subcommand, so which flags a kind cannot do without is the CLI's own `mandatory_flags` and reaches no document. `form::REQUIRED` is the one thing written down rather than read — and it is measured, not trusted: the suite leaves each name out in turn, drives the binary, and requires a refusal. The per-kind foreign-flag refusals (`--verify` on an ADR, `--constraint` on a spec) stay the CLI's, like every refusal in this crate.

## Structure

- `ACTS` widens by one and stays hand-written; the test that every spelled verb is in the gate now filters on `verb.is_some()` rather than `Group::Write`, so a new group cannot walk past it.
- `Act` gains a `Subject`, so `ank new <kind>` is not handed a row's identifier. Asked of the act and never of the verb's name — `App::propose` stays one function, `Command::Act` stays one match arm, `Ank::act` keeps its single caller behind the confirmation.
- `new` is `Group::Create`, on its own key-list line: the corpus line ends "(the marked panel's entity, then y)", which is false of a verb whose first positional is a kind.
- The form is an overlay on the key list's rectangle, so `arrange()` does not know it exists and the four non-panel rows TASK-9a402a54886f left the frame are untouched. Closing it gives the frame back character for character, at 80x24, 40x30, 120x40 and 40x12.

## Two defects found on the way

- **A capital letter could not be typed.** `Form::press` turned down every keystroke with a modifier held, copying `keys::typed`'s rule — and a terminal reports a capital as `Char('A')` with Shift. The first title driven through the form arrived as `task the reader made`, with every unit test green. A field belongs with `keys::edit`, where Control is the only modifier that means anything else. Shift-Tab was broken by the same line.
- **`crates/ank-cli/tests/tui.rs` hung.** It sent two `n`s to page a body; `n` opens a form now, so every key after them went into a title, `q` included. Space is the paging key. `cargo test --workspace` did not fail — it hung, which is the shape this class of defect always takes.

`cargo test --workspace` green, `cargo fmt --check` clean, `ank check` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qRCAKDE6jEDZLTbdkCfX2