### PR TITLE
Plan the reader's redesign: two decisions and fourteen tasks

### DIFF
--- a/.ank/entities/ADR-559eebf5c6f5.md
+++ b/.ank/entities/ADR-559eebf5c6f5.md
@@ -1,0 +1,96 @@
+---
+id: ADR-559eebf5c6f5
+type: adr
+slug: the-reader-is-one-list-and-one-document-and-what
+title: The reader is one list and one document, and what it shows first is what moved last
+created: 2026-08-27T16:32:47Z
+author: haksolot@vmi3223161
+status: proposed
+scope:
+  - crates/ank-tui/**
+constraint: |
+  The terminal reader is a full-screen application drawn with ratatui over crossterm. Those two dependencies are spent here and nowhere else in the workspace, and what they buy is stated rather than assumed: one full-screen region, a scrollbar over it, keystroke input in raw mode, terminal resize, and mouse events including the wheel. No FFI enters this tree for any of it, on any platform.
+  
+  The reader is a list and a document, and never both at once. Opening a row replaces the list with the document it names; leaving that document gives the list back with the same row selected. There is no panel to choose between and so no focus to arbitrate: one row is selected, one function composes a row, and a row is drawn the same way wherever it is drawn. What was a panel is a screen reached in its turn or a section of the one list, never a rule drawn around emptiness. A search narrows the list as it is typed and is not a line to compose and submit.
+  
+  Input is a keystroke and no longer a line. Every command that only moves the screen is one key. Every verb that writes is reached through a confirmation that shows the exact command line about to be run and does not run it until the person confirms: it must be impossible to reach a spawned write without passing through it, and a verb added to the reader is inside that rule on the day it arrives. Which verbs may be spawned at all stays a list written in the code, measured against the key table and never generated from it.
+  
+  The reader answers a person who is not at a desk. One screen is what every width gets, so no arrangement reflows and nothing collapses to a border with nothing inside it; where a row cannot afford its fields it drops them from the right, and the identifier and the marker are the two it never drops. Touching the row already selected opens it. Every action a screen offers is reachable by touch through permanently visible targets carved out of the header the reader draws anyway, so they cost no row; the kind in force is one of them. No command requires a modifier chord, and no offer is drawn at rest.
+  
+  A key is the verb it runs. Where the CLI declares a verb the reader binds that verb's own initial to it and navigation takes what is left. What the reader offers is read out of the contract's own verb table rather than transcribed beside it.
+  
+  What the reader shows first is chosen rather than inherited: the work that is alive, then what waits for a ratification, then what was created most recently. An identifier orders nothing. Log entries are read under the entity they annotate and are never rows of the list.
+  
+  Structure is drawn with box-drawing glyphs and drops to ASCII on the terminal that declares it can render neither those nor colour; that probe is the terminal's own declaration and never NO_COLOR. The same corpus drawn with the paint and without it is identical character for character. Where a person is standing is carried by the marker on the row and never by colour. A scrollbar is characters or it is not drawn.
+  
+  What ADR-8bd76e8d7c4e fixed is untouched and this restates none of it: the reader reaches the corpus only by running the CLI with --json, it writes nothing the person at the keyboard did not ask for, it renews no claim on its own, and accept stays a signed human act it may drive and never perform. No browser reader, nothing under a viewer/ directory, no HTML page.
+supersedes: ADR-c07e2694f0e1
+schema: 4
+version: 2
+---
+
+ADR-c07e2694f0e1 is one day old and this supersedes it, which needs saying
+plainly. Six of its eight clauses are carried forward, three of them word for
+word. What changes is the shape of the screen and the order of what is on it,
+and neither was wrong when it was written: they were inherited.
+
+## The inheritance, and why it ends
+
+ADR-0b55983421dd said it outright: "lazygit is the reference, and it was the
+reference before any of this was written -- the intention simply never reached
+the corpus". ADR-c07e2694f0e1 then spent its whole argument on what the panels
+cost and none on whether there should be panels, because the panels were not up
+for decision. They are now.
+
+lazygit shows four planes of one repository that a person compares by eye: the
+files, the branches, the commits, the diff. Comparison is what the arrangement
+buys. ank shows a corpus of entities that a person walks and opens. Nothing on
+that screen is compared with anything else on it, so the arrangement buys
+nothing and is paid for anyway -- in rows, in borders, and in the four separate
+answers the code now gives to "how is a row drawn".
+
+## What four panels actually cost, measured
+
+Three row schemas with no shared composer: claims is cursor, held marker, short
+identifier, holder, expiry, title; entities is cursor, row number, short
+identifier, status, title, and a trailing `[held]` word for the same fact the
+claims panel draws as a marker; the queue has no status column at all. Only
+entities prints row numbers, but a bare number at the prompt selects a row on
+any focused listing, so two panels ask for a number they do not show.
+
+Focus is a border weight, and every overlay draws the focused border
+unconditionally, so a modal looks exactly like the panel behind it. That is the
+inconsistency the owner saw, and it is not a rendering bug: it is what happens
+when four things can be focused and one glyph has to say which.
+
+With one region none of that has anywhere to live. That is the argument.
+
+## Why the order was noise
+
+`crates/ank-cli/src/index.rs:709` orders by identifier, and identifiers are
+`KIND-<hex>`. On this corpus the first row is `ADR-01b6` because `01b6` sorts
+first. It is not creation order, not recency, not relevance; it is a hash, shown
+in the position a person reads as "most important".
+
+The fix is cheap because the data is already there. The index stores `created`
+at `index.rs:106` and `SELECT_ROW` already selects it; it is simply never
+serialised into `find --json`. Logs already carry an `about` column with an
+index on it, so folding them under the entity they annotate is a query that
+exists. What was missing was the decision about what order means, and that is
+this clause.
+
+Seventy per cent of this corpus is log entries. A list that opens on them is a
+list that has answered a question nobody asked.
+
+## The target that costs no row
+
+ADR-c07e2694f0e1 removed a band of touch targets because it cost four rows of
+twenty-four, and it replaced it with `?` in the header plus second-touch-to-
+open. That pattern is right and this extends it rather than reopening it:
+`help_rect` carves `?` out of the header that is drawn anyway. The kind in force
+has to be written somewhere regardless -- a person must be able to see what they
+are looking at -- so making that cell a target adds nothing to the frame. It is
+information made touchable, which is the opposite of an offer drawn at rest.
+
+That is what answers "on a phone you cannot even change the type you are
+searching", without buying back the tax.

--- a/.ank/entities/ADR-f3d1dea65d84.md
+++ b/.ank/entities/ADR-f3d1dea65d84.md
@@ -1,0 +1,69 @@
+---
+id: ADR-f3d1dea65d84
+type: adr
+slug: a-verb-pays-for-the-answer-it-gives-and-status-d
+title: A verb pays for the answer it gives, and status does not read the corpus to count what it reports
+created: 2026-08-27T16:31:52Z
+author: haksolot@vmi3223161
+status: proposed
+scope:
+  - crates/ank-cli/**
+constraint: |
+  A verb pays for the answer it gives. A verb whose answer is a handful of fields does not pay a cost that grows with the corpus to produce them, and a counter it reports is served from the index that already holds the parse rather than from a fresh read of every file on disk.
+  
+  status is where this is measured, because it is the verb a reader asks first and the one that costs the most. It reports faults and signals, and it obtains them without reading the corpus a second time: the verdict of the mechanical check is memoised in the index, keyed on the state the index already tracks for the files together with the tip of refs/ank/*. Both halves of that key are required and neither is sufficient, because the check inspects orphaned claims, which live in the refs and not in the files. On a key that does not match, the verb pays once and stores what it found.
+  
+  What the verb answers does not move to buy this. status --json keeps every field it has, under the same key and with the same type: the machine contract lets a document gain a field within a version and never lose, rename or retype one, so no counter becomes absent, optional or null in exchange for speed. Speed is bought from where an answer is computed and never from what the answer says.
+  
+  A cache whose key is wrong makes the verb lie, and a lying status is worse than a slow one. So the key is stated here rather than left to the implementation, and a verb that cannot establish its key pays the full cost rather than guessing.
+schema: 4
+version: 1
+---
+
+`ank status --json` costs 2750 to 2850 milliseconds on this corpus of 1471
+entities. `ank find --json`, which returns every one of those entities and 216
+kilobytes of JSON, costs 530 to 820. The verb that answers in fourteen fields is
+four times more expensive than the verb that answers with the whole corpus.
+
+## Where it goes
+
+`crates/ank-cli/src/status.rs:256` calls `human::inspect(repo, cfg, None,
+false)`. That walks both storage layouts, parses every entity file in the
+corpus, and returns a `Report`. Three of that report's fields are used:
+`report.drift`, `report.faults()` and `report.signals()`. The last two are
+printed as two integers at `status.rs:404-408`.
+
+So the corpus is read from disk, in full, to print `"faults":0,"signals":396`.
+
+The `prune: false` argument is right and stays: a reader does not sanitise the
+coordination plane underneath everyone else. It is also not where the cost is.
+The cost is the read, and the read is not needed.
+
+## Why a cache and not a flag
+
+The obvious answer is to compute the counters only when asked. It is not
+available, and the reason is written into `crates/ank-contract/src/lib.rs:40`:
+
+> Within one version a document may *gain* a field, and may never lose, rename
+> or *retype* one.
+
+A `faults` that is a number when asked for and `null` otherwise has been
+retyped. So has one that is absent without a flag. Either would force
+`CONTRACT_VERSION` from 1 to 2, which is the most expensive change this
+repository can make, and it would buy nothing a cache does not.
+
+The `null` idiom ten lines further down in the same file -- `refs` is null
+without `--remote`, because "null is the question never asked" -- is not a
+counter-example. That field was born null. Retyping one that was born a number
+is the thing the contract forbids.
+
+## What this is not
+
+It is not a claim that verbs must be fast. `ank check` reads the corpus because
+reading the corpus is its answer, and it should go on costing what it costs.
+The rule is narrower and harder: a verb does not pay for an answer it is not
+giving. `status` gives a summary, and a summary is not a re-derivation.
+
+Nor does it make the daemon load-bearing. ADR-a22cd3196529 says nothing depends
+on `ank watch`, and nothing here does: the cache lives in the index every verb
+already opens, and a cold index simply pays once.

--- a/.ank/entities/LOG-532853e2478e.md
+++ b/.ank/entities/LOG-532853e2478e.md
@@ -1,0 +1,25 @@
+---
+id: LOG-532853e2478e
+type: log
+title: Measured on this corpus before any of this was written, release binary, 1471 entities (1037 log,
+created: 2026-08-27T16:36:00Z
+author: haksolot@vmi3223161
+scope:
+  - crates/ank-tui/**
+about: ADR-559eebf5c6f5
+seq: 0
+schema: 4
+version: 1
+---
+
+ 325 task, 75 adr, 34 spec).
+
+The opening frame costs 4.2 seconds on a pseudo-terminal, and ank status --json is spawned twice before it: once at crates/ank-tui/src/lib.rs:317, which spends a whole status call to read one field, corpus, for the event stream to key on, and once at crates/ank-tui/src/model.rs:100 inside Snapshot::load. status --json costs 2750 to 2850 ms because crates/ank-cli/src/status.rs:256 parses every entity file on disk to print faults and signals.
+
+Narrowing find buys nothing and the plan must not spend a contract change on it: find --json whole is 530 to 820 ms for 1471 rows, and find --json --type spec is 825 to 1516 ms for 34. The cost is opening the index, not the payload.
+
+Ordering by identifier is ordering by hash: crates/ank-cli/src/index.rs:709 is ORDER BY id, and identifiers are KIND-<hex>, so the first row of this corpus is ADR-01b6 because 01b6 sorts first. created is already stored at index.rs:106 and already selected by SELECT_ROW, merely never serialised.
+
+Folding log entries under the entity they annotate needs no CLI change: show --json already answers with log, machinery, log_total and log_shown, and the reader discards them.
+
+ADR-3b6ba766a42e forces the order of the whole plan. A hundred and thirty-two citations of ADR-c07e2694f0e1 stand in twenty-five tracked files, so accept refuses until TASK-73b1eea6cecb has swept them. The signature is therefore the last act of this plan and not the first, and code lands citing this decision while it is still proposed. That is deliberate: accepting first would put prose describing one screen above code drawing four.

--- a/.ank/entities/LOG-8a039387d13b.md
+++ b/.ank/entities/LOG-8a039387d13b.md
@@ -1,0 +1,17 @@
+---
+id: LOG-8a039387d13b
+type: log
+title: +blocked_by TASK-b917fc12fee8, -blocked_by TASK-be17972988d9, done_criteria (version 1 to 2,
+created: 2026-08-27T16:35:23Z
+author: haksolot@vmi3223161
+scope:
+  - crates/ank-tui/src/model.rs
+  - crates/ank-tui/src/lib.rs
+about: TASK-fff0a98511b2
+seq: 0
+records: edit
+schema: 4
+version: 1
+---
+
+ replaced a972cb6db33f, produced ff73548fb891)

--- a/.ank/entities/LOG-8a97435ba890.md
+++ b/.ank/entities/LOG-8a97435ba890.md
@@ -1,0 +1,14 @@
+---
+id: LOG-8a97435ba890
+type: log
+title: constraint (version 1 to 2, replaced 2032c983ed41, produced a06b76a18441)
+created: 2026-08-27T16:38:08Z
+author: haksolot@vmi3223161
+scope:
+  - crates/ank-tui/**
+about: ADR-559eebf5c6f5
+seq: 1
+records: edit
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-d5e1e56bdea0.md
+++ b/.ank/entities/LOG-d5e1e56bdea0.md
@@ -1,0 +1,14 @@
+---
+id: LOG-d5e1e56bdea0
+type: log
+title: done_criteria (version 1 to 2, replaced be563af7783e, produced 57eaa97c6413)
+created: 2026-08-27T16:35:22Z
+author: haksolot@vmi3223161
+scope:
+  - crates/ank-cli/src/commands.rs
+about: TASK-b917fc12fee8
+seq: 0
+records: edit
+schema: 4
+version: 1
+---

--- a/.ank/entities/TASK-12bd5acbf706.md
+++ b/.ank/entities/TASK-12bd5acbf706.md
@@ -1,0 +1,17 @@
+---
+id: TASK-12bd5acbf706
+type: task
+slug: the-kind-in-force-is-written-in-the-header-and-t
+title: The kind in force is written in the header, and the cell that writes it is a target
+created: 2026-08-27T16:34:09Z
+author: haksolot@vmi3223161
+status: open
+scope:
+  - crates/ank-tui/src/view.rs
+blocked_by: [TASK-252bf02de218]
+done_criteria: |
+  The kind the list is restricted to is written in the header at every width the harness opens. One keystroke advances it through the kinds a row may have and back to all of them, and a press on that cell of the header advances the same cycle by the same step. The header occupies the same number of rows after this task as before it. Measured through the binary.
+criteria_by: creator
+schema: 4
+version: 1
+---

--- a/.ank/entities/TASK-252bf02de218.md
+++ b/.ank/entities/TASK-252bf02de218.md
@@ -1,0 +1,18 @@
+---
+id: TASK-252bf02de218
+type: task
+slug: the-reader-is-one-region-a-list-and-the-document
+title: "The reader is one region: a list, and the document a row opens over it"
+created: 2026-08-27T16:33:29Z
+author: haksolot@vmi3223161
+status: open
+scope:
+  - crates/ank-tui/src/view.rs
+  - crates/ank-tui/src/lib.rs
+blocked_by: [TASK-fff0a98511b2]
+done_criteria: |
+  At every width the pseudo-terminal harness can open, from forty columns to a hundred and fifty, the frame carries exactly one bordered region. Opening a row replaces the list with that entity's document; leaving the document gives the list back with the same row selected as before. Neither the claims nor the ratification queue is a panel any more, and each stays reachable by the key it already had. Nothing in the frame collapses to a border with no content inside it, at any width. Measured through the binary.
+criteria_by: creator
+schema: 4
+version: 1
+---

--- a/.ank/entities/TASK-3fa4892f17c0.md
+++ b/.ank/entities/TASK-3fa4892f17c0.md
@@ -1,0 +1,18 @@
+---
+id: TASK-3fa4892f17c0
+type: task
+slug: a-log-entry-is-read-under-the-entity-it-annotate
+title: A log entry is read under the entity it annotates and is never a row of the list
+created: 2026-08-27T16:33:58Z
+author: haksolot@vmi3223161
+status: open
+scope:
+  - crates/ank-tui/src/model.rs
+  - crates/ank-tui/src/view.rs
+blocked_by: [TASK-252bf02de218]
+done_criteria: |
+  No entity of kind log is a row of the list, under any filter the reader offers, and the kinds the filter cycles through are the kinds a row may have. The document of an entity carrying log entries shows them beneath it in the order they were written; the document of one carrying none draws no empty rule where they would be. Measured through the binary.
+criteria_by: creator
+schema: 4
+version: 1
+---

--- a/.ank/entities/TASK-42de0df951a4.md
+++ b/.ank/entities/TASK-42de0df951a4.md
@@ -1,0 +1,17 @@
+---
+id: TASK-42de0df951a4
+type: task
+slug: one-press-chooses-a-row-and-two-on-the-same-row
+title: One press chooses a row, and two on the same row open it
+created: 2026-08-27T16:34:09Z
+author: haksolot@vmi3223161
+status: open
+scope:
+  - crates/ank-tui/src/view.rs
+blocked_by: [TASK-252bf02de218]
+done_criteria: |
+  The pseudo-terminal harness shows that one press selects the row under the pointer, that two presses on that row inside the interval the code names open its document, and that two presses on different rows open nothing. The interval is a named constant and not a number written at the place it is compared. Measured through the binary.
+criteria_by: creator
+schema: 4
+version: 1
+---

--- a/.ank/entities/TASK-73b1eea6cecb.md
+++ b/.ank/entities/TASK-73b1eea6cecb.md
@@ -1,0 +1,19 @@
+---
+id: TASK-73b1eea6cecb
+type: task
+slug: the-workspace-cites-the-decision-that-binds-it-a
+title: The workspace cites the decision that binds it, and the supersession can land
+created: 2026-08-27T16:35:42Z
+author: haksolot@vmi3223161
+status: open
+scope:
+  - crates/ank-tui/**
+  - crates/ank-cli/tests/tui.rs
+  - crates/ank-contract/src/verbs.rs
+blocked_by: [TASK-b5185df7aa44, TASK-3fa4892f17c0, TASK-d58efe37eb7b, TASK-c94d086682f3, TASK-d712d7f9a326, TASK-42de0df951a4, TASK-12bd5acbf706]
+done_criteria: |
+  No tracked file outside .ank/ names ADR-c07e2694f0e1, and every sentence that quoted one of its clauses says what the clause replacing it says rather than being deleted with the identifier. The count is a hundred and thirty-two citations across twenty-five files at the time this was written, in crates/ank-tui, crates/ank-cli/tests/tui.rs and crates/ank-contract/src/verbs.rs. The diagram at the head of view.rs is the frame the binary actually draws, checked against a session on a pseudo-terminal and not against a drawing. cargo test is green, ank check reports no new fault, and ank graph shows no cycle and no orphan.
+criteria_by: creator
+schema: 4
+version: 1
+---

--- a/.ank/entities/TASK-b5185df7aa44.md
+++ b/.ank/entities/TASK-b5185df7aa44.md
@@ -1,0 +1,17 @@
+---
+id: TASK-b5185df7aa44
+type: task
+slug: the-order-is-the-work-that-is-alive-then-what-wa
+title: The order is the work that is alive, then what waits for a signature, then what moved last
+created: 2026-08-27T16:33:58Z
+author: haksolot@vmi3223161
+status: open
+scope:
+  - crates/ank-tui/src/model.rs
+blocked_by: [TASK-b917fc12fee8, TASK-252bf02de218]
+done_criteria: |
+  On a corpus carrying an open task, a task a live claim holds, a proposed decision and at least ten finished entities, the list opens on the open and the claimed, then the proposed, then the rest in decreasing order of created. No identifier takes part in the ordering. Two runs over an unchanged corpus put the rows in the same order. Measured through the binary.
+criteria_by: creator
+schema: 4
+version: 1
+---

--- a/.ank/entities/TASK-b917fc12fee8.md
+++ b/.ank/entities/TASK-b917fc12fee8.md
@@ -1,0 +1,17 @@
+---
+id: TASK-b917fc12fee8
+type: task
+slug: every-row-of-find-json-says-when-the-entity-it-n
+title: Every row of find --json says when the entity it names was created
+created: 2026-08-27T16:33:10Z
+author: haksolot@vmi3223161
+status: open
+scope:
+  - crates/ank-cli/src/commands.rs
+blocked_by: []
+done_criteria: |
+  Every row of ank find --json carries created, an RFC3339 timestamp equal to the created of the entity that row names. The document carries corpus, equal to the corpus ank status --json reports for the same repository. Every key those documents already carry keeps its name, its type and its value, and the document still reports contract 1. Measured through the binary.
+criteria_by: creator
+schema: 4
+version: 2
+---

--- a/.ank/entities/TASK-be17972988d9.md
+++ b/.ank/entities/TASK-be17972988d9.md
@@ -1,0 +1,18 @@
+---
+id: TASK-be17972988d9
+type: task
+slug: status-counts-what-it-reports-without-reading-th
+title: status counts what it reports without reading the corpus to do it
+created: 2026-08-27T16:33:10Z
+author: haksolot@vmi3223161
+status: open
+scope:
+  - crates/ank-cli/src/status.rs
+  - crates/ank-cli/src/index.rs
+blocked_by: []
+done_criteria: |
+  On a corpus of at least a thousand entities with a warm index, ank status --json answers in under 250 milliseconds. Its faults and signals stay numbers under the keys they already have, and their values equal what ank check --json reports for the same corpus. An entity written, edited or removed between two runs changes them, and so does a claim ref appearing or going stale, so the memoised verdict is keyed on the files and on the tip of refs/ank/* and not on one of the two. Measured through the binary.
+criteria_by: creator
+schema: 4
+version: 1
+---

--- a/.ank/entities/TASK-c94d086682f3.md
+++ b/.ank/entities/TASK-c94d086682f3.md
@@ -1,0 +1,18 @@
+---
+id: TASK-c94d086682f3
+type: task
+slug: a-search-narrows-as-it-is-typed-and-the-line-to
+title: A search narrows as it is typed, and the line to compose goes with the grammar that read it
+created: 2026-08-27T16:33:58Z
+author: haksolot@vmi3223161
+status: open
+scope:
+  - crates/ank-tui/src/input.rs
+  - crates/ank-tui/src/keys.rs
+blocked_by: [TASK-252bf02de218]
+done_criteria: |
+  Pressing the search key and then characters narrows the list on every keystroke with nothing to submit, and Escape gives back the list unnarrowed. The prompt grammar of input.rs is gone from the crate. Every movement that survives it is a key in the binding table, and the key list the reader draws names each of them. Measured through the binary.
+criteria_by: creator
+schema: 4
+version: 1
+---

--- a/.ank/entities/TASK-d58efe37eb7b.md
+++ b/.ank/entities/TASK-d58efe37eb7b.md
@@ -1,0 +1,18 @@
+---
+id: TASK-d58efe37eb7b
+type: task
+slug: one-function-composes-a-row-and-a-test-refuses-a
+title: One function composes a row, and a test refuses a second one
+created: 2026-08-27T16:33:58Z
+author: haksolot@vmi3223161
+status: open
+scope:
+  - crates/ank-tui/src/view.rs
+  - crates/ank-tui/src/text.rs
+blocked_by: [TASK-252bf02de218]
+done_criteria: |
+  Exactly one function in the crate composes a row of the list, and a test walking the sources fails when a second place assembles one, the way paint.rs already fails when a second place names a colour. At every width the harness opens, the frame drawn with paint and the frame drawn without it are identical character for character.
+criteria_by: creator
+schema: 4
+version: 1
+---

--- a/.ank/entities/TASK-d712d7f9a326.md
+++ b/.ank/entities/TASK-d712d7f9a326.md
@@ -1,0 +1,18 @@
+---
+id: TASK-d712d7f9a326
+type: task
+slug: the-wheel-moves-the-view-and-not-the-cursor-and
+title: The wheel moves the view and not the cursor, and a bar appears only where the content overruns
+created: 2026-08-27T16:34:09Z
+author: haksolot@vmi3223161
+status: open
+scope:
+  - crates/ank-tui/src/view.rs
+  - crates/ank-tui/src/text.rs
+blocked_by: [TASK-252bf02de218]
+done_criteria: |
+  A wheel event over a list longer than the region changes which row is drawn first and leaves the selected row where it was. A bar saying where the view sits is drawn while the content is longer than the region and not otherwise, and it is drawn in characters: the frame with paint and the frame without it stay identical character for character. Measured through the binary.
+criteria_by: creator
+schema: 4
+version: 1
+---

--- a/.ank/entities/TASK-def2cadf48b1.md
+++ b/.ank/entities/TASK-def2cadf48b1.md
@@ -1,0 +1,17 @@
+---
+id: TASK-def2cadf48b1
+type: task
+slug: the-filter-is-computed-once-for-a-frame-and-not
+title: The filter is computed once for a frame and not once for every question asked about it
+created: 2026-08-27T16:33:11Z
+author: haksolot@vmi3223161
+status: open
+scope:
+  - crates/ank-tui/src/view.rs
+blocked_by: []
+done_criteria: |
+  Drawing one frame over a corpus of at least a thousand entities walks the entity rows a number of times that does not grow with the number of questions the frame asks about them, and a test counts the walks and names the number. Every existing test of the crate stays green.
+criteria_by: creator
+schema: 4
+version: 1
+---

--- a/.ank/entities/TASK-f0c6372d8dc0.md
+++ b/.ank/entities/TASK-f0c6372d8dc0.md
@@ -1,0 +1,17 @@
+---
+id: TASK-f0c6372d8dc0
+type: task
+slug: the-reader-parses-the-answers-it-is-given-with-a
+title: The reader parses the answers it is given with a parser for the language they are in
+created: 2026-08-27T16:33:10Z
+author: haksolot@vmi3223161
+status: open
+scope:
+  - crates/ank-tui/src/ank.rs
+blocked_by: []
+done_criteria: |
+  serde_yaml appears nowhere in the dependency tree of ank-tui, and crates/ank-tui/tests/dependencies.rs asserts its absence the way that suite already asserts ank-core's. Every existing test of the crate stays green.
+criteria_by: creator
+schema: 4
+version: 1
+---

--- a/.ank/entities/TASK-fff0a98511b2.md
+++ b/.ank/entities/TASK-fff0a98511b2.md
@@ -1,0 +1,18 @@
+---
+id: TASK-fff0a98511b2
+type: task
+slug: the-reader-draws-its-first-frame-from-one-answer
+title: The reader draws its first frame from one answer and waits for no second one
+created: 2026-08-27T16:33:20Z
+author: haksolot@vmi3223161
+status: open
+scope:
+  - crates/ank-tui/src/model.rs
+  - crates/ank-tui/src/lib.rs
+blocked_by: [TASK-b917fc12fee8]
+done_criteria: |
+  On a corpus of at least a thousand entities the reader draws its first frame having spawned no child that reads the corpus, and the rows arrive after it. ank status is spawned from no place on the opening road: neither for the corpus identity the event stream needs, which find now carries, nor inside the snapshot. A test names the two call sites that are gone -- crates/ank-tui/src/lib.rs and crates/ank-tui/src/model.rs -- and fails if a status spawn returns to either. ank tui --json still answers with branch, default_branch and identity, which is a different road and keeps its price. The pseudo-terminal harness sees a frame in under one second. Measured through the binary.
+criteria_by: creator
+schema: 4
+version: 2
+---


### PR DESCRIPTION
## Why

The reader was built with lazygit as its reference, and three rounds of planning kept the panel model while moving furniture inside it. This round names the model itself: ank shows a corpus a person walks and opens. Nothing on that screen is compared with anything else on it, so an arrangement buys nothing and is paid for anyway — in rows, in borders, and in four separate answers to *how is a row drawn*.

## Measured before deciding

| call | cost |
|---|---|
| `ank status --json` | **2750–2850 ms** |
| `ank find --json` (1471 rows, 216 KB) | 530–820 ms |
| `ank find --json --type spec` (34 rows) | 825–1516 ms |
| opening frame, on a pty | **4.2 s** |

Three findings that changed the plan:

- **`status` is spawned twice before the first frame** — `crates/ank-tui/src/lib.rs:317` spends a whole status call to read one field, `corpus`, and `model.rs:100` spends another inside `Snapshot::load`. `status.rs:256` parses every entity file on disk to print `faults` and `signals`.
- **Narrowing `find` buys nothing.** 34 rows cost as much as 1471; the cost is opening the index, not the payload. So no `--limit`, no repeated `--type`, no contract change that way.
- **Ordering is `ORDER BY id` over a hash** (`index.rs:709`). `ADR-01b6` is first because `01b6` sorts first. `created` is already stored and already selected — merely never serialised. Logs already carry an indexed `about` column, and `show --json` already answers with `log` and `machinery`.

## The decisions

Two, because ADR-6e09 prices the smallest perimeter and a rule about `status`'s cost governs `crates/ank-cli`, not the reader.

- **ADR-f3d1dea65d84** — *A verb pays for the answer it gives*. The counters are memoised in the index, keyed on the files **and** the tip of `refs/ank/*`, because the check inspects orphaned claims. `status --json` stays byte-for-byte identical: `CONTRACT_VERSION`'s own promise forbids retyping a field, so a nullable or flag-gated counter would force the contract to 2.
- **ADR-559eebf5c6f5** — *The reader is one list and one document*. Supersedes ADR-c07e2694f0e1. The confirmation gate, the hand-written spawn allowlist, the verb-initial keys read from the contract, the glyph probe and the character-for-character rule all carry forward unchanged.

Both land **proposed**. `ank accept` is yours.

## The order is forced

`ADR-c07e2694f0e1` is cited **132 times across 25 tracked files**, and ADR-3b6b refuses a supersession the workspace still cites. So the signature is the **last** act of this plan: code lands citing a proposed ADR, and `TASK-73b1eea6cecb` sweeps the citations as the sink of the graph. Accepting first would put prose describing one screen above code drawing four.

## The waves

- **1 — perf, screen unchanged, no signature needed.** `status` stops rescanning; `find --json` gains `created` and `corpus` (additive, contract stays 1); the reader's first frame spawns nothing that reads the corpus; JSON stops being parsed by a YAML parser.
- **2 — the shape.** One region; living work then awaiting ratification then recency; logs under their entity; one row composer; incremental search.
- **3 — mouse, scroll, thumb.** The wheel moves the view and not the cursor; a bar only on overflow; the kind in force becomes a header target — the same zero-row trick `help_rect` already uses for `?`.

## Verification

`cargo test --workspace` green, `cargo fmt --check` clean, `ank check` ok (0 faults), `ank graph` no cycle and no orphan.

One thing to know: all fourteen tasks raise an **over-constrained scope** signal. Any open task inside `crates/ank-tui/**` inherits ADR-c07e's 3368-character constraint plus 1530 characters of project-wide ADRs, against a 4000 limit. I cut the new ADR's constraint from 4747 to 3431 — parity with what it replaces — but clearing the budget outright would mean dropping rules that bind, which is the wrong trade. Flagging it rather than hiding it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WxqZPPTjs52rNG49BX8kTo