### PR TITLE
The reader reads and sets the config

### DIFF
--- a/.ank/entities/LOG-caa1ebf85848.md
+++ b/.ank/entities/LOG-caa1ebf85848.md
@@ -1,0 +1,39 @@
+---
+id: LOG-caa1ebf85848
+type: log
+title: WHAT I TOUCHED OUTSIDE crates/ank-tui/**, said explicitly because the scope is the reader's.
+created: 2026-08-27T05:49:01Z
+author: claude-code/opus-5+config
+scope:
+  - crates/ank-tui/**
+about: TASK-b08d090f699c
+seq: 3
+schema: 4
+version: 1
+---
+
+ crates/ank-contract/src/verbs.rs gains CONFIG_KEYS and CONFIG_KEYS_NOTE -- the eight keys written once, in a macro invocation that expands to both the slice and the space-separated sentence config's own note carries -- and the note is now that constant. crates/ank-cli/src/config.rs's KEYS is that constant rather than a second literal, and the doc on cli.rs's the_config_note_names_every_key_the_verb_addresses says what it measures now: a rendering and the shape a reader with only the note to go on would split it by, rather than two memories being arbitrated. That is the body's recorded intent, one table instead of three, and it is the only reason the reader could reach the set at all -- ADR-8bd76e8d7c4e forbids it linking ank-cli, and a space-separated line inside a note is a string to split rather than a list to read.
+
+CONCAT AND NOT A JOIN, because the note is a &'static str inside a const table: joining a slice at run time needs an allocation the table cannot hold, and concat! takes literals rather than constants. The macro is what lets the literals be written once and expanded into both shapes.
+
+THE GATE IS THE ONE THE BODY RECORDED AND I DID NOT INVENT ANOTHER. ank::BOTH_ROADS names exactly one verb and buys nothing on its own; ank::reading_shape is what decides, and Ank::json admits a verb named there only in that shape. One positional is a read; everything else is refused before anything is spawned. I made it stricter than 'two positionals is a write' in one direction and the reason is on the function: --unset is ONE positional and removes a line from the file, so a gate that counted positionals alone would have left a write on the reading road -- which is the exact hole the exception exists to not open. 'Exactly one word and it is not a flag' covers the value, --unset and --user together, and errs towards refusing.
+
+Failed gains NotAReadingShape rather than reusing NotARead, because the two say different things and only one is true: config IS a verb this reader reads with, and 'config <key> <value>' is not a read.
+
+WHAT o OPENS IS A PANE AND NOT A FIFTH PANEL. LOG-1afc1b09f95b spends a whole entry on rows being a budget and a panel costing two of them at every window whether or not anybody looks at it. Pane::Config sits beside Pane::Body and Pane::Constraints, s and o toggle into their own through one App::pane_to, and the pane costs nothing at rest. It is the one pane that names no entity -- what a corpus is configured to do is a fact about the repository -- so pane_content answers it before the document is asked for, body_lines does not draw 'nothing is open here' over it, and title_of says CONFIG rather than BODY.
+
+AND OPENING AN ENTITY LEAVES IT. show() is called by open_selected (a person asking) and by reopen (a refresh after a write), so the pane is dropped in the first and not the second: a person who pressed Enter on a listing row and got a list of settings would have been answered with something else, and a config write that flipped the pane back to the document would undo what they were doing. The constraints pane stays, because it follows the entity it is about.
+
+THE FORM IS THE ONE THAT WAS ALREADY THERE, WIDENED BY ONE FACT. Form::on(verb, front) takes the positionals the caller has already decided, and form::taken reads the placeholder of the NEXT one off the verb's own positional_help -- '<key> [<value>]' word by word, brackets trimmed -- so <value> is a row of the form and composes as a bare word. taken answers None while nothing has been supplied, which is what keeps new/edit/close/attest untouched: their first positional is always somebody else's, the kind or the view's <id>. NEEDS gains (config, '', Need::Any([VALUE, '--unset'])) -- the reading shape is what it refuses, and either thing that writes is enough.
+
+Need::Any gained a second field and it had to. Its legend said 'a call naming none opens $EDITOR', which is true of edit and false of config: ank config <key> READS. A screen telling a person that setting nothing opens an editor is worse than one that says nothing, so the sentence is a field of the variant now and each row carries its own.
+
+--user is drawn on that form like every other flag the verb declares, deliberately: a form that hid one would be this reader deciding which half of a verb a person may reach, and what stands between the switch and the file is what stands in front of every act here -- the command line on the screen and one key.
+
+THE TWO TRAPS THE TASK RECORDED WERE NOT REDISCOVERED, and the first one bit exactly as described. I mutated model::Settings::load to take only three of the eight keys and ran cargo test -p ank-tui --test config: it PASSED, against target/debug/ank as it was before the edit. cargo build --workspace and the same command then failed on the equality. Every pty result in this task was taken after a workspace build. The second trap cost nothing: ank.rs names no binding, no BINDINGS and no bindings:: anywhere, comments included, and the scan is green.
+
+WHERE THE PRICE IS CHARGED. App::reconfig refuses unless the focus is the body panel AND the pane is Config, and it is called from three places: the o command, focus_on arriving at the body panel, and confirmed after a config write. reload does not call it and repaint reaches reload, so a watcher's news puts no ank config on the wire -- which matters more here than for the queue, because §4 gives config one key at a time and the pane is one spawn per declared key.
+
+MEASURED, NOT ASSERTED. crates/ank-tui/tests/config.rs drives the binary on a pseudo-terminal at 140x40. The keys drawn are compared with the keys 'ank help config' declares, in order, so the pane and the CLI's own page have to agree; the value and the source on each row are compared with what 'ank config <key> --json' answers; peers.<name> is refused by the verb and is still a row carrying what it said, and both an answered key and a refused one are required to have been seen or the loop asserted nothing. Dismissing is measured on Repo::corpus(), every byte under .ank/ before and after. Confirming is measured by asking the binary again. Unsetting is measured on the SOURCE -- claim_ttl_default starts at 'default', goes to 'file', comes back to 'default' with the same value -- which is why that key and not one the file already carries: a key already in the file returns to 'file' either way and the assertion would say nothing. 'On no repaint' is measured by moving the corpus twice at the shell, a config key and a new task: the task arriving on the listing is what says the reload ran, and the config row not moving beside it is the claim.
+
+I also checked the criterion's other half by hand rather than only by test: adding a ninth key to CONFIG_KEYS and rebuilding put nine rows on the pane and nine keys on 'ank help config', with no edit in crates/ank-tui at all. Reverted.

--- a/.ank/entities/LOG-d074499c8a1a.md
+++ b/.ank/entities/LOG-d074499c8a1a.md
@@ -1,0 +1,13 @@
+---
+id: LOG-d074499c8a1a
+type: log
+title: done, proof commit:ed689f6
+created: 2026-08-27T05:51:40Z
+author: claude-code/opus-5+config
+scope:
+  - crates/ank-tui/**
+about: TASK-b08d090f699c
+seq: 4
+schema: 4
+version: 1
+---

--- a/.ank/entities/TASK-b08d090f699c.md
+++ b/.ank/entities/TASK-b08d090f699c.md
@@ -5,7 +5,7 @@ slug: the-reader-reads-and-sets-the-config
 title: The reader reads and sets the config
 created: 2026-08-26T17:07:37Z
 author: claude-code/opus-5+reader-redesign
-status: open
+status: in_progress
 scope:
   - crates/ank-tui/**
 blocked_by: [TASK-d832452630d2]
@@ -13,7 +13,7 @@ done_criteria: |
   The built binary lists, on o, every key ank config declares, each with the value in effect and where that value came from, charged when the pane is focused and on no repaint. The reader carries no copy of that key list: it reads it from the contract, and a key added to the CLI reaches this pane without a second edit. Setting one raises the confirmation spelling ank config <key> <value>; dismissing writes nothing, measured on the bytes of the file; confirming changes what ank config <key> --json answers, and unsetting returns the key to the source it had before. config is the one verb on both the reading and the writing road, and which road an invocation takes is decided by its arguments rather than by its name -- the writing shape is refused on the reading road, and accept is on neither list but the writing one.
 criteria_by: creator
 schema: 4
-version: 4
+version: 5
 ---
 
 **The reader may not link `ank-cli`**, so `crates/ank-cli/src/config.rs`'s list

--- a/.ank/entities/TASK-b08d090f699c.md
+++ b/.ank/entities/TASK-b08d090f699c.md
@@ -5,15 +5,20 @@ slug: the-reader-reads-and-sets-the-config
 title: The reader reads and sets the config
 created: 2026-08-26T17:07:37Z
 author: claude-code/opus-5+reader-redesign
-status: in_progress
+status: done
 scope:
   - crates/ank-tui/**
 blocked_by: [TASK-d832452630d2]
 done_criteria: |
   The built binary lists, on o, every key ank config declares, each with the value in effect and where that value came from, charged when the pane is focused and on no repaint. The reader carries no copy of that key list: it reads it from the contract, and a key added to the CLI reaches this pane without a second edit. Setting one raises the confirmation spelling ank config <key> <value>; dismissing writes nothing, measured on the bytes of the file; confirming changes what ank config <key> --json answers, and unsetting returns the key to the source it had before. config is the one verb on both the reading and the writing road, and which road an invocation takes is decided by its arguments rather than by its name -- the writing shape is refused on the reading road, and accept is on neither list but the writing one.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: ed689f6
+    criteria: 801769feb42c
+    via: submitted
 schema: 4
-version: 5
+version: 6
 ---
 
 **The reader may not link `ank-cli`**, so `crates/ank-cli/src/config.rs`'s list

--- a/crates/ank-cli/src/cli.rs
+++ b/crates/ank-cli/src/cli.rs
@@ -1361,8 +1361,15 @@ mod tests {
     /// and the mirror of that is a key the verb takes and the note never names:
     /// the note is where a caller looks before typing, and `claim_ttl_default`
     /// was one edit away from being addressable and undocumented
-    /// (ADR-0bb7ea8991bc). The list is a literal because a note is one, and this
-    /// is what keeps it the same list.
+    /// (ADR-0bb7ea8991bc).
+    ///
+    /// **It measures a rendering now rather than arbitrating between two
+    /// memories** (TASK-b08d090f699c). Both halves are
+    /// `ank_contract::verbs::CONFIG_KEYS` -- the note is `concat!`-ed from it
+    /// and `config::KEYS` is it -- so what is left to go wrong is the shape:
+    /// the prefix the note is found by, and the split that reads the set back
+    /// out of the sentence. A reader that has only the note to go on splits it
+    /// exactly this way, so this is the assertion that keeps that road open.
     #[test]
     fn the_config_note_names_every_key_the_verb_addresses() {
         let note = spec_of("config")

--- a/crates/ank-cli/src/config.rs
+++ b/crates/ank-cli/src/config.rs
@@ -401,16 +401,15 @@ pub fn declarations() -> Result<BTreeMap<String, String>> {
 // and leaves every other byte alone.
 
 /// The keys this verb addresses, spelled the way §4's table spells them.
-pub const KEYS: &[&str] = &[
-    "schema",
-    "context_budget",
-    "claim_ttl_max",
-    "claim_ttl_default",
-    "default_branch",
-    "peers.<name>",
-    "verifiers.<name>.run",
-    "verifiers.<name>.timeout",
-];
+///
+/// **The contract's own set, and no longer a literal here**
+/// (TASK-b08d090f699c). It was written out below and compared with `config`'s
+/// note by a test, which held two renderings in step; the terminal reader is a
+/// third consumer and may not link this crate (ADR-8bd76e8d7c4e), so the set
+/// moved to `ank-contract` -- where the note is rendered from it too. One
+/// table, three surfaces, and the test that compared the first two is now
+/// measuring a rendering rather than arbitrating between two memories.
+pub const KEYS: &[&str] = ank_contract::verbs::CONFIG_KEYS;
 
 /// A dotted path, resolved against the closed key set.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/ank-contract/src/verbs.rs
+++ b/crates/ank-contract/src/verbs.rs
@@ -587,6 +587,46 @@ pub const GROUPS: &[&str] = &[
     "set up a repository",
 ];
 
+/// The keys `ank config` addresses, and the note that names them, from one
+/// table (TASK-b08d090f699c).
+///
+/// **One declaration, two renderings.** The set was a literal in `ank-cli` and
+/// a space-separated sentence in `config`'s own note, held together by a test
+/// that compared them; a third consumer arrived when the terminal reader had to
+/// list every key -- and the reader may not link `ank-cli` (ADR-8bd76e8d7c4e),
+/// so it could reach neither the list nor anything but the note's own bytes to
+/// split. What a caller needs is the set, so the set is what is declared, and
+/// the note is `concat!`-ed from it at compile time rather than written beside
+/// it. `ank-cli`'s `KEYS` is this constant, the note below is this constant,
+/// and a key added here reaches all three surfaces with no second edit.
+///
+/// A macro because a note is a `&'static str` inside a `const` table: joining a
+/// slice at run time would need an allocation the table cannot hold, and
+/// `concat!` takes literals rather than constants. So the literals are written
+/// once, in the macro's own invocation, and expanded into both shapes.
+macro_rules! config_keys {
+    ($($key:literal),+ $(,)?) => {
+        /// The keys `ank config` addresses, spelled the way §4's table spells
+        /// them, and the whole of them.
+        pub const CONFIG_KEYS: &[&str] = &[$($key),+];
+
+        /// [`CONFIG_KEYS`] as `config`'s own note renders them: the word
+        /// `keys:` and the set, space-separated.
+        pub const CONFIG_KEYS_NOTE: &str = concat!("keys:" $(, " ", $key)+);
+    };
+}
+
+config_keys!(
+    "schema",
+    "context_budget",
+    "claim_ttl_max",
+    "claim_ttl_default",
+    "default_branch",
+    "peers.<name>",
+    "verifiers.<name>.run",
+    "verifiers.<name>.timeout",
+);
+
 /// The twelve verbs of §4, plus `init` and `help` (§9).
 ///
 /// **The order is the specification's, and it is load-bearing**: §4 puts the
@@ -1297,7 +1337,7 @@ pub const COMMANDS: &[CommandSpec] = &[
             refuses(ExitCode::Prerequisite, "verifiers.<name>.timeout on a verifier that is not declared"),
         ],
         notes: &[
-            "keys: schema context_budget claim_ttl_max claim_ttl_default default_branch peers.<name> verifiers.<name>.run verifiers.<name>.timeout",
+            CONFIG_KEYS_NOTE,
             "a resolved default prints marked as one; --json carries value and source as separate fields",
             "--unset verifiers.<name> removes a whole verifier, which is what makes declaring one reversible",
             "--user reads and writes the reader's corpora.yml instead, whose only key is corpora.<identity>",

--- a/crates/ank-tui/src/ank.rs
+++ b/crates/ank-tui/src/ank.rs
@@ -1,15 +1,23 @@
 //! The one road to the corpus: running `ank <verb> --json` (ADR-8bd76e8d7c4e).
 //!
-//! Eleven verbs are reached from here, in two lists that are policy made
+//! Twelve verbs are reached from here, in two lists that are policy made
 //! mechanical rather than policy stated in prose. [`READS`] is the five that
 //! only read -- `status`, `find`, `show`, `scope` and `review` -- and
 //! [`Ank::json`] refuses anything else before spawning. [`ACTS`] is what the
 //! person at the keyboard may ask for -- `claim`, `log`, `release`, `done`,
-//! `amend`, `accept`, `new`, `edit`, `close`, `attest` and `read` -- and
-//! [`Ank::act`] refuses anything else the same way.
+//! `amend`, `accept`, `new`, `edit`, `close`, `attest`, `read` and `config` --
+//! and [`Ank::act`] refuses anything else the same way.
 //! Two gates and not one, because the difference between them is the whole of
 //! what a reader is allowed to do on its own: a screen repaints by reading, and
 //! it writes only where a command was typed.
+//!
+//! **One verb is on both, and it is one verb by name rather than by kind**
+//! (TASK-b08d090f699c). `ank config <key>` reads and `ank config <key> <value>`
+//! writes, which is one word for two verbs -- so [`BOTH_ROADS`] names it, and
+//! [`reading_shape`] is what actually decides: the reading road takes exactly
+//! one positional and refuses everything else, the writing shape included. The
+//! two lists still do not overlap, and the sentence they hold up is unchanged:
+//! nothing a repaint can reach writes.
 //!
 //! **`accept` is on the acting list, and the reader still never performs one**
 //! (TASK-d90e94afca08). ADR-8bd76e8d7c4e lets the reader *drive* a
@@ -61,6 +69,47 @@ pub use serde_yaml::Value;
 /// on a watcher's news renews no lease and takes no ref -- which is what lets
 /// the queue be repainted at all (ADR-0bb7ea8991bc).
 pub const READS: &[&str] = &["status", "find", "show", "scope", "review"];
+
+/// The one verb that is on both roads, and the whole of the exception
+/// (TASK-b08d090f699c).
+///
+/// **A named list of one, because the property the two gates hold is that
+/// nothing is on both.** `ank config <key>` answers what a key is set to and
+/// writes nothing; `ank config <key> <value>` writes the file. One name, two
+/// verbs, and §4 tells them apart by the arguments rather than by the word --
+/// so this reader does too, in [`reading_shape`], and the name alone buys
+/// nothing.
+///
+/// The property being spent is real and is worth stating in full. A repaint
+/// calls [`Ank::json`] and only that, so a verb reachable from the reading road
+/// is a verb a watcher's news can reach: a screen left open all night would
+/// have a road to it with nobody at the keyboard. What keeps that shut is that
+/// the *writing shape* never passes [`Ank::json`] -- one positional is a read,
+/// anything else is refused there -- so the news can reach `ank config <key>`
+/// and can reach nothing that writes.
+///
+/// One verb and not a category. A second name here would need the same argument
+/// made again about its own arguments, and the shape gate below is `config`'s
+/// grammar rather than a rule about verbs in general.
+pub const BOTH_ROADS: &[&str] = &["config"];
+
+/// Whether these arguments are the reading shape of a verb on both roads.
+///
+/// **The shape and never the name** (TASK-b08d090f699c). §4 gives `config`
+/// `max_positionals: 2` and says it outright: the key alone reads, a value
+/// writes, `--unset` removes. So one positional is a read and everything else
+/// is refused on the reading road -- the second positional that writes a value,
+/// and every flag, because `--unset` is one positional and removes a line from
+/// the file. "Exactly one word, and it is not a flag" is the whole of it, and
+/// it errs towards refusing: a shape this does not recognise is refused on the
+/// reading road and remains reachable on the acting one, where a person has
+/// read the command line and answered it.
+fn reading_shape(args: &[String]) -> bool {
+    match args {
+        [only] => !only.starts_with('-'),
+        _ => false,
+    }
+}
 
 /// The verbs whose exit 8 carries a document rather than a refusal.
 ///
@@ -118,11 +167,23 @@ const FINDINGS_ARE_AN_ANSWER: &[&str] = &["review"];
 /// is measured against this constant in both directions, by the suite beside
 /// the key table itself.
 ///
+/// **`config` is the twelfth, and it is the one that is also on the reading
+/// road** (TASK-b08d090f699c). Every other name here is refused by
+/// [`Ank::json`] outright; this one is refused in every shape but
+/// `ank config <key>`, and what reaches this list is the writing shape -- a
+/// value to set, or `--unset` to remove one. It is here because a reader that
+/// could list what a corpus is configured to do and not change it would be
+/// showing a person a screen and telling them to leave it, and what keeps the
+/// act deliberate is what keeps every other one deliberate: the form composes,
+/// `App::propose` shows the command line, and `App::confirmed` is still the one
+/// caller of [`Ank::act`].
+///
 /// `check` and `init` are not here and must not arrive. `check` answers a
 /// question about the corpus that the reader has no screen for, and `init`
 /// makes the corpus this reader is already looking at.
 pub const ACTS: &[&str] = &[
     "claim", "log", "release", "done", "amend", "accept", "new", "edit", "close", "attest", "read",
+    "config",
 ];
 
 /// A call that did not produce a document, in the three ways it can fail.
@@ -156,6 +217,15 @@ pub enum Failed {
     /// next edit that adds a command for a verb the list does not carry --
     /// `accept` above all, which is the one this gate exists for.
     NotAnAct { verb: String },
+    /// A verb of [`BOTH_ROADS`], asked for on the reading road in a shape that
+    /// is not the reading one (TASK-b08d090f699c).
+    ///
+    /// Its own variant and not [`Failed::NotARead`], because the two say
+    /// different things and only one of them is true here: `config` *is* a verb
+    /// this reader may read with, and this call is not a read. Never reached
+    /// from a running reader -- the pane asks for one positional -- and reached
+    /// by the next edit that tries to make a repaint set a key.
+    NotAReadingShape { verb: String, args: Vec<String> },
 }
 
 impl Failed {
@@ -231,6 +301,14 @@ impl fmt::Display for Failed {
                     "'{verb}' is not one of the verbs this reader may act with"
                 )
             }
+            Failed::NotAReadingShape { verb, args } => {
+                let said: Vec<String> = args.iter().map(|a| quoted(a)).collect();
+                write!(
+                    f,
+                    "'{verb} {}' writes, and the reading road takes '{verb} <key>' alone",
+                    said.join(" ")
+                )
+            }
         }
     }
 }
@@ -251,13 +329,28 @@ impl Ank {
     /// The gate is [`READS`] and it is checked before anything is spawned, so a
     /// later edit that reached for `claim` from a repaint would fail here rather
     /// than write.
+    ///
+    /// **[`BOTH_ROADS`] is the one way past that list, and it is a gate of its
+    /// own rather than a hole in this one** (TASK-b08d090f699c). A verb named
+    /// there is admitted only in [`reading_shape`] -- one positional, no flag --
+    /// so what a repaint can reach is `ank config <key>` and nothing that
+    /// writes. The arguments are read before anything is spawned, exactly as
+    /// the name is.
     pub fn json(&self, verb: &str, args: &[&str]) -> Result<Value, Failed> {
-        if !READS.contains(&verb) {
-            return Err(Failed::NotARead {
-                verb: verb.to_string(),
-            });
-        }
         let owned: Vec<String> = args.iter().map(|a| a.to_string()).collect();
+        if !READS.contains(&verb) {
+            if !BOTH_ROADS.contains(&verb) {
+                return Err(Failed::NotARead {
+                    verb: verb.to_string(),
+                });
+            }
+            if !reading_shape(&owned) {
+                return Err(Failed::NotAReadingShape {
+                    verb: verb.to_string(),
+                    args: owned,
+                });
+            }
+        }
         Ok(self.spawn(verb, &owned)?.answered)
     }
 
@@ -511,6 +604,66 @@ mod tests {
         }
     }
 
+    /// **The one verb on both roads is admitted by its arguments and never by
+    /// its name** (TASK-b08d090f699c).
+    ///
+    /// Both halves, because either alone is half a claim. The reading shape --
+    /// one positional -- passes the gate, so the pane can ask what a key is set
+    /// to; and every writing shape is refused *before anything is spawned*,
+    /// which is what the address of a binary that does not exist measures:
+    /// reaching a refusal at all proves nothing ran.
+    ///
+    /// The shapes are the verb's own, out of §4: a value to set, `--unset` to
+    /// remove one, and `--user` to address the other file. The second and third
+    /// are one positional apiece, which is why the gate asks for a positional
+    /// rather than counting words.
+    #[test]
+    fn the_verb_on_both_roads_is_read_in_one_shape_and_refused_in_the_others() {
+        let ank = nowhere();
+        assert_eq!(BOTH_ROADS, &["config"], "the exception is one verb");
+        for verb in BOTH_ROADS {
+            assert!(
+                !READS.contains(verb),
+                "{verb} is on the reading list, and then the shape gate says nothing"
+            );
+            assert!(
+                ACTS.contains(verb),
+                "{verb} is excepted onto the reading road and cannot be written with"
+            );
+            // The reading shape reaches the spawn, which is the only thing that
+            // can fail against a binary that is not there.
+            assert!(
+                matches!(
+                    ank.json(verb, &["claim_ttl_max"]),
+                    Err(Failed::Spawn { .. })
+                ),
+                "the reading shape of '{verb}' was refused by the gate"
+            );
+            for shape in [
+                vec!["claim_ttl_max", "4h"],
+                vec!["claim_ttl_max", "--unset"],
+                vec!["--unset", "claim_ttl_max"],
+                vec!["claim_ttl_max", "4h", "--user"],
+                vec![],
+            ] {
+                let refused = ank.json(verb, &shape);
+                assert!(
+                    matches!(refused, Err(Failed::NotAReadingShape { .. })),
+                    "'{verb} {}' reached the spawn on the reading road: {refused:?}",
+                    shape.join(" ")
+                );
+            }
+        }
+        // And what it says names the shape rather than the verb: `config` is a
+        // verb this reader reads with, and this call is not a read.
+        let said = ank
+            .json("config", &["claim_ttl_max", "4h"])
+            .expect_err("the writing shape is refused")
+            .to_string();
+        assert!(said.contains("config claim_ttl_max 4h"), "{said}");
+        assert!(said.contains("<key>"), "{said}");
+    }
+
     /// The acting gate, and the same proof that it comes first.
     ///
     /// **`close` and `attest` left this list too** (TASK-e8da6a00564a), by the
@@ -545,10 +698,19 @@ mod tests {
     /// is what makes "the reader never performs one unattended" a property of
     /// the code: there is no road from a watcher's news to this verb, whatever
     /// a screen is showing when the news arrives.
+    ///
+    /// **It is on neither list but the writing one, and that is now something
+    /// to say** (TASK-b08d090f699c). `config` arrived on both, so "an act is
+    /// not a read" stopped being a property of the two constants alone; what
+    /// holds it up is stated here in the shape it would break in. Every act
+    /// outside [`BOTH_ROADS`] is refused by name, the one inside it is refused
+    /// in every shape that writes, and `accept` is measured against the first
+    /// of those two by being asked for.
     #[test]
     fn accept_is_an_act_and_never_a_read() {
         let ank = nowhere();
         assert!(!READS.contains(&"accept"));
+        assert!(!BOTH_ROADS.contains(&"accept"), "accept is excepted");
         assert_eq!(
             ank.json("accept", &["ADR-0001"]),
             Err(Failed::NotARead {
@@ -562,6 +724,21 @@ mod tests {
                 !READS.contains(verb),
                 "{verb} is on both roads, and the gates then say nothing"
             );
+            if BOTH_ROADS.contains(verb) {
+                continue;
+            }
+            // Every other act is refused on the reading road by its name, in
+            // every shape: a verb that writes has no reading shape at all.
+            for shape in [vec![], vec!["TASK-0001"], vec!["TASK-0001", "--json"]] {
+                assert_eq!(
+                    ank.json(verb, &shape),
+                    Err(Failed::NotARead {
+                        verb: verb.to_string()
+                    }),
+                    "'{verb} {}' is not refused by name",
+                    shape.join(" ")
+                );
+            }
         }
     }
 

--- a/crates/ank-tui/src/bindings.rs
+++ b/crates/ank-tui/src/bindings.rs
@@ -180,6 +180,17 @@ pub enum Group {
     /// six rows and false of the seventh would be prose the table cannot be
     /// held to.
     Create,
+    /// Reads what the corpus is configured to do, and sets one key of it
+    /// (TASK-b08d090f699c).
+    ///
+    /// Its own group for [`Group::Create`]'s and [`Group::Change`]'s reason,
+    /// from a third side. The key opens a *pane* and writes nothing -- so the
+    /// writing half's note, which says every one of its keys lands on the
+    /// marked panel's entity and then asks for `y`, is false of it twice over:
+    /// there is no entity, and pressing it composes nothing at all. What is
+    /// true of it is the sentence under this line: the pane lists what
+    /// `ank config` declares, and a row of it is where a value is typed.
+    Settings,
     /// Changes what an entity says, on a form (TASK-e8da6a00564a).
     ///
     /// Its own group for [`Group::Create`]'s reason, from the other side. It
@@ -706,6 +717,37 @@ pub static BINDINGS: &[Binding] = &[
         }),
     },
     // -----------------------------------------------------------------------
+    // What the corpus is configured to do (TASK-b08d090f699c)
+    //
+    // `o` and not `c`, which is `claim`'s. ADR-c07e2694f0e1 binds a verb's own
+    // initial where the initial is free, and `m` for `amend` is already the row
+    // that shows what happens when it is not: the letter goes to the verb whose
+    // hand a person's should go to, and the other takes what is left of its own
+    // name. `o` is the second letter of `config` and the only one of the six
+    // nothing else had claimed.
+    //
+    // It is `Runs::Press` and not `Runs::Form`, which is the whole of why this
+    // row is not on the writing half's line: pressing it opens the pane that
+    // lists what `ank config` declares, which is a read. What writes is a row
+    // of that pane, opened the way every other row in this reader is opened,
+    // onto the form the value is typed on -- and that form reaches
+    // `App::propose` like every other act. The verb is named here all the same,
+    // because it is the verb this key spells, and the gate below is measured
+    // against that name.
+    // -----------------------------------------------------------------------
+    Binding {
+        key: KeyCode::Char('o'),
+        aliases: &[],
+        runs: Runs::Press(Press::Run(Command::Config)),
+        word: "config",
+        group: Group::Settings,
+        offered: Offered::Never,
+        verb: Some(Verb {
+            name: crate::form::SET,
+            tail: Tail::Form,
+        }),
+    },
+    // -----------------------------------------------------------------------
     // What answers the reader (TASK-d4a882345837). Both states are modal, and
     // both grammars are stated over the whole keyboard in `keys.rs`: these two
     // rows are the keys the screen *offers*, not the whole of what it reads.
@@ -873,7 +915,12 @@ pub fn of_key(code: KeyCode) -> Option<&'static Binding> {
         .filter(|b| {
             matches!(
                 b.group,
-                Group::Screen | Group::Panel | Group::Write | Group::Create | Group::Change
+                Group::Screen
+                    | Group::Panel
+                    | Group::Write
+                    | Group::Create
+                    | Group::Change
+                    | Group::Settings
             )
         })
         .find(|b| b.answers(code))
@@ -967,6 +1014,11 @@ const CREATE_NOTE: &str = "   (a form of the flags ank new takes, then";
 /// the entity is the marked panel's, and the fields are a form.
 const CHANGE_NOTE: &str = "   (a form of the fields ank edit takes, on the marked panel's entity, \
                            then";
+/// What it says after the key that opens the config pane
+/// (TASK-b08d090f699c): the key reads, and what writes is a row of what it
+/// opened.
+const SETTINGS_NOTE: &str = "   (what ank config declares, read when it opens; Enter on a row \
+                             sets that key, then";
 /// What it says after `accept`, which is a different kind of offer: the other
 /// five move a corpus, and this one asks a person for a signature ank has no
 /// way to produce.
@@ -1122,6 +1174,23 @@ fn change() -> Line {
     }
 }
 
+/// The key that opens the config pane, on a line of its own
+/// (TASK-b08d090f699c).
+///
+/// Separate from the three lines above it for the reason [`Group::Settings`]
+/// gives: this key composes nothing and lands on no entity, so both of their
+/// notes are false of it, and what is true of it -- that the pane is where a
+/// key is set, one row at a time -- is true of nothing else.
+fn settings() -> Line {
+    Line {
+        title: "settings",
+        bindings: of_group(Group::Settings),
+        lead: String::new(),
+        between: "  ",
+        note: format!("{SETTINGS_NOTE} {})", named(KeyCode::Char(CONFIRM))),
+    }
+}
+
 /// The sixth act, on a line of its own, and only where the verb would take it.
 fn ratify() -> Line {
     Line {
@@ -1169,6 +1238,7 @@ fn lines() -> Vec<Line> {
         write(),
         create(),
         change(),
+        settings(),
         ratify(),
         waiting(),
         typing(),
@@ -1369,10 +1439,11 @@ mod tests {
             }
         }
         assert_eq!(
-            named, 8,
+            named, 9,
             "the verbs this reader spells are the six that move an entity, the \
-             one that makes one (TASK-d832452630d2) and the one that changes \
-             what one says (TASK-e8da6a00564a)"
+             one that makes one (TASK-d832452630d2), the one that changes what \
+             one says (TASK-e8da6a00564a) and the one that reads and sets the \
+             config (TASK-b08d090f699c)"
         );
         // And the three the list `x` opens are verbs of the contract too, with
         // the flags this reader will draw for them: a row naming `close`
@@ -1637,7 +1708,12 @@ mod tests {
         for binding in BINDINGS.iter().filter(|b| {
             matches!(
                 b.group,
-                Group::Screen | Group::Panel | Group::Write | Group::Create | Group::Change
+                Group::Screen
+                    | Group::Panel
+                    | Group::Write
+                    | Group::Create
+                    | Group::Change
+                    | Group::Settings
             )
         }) {
             for key in std::iter::once(binding.key).chain(binding.aliases.iter().copied()) {

--- a/crates/ank-tui/src/form.rs
+++ b/crates/ank-tui/src/form.rs
@@ -1,12 +1,26 @@
 //! The form a verb with flags is filled in on, and the whole of why it cannot
 //! open an editor (TASK-d832452630d2, TASK-e8da6a00564a, ADR-c07e2694f0e1).
 //!
-//! **Four verbs and one form.** It arrived carrying `ank new` alone and
-//! TASK-e8da6a00564a puts `ank edit`, `ank close` and `ank attest` on it. What
-//! made that one form rather than four is that nothing here is written per
-//! verb: the fields are the contract's, the kinds are the contract's, and the
-//! only thing this file declares is [`NEEDS`] -- which flags a call cannot be
-//! composed without, the one fact `ank help --json` does not carry.
+//! **Five verbs and one form.** It arrived carrying `ank new` alone,
+//! TASK-e8da6a00564a put `ank edit`, `ank close` and `ank attest` on it, and
+//! TASK-b08d090f699c puts `ank config` on it. What made that one form rather
+//! than five is that nothing here is written per verb: the fields are the
+//! contract's, the kinds are the contract's, the positionals are the
+//! contract's, and the only thing this file declares is [`NEEDS`] -- which
+//! flags a call cannot be composed without, the one fact `ank help --json` does
+//! not carry.
+//!
+//! # The one field that is not a flag
+//!
+//! `ank config <key> <value>` takes what it writes as a word rather than behind
+//! a flag, and a form over the flags alone could compose nothing but
+//! `ank config <key>` -- which is the *reading* shape, the one the pane has
+//! already asked and drawn. So a form can be opened on positionals the caller
+//! has already decided ([`Form::on`]), and the placeholder of the next one is
+//! read off the verb's own usage line ([`taken`]) and drawn as the first row.
+//! What differs about that row is one thing and it is stated on the field: it
+//! composes as a bare word. Everything else -- the requirement, the mark, the
+//! refusal, the cursor -- asks it the same questions it asks a flag.
 //!
 //! **The fields are the contract's and not this file's.** `ank help --json`
 //! declares what each verb takes, [`ank_contract::verbs`] is where that
@@ -23,7 +37,7 @@
 //!
 //! # The editor, and why this form is a `Result`
 //!
-//! **Two verbs of the four reach `$EDITOR`, and they reach it by different
+//! **Two verbs of the five reach `$EDITOR`, and they reach it by different
 //! doors.** `ank new` opens one **precisely when every mandatory flag is
 //! absent** -- that is the CLI's `is_interactive`, and it is `all` and not
 //! `any`: `ank new task --title x` still refuses on the missing scope, and
@@ -72,6 +86,16 @@ use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 /// composed argv are the same string.
 pub const MAKE: &str = "new";
 
+/// The verb that reads and sets one key of the configuration, named once for
+/// [`MAKE`]'s reason (TASK-b08d090f699c).
+///
+/// Four surfaces spell it and they spell this: the binding `o` carries, the
+/// pane that reads every key, the form one row of that pane opens, and the argv
+/// the form composes. The gate in `crate::ank` deliberately does *not* read it
+/// -- a gate built from what it guards guards nothing -- and the suite there
+/// measures the two against each other instead.
+pub const SET: &str = "config";
+
 /// What a call cannot be composed without, in the two shapes the CLI has.
 ///
 /// **Two variants because the editor is reached by two different doors**, and
@@ -80,12 +104,27 @@ pub const MAKE: &str = "new";
 /// for it must hold all of them. `ank edit` opens one when *no* field is named
 /// at all, so a form for it must hold at least one. Written down as two, so a
 /// verb added to [`NEEDS`] has to say which door it is standing in front of.
+///
+/// **And the second shape is not only about editors** (TASK-b08d090f699c).
+/// `ank config <key>` with no value *reads* -- it opens nothing and writes
+/// nothing -- and a form that composed it would be a write that read. It is the
+/// same refusal for a different reason, which is why the reason is a field of
+/// the variant rather than a sentence in the legend.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Need {
     /// Every one of these, or the form composes nothing.
     All(&'static [&'static str]),
-    /// At least one of these, or the form composes nothing.
-    Any(&'static [&'static str]),
+    /// At least one of these, or the form composes nothing -- and what a call
+    /// naming none of them would do instead.
+    ///
+    /// **The sentence is carried on the row because it differs per verb**
+    /// (TASK-b08d090f699c). `ank edit <id>` with no field named opens `$EDITOR`
+    /// and `ank config <key>` with no value reads the key; both are calls this
+    /// form refuses to compose, and for different reasons. It was written into
+    /// the legend while `edit` was the only `Any`, and a second row would have
+    /// made the screen tell a person that setting nothing opens an editor,
+    /// which is not what the verb does.
+    Any(&'static [&'static str], &'static str),
 }
 
 impl Need {
@@ -96,7 +135,7 @@ impl Need {
     /// flag that moves moves on both.
     pub fn flags(&self) -> &'static [&'static str] {
         match self {
-            Need::All(flags) | Need::Any(flags) => flags,
+            Need::All(flags) | Need::Any(flags, _) => flags,
         }
     }
 }
@@ -135,13 +174,50 @@ const NEEDS: &[(&str, &str, Need)] = &[
     (
         "edit",
         "",
-        Need::Any(&["--title", "--body", "--constraint"]),
+        Need::Any(
+            &["--title", "--body", "--constraint"],
+            "a call naming none opens $EDITOR",
+        ),
     ),
     // "a closure nobody explained is one nobody can reopen" is the verb's own
     // refusal, and this is that refusal on this side of the pipe.
     ("close", "", Need::All(&["--reason"])),
     ("attest", "", Need::All(&["--proof"])),
+    // The one requirement naming a positional (TASK-b08d090f699c). `ank config
+    // <key>` alone is the *reading* shape, and a form that composed it would be
+    // a write that read: the pane has already asked that question and drawn the
+    // answer. So the form will not compose until it carries something that
+    // writes -- a value to set, or `--unset` to remove one -- and `Any` is the
+    // shape of that because either is enough and neither is required.
+    //
+    // `--user` is a row of this form like any other flag the verb declares, and
+    // that is deliberate rather than overlooked. It addresses the reader's own
+    // `corpora.yml` instead of the corpus, whose key set is a different one --
+    // so `ank config claim_ttl_max 4h --user` is a refusal the CLI gives
+    // precisely, and `ank config schema 1 --user` is a thing the verb does. A
+    // form that hid a declared flag would be this reader deciding which half of
+    // a verb a person is allowed to reach, and what stands between the switch
+    // and the file is what stands in front of every other act: the command line
+    // on the screen, and one key.
+    (
+        SET,
+        "",
+        Need::Any(
+            &[VALUE, "--unset"],
+            "a call naming neither reads the key rather than setting it",
+        ),
+    ),
 ];
+
+/// The placeholder `ank config`'s second positional is spelled with.
+///
+/// Written here because [`NEEDS`] is written here and for the same reason: what
+/// a call cannot be composed without is this file's one declaration. It is held
+/// to the contract's own usage line by the suite below -- [`taken`] reads the
+/// placeholder off `positional_help`, and a form's field carries what that read
+/// -- so a verb whose usage line moves fails there rather than composing a
+/// requirement no field answers.
+const VALUE: &str = "<value>";
 
 /// What every kind of `ank new` needs: a title, and the scope that attaches it
 /// to something.
@@ -240,9 +316,24 @@ impl Entry {
 /// One field: the flag the contract declared, and what has been put in it.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Field {
-    /// The flag, as `ank` spells it. Copied from [`FlagSpec::name`] and never
-    /// written here.
+    /// The flag, as `ank` spells it -- or the placeholder of a positional the
+    /// form fills in, as the verb's own usage line spells that
+    /// (TASK-b08d090f699c). Copied from [`FlagSpec::name`] or from
+    /// [`CommandSpec::positional_help`] and never written here.
+    ///
+    /// One field for both because every surface asks the same question of it:
+    /// the requirement names what it will not compose without, the row marks it
+    /// with `*`, and the refusal spells it. `<value>` reads as what a person
+    /// would have typed, exactly as `--proof` does.
     pub flag: &'static str,
+    /// Whether it is a positional: composed as a bare word, with nothing in
+    /// front of it (TASK-b08d090f699c).
+    ///
+    /// The one thing that differs between the two kinds. `ank config <key>
+    /// <value>` takes its value as a word rather than behind a flag, so a form
+    /// that pushed the placeholder in front of what was typed would compose a
+    /// command line nobody could have typed.
+    pub positional: bool,
     /// Whether the CLI takes a repeat of it. Drawn as a fact about the flag,
     /// and not acted on: this form offers a repeatable flag once, which is a
     /// subset of what a shell can say and never a form the CLI refuses.
@@ -289,6 +380,15 @@ pub struct Form {
     /// where [`Form::kind`] is the empty string and the verb takes `<id>`
     /// first, which is the view's to supply.
     kind: usize,
+    /// The positionals the form supplies itself, in front of everything it
+    /// composes (TASK-b08d090f699c).
+    ///
+    /// Empty on the four forms that arrived before it, and one word on
+    /// `ank config <key>`: the key is what the row the person opened *is*, so
+    /// it is neither typed into a field nor looked up again when the form
+    /// composes -- frozen the way the confirmation freezes an argv, and for the
+    /// same reason.
+    front: Vec<String>,
     fields: Vec<Field>,
     /// The row the cursor is on.
     at: usize,
@@ -313,21 +413,55 @@ impl Form {
     /// empty submission is the flagless call, and for `new` and `edit` alike
     /// that call is `$EDITOR`.
     pub fn open(verb: &'static str) -> Option<Form> {
+        Form::on(verb, Vec::new())
+    }
+
+    /// The same form, with the positionals the caller has already decided
+    /// (TASK-b08d090f699c).
+    ///
+    /// **What `front` buys is a field the contract declares and no flag
+    /// carries.** `ank config <key> <value>` takes its value as a word, and a
+    /// form over the flags alone could compose only `ank config <key>` -- which
+    /// is the reading shape, and a write that read. So the verb's own usage
+    /// line is asked what positional comes after the ones supplied
+    /// ([`taken`]), and that placeholder is the first row of the form.
+    ///
+    /// The four forms that arrived before this supply nothing and are
+    /// untouched: `front` is empty, [`taken`] answers `None` on a verb whose
+    /// positionals the caller has not started filling in, and the fields are the
+    /// flags exactly as they were.
+    pub fn on(verb: &'static str, front: Vec<String>) -> Option<Form> {
         let spec = verbs::spec_of(verb)?;
         for kind in kinds_of(spec) {
             need(verb, kind)?;
         }
-        let fields: Vec<Field> = spec.flags.iter().filter(|f| f.listed).map(field).collect();
+        let mut fields: Vec<Field> = Vec::new();
+        if let Some(name) = taken(spec, front.len()) {
+            fields.push(Field {
+                flag: name,
+                positional: true,
+                repeatable: false,
+                entry: Entry::Typed(String::new()),
+            });
+        }
+        fields.extend(spec.flags.iter().filter(|f| f.listed).map(field));
         if fields.is_empty() {
             return None;
         }
         Some(Form {
             verb,
             kind: 0,
+            front,
             fields,
             at: 0,
             said: None,
         })
+    }
+
+    /// The positionals this form supplies itself, in the order they are
+    /// composed.
+    pub fn front(&self) -> &[String] {
+        &self.front
     }
 
     /// The verb this form is filled in for.
@@ -351,18 +485,25 @@ impl Form {
     /// What the form's own border says it is: the verb, and the kind where the
     /// verb has one.
     ///
-    /// `NEW TASK`, `EDIT`, `CLOSE`, `ATTEST`. Read off the verb rather than
-    /// written per form, so a fifth form is a row of [`NEEDS`] and not a
-    /// heading somewhere to remember.
+    /// `NEW TASK`, `EDIT`, `CLOSE`, `ATTEST`, `CONFIG CLAIM_TTL_MAX`. Read off
+    /// the verb rather than written per form, so a fifth form is a row of
+    /// [`NEEDS`] and not a heading somewhere to remember.
+    ///
+    /// The positionals the form supplies are on it too (TASK-b08d090f699c):
+    /// `ank config` is one form per key, and a border reading `CONFIG` over a
+    /// row that will write `claim_ttl_max` would be a heading that says less
+    /// than the form knows.
     pub fn banner(&self) -> String {
-        match self.kind().is_empty() {
-            true => self.verb.to_ascii_uppercase(),
-            false => format!(
-                "{} {}",
-                self.verb.to_ascii_uppercase(),
-                self.kind().to_ascii_uppercase()
-            ),
+        let mut said = self.verb.to_ascii_uppercase();
+        for word in &self.front {
+            said.push(' ');
+            said.push_str(&word.to_ascii_uppercase());
         }
+        if !self.kind().is_empty() {
+            said.push(' ');
+            said.push_str(&self.kind().to_ascii_uppercase());
+        }
+        said
     }
 
     /// What this form will not compose without, or `None` where this build
@@ -383,11 +524,22 @@ impl Form {
     /// `ank new task` where there is a kind and `ank close` where there is not,
     /// so a sentence about what the form will not compose says the same words a
     /// person would have typed.
+    ///
+    /// The positionals the form supplies are in it, in front of the kind:
+    /// `ank config claim_ttl_max` is what a person opening that row would have
+    /// typed, and a refusal naming `ank config` alone would name a command line
+    /// that is not the one being filled in (TASK-b08d090f699c).
     fn spelled(&self) -> String {
-        match self.kind().is_empty() {
-            true => format!("ank {}", self.verb),
-            false => format!("ank {} {}", self.verb, self.kind()),
+        let mut said = format!("ank {}", self.verb);
+        for word in &self.front {
+            said.push(' ');
+            said.push_str(word);
         }
+        if !self.kind().is_empty() {
+            said.push(' ');
+            said.push_str(self.kind());
+        }
+        said
     }
 
     pub fn fields(&self) -> &[Field] {
@@ -587,12 +739,18 @@ impl Form {
             }
         }
         self.answered()?;
-        let mut args = Vec::new();
+        let mut args = self.front.clone();
         if !self.kind().is_empty() {
             args.push(self.kind().to_string());
         }
         for field in &self.fields {
             match &field.entry {
+                // A positional is the word itself and nothing in front of it:
+                // `ank config <key> 4h`, which is what a person would have
+                // typed (TASK-b08d090f699c).
+                Entry::Typed(text) if !text.trim().is_empty() && field.positional => {
+                    args.push(text.trim().to_string())
+                }
                 Entry::Typed(text) if !text.trim().is_empty() => {
                     args.push(field.flag.to_string());
                     args.push(text.trim().to_string());
@@ -605,10 +763,11 @@ impl Form {
             verb: self.verb,
             args,
             // The question is asked of the form's own first positional and
-            // never of the verb's name: `ank new <kind>` carries its own, so
-            // nothing goes in front of it, and the three that name an entity
-            // take the row the view has marked.
-            subject: match self.kind().is_empty() {
+            // never of the verb's name: `ank new <kind>` carries its own and so
+            // does a form opened on a config key, so nothing goes in front of
+            // either, and the three that name an entity take the row the view
+            // has marked.
+            subject: match self.front.is_empty() && self.kind().is_empty() {
                 true => Subject::Selected,
                 false => Subject::Given,
             },
@@ -668,7 +827,7 @@ impl Form {
                 }
                 Ok(())
             }
-            Need::Any(flags) => {
+            Need::Any(flags, otherwise) => {
                 let answered = flags.iter().any(|flag| {
                     self.fields
                         .iter()
@@ -683,8 +842,7 @@ impl Form {
                         .find_map(|flag| self.fields.iter().position(|f| f.flag == *flag))
                         .unwrap_or(self.at),
                     said: format!(
-                        "every field is empty: '{}' needs one of {}, and a call naming none \
-                         opens $EDITOR",
+                        "every field is empty: '{}' needs one of {}, and {otherwise}",
                         self.spelled(),
                         flags.join(", ")
                     ),
@@ -785,6 +943,14 @@ impl Form {
             .filter(|k| *k != self.kind())
             .collect();
         if others.is_empty() {
+            // The verb's own usage line, where nothing of it has been supplied
+            // yet. Where the form carries a positional already, that line would
+            // spell it twice -- `ank config claim_ttl_max <key> [<value>]` --
+            // and what is left of it is a row of the form rather than a word of
+            // the heading (TASK-b08d090f699c).
+            if !self.front.is_empty() {
+                return self.spelled();
+            }
             let positional = spec_of(self.verb)
                 .map(|spec| spec.positional_help)
                 .unwrap_or_default();
@@ -816,9 +982,8 @@ impl Form {
                 "* is a flag '{}' will not compose without: {closes}",
                 self.spelled()
             ),
-            Some(Need::Any(_)) => format!(
-                "'{}' needs one of the fields marked *, and a call naming none opens $EDITOR: \
-                 {closes}",
+            Some(Need::Any(_, otherwise)) => format!(
+                "'{}' needs one of the fields marked *, and {otherwise}: {closes}",
                 self.spelled()
             ),
             None => closes,
@@ -868,10 +1033,36 @@ fn kinds_of(spec: &'static CommandSpec) -> &'static [&'static str] {
 /// The one kind a verb with no subcommands has.
 const NO_KIND: &[&str] = &[""];
 
+/// The positional a form fills in, where the caller has supplied the ones
+/// before it (TASK-b08d090f699c).
+///
+/// **Read off the verb's own usage line**, which is where §4 spells its
+/// positionals: `<key> [<value>]`, taken word by word, with the brackets that
+/// say "optional" trimmed off. So the placeholder a row draws is the one
+/// `ank help config` prints, and a verb whose usage line moves moves this with
+/// it.
+///
+/// `None` where the caller has supplied nothing, and that is the rule rather
+/// than a guard against an index. **The first positional is never the form's**:
+/// it is the kind `ank new` cycles, or the `<id>` the view supplies off the
+/// marked panel, and a form that typed either into a field would be offering to
+/// re-answer a question the screen has already answered. `None` too where the
+/// verb declares no positional that far along, which is every verb the four
+/// earlier forms serve.
+fn taken(spec: &'static CommandSpec, supplied: usize) -> Option<&'static str> {
+    if supplied == 0 || supplied >= spec.max_positionals {
+        return None;
+    }
+    let word = spec.positional_help.split_whitespace().nth(supplied)?;
+    let name = word.trim_matches(['[', ']']);
+    (!name.is_empty()).then_some(name)
+}
+
 /// One field, from the flag the contract declared.
 fn field(spec: &FlagSpec) -> Field {
     Field {
         flag: spec.name,
+        positional: false,
         repeatable: spec.repeatable,
         entry: match spec.takes_value {
             true => Entry::Typed(String::new()),
@@ -972,6 +1163,89 @@ mod tests {
         assert!(!spec.subcommands.is_empty(), "ank new makes something");
     }
 
+    /// **The positional a form fills in is the verb's own, read off its usage
+    /// line** (TASK-b08d090f699c).
+    ///
+    /// [`VALUE`] is written in this file because [`NEEDS`] is, and this is what
+    /// holds it to the contract rather than to a memory of it: the form for
+    /// `ank config <key>` draws a first row, that row is a positional, and the
+    /// placeholder on it is the word `ank help config` prints. A usage line
+    /// that moved would leave the requirement naming a field no row answers,
+    /// and it fails here rather than composing without it.
+    ///
+    /// The other half is the rule that keeps the four earlier forms untouched:
+    /// nothing is taken while the caller has supplied no positional, because
+    /// the first one is always somebody else's -- the kind `ank new` cycles, or
+    /// the `<id>` the view supplies.
+    #[test]
+    fn the_positional_a_form_fills_in_is_the_one_the_usage_line_declares() {
+        let spec = spec_of(SET).expect("'config' is a verb of the contract");
+        assert_eq!(
+            taken(spec, 1),
+            Some(VALUE),
+            "the second positional of '{}' is not what this file needs",
+            spec.positional_help
+        );
+        assert_eq!(taken(spec, 0), None, "the first positional is the caller's");
+        assert_eq!(
+            taken(spec, spec.max_positionals),
+            None,
+            "a positional past what the verb takes"
+        );
+
+        let form = Form::on(SET, vec!["claim_ttl_max".to_string()]).expect("a form for a key");
+        let first = form.fields().first().expect("the form has rows");
+        assert_eq!((first.flag, first.positional), (VALUE, true));
+        // And every verb served with nothing supplied draws flags alone, which
+        // is what the four earlier forms are and must stay.
+        for verb in served() {
+            for field in Form::open(verb)
+                .unwrap_or_else(|| panic!("a form for '{verb}'"))
+                .fields()
+            {
+                assert!(
+                    !field.positional,
+                    "'{}' is a positional on a form nobody supplied one to",
+                    field.flag
+                );
+            }
+        }
+    }
+
+    /// **A form opened on a key composes the key, the value and nothing else**
+    /// (TASK-b08d090f699c).
+    ///
+    /// The reading shape is what it refuses -- `ank config <key>` alone reads,
+    /// and the pane has drawn that answer already -- and either of the two
+    /// things that write satisfies it. The composed argv is the key in front,
+    /// because the form supplies it, and [`Subject::Given`] so that the view
+    /// puts no entity identifier there.
+    #[test]
+    fn a_form_on_a_key_composes_the_key_and_what_writes() {
+        let key = "claim_ttl_max";
+        let mut form = Form::on(SET, vec![key.to_string()]).expect("a form for a key");
+        assert!(form.composed().is_err(), "an empty form composed a read");
+
+        filled(&mut form, VALUE, "4h");
+        let act = form.composed().expect("a value is enough");
+        assert_eq!(act.verb, SET);
+        assert_eq!(act.args, [key.to_string(), "4h".to_string()]);
+        assert_eq!(act.subject, Subject::Given);
+
+        // The other thing that writes, on its own: `--unset` is a switch, and
+        // the value beside it is what a person would have cleared first.
+        let mut form = Form::on(SET, vec![key.to_string()]).expect("a form for a key");
+        let at = form
+            .fields()
+            .iter()
+            .position(|f| f.flag == "--unset")
+            .expect("the verb declares it");
+        form.select(at);
+        form.press(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE));
+        let act = form.composed().expect("--unset is enough");
+        assert_eq!(act.args, [key.to_string(), "--unset".to_string()]);
+    }
+
     /// **Every kind has a flag this form will not compose without, and every
     /// name in that list is a flag the verb declares.**
     ///
@@ -1013,9 +1287,19 @@ mod tests {
                     "'ank {verb} {kind}' needs an empty list, which every form meets"
                 );
                 for flag in need.flags() {
+                    // A flag of the verb, or the positional its own usage line
+                    // declares (TASK-b08d090f699c). Both are fields of the
+                    // form, and a requirement naming neither would be one no
+                    // field could ever answer -- which `Form::answered` refuses
+                    // rather than composes, and which nothing should ever
+                    // reach.
+                    let flagged = spec.flags.iter().any(|f| f.name == *flag && f.listed);
+                    let positional = (1..spec.max_positionals)
+                        .any(|supplied| taken(spec, supplied) == Some(*flag));
                     assert!(
-                        spec.flags.iter().any(|f| f.name == *flag && f.listed),
-                        "'{flag}' is needed by 'ank {verb} {kind}' and is no flag of it"
+                        flagged || positional,
+                        "'{flag}' is needed by 'ank {verb} {kind}' and is neither a flag of \
+                         it nor a positional of its usage line"
                     );
                 }
             }

--- a/crates/ank-tui/src/input.rs
+++ b/crates/ank-tui/src/input.rs
@@ -88,6 +88,16 @@ pub enum Command {
     Search(Option<String>),
     /// Show the constraints binding the open entity, or hide them for the body.
     Constraints,
+    /// Show what `ank config` declares and what each key is set to, or hide it
+    /// for the body (TASK-b08d090f699c).
+    ///
+    /// A key and no word, like [`Command::Further`] and [`Command::Form`]. It
+    /// is a *read* -- what it opens is a pane, asked for once when it opens --
+    /// and what writes is a row of that pane, which reaches the form and then
+    /// the confirmation. So there is nothing here for a line to have carried,
+    /// and a word that spelled `config` would be the second road to a write
+    /// ADR-c07e2694f0e1 closed.
+    Config,
     /// Focus the ratification queue, and ask `review` for it
     /// (TASK-d90e94afca08). A read and nothing else -- `ank review` writes no
     /// file, takes no ref and renews no lease (§4).

--- a/crates/ank-tui/src/keys.rs
+++ b/crates/ank-tui/src/keys.rs
@@ -15,9 +15,9 @@
 //! spells, which is ADR-c07e2694f0e1's rule and the whole of why these letters. What only moves
 //! the screen takes what is left: `j` and `k` move, Space pages, `g` goes to
 //! the top, Enter opens, `b` goes back, `s` shows the constraints, `v` opens
-//! the queue, `u` reads the corpus again, `f` narrows to the next kind, `x`
-//! opens the three verbs with no letter of their own, `?` says what all of them
-//! are, `q` quits. Each has an arrow or a named key beside it -- Down for `j`,
+//! the queue, `o` shows what `ank config` declares, `u` reads the corpus again,
+//! `f` narrows to the next kind, `x` opens the three verbs with no letter of
+//! their own, `?` says what all of them are, `q` quits. Each has an arrow or a named key beside it -- Down for `j`,
 //! PageDown for Space, Home for `g`, Escape for `b` -- because a person who has
 //! never read the key line still has hands.
 //!

--- a/crates/ank-tui/src/lib.rs
+++ b/crates/ank-tui/src/lib.rs
@@ -3,8 +3,8 @@
 //!
 //! **It reaches the corpus by running the CLI, and by nothing else.** Every row
 //! of corpus data on the screen arrives as a `--json` document written by
-//! `ank find`, `ank status`, `ank show`, `ank scope` or `ank review`, spawned as
-//! a shell would spawn them. Nothing here links `ank-core`, opens `.ank/`, or touches
+//! `ank find`, `ank status`, `ank show`, `ank scope`, `ank review` or
+//! `ank config <key>`, spawned as a shell would spawn them. Nothing here links `ank-core`, opens `.ank/`, or touches
 //! `refs/ank/*`. That is slower than linking the core and the trade is taken
 //! deliberately: every refusal in this project is a refusal on state, a reader
 //! that reproduced them would get one subtly wrong, and the first symptom would
@@ -17,10 +17,12 @@
 //!
 //! **It writes nothing the person at the keyboard did not ask for**
 //! (ADR-8bd76e8d7c4e). Repainting runs the verbs that only read, so a screen
-//! left open all night runs no command at all and renews no claim; the six that
-//! write -- `claim`, `log`, `release`, `done`, `amend` and `accept` -- run once
-//! each, when their word is typed whole into the prompt *and* the command that
-//! composed has been shown and answered with one key (TASK-d4a882345837).
+//! left open all night runs no command at all and renews no claim; the verbs
+//! that write -- `crate::ank::ACTS`, which is `claim`, `log`, `release`,
+//! `done`, `amend`, `accept`, `new`, `edit`, `close`, `attest`, `read` and the
+//! writing shape of `config` -- run once each, when the key that spells one has
+//! been pressed *and* the command that composed has been shown and answered
+//! with one key (TASK-d4a882345837).
 //! Nothing here is on a timer, and there is no timer to put anything on. The
 //! assertion is in the suite, not in this sentence.
 //!
@@ -75,6 +77,17 @@
 //! and every surface -- the mapping, the offer, the key list -- is computed
 //! from it.
 //!
+//! **And one key spells a verb that reads before it writes** (`o`,
+//! TASK-b08d090f699c). `ank config <key>` reads and `ank config <key> <value>`
+//! writes, which is one word for two verbs; what `o` opens is the reading half,
+//! a pane listing every key the contract declares with the value in effect and
+//! where it came from, and what writes is a row of that pane opened onto a
+//! form. So `config` is the one verb on both roads, and which road an
+//! invocation takes is decided by its arguments rather than by its name --
+//! `crate::ank::BOTH_ROADS` names it and `crate::ank::json` refuses every shape
+//! but one positional, so a repaint can reach the reading half and nothing that
+//! writes.
+//!
 //! What is left of the typed word is two places, and neither of them reaches a
 //! verb by being read. `/` opens the one-line prompt on a search, and
 //! [`input`]'s grammar carries no verb at all. `n` opens the form
@@ -112,7 +125,10 @@
 //!   focuses the panel and never on the reader's own initiative.
 //! * [`view::Focus::Body`] -- one entity: what holds it, the constraints
 //!   binding its declared scope, and its body, paged rather than cut. This is
-//!   the only panel `accept` can be typed in.
+//!   the only panel `accept` can be typed in. It is also where the config pane
+//!   is drawn (TASK-b08d090f699c): the one thing this panel shows that is not
+//!   about an entity at all, opened with `o`, read when a person arrives at it
+//!   and on no repaint.
 //!
 //! Focus moves by key and is drawn in characters -- a heavy border and the
 //! `> ` marker -- so the screen says where a reader is with no colour at all.

--- a/crates/ank-tui/src/model.rs
+++ b/crates/ank-tui/src/model.rs
@@ -252,6 +252,88 @@ fn waiting(value: &ank::Value) -> Row {
     }
 }
 
+/// One key of `.ank`'s configuration, as `ank config <key> --json` answers it
+/// (TASK-b08d090f699c).
+///
+/// Three facts and the reader derives none of them. The key is the contract's,
+/// the value and the source are the CLI's own two fields, and a key the CLI
+/// refused about carries what it said instead -- because "where that value came
+/// from" is a question with an answer even when the answer is that the shape
+/// names a family rather than a key.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Setting {
+    /// The key, as `ank config` declares it.
+    pub key: &'static str,
+    /// What it is set to, and `None` where the CLI answered null -- which is
+    /// what an unset key answers, and what a refused one has.
+    pub value: Option<String>,
+    /// Where that value came from, in the CLI's own word: `file`, `default`,
+    /// `unset`.
+    pub source: String,
+    /// What the CLI said instead of answering, where it refused the key.
+    ///
+    /// A row and never a whole-pane failure: `peers.<name>` names a family and
+    /// the peer name in it is not one a peer could have, so the verb refuses --
+    /// and a pane that showed nothing because one row of it was a placeholder
+    /// would be a pane that hides seven answers to protect one.
+    pub refused: Option<String>,
+}
+
+impl Setting {
+    /// Whether this row is the CLI declining rather than answering.
+    pub fn is_refusal(&self) -> bool {
+        self.refused.is_some()
+    }
+}
+
+/// Every key `ank config` declares, with what it is set to
+/// (TASK-b08d090f699c).
+///
+/// **The keys are the contract's and the reader holds no copy of them.**
+/// `ank_contract::verbs::CONFIG_KEYS` is the one table -- `ank-cli`'s own list
+/// is that constant and `config`'s note is rendered from it -- so a key added
+/// to the CLI is a row of this pane with no second edit anywhere.
+///
+/// **One call per key, and there is no verb that answers them together.** §4
+/// gives `config` one key at a time, so this is what asking costs; it is why
+/// the pane is charged when it is opened and on no repaint, exactly as the
+/// ratification queue is (ADR-0bb7ea8991bc's reasoning, applied to a price
+/// rather than to a lease).
+#[derive(Debug, Clone, Default)]
+pub struct Settings {
+    pub keys: Vec<Setting>,
+}
+
+impl Settings {
+    /// Every declared key, asked for once.
+    ///
+    /// **The reading shape and only ever the reading shape**: one positional,
+    /// which is what `crate::ank::Ank::json` admits `config` on. A call from
+    /// here that carried a value would be refused by that gate before anything
+    /// was spawned, which is the point of it.
+    pub fn load(ank: &Ank) -> Settings {
+        Settings {
+            keys: ank_contract::verbs::CONFIG_KEYS
+                .iter()
+                .map(|key| match ank.json(crate::form::SET, &[key]) {
+                    Ok(answer) => Setting {
+                        key,
+                        value: ank::maybe(&answer, "value"),
+                        source: ank::text(&answer, "source"),
+                        refused: None,
+                    },
+                    Err(failed) => Setting {
+                        key,
+                        value: None,
+                        source: String::new(),
+                        refused: Some(failed.to_string()),
+                    },
+                })
+                .collect(),
+        }
+    }
+}
+
 /// One entity, opened.
 #[derive(Debug, Clone)]
 pub struct Detail {

--- a/crates/ank-tui/src/view.rs
+++ b/crates/ank-tui/src/view.rs
@@ -39,7 +39,15 @@
 //! * **3 BODY** -- the entity somebody opened, whole: its frontmatter as a
 //!   block of labelled fields, who holds it, the constraints binding its
 //!   declared scope, and its prose under them, paged rather than cut
-//!   (TASK-082301b40a27). `c` swaps it for the constraints alone.
+//!   (TASK-082301b40a27). `s` swaps it for the constraints alone, and `o` for
+//!   what `ank config` declares (TASK-b08d090f699c) -- a pane and not a fifth
+//!   panel, because a panel costs two rows at every window whether or not
+//!   anybody is looking at it (LOG-1afc1b09f95b), and a screen a person opens,
+//!   reads and leaves is what a pane is for. It is the one pane that names no
+//!   entity: what a corpus is configured to do is a fact about the repository,
+//!   so it draws with nothing open, and it is read when a person arrives at it
+//!   and on no repaint -- the queue's rule, over one `ank config <key>` per key
+//!   the contract declares.
 //! * **4 QUEUE** -- what is proposed and waiting for a signature, and which
 //!   regime the corpus is in. Full width for the same reason the claims are:
 //!   the sentence saying a corpus has declared no ratification key is
@@ -229,10 +237,10 @@
 
 use crate::ank::{Ank, Failed, Ran};
 use crate::bindings::{self, Binding, Holding};
-use crate::form::{Filled, Form};
+use crate::form::{Filled, Form, SET as SETTING};
 use crate::input::{Act, Command, Subject};
 use crate::keys::{self, Editing, Press};
-use crate::model::{self, short_of, Detail, Queue, Row, Snapshot};
+use crate::model::{self, short_of, Detail, Queue, Row, Setting, Settings, Snapshot};
 use crate::paint::{self, role_of_id, Composed, Ink};
 use crate::stream::Stream;
 use crate::text::{self, fit, pad, window, wrap};
@@ -372,10 +380,19 @@ struct Target {
 }
 
 /// What the body panel is paging through.
+///
+/// Three things now, and the third is the one that is not about an entity at
+/// all (TASK-b08d090f699c): what the corpus is configured to do is a fact about
+/// the repository, so the config pane draws with nothing open and says so on
+/// its own title. It is a pane and not a fifth panel for the reason
+/// LOG-1afc1b09f95b spends the whole of: rows are a budget, a panel costs two
+/// of them at every window whether or not anybody is looking at it, and this is
+/// a screen a person opens, reads and leaves.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Pane {
     Body,
     Constraints,
+    Config,
 }
 
 /// A verb composed, shown, and waiting for one key (TASK-d4a882345837).
@@ -463,6 +480,23 @@ pub struct App {
     /// before that. Never loaded on the reader's own initiative: `review` is
     /// the one read here that inspects the whole corpus.
     queue: Option<Queue>,
+    /// Every key `ank config` declares with what it is set to, once somebody
+    /// has opened the pane that draws them, and `None` before that
+    /// (TASK-b08d090f699c).
+    ///
+    /// **Charged when the pane is focused and on no repaint**, which is the
+    /// queue's rule and it is here for the queue's reason with the price
+    /// counted differently: `review` is one expensive call and this is one call
+    /// per declared key, because §4 gives `config` one key at a time. A screen
+    /// left open all night with the pane closed asks nothing, and one with the
+    /// pane open asks again when its person comes back to it -- which is what
+    /// makes the values on it current rather than as old as the session.
+    ///
+    /// So [`App::reload`] does not touch it. That is deliberate and it is the
+    /// whole of the criterion's "on no repaint": a watcher's news reaches
+    /// `reload`, and a pane refreshed from there would be a stream of `ank
+    /// config` calls nobody asked for.
+    config: Option<Settings>,
     /// The one-line prompt, open, with what has been typed into it so far.
     ///
     /// `None` is the ordinary state and it is where every key is a command. The
@@ -559,6 +593,7 @@ impl App {
             offset: 0,
             stream,
             queue: None,
+            config: None,
             prompt: None,
             pending: None,
             // The two reads of the environment this crate makes, and they
@@ -1250,15 +1285,22 @@ impl App {
                 self.cursors[Focus::Entities.number() - 1] = Cursor::default();
                 self.cursors[Focus::Queue.number() - 1] = Cursor::default();
             }
-            Command::Constraints => {
-                self.pane = match self.pane {
-                    Pane::Body => Pane::Constraints,
-                    Pane::Constraints => Pane::Body,
-                };
-                self.offset = 0;
-                self.cursors[Focus::Body.number() - 1] = Cursor::default();
-                // The pane that was asked for is the pane to be looking at.
-                self.focus = Focus::Body;
+            Command::Constraints => self.pane_to(Pane::Constraints),
+            // The pane, opened, and the keys read once because it was
+            // (TASK-b08d090f699c). Closing it again reads nothing: `reconfig`
+            // asks what the pane is before it asks the CLI anything.
+            Command::Config => {
+                self.pane_to(Pane::Config);
+                self.reconfig(ank);
+                // On the first key and not on the sentence over it: the rows
+                // this pane opens are the keys, and a cursor parked on prose is
+                // a cursor Enter has no answer for. Done here rather than in
+                // `reconfig`, which runs again every time a person comes back
+                // to the pane and must not move the row they left it on.
+                if self.pane == Pane::Config {
+                    self.cursors[Focus::Body.number() - 1].at = self.first_key_row();
+                    self.clamp_body();
+                }
             }
             Command::Act(act) => self.propose(act, ank),
             Command::Malformed(said) => self.note = Some(said),
@@ -1323,16 +1365,65 @@ impl App {
         self.form = Some(form);
     }
 
+    /// The body panel showing one of the things it can show, or the document
+    /// again where it is showing that already.
+    ///
+    /// One toggle for the two panes that are reached by a key
+    /// (TASK-b08d090f699c). What it does is what `s` always did -- the pane
+    /// asked for, or back to the body if it was already there, and the window
+    /// and the cursor to the top because a different set of rows is a different
+    /// place -- and it is one function because two of them would be two answers
+    /// to "what does pressing this a second time do".
+    fn pane_to(&mut self, pane: Pane) {
+        self.pane = match self.pane == pane {
+            true => Pane::Body,
+            false => pane,
+        };
+        self.offset = 0;
+        self.cursors[Focus::Body.number() - 1] = Cursor::default();
+        // The pane that was asked for is the pane to be looking at.
+        self.focus = Focus::Body;
+    }
+
+    /// Asks `config` again for every declared key, but only where the pane that
+    /// draws them is the one in front of the person (TASK-b08d090f699c).
+    ///
+    /// **The condition is the whole of the design**, and it is
+    /// [`App::requeue`]'s condition with a different price behind it. §4 gives
+    /// `config` one key at a time, so this is one spawn per key the contract
+    /// declares -- eight of them today -- and putting that on every event a
+    /// watcher sends would undo what TASK-2f7777a1fdff bought as surely as
+    /// running `review` there would.
+    ///
+    /// A pane nobody is looking at is not stale, and one that is open has to be
+    /// current: a value somebody set at the shell a minute ago is exactly the
+    /// row a person would otherwise read wrongly. So it is charged where a
+    /// person arrives at the pane -- opening it with the key, or bringing the
+    /// focus back to the panel it is drawn in -- and nowhere else.
+    fn reconfig(&mut self, ank: &Ank) {
+        if self.focus != Focus::Body || self.pane != Pane::Config {
+            return;
+        }
+        self.config = Some(Settings::load(ank));
+        self.clamp_body();
+    }
+
     /// Move focus, and pay whatever the panel arriving costs.
     ///
-    /// The queue is the only one that costs anything, and it is charged here
-    /// rather than at every repaint: focusing it is a person asking for
-    /// `ank review`, which is a whole inspection of the corpus.
+    /// Two panels cost something now and both are charged here rather than at
+    /// every repaint: focusing the queue is a person asking for `ank review`,
+    /// which is a whole inspection of the corpus, and arriving at the body
+    /// panel with the config pane open is a person asking for one
+    /// `ank config <key>` per key the contract declares. Neither price is paid
+    /// by a screen nobody is at.
     fn focus_on(&mut self, focus: Focus, ank: &Ank) {
         self.focus = focus;
         if focus == Focus::Queue {
             self.requeue(ank);
             self.clamp(Focus::Queue);
+        }
+        if focus == Focus::Body {
+            self.reconfig(ank);
         }
     }
 
@@ -1475,6 +1566,14 @@ impl App {
                 self.queue = Some(queue);
             }
         }
+        // And a key that was set is a row of the pane that is wrong the moment
+        // it lands (TASK-b08d090f699c). Asked again here and nowhere else, for
+        // the queue's reason: `reload` refreshes the pane only where a person
+        // arrived at it, and nobody arrived -- they were already there and they
+        // asked for this.
+        if verb == SETTING {
+            self.reconfig(ank);
+        }
         // Under whatever the reread had to say, and never instead of it: a
         // reload that failed after a write that landed is the one moment a
         // reader most needs both halves.
@@ -1493,6 +1592,13 @@ impl App {
     /// to look it up. Every other row of a document names nothing, and Enter on
     /// one says so rather than opening whatever happened to be selected.
     fn open_selected(&mut self, ank: &Ank) {
+        // A row of the config pane names a key and never an entity, so what
+        // opening it reaches is the form that sets it and not `ank show`
+        // (TASK-b08d090f699c). Asked of the pane and before the row, because
+        // the pane is what decides which question the row is an answer to.
+        if self.focus == Focus::Body && self.pane == Pane::Config {
+            return self.open_setting();
+        }
         let Some(id) = self.selected_id(self.focus) else {
             self.note = Some(match self.focus {
                 Focus::Body => {
@@ -1502,7 +1608,52 @@ impl App {
             });
             return;
         };
+        // Opening a document puts the body panel back on the document
+        // (TASK-b08d090f699c). The constraints pane stays where it is, because
+        // it is about whatever entity is open and follows it; the config pane
+        // is about the repository, so a person who asked for an entity and got
+        // a list of settings would have been answered with something else. Here
+        // rather than in `show`, which `App::reopen` also calls: re-reading the
+        // document that is already open is not somebody asking for it.
+        if self.pane == Pane::Config {
+            self.pane = Pane::Body;
+        }
         self.show(ank, &id);
+    }
+
+    /// The form for the config key under the cursor, opened over the panels
+    /// (TASK-b08d090f699c).
+    ///
+    /// **The key is frozen into the form and never looked up again.** It is the
+    /// row the person opened, and a form that resolved the cursor a second time
+    /// when it composed would be a value landing on whatever the cursor had
+    /// reached by then -- the defect the confirmation avoids by freezing its
+    /// argv, one screen earlier.
+    ///
+    /// Nothing is composed here and nothing is spawned: what is filled in
+    /// reaches `App::propose` through [`App::filling`], and the confirmation is
+    /// on that road exactly as it is for every other act.
+    fn open_setting(&mut self) {
+        let Some(key) = self.pane_target() else {
+            self.note = Some(format!(
+                "nothing here to set: {} opens a key of the list",
+                bindings::spelling_of(&Command::Open)
+            ));
+            return;
+        };
+        match Form::on(SETTING, vec![key.clone()]) {
+            Some(form) => self.form = Some(form),
+            // A build whose contract does not declare the verb, or declares it
+            // with nothing this reader will compose without: said rather than
+            // drawn as an empty form, which is `App::open_form`'s reasoning and
+            // its sentence.
+            None => {
+                self.note = Some(format!(
+                    "this build of ank has no form for '{SETTING} {key}': it declares no such \
+                     verb, or nothing the verb cannot do without"
+                ))
+            }
+        }
     }
 
     /// Asks `show` for whatever the body panel is already holding, leaving the
@@ -1873,6 +2024,15 @@ impl App {
                 }
             },
             Focus::Body => {
+                // Before the document, because this pane names none
+                // (TASK-b08d090f699c). `CONFIG` and not `BODY`, for the reason
+                // the constraints pane has its own title: a heading that said
+                // `BODY` over a list of settings would be a heading that lies.
+                if self.pane == Pane::Config {
+                    let counted = self.counted(width);
+                    let keys = self.config.as_ref().map_or(0, |s| s.keys.len());
+                    return Composed::of(&format!("CONFIG   {counted}   ({keys} key(s))"));
+                }
                 let Some(detail) = &self.detail else {
                     return Composed::of(name);
                 };
@@ -1880,7 +2040,17 @@ impl App {
                 let counted = self.counted(width);
                 let short = short_of(&detail.id);
                 match self.pane {
-                    Pane::Body => {
+                    // The one title that is not the panel's name: the panel is
+                    // showing the other thing it can show about a document, and
+                    // saying `BODY` over a list of decisions would be a heading
+                    // that lies.
+                    Pane::Constraints => Composed::new()
+                        .plain("CONSTRAINTS   ")
+                        .named(&short, role_of_id(&detail.id))
+                        .plain(&format!("   {counted}")),
+                    // The document. The config pane answered above, before the
+                    // document was asked for at all.
+                    _ => {
                         let status = row.map(|r| r.status.clone()).unwrap_or_default();
                         Composed::new()
                             .plain(&format!("{name}   "))
@@ -1892,13 +2062,6 @@ impl App {
                             .named(&status, role_of_status(&status))
                             .plain(&format!("   rows {counted}"))
                     }
-                    // The one title that is not the panel's name: the panel is
-                    // showing the other thing it can show, and saying `BODY`
-                    // over a list of decisions would be a heading that lies.
-                    Pane::Constraints => Composed::new()
-                        .plain("CONSTRAINTS   ")
-                        .named(&short, role_of_id(&detail.id))
-                        .plain(&format!("   {counted}")),
                 }
             }
         }
@@ -2069,7 +2232,9 @@ impl App {
     /// panel pages, not a band standing over them, so `j` walks out of the
     /// frontmatter and into the prose without a second arithmetic.
     fn body_lines(&self, width: usize, height: usize) -> Vec<Composed> {
-        if self.detail.is_none() {
+        // The config pane is not about a document, so "nothing is open here"
+        // is not what it has to say (TASK-b08d090f699c).
+        if self.detail.is_none() && self.pane != Pane::Config {
             return [
                 "  nothing is open here",
                 "  Enter opens the row a listing's cursor is on, and hands this panel the",
@@ -2114,16 +2279,19 @@ impl App {
     /// exactly where there is something to open, rather than on a rule of
     /// arithmetic about which rows the block spent.
     fn pane_content(&self, width: usize) -> Vec<(Composed, Option<String>)> {
+        // Before the document is asked for, because this pane is not about one
+        // (TASK-b08d090f699c): what a corpus is configured to do is a fact
+        // about the repository, and a pane that drew nothing until somebody had
+        // opened an entity would be answering a question with an unrelated
+        // precondition.
+        if self.pane == Pane::Config {
+            return self.config_rows(width);
+        }
         let Some(detail) = &self.detail else {
             return Vec::new();
         };
         match self.pane {
-            Pane::Body => {
-                let mut out = self.block(width);
-                out.extend(self.prose_rows(width).into_iter().map(|line| (line, None)));
-                out
-            }
-            // The list whole, and the same rows: `c` is the block's constraints
+            // The list whole, and the same rows: `s` is the block's constraints
             // with the document taken away, not a second rendering of them.
             Pane::Constraints => {
                 let at = self.cursors[Focus::Body.number() - 1].at;
@@ -2139,7 +2307,61 @@ impl App {
                     })
                     .collect()
             }
+            // The document, and the pane above answered already.
+            _ => {
+                let mut out = self.block(width);
+                out.extend(self.prose_rows(width).into_iter().map(|line| (line, None)));
+                out
+            }
         }
+    }
+
+    /// The config pane's rows: what the pane says it is, then one row per key
+    /// `ank config` declares (TASK-b08d090f699c).
+    ///
+    /// **Every key, and the reader holds no list of them.** The keys are
+    /// `ank_contract::verbs::CONFIG_KEYS` -- the same constant `ank-cli`'s own
+    /// list is and the verb's note is rendered from -- so a key the CLI gains
+    /// reaches this pane with no edit here at all.
+    ///
+    /// Each row carries the key it would set, which is what makes Enter mean
+    /// something on this pane exactly as it does on the field block: a row that
+    /// names something to open carries it, and the two rows of prose above them
+    /// carry nothing.
+    ///
+    /// **A key the CLI refused is a row and never a missing row.**
+    /// `peers.<name>` names a family rather than a key and the verb says so;
+    /// the sentence it said is the row, because "where that value came from"
+    /// has an answer there too and hiding it would leave a person wondering
+    /// which keys the pane had decided not to show them.
+    fn config_rows(&self, width: usize) -> Vec<(Composed, Option<String>)> {
+        let mut out: Vec<(Composed, Option<String>)> = Vec::new();
+        for line in wrap(CONFIG_ABOUT, width.max(1)) {
+            out.push((Composed::of(&line).fitted(width), None));
+        }
+        for line in wrap(&config_offer(), width.max(1)) {
+            out.push((Composed::of(&line).fitted(width), None));
+        }
+        out.push((Composed::new(), None));
+        let Some(settings) = &self.config else {
+            // Never drawn from a running reader -- the pane is charged the
+            // moment it opens -- and said rather than left blank all the same,
+            // because a pane with no rows reads as a corpus with no keys.
+            out.push((
+                Composed::of("  the keys have not been read").fitted(width),
+                None,
+            ));
+            return out;
+        };
+        let at = self.cursors[Focus::Body.number() - 1].at;
+        for setting in &settings.keys {
+            let here = self.marker(out.len() == at);
+            out.push((
+                setting_row(setting, here, width),
+                Some(setting.key.to_string()),
+            ));
+        }
+        out
     }
 
     /// The document's own prose, wrapped to the panel and painted with nothing.
@@ -2258,6 +2480,20 @@ impl App {
             .into_iter()
             .nth(at)
             .and_then(|(_, id)| id)
+    }
+
+    /// The first row of the body panel that names something to open, and the
+    /// first row of all where none does.
+    ///
+    /// Read off [`App::pane_content`] rather than counted: the rows of prose
+    /// over the config pane's keys are wrapped to the panel, so how many there
+    /// are is a fact about the width and never an arithmetic to keep in step
+    /// with the sentence.
+    fn first_key_row(&self) -> usize {
+        self.pane_content(self.body_width())
+            .iter()
+            .position(|(_, opens)| opens.is_some())
+            .unwrap_or(0)
     }
 
     /// The width the body panel's rows are composed at.
@@ -3352,6 +3588,71 @@ fn constraint_row(c: &Row, here: &str) -> Composed {
         .plain(&c.title)
 }
 
+/// One key of the configuration, with what it is set to and where that came
+/// from (TASK-b08d090f699c).
+///
+/// **Three columns, and the reader composes none of the three.** The key is the
+/// contract's, the value and the source are the two fields `ank config <key>
+/// --json` answers with, and a key the CLI refused carries the first line of
+/// what it said in place of both -- which is what it has instead of a value,
+/// and is still an answer to where one would come from.
+///
+/// Painted with nothing. There is one table of what a word means
+/// (ADR-1f70ce2c3eac) and `file`, `default` and `unset` are not in it: a source
+/// is not a status, and colouring one here would be this reader inventing a
+/// second opinion about what a colour says.
+fn setting_row(setting: &Setting, here: &str, width: usize) -> Composed {
+    let said = match &setting.refused {
+        Some(refusal) => refusal.lines().next().unwrap_or_default().to_string(),
+        None => format!(
+            "{}  {}",
+            pad(setting.value.as_deref().unwrap_or_default(), SET_TO),
+            setting.source
+        ),
+    };
+    Composed::of(&format!("{here}{}  {said}", pad(setting.key, CONFIG_KEY))).fitted(width)
+}
+
+/// The column a config key is drawn in.
+///
+/// Wide enough for the longest key §4 declares -- `verifiers.<name>.timeout` is
+/// twenty-four -- so no key is cut. A key that was cut would be a key nobody
+/// could type back at the shell, which is the whole of what this pane is for.
+const CONFIG_KEY: usize = 25;
+
+/// The column a config value is drawn in.
+///
+/// A duration, a branch name, a number of tokens: values here are short, and
+/// the room left over goes to the source beside them.
+const SET_TO: usize = 18;
+
+/// What the config pane says it is, over its rows.
+///
+/// Public because the suite that drives the binary looks for it, and a suite
+/// carrying its own copy of a sentence would agree with a screen that had
+/// stopped saying it.
+pub const CONFIG_ABOUT: &str =
+    "  every key ank config declares, with the value in effect and where it came from";
+
+/// What the config pane says a row of it costs.
+///
+/// **Both keys are read out of the table and the shape out of the contract**
+/// (ADR-c07e2694f0e1). The key that opens a row is whatever runs
+/// [`Command::Open`], the key that runs a composed command is [`keys::CONFIRM`],
+/// and the command line is the verb's own usage. A sentence carrying its own
+/// copy of any of the three would be one of the five parallel tables that
+/// decision was written against, in prose.
+fn config_offer() -> String {
+    let shape = crate::form::spec_of(SETTING)
+        .map(|spec| spec.positional_help)
+        .unwrap_or_default();
+    format!(
+        "  {} on a key composes ank config {shape}, and {} runs it",
+        bindings::spelling_of(&Command::Open),
+        keys::CONFIRM
+    )
+}
+
 /// The column a field's label is drawn in.
 ///
 /// Wide enough for the longest name this format writes -- `done_criteria` and
@@ -4246,6 +4547,264 @@ mod tests {
             a.note.clone().unwrap_or_default().contains("ank review"),
             "focusing the queue did not run review at all: {:?}",
             a.note
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // The config pane (TASK-b08d090f699c)
+    // -----------------------------------------------------------------------
+
+    /// A pane holding one row per key, planted so that "this was read again"
+    /// is a fact a test can see against a CLI that is not there.
+    fn planted() -> Settings {
+        Settings {
+            keys: vec![Setting {
+                key: "planted",
+                value: Some("a value nothing would answer".to_string()),
+                source: "planted".to_string(),
+                refused: None,
+            }],
+        }
+    }
+
+    /// **The pane lists every key the contract declares, and the reader holds
+    /// no copy of them** (TASK-b08d090f699c).
+    ///
+    /// Measured against `ank_contract::verbs::CONFIG_KEYS` -- which is what
+    /// `ank-cli`'s own list *is* and what the verb's note is rendered from --
+    /// in both directions: a key the CLI gains is a row here with no edit, and
+    /// a row here that the contract does not declare would be this reader
+    /// inventing one.
+    #[test]
+    fn the_config_pane_draws_one_row_per_key_the_contract_declares() {
+        let declared = ank_contract::verbs::CONFIG_KEYS;
+        let mut a = app();
+        let ank = nowhere();
+        tap(&mut a, &ank, KeyCode::Char('o'));
+        let opened: Vec<String> = a
+            .pane_content(a.body_width())
+            .into_iter()
+            .filter_map(|(_, key)| key)
+            .collect();
+        assert_eq!(
+            opened, declared,
+            "the rows that open a key are not the keys the contract declares"
+        );
+        // And the key itself is on the row a person reads, whole: a key cut to
+        // fit is a key nobody can type back at the shell.
+        let frame = a.frame();
+        for key in declared {
+            assert!(frame.contains(key), "'{key}' is not on the pane:\n{frame}");
+        }
+    }
+
+    /// **The pane is charged when it is focused, and on no repaint**
+    /// (TASK-b08d090f699c).
+    ///
+    /// Three claims and each is measured in the shape it would break in. A
+    /// reader that has never opened the pane has asked nothing. A reload and a
+    /// watcher's news leave what the pane holds exactly as it was -- planted
+    /// here, because against a CLI that is not there every read answers the
+    /// same refusal and "it was read again" would otherwise be invisible. And
+    /// coming back to the panel with the pane open reads again, which is what
+    /// keeps a value somebody set at the shell from sitting stale on a screen.
+    #[test]
+    fn the_config_pane_is_read_when_it_is_focused_and_on_no_repaint() {
+        let mut a = app();
+        let ank = nowhere();
+        a.reload(&ank);
+        a.repaint(&ank);
+        for c in ['j', 'k', 'u', 'f', 'b', 's'] {
+            tap(&mut a, &ank, KeyCode::Char(c));
+        }
+        assert!(
+            a.config.is_none(),
+            "config was read while nobody had opened the pane"
+        );
+
+        tap(&mut a, &ank, KeyCode::Char('o'));
+        assert_eq!(a.pane, Pane::Config, "'o' did not open the pane");
+        assert!(a.config.is_some(), "opening the pane read nothing");
+
+        // A repaint is a watcher's news, and it must not put one
+        // `ank config <key>` per declared key on every event.
+        a.config = Some(planted());
+        a.reload(&ank);
+        a.repaint(&ank);
+        assert_eq!(
+            a.config.as_ref().map(|s| s.keys.len()),
+            Some(1),
+            "a repaint charged the pane"
+        );
+
+        // Arriving at the panel again is a person coming back to it, and that
+        // is where the price is paid.
+        tap(&mut a, &ank, KeyCode::Char('2'));
+        assert_eq!(a.focus(), Focus::Entities);
+        assert_eq!(
+            a.config.as_ref().map(|s| s.keys.len()),
+            Some(1),
+            "leaving the panel charged the pane"
+        );
+        tap(&mut a, &ank, KeyCode::Char('3'));
+        assert_eq!(
+            a.config.as_ref().map(|s| s.keys.len()),
+            Some(ank_contract::verbs::CONFIG_KEYS.len()),
+            "coming back to the pane did not read it again"
+        );
+
+        // And closing it reads nothing at all: `o` a second time is the body
+        // again, which is what `s` does with the constraints.
+        a.config = Some(planted());
+        tap(&mut a, &ank, KeyCode::Char('o'));
+        assert_eq!(a.pane, Pane::Body, "'o' did not close the pane");
+        assert_eq!(a.config.as_ref().map(|s| s.keys.len()), Some(1));
+    }
+
+    /// **A key the CLI refused is a row and never a missing row**
+    /// (TASK-b08d090f699c).
+    ///
+    /// `nowhere()` is a CLI that cannot be spawned, so every row is a refusal
+    /// -- which is the shape `peers.<name>` has against a real one, and the
+    /// question is the same either way: does the pane still name every key. A
+    /// pane that dropped what it could not answer for would be a pane hiding
+    /// which keys it had decided not to show.
+    #[test]
+    fn a_key_the_cli_refused_is_drawn_with_what_it_said() {
+        let mut a = app();
+        let ank = nowhere();
+        tap(&mut a, &ank, KeyCode::Char('o'));
+        let settings = a.config.as_ref().expect("the pane was charged");
+        assert_eq!(settings.keys.len(), ank_contract::verbs::CONFIG_KEYS.len());
+        for setting in &settings.keys {
+            assert!(setting.is_refusal(), "'{}' answered", setting.key);
+        }
+        let frame = a.frame();
+        assert!(
+            frame.contains("ank config"),
+            "the pane does not say what it could not run:\n{frame}"
+        );
+    }
+
+    /// **Opening a row of the pane opens the form that sets that key, and
+    /// nothing is spawned** (TASK-b08d090f699c).
+    ///
+    /// The key is the row the person opened and it is frozen into the form:
+    /// what the form composes is `ank config <key> <value>`, on the key that
+    /// was under the cursor when Enter was pressed rather than on whatever the
+    /// cursor has reached since.
+    #[test]
+    fn a_row_of_the_config_pane_opens_the_form_that_sets_that_key() {
+        let mut a = app();
+        let ank = nowhere();
+        tap(&mut a, &ank, KeyCode::Char('o'));
+        // The cursor opens on the first key and not on the sentence over it.
+        tap(&mut a, &ank, KeyCode::Enter);
+        let form = a.form.as_ref().expect("Enter on a key opens a form");
+        assert_eq!(form.verb(), SETTING);
+        assert_eq!(form.front(), [ank_contract::verbs::CONFIG_KEYS[0]]);
+        assert_eq!(
+            form.fields().first().map(|f| (f.flag, f.positional)),
+            Some(("<value>", true)),
+            "the first field is not the value the verb takes as a word"
+        );
+        assert!(a.pending.is_none(), "opening a row composed a command");
+        assert!(a.note.is_none(), "opening a row said something went wrong");
+
+        // And the key it carries is the row under the cursor, whichever that
+        // is: a second row opens a second form.
+        a.form = None;
+        tap(&mut a, &ank, KeyCode::Char('j'));
+        tap(&mut a, &ank, KeyCode::Enter);
+        assert_eq!(
+            a.form.as_ref().map(|f| f.front().to_vec()),
+            Some(vec![ank_contract::verbs::CONFIG_KEYS[1].to_string()])
+        );
+    }
+
+    /// **The pane composes nothing until a value is in it, and what it composes
+    /// goes through the confirmation** (TASK-b08d090f699c).
+    ///
+    /// `ank config <key>` alone is the reading shape -- the pane has drawn that
+    /// answer already -- so a form submitted empty says so and spawns nothing.
+    /// Filled in, what reaches the screen is the command line and not a
+    /// document: `App::confirmed` is still the one caller of `Ank::act`, and
+    /// nothing here has called it.
+    #[test]
+    fn the_form_refuses_an_empty_value_and_the_filled_one_is_shown_before_it_runs() {
+        let mut a = app();
+        let ank = nowhere();
+        tap(&mut a, &ank, KeyCode::Char('o'));
+        tap(&mut a, &ank, KeyCode::Enter);
+        tap(&mut a, &ank, KeyCode::Enter);
+        assert!(a.form.is_some(), "an empty form composed and closed");
+        assert!(a.pending.is_none(), "an empty form composed a command");
+        let said = a
+            .form
+            .as_ref()
+            .and_then(|f| f.said().map(|s| s.to_string()))
+            .expect("the form says which field it refused on");
+        assert!(said.contains("<value>"), "{said}");
+        assert!(said.contains("--unset"), "{said}");
+
+        for c in ['4', 'h'] {
+            tap(&mut a, &ank, KeyCode::Char(c));
+        }
+        tap(&mut a, &ank, KeyCode::Enter);
+        assert!(a.form.is_none(), "a form that composed stayed open");
+        let pending = a.pending.as_ref().expect("the command is on the screen");
+        assert_eq!(pending.verb, SETTING);
+        assert_eq!(
+            pending.args,
+            [
+                ank_contract::verbs::CONFIG_KEYS[0].to_string(),
+                "4h".to_string()
+            ],
+            "the composed argv is not the key and the value"
+        );
+        assert!(
+            pending.shown.contains(&format!(
+                "ank config {} 4h",
+                ank_contract::verbs::CONFIG_KEYS[0]
+            )),
+            "the confirmation does not spell the command: {}",
+            pending.shown
+        );
+    }
+
+    /// **Opening a document puts the body panel back on the document**
+    /// (TASK-b08d090f699c).
+    ///
+    /// The config pane is the one thing that panel shows which is not about an
+    /// entity, so a person who pressed Enter on a row of the entities listing
+    /// and got a list of settings would have been answered with something else.
+    /// The constraints pane is the other way round and stays: it follows
+    /// whatever document is open, because that is what it is about.
+    #[test]
+    fn opening_an_entity_leaves_the_config_pane_and_the_constraints_pane_stays() {
+        let mut a = app();
+        let ank = nowhere();
+        a.detail = Some(detail(
+            "TASK-49746735127f",
+            "---\nid: TASK-49746735127f\n---\n",
+        ));
+
+        a.pane = Pane::Config;
+        a.focus = Focus::Entities;
+        a.open_selected(&ank);
+        assert_eq!(
+            a.pane,
+            Pane::Body,
+            "a document was opened and the settings stayed on the screen"
+        );
+
+        a.pane = Pane::Constraints;
+        a.focus = Focus::Entities;
+        a.open_selected(&ank);
+        assert_eq!(
+            a.pane,
+            Pane::Constraints,
+            "the constraints pane follows the document it is about"
         );
     }
 

--- a/crates/ank-tui/tests/config.rs
+++ b/crates/ank-tui/tests/config.rs
@@ -1,0 +1,507 @@
+//! The config pane, through the binary, on a real terminal
+//! (TASK-b08d090f699c).
+//!
+//! CLAUDE.md leaves no choice about where this is measured and the criterion
+//! names every instrument: the keys are what `ank config` *declares*, the
+//! values are what `ank config <key> --json` *answers*, dismissing is measured
+//! **on the bytes of the file**, confirming is measured by asking the binary
+//! again, and unsetting is measured by the *source* the key comes back with.
+//! A unit test can say which argv a form composed; it cannot say that a process
+//! holding a terminal in raw mode listed eight keys it never wrote down, showed
+//! a command line before spawning it, and left `config.yml` byte for byte
+//! unchanged when the person said no.
+//!
+//! **The key list is read off the binary's own page and never spelled here.**
+//! `ank help config`'s note is rendered from `ank_contract::verbs::CONFIG_KEYS`
+//! -- the same constant `ank-cli`'s own closed key set *is* -- so a suite that
+//! reads the note and compares it with what the pane drew is measuring the
+//! whole chain the criterion asks about: contract to CLI, contract to pane, and
+//! the two agreeing because they are one table rather than three.
+//!
+//! **And "on no repaint" is measured by making the corpus move.** A reload that
+//! did nothing at all would pass an assertion that the values had not changed,
+//! so the corpus is changed at the shell *and* an entity is added: the entity
+//! arriving on the listing is what says the reload ran, and the value not
+//! moving beside it is what says the reload did not charge this pane.
+//!
+//! The terminal, the corpus and the driven session are `terminal/mod.rs`, which
+//! `tests/confirmation.rs` and `tests/entity.rs` declare too.
+
+#![cfg(unix)]
+
+mod terminal;
+
+use terminal::{ids_of, short_of, Live, Repo};
+
+/// The key that answers a confirmation, out of the reader's own table.
+const CONFIRM: char = ank_tui::keys::CONFIRM;
+/// What the confirmation says above the command line, and what it says after a
+/// person has declined one.
+const ABOUT: &str = ank_tui::view::ABOUT;
+const DISMISSED: &str = ank_tui::view::DISMISSED;
+
+/// Wide enough that a composed `ank config <key> <value>` fits one row and a
+/// key row is drawn whole, so an assertion on either is an assertion on a line
+/// and not on a reflow.
+const WINDOW: (u16, u16) = (140, 40);
+
+/// The letter the config pane is opened with, out of the reader's own table.
+///
+/// Never `o` written here. The point of the wave is that a key *is* the verb,
+/// and a suite that typed the letter `config` happens to be bound to today
+/// would go on passing against a table that moved it.
+fn key_of_config() -> String {
+    let binding = ank_tui::bindings::of_verb(ank_tui::form::SET)
+        .expect("the reader binds a key to the config pane");
+    let letter = ank_tui::bindings::named(binding.key);
+    assert_eq!(
+        letter.chars().count(),
+        1,
+        "the key is named '{letter}', which is not one keystroke to send"
+    );
+    letter
+}
+
+/// The key that reads the corpus again, and the digit that reaches the body
+/// panel: both out of the reader's own table rather than typed here.
+fn key_of_reload() -> String {
+    let said = ank_tui::bindings::spelling_of(&ank_tui::input::Command::Reload);
+    assert_eq!(said.chars().count(), 1, "reload is named '{said}'");
+    said
+}
+
+fn digit_of_body() -> String {
+    ank_tui::view::Focus::Body.number().to_string()
+}
+
+// ---------------------------------------------------------------------------
+// What the binary says the verb declares
+// ---------------------------------------------------------------------------
+
+/// The keys `ank config` declares, read off the binary's own page.
+///
+/// The note and not this suite's memory of it: the page is rendered from the
+/// contract's own constant, which is what the reader's pane reads and what
+/// `ank-cli`'s closed key set is. A suite carrying its own copy of the eight
+/// would agree with a pane that had drifted, which is the whole failure
+/// ADR-c07e2694f0e1 was written against.
+fn declared(repo: &Repo) -> Vec<String> {
+    let page = String::from_utf8_lossy(&repo.ank(&["help", "config"]).stdout).to_string();
+    let line = page
+        .lines()
+        .map(|l| l.trim())
+        .find_map(|l| l.strip_prefix("note:").map(|r| r.trim().to_string()))
+        .unwrap_or_default();
+    let keys: Vec<String> = line
+        .strip_prefix("keys:")
+        .unwrap_or_default()
+        .split_whitespace()
+        .map(|k| k.to_string())
+        .collect();
+    assert!(
+        !keys.is_empty(),
+        "'ank help config' declared no keys:\n{page}"
+    );
+    keys
+}
+
+/// One field of `ank config <key> --json`, or `None` where the verb refused.
+///
+/// Read out of the document the CLI writes rather than off its human page,
+/// which is what the criterion names: "what `ank config <key> --json`
+/// answers".
+fn answered(repo: &Repo, key: &str, field: &str) -> Option<String> {
+    // `tried` and not `ank`, because a refusal is one of the two answers being
+    // measured: `peers.<name>` names a family and the verb declines it, which
+    // is a row of the pane rather than a failure of this suite.
+    let out = repo.tried(&["config", key, "--json"], &[]);
+    if !out.status.success() {
+        return None;
+    }
+    let doc = String::from_utf8_lossy(&out.stdout).to_string();
+    let at = doc.find(&format!("\"{field}\":"))? + field.len() + 3;
+    let rest = &doc[at..];
+    let value = rest.strip_prefix('"')?;
+    let end = value.find('"')?;
+    Some(value[..end].to_string())
+}
+
+// ---------------------------------------------------------------------------
+// Driving the pane
+// ---------------------------------------------------------------------------
+
+/// The screen, flattened to one line, so an assertion about a command line
+/// survives the row it happens to have wrapped onto.
+fn flat(frame: &str) -> String {
+    frame
+        .lines()
+        .map(|l| l.trim())
+        .collect::<Vec<&str>>()
+        .join(" ")
+        .split_whitespace()
+        .collect::<Vec<&str>>()
+        .join(" ")
+}
+
+/// The config keys the pane drew, in the order it drew them.
+///
+/// Read as words rather than by column, so a border glyph, a marker or a
+/// padding change does not turn this into an assertion about the layout: what
+/// is being asked is which keys are on the screen and in what order.
+fn drawn(frame: &str, keys: &[String]) -> Vec<String> {
+    let mut out = Vec::new();
+    for line in frame.lines() {
+        if let Some(key) = line
+            .split_whitespace()
+            .find(|word| keys.iter().any(|k| k == word))
+        {
+            out.push(key.to_string());
+        }
+    }
+    out
+}
+
+/// The one row of a frame that carries this key, where there is one.
+///
+/// A whole line and not a word, which is what tells a row of the pane from the
+/// same key named in the note band under it: the pane draws the key and its
+/// value on one line, and the answer a verb reported puts each field on a line
+/// of its own.
+fn row_of(frame: &str, key: &str) -> Option<String> {
+    frame
+        .lines()
+        .find(|l| l.split_whitespace().any(|w| w == key))
+        .map(|l| l.to_string())
+}
+
+/// Opens the pane and waits for it to have been read.
+fn open_pane(live: &mut Live, keys: &[String]) {
+    live.send(&key_of_config());
+    live.until("the config pane to open and be read", |t| {
+        t.contains("CONFIG") && drawn(t, keys).len() == keys.len()
+    });
+}
+
+/// The row one key is on, which is the row it is drawn on.
+fn row_at(keys: &[String], key: &str) -> usize {
+    keys.iter()
+        .position(|k| k == key)
+        .unwrap_or_else(|| panic!("'{key}' is no key of this build"))
+}
+
+/// Puts the cursor on one key of the pane and opens it onto its form.
+///
+/// `from` is the key the cursor is on now: the first of them where the pane has
+/// just been opened, and whatever was opened last after that -- a pane is a
+/// place and it leaves the cursor where its person left it, which is the same
+/// rule every listing in this reader follows.
+///
+/// What is waited for is the form's own banner, which carries the key. A suite
+/// that counted keystrokes and asserted nothing would go on passing against a
+/// pane whose rows had moved, and would have opened the wrong one.
+fn open_key(live: &mut Live, keys: &[String], from: &str, key: &str) {
+    let (at, now) = (row_at(keys, key), row_at(keys, from));
+    let step = match at >= now {
+        true => "j",
+        false => "k",
+    };
+    for _ in 0..at.abs_diff(now) {
+        live.send(step);
+    }
+    live.send("\r");
+    let banner = format!("CONFIG {}", key.to_ascii_uppercase());
+    live.until("the form for that key to open", |t| t.contains(&banner));
+}
+
+// ---------------------------------------------------------------------------
+// The pane
+// ---------------------------------------------------------------------------
+
+/// **The pane lists every key `ank config` declares, each with the value in
+/// effect and where that value came from** (TASK-b08d090f699c).
+///
+/// Both halves and in order, which is what makes "the reader carries no copy of
+/// that key list" measurable at all: the keys on the screen are compared with
+/// the keys the *binary* declares, so a reader holding a list of its own could
+/// only pass by holding the same list -- and it holds none, because the pane
+/// reads the contract's constant that the note is rendered from.
+///
+/// The value and the source are compared per key with what `ank config <key>
+/// --json` answers, which is the criterion's own instrument. A key the verb
+/// refuses about -- `peers.<name>` names a family and no peer can be called
+/// that -- is still a row, carrying what the CLI said: a pane that dropped it
+/// would be short by one and would not say which.
+#[test]
+fn the_pane_lists_every_declared_key_with_its_value_and_its_source() {
+    let repo = Repo::seeded();
+    repo.warm();
+    let keys = declared(&repo);
+
+    let mut live = Live::open(&repo, WINDOW.0, WINDOW.1);
+    live.until("the session to open", |t| t.contains("2 ENTITIES"));
+    open_pane(&mut live, &keys);
+    let frame = live.frame();
+    live.quit();
+
+    assert_eq!(
+        drawn(&frame, &keys),
+        keys,
+        "the pane's keys are not the keys the binary declares:\n{frame}"
+    );
+    let said = flat(&frame);
+    let mut answered_any = 0;
+    let mut refused_any = 0;
+    for key in &keys {
+        match answered(&repo, key, "source") {
+            Some(source) => {
+                answered_any += 1;
+                assert!(
+                    said.contains(&format!("{key}")),
+                    "'{key}' is not on the pane:\n{frame}"
+                );
+                assert!(
+                    said.contains(&source),
+                    "'{key}' does not say its value came from '{source}':\n{frame}"
+                );
+                if let Some(value) = answered(&repo, key, "value") {
+                    assert!(
+                        said.contains(&value),
+                        "'{key}' does not carry the value '{value}' in effect:\n{frame}"
+                    );
+                }
+            }
+            // The verb declined this shape, and what it said is the row.
+            None => {
+                refused_any += 1;
+                assert!(
+                    said.contains(&format!("{key}")),
+                    "'{key}' was refused and dropped from the pane:\n{frame}"
+                );
+            }
+        }
+    }
+    assert!(
+        answered_any > 0,
+        "no key answered at all, so nothing above was measured"
+    );
+    assert!(
+        refused_any > 0,
+        "no key was refused, so the row that carries a refusal was never drawn"
+    );
+    // And the pane says what it is, over the rows: a screen of keys with no
+    // sentence over them is a screen a person has to be told about elsewhere.
+    assert!(
+        said.contains(ank_tui::view::CONFIG_ABOUT.trim()),
+        "the pane does not say what it is:\n{frame}"
+    );
+}
+
+/// **Setting one raises the confirmation spelling `ank config <key> <value>`,
+/// and dismissing writes nothing** (TASK-b08d090f699c).
+///
+/// The negative is measured where the criterion puts it: on the bytes of the
+/// file. Every file under `.ank/` is compared before and after, so a reader
+/// that spawned the verb it had only offered would be caught whatever it wrote
+/// -- and the binary is asked again afterwards as well, because a corpus can be
+/// unchanged for the wrong reason.
+#[test]
+fn setting_a_key_is_shown_first_and_dismissing_it_writes_nothing() {
+    let repo = Repo::seeded();
+    repo.warm();
+    let keys = declared(&repo);
+    let key = "claim_ttl_max";
+    let was = answered(&repo, key, "value").expect("the corpus has a claim ttl");
+    let before = repo.corpus();
+    assert!(!before.is_empty(), "the corpus has files to compare");
+
+    let mut live = Live::open(&repo, WINDOW.0, WINDOW.1);
+    live.until("the session to open", |t| t.contains("2 ENTITIES"));
+    open_pane(&mut live, &keys);
+    open_key(&mut live, &keys, &keys[0], key);
+
+    live.send("4h");
+    live.send("\r");
+    let wanted = format!("ank config {key} 4h --json");
+    live.until("the confirmation to be shown", |t| {
+        flat(t).contains(&wanted)
+    });
+    let asking = live.frame();
+    let asked = flat(&asking);
+    assert!(
+        asked.contains(ABOUT),
+        "the write was not asked about:\n{asking}"
+    );
+    assert!(
+        asked.contains(&format!("{CONFIRM} runs it")),
+        "no key was offered to run it with:\n{asking}"
+    );
+
+    // Dismissed with Escape, which is the key a person reaches for and the key
+    // a slipped finger finds.
+    live.send("\u{1b}");
+    live.until("the command to be dismissed", |t| {
+        flat(t).contains(DISMISSED)
+    });
+    let after = live.frame();
+    assert!(
+        flat(&after).contains(&wanted),
+        "the reader did not say what it had not done:\n{after}"
+    );
+    live.quit();
+
+    assert_eq!(
+        before,
+        repo.corpus(),
+        "a file under .ank/ moved, and the write was dismissed"
+    );
+    assert_eq!(
+        answered(&repo, key, "value").as_deref(),
+        Some(was.as_str()),
+        "'{key}' moved, and the write was dismissed"
+    );
+}
+
+/// **Confirming changes what `ank config <key> --json` answers, and unsetting
+/// returns the key to the source it had before** (TASK-b08d090f699c).
+///
+/// One session for both, on a key that starts *unset* -- so "the source it had
+/// before" is a fact with two different values to distinguish it by, and not
+/// only a value that came back. A key already in the file would return to
+/// `file` either way and the assertion would say nothing.
+#[test]
+fn confirming_writes_the_key_and_unsetting_returns_it_to_the_source_it_had() {
+    let repo = Repo::seeded();
+    repo.warm();
+    let keys = declared(&repo);
+    let key = "claim_ttl_default";
+    let source = answered(&repo, key, "source").expect("the key answers");
+    let value = answered(&repo, key, "value").expect("the key resolves to something");
+    assert_eq!(
+        source, "default",
+        "this suite needs a key the file does not carry"
+    );
+
+    let mut live = Live::open(&repo, WINDOW.0, WINDOW.1);
+    live.until("the session to open", |t| t.contains("2 ENTITIES"));
+    open_pane(&mut live, &keys);
+
+    // Set it, and answer yes.
+    open_key(&mut live, &keys, &keys[0], key);
+    live.send("45m");
+    live.send("\r");
+    live.until("the confirmation to be shown", |t| {
+        flat(t).contains(&format!("ank config {key} 45m --json"))
+    });
+    live.send(&CONFIRM.to_string());
+    live.until("the write to be reported", |t| flat(t).contains("changed"));
+    assert_eq!(answered(&repo, key, "value").as_deref(), Some("45m"));
+    assert_eq!(answered(&repo, key, "source").as_deref(), Some("file"));
+    // And the pane says so without anybody asking it to: the key that was set
+    // is a row that was wrong the moment the verb answered.
+    live.until("the pane to carry the new value", |t| {
+        row_of(t, key).is_some_and(|row| row.contains("45m") && row.contains("file"))
+    });
+
+    // Unset it, and answer yes again. The switch is the verb's own flag, on a
+    // row of the same form: Tab reaches it and Space turns it over.
+    open_key(&mut live, &keys, key, key);
+    live.send("\t ");
+    live.send("\r");
+    live.until("the unset to be shown", |t| {
+        flat(t).contains(&format!("ank config {key} --unset --json"))
+    });
+    live.send(&CONFIRM.to_string());
+    live.until("the removal to be reported", |t| {
+        flat(t).contains("changed")
+    });
+    live.quit();
+
+    assert_eq!(
+        answered(&repo, key, "source").as_deref(),
+        Some(source.as_str()),
+        "'{key}' did not come back to the source it had"
+    );
+    assert_eq!(
+        answered(&repo, key, "value").as_deref(),
+        Some(value.as_str()),
+        "'{key}' came back to its old source with a different value"
+    );
+}
+
+/// **The pane is charged when it is focused, and on no repaint**
+/// (TASK-b08d090f699c).
+///
+/// The corpus is moved at the shell in two ways at once: a config key is set,
+/// and an entity is made. The entity is what makes the negative honest -- it
+/// arrives on the listing, so the reload demonstrably ran -- and the config
+/// value not moving beside it is the claim: a watcher's news does not put one
+/// `ank config <key>` per declared key on the wire.
+///
+/// Then the focus leaves the panel and comes back, which is a person arriving
+/// at the pane, and the new value is there. A pane that could only be made
+/// current by reopening the session would be a pane showing values as old as
+/// the session.
+#[test]
+fn the_pane_is_read_when_it_is_focused_and_a_reload_does_not_charge_it() {
+    let repo = Repo::seeded();
+    repo.warm();
+    let keys = declared(&repo);
+    let key = "claim_ttl_max";
+    let was = answered(&repo, key, "value").expect("the corpus has a claim ttl");
+
+    let mut live = Live::open(&repo, WINDOW.0, WINDOW.1);
+    live.until("the session to open", |t| t.contains("2 ENTITIES"));
+    open_pane(&mut live, &keys);
+    assert!(
+        flat(&live.frame()).contains(&was),
+        "the pane did not carry the value it opened on"
+    );
+
+    // The corpus moves under the reader, in both the ways it can.
+    let before = ids_of(&repo.stdout(&["find", "--json"]));
+    repo.ank(&["config", key, "8h"]);
+    repo.ank(&[
+        "new",
+        "task",
+        "--title",
+        "A task made while the reader was open",
+        "--scope",
+        "src/**",
+        "--criteria",
+        "It arrives on the listing when the reader reads again.",
+    ]);
+    repo.warm();
+    let made = ids_of(&repo.stdout(&["find", "--json"]))
+        .into_iter()
+        .find(|id| !before.contains(id))
+        .expect("a task was made while the reader was open");
+
+    // The entity arriving is what says the reload ran, and it is what makes the
+    // two assertions under it worth anything: a reload that did nothing at all
+    // would leave the config row alone too.
+    live.send(&key_of_reload());
+    live.until("the reload to reach the listing", |t| {
+        t.contains(&short_of(&made))
+    });
+    let after = live.frame();
+    let row = row_of(&after, key).expect("the pane still draws the key");
+    assert!(
+        row.contains(&was),
+        "a reload charged the config pane: the row already moved:\n{after}"
+    );
+    assert!(
+        !row.contains("8h"),
+        "a reload charged the config pane:\n{after}"
+    );
+
+    // And arriving at the panel again is where the price is paid.
+    live.send("2");
+    live.until("the entities panel to take the focus", |t| {
+        t.contains("> 2 ENTITIES")
+    });
+    live.send(&digit_of_body());
+    live.until("the pane to be read again", |t| {
+        row_of(t, key).is_some_and(|row| row.contains("8h"))
+    });
+    live.quit();
+}


### PR DESCRIPTION
Closes TASK-b08d090f699c, the last of the reader wave.

## What `o` opens

A pane in the body panel listing every key `ank config` declares, each with the value in effect and where it came from. Enter on a row opens the form that sets that key, and what the form composes goes through the confirmation every other act in this reader goes through.

A pane and not a fifth panel: LOG-1afc1b09f95b spends a whole entry on rows being a budget, and a panel costs two of them at every window whether or not anybody is looking at it. It is the one pane that names no entity — what a corpus is configured to do is a fact about the repository — so it draws with nothing open and its title says `CONFIG` rather than `BODY`.

## `config` is the one verb on both roads

`ank.rs` asserted that nothing on `ACTS` is on `READS`, and the property is real: a repaint calls `Ank::json`, so a verb on both roads is a verb a watcher's news can reach.

The answer is the one the task body recorded: `BOTH_ROADS`, a named list of exactly one verb, and `reading_shape`, a gate that reads the argument shape rather than the name. One positional is a read; every other shape is refused before anything is spawned.

It is stricter than "two positionals is a write" in one direction, and deliberately: `--unset` is **one** positional and removes a line from the file, so a gate that counted positionals alone would have left a write on the reading road — the exact hole the exception exists not to open. "Exactly one word, and it is not a flag" covers the value, `--unset` and `--user` together.

`Failed` gains `NotAReadingShape` rather than reusing `NotARead`: `config` *is* a verb this reader reads with, and `config <key> <value>` is not a read.

## Outside `crates/ank-tui/**`, said explicitly

- `crates/ank-contract/src/verbs.rs` gains `CONFIG_KEYS` and `CONFIG_KEYS_NOTE` — the eight keys written once, in a macro invocation expanding to both the slice and the space-separated sentence `config`'s note carries — and the note is now that constant. `concat!` and not a join, because a note is a `&'static str` inside a `const` table.
- `crates/ank-cli/src/config.rs`'s `KEYS` is that constant rather than a second literal, and `cli.rs`'s note test now says what it measures: a rendering, and the shape a reader with only the note to go on would split it by.

One table instead of three, which is the task body's recorded intent and the only way the reader could reach the set at all: ADR-8bd76e8d7c4e forbids it linking `ank-cli`.

## The form, widened by one fact

`Form::on(verb, front)` takes positionals the caller has already decided, and `form::taken` reads the placeholder of the *next* one off the verb's own `positional_help`. So `<value>` is a row of the form and composes as a bare word. Nothing is taken while nothing has been supplied, which is what keeps `new`, `edit`, `close` and `attest` untouched.

`Need::Any` gained a second field. Its legend said "a call naming none opens `$EDITOR`", true of `edit` and false of `config`: `ank config <key>` **reads**. A screen telling a person that setting nothing opens an editor is worse than one that says nothing, so the sentence is a field of the variant now.

## Measured, not asserted

`crates/ank-tui/tests/config.rs` drives the binary on a pseudo-terminal at 140x40:

- the keys drawn, in order, against the keys `ank help config` declares;
- the value and source per row against `ank config <key> --json`, with an answered key and a refused one (`peers.<name>`) both required to have been seen;
- dismissing measured on `Repo::corpus()` — every byte under `.ank/` before and after;
- confirming by asking the binary again;
- unsetting on the **source**: `claim_ttl_default` goes `default` → `file` → `default`, which is why that key and not one the file already carries;
- "on no repaint" by moving the corpus twice at the shell — a config key and a new task — where the task arriving on the listing says the reload ran and the config row not moving beside it is the claim.

The two traps the previous agent logged were not rediscovered, and the first bit exactly as recorded: a mutation that dropped five of the eight keys **passed** under `cargo test -p ank-tui --test config` against the stale binary, and failed after `cargo build --workspace`. Every pty result here was taken after a workspace build.

`cargo test --workspace` green, `cargo fmt --check` clean, `ank check` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G756nXSs4bg5HEFL7XpMJC