### PR TITLE
An edit names its field, and close, attest and read are reachable

### DIFF
--- a/.ank/entities/LOG-21ffb657ca2a.md
+++ b/.ank/entities/LOG-21ffb657ca2a.md
@@ -1,0 +1,15 @@
+---
+id: LOG-21ffb657ca2a
+type: log
+title: "Read the four base tasks' logs and the four surfaces this touches. The shape settled: 'e' binds"
+created: 2026-08-27T04:11:06Z
+author: claude-code/opus-5+edit
+scope:
+  - crates/ank-tui/**
+about: TASK-e8da6a00564a
+seq: 2
+schema: 4
+version: 1
+---
+
+ edit and opens a form, so the form module stops being ank new's and becomes the one every verb with flags is filled in on; the x list stops being a note and becomes an overlay whose rows are opened with Enter, which is how close and attest reach a form and read reaches the confirmation with no key of its own. The gate widens by four -- edit, close, attest, read -- and check and init stay out. The requirement shape has to grow a second variant: ank new refuses until every mandatory flag is there, ank edit opens $EDITOR when *no* field is named, so All and Any are two guarantees and not one written twice.

--- a/.ank/entities/LOG-3317164c7d8a.md
+++ b/.ank/entities/LOG-3317164c7d8a.md
@@ -1,0 +1,15 @@
+---
+id: LOG-3317164c7d8a
+type: log
+title: Two smaller things. edit went to a group of its own on the key list rather than onto the corpus
+created: 2026-08-27T04:39:41Z
+author: claude-code/opus-5+edit
+scope:
+  - crates/ank-tui/**
+about: TASK-e8da6a00564a
+seq: 6
+schema: 4
+version: 1
+---
+
+ line, for the reason Group::Create already gives from the other side: the writing half's note says where the key lands and not that a form stands in between, and the create line's note says a form and not that it lands on the marked panel's entity. e is both, so a note true of six rows and false of the seventh would have been prose the table cannot be held to -- one heading row on a scrollable overlay is what that costs. And the refusal for a verb with no entity under the cursor moved in front of the form: three of the four verbs a form serves take <id> first, and refusing after somebody has typed a title throws the title away with it. It is view::NOTHING_NAMED now, said in both places, because two spellings of one refusal are two things to work out are the same. tests/entity.rs's Editor moved into terminal/mod.rs -- two suites need a sentinel now, and both criteria are measured with it.

--- a/.ank/entities/LOG-427105fdcbae.md
+++ b/.ank/entities/LOG-427105fdcbae.md
@@ -1,0 +1,15 @@
+---
+id: LOG-427105fdcbae
+type: log
+title: The x list stopped being a note and became the third overlay. It was two lines in the note band,
+created: 2026-08-27T04:39:15Z
+author: claude-code/opus-5+edit
+scope:
+  - crates/ank-tui/**
+about: TASK-e8da6a00564a
+seq: 4
+schema: 4
+version: 1
+---
+
+ which arrange() measures, so moving it over the panels gave a row back rather than spending one -- TASK-9a402a54886f's budget of five is untouched and the desk frame is what it was. Its grammar is not the key list's and could not be: every row of the key list IS the key it names, so a press on a row presses that key; none of these three is a key at all, so the row is opened the way a row of any panel is opened -- j/k walk a cursor, Enter opens, and a tap on the row does what Enter does. One vocabulary applied to an overlay, not a sixth key table. close and attest open the form their mandatory flag is filled in on; read declares no flag in §4, so bindings::beyond composes it straight and the confirmation is the next thing on the screen. Every one of the three lands on the single Command::Act arm, so tests/dependencies.rs still counts one road to a spawn.

--- a/.ank/entities/LOG-68c7c984b63e.md
+++ b/.ank/entities/LOG-68c7c984b63e.md
@@ -1,0 +1,15 @@
+---
+id: LOG-68c7c984b63e
+type: log
+title: The form stopped being ank new's. Form::open takes a verb, the fields and kinds are read out of the
+created: 2026-08-27T04:38:59Z
+author: claude-code/opus-5+edit
+scope:
+  - crates/ank-tui/**
+about: TASK-e8da6a00564a
+seq: 3
+schema: 4
+version: 1
+---
+
+ contract against it, and the one thing this file still declares is NEEDS -- which grew a second shape rather than a second row. ank new opens $EDITOR when EVERY mandatory flag is absent; ank edit opens one when NO field is named at all. Those are two conditions, not one, so Need is All and Any and a verb added to the table has to say which door it stands in front of. Need::Any over --title/--body/--constraint is the whole of the criterion: composed() answers Err until one of them is filled, so a named field stands ahead of the search for an editor by construction and not by care. Form::open answers None for a verb NEEDS does not name, which is the second lock -- there is no way to build a form whose requirement is nothing.

--- a/.ank/entities/LOG-a3b83f1ab882.md
+++ b/.ank/entities/LOG-a3b83f1ab882.md
@@ -1,0 +1,13 @@
+---
+id: LOG-a3b83f1ab882
+type: log
+title: done, proof commit:1c1480c
+created: 2026-08-27T04:40:05Z
+author: claude-code/opus-5+edit
+scope:
+  - crates/ank-tui/**
+about: TASK-e8da6a00564a
+seq: 7
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-a4705130c101.md
+++ b/.ank/entities/LOG-a4705130c101.md
@@ -1,0 +1,15 @@
+---
+id: LOG-a4705130c101
+type: log
+title: The gate widened by four and the key table by one. ACTS carries edit, close, attest and read; check
+created: 2026-08-27T04:39:28Z
+author: claude-code/opus-5+edit
+scope:
+  - crates/ank-tui/**
+about: TASK-e8da6a00564a
+seq: 5
+schema: 4
+version: 1
+---
+
+ and init stay out, and the two ank.rs tests that named four now name two. The half that had to change shape is bindings.rs's 'every verb the gate allows is reachable': close, attest and read are on no row of BINDINGS, so it now asks 'a binding spells it OR the further list names it', and both directions are still asserted -- a verb added to either alone fails. Two traps found on the way. ank.rs's own suite reads its source for the string 'crate::bindings' to prove the gate is not derived from the table it guards, and a DOC COMMENT naming crate::bindings::FURTHER trips it: the scan is over the file, not over the code, so a cross-reference is as fatal as a use. Reworded to prose. And a mutation check on Runs::Form -> Runs::Compose passed until I rebuilt: the pty suites drive target/debug/ank, which belongs to ank-cli, so 'cargo test -p ank-tui' leaves a stale binary and measures nothing. cargo build -p ank-cli first, or cargo test --workspace. With the binary rebuilt the mutation fails as a TIMEOUT and not an assertion, which is the criterion's own point: an editor reached from this reader is a hang.

--- a/.ank/entities/TASK-e8da6a00564a.md
+++ b/.ank/entities/TASK-e8da6a00564a.md
@@ -5,7 +5,7 @@ slug: an-edit-names-its-field-and-close-attest-and-rea
 title: An edit names its field, and close, attest and read are reachable
 created: 2026-08-26T17:07:37Z
 author: claude-code/opus-5+reader-redesign
-status: open
+status: in_progress
 scope:
   - crates/ank-tui/**
 blocked_by: [TASK-d832452630d2]
@@ -13,5 +13,5 @@ done_criteria: |
   The built binary raises, on e, a form whose submission spells ank edit <id> with --title, --body or --constraint, and never a bare ank edit <id>: a named field stands ahead of the search for an editor, and an editor is what this reader must never spawn. close, attest and read are reached from x and from no key, each with the flags its verb requires, and each passes the same confirmation. Every one of the three leaves every byte under .ank/ and every ref under refs/ank/ unchanged when the confirmation is dismissed. Measured with $EDITOR pointed at a script that writes a sentinel the test then finds absent.
 criteria_by: creator
 schema: 4
-version: 3
+version: 4
 ---

--- a/.ank/entities/TASK-e8da6a00564a.md
+++ b/.ank/entities/TASK-e8da6a00564a.md
@@ -5,13 +5,18 @@ slug: an-edit-names-its-field-and-close-attest-and-rea
 title: An edit names its field, and close, attest and read are reachable
 created: 2026-08-26T17:07:37Z
 author: claude-code/opus-5+reader-redesign
-status: in_progress
+status: done
 scope:
   - crates/ank-tui/**
 blocked_by: [TASK-d832452630d2]
 done_criteria: |
   The built binary raises, on e, a form whose submission spells ank edit <id> with --title, --body or --constraint, and never a bare ank edit <id>: a named field stands ahead of the search for an editor, and an editor is what this reader must never spawn. close, attest and read are reached from x and from no key, each with the flags its verb requires, and each passes the same confirmation. Every one of the three leaves every byte under .ank/ and every ref under refs/ank/ unchanged when the confirmation is dismissed. Measured with $EDITOR pointed at a script that writes a sentinel the test then finds absent.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 1c1480c
+    criteria: b182a984911a
+    via: submitted
 schema: 4
-version: 4
+version: 5
 ---

--- a/crates/ank-tui/src/ank.rs
+++ b/crates/ank-tui/src/ank.rs
@@ -3,9 +3,10 @@
 //! Eleven verbs are reached from here, in two lists that are policy made
 //! mechanical rather than policy stated in prose. [`READS`] is the five that
 //! only read -- `status`, `find`, `show`, `scope` and `review` -- and
-//! [`Ank::json`] refuses anything else before spawning. [`ACTS`] is the six the
+//! [`Ank::json`] refuses anything else before spawning. [`ACTS`] is what the
 //! person at the keyboard may ask for -- `claim`, `log`, `release`, `done`,
-//! `amend` and `accept` -- and [`Ank::act`] refuses anything else the same way.
+//! `amend`, `accept`, `new`, `edit`, `close`, `attest` and `read` -- and
+//! [`Ank::act`] refuses anything else the same way.
 //! Two gates and not one, because the difference between them is the whole of
 //! what a reader is allowed to do on its own: a screen repaints by reading, and
 //! it writes only where a command was typed.
@@ -21,9 +22,9 @@
 //! one, whatever a later edit intends. The signature is git's and the person's,
 //! and it is unreachable from here by construction rather than by restraint.
 //!
-//! The four that must stay out of both lists are `close`, `check`, `attest` and
-//! `init`, and a verb absent from a list is absent silently -- so the absence
-//! is asserted below rather than left to whoever reads the two constants next.
+//! The two that must stay out of both lists are `check` and `init`, and a verb
+//! absent from a list is absent silently -- so the absence is asserted below
+//! rather than left to whoever reads the two constants next.
 //!
 //! **An act runs with `--json` like a read does.** ADR-8bd76e8d7c4e and
 //! SPEC-93531977642f both say the reader reaches the corpus only by running the
@@ -100,8 +101,29 @@ const FINDINGS_ARE_AN_ANSWER: &[&str] = &["review"];
 /// form itself cannot compose the flagless call that would open `$EDITOR` into
 /// a child with no stdin.
 ///
-/// `close`, `check`, `attest` and `init` are not here and must not arrive.
-pub const ACTS: &[&str] = &["claim", "log", "release", "done", "amend", "accept", "new"];
+/// **`edit`, `close`, `attest` and `read` are the last four**
+/// (TASK-e8da6a00564a). `edit` is the one that had to be argued for and it is
+/// argued for on exactly `new`'s ground: `ank edit <id>` with no field named
+/// opens `$EDITOR`, so the verb is reached through a form that will not compose
+/// until one of `--title`, `--body` and `--constraint` is filled in, and the
+/// flagless call is a state `crate::form::Form::composed` cannot produce. The
+/// other three carry no editor at all -- `close` refuses without `--reason`,
+/// `attest` without `--proof`, and `read` takes no flag whatever -- and they
+/// are here because the alternative was a reader that draws three verbs it
+/// cannot run, which is an offer nothing keeps.
+///
+/// What they do *not* get is a letter. `edit` has one -- `e`, the verb's own
+/// initial -- and the other three are reached from the list `x` opens, which is
+/// why widening this constant by four widened the key table by one. That list
+/// is measured against this constant in both directions, by the suite beside
+/// the key table itself.
+///
+/// `check` and `init` are not here and must not arrive. `check` answers a
+/// question about the corpus that the reader has no screen for, and `init`
+/// makes the corpus this reader is already looking at.
+pub const ACTS: &[&str] = &[
+    "claim", "log", "release", "done", "amend", "accept", "new", "edit", "close", "attest", "read",
+];
 
 /// A call that did not produce a document, in the three ways it can fail.
 ///
@@ -491,15 +513,15 @@ mod tests {
 
     /// The acting gate, and the same proof that it comes first.
     ///
-    /// **`accept` left this list and the other four did not** (TASK-d90e94afca08).
-    /// The reader drives a ratification now, so the verb reaches the spawn; that
-    /// is a decision about one verb, and it says nothing whatever about `close`,
-    /// `check`, `attest` or `init`, which stay out for the reasons they always
-    /// had. The list below is the whole of what widened, and it widened by one.
+    /// **`close` and `attest` left this list too** (TASK-e8da6a00564a), by the
+    /// same road `accept` left it before them (TASK-d90e94afca08): a decision
+    /// about a named verb, taken because the reader now has a way to reach it
+    /// that passes the confirmation. `check` and `init` stay out for the
+    /// reasons they always had, and they are what is asserted here.
     #[test]
     fn a_verb_outside_the_acting_list_is_refused_before_anything_is_spawned() {
         let ank = nowhere();
-        for verb in ["close", "check", "attest", "init"] {
+        for verb in ["check", "init"] {
             assert_eq!(
                 ank.act(verb, &["TASK-0001".to_string()]),
                 Err(Failed::NotAnAct {
@@ -543,15 +565,15 @@ mod tests {
         }
     }
 
-    /// `review` is a read, and the four the reader may never run stay out of
+    /// `review` is a read, and the two the reader may never run stay out of
     /// both lists.
     #[test]
-    fn review_reads_and_the_four_that_must_stay_out_are_on_neither_road() {
+    fn review_reads_and_the_two_that_must_stay_out_are_on_neither_road() {
         assert!(
             READS.contains(&"review"),
             "the queue is read by asking review"
         );
-        for verb in ["close", "check", "attest", "init"] {
+        for verb in ["check", "init"] {
             assert!(
                 !READS.contains(&verb),
                 "{verb} is not a read of this reader"

--- a/crates/ank-tui/src/bindings.rs
+++ b/crates/ank-tui/src/bindings.rs
@@ -132,14 +132,20 @@ pub enum Runs {
     /// (TASK-d832452630d2) -- but these six still compose the identifier and
     /// nothing else, and TASK-e8da6a00564a is where their tails come back.
     Compose,
-    /// The form `ank new` is filled in on, opened (TASK-d832452630d2).
+    /// The form this binding's verb is filled in on
+    /// (TASK-d832452630d2, TASK-e8da6a00564a).
     ///
-    /// Not [`Runs::Compose`], and the difference is the verb's first
-    /// positional: the six compose against the entity the focused panel names,
-    /// and `ank new <kind>` names a kind no panel holds. So this opens a form
-    /// and composes nothing, and what the form composes goes through the same
-    /// confirmation the other seven rows do -- `crate::form::Form::composed` is
-    /// the one road out of it, and `App::propose` is where it lands.
+    /// Not [`Runs::Compose`], and the difference is where the tail comes from:
+    /// a composing row spells the verb and the identifier and nothing else, and
+    /// a row of this kind opens the flags the contract declares. So this opens
+    /// a form and composes nothing, and what the form composes goes through the
+    /// same confirmation every other row does -- `crate::form::Form::composed`
+    /// is the one road out of it, and `App::propose` is where it lands.
+    ///
+    /// Two rows carry it. `ank new <kind>` names a kind no panel holds and
+    /// supplies its own first positional; `ank edit <id>` names the entity the
+    /// focused panel does, exactly as the six do. The form answers which of the
+    /// two it is, off the verb's own subcommands, so this row does not have to.
     Form,
     /// The command on the screen, run.
     Run,
@@ -174,6 +180,15 @@ pub enum Group {
     /// six rows and false of the seventh would be prose the table cannot be
     /// held to.
     Create,
+    /// Changes what an entity says, on a form (TASK-e8da6a00564a).
+    ///
+    /// Its own group for [`Group::Create`]'s reason, from the other side. It
+    /// lands on the marked panel's entity, which the writing half's note says
+    /// and `ank new`'s cannot; and what it opens is a form, which the create
+    /// line's note says and the writing half's cannot -- those six compose an
+    /// argv on the keystroke, and this one asks for a field first. Two notes
+    /// each true of every row under them, rather than one true of most.
+    Change,
     /// Answers what the reader is asking: a command waiting, or a line open.
     Answer,
 }
@@ -426,12 +441,14 @@ pub static BINDINGS: &[Binding] = &[
         offered: Offered::Never,
         verb: None,
     },
-    // The verbs past the six, named and not bound (TASK-1a415107fd56). `close`,
-    // `attest` and `read` are §4 verbs this reader does not run: they are
-    // absent from [`crate::ank::ACTS`] and the gate refuses them, so a letter
-    // apiece would be six offers and three pretences. `x` says what they are
-    // and where they are spelled instead, out of the contract's own table, and
-    // TASK-e8da6a00564a is where the list stops being only a list.
+    // The verbs past the six, reached and not bound
+    // (TASK-1a415107fd56, TASK-e8da6a00564a). `close`, `attest` and `read` are
+    // §4 verbs this reader runs and gives no letter to: `x` opens the list they
+    // are on and a row of it is opened like a row of any listing, with Enter or
+    // a touch. A letter apiece would be three more keys on a keyboard whose
+    // free ones are nearly spent, for three verbs a person reaches once a
+    // fortnight; the list is where the offer belongs and the note under it says
+    // what running one costs.
     Binding {
         key: KeyCode::Char('x'),
         aliases: &[],
@@ -637,6 +654,33 @@ pub static BINDINGS: &[Binding] = &[
         }),
     },
     // -----------------------------------------------------------------------
+    // What changes what an entity says (TASK-e8da6a00564a)
+    //
+    // `e` is `edit`'s own initial, which is ADR-c07e2694f0e1's rule and the
+    // same reason the six above have theirs; the letter was free.
+    //
+    // It is `Runs::Form` and not `Runs::Compose`, and that is the whole of the
+    // criterion. `ank edit <id>` with no field named opens `$EDITOR` on the
+    // whole entity -- and an editor spawned by a child with no stdin, out of a
+    // process holding the terminal in raw mode on the alternate screen, is a
+    // hang and not an error on the screen. A composing row would spell exactly
+    // that call. A form cannot: `crate::form::Form::composed` refuses until one
+    // of `--title`, `--body` and `--constraint` is filled in, so a named field
+    // stands ahead of the search for an editor by construction.
+    // -----------------------------------------------------------------------
+    Binding {
+        key: KeyCode::Char('e'),
+        aliases: &[],
+        runs: Runs::Form,
+        word: "edit",
+        group: Group::Change,
+        offered: Offered::Anywhere,
+        verb: Some(Verb {
+            name: "edit",
+            tail: Tail::Form,
+        }),
+    },
+    // -----------------------------------------------------------------------
     // What makes an entity (TASK-d832452630d2)
     //
     // `n` is `new`'s own initial, which is ADR-c07e2694f0e1's rule and the same
@@ -657,7 +701,7 @@ pub static BINDINGS: &[Binding] = &[
         group: Group::Create,
         offered: Offered::Anywhere,
         verb: Some(Verb {
-            name: crate::form::VERB,
+            name: crate::form::MAKE,
             tail: Tail::Form,
         }),
     },
@@ -721,7 +765,13 @@ impl Binding {
             Runs::Press(press) => press.clone(),
             Runs::Stepped(by) => Press::Run(Command::Panel(focus.stepped(*by))),
             Runs::Sideways(to) if focus != *to => Press::Run(Command::Panel(*to)),
-            Runs::Form => Press::Run(Command::Form),
+            Runs::Form => match self.verb {
+                Some(verb) => Press::Run(Command::Form(verb.name)),
+                // Unreachable from this table -- a form row spells a verb, and
+                // the test below holds that -- and `Ignored` rather than a
+                // panic all the same: a reader must not die on a keystroke.
+                None => Press::Ignored,
+            },
             Runs::Compose => match self.verb {
                 Some(verb) => composed(verb, focus),
                 // Unreachable from this table -- a composing row spells a verb,
@@ -823,7 +873,7 @@ pub fn of_key(code: KeyCode) -> Option<&'static Binding> {
         .filter(|b| {
             matches!(
                 b.group,
-                Group::Screen | Group::Panel | Group::Write | Group::Create
+                Group::Screen | Group::Panel | Group::Write | Group::Create | Group::Change
             )
         })
         .find(|b| b.answers(code))
@@ -889,20 +939,34 @@ pub fn named(key: KeyCode) -> String {
 const PANEL_NOTE: &str = "   (the marked panel is the one keys reach)";
 /// What it says after the five, about where they land and what runs them.
 const WRITE_NOTE: &str = "   (the marked panel's entity, then";
-/// The verbs `x` names, in §4's order, and the whole of them.
+/// The verbs `x` reaches, in §4's order, and the whole of them.
 ///
-/// Not rows of [`BINDINGS`]: a row is a key this reader answers, and these
-/// three are absent from [`crate::ank::ACTS`], so the gate refuses them and a
-/// binding would be an offer nothing keeps. What is drawn is read out of
-/// [`ank_contract::verbs`] -- the name, the positional and the flags the verb
-/// itself declares -- so the list cannot teach a form the CLI does not take.
-const FURTHER: &[&str] = &["close", "attest", "read"];
-/// What `x` says under them, which is the fact that makes the list honest.
-const FURTHER_NOTE: &str = "   (a shell runs these: this reader does not, yet)";
+/// **Not rows of [`BINDINGS`], and still reachable** (TASK-e8da6a00564a). A row
+/// of that table is a key this reader answers to, and these three have no key:
+/// what they have is a row of the list `x` opens, opened the way every other
+/// listing's row is opened. So the offer is complete and the keyboard is not
+/// three letters poorer.
+///
+/// It is measured against [`crate::ank::ACTS`] in both directions by the suite
+/// at the foot of this file, exactly as the bound verbs are: a name here that
+/// the gate refuses would be a row that reads as an offer and answers with a
+/// refusal of the reader's own.
+///
+/// What is drawn is read out of [`ank_contract::verbs`] -- the name, the
+/// positional and the flags the verb itself declares -- so the list cannot
+/// teach a form the CLI does not take.
+pub const FURTHER: &[&str] = &["close", "attest", "read"];
+/// What `x` says under them, which is what makes the list honest about itself.
+const FURTHER_NOTE: &str =
+    "(Enter opens the row under the cursor: what it composes is shown first)";
 /// What it says after the verb that makes one: the fields are the flags the CLI
 /// declares, and nothing on that form is typed at a corpus until it has been
-/// through the confirmation the other seven rows go through.
+/// through the confirmation every other row goes through.
 const CREATE_NOTE: &str = "   (a form of the flags ank new takes, then";
+/// What it says after the verb that changes one, which is both facts at once:
+/// the entity is the marked panel's, and the fields are a form.
+const CHANGE_NOTE: &str = "   (a form of the fields ank edit takes, on the marked panel's entity, \
+                           then";
 /// What it says after `accept`, which is a different kind of offer: the other
 /// five move a corpus, and this one asks a person for a signature ank has no
 /// way to produce.
@@ -1042,6 +1106,22 @@ fn create() -> Line {
     }
 }
 
+/// The verb that changes what an entity says, on a line of its own
+/// (TASK-e8da6a00564a).
+///
+/// Separate from both lines above for the reason [`Group::Change`] gives: the
+/// writing half's note does not mention a form and the create line's note does
+/// not mention the marked panel's entity, and this row is both.
+fn change() -> Line {
+    Line {
+        title: "content",
+        bindings: of_group(Group::Change),
+        lead: String::new(),
+        between: "  ",
+        note: format!("{CHANGE_NOTE} {})", named(KeyCode::Char(CONFIRM))),
+    }
+}
+
 /// The sixth act, on a line of its own, and only where the verb would take it.
 fn ratify() -> Line {
     Line {
@@ -1079,15 +1159,16 @@ fn typing() -> Line {
 ///
 /// **Every binding of the table is on exactly one of these, and nothing else
 /// is** -- which is the property `?` is answerable for and the test below
-/// measures. Six lines because there are six kinds of offer, and the two modal
-/// ones are named rather than left to be discovered: a person who has a command
-/// waiting on the screen cannot press `?` to find out what answers it.
+/// measures. One line per kind of offer, and the two modal ones are named
+/// rather than left to be discovered: a person who has a command waiting on the
+/// screen cannot press `?` to find out what answers it.
 fn lines() -> Vec<Line> {
     vec![
         screen(),
         panel(),
         write(),
         create(),
+        change(),
         ratify(),
         waiting(),
         typing(),
@@ -1150,21 +1231,41 @@ pub fn listing() -> Vec<Item> {
     out
 }
 
-/// What `x` answers with: the verbs past the six, named and placed
-/// (TASK-1a415107fd56).
+/// One row of the list `x` opens, and the verb opening it reaches
+/// (TASK-e8da6a00564a).
 ///
-/// **A list and not an offer.** `close`, `attest` and `read` are §4 verbs this
-/// reader has no road to -- [`crate::ank::ACTS`] does not carry them and
-/// [`crate::ank::Ank::act`] refuses anything it does not -- so what this says
-/// is what they are and where they are spelled, and the note says which of the
-/// two it is. TASK-e8da6a00564a is where they stop being only a list, and it
-/// widens the gate to do it.
+/// **The row and its verb are one value**, for the reason [`Item`] gives about
+/// the key list: a screen that drew the rows from one function and resolved a
+/// press with another would be two orderings agreeing by luck.
+///
+/// `verb` is `None` on the note, which is prose about the rows above it and the
+/// one row of this list that opens nothing.
+#[derive(Debug, Clone)]
+pub struct Beyond {
+    /// What the row reads: the verb, its positional and its flags, spelled as
+    /// the contract declares them.
+    pub text: String,
+    /// What opening it reaches, where the row names one.
+    pub verb: Option<&'static str>,
+}
+
+/// What `x` answers with: the verbs past the six, named, placed and reachable
+/// (TASK-1a415107fd56, TASK-e8da6a00564a).
+///
+/// **A list that is now an offer.** It was a list and nothing else for as long
+/// as [`crate::ank::ACTS`] refused these three; the gate carries them now, so
+/// every row of this list opens the verb it names -- `close` and `attest` onto
+/// the form their mandatory flag is filled in on, `read` straight onto the
+/// confirmation, since §4 gives it no flag at all.
 ///
 /// Read out of the contract's own table, name, positional and flags alike, so
 /// a form drawn here is a form `ank` takes (ADR-c07e2694f0e1: what the reader
 /// offers is read out of the verb table rather than transcribed beside it).
-pub fn further() -> Vec<String> {
-    let named: Vec<String> = FURTHER
+/// One row per verb and not one line carrying all three: a row is a rectangle a
+/// finger fits in, which is what the key list's overlay bought and what makes
+/// these three reachable by a thumb as well as by Enter.
+pub fn further() -> Vec<Beyond> {
+    let mut out: Vec<Beyond> = FURTHER
         .iter()
         .map(|verb| {
             let spec = ank_contract::verbs::spec_of(verb);
@@ -1178,10 +1279,43 @@ pub fn further() -> Vec<String> {
                 said.push(' ');
                 said.push_str(flag.name);
             }
-            said
+            Beyond {
+                text: said,
+                verb: Some(*verb),
+            }
         })
         .collect();
-    vec![named.join("   "), FURTHER_NOTE.to_string()]
+    out.push(Beyond {
+        text: FURTHER_NOTE.to_string(),
+        verb: None,
+    });
+    out
+}
+
+/// What opening one row of that list asks for.
+///
+/// **Two answers, and the verb's own declaration is what picks between them.**
+/// A verb the form serves opens a form -- `close` will not run without
+/// `--reason` and `attest` will not run without `--proof`, and a line is not
+/// where either of those is typed. A verb it does not serve declares no flag at
+/// all, which is `ank read <id>`: there is nothing to fill in, so what it
+/// composes is the identifier and the confirmation is the next thing on the
+/// screen.
+///
+/// Either way the road is the one every other act takes. This composes and
+/// hands back; `App::propose` shows; `App::confirmed` is the only caller of
+/// [`crate::ank::Ank::act`] in this crate.
+pub fn beyond(verb: &'static str) -> Command {
+    if crate::form::serves(verb) {
+        return Command::Form(verb);
+    }
+    Command::Act(Act {
+        verb,
+        args: Vec::new(),
+        // All three take `<id>` first, and the view is what knows which entity
+        // the person meant.
+        subject: Subject::Selected,
+    })
 }
 
 /// Every binding of a group, in the table's order.
@@ -1235,10 +1369,27 @@ mod tests {
             }
         }
         assert_eq!(
-            named, 7,
-            "the verbs this reader spells are the six that move an entity and \
-             the one that makes one (TASK-d832452630d2)"
+            named, 8,
+            "the verbs this reader spells are the six that move an entity, the \
+             one that makes one (TASK-d832452630d2) and the one that changes \
+             what one says (TASK-e8da6a00564a)"
         );
+        // And the three the list `x` opens are verbs of the contract too, with
+        // the flags this reader will draw for them: a row naming `close`
+        // without `--reason` would be teaching a command line the CLI refuses.
+        for verb in FURTHER {
+            let spec = verbs::spec_of(verb)
+                .unwrap_or_else(|| panic!("'{verb}' is no verb of the contract"));
+            for flag in crate::form::need(verb, "")
+                .map(|n| n.flags())
+                .unwrap_or(&[])
+            {
+                assert!(
+                    spec.flags.iter().any(|f| f.name == *flag && f.listed),
+                    "'{flag}' is no flag of 'ank {verb}'"
+                );
+            }
+        }
     }
 
     /// **The gate is measured against the table and never generated from it**
@@ -1264,10 +1415,26 @@ mod tests {
                 "'{verb}' is offered and the gate would refuse it"
             );
         }
+        for verb in FURTHER {
+            assert!(
+                crate::ank::ACTS.contains(verb),
+                "'{verb}' is a row of the list `x` opens and the gate would \
+                 refuse it"
+            );
+            assert!(
+                of_verb(verb).is_none(),
+                "'{verb}' has a key of its own, and the list `x` opens is for \
+                 the verbs that have none"
+            );
+        }
+        // Both directions, so a verb added to the gate alone fails here. A verb
+        // this reader may spawn is a verb somebody can reach: a key of the
+        // table, or a row of the list `x` opens.
         for verb in crate::ank::ACTS {
             assert!(
-                of_verb(verb).is_some(),
-                "'{verb}' may be spawned and no binding spells it"
+                of_verb(verb).is_some() || FURTHER.contains(verb),
+                "'{verb}' may be spawned and nothing reaches it: no binding \
+                 spells it and no row of the list `x` opens names it"
             );
         }
         let gate = include_str!("ank.rs");
@@ -1470,7 +1637,7 @@ mod tests {
         for binding in BINDINGS.iter().filter(|b| {
             matches!(
                 b.group,
-                Group::Screen | Group::Panel | Group::Write | Group::Create
+                Group::Screen | Group::Panel | Group::Write | Group::Create | Group::Change
             )
         }) {
             for key in std::iter::once(binding.key).chain(binding.aliases.iter().copied()) {

--- a/crates/ank-tui/src/form.rs
+++ b/crates/ank-tui/src/form.rs
@@ -1,8 +1,15 @@
-//! The form `ank new` is filled in on, and the whole of why it cannot open an
-//! editor (TASK-d832452630d2, ADR-c07e2694f0e1).
+//! The form a verb with flags is filled in on, and the whole of why it cannot
+//! open an editor (TASK-d832452630d2, TASK-e8da6a00564a, ADR-c07e2694f0e1).
+//!
+//! **Four verbs and one form.** It arrived carrying `ank new` alone and
+//! TASK-e8da6a00564a puts `ank edit`, `ank close` and `ank attest` on it. What
+//! made that one form rather than four is that nothing here is written per
+//! verb: the fields are the contract's, the kinds are the contract's, and the
+//! only thing this file declares is [`NEEDS`] -- which flags a call cannot be
+//! composed without, the one fact `ank help --json` does not carry.
 //!
 //! **The fields are the contract's and not this file's.** `ank help --json`
-//! declares what `ank new` takes, [`ank_contract::verbs`] is where that
+//! declares what each verb takes, [`ank_contract::verbs`] is where that
 //! declaration lives, and [`Form::fields`] is that list read in its own order.
 //! Nothing here writes a flag name down: this crate has already been burned
 //! once by five parallel key tables (ADR-c07e2694f0e1 records what they cost),
@@ -16,33 +23,42 @@
 //!
 //! # The editor, and why this form is a `Result`
 //!
-//! `ank new` opens `$EDITOR` **precisely when every mandatory flag is absent**
-//! -- that is the CLI's `is_interactive`, and it is `all` and not `any`: `ank
-//! new task --title x` still refuses on the missing scope, and `ank new task`
-//! alone opens an editor. The reader's child is spawned with `output()`'s null
-//! stdin, into a process that has taken the terminal into raw mode on the
-//! alternate screen. An editor reached from here is therefore not an error that
-//! shows up on the screen; it is a full-screen program drawing into a captured
-//! pipe, reading from nothing, for as long as the reader is up.
+//! **Two verbs of the four reach `$EDITOR`, and they reach it by different
+//! doors.** `ank new` opens one **precisely when every mandatory flag is
+//! absent** -- that is the CLI's `is_interactive`, and it is `all` and not
+//! `any`: `ank new task --title x` still refuses on the missing scope, and
+//! `ank new task` alone opens an editor. `ank edit` opens one when **no field
+//! is named at all**: `ank edit <id> --title x` writes a title, and
+//! `ank edit <id>` alone opens the whole entity in an editor. Those are two
+//! different conditions and [`Need`] is the two of them, written down as the
+//! two shapes they are rather than as one rule that happens to cover both
+//! today.
+//!
+//! The reader's child is spawned with `output()`'s null stdin, into a process
+//! that has taken the terminal into raw mode on the alternate screen. An editor
+//! reached from here is therefore not an error that shows up on the screen; it
+//! is a full-screen program drawing into a captured pipe, reading from nothing,
+//! for as long as the reader is up.
 //!
 //! So the form is not *unlikely* to compose one, it is structurally incapable
 //! of it. [`Form::composed`] is the one road from a form to an [`Act`], it
-//! answers `Err` while a mandatory field is blank, and [`REQUIRED`] gives every
-//! kind at least one -- which is what makes "every mandatory flag absent"
-//! unreachable rather than merely unusual. The suite measures it the way the
-//! criterion asks: `$EDITOR` points at a script that writes a sentinel, and the
-//! sentinel is not there afterwards.
+//! answers `Err` until the verb's own [`Need`] is met, and [`Form::open`]
+//! refuses outright to build a form for a verb [`NEEDS`] does not name -- so
+//! "the flagless call" is a state this cannot produce rather than a state it is
+//! careful about. The suite measures it the way the criterion asks: `$EDITOR`
+//! points at a script that writes a sentinel, and the sentinel is not there
+//! afterwards.
 //!
 //! # Where the mandatory list comes from, and why it is here
 //!
 //! It is the one fact this form needs that the contract does not carry.
-//! `ank help --json` declares the flags of the *verb* `new`, and `new` makes
-//! three kinds out of one flag set; which of them a kind cannot do without is
-//! the CLI's own `mandatory_flags`, and it reaches no document. So [`REQUIRED`]
-//! is written below -- and it is *measured* rather than trusted: `tests/
-//! entity.rs` runs the built binary once per name in it with that flag left
-//! out and finds a refusal, and once with the whole set and finds an entity. A
-//! list that drifted from the CLI fails there rather than surviving review.
+//! `ank help --json` declares the flags of the *verb*, and `new` makes three
+//! kinds out of one flag set; which of them a call cannot do without is the
+//! CLI's own `mandatory_flags`, and it reaches no document. So [`NEEDS`] is
+//! written below -- and it is *measured* rather than trusted: `tests/entity.rs`
+//! runs the built binary once per name in it with that flag left out and finds
+//! a refusal, and once with the whole set and finds an entity. A list that
+//! drifted from the CLI fails there rather than surviving review.
 //!
 //! Every name in it is held to the contract's own flags by the suite at the
 //! foot of this file, so the two halves cannot disagree either.
@@ -52,49 +68,137 @@ use crate::text::fit;
 use ank_contract::verbs::{self, CommandSpec, FlagSpec};
 use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
-/// The verb this form spells, named once so the binding, the gate and the
+/// The verb that makes an entity, named once so the binding, the gate and the
 /// composed argv are the same string.
-pub const VERB: &str = "new";
+pub const MAKE: &str = "new";
 
-/// The flags `ank new` will not make an entity of this kind without.
+/// What a call cannot be composed without, in the two shapes the CLI has.
+///
+/// **Two variants because the editor is reached by two different doors**, and
+/// a single rule covering both would be a coincidence rather than a guarantee.
+/// `ank new` opens `$EDITOR` when *every* mandatory flag is absent, so a form
+/// for it must hold all of them. `ank edit` opens one when *no* field is named
+/// at all, so a form for it must hold at least one. Written down as two, so a
+/// verb added to [`NEEDS`] has to say which door it is standing in front of.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Need {
+    /// Every one of these, or the form composes nothing.
+    All(&'static [&'static str]),
+    /// At least one of these, or the form composes nothing.
+    Any(&'static [&'static str]),
+}
+
+impl Need {
+    /// The flags it names, whichever shape it is.
+    ///
+    /// What a row marks with `*` and what a refusal spells: the two surfaces
+    /// read the names off the requirement rather than off a second list, so a
+    /// flag that moves moves on both.
+    pub fn flags(&self) -> &'static [&'static str] {
+        match self {
+            Need::All(flags) | Need::Any(flags) => flags,
+        }
+    }
+}
+
+/// Every verb this reader fills in on a form, and what each will not compose
+/// without.
 ///
 /// **Not read from the contract, because the contract does not carry it** --
 /// see the module header for what is declared where, and `tests/entity.rs` for
 /// how this is held to the binary rather than to a memory of it.
 ///
-/// A kind the contract declares and this list does not name falls to
-/// [`BASE`], which is what all three kinds share: a title and a scope. That is
-/// the conservative direction -- it can only ask for more than the CLI needs,
-/// never less -- and asking for more is a refusal on this side of the pipe,
-/// where asking for less would be the editor.
-const REQUIRED: &[(&str, &[&str])] = &[
+/// The second column is the verb's own subcommand where it has them and the
+/// empty string where it has none, and an empty string is also the fallback: a
+/// kind the contract declares and no row names falls to the verb's own bare
+/// row. For `new` that is [`BASE`], what all three kinds share, which is the
+/// conservative direction -- it can only ask for more than the CLI needs, never
+/// less -- and asking for more is a refusal on this side of the pipe, where
+/// asking for less would be the editor.
+///
+/// **A verb absent from this table has no form at all**, and that is the point
+/// rather than an omission: [`Form::open`] answers `None` for it, so there is
+/// no way to build a form whose requirement is nothing and whose composed argv
+/// is therefore the flagless call.
+const NEEDS: &[(&str, &str, Need)] = &[
     // An ADR is a rule, and a rule with no sentence in it binds nothing.
-    ("adr", &["--title", "--scope", "--constraint"]),
+    (
+        MAKE,
+        "adr",
+        Need::All(&["--title", "--scope", "--constraint"]),
+    ),
+    (MAKE, "", Need::All(BASE)),
+    // The one `Any` (TASK-e8da6a00564a). `ank edit <id>` with no field named is
+    // the call that opens `$EDITOR`, and every one of these three names a field
+    // -- so a form that holds any of them has already spelled the verb out of
+    // the editor's reach.
+    (
+        "edit",
+        "",
+        Need::Any(&["--title", "--body", "--constraint"]),
+    ),
+    // "a closure nobody explained is one nobody can reopen" is the verb's own
+    // refusal, and this is that refusal on this side of the pipe.
+    ("close", "", Need::All(&["--reason"])),
+    ("attest", "", Need::All(&["--proof"])),
 ];
 
-/// What every kind needs: a title, and the scope that attaches it to something.
+/// What every kind of `ank new` needs: a title, and the scope that attaches it
+/// to something.
 ///
 /// "a scope is mandatory: an entity attached to nothing is invisible" is the
 /// verb's own note, and it is the sentence this form refuses on.
 const BASE: &[&str] = &["--title", "--scope"];
 
-/// The mandatory flags of one kind.
-pub fn required(kind: &str) -> &'static [&'static str] {
-    REQUIRED
+/// What a form for this verb and this kind will not compose without, or `None`
+/// where no form serves the verb at all.
+///
+/// The kind first and the verb's bare row after it, so a kind with a
+/// requirement of its own is answered by that one and every other kind falls to
+/// what the verb shares.
+pub fn need(verb: &str, kind: &str) -> Option<Need> {
+    NEEDS
         .iter()
-        .find(|(named, _)| *named == kind)
-        .map(|(_, flags)| *flags)
-        .unwrap_or(BASE)
+        .find(|(named, on, _)| *named == verb && *on == kind)
+        .or_else(|| {
+            NEEDS
+                .iter()
+                .find(|(named, on, _)| *named == verb && on.is_empty())
+        })
+        .map(|(_, _, need)| *need)
 }
 
-/// The verb's own declaration, or `None` where this build's contract has no
-/// `new` at all.
+/// Whether a form is what this verb is filled in on.
+///
+/// What [`crate::bindings::beyond`] asks before it composes: a verb with a form
+/// opens one, and a verb with none -- `ank read`, which declares no flag at all
+/// -- goes straight to the confirmation with the identifier and nothing else.
+pub fn serves(verb: &str) -> bool {
+    NEEDS.iter().any(|(named, _, _)| *named == verb)
+}
+
+/// Every verb a form serves, once each, in the order [`NEEDS`] declares them.
+///
+/// For the suite, which has to be able to say "every verb with a form is a verb
+/// the gate allows" over the table rather than over a list beside it.
+pub fn served() -> Vec<&'static str> {
+    let mut out: Vec<&'static str> = Vec::new();
+    for (verb, _, _) in NEEDS {
+        if !out.contains(verb) {
+            out.push(verb);
+        }
+    }
+    out
+}
+
+/// The declaration of the verb a form is for, or `None` where this build's
+/// contract has not got it.
 ///
 /// `None` rather than a panic, for [`crate::bindings::further`]'s reason: a
 /// reader must not die because a verb moved, and a form with no contract behind
 /// it is a form that refuses rather than one that invents a flag set.
-pub fn spec() -> Option<&'static CommandSpec> {
-    verbs::spec_of(VERB)
+pub fn spec_of(verb: &str) -> Option<&'static CommandSpec> {
+    verbs::spec_of(verb)
 }
 
 /// What one field of the form holds.
@@ -170,9 +274,20 @@ pub struct Missing {
 /// The form, open.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Form {
+    /// The verb it is filled in for (TASK-e8da6a00564a).
+    ///
+    /// Carried rather than assumed, because there are four of them and every
+    /// other field of this struct is read out of the contract against it: the
+    /// rows, the kinds, the requirement and the composed argv all follow from
+    /// this one string.
+    verb: &'static str,
     /// Which of the verb's own subcommands this form is for, as an index into
     /// [`Form::kinds`]: the kind is the first positional of `ank new` and never
     /// a field, so it is drawn on the heading rather than in the rows.
+    ///
+    /// Zero and unread on the three verbs that declare no subcommand at all,
+    /// where [`Form::kind`] is the empty string and the verb takes `<id>`
+    /// first, which is the view's to supply.
     kind: usize,
     fields: Vec<Field>,
     /// The row the cursor is on.
@@ -187,31 +302,92 @@ pub struct Form {
 }
 
 impl Form {
-    /// A form for the first kind the contract declares, with every field empty.
+    /// A form for one verb, on the first kind the contract declares for it,
+    /// with every field empty.
     ///
-    /// `None` where this build's contract declares no `new`, or declares it
-    /// with no subcommands: a form with no kind has nothing to compose.
-    pub fn open() -> Option<Form> {
-        let spec = spec()?;
-        if spec.subcommands.is_empty() {
+    /// **`None` is a refusal to draw a form that could compose an editor**, and
+    /// it is answered in three cases. This build's contract has no such verb;
+    /// the verb declares no flag a form could carry; or [`NEEDS`] declares
+    /// nothing the verb -- on any one of its kinds -- cannot do without. The
+    /// last is the one that matters: a form with no requirement is a form whose
+    /// empty submission is the flagless call, and for `new` and `edit` alike
+    /// that call is `$EDITOR`.
+    pub fn open(verb: &'static str) -> Option<Form> {
+        let spec = verbs::spec_of(verb)?;
+        for kind in kinds_of(spec) {
+            need(verb, kind)?;
+        }
+        let fields: Vec<Field> = spec.flags.iter().filter(|f| f.listed).map(field).collect();
+        if fields.is_empty() {
             return None;
         }
         Some(Form {
+            verb,
             kind: 0,
-            fields: spec.flags.iter().filter(|f| f.listed).map(field).collect(),
+            fields,
             at: 0,
             said: None,
         })
     }
 
-    /// The kinds this form can be for, in the contract's own order.
-    pub fn kinds(&self) -> &'static [&'static str] {
-        spec().map(|s| s.subcommands).unwrap_or_default()
+    /// The verb this form is filled in for.
+    pub fn verb(&self) -> &'static str {
+        self.verb
     }
 
-    /// The kind it is for now.
+    /// The kinds this form can be for, in the contract's own order, and none at
+    /// all where the verb declares no subcommand.
+    pub fn kinds(&self) -> &'static [&'static str] {
+        verbs::spec_of(self.verb)
+            .map(|s| s.subcommands)
+            .unwrap_or_default()
+    }
+
+    /// The kind it is for now, and the empty string where the verb has none.
     pub fn kind(&self) -> &'static str {
         self.kinds().get(self.kind).copied().unwrap_or_default()
+    }
+
+    /// What the form's own border says it is: the verb, and the kind where the
+    /// verb has one.
+    ///
+    /// `NEW TASK`, `EDIT`, `CLOSE`, `ATTEST`. Read off the verb rather than
+    /// written per form, so a fifth form is a row of [`NEEDS`] and not a
+    /// heading somewhere to remember.
+    pub fn banner(&self) -> String {
+        match self.kind().is_empty() {
+            true => self.verb.to_ascii_uppercase(),
+            false => format!(
+                "{} {}",
+                self.verb.to_ascii_uppercase(),
+                self.kind().to_ascii_uppercase()
+            ),
+        }
+    }
+
+    /// What this form will not compose without, or `None` where this build
+    /// declares nothing.
+    ///
+    /// `Option` and not a default, because there is no safe default: a
+    /// requirement of nothing is met by an empty form, and an empty form
+    /// composes the call that opens an editor. [`Form::open`] refuses to build
+    /// one this answers `None` for, and [`Form::composed`] refuses to compose
+    /// one all the same -- two refusals, because the state is the one this
+    /// module exists to make unreachable.
+    pub fn need(&self) -> Option<Need> {
+        need(self.verb, self.kind())
+    }
+
+    /// The verb and its kind, as a command line names them.
+    ///
+    /// `ank new task` where there is a kind and `ank close` where there is not,
+    /// so a sentence about what the form will not compose says the same words a
+    /// person would have typed.
+    fn spelled(&self) -> String {
+        match self.kind().is_empty() {
+            true => format!("ank {}", self.verb),
+            false => format!("ank {} {}", self.verb, self.kind()),
+        }
     }
 
     pub fn fields(&self) -> &[Field] {
@@ -226,9 +402,16 @@ impl Form {
         self.said.as_deref()
     }
 
-    /// Whether this flag is one the kind cannot do without.
-    pub fn needed(&self, flag: &str) -> bool {
-        required(self.kind()).contains(&flag)
+    /// Whether this flag is one the form marks, which is one the requirement
+    /// names.
+    ///
+    /// The same answer for either shape of [`Need`], and the note over the rows
+    /// is what says which shape it is: under `All` a marked row is one the form
+    /// refuses without, and under `Any` a marked row is one of the set it needs
+    /// one of. A second marker for the second shape would be a legend to learn
+    /// where a sentence already says it.
+    pub fn marked(&self, flag: &str) -> bool {
+        self.need().is_some_and(|need| need.flags().contains(&flag))
     }
 
     /// The kind after this one, and back to the first after the last.
@@ -369,34 +552,27 @@ impl Form {
     /// The act this form composes, or the field that is still empty.
     ///
     /// **This is the one road from a form to an argv**, and it is a `Result`
-    /// for the reason the module header gives: `ank new` with every mandatory
-    /// flag absent opens `$EDITOR`, and an editor spawned by a child with no
-    /// stdin into a raw-mode alternate screen is a hang. Every kind has at
-    /// least one flag it refuses without ([`required`], held non-empty by the
-    /// suite below), so an argv this answers `Ok` to always carries one -- and
-    /// "every mandatory flag absent" is a state this cannot produce rather than
-    /// a state it is careful about.
+    /// for the reason the module header gives: the flagless call opens
+    /// `$EDITOR` on two of these four verbs, and an editor spawned by a child
+    /// with no stdin into a raw-mode alternate screen is a hang. Every verb a
+    /// form serves declares a [`Need`] and every `Need` names at least one flag
+    /// (both held by the suite below), so an argv this answers `Ok` to always
+    /// carries a flag with a value -- and "no field named" is a state this
+    /// cannot produce rather than a state it is careful about.
     ///
-    /// The kind goes in front because it is `ank new`'s first positional, and
-    /// the flags follow in the contract's own order, a blank field passing
-    /// nothing at all.
+    /// The kind goes in front where the verb has one, because it is `ank new`'s
+    /// first positional; the three that have none take `<id>` first and the
+    /// view supplies it. The flags follow in the contract's own order, a blank
+    /// field passing nothing at all.
     pub fn composed(&self) -> Result<Act, Missing> {
+        // The lone dash is the CLI's "the value is on stdin", and this reader's
+        // child has none: `Ank::spawn` gives it `output()`'s null pipe, so a
+        // dash reaching a composed argv would be a child waiting on a thing
+        // nothing will ever write. Refused here, where the person who typed it
+        // can read why, rather than left to hang. `ank edit --body -` is the
+        // call the CLI itself documents for it, which is why this is stated
+        // over every typed field and not over the ones that looked risky.
         for (at, field) in self.fields.iter().enumerate() {
-            if self.needed(field.flag) && field.entry.blank() {
-                return Err(Missing {
-                    at,
-                    said: format!(
-                        "{} is empty, and 'ank {VERB} {}' will not make one without it",
-                        field.flag,
-                        self.kind()
-                    ),
-                });
-            }
-            // The lone dash is the CLI's "the value is on stdin", and this
-            // reader's child has none: `Ank::spawn` gives it `output()`'s null
-            // pipe, so a dash reaching a composed argv would be a child waiting
-            // on a thing nothing will ever write. Refused here, where the person
-            // who typed it can read why, rather than left to hang.
             if let Entry::Typed(text) = &field.entry {
                 if text.trim() == "-" {
                     return Err(Missing {
@@ -410,7 +586,11 @@ impl Form {
                 }
             }
         }
-        let mut args = vec![self.kind().to_string()];
+        self.answered()?;
+        let mut args = Vec::new();
+        if !self.kind().is_empty() {
+            args.push(self.kind().to_string());
+        }
         for field in &self.fields {
             match &field.entry {
                 Entry::Typed(text) if !text.trim().is_empty() => {
@@ -422,12 +602,95 @@ impl Form {
             }
         }
         Ok(Act {
-            verb: VERB,
+            verb: self.verb,
             args,
-            // `ank new <kind>` names a kind and not an entity, so there is no
-            // row for the view to put in front of it.
-            subject: Subject::Given,
+            // The question is asked of the form's own first positional and
+            // never of the verb's name: `ank new <kind>` carries its own, so
+            // nothing goes in front of it, and the three that name an entity
+            // take the row the view has marked.
+            subject: match self.kind().is_empty() {
+                true => Subject::Selected,
+                false => Subject::Given,
+            },
         })
+    }
+
+    /// Whether what has been filled in answers what the verb needs.
+    ///
+    /// The two shapes of [`Need`], answered as the two different questions they
+    /// are. `All` walks the named flags and stops at the first blank one, which
+    /// is the field the cursor is sent to. `Any` asks one question of the whole
+    /// set and, where the answer is no, sends the cursor to the first of them --
+    /// there is no single field to blame, so the sentence names them all.
+    fn answered(&self) -> Result<(), Missing> {
+        let Some(need) = self.need() else {
+            // Unreachable from a form `open` built, which refuses a verb with
+            // no requirement declared. Stated all the same, because the state
+            // it guards against is the one the module exists for.
+            return Err(Missing {
+                at: self.at,
+                said: format!(
+                    "this build declares nothing '{}' cannot do without, and a call naming no \
+                     field opens $EDITOR",
+                    self.spelled()
+                ),
+            });
+        };
+        match need {
+            Need::All(flags) => {
+                for flag in flags {
+                    match self.fields.iter().position(|f| f.flag == *flag) {
+                        Some(at) if !self.fields[at].entry.blank() => {}
+                        Some(at) => {
+                            return Err(Missing {
+                                at,
+                                said: format!(
+                                    "{flag} is empty, and '{}' will not compose without it",
+                                    self.spelled()
+                                ),
+                            })
+                        }
+                        // A requirement naming a flag the verb does not
+                        // declare: the form cannot answer it, so it composes
+                        // nothing rather than composing without it. The suite
+                        // below holds the table to the contract so this is a
+                        // refusal nobody meets.
+                        None => {
+                            return Err(Missing {
+                                at: self.at,
+                                said: format!(
+                                    "{flag} is no field of this form, and '{}' needs it",
+                                    self.spelled()
+                                ),
+                            })
+                        }
+                    }
+                }
+                Ok(())
+            }
+            Need::Any(flags) => {
+                let answered = flags.iter().any(|flag| {
+                    self.fields
+                        .iter()
+                        .any(|f| f.flag == *flag && !f.entry.blank())
+                });
+                if answered {
+                    return Ok(());
+                }
+                Err(Missing {
+                    at: flags
+                        .iter()
+                        .find_map(|flag| self.fields.iter().position(|f| f.flag == *flag))
+                        .unwrap_or(self.at),
+                    said: format!(
+                        "every field is empty: '{}' needs one of {}, and a call naming none \
+                         opens $EDITOR",
+                        self.spelled(),
+                        flags.join(", ")
+                    ),
+                })
+            }
+        }
     }
 
     /// The act, with the cursor moved onto whatever is missing where there is
@@ -463,7 +726,11 @@ impl Form {
         // put: what this says is either how the form works or which field it
         // refused on, and a window too short for the whole form would have
         // scrolled the second one off the bottom exactly when it was needed.
-        for line in crate::text::wrap(self.said.as_deref().unwrap_or(REQUIRED_NOTE), width.max(1)) {
+        let note = match &self.said {
+            Some(said) => said.clone(),
+            None => self.legend(),
+        };
+        for line in crate::text::wrap(&note, width.max(1)) {
             out.push((fit(&line, width), None));
         }
         out.push((String::new(), None));
@@ -472,7 +739,7 @@ impl Form {
                 true => crate::text::CURSOR,
                 false => crate::text::PLAIN,
             };
-            let needed = match self.needed(field.flag) {
+            let needed = match self.marked(field.flag) {
                 true => '*',
                 false => ' ',
             };
@@ -504,8 +771,12 @@ impl Form {
             .unwrap_or(0)
     }
 
-    /// What stands over the rows: which kind is being made, and how to reach
-    /// the other two.
+    /// What stands over the rows: the command line being filled in, and how to
+    /// reach the other kinds where the verb has any.
+    ///
+    /// The verb's own positional after it where there is no kind, so a form for
+    /// `ank edit` says `ank edit <id>` -- the same words the list `x` opens
+    /// draws, out of the same table.
     fn heading(&self) -> String {
         let others: Vec<&str> = self
             .kinds()
@@ -513,20 +784,47 @@ impl Form {
             .copied()
             .filter(|k| *k != self.kind())
             .collect();
-        match others.is_empty() {
-            true => format!("ank {VERB} {}", self.kind()),
-            false => format!(
-                "ank {VERB} {}   (Left/Right for {})",
-                self.kind(),
-                others.join(", ")
+        if others.is_empty() {
+            let positional = spec_of(self.verb)
+                .map(|spec| spec.positional_help)
+                .unwrap_or_default();
+            return format!("{} {positional}", self.spelled())
+                .trim_end()
+                .to_string();
+        }
+        format!(
+            "{}   (Left/Right for {})",
+            self.spelled(),
+            others.join(", ")
+        )
+    }
+
+    /// What the form says over the rows while it has nothing else to say.
+    ///
+    /// **The sentence is the requirement's** (TASK-e8da6a00564a). `All` and
+    /// `Any` mark their rows the same way and mean different things by the
+    /// mark, so the legend is what tells them apart -- a person filling in
+    /// `ank edit` reads that one of the three is enough, and a person filling
+    /// in `ank new` reads that every mark is a refusal.
+    fn legend(&self) -> String {
+        let closes = format!(
+            "Enter composes, {} closes",
+            crate::bindings::named(KeyCode::Esc)
+        );
+        match self.need() {
+            Some(Need::All(_)) => format!(
+                "* is a flag '{}' will not compose without: {closes}",
+                self.spelled()
             ),
+            Some(Need::Any(_)) => format!(
+                "'{}' needs one of the fields marked *, and a call naming none opens $EDITOR: \
+                 {closes}",
+                self.spelled()
+            ),
+            None => closes,
         }
     }
 }
-
-/// What the form says under the rows while it has nothing else to say.
-const REQUIRED_NOTE: &str =
-    "* is a flag ank new will not make one without: Enter composes, Esc closes";
 
 /// The column the values line up in, which is wide enough for the longest flag
 /// `ank new` declares and its repeat marker.
@@ -553,6 +851,23 @@ fn shown(entry: &Entry, room: usize, focused: bool) -> String {
     text.chars().skip(over + 1).collect::<String>()
 }
 
+/// The kinds a verb's form can be for, and the one nameless kind where it
+/// declares no subcommand.
+///
+/// The empty string is what [`NEEDS`] keys a verb with no subcommands on, and
+/// it is what [`Form::kind`] answers with: one word for "this verb takes no
+/// kind", used by the table, the requirement and the composed argv alike rather
+/// than three ways of saying the same absence.
+fn kinds_of(spec: &'static CommandSpec) -> &'static [&'static str] {
+    match spec.subcommands.is_empty() {
+        true => NO_KIND,
+        false => spec.subcommands,
+    }
+}
+
+/// The one kind a verb with no subcommands has.
+const NO_KIND: &[&str] = &[""];
+
 /// One field, from the flag the contract declared.
 fn field(spec: &FlagSpec) -> Field {
     Field {
@@ -570,7 +885,19 @@ mod tests {
     use super::*;
 
     fn form() -> Form {
-        Form::open().expect("this build's contract declares 'ank new'")
+        Form::open(MAKE).expect("this build's contract declares 'ank new'")
+    }
+
+    /// The mandatory flags of one kind of `ank new`, which is what most of the
+    /// suite below is about.
+    fn required(kind: &str) -> &'static [&'static str] {
+        need(MAKE, kind)
+            .expect("'ank new' declares what it will not compose without")
+            .flags()
+    }
+
+    fn spec() -> Option<&'static CommandSpec> {
+        spec_of(MAKE)
     }
 
     fn filled(form: &mut Form, flag: &str, value: &str) {
@@ -666,13 +993,33 @@ mod tests {
             for flag in needed {
                 assert!(
                     spec.flags.iter().any(|f| f.name == *flag && f.listed),
-                    "'{flag}' is mandatory for '{kind}' and is no flag of 'ank {VERB}'"
+                    "'{flag}' is mandatory for '{kind}' and is no flag of 'ank {MAKE}'"
                 );
             }
         }
         // A kind the contract has not got falls to the base, which is what all
         // three share rather than nothing at all.
         assert_eq!(required("a kind nobody declared"), BASE);
+        // And every verb the table serves declares something, on every kind it
+        // has: a verb with nothing mandatory is a verb whose empty form
+        // composes the flagless call.
+        for verb in served() {
+            let spec = spec_of(verb).unwrap_or_else(|| panic!("'{verb}' is a verb of §4"));
+            for kind in kinds_of(spec) {
+                let need = need(verb, kind)
+                    .unwrap_or_else(|| panic!("'ank {verb} {kind}' needs nothing declared"));
+                assert!(
+                    !need.flags().is_empty(),
+                    "'ank {verb} {kind}' needs an empty list, which every form meets"
+                );
+                for flag in need.flags() {
+                    assert!(
+                        spec.flags.iter().any(|f| f.name == *flag && f.listed),
+                        "'{flag}' is needed by 'ank {verb} {kind}' and is no flag of it"
+                    );
+                }
+            }
+        }
     }
 
     /// **A form with a mandatory field empty composes nothing, and says which**
@@ -686,7 +1033,7 @@ mod tests {
         let mut form = form();
         for kind in form.kinds() {
             for left_out in required(kind) {
-                let mut form = Form::open().expect("a form");
+                let mut form = Form::open(MAKE).expect("a form");
                 on(&mut form, kind);
                 for flag in required(kind) {
                     if flag != left_out {
@@ -710,7 +1057,7 @@ mod tests {
             // Whitespace is not an answer: the CLI reads a blank `--title` as
             // absent, so a form that let one through would be a form composing
             // the editor.
-            let mut blank = Form::open().expect("a form");
+            let mut blank = Form::open(MAKE).expect("a form");
             on(&mut blank, kind);
             for flag in required(kind) {
                 filled(&mut blank, flag, "   ");
@@ -729,7 +1076,7 @@ mod tests {
         filled(&mut form, "--title", "The reader makes an entity");
         filled(&mut form, "--scope", "crates/ank-tui/**");
         let act = form.composed().expect("a filled form composes");
-        assert_eq!(act.verb, VERB);
+        assert_eq!(act.verb, MAKE);
         assert_eq!(act.subject, Subject::Given);
         assert_eq!(
             act.args,
@@ -748,6 +1095,105 @@ mod tests {
             "an empty field reached the argv: {:?}",
             act.args
         );
+    }
+
+    /// **No form this module serves composes anything while it is empty**
+    /// (TASK-e8da6a00564a).
+    ///
+    /// The structural half of the criterion, stated over every verb and every
+    /// kind rather than over the one that is dangerous. `ank new` and `ank edit`
+    /// open `$EDITOR` on the flagless call and `ank close` and `ank attest`
+    /// refuse it; what makes the first two unreachable is not that they are
+    /// treated carefully but that `composed` answers `Err` on an empty form,
+    /// whichever shape of [`Need`] it is holding. A verb added to [`NEEDS`] with
+    /// nothing mandatory fails here rather than surviving review.
+    #[test]
+    fn an_empty_form_composes_nothing_whatever_verb_it_is_for() {
+        for verb in served() {
+            let mut form = Form::open(verb).unwrap_or_else(|| panic!("a form for '{verb}'"));
+            for kind in form.kinds().to_vec() {
+                on(&mut form, kind);
+                assert!(
+                    form.composed().is_err(),
+                    "an empty form for 'ank {verb} {kind}' composed something"
+                );
+            }
+            if form.kinds().is_empty() {
+                assert!(
+                    form.composed().is_err(),
+                    "an empty form for 'ank {verb}' composed something"
+                );
+            }
+        }
+        // And a verb with no row of the table has no form at all, which is the
+        // other half: there is no way to build one whose requirement is
+        // nothing. `read` is the live case -- it declares no flag, and the list
+        // `x` opens composes it straight rather than drawing an empty form.
+        assert!(!serves("read"), "'read' has a form and declares no flag");
+        assert!(Form::open("read").is_none(), "a form was built for 'read'");
+    }
+
+    /// **`ank edit` composes on any one of its three fields and on none**
+    /// (TASK-e8da6a00564a).
+    ///
+    /// The `Any` shape, measured as what it is. `--title` alone is a complete
+    /// `ank edit` and so is `--body` alone and `--constraint` alone, so a form
+    /// that demanded all three would be refusing command lines the CLI takes;
+    /// and none of them is the call that opens an editor, which is what the
+    /// refusal is for. The identifier is not here because it is not the form's:
+    /// the act says [`Subject::Selected`] and the view puts the row in front.
+    #[test]
+    fn an_edit_composes_on_any_one_of_its_fields_and_never_on_none() {
+        let flags = need("edit", "")
+            .expect("'ank edit' declares what it will not compose without")
+            .flags();
+        assert!(flags.len() > 1, "the `Any` shape is worth stating over one");
+        for only in flags {
+            let mut form = Form::open("edit").expect("a form for 'ank edit'");
+            filled(&mut form, only, "a value");
+            let act = form
+                .composed()
+                .unwrap_or_else(|e| panic!("'{only}' alone did not compose: {}", e.said));
+            assert_eq!(act.verb, "edit");
+            assert_eq!(act.args, [only.to_string(), "a value".to_string()]);
+            // The view supplies `<id>`, so the form must not.
+            assert_eq!(act.subject, Subject::Selected);
+        }
+        // And with none of them, the refusal names all three -- there is no one
+        // field to blame -- and puts the cursor on the first.
+        let form = Form::open("edit").expect("a form");
+        let missing = form
+            .composed()
+            .expect_err("an edit naming no field composed");
+        for flag in flags {
+            assert!(missing.said.contains(flag), "{}", missing.said);
+        }
+        assert_eq!(form.fields()[missing.at].flag, flags[0]);
+    }
+
+    /// `close` and `attest` take the entity the view names, and each refuses
+    /// without the flag §4 refuses without (TASK-e8da6a00564a).
+    #[test]
+    fn close_and_attest_refuse_without_their_flag_and_take_the_views_entity() {
+        for (verb, flag) in [("close", "--reason"), ("attest", "--proof")] {
+            let form = Form::open(verb).unwrap_or_else(|| panic!("a form for 'ank {verb}'"));
+            let need = need(verb, "").unwrap_or_else(|| panic!("'ank {verb}' declares a need"));
+            assert!(matches!(need, Need::All(_)), "{need:?}");
+            assert_eq!(need.flags(), [flag]);
+            let missing = form
+                .composed()
+                .err()
+                .unwrap_or_else(|| panic!("an empty 'ank {verb}' composed"));
+            assert!(missing.said.contains(flag), "{}", missing.said);
+            let mut filled_in = form.clone();
+            filled(&mut filled_in, flag, "a value");
+            let act = filled_in
+                .composed()
+                .unwrap_or_else(|e| panic!("'ank {verb} {flag}' did not compose: {}", e.said));
+            assert_eq!(act.verb, verb);
+            assert_eq!(act.args, [flag.to_string(), "a value".to_string()]);
+            assert_eq!(act.subject, Subject::Selected);
+        }
     }
 
     /// The lone dash never reaches an argv (ADR-c07e2694f0e1's null stdin).
@@ -808,7 +1254,7 @@ mod tests {
         assert_eq!(form.press(bare(KeyCode::Enter)), Filled::Compose);
         assert_eq!(form.press(bare(KeyCode::Esc)), Filled::Close);
         // Backspacing an empty field is not a way out: a form is not a prompt.
-        let mut empty = Form::open().expect("a form");
+        let mut empty = Form::open(MAKE).expect("a form");
         assert_eq!(empty.press(bare(KeyCode::Backspace)), Filled::Filling);
         assert!(empty.fields()[0].entry.blank());
     }

--- a/crates/ank-tui/src/input.rs
+++ b/crates/ank-tui/src/input.rs
@@ -114,13 +114,19 @@ pub enum Command {
     /// what it opens is a list of what this reader does not run, so there is
     /// nothing for a person to have typed.
     Further,
-    /// The form `ank new` is filled in on (TASK-d832452630d2).
+    /// The form one verb is filled in on, named
+    /// (TASK-d832452630d2, TASK-e8da6a00564a).
     ///
     /// A key and no word, like [`Command::Further`]: what it opens is a form
     /// whose fields are read out of the contract, and a line that spelled the
-    /// verb would be the second road to a write ADR-c07e2694f0e1 closed. It
-    /// carries nothing, because what the form holds is the form's.
-    Form,
+    /// verb would be the second road to a write ADR-c07e2694f0e1 closed.
+    ///
+    /// It carries the verb and nothing else. There are four forms now -- `new`,
+    /// `edit`, `close` and `attest` -- and what differs between them is entirely
+    /// read out of the contract against this one string, so a fifth is a row of
+    /// [`crate::form::NEEDS`] and never an arm here. What the form *holds* is
+    /// still the form's.
+    Form(&'static str),
     /// A line that asked for nothing: an empty prompt, or one carrying only
     /// whitespace.
     Nothing,

--- a/crates/ank-tui/src/keys.rs
+++ b/crates/ank-tui/src/keys.rs
@@ -11,13 +11,13 @@
 //!
 //! **Every command is a key, and the verbs are keys too**
 //! (TASK-1a415107fd56). `c` claims, `l` logs, `d` finishes, `r` releases, `m`
-//! amends and `a` ratifies -- the initial the CLI already spells, which is
-//! ADR-c07e2694f0e1's rule and the whole of why these letters. What only moves
+//! amends, `a` ratifies, `n` makes and `e` edits -- the initial the CLI already
+//! spells, which is ADR-c07e2694f0e1's rule and the whole of why these letters. What only moves
 //! the screen takes what is left: `j` and `k` move, Space pages, `g` goes to
 //! the top, Enter opens, `b` goes back, `s` shows the constraints, `v` opens
 //! the queue, `u` reads the corpus again, `f` narrows to the next kind, `x`
-//! names the verbs this reader does not run, `?` says what all of them are,
-//! `q` quits. Each has an arrow or a named key beside it -- Down for `j`,
+//! opens the three verbs with no letter of their own, `?` says what all of them
+//! are, `q` quits. Each has an arrow or a named key beside it -- Down for `j`,
 //! PageDown for Space, Home for `g`, Escape for `b` -- because a person who has
 //! never read the key line still has hands.
 //!
@@ -56,13 +56,14 @@
 //! one-line prompt seeded with a slash and what is typed there goes through
 //! [`crate::input::parse`]; no word that grammar reads writes anything, and the
 //! prompt a verb used to be spelled into is gone with the key that opened it.
-//! What the six carried in a tail -- a message, a reason, a proof, a flag --
-//! comes back as a form, and TASK-e8da6a00564a is where. The form itself
-//! arrived with TASK-d832452630d2, on the seventh verb: `n` opens
-//! [`crate::form`], whose fields are the flags the contract declares for `ank
-//! new` and which is modal, so no letter typed into it is a command and no
-//! word typed into it reaches a verb -- what reaches one is Enter, and what
-//! Enter reaches is the confirmation.
+//! What a verb carries in a tail -- a message, a reason, a proof, a field --
+//! comes back as a form. It arrived with TASK-d832452630d2, on `ank new`, and
+//! TASK-e8da6a00564a puts `edit`, `close` and `attest` on the same one: `n` and
+//! `e` open [`crate::form`], and so does a row of the list `x` opens. Its
+//! fields are the flags the contract declares for the verb, and it is modal, so
+//! no letter typed into it is a command and no word typed into it reaches a
+//! verb -- what reaches one is Enter, and what Enter reaches is the
+//! confirmation.
 //!
 //! # The guarantee, now that the letter is one keystroke
 //!
@@ -366,12 +367,15 @@ mod tests {
                 panic!("'l' in {view:?} is {reached:?}");
             };
             assert_eq!(act.verb, "log");
-            // `n` is `new`, which opens a form and moves no cursor either.
-            assert_eq!(
-                press('n', view),
-                Press::Run(Command::Form),
-                "'n' in {view:?}"
-            );
+            // `n` is `new` and `e` is `edit`: each opens a form, and neither
+            // moves a cursor either.
+            for (c, verb) in [('n', "new"), ('e', "edit")] {
+                assert_eq!(
+                    press(c, view),
+                    Press::Run(Command::Form(verb)),
+                    "'{c}' in {view:?}"
+                );
+            }
         }
     }
 

--- a/crates/ank-tui/src/view.rs
+++ b/crates/ank-tui/src/view.rs
@@ -229,7 +229,7 @@
 
 use crate::ank::{Ank, Failed, Ran};
 use crate::bindings::{self, Binding, Holding};
-use crate::form::{self, Filled, Form};
+use crate::form::{Filled, Form};
 use crate::input::{Act, Command, Subject};
 use crate::keys::{self, Editing, Press};
 use crate::model::{self, short_of, Detail, Queue, Row, Snapshot};
@@ -422,6 +422,23 @@ enum Listed {
     Through,
 }
 
+/// What the list `x` opens did with a key pressed over it (TASK-e8da6a00564a).
+///
+/// [`Listed`] with a third answer, and the third is the whole difference between
+/// the two lists: a row of the key list is a key, so pressing it is
+/// [`App::press`] again and there is nothing to hand back; a row of this one is
+/// a verb with no key, so what a press on it produces is the verb itself.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Opened {
+    /// The list answered it: the cursor moved, or the list closed.
+    Answered,
+    /// The row under the cursor was opened, and this is the verb it names.
+    Ran(&'static str),
+    /// The list has no answer for it. It closes, and the key goes on to the
+    /// reader as if the list had not been there.
+    Through,
+}
+
 pub struct App {
     size: (usize, usize),
     focus: Focus,
@@ -504,6 +521,23 @@ pub struct App {
     /// grammar, and what it composes reaches the confirmation like every other
     /// act.
     form: Option<Form>,
+    /// The list `x` opens, with the row of it the cursor is on
+    /// (TASK-e8da6a00564a).
+    ///
+    /// `None` is the ordinary state and it costs nothing at rest, for the key
+    /// list's reason and the form's: it is drawn *over* the panels rather than
+    /// into a band the layout gave rows up for, so [`App::arrange`] does not
+    /// know it exists and closing it gives back exactly the frame that was
+    /// there. It is cheaper at rest than what it replaced -- `x` used to fill
+    /// the note band with two lines, and the note band is measured by
+    /// `arrange`.
+    ///
+    /// A cursor and not a flag, because this list is not a list of keys. Every
+    /// row of the key list *is* the key it names and a press on it presses that
+    /// key; these three verbs have no key, so the row is opened the way a row
+    /// of any listing is opened -- the cursor walks, and Enter opens what it is
+    /// on. One vocabulary, applied to an overlay.
+    beyond: Option<usize>,
 }
 
 impl App {
@@ -537,6 +571,7 @@ impl App {
             glyphs: Glyphs::detect(),
             overlay: None,
             form: None,
+            beyond: None,
         }
     }
 
@@ -782,6 +817,22 @@ impl App {
         if self.form.is_some() {
             return self.filling(key, ank);
         }
+        // After the form, which is where words are typed, and before the key
+        // list, which is a different list with a different grammar: this one has
+        // a cursor, because its rows are verbs with no keys.
+        if self.beyond.is_some() {
+            match self.over_beyond(key) {
+                Opened::Answered => return false,
+                Opened::Ran(verb) => {
+                    self.beyond = None;
+                    return self.act(bindings::beyond(verb), ank);
+                }
+                // The list closes on a key it has no answer for, and that key
+                // goes on to do what it does -- the key list's rule, for the
+                // key list's reason.
+                Opened::Through => self.beyond = None,
+            }
+        }
         if self.overlay.is_some() {
             match self.over_list(key) {
                 Listed::Answered => return false,
@@ -853,6 +904,17 @@ impl App {
                     }
                     return false;
                 }
+                // The list `x` opened is over the panels and over the bands
+                // like the other two, and a touch on a row of it opens that row
+                // -- which is what Enter does on it, and the whole of what
+                // ADR-c07e2694f0e1 asks of an offer: a thumb reaches it.
+                if self.beyond.is_some() {
+                    let Some(verb) = self.beyond_at(at) else {
+                        return false;
+                    };
+                    self.beyond = None;
+                    return self.act(bindings::beyond(verb), ank);
+                }
                 if self.overlay.is_some() {
                     return match self.list_at(at) {
                         Some(binding) => self.ran(binding, ank),
@@ -909,6 +971,12 @@ impl App {
             form.press(KeyEvent::new(key, KeyModifiers::NONE));
             return false;
         }
+        // A swipe over the list `x` opened walks its cursor, which is what the
+        // arrows do on it: what a scroll moves is what the finger is on.
+        if self.beyond.is_some() {
+            self.walk_beyond(by);
+            return false;
+        }
         // A swipe over the key list scrolls the key list, which is the same
         // rule: what a scroll moves is what the finger is on.
         if self.overlay.is_some() {
@@ -947,6 +1015,55 @@ impl App {
             _ => return Listed::Through,
         }
         Listed::Answered
+    }
+
+    /// What one key does to the list `x` opened under it (TASK-e8da6a00564a).
+    ///
+    /// **Read as commands and never as letters**, which is [`App::over_list`]'s
+    /// rule and keeps this from being a sixth key table. What differs is what
+    /// the commands mean here, and it is what the two lists *are*: every row of
+    /// the key list is a key, so movement scrolls it and a row is reached by
+    /// pressing the key it names; no row of this one is a key, so movement walks
+    /// a cursor and `open` -- Enter, which is the same command that opens a row
+    /// of any panel -- opens the row it is on.
+    ///
+    /// Not modal, and for the key list's reason: what a person must not have
+    /// move under them is a command they are saying yes to, and this list has
+    /// nothing to say yes to yet. The confirmation is where that starts.
+    fn over_beyond(&mut self, key: KeyEvent) -> Opened {
+        let Press::Run(command) = keys::typed(key, self.focus) else {
+            return Opened::Through;
+        };
+        match command {
+            Command::Move(by) => self.walk_beyond(by),
+            Command::Top => self.beyond = Some(0),
+            Command::Open => {
+                if let Some(verb) = self.beyond_verb() {
+                    return Opened::Ran(verb);
+                }
+            }
+            // The key the list is named after, and `back`, which is where Esc
+            // lands.
+            Command::Further | Command::Back => self.beyond = None,
+            _ => return Opened::Through,
+        }
+        Opened::Answered
+    }
+
+    /// The cursor of that list, moved, and never off either end.
+    ///
+    /// Clamped against the rows that name a verb rather than against the rows
+    /// drawn: the note under them is prose, and a cursor that could stand on it
+    /// would be a cursor Enter has no answer for.
+    fn walk_beyond(&mut self, by: isize) {
+        let last = bindings::FURTHER.len().saturating_sub(1);
+        let at = self.beyond.unwrap_or(0) as isize + by;
+        self.beyond = Some(at.clamp(0, last as isize) as usize);
+    }
+
+    /// The verb the cursor of that list is on, where it is on one.
+    fn beyond_verb(&self) -> Option<&'static str> {
+        bindings::FURTHER.get(self.beyond?).copied()
     }
 
     /// The key list, moved by this many rows, and never past either end.
@@ -1149,35 +1266,61 @@ impl App {
             // read by `press` before the dispatch is reached, so this arm only
             // ever runs on a screen that has none.
             Command::Help => self.overlay = Some(0),
-            // The three §4 verbs this reader has no road to, named in the note
-            // band and not over the panels (TASK-1a415107fd56). It is two rows
-            // and it is not a list a finger acts on: every row of the overlay
-            // *is* the key it names, and none of these three is a key at all,
-            // so drawing them there would be the one thing that list must never
-            // carry.
-            Command::Further => self.note = Some(bindings::further().join("\n")),
+            // The three §4 verbs with no letter of their own, opened as a list
+            // over the panels (TASK-1a415107fd56, TASK-e8da6a00564a). It was
+            // two lines in the note band while it was only a list; it is an
+            // overlay now, because a row a person opens has to be a rectangle a
+            // finger fits in, and because the note band is a row `arrange`
+            // measures and this costs none.
+            //
+            // Not the key list, and never a row of it: every row of *that*
+            // overlay is the key it names, and none of these three is a key at
+            // all.
+            Command::Further => self.beyond = Some(0),
             // The form, opened. Nothing is composed here and nothing is
             // spawned: what a person fills in reaches `propose` through
             // `App::filling`, and the confirmation is on that road like every
             // other (TASK-d832452630d2).
-            Command::Form => match Form::open() {
-                Some(form) => self.form = Some(form),
-                // A build whose contract declares no `new` at all. Said rather
-                // than drawn as an empty form: a form with no fields is a
-                // screen that reads as a defect of the reader.
-                None => {
-                    self.note = Some(format!(
-                        "this build of ank declares no '{}' to make one with",
-                        form::VERB
-                    ))
-                }
-            },
+            Command::Form(verb) => self.open_form(verb),
             Command::Nothing => {}
             Command::Unknown(word) => {
                 self.note = Some(format!("no command '{word}'; ? for the list"))
             }
         }
         false
+    }
+
+    /// The form for one verb, opened over the panels (TASK-e8da6a00564a).
+    ///
+    /// **The entity is looked for before the form opens and not after it is
+    /// filled in.** Three of the four verbs a form serves take `<id>` first, so
+    /// a form composed with no row under the cursor would be refused by
+    /// [`App::propose`] -- after a person had typed a title into it, and with
+    /// everything they typed gone. The refusal is `propose`'s own sentence,
+    /// said here where it costs nothing.
+    ///
+    /// `ank new` is the one that asks for no entity, and the question is asked
+    /// of the verb's own subcommands rather than of its name: a verb that
+    /// supplies its own first positional needs no row, exactly as
+    /// `crate::form::Form::composed` decides the same thing the same way.
+    fn open_form(&mut self, verb: &'static str) {
+        let Some(form) = Form::open(verb) else {
+            // A build whose contract does not declare the verb, or declares it
+            // with nothing this reader will compose without. Said rather than
+            // drawn as an empty form: a form with no fields is a screen that
+            // reads as a defect of the reader, and one with nothing mandatory
+            // is a form whose empty submission opens an editor.
+            self.note = Some(format!(
+                "this build of ank has no form for '{verb}': it declares no such verb, or nothing \
+                 the verb cannot do without"
+            ));
+            return;
+        };
+        if form.kinds().is_empty() && self.target().is_none() {
+            self.note = Some(NOTHING_NAMED.to_string());
+            return;
+        }
+        self.form = Some(form);
     }
 
     /// Move focus, and pay whatever the panel arriving costs.
@@ -1236,10 +1379,7 @@ impl App {
         // name, so a second verb of that shape declares itself.
         if act.subject == Subject::Selected {
             let Some(id) = self.target() else {
-                self.note = Some(
-                    "no entity is named here: move onto a row, or open one into the body"
-                        .to_string(),
-                );
+                self.note = Some(NOTHING_NAMED.to_string());
                 return;
             };
             args.push(id);
@@ -1652,6 +1792,7 @@ impl App {
         // key the list passes through and opening the form closes it.
         self.list(area, buf);
         self.form(area, buf);
+        self.beyond(area, buf);
     }
 
     /// One panel: its border, its title, and the lines it holds.
@@ -2636,6 +2777,94 @@ impl App {
     }
 
     // -----------------------------------------------------------------------
+    // The list `x` opens, and where a finger lands on it (TASK-e8da6a00564a)
+    // -----------------------------------------------------------------------
+
+    /// The rows of that list, wrapped to the width the overlay draws them at,
+    /// each with the verb opening it reaches.
+    ///
+    /// [`bindings::further`] and never a second rendering of the same three
+    /// verbs: a row a person can see and a row a press resolves to are the same
+    /// row, or they are two and the screen answers somewhere other than where
+    /// it was touched. Wrapped rather than cut, because the note under them is
+    /// a sentence; every row of a wrapped entry carries the same verb, so a
+    /// press anywhere on it opens what it names.
+    fn beyond_lines(&self) -> Vec<(String, Option<&'static str>)> {
+        let width = inside(self.list_rect(self.area())).width as usize;
+        bindings::further()
+            .into_iter()
+            .flat_map(|row| {
+                let verb = row.verb;
+                let marker = match verb == self.beyond_verb() {
+                    true => text::CURSOR,
+                    false => text::PLAIN,
+                };
+                wrap(&format!("{marker}{}", row.text), width.max(1))
+                    .into_iter()
+                    .map(move |line| (line, verb))
+            })
+            .collect()
+    }
+
+    /// The verb a press on that list reached.
+    ///
+    /// `None` on the note, on the border, and on a row past the end of a list
+    /// shorter than its window. A press that named no verb does nothing at all
+    /// rather than closing the list -- a finger that missed is a finger that
+    /// missed, which is [`App::list_at`]'s rule and the same one.
+    fn beyond_at(&self, at: Position) -> Option<&'static str> {
+        self.beyond?;
+        let inside = inside(self.list_rect(self.area()));
+        if !inside.contains(at) {
+            return None;
+        }
+        let row = (at.y - inside.y) as usize;
+        self.beyond_lines().get(row).and_then(|(_, verb)| *verb)
+    }
+
+    /// That list, drawn over the frame it was asked for from.
+    ///
+    /// Cleared first for the key list's reason: a `Block` paints a border and a
+    /// `Paragraph` paints the rows it was given, so the cells between the last
+    /// row and the bottom border would otherwise still carry whatever panel is
+    /// underneath.
+    ///
+    /// Not scrolled, and it is the one overlay that is not: the key list is
+    /// thirty-seven rows and the form is nine, and this is three and a
+    /// sentence. What a window too short for it loses is the sentence, which is
+    /// why the rows come first.
+    fn beyond(&self, area: Rect, buf: &mut Buffer) {
+        if self.beyond.is_none() {
+            return;
+        }
+        let rect = self.list_rect(area);
+        if rect.width < 2 || rect.height < 2 {
+            return;
+        }
+        let inside = inside(rect);
+        let heading = format!(
+            "MORE VERBS   {} closes",
+            named(bindings::of_command(&Command::Further).map_or(KeyCode::Esc, |b| b.key))
+        );
+        let title = Composed::new()
+            .plain(text::CURSOR)
+            .plain(&heading)
+            .fitted(rect.width as usize - 2);
+        Clear.render(rect, buf);
+        Block::bordered()
+            .border_set(self.glyphs.border(true))
+            .title(title.line(self.ink))
+            .render(rect, buf);
+        let rows: Vec<String> = self
+            .beyond_lines()
+            .iter()
+            .take(inside.height as usize)
+            .map(|(line, _)| fit(line, inside.width as usize))
+            .collect();
+        paragraph(&rows).render(inside, buf);
+    }
+
+    // -----------------------------------------------------------------------
     // The form, and where a finger lands on it (TASK-d832452630d2)
     // -----------------------------------------------------------------------
 
@@ -2707,11 +2936,7 @@ impl App {
             return;
         }
         let inside = inside(rect);
-        let heading = format!(
-            "NEW {}   {} closes",
-            form.kind().to_ascii_uppercase(),
-            named(KeyCode::Esc)
-        );
+        let heading = format!("{}   {} closes", form.banner(), named(KeyCode::Esc));
         let title = Composed::new()
             .plain(text::CURSOR)
             .plain(&heading)
@@ -3302,6 +3527,15 @@ pub const CONFIRM_KEY: &str = "y runs it -- every other key dismisses it, and no
 /// The command and not only the verdict: "nothing ran" is reassuring only to
 /// somebody who can see what did not.
 pub const DISMISSED: &str = "dismissed, and nothing was run:";
+/// What a verb that acts on an entity says where the screen names none.
+///
+/// One sentence and one constant (TASK-e8da6a00564a). It is said in two places
+/// -- before a form opens, so nothing typed into one is thrown away, and in
+/// front of the confirmation, where a composed act still has to find its
+/// subject -- and two spellings of one refusal would be two things for a person
+/// to work out are the same.
+pub const NOTHING_NAMED: &str =
+    "no entity is named here: move onto a row, or open one into the body";
 
 #[cfg(test)]
 mod tests {
@@ -5794,7 +6028,7 @@ mod tests {
 
     /// The key the form is opened with, out of the table.
     fn form_key() -> KeyCode {
-        bindings::of_verb(crate::form::VERB)
+        bindings::of_verb(crate::form::MAKE)
             .expect("a key opens the form")
             .key
     }

--- a/crates/ank-tui/tests/edit.rs
+++ b/crates/ank-tui/tests/edit.rs
@@ -1,0 +1,654 @@
+//! `e`, and the three verbs with no letter, through the binary, on a real
+//! terminal (TASK-e8da6a00564a).
+//!
+//! CLAUDE.md leaves no choice about where this is measured and the criterion
+//! names the instrument outright: *the built binary raises, on e, a form whose
+//! submission spells `ank edit <id>` with `--title`, `--body` or `--constraint`,
+//! and never a bare `ank edit <id>` ... measured with `$EDITOR` pointed at a
+//! script that writes a sentinel the test then finds absent*. Every clause of
+//! that is about a process, and this repository has twice shipped green unit
+//! tests over code the binary never reached.
+//!
+//! **The sentinel is proved to work before it is used as a negative**, exactly
+//! as `tests/entity.rs` proves it: the first thing done here is run
+//! `ank edit <id>` from a shell with the same `$EDITOR`, and find the sentinel
+//! *there*. So "the sentinel is absent" afterwards is a fact about the reader
+//! rather than about a script that never ran, and the call it is proved on is
+//! the very call the form must never compose.
+//!
+//! **The three with no letter are measured as three claims and not one.** That
+//! they are reachable at all, from `x` and from a row of the list it opens;
+//! that each spells the flags its verb requires -- `--reason` on `close`,
+//! `--proof` on `attest`, and nothing at all on `read`, which declares no flag;
+//! and that each stops at the same confirmation the lettered verbs stop at. The
+//! fourth claim is the corpus: every one of them is dismissed, and the bytes
+//! under `.ank/` and the refs under `refs/ank/` are compared before and after,
+//! because "nothing ran" is a claim about a git repository and not about a
+//! sentence on a screen.
+//!
+//! `#[cfg(unix)]` for the reason the other suites give: a pseudo-terminal on
+//! Windows is ConPTY, and reaching it means the console API this workspace does
+//! not otherwise call.
+
+#![cfg(unix)]
+
+mod terminal;
+
+use ank_tui::view::{ABOUT, DISMISSED, NOTHING_NAMED};
+use std::sync::Mutex;
+use terminal::{short_of, Editor, Live, Repo};
+
+/// One pseudo-terminal open at a time, in this suite.
+///
+/// `terminal::pty::open` asks `ptsname(3)` for the slave's path and that
+/// function answers out of a static buffer, so two threads opening a session at
+/// once can both attach to one terminal. LOG-3b0bc419c884 records the defect
+/// and where its fix belongs; this is the local answer `tests/verbs.rs` already
+/// takes.
+static ONE_AT_A_TIME: Mutex<()> = Mutex::new(());
+
+/// Wide enough that a composed `ank edit <id> --title ...` fits one row, so an
+/// assertion about an argv is an assertion about a line and not about a reflow.
+const WINDOW: (u16, u16) = (120, 34);
+
+const CONFIRM: char = ank_tui::keys::CONFIRM;
+
+/// The screen, flattened to one line, so an assertion about a command line
+/// survives the row it happens to have wrapped onto.
+fn flat(frame: &str) -> String {
+    frame
+        .lines()
+        .map(str::trim)
+        .collect::<Vec<&str>>()
+        .join(" ")
+        .split_whitespace()
+        .collect::<Vec<&str>>()
+        .join(" ")
+}
+
+/// The letter one verb is bound to, read out of the reader's own table.
+///
+/// Never spelled here. The whole of the wave is that a key *is* the verb, and a
+/// suite typing `e` because that is what `edit` happens to be bound to today
+/// would go on passing against a table that moved the letter.
+fn letter(verb: &str) -> String {
+    let binding = ank_tui::bindings::of_verb(verb)
+        .unwrap_or_else(|| panic!("'{verb}' is a verb this reader binds a key to"));
+    let named = ank_tui::bindings::named(binding.key);
+    assert_eq!(
+        named.chars().count(),
+        1,
+        "'{verb}' is named '{named}', which is not one keystroke to send"
+    );
+    named
+}
+
+/// The key that opens the list of verbs with no letter, out of the same table.
+fn key_of_further() -> String {
+    let binding = ank_tui::bindings::of_command(&ank_tui::input::Command::Further)
+        .expect("a key opens the list of verbs past the lettered ones");
+    ank_tui::bindings::named(binding.key)
+}
+
+/// The fields a form for one verb draws, in the order the contract declares
+/// them.
+fn fields_of(verb: &'static str) -> Vec<&'static str> {
+    ank_tui::form::Form::open(verb)
+        .unwrap_or_else(|| panic!("this build declares a form for 'ank {verb}'"))
+        .fields()
+        .iter()
+        .map(|f| f.flag)
+        .collect()
+}
+
+/// The flags one form will not compose without, as the reader has them.
+fn needed(verb: &str) -> &'static [&'static str] {
+    ank_tui::form::need(verb, "")
+        .unwrap_or_else(|| panic!("'ank {verb}' declares what it will not compose without"))
+        .flags()
+}
+
+/// Focuses the entities panel and puts the cursor on one entity, by narrowing
+/// the listing to it.
+///
+/// By identifier and through the search, which is the one line this reader
+/// still takes: the needle leaves one row and a search puts the cursor back at
+/// the top, so the panel names the entity meant rather than whichever one
+/// `find` happened to put first.
+fn select(live: &mut Live, id: &str) {
+    live.send("2");
+    live.until("the entities panel to take the focus", |t| {
+        t.contains("> 2 ENTITIES")
+    });
+    live.send(&format!("{}{}\r", ank_tui::keys::FIND, short_of(id)));
+    live.until("the listing to narrow to one row", |t| {
+        t.contains("ENTITIES all 1")
+    });
+}
+
+/// Opens the form for one verb and waits until it is on the screen.
+fn open_form(live: &mut Live, verb: &str, by: &str) {
+    live.send(by);
+    live.until(&format!("the form for '{verb}' to open"), |t| {
+        t.contains(&banner(verb))
+    });
+}
+
+/// What a form's own border says while it is being filled in.
+fn banner(verb: &str) -> String {
+    verb.to_ascii_uppercase()
+}
+
+/// Whether the cursor is on the row this flag names.
+fn on_field(frame: &str, flag: &str) -> bool {
+    frame
+        .lines()
+        .any(|line| line.contains("> ") && named_on(line, flag))
+}
+
+/// Whether a drawn row is this flag's, repeat marker and all.
+fn named_on(line: &str, flag: &str) -> bool {
+    line.split_whitespace()
+        .any(|word| word.trim_end_matches("...") == flag)
+}
+
+/// Walks the cursor from the field the form opens on to the one named, and
+/// types a value into it.
+///
+/// The walk counts its steps from the first field, which is where a form opens,
+/// and the rows are visited in the order the contract declares them: a walk
+/// that assumed where the cursor already was would be a suite driving a form it
+/// had not looked at.
+fn fill(live: &mut Live, verb: &'static str, flag: &str, value: &str) {
+    let at = fields_of(verb)
+        .iter()
+        .position(|f| *f == flag)
+        .unwrap_or_else(|| panic!("'{flag}' is a field of the form for 'ank {verb}'"));
+    for _ in 0..at {
+        live.send("\t");
+    }
+    live.until(&format!("the cursor to reach {flag}"), |t| {
+        on_field(t, flag)
+    });
+    live.send(value);
+    live.until(&format!("'{value}' to be typed into {flag}"), |t| {
+        t.lines()
+            .any(|line| named_on(line, flag) && line.contains(value))
+    });
+}
+
+/// A value with a space in it, so what the confirmation shows is a command line
+/// a shell would have had to quote.
+fn sentence(flag: &str) -> String {
+    format!("a value for {}", flag.trim_start_matches("--"))
+}
+
+/// The command line the reader would spell for a verb, its entity and one flag.
+fn spelled(verb: &str, id: &str, flag: &str) -> String {
+    format!("ank {verb} {id} {flag} '{}' --json", sentence(flag))
+}
+
+/// Dismisses the command waiting on the screen and reads the frame after it.
+fn dismiss(live: &mut Live, what: &str) -> String {
+    live.send("\u{1b}");
+    live.until(&format!("'{what}' to be dismissed"), |t| {
+        flat(t).contains(DISMISSED)
+    });
+    let after = live.frame();
+    assert!(
+        !after.contains("error["),
+        "'{what}' reached the CLI on a dismissal:\n{after}"
+    );
+    after
+}
+
+// ---------------------------------------------------------------------------
+// e, and the editor it must never reach
+// ---------------------------------------------------------------------------
+
+/// **`e` raises a form whose submission names a field, and never a bare
+/// `ank edit <id>`** (TASK-e8da6a00564a).
+///
+/// The criterion's dangerous half, measured the way the criterion asks. `ank
+/// edit <id>` with no field named opens `$EDITOR` on the whole entity, and this
+/// reader's child is spawned with `output()`'s null stdin from a process
+/// holding the terminal in raw mode on the alternate screen -- so an editor
+/// reached from here is a hang and not an error on the screen.
+///
+/// The sentinel is proved first, from a shell, on that very call. Then the form
+/// is submitted empty -- which is the state a composing key would have produced
+/// outright -- and what has to be true is three things at once: it refused, no
+/// confirmation appeared, and the sentinel is still not there. Then each of the
+/// three fields is filled in alone, and each composes a command line that names
+/// it.
+#[test]
+fn e_raises_a_form_that_names_a_field_and_never_composes_a_bare_edit() {
+    let _one = ONE_AT_A_TIME
+        .lock()
+        .unwrap_or_else(|held| held.into_inner());
+    let repo = Repo::seeded();
+    let editor = Editor::beside(&repo);
+    let task = repo.only(&["--type", "task"]);
+
+    // The instrument, checked. `ank edit <id>` with no field named is exactly
+    // the call the form must never compose, and from a shell it reaches the
+    // editor -- which is what makes the absence below a measurement.
+    let tried = repo.tried(&["edit", &task], &editor.env());
+    assert!(
+        editor.ran(),
+        "the sentinel never appeared even from a shell, so this suite would \
+         measure nothing: {}",
+        String::from_utf8_lossy(&tried.stderr)
+    );
+    editor.forget();
+
+    repo.warm();
+    let before = repo.corpus();
+    let refs = repo.refs();
+    assert!(!before.is_empty(), "the corpus has files to compare");
+
+    let mut live = Live::with(&repo, WINDOW.0, WINDOW.1, &editor.env());
+    live.until("the session to open", |t| t.contains("2 ENTITIES"));
+    select(&mut live, &task);
+
+    // Empty, which is the whole of what a composing key would have spelled.
+    open_form(&mut live, "edit", &letter("edit"));
+    live.send("\r");
+    live.until("the form to refuse an edit that names no field", |t| {
+        flat(t).contains("every field is empty")
+    });
+    let said = live.frame();
+    let refusal = flat(&said);
+    assert!(
+        !refusal.contains(ABOUT),
+        "an edit naming no field composed a command:\n{said}"
+    );
+    for flag in needed("edit") {
+        assert!(
+            refusal.contains(flag),
+            "the refusal does not name {flag}:\n{said}"
+        );
+    }
+    assert!(
+        said.contains(&banner("edit")),
+        "the form closed on a refusal, and everything typed with it:\n{said}"
+    );
+    editor.never_ran("on a form that named no field");
+    live.send("\u{1b}");
+    live.until("the form to close", |t| !t.contains(&banner("edit")));
+
+    // And each of the three fields alone composes a command line that names it.
+    for flag in needed("edit") {
+        open_form(&mut live, "edit", &letter("edit"));
+        fill(&mut live, "edit", flag, &sentence(flag));
+        let wanted = spelled("edit", &task, flag);
+        live.send("\r");
+        live.until(&format!("the confirmation for an edit of {flag}"), |t| {
+            flat(t).contains(&wanted)
+        });
+        let asking = live.frame();
+        let asked = flat(&asking);
+        assert!(
+            asked.contains(ABOUT),
+            "an edit of {flag} was not asked about:\n{asking}"
+        );
+        assert!(
+            asked.contains(&format!("{CONFIRM} runs it")),
+            "an edit of {flag} offered no key to run it with:\n{asking}"
+        );
+        // The form is gone: what is being answered for is the command line, and
+        // a form still on the screen would be a second thing to read.
+        assert!(
+            !asking.contains(&banner("edit")),
+            "the form is still drawn over the command it composed:\n{asking}"
+        );
+        let after = dismiss(&mut live, flag);
+        assert!(
+            flat(&after).contains(&wanted),
+            "the dismissal did not say what it had not done:\n{after}"
+        );
+        editor.never_ran(&format!(
+            "while an edit of {flag} was composed and dismissed"
+        ));
+    }
+
+    live.quit();
+    editor.never_ran("during the session");
+    assert_eq!(
+        before,
+        repo.corpus(),
+        "a file under .ank/ moved, and every composed edit was dismissed"
+    );
+    assert_eq!(
+        refs,
+        repo.refs(),
+        "a ref under refs/ank/ moved, and every composed edit was dismissed"
+    );
+}
+
+/// **A confirmed edit writes the field it named, and `ank show` says so**
+/// (TASK-e8da6a00564a).
+///
+/// The half that keeps the test above from being vacuous: a form that refused
+/// everything would pass every assertion in it and be a reader nobody can edit
+/// anything with. What is compared is the title on the screen with the title in
+/// the corpus, because there is no second dispatch path -- the reader spawned
+/// `ank edit`, and what it drew is the document that verb answered with.
+///
+/// And the editor still never ran, on the one call in this whole suite that
+/// reaches the CLI at all.
+#[test]
+fn a_confirmed_edit_writes_the_field_it_named_and_no_editor_was_opened() {
+    let _one = ONE_AT_A_TIME
+        .lock()
+        .unwrap_or_else(|held| held.into_inner());
+    let repo = Repo::seeded();
+    let editor = Editor::beside(&repo);
+    repo.warm();
+    let task = repo.only(&["--type", "task"]);
+    const TITLE: &str = "A title the reader wrote through a form";
+
+    let mut live = Live::with(&repo, WINDOW.0, WINDOW.1, &editor.env());
+    live.until("the session to open", |t| t.contains("2 ENTITIES"));
+    select(&mut live, &task);
+
+    open_form(&mut live, "edit", &letter("edit"));
+    fill(&mut live, "edit", "--title", TITLE);
+    live.send("\r");
+    live.until("the confirmation for the edit", |t| {
+        flat(t).contains(&format!("ank edit {task} --title '{TITLE}'"))
+    });
+    live.send(&CONFIRM.to_string());
+    live.until("the edit to be answered", |t| flat(t).contains("changed"));
+    let answered = live.frame();
+    assert!(
+        !answered.contains("error["),
+        "the confirmed edit was refused:\n{answered}"
+    );
+
+    live.quit();
+    editor.never_ran("while an edit was composed, confirmed and answered");
+
+    let doc = repo.stdout(&["show", &task, "--json"]);
+    assert!(
+        doc.contains(TITLE),
+        "'ank show {task}' does not carry the title the reader wrote:\n{doc}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// close, attest and read: from x, and from no key
+// ---------------------------------------------------------------------------
+
+/// **No key of the table reaches `close`, `attest` or `read`**
+/// (TASK-e8da6a00564a).
+///
+/// Stated over the table rather than over the three letters a suite might try,
+/// because "from no key" is a claim about the whole of it: a row added later
+/// that spelled one of these would be a fourth letter spent and this list is
+/// where the offer belongs. It is the other half of the sentence the criterion
+/// makes -- *reached from x, and from no key* -- and the first half is measured
+/// through the binary below.
+#[test]
+fn no_letter_of_the_table_spells_the_three_verbs_the_list_opens() {
+    for verb in ank_tui::bindings::FURTHER {
+        assert!(
+            ank_tui::bindings::of_verb(verb).is_none(),
+            "'{verb}' has a key of its own, and the list `x` opens is for the \
+             verbs that have none"
+        );
+    }
+    // Not vacuous: a verb that *does* have one answers.
+    assert!(ank_tui::bindings::of_verb("edit").is_some());
+}
+
+/// **`close`, `attest` and `read` are reached from the list `x` opens, each
+/// with the flags its verb requires, and each stops at the same confirmation**
+/// (TASK-e8da6a00564a).
+///
+/// Three verbs and three shapes, and the shapes are the verbs' own. `close`
+/// will not run without `--reason` and `attest` will not run without `--proof`,
+/// so each of those opens a form; `read` declares no flag at all, so it goes
+/// straight to the confirmation with the identifier and nothing else. What is
+/// the same for all three is the last step, which is the whole of the
+/// guarantee: the argv is on the screen, and one key runs it.
+///
+/// Every one is dismissed, and the corpus and the refs are compared byte for
+/// byte afterwards -- because the criterion asks for the bytes and the refs,
+/// not for the intent.
+#[test]
+fn the_three_verbs_the_list_opens_reach_the_confirmation_and_dismissing_writes_nothing() {
+    let _one = ONE_AT_A_TIME
+        .lock()
+        .unwrap_or_else(|held| held.into_inner());
+    let repo = Repo::seeded();
+    let editor = Editor::beside(&repo);
+    repo.warm();
+    let task = repo.only(&["--type", "task"]);
+    let before = repo.corpus();
+    let refs = repo.refs();
+    assert!(!before.is_empty(), "the corpus has files to compare");
+
+    let mut live = Live::with(&repo, WINDOW.0, WINDOW.1, &editor.env());
+    live.until("the session to open", |t| t.contains("2 ENTITIES"));
+    select(&mut live, &task);
+
+    // Not on the screen before it is asked for, so every wait below is waiting
+    // for something.
+    assert!(
+        !live.frame().contains("attest"),
+        "the list is on the screen before anybody asked for it"
+    );
+
+    let further = key_of_further();
+    for (at, verb) in ank_tui::bindings::FURTHER.iter().enumerate() {
+        live.send(&further);
+        live.until("the list to be drawn", |t| t.contains("MORE VERBS"));
+        let list = live.frame();
+        assert!(
+            !flat(&list).contains(ABOUT) && !list.contains("error["),
+            "the list ran something by being opened:\n{list}"
+        );
+        // Down to the row this verb is on, and Enter to open it: the cursor and
+        // the key that opens a row, which is what every listing in this reader
+        // answers to.
+        for _ in 0..at {
+            live.send("j");
+        }
+        live.until(&format!("the cursor to reach '{verb}'"), |t| {
+            t.lines()
+                .any(|line| line.contains("> ") && line.contains(verb))
+        });
+        live.send("\r");
+
+        let wanted = match ank_tui::form::serves(verb) {
+            // A verb whose mandatory flag has to be filled in first.
+            true => {
+                let flag = needed(verb)[0];
+                live.until(&format!("the form for '{verb}' to open"), |t| {
+                    t.contains(&banner(verb))
+                });
+                let form = live.frame();
+                for field in fields_of(verb) {
+                    assert!(
+                        form.lines().any(|line| named_on(line, field)),
+                        "the form for '{verb}' does not draw {field}:\n{form}"
+                    );
+                }
+                fill(&mut live, verb, flag, &sentence(flag));
+                live.send("\r");
+                spelled(verb, &task, flag)
+            }
+            // `ank read <id>`: §4 gives it no flag, so there is nothing to fill
+            // in and the identifier is the whole of the tail.
+            false => format!("ank {verb} {task} --json"),
+        };
+
+        live.until(&format!("the confirmation for '{verb}'"), |t| {
+            flat(t).contains(&wanted)
+        });
+        let asking = live.frame();
+        let asked = flat(&asking);
+        assert!(
+            asked.contains(ABOUT),
+            "'{verb}' was not asked about:\n{asking}"
+        );
+        assert!(
+            asked.contains(&format!("{CONFIRM} runs it")),
+            "'{verb}' offered no key to run it with:\n{asking}"
+        );
+        assert!(
+            !asking.contains("error["),
+            "'{verb}' reached the CLI before it was answered:\n{asking}"
+        );
+        let after = dismiss(&mut live, verb);
+        assert!(
+            flat(&after).contains(&wanted),
+            "the dismissal of '{verb}' did not say what it had not done:\n{after}"
+        );
+    }
+
+    live.quit();
+    editor.never_ran("while three verbs were composed and dismissed");
+    assert_eq!(
+        before,
+        repo.corpus(),
+        "a file under .ank/ moved, and every one of the three was dismissed"
+    );
+    assert_eq!(
+        refs,
+        repo.refs(),
+        "a ref under refs/ank/ moved, and every one of the three was dismissed"
+    );
+}
+
+/// **A row of that list is a target a thumb reaches, and confirming one runs
+/// the verb** (TASK-e8da6a00564a, ADR-c07e2694f0e1).
+///
+/// Two halves that belong together. The touch, because the decision asks that
+/// every action the reader offers be reachable by a finger and this list is
+/// where three verbs now live; and the confirmation answered `yes`, because a
+/// list every row of which stopped at a refusal would satisfy the test above
+/// and be a reader nobody can read an entity with.
+///
+/// `read` is the one taken all the way, and it is the right one: it writes a
+/// reading onto the entity and touches no ref, so what it changed is
+/// `ank show`'s answer and nothing else.
+#[test]
+fn a_touch_on_a_row_of_the_list_opens_it_and_confirming_runs_the_verb() {
+    let _one = ONE_AT_A_TIME
+        .lock()
+        .unwrap_or_else(|held| held.into_inner());
+    let repo = Repo::seeded();
+    let editor = Editor::beside(&repo);
+    repo.warm();
+    let task = repo.only(&["--type", "task"]);
+    // The `verified:` block of the entity, one entry per reading. Counted off
+    // `ank show --json`, whose `content` is the document itself, so what is
+    // compared is the corpus and not a sentence the reader drew.
+    let readings = |doc: &str| doc.matches("- by: ").count();
+    let before = readings(&repo.stdout(&["show", &task, "--json"]));
+
+    let mut live = Live::with(&repo, WINDOW.0, WINDOW.1, &editor.env());
+    live.until("the session to open", |t| t.contains("2 ENTITIES"));
+    select(&mut live, &task);
+
+    live.send(&key_of_further());
+    live.until("the list to be drawn", |t| t.contains("MORE VERBS"));
+    let list = live.frame();
+    let row = list
+        .lines()
+        .position(|line| line.contains("read "))
+        .unwrap_or_else(|| panic!("no row of the list names 'read':\n{list}"));
+    let column = list
+        .lines()
+        .nth(row)
+        .expect("the row")
+        .find("read")
+        .expect("the word") as u16;
+    live.tap(column, row as u16);
+
+    let wanted = format!("ank read {task} --json");
+    live.until("the confirmation a touch composed", |t| {
+        flat(t).contains(&wanted)
+    });
+    let asking = live.frame();
+    assert!(
+        flat(&asking).contains(ABOUT),
+        "a touch on the row composed nothing to answer for:\n{asking}"
+    );
+    live.send(&CONFIRM.to_string());
+    live.until("the reading to be recorded", |t| {
+        flat(t).contains("readings")
+    });
+    let answered = live.frame();
+    assert!(
+        !answered.contains("error["),
+        "the confirmed read was refused:\n{answered}"
+    );
+
+    live.quit();
+    editor.never_ran("while a verb was reached by touch");
+    let after = readings(&repo.stdout(&["show", &task, "--json"]));
+    assert!(
+        after > before,
+        "the reader spawned 'ank read' and the entity carries no more readings \
+         than it did ({before} then, {after} now)"
+    );
+}
+
+/// **A form for a verb that names an entity refuses before it opens where the
+/// screen names none** (TASK-e8da6a00564a).
+///
+/// The order is the whole of the point. Three of the four verbs a form serves
+/// take `<id>` first, so a form filled in over a screen with no row under the
+/// cursor would be refused after a person had typed into it -- and everything
+/// they typed would go with it. The refusal is said in front, where it costs
+/// nothing, and it is the same sentence a composed act meets.
+///
+/// `ank new` is the one that must still open, because it names no entity at
+/// all: a reader that could not make the first task in an empty corpus would be
+/// a reader with no way in.
+#[test]
+fn a_form_that_names_an_entity_refuses_in_front_of_itself_and_new_still_opens() {
+    let _one = ONE_AT_A_TIME
+        .lock()
+        .unwrap_or_else(|held| held.into_inner());
+    let repo = Repo::seeded();
+    let editor = Editor::beside(&repo);
+    repo.warm();
+
+    let mut live = Live::with(&repo, WINDOW.0, WINDOW.1, &editor.env());
+    live.until("the session to open", |t| t.contains("2 ENTITIES"));
+
+    // The body panel, which names nothing until something is opened into it.
+    live.send("3");
+    live.until("the body panel to take the focus", |t| {
+        t.contains("> 3 BODY")
+    });
+
+    live.send(&letter("edit"));
+    live.until("the reader to refuse an edit of nothing", |t| {
+        flat(t).contains(NOTHING_NAMED)
+    });
+    let said = live.frame();
+    assert!(
+        !said.contains(&banner("edit")),
+        "a form opened over a screen that names no entity:\n{said}"
+    );
+    assert!(
+        !flat(&said).contains(ABOUT),
+        "an edit of nothing composed a command:\n{said}"
+    );
+
+    // And `ank new`, which names no entity by design, opens all the same.
+    live.send(&letter(ank_tui::form::MAKE));
+    live.until("the form that makes an entity to open", |t| {
+        t.contains("NEW ")
+    });
+    live.send("\u{1b}");
+    live.until("the form to close", |t| !t.contains("NEW "));
+
+    live.quit();
+    editor.never_ran("while a form was refused and another was opened");
+}

--- a/crates/ank-tui/tests/entity.rs
+++ b/crates/ank-tui/tests/entity.rs
@@ -28,8 +28,7 @@
 
 mod terminal;
 
-use std::path::PathBuf;
-use terminal::{Live, Repo};
+use terminal::{Editor, Live, Repo};
 
 /// What the confirmation says above the command line, and what it says after a
 /// person has declined one. Read out of the reader, never spelled here.
@@ -48,7 +47,7 @@ const WINDOW: (u16, u16) = (120, 34);
 /// and a suite that typed the letter `new` happens to be bound to today would
 /// go on passing against a table that moved it.
 fn key_of_new() -> String {
-    let binding = ank_tui::bindings::of_verb(ank_tui::form::VERB)
+    let binding = ank_tui::bindings::of_verb(ank_tui::form::MAKE)
         .expect("the reader binds a key to 'ank new'");
     let letter = ank_tui::bindings::named(binding.key);
     assert_eq!(
@@ -61,7 +60,7 @@ fn key_of_new() -> String {
 
 /// The kinds `ank new` makes, in the order the form cycles them.
 fn kinds() -> Vec<&'static str> {
-    ank_tui::form::Form::open()
+    ank_tui::form::Form::open(ank_tui::form::MAKE)
         .expect("this build declares 'ank new'")
         .kinds()
         .to_vec()
@@ -69,63 +68,9 @@ fn kinds() -> Vec<&'static str> {
 
 /// The mandatory flags of one kind, as the reader has them.
 fn required(kind: &str) -> &'static [&'static str] {
-    ank_tui::form::required(kind)
-}
-
-// ---------------------------------------------------------------------------
-// The editor, and the sentinel that says it ran
-// ---------------------------------------------------------------------------
-
-/// An `$EDITOR` that writes a file and exits.
-///
-/// It writes and does not edit, deliberately: what is being measured is whether
-/// the editor was *reached*, and a script that filled the template in would
-/// make the reader's failure look like a success.
-struct Editor {
-    script: PathBuf,
-    sentinel: PathBuf,
-}
-
-impl Editor {
-    fn beside(repo: &Repo) -> Editor {
-        use std::os::unix::fs::PermissionsExt;
-        let script = repo.0.join("editor.sh");
-        let sentinel = repo.0.join("the-editor-ran");
-        std::fs::write(
-            &script,
-            format!(
-                "#!/bin/sh\nprintf 'the editor ran on %s\\n' \"$1\" > {}\n",
-                sentinel.display()
-            ),
-        )
-        .expect("the script must be writable");
-        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755))
-            .expect("the script must be executable");
-        Editor { script, sentinel }
-    }
-
-    fn env(&self) -> Vec<(&str, &str)> {
-        vec![("EDITOR", self.script.to_str().expect("a UTF-8 path"))]
-    }
-
-    fn ran(&self) -> bool {
-        self.sentinel.is_file()
-    }
-
-    fn forget(&self) {
-        let _ = std::fs::remove_file(&self.sentinel);
-    }
-
-    /// The assertion this whole suite turns on, made wherever it is worth
-    /// making: the reader never reached an editor.
-    fn never_ran(&self, when: &str) {
-        assert!(
-            !self.ran(),
-            "the reader opened $EDITOR {when}, into a child with no stdin and a \
-             terminal in raw mode on the alternate screen: {}",
-            self.sentinel.display()
-        );
-    }
+    ank_tui::form::need(ank_tui::form::MAKE, kind)
+        .expect("'ank new' declares what it will not compose without")
+        .flags()
 }
 
 // ---------------------------------------------------------------------------
@@ -255,7 +200,7 @@ fn to_kind(live: &mut Live, kind: &str) {
 /// walk that assumed where the cursor already was would be a suite driving a
 /// form it had not looked at.
 fn fill_required(live: &mut Live, kind: &str, value_of: impl Fn(&str) -> Option<String>) {
-    let form = ank_tui::form::Form::open().expect("a form");
+    let form = ank_tui::form::Form::open(ank_tui::form::MAKE).expect("a form");
     let mut wanted: Vec<(usize, &str, String)> = Vec::new();
     for flag in required(kind) {
         let Some(value) = value_of(flag) else {

--- a/crates/ank-tui/tests/terminal/mod.rs
+++ b/crates/ank-tui/tests/terminal/mod.rs
@@ -253,6 +253,67 @@ impl Repo {
     }
 }
 
+// ---------------------------------------------------------------------------
+// The editor, and the sentinel that says it ran
+// ---------------------------------------------------------------------------
+
+/// An `$EDITOR` that writes a file and exits (TASK-d832452630d2).
+///
+/// It writes and does not edit, deliberately: what is being measured is whether
+/// the editor was *reached*, and a script that filled the template in would
+/// make the reader's failure look like a success.
+///
+/// Here rather than in one suite because two now need it (TASK-e8da6a00564a).
+/// `ank new` opens an editor when every mandatory flag is absent and `ank edit`
+/// opens one when no field is named at all, and both criteria are measured the
+/// same way: point `$EDITOR` at this, and find the sentinel absent.
+pub struct Editor {
+    pub script: std::path::PathBuf,
+    sentinel: std::path::PathBuf,
+}
+
+impl Editor {
+    pub fn beside(repo: &Repo) -> Editor {
+        use std::os::unix::fs::PermissionsExt;
+        let script = repo.0.join("editor.sh");
+        let sentinel = repo.0.join("the-editor-ran");
+        std::fs::write(
+            &script,
+            format!(
+                "#!/bin/sh\nprintf 'the editor ran on %s\\n' \"$1\" > {}\n",
+                sentinel.display()
+            ),
+        )
+        .expect("the script must be writable");
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755))
+            .expect("the script must be executable");
+        Editor { script, sentinel }
+    }
+
+    pub fn env(&self) -> Vec<(&str, &str)> {
+        vec![("EDITOR", self.script.to_str().expect("a UTF-8 path"))]
+    }
+
+    pub fn ran(&self) -> bool {
+        self.sentinel.is_file()
+    }
+
+    pub fn forget(&self) {
+        let _ = std::fs::remove_file(&self.sentinel);
+    }
+
+    /// The assertion these suites turn on, made wherever it is worth making:
+    /// the reader never reached an editor.
+    pub fn never_ran(&self, when: &str) {
+        assert!(
+            !self.ran(),
+            "the reader opened $EDITOR {when}, into a child with no stdin and a \
+             terminal in raw mode on the alternate screen: {}",
+            self.sentinel.display()
+        );
+    }
+}
+
 /// Every `"id":"..."` of a document, in the order it carries them.
 pub fn ids_of(doc: &str) -> Vec<String> {
     let mut out = Vec::new();

--- a/crates/ank-tui/tests/verbs.rs
+++ b/crates/ank-tui/tests/verbs.rs
@@ -285,19 +285,22 @@ fn the_four_letters_the_verbs_cost_move_nothing_on_the_screen() {
     live.quit();
 }
 
-/// **`x` opens a list naming close, attest and read** (TASK-1a415107fd56).
+/// **`x` opens a list naming close, attest and read**
+/// (TASK-1a415107fd56, TASK-e8da6a00564a).
 ///
-/// The three §4 verbs this reader has no road to. They are named rather than
-/// bound because `ank.rs`'s gate refuses them and a letter apiece would be
-/// three offers nothing keeps -- so what the list says is what they are and
-/// that a shell is where they are spelled, and TASK-e8da6a00564a is where that
-/// stops being true.
+/// The three §4 verbs with no letter of their own. They were named and not
+/// bound because the gate refused them; the gate carries them now, and they are
+/// still not bound -- a letter apiece would be three more keys spent on three
+/// verbs a person reaches once a fortnight, and the list is where the offer
+/// belongs. What this test is answerable for is the naming: the three are on
+/// the list, each with the form its verb declares, and opening the list runs
+/// nothing. That opening a *row* of it reaches the verb is
+/// `tests/edit.rs`'s.
 ///
-/// The forms are read back too, out of the contract's own table: a list that
-/// named `close` without `--reason` would be teaching a command the CLI
-/// refuses.
+/// The forms are read back out of the contract's own table: a list that named
+/// `close` without `--reason` would be teaching a command the CLI refuses.
 #[test]
-fn the_key_past_the_six_names_the_verbs_this_reader_does_not_run() {
+fn the_key_past_the_six_names_the_verbs_with_no_letter_of_their_own() {
     let _one = ONE_AT_A_TIME
         .lock()
         .unwrap_or_else(|held| held.into_inner());
@@ -316,6 +319,12 @@ fn the_key_past_the_six_names_the_verbs_this_reader_does_not_run() {
     );
     live.send("x");
     live.until("the list to be drawn", |t| t.contains("attest"));
+    // Over the panels and not in the note band, which is a row `arrange`
+    // measures: the list costs the frame nothing at rest and nothing while it
+    // is open (TASK-9a402a54886f's budget, TASK-e8da6a00564a's overlay).
+    live.until("the list to be an overlay of its own", |t| {
+        t.contains("MORE VERBS")
+    });
     let frame = live.frame();
     let shown = flat(&frame);
     for verb in ["close", "attest", "read"] {


### PR DESCRIPTION
TASK-e8da6a00564a. Proof `commit:1c1480c`.

## What moved

**`e` opens a form for `ank edit`.** The form is no longer `ank new`'s alone: `Form::open` takes a verb, and the fields, the kinds, the heading and the composed argv are all read out of the contract against that one string. Four verbs, one form.

**The requirement grew a second shape rather than a second row.** `ank new` opens `$EDITOR` when *every* mandatory flag is absent; `ank edit` opens one when *no* field is named at all. Those are two conditions and `Need::All`/`Need::Any` are the two of them. `Need::Any` over `--title`, `--body` and `--constraint` is the whole of the criterion: `Form::composed` answers `Err` until one of them is filled in, so a named field stands ahead of the search for an editor by construction. `Form::open` answers `None` for a verb `NEEDS` does not name, so a form whose requirement is nothing cannot be built either.

**`x` stopped being a note and became the third overlay.** It was two lines in the note band, which `arrange` measures — so moving it over the panels gave a row back rather than spending one, and TASK-9a402a54886f's budget of five is untouched. Its grammar is not the key list's and could not be: every row of *that* list **is** the key it names, and none of these three is a key at all. So a row is opened the way a row of any panel is opened — `j`/`k` walk a cursor, Enter opens, a tap does what Enter does. `close` and `attest` open the form their mandatory flag is filled in on; `read` declares no flag in §4, so it composes straight. All three land on the single `Command::Act` arm.

**The gate widened by four** — `edit`, `close`, `attest`, `read`; `check` and `init` stay out — and the key table by one. It is still measured against the table rather than generated from it, in both directions, with the further list as the second way a verb may be reached.

`edit` took a group of its own on the key list, for the reason `Group::Create` already gives from the other side: the writing half's note does not mention a form and the create line's note does not mention the marked panel's entity, and `e` is both.

## How it is measured

`crates/ank-tui/tests/edit.rs`, through the built binary on a pseudo-terminal, as CLAUDE.md and the criterion both require. `$EDITOR` points at a script that writes a sentinel; the sentinel is **proved first from a shell, on `ank edit <id>` itself** — the very call the form must never compose — and found absent everywhere afterwards. Every composed command is dismissed, and the bytes under `.ank/` and the refs under `refs/ank/` are compared before and after.

A mutation check (`Runs::Form` → `Runs::Compose` on `e`, binary rebuilt) fails the suite as a **timeout** rather than an assertion, which is the criterion's own point: an editor reached from this reader is a hang, not an error on the screen.

`cargo test --workspace` green, `cargo fmt --check` clean, `ank check` exit 0 (signals only).

## Not in scope

The two documentation drifts LOG-f455c09157bc records — `ank-contract`'s `tui` note listing six verbs, and `view.rs`'s header diagram drawing the key trailer TASK-9a402a54886f deleted — are left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Acvw9s8Z1XA79MvKCg4VmG