### PR TITLE
Ratify ADR-93d8ef477c00

### DIFF
--- a/.ank/entities/ADR-93d8ef477c00.md
+++ b/.ank/entities/ADR-93d8ef477c00.md
@@ -5,13 +5,17 @@ slug: a-pseudo-terminal-suite-drives-the-binary-alread
 title: A pseudo-terminal suite drives the binary already on disk, and only a workspace build replaces it
 created: 2026-08-27T06:12:42Z
 author: claude-code/opus-5
-status: proposed
+status: accepted
 scope:
   - crates/*/tests/**
 constraint: |
   A pseudo-terminal result is evidence only after cargo build --workspace has rebuilt the ank binary in the profile the suite reads. cargo test -p <crate> does not build that binary: CARGO_BIN_EXE_ank is defined only for ank-cli, so a package-scoped run drives whatever executable is already on disk and reports green about it. A criterion phrased about the binary and measured with -p alone is unmeasured, and a mutation check run that way proves nothing about the instrument.
+ratified: 04af5eb4f073
+verified:
+  - by: haksolot@vmi3223161
+    at: 2026-08-27T06:42:19Z
 schema: 4
-version: 1
+version: 2
 ---
 
 CLAUDE.md already says that a criterion talking about the binary is tested


### PR DESCRIPTION
`ADR-93d8ef477c00` — "A pseudo-terminal suite drives the binary already on disk, and only a workspace build replaces it" — is now **accepted**. The ratification commit `12f70e1` carries Sean's SSH signature (`sean.lamet@dekrow.com`, ed25519), and `ank accept` verified it against the corpus's own allowed-signers list before writing.

Not a supersession, so there is no citation sweep to carry alongside: nothing in the workspace cites a document this retires, and `ank check` is green — 325 tasks, 75 adr, 0 faults.

## What now binds

A pty result is evidence only after `cargo build --workspace` has rebuilt the `ank` binary in the profile the suite reads. `cargo test -p <crate>` does not build it — `CARGO_BIN_EXE_ank` is defined only for `ank-cli`, so a package-scoped run drives whatever executable is already on disk and reports green about it.

Scope is `crates/*/tests/**`, so it reaches every suite that drives the binary, including ones not yet written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018LQxhwYnHgQsixy7WbtSxw