### PR TITLE
Propose that a pty result is evidence only after a workspace build

### DIFF
--- a/.ank/entities/ADR-93d8ef477c00.md
+++ b/.ank/entities/ADR-93d8ef477c00.md
@@ -1,0 +1,52 @@
+---
+id: ADR-93d8ef477c00
+type: adr
+slug: a-pseudo-terminal-suite-drives-the-binary-alread
+title: A pseudo-terminal suite drives the binary already on disk, and only a workspace build replaces it
+created: 2026-08-27T06:12:42Z
+author: claude-code/opus-5
+status: proposed
+scope:
+  - crates/*/tests/**
+constraint: |
+  A pseudo-terminal result is evidence only after cargo build --workspace has rebuilt the ank binary in the profile the suite reads. cargo test -p <crate> does not build that binary: CARGO_BIN_EXE_ank is defined only for ank-cli, so a package-scoped run drives whatever executable is already on disk and reports green about it. A criterion phrased about the binary and measured with -p alone is unmeasured, and a mutation check run that way proves nothing about the instrument.
+schema: 4
+version: 1
+---
+
+CLAUDE.md already says that a criterion talking about the binary is tested
+through the binary. That rule earned its keep twice in this wave. What it does
+not say, and what cost two agents a false green, is which cargo invocation
+actually puts a current binary under the test that drives it.
+
+WHY A PACKAGE-SCOPED RUN DRIVES A STALE BINARY. `CARGO_BIN_EXE_ank` is defined
+only for the package that declares the binary, and that is `ank-cli`. So
+`crates/ank-tui/tests/terminal/mod.rs` looks for `ank` beside its own test
+executable -- `<target>/<profile>/` where cargo puts a binary next to
+`deps/`. Nothing in that lookup builds anything. `cargo test -p ank-tui`
+compiles ank-tui and its suites, finds whatever `ank` is already on disk, and
+drives that. The module's own header calls it "the `ank` this workspace just
+built", which is true under `--workspace` and false under `-p`.
+
+THE FAILURE MODE IS A PASSING TEST, WHICH IS THE WORST ONE. It does not error
+and it does not hang. It measures a real binary carefully and reports green
+about a build that no longer exists. TASK-e8da6a00564a mutated `Runs::Form` to
+`Runs::Compose` to check its own pty test could see the difference; the test
+passed. Rebuilt, it failed as a timeout. TASK-b08d090f699c dropped five of eight
+config keys; the suite passed under `cargo test -p ank-tui --test config`, and
+failed after `cargo build --workspace`. Two agents, two tasks, the same shape:
+the instrument was checked and the instrument was measuring yesterday.
+
+WHY THIS IS A CONSTRAINT AND NOT A NOTE IN A LOG. Both occurrences are recorded
+in logs attached to tasks that are done. A log explains what one agent found; it
+binds nobody afterwards, and the second agent hit this after the first had
+already written it down. The corpus's whole claim is that a rule with a glob
+reaches work that did not exist when the rule was written. An agent about to
+verify a criterion against a pseudo-terminal is exactly that work.
+
+WHAT IT DOES NOT SAY. It does not forbid `-p` for iterating: a package-scoped
+run is the fast way to compile and to exercise unit tests, and nothing here
+argues otherwise. It binds the moment a pty result is used as evidence -- a
+mutation check, a criterion measured, a `done` about to be recorded. At that
+moment the binary under the test must be the binary the change produced, and
+`--workspace` is what makes that true.


### PR DESCRIPTION
`ADR-93d8ef477c00`, **proposed** — it binds nobody until ratified, and ratification is not mine to run.

## What it records

`CARGO_BIN_EXE_ank` is defined only for the package that declares the binary, and that is `ank-cli`. So `crates/ank-tui/tests/terminal/mod.rs` looks for `ank` beside its own test executable and drives whatever is already on disk. `cargo test -p ank-tui` compiles the suites, finds a stale binary, and reports green about it. That module's header calls it "the `ank` this workspace just built" — true under `--workspace`, false under `-p`.

## Why it is worth a constraint

The failure mode is a **passing test**, not an error and not a hang. Two agents in this wave checked their own instrument with a mutation and were told it worked:

- `TASK-e8da6a00564a` mutated `Runs::Form` → `Runs::Compose`; the pty test passed. Rebuilt, it failed as a timeout.
- `TASK-b08d090f699c` dropped five of eight config keys; the suite passed under `cargo test -p ank-tui --test config`, and failed after `cargo build --workspace`.

Both are recorded in logs attached to tasks that are now done. A log explains what one agent found and binds nobody afterwards — the second agent hit this *after* the first had already written it down. A rule with a glob reaches work that did not exist when it was written; an agent about to verify a criterion against a pseudo-terminal is exactly that work.

## What it does not say

It does not forbid `-p` for iterating. It binds the moment a pty result is used as evidence — a mutation check, a criterion measured, a `done` about to be recorded.

Scope is `crates/*/tests/**`. No code changes — one entity added to `.ank/`. `ank check` green (325 tasks, 75 adr).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018LQxhwYnHgQsixy7WbtSxw