### PR TITLE
The reader reads JSON with a parser for JSON

### DIFF
--- a/.ank/entities/LOG-2f13e9a2e305.md
+++ b/.ank/entities/LOG-2f13e9a2e305.md
@@ -1,0 +1,17 @@
+---
+id: LOG-2f13e9a2e305
+type: log
+title: serde_yaml is reached from three sources of this crate, not one. ank.rs:438 is the parse the task
+created: 2026-08-27T17:15:28Z
+author: claude-code/opus-5+reader-json
+scope:
+  - crates/ank-tui/src/ank.rs
+  - crates/ank-tui/Cargo.toml
+  - crates/ank-tui/tests/dependencies.rs
+about: TASK-f0c6372d8dc0
+seq: 1
+schema: 4
+version: 1
+---
+
+ names; src/stream.rs:194 parses each watcher event line with serde_yaml::from_str::<serde_yaml::Value> on its own; src/view.rs matches serde_yaml's own Value variants in flat() (Sequence, Mapping, Tagged) and two of its tests build a Ran from YAML flow scalars that are not JSON. Dropping the dependency stops the crate compiling until all three move, so the criterion -- serde_yaml nowhere in ank-tui's graph -- cannot be met inside the three files the scope declares. Not editing outside it; asking for the scope instead.

--- a/.ank/entities/LOG-3bfd7ce4a457.md
+++ b/.ank/entities/LOG-3bfd7ce4a457.md
@@ -1,0 +1,19 @@
+---
+id: LOG-3bfd7ce4a457
+type: log
+title: Restored a second time; the five-file swap is on disk and unchanged. All that remains is one full
+created: 2026-08-27T17:50:20Z
+author: claude-code/opus-5+reader-json
+scope:
+  - crates/ank-tui/src/ank.rs
+  - crates/ank-tui/Cargo.toml
+  - crates/ank-tui/tests/dependencies.rs
+  - crates/ank-tui/src/stream.rs
+  - crates/ank-tui/src/view.rs
+about: TASK-f0c6372d8dc0
+seq: 4
+schema: 4
+version: 1
+---
+
+ workspace run and the commit. Running it once and reading the result rather than re-running: the crate's own lib tests were green before the kill, and the two pty suites that failed did so only because target/debug/ank was not built yet, which a workspace run builds.

--- a/.ank/entities/LOG-a932b97fcd05.md
+++ b/.ank/entities/LOG-a932b97fcd05.md
@@ -1,0 +1,17 @@
+---
+id: LOG-a932b97fcd05
+type: log
+title: done, proof commit:76a3ed5f9bfbad3ec668ec210ccc4c42ce4fcfd0
+created: 2026-08-27T18:02:38Z
+author: claude-code/opus-5+reader-json
+scope:
+  - crates/ank-tui/src/ank.rs
+  - crates/ank-tui/Cargo.toml
+  - crates/ank-tui/tests/dependencies.rs
+  - crates/ank-tui/src/stream.rs
+  - crates/ank-tui/src/view.rs
+about: TASK-f0c6372d8dc0
+seq: 5
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-cdab7ded4327.md
+++ b/.ank/entities/LOG-cdab7ded4327.md
@@ -1,0 +1,20 @@
+---
+id: LOG-cdab7ded4327
+type: log
+title: +scope crates/ank-tui/src/stream.rs, +scope crates/ank-tui/src/view.rs (version 3 to 4, replaced
+created: 2026-08-27T17:16:30Z
+author: claude-code/opus-5+reader-json
+scope:
+  - crates/ank-tui/src/ank.rs
+  - crates/ank-tui/Cargo.toml
+  - crates/ank-tui/tests/dependencies.rs
+  - crates/ank-tui/src/stream.rs
+  - crates/ank-tui/src/view.rs
+about: TASK-f0c6372d8dc0
+seq: 2
+records: edit
+schema: 4
+version: 1
+---
+
+ 6e7a28c09140, produced 2456367a37eb)

--- a/.ank/entities/LOG-d60b7dbdfb54.md
+++ b/.ank/entities/LOG-d60b7dbdfb54.md
@@ -1,0 +1,19 @@
+---
+id: LOG-d60b7dbdfb54
+type: log
+title: "Swap is written across all five files and ank-tui compiles: serde_json (preserve_order, to keep"
+created: 2026-08-27T17:39:11Z
+author: claude-code/opus-5+reader-json
+scope:
+  - crates/ank-tui/src/ank.rs
+  - crates/ank-tui/Cargo.toml
+  - crates/ank-tui/tests/dependencies.rs
+  - crates/ank-tui/src/stream.rs
+  - crates/ank-tui/src/view.rs
+about: TASK-f0c6372d8dc0
+seq: 3
+schema: 4
+version: 1
+---
+
+ view.rs::answered drawing fields in the CLI's own order) replaces serde_yaml in the manifest, ank.rs exposes document() as the crate's one parse and both spawn() and stream.rs's follower ask it, view.rs::flat() matches JSON's six shapes instead of YAML's seven, and tests/dependencies.rs asserts serde_yaml's absence from the graph beside ank-core's. The lockfile gained one package block and nothing else; every crate serde_json pulls was already locked. Was mid-run on the workspace suite when killed: the crate's own lib tests are green, the pty suites need target/debug/ank built first.

--- a/.ank/entities/TASK-f0c6372d8dc0.md
+++ b/.ank/entities/TASK-f0c6372d8dc0.md
@@ -5,15 +5,17 @@ slug: the-reader-parses-the-answers-it-is-given-with-a
 title: The reader parses the answers it is given with a parser for the language they are in
 created: 2026-08-27T16:33:10Z
 author: haksolot@vmi3223161
-status: open
+status: in_progress
 scope:
   - crates/ank-tui/src/ank.rs
   - crates/ank-tui/Cargo.toml
   - crates/ank-tui/tests/dependencies.rs
+  - crates/ank-tui/src/stream.rs
+  - crates/ank-tui/src/view.rs
 blocked_by: []
 done_criteria: |
   serde_yaml appears nowhere in the dependency tree of ank-tui, and crates/ank-tui/tests/dependencies.rs asserts its absence the way that suite already asserts ank-core's. Every existing test of the crate stays green.
 criteria_by: creator
 schema: 4
-version: 2
+version: 4
 ---

--- a/.ank/entities/TASK-f0c6372d8dc0.md
+++ b/.ank/entities/TASK-f0c6372d8dc0.md
@@ -5,7 +5,7 @@ slug: the-reader-parses-the-answers-it-is-given-with-a
 title: The reader parses the answers it is given with a parser for the language they are in
 created: 2026-08-27T16:33:10Z
 author: haksolot@vmi3223161
-status: in_progress
+status: done
 scope:
   - crates/ank-tui/src/ank.rs
   - crates/ank-tui/Cargo.toml
@@ -16,6 +16,11 @@ blocked_by: []
 done_criteria: |
   serde_yaml appears nowhere in the dependency tree of ank-tui, and crates/ank-tui/tests/dependencies.rs asserts its absence the way that suite already asserts ank-core's. Every existing test of the crate stays green.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 76a3ed5f9bfbad3ec668ec210ccc4c42ce4fcfd0
+    criteria: 495a6b8d366b
+    via: submitted
 schema: 4
-version: 4
+version: 5
 ---

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,7 +73,7 @@ dependencies = [
  "ank-contract",
  "crossterm",
  "ratatui",
- "serde_yaml",
+ "serde_json",
 ]
 
 [[package]]
@@ -1273,6 +1273,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.143"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/crates/ank-tui/Cargo.toml
+++ b/crates/ank-tui/Cargo.toml
@@ -53,11 +53,26 @@ ank-contract = { path = "../ank-contract" }
 # window and the rows inside it are one arithmetic.
 crossterm = { version = "0.29", default-features = false, features = ["events", "windows"] }
 ratatui = { version = "0.30", default-features = false, features = ["std", "crossterm", "layout-cache", "underline-color"] }
-# **The CLI's `--json` has to be *read*, and no crate entered for that.**
-# `ank-contract::json` writes and does not read, and `serde_yaml` is already a
-# dependency of `ank-core`, `ank-cli`, `ank-daemon` and `ank-mcp`. YAML 1.2 is a
-# superset of JSON, so a one-line document parses as flow YAML.
-# `ank-mcp` reads JSON-RPC requests this way already (§13 spends a dependency
-# only on necessity), and the escaper on the other side emits only `\"`, `\\`,
-# `\n` and `\u00xx`, every one of which a double-quoted YAML scalar carries.
-serde_yaml = "0.9"
+# **The CLI's `--json` has to be *read*, and this is what reads it.**
+# `ank-contract::json` writes and does not read, so something here has to.
+#
+# **What this replaces, and why the replacement is worth a crate.** This was
+# `serde_yaml`, on the argument that YAML 1.2 is a superset of JSON and a crate
+# already in the tree four times over costs nothing more. The argument is true
+# about the grammar and was the wrong instrument all the same: `ank find --json`
+# answers this corpus with 216 KB, every byte of which is JSON, and a YAML
+# reader arrives at it through a resolver that has to decide whether `yes` is a
+# boolean, whether `2026-08-25` is a timestamp and whether `TASK-0001` opens a
+# tag -- questions the document's own language does not ask. §13 spends a
+# dependency only on necessity, and reading a language with a parser for that
+# language is the necessity: the alternative to this crate is not the previous
+# crate, it is a JSON reader written in this tree, which would be a second
+# reading of `ank_contract::json`'s escaping convention to keep in step with the
+# first. serde_json is the neutral referee between the two sides, and `serde`,
+# which it brings, is already a workspace dependency pinned at `=1.0.210`.
+# `preserve_order` is not decoration. `view.rs::answered` draws a document's own
+# fields "in the order it wrote them", which is what lets a person check a
+# screen against the bytes the CLI printed; serde_json's default map is sorted,
+# and the feature is what keeps that sentence true. It costs `indexmap` and its
+# two, all three of which this workspace's lockfile already carries.
+serde_json = { version = "1", features = ["preserve_order"] }

--- a/crates/ank-tui/src/ank.rs
+++ b/crates/ank-tui/src/ank.rs
@@ -41,19 +41,44 @@
 //! `error[N]:` and the command that resolves it on stderr whatever `--json`
 //! says, so a refusal arrives in the CLI's own bytes either way.
 //!
-//! **The document is read with `serde_yaml`, not with a parser written here.**
-//! YAML 1.2 is a superset of JSON, `ank-mcp` already reads JSON-RPC that way,
-//! and the escaper on the other side (`ank_contract::json::string`) emits only
-//! `\"`, `\\`, `\n` and `\u00xx` -- every one of which a double-quoted YAML
-//! scalar carries with the same meaning. So no crate enters the tree for this
-//! and there is no second escaping convention to keep in step.
+//! **The document is read with `serde_json`, and it is read here alone.**
+//! [`document`] is the only call in this crate that turns bytes into a
+//! [`Value`], and the follower asks it too -- so there is one answer to "what
+//! language is an answer written in" and the escaper on the other side
+//! (`ank_contract::json::string`) faces one reader rather than two.
+//!
+//! **What that replaced, and why it had to** (TASK-f0c6372d8dc0). This was
+//! `serde_yaml`, on the argument that YAML 1.2 is a superset of JSON so a
+//! document parses as flow YAML and no crate enters the tree. The grammar half
+//! of that is true. What it left out is that a YAML reader does not stop at the
+//! grammar: it resolves every unquoted scalar against a tag schema, deciding
+//! whether `yes` is a boolean and `2026-08-25` a timestamp -- questions JSON
+//! does not ask and this corpus should not be answering, over the 216 KB that
+//! `ank find --json` hands back here. A parser for the language the bytes are
+//! in asks none of them.
 
 use crate::Address;
 use ank_contract::ExitCode;
 use std::fmt;
 use std::process::Command;
 
-pub use serde_yaml::Value;
+pub use serde_json::Value;
+
+/// One document, read out of the language the CLI wrote it in
+/// (TASK-f0c6372d8dc0).
+///
+/// **The one place this crate turns bytes into a [`Value`]**, which is the same
+/// argument [`Ank::spawn`] is: a second parse would be a second reading of
+/// `ank_contract::json`'s escaping convention, free to drift from the first.
+/// [`Ank::spawn`] reads an answer with it and `stream::Follower` reads a
+/// watcher's line with it, and neither names a parser of its own.
+///
+/// The error is a `String` because both callers want a sentence and neither
+/// wants the parser in its signature: `spawn` puts it in [`Failed::Unreadable`]
+/// beside the command line that produced it, and the follower drops the line.
+pub fn document(text: &str) -> Result<Value, String> {
+    serde_json::from_str(text).map_err(|e| e.to_string())
+}
 
 /// The verbs this reader may run on its own, and the whole of them.
 ///
@@ -435,9 +460,9 @@ impl Ank {
             });
         }
         let text = String::from_utf8_lossy(&out.stdout).to_string();
-        let answered = serde_yaml::from_str(&text).map_err(|e| Failed::Unreadable {
+        let answered = document(&text).map_err(|error| Failed::Unreadable {
             shown: shown.clone(),
-            error: e.to_string(),
+            error,
         })?;
         Ok(Ran { shown, answered })
     }
@@ -525,7 +550,7 @@ pub fn maybe(value: &Value, key: &str) -> Option<String> {
 pub fn rows<'a>(value: &'a Value, key: &str) -> &'a [Value] {
     value
         .get(key)
-        .and_then(|v| v.as_sequence())
+        .and_then(|v| v.as_array())
         .map(|s| s.as_slice())
         .unwrap_or(&[])
 }
@@ -540,22 +565,95 @@ mod tests {
     use super::*;
 
     fn doc(s: &str) -> Value {
-        serde_yaml::from_str(s).expect("the CLI's own shape must parse")
+        document(s).expect("the CLI's own shape must parse")
     }
 
-    /// The premise this crate rests on: the CLI's escaper and a YAML reader
-    /// agree. If they ever stop agreeing, this is where it shows.
+    /// The premise this crate rests on: what the CLI's escaper writes is what
+    /// this reader reads back (TASK-f0c6372d8dc0).
+    ///
+    /// **Asked of the escaper and no longer of a literal copied from it**, which
+    /// is the whole reason this is worth a test. The version of this that read
+    /// the corpus with a YAML parser wrote the document out by hand, and the
+    /// hand slipped: it put a raw tab inside a string, JSON forbids an unescaped
+    /// byte under 0x20 there, and the test passed for years because a YAML
+    /// reader takes one. So the assertion that the two sides agree was being
+    /// made against bytes the CLI has never emitted -- `ank_contract::json`
+    /// writes that tab as `\u0009` -- and the one thing it existed to catch was
+    /// the one thing it could not see. Asking the escaper closes that: the
+    /// strings below go through the function the CLI calls, and what comes back
+    /// is compared against what went in.
     #[test]
-    fn the_clis_json_reads_as_flow_yaml() {
-        let line = r#"{"contract":1,"total":2,"results":[{"id":"TASK-0001","title":"a \"quoted\" title"},{"id":"ADR-0002","title":"two\nlines and a tab 	 in the middle"}]}"#;
-        let v = doc(line);
-        assert_eq!(count(&v, "contract"), 1);
-        assert_eq!(rows(&v, "results").len(), 2);
-        assert_eq!(text(&rows(&v, "results")[0], "title"), "a \"quoted\" title");
-        assert_eq!(
-            text(&rows(&v, "results")[1], "title"),
-            "two\nlines and a tab \t in the middle"
+    fn what_the_clis_escaper_writes_is_what_this_reader_reads() {
+        use ank_contract::json;
+        // The characters a criterion, a title and a log message actually carry:
+        // a quote, a backslash, a newline, a tab, and a character past ASCII.
+        let awkward = [
+            "a \"quoted\" title",
+            "a windows glob crates\\ank-tui\\**",
+            "two\nlines and a tab \t in the middle",
+            "an em dash -- and a caf\u{e9}",
+            "",
+        ];
+        let mut results = String::new();
+        for (i, title) in awkward.iter().enumerate() {
+            if i > 0 {
+                results.push(',');
+            }
+            results.push_str(&format!(
+                r#"{{"id":"TASK-{i:04}","title":{}}}"#,
+                json::string(title)
+            ));
+        }
+        let line = format!(
+            r#"{{"contract":1,"total":{},"results":[{results}]}}"#,
+            awkward.len()
         );
+        // The escaper's own output has no raw control byte in it, which is the
+        // property the old literal violated without anyone noticing.
+        assert!(
+            !line.chars().any(|c| (c as u32) < 0x20),
+            "the escaper emitted a raw control character: {line:?}"
+        );
+        let v = doc(&line);
+        assert_eq!(count(&v, "contract"), 1);
+        assert_eq!(count(&v, "total"), awkward.len() as u64);
+        assert_eq!(rows(&v, "results").len(), awkward.len());
+        for (i, title) in awkward.iter().enumerate() {
+            let row = &rows(&v, "results")[i];
+            assert_eq!(text(row, "id"), format!("TASK-{i:04}"));
+            assert_eq!(text(row, "title"), *title, "round trip {i}");
+        }
+    }
+
+    /// A raw control byte inside a string is refused rather than accepted
+    /// (TASK-f0c6372d8dc0).
+    ///
+    /// The other half of the test above, and the one that says the parser
+    /// changed rather than only the crate name. JSON forbids an unescaped byte
+    /// under 0x20 in a string; the YAML reader this replaced took one and
+    /// handed back a document. Nothing the CLI writes contains one, so refusing
+    /// it costs this reader nothing -- and a document that does contain one did
+    /// not come from `ank_contract::json`, which is worth finding out about.
+    #[test]
+    fn a_raw_control_byte_in_a_string_is_not_a_document() {
+        let refused = document("{\"title\":\"a tab \t in the middle\"}");
+        assert!(
+            refused.is_err(),
+            "a raw tab inside a string was read as a document: {refused:?}"
+        );
+        // And the escaped spelling of the same character is read.
+        let read = doc(r#"{"title":"a tab \u0009 in the middle"}"#);
+        assert_eq!(text(&read, "title"), "a tab \t in the middle");
+    }
+
+    /// The reader is handed one document per call and never a stream of them.
+    ///
+    /// `--json` answers with exactly one, so trailing bytes after it are a sign
+    /// something went wrong upstream rather than a second answer to read.
+    #[test]
+    fn bytes_after_the_document_are_a_refusal() {
+        assert!(document(r#"{"contract":1} {"contract":1}"#).is_err());
+        assert!(document("").is_err(), "no answer is not an empty document");
     }
 
     #[test]

--- a/crates/ank-tui/src/stream.rs
+++ b/crates/ank-tui/src/stream.rs
@@ -181,9 +181,12 @@ impl Follower {
 
     /// Whether one line is an event about the corpus this reader is on.
     ///
-    /// Read with `serde_yaml`, which is how this crate reads every document the
-    /// CLI answers with, and by the key names [`events`] declares rather than by
-    /// strings written here.
+    /// Read with [`crate::ank::document`], which is how this crate reads every
+    /// document the CLI answers with, and by the key names [`events`] declares
+    /// rather than by strings written here. Asked of that function rather than
+    /// of a parser named here (TASK-f0c6372d8dc0): a watcher's line and a
+    /// verb's answer are the same language, and one call is what keeps them
+    /// from becoming two readings of it.
     ///
     /// **A line of a schema this build does not read is skipped**, on the rule
     /// `watch.yml` already holds: a reader that guessed at a shape it does not
@@ -191,7 +194,7 @@ impl Follower {
     /// parse is skipped for the same reason and neither is an error, because
     /// there is nobody to report it to and nothing depends on it.
     fn mine(&self, line: &str) -> bool {
-        let Ok(value) = serde_yaml::from_str::<serde_yaml::Value>(line) else {
+        let Ok(value) = crate::ank::document(line) else {
             return false;
         };
         let schema = value

--- a/crates/ank-tui/src/view.rs
+++ b/crates/ank-tui/src/view.rs
@@ -3548,9 +3548,9 @@ fn rows_of(buf: &Buffer) -> String {
 /// construction and says nothing about the act.
 fn answered(ran: &Ran) -> String {
     let mut lines = vec![ran.shown.clone()];
-    if let Some(fields) = ran.answered.as_mapping() {
+    if let Some(fields) = ran.answered.as_object() {
         for (key, value) in fields {
-            let name = key.as_str().unwrap_or_default();
+            let name = key.as_str();
             if name.is_empty() || name == "contract" {
                 continue;
             }
@@ -3570,6 +3570,14 @@ fn answered(ran: &Ran) -> String {
 /// here, because the alternative is a field that arrives one day and is silently
 /// dropped -- which is the strict-reader failure ADR-6fd69efb629c warns against,
 /// wearing the other mask.
+///
+/// **Six shapes and not seven** (TASK-f0c6372d8dc0). The reader used to arrive
+/// here through a YAML parser, whose value carries a seventh -- a scalar under
+/// an explicit `!tag` -- that this arm had to unwrap because the type declared
+/// it and never because a document could hold one. JSON has no tags, so the
+/// match below is the document's own grammar exactly: totality is now the
+/// language saying there is nothing else, rather than a rendering standing by
+/// for a shape the CLI cannot write.
 fn flat(value: &crate::ank::Value) -> String {
     use crate::ank::Value;
     match value {
@@ -3577,14 +3585,15 @@ fn flat(value: &crate::ank::Value) -> String {
         Value::Bool(b) => b.to_string(),
         Value::Number(n) => n.to_string(),
         Value::String(s) => s.replace('\n', " "),
-        Value::Sequence(items) if items.is_empty() => "(none)".to_string(),
-        Value::Sequence(items) => items.iter().map(flat).collect::<Vec<_>>().join(", "),
-        Value::Mapping(fields) => fields
+        Value::Array(items) if items.is_empty() => "(none)".to_string(),
+        Value::Array(items) => items.iter().map(flat).collect::<Vec<_>>().join(", "),
+        // A key is a string in this language and never a value, so it is written
+        // rather than rendered: `flat` on it would be quoting nothing.
+        Value::Object(fields) => fields
             .iter()
-            .map(|(k, v)| format!("{}={}", flat(k), flat(v)))
+            .map(|(k, v)| format!("{k}={}", flat(v)))
             .collect::<Vec<_>>()
             .join(", "),
-        Value::Tagged(t) => flat(&t.value),
     }
 }
 
@@ -5420,8 +5429,8 @@ mod tests {
     fn an_answer_is_the_documents_own_fields_under_the_command_that_ran() {
         let ran = Ran {
             shown: "ank claim TASK-49746735127f".to_string(),
-            answered: serde_yaml::from_str(
-                "{contract: 4, id: TASK-49746735127f, expires: 2026-08-25T04:36:32Z, warnings: []}",
+            answered: crate::ank::document(
+                r#"{"contract":4,"id":"TASK-49746735127f","expires":"2026-08-25T04:36:32Z","warnings":[]}"#,
             )
             .expect("a document"),
         };
@@ -5437,7 +5446,7 @@ mod tests {
     fn a_field_this_reader_never_heard_of_is_shown_rather_than_dropped() {
         let ran = Ran {
             shown: "ank done TASK-49746735127f".to_string(),
-            answered: serde_yaml::from_str("{invented_later: {a: 1, b: [x, y]}}")
+            answered: crate::ank::document(r#"{"invented_later":{"a":1,"b":["x","y"]}}"#)
                 .expect("a document"),
         };
         let said = answered(&ran);

--- a/crates/ank-tui/tests/dependencies.rs
+++ b/crates/ank-tui/tests/dependencies.rs
@@ -129,7 +129,7 @@ fn the_graph_carries_neither_ank_core_nor_git() {
     // And the walk reaches what the manifest declares. Without this the two
     // assertions below would pass on a graph that lost its edges: "ank-core is
     // not in it" is worth nothing when nothing is in it.
-    for declared in ["ank-contract", "crossterm", "ratatui", "serde_yaml"] {
+    for declared in ["ank-contract", "crossterm", "ratatui", "serde_json"] {
         assert!(
             names.iter().any(|n| n == declared),
             "the walk did not reach {declared}, which the manifest declares: \
@@ -141,6 +141,26 @@ fn the_graph_carries_neither_ank_core_nor_git() {
         "ank-tui links ank-core, and ADR-8bd76e8d7c4e forbids it: the reader \
          reaches the corpus by running the CLI, or there are two dispatch \
          paths.\n{tree}"
+    );
+    // **And no YAML reader, by the same instrument** (TASK-f0c6372d8dc0). The
+    // CLI answers this reader in JSON and in nothing else, so a YAML parser in
+    // this graph is a parser for a language nothing here is written in --
+    // reached, when it was, because the grammar happens to accept the bytes and
+    // not because anybody wanted its tag resolution deciding whether `yes` is a
+    // boolean. Stated the way `ank-core` is stated, on the graph and not on the
+    // manifest, because the manifest only says what this crate chose: a
+    // dependency that arrived underneath one of the four would be just as much
+    // a second reading of `ank_contract::json`, and the walk is what sees it.
+    //
+    // `serde_yaml` by name and not a substring: the workspace carries it for
+    // `ank-core`, `ank-cli`, `ank-daemon` and `ank-mcp`, all of which read the
+    // corpus files themselves and are right to, and none of which is in this
+    // graph.
+    assert!(
+        !names.iter().any(|n| n == "serde_yaml"),
+        "serde_yaml is in ank-tui's graph, and the reader reads JSON: the CLI \
+         answers `--json` and the language of an answer is read with a parser \
+         for that language.\n{tree}"
     );
     // Not a list of the git libraries there are, which would go stale the day a
     // new one is published: anything whose name carries `git` is refused, and a
@@ -160,10 +180,12 @@ fn the_graph_carries_neither_ank_core_nor_git() {
 ///
 /// The list is the manifest's argument written as an assertion. `ank-contract`
 /// is the machine contract every surface consumes (ADR-6fd69efb629c);
-/// `serde_yaml` is already in the tree four times over and is what reads the
-/// CLI's `--json`; `ratatui` and `crossterm` are what ADR-c07e2694f0e1 spends
-/// and the whole of what it spends; the rest is what those four bring with them
-/// and nothing this crate chose.
+/// `serde_json` is what reads the CLI's `--json`, and is the crate this list
+/// gained when `serde_yaml` left it (TASK-f0c6372d8dc0) -- the argument for
+/// spending it is in the manifest beside the declaration, where
+/// ADR-c07e2694f0e1's first clause puts it; `ratatui` and `crossterm` are what
+/// that decision spends and the whole of what it spends; the rest is what those
+/// four bring with them and nothing this crate chose.
 #[test]
 fn the_crate_takes_nothing_the_tree_did_not_already_carry() {
     let (tree, _) = graph();
@@ -179,7 +201,7 @@ fn the_crate_takes_nothing_the_tree_did_not_already_carry() {
     direct.sort();
     assert_eq!(
         direct,
-        ["ank-contract", "crossterm", "ratatui", "serde_yaml"],
+        ["ank-contract", "crossterm", "ratatui", "serde_json"],
         "a dependency arrived. It may well be the right call -- and the \
          argument for it belongs in the manifest beside the two that are \
          there, and in this list.\n{tree}"


### PR DESCRIPTION
Closes TASK-f0c6372d8dc0.

`crates/ank-tui/src/ank.rs` handed the CLI's `--json` to `serde_yaml`, on the argument that YAML 1.2 is a superset of JSON so a document parses as flow YAML and no crate enters the tree. The grammar half of that is true. What it leaves out is that a YAML reader does not stop at the grammar: it resolves every unquoted scalar against a tag schema, deciding whether `yes` is a boolean and `2026-08-25` a timestamp — questions the document's own language does not ask, over the 216 KB `ank find --json` hands back on this corpus.

`serde_json` replaces it. The argument for spending it is in the manifest beside the declaration, where ADR-c07e2694f0e1's first clause puts it, and in `tests/dependencies.rs`'s EXPECTED list. `preserve_order` is not decoration: `view.rs::answered` draws a document's fields *in the order it wrote them*, which is what lets a screen be checked against the bytes the CLI printed, and serde_json's default map is sorted. The lockfile gains one package block; every crate it pulls — `indexmap`, `itoa`, `memchr`, `ryu`, `serde` — was already locked.

### The scope was amended rather than widened in silence

`serde_yaml` was reached from three sources, not the one the task named: `ank.rs:438`, `stream.rs:194` (each watcher event line, parsed independently), and `view.rs` (`flat()` matched serde_yaml's own `Sequence`/`Mapping`/`Tagged` variants, and two of its tests built a `Ran` from YAML flow scalars that are not JSON). Dropping the dependency stops the crate compiling until all three move, so the criterion could not be met inside the three declared files. Logged as LOG-2f13e9a2e305, then `ank amend --scope crates/ank-tui/src/stream.rs --scope crates/ank-tui/src/view.rs`. The criterion itself is untouched and stayed frozen throughout.

`ank::document` is now the crate's single parse and the follower asks it too: a watcher's line and a verb's answer are the same language, and one call is what keeps them from becoming two readings of `ank_contract::json`'s escaping convention. `flat()` matches JSON's six shapes instead of YAML's seven — the `Tagged` arm existed because the type declared it, never because a document could hold one.

### The premise test was asserting against bytes the CLI has never emitted

`the_clis_json_reads_as_flow_yaml` existed to catch the escaper and the reader disagreeing. It wrote the document out by hand, and the hand had put a **raw tab inside a string**. JSON forbids an unescaped byte under `0x20` there; `ank_contract::json::string` writes it `	`; the YAML reader took the raw one. So the one thing that test existed to see was the one thing it could not.

It now asks the escaper for the bytes instead of copying them, round-tripping a quote, a backslash, a newline, a tab, a non-ASCII character and the empty string, and asserting the escaper's output carries no raw control byte. Two tests beside it say a raw control byte is refused and that trailing bytes after a document are not a second answer.

### The guard

`tests/dependencies.rs` asserts `serde_yaml`'s absence the way it already asserts `ank-core`'s — on the lockfile walk rather than on the manifest, because a YAML parser arriving *underneath* one of the four would be just as much a second reader. Every other assertion in that suite is untouched and green: no `ank-core`, no git library, no `extern`/`unsafe`, one `Command::new`, one `ank.act(` outside `ank.rs`, one arm answering `Command::Act`.

### Verification

- `cargo test --workspace` — green, 0 failures. The pty suites (`panels.rs`, `phone.rs`, `verbs.rs`, `bindings.rs`) drive the built binary against this corpus, which is the criterion measured through the binary rather than through the function.
- `cargo fmt --check` — clean.
- `ank check` — `ok`, no new fault.
- `cargo tree -p ank-tui -e all | grep -c serde_yaml` → `0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ECExQYzfP3S4xeigCarPj