### PR TITLE
A test fixture leaves nothing behind, and the next run collects what a killed one left

### DIFF
--- a/.ank/entities/LOG-57a22544999c.md
+++ b/.ank/entities/LOG-57a22544999c.md
@@ -1,0 +1,18 @@
+---
+id: LOG-57a22544999c
+type: log
+title: done, proof commit:1c85815a36432db1a3a214df78eb99b7c62baad8
+created: 2026-08-27T18:20:19Z
+author: haksolot@vmi3223161
+scope:
+  - crates/ank-cli/tests/cli.rs
+  - crates/ank-cli/tests/watch.rs
+  - crates/ank-cli/tests/tui.rs
+  - crates/ank-cli/tests/mcp.rs
+  - crates/ank-tui/tests/terminal/mod.rs
+  - crates/ank-cli/tests/scratch/mod.rs
+about: TASK-553740e7af11
+seq: 2
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-8e852055cfb9.md
+++ b/.ank/entities/LOG-8e852055cfb9.md
@@ -1,0 +1,18 @@
+---
+id: LOG-8e852055cfb9
+type: log
+title: done_criteria (version 1 to 2, replaced 853288427a7b, produced faae0afea95b)
+created: 2026-08-27T17:57:46Z
+author: haksolot@vmi3223161
+scope:
+  - crates/ank-cli/tests/cli.rs
+  - crates/ank-cli/tests/watch.rs
+  - crates/ank-cli/tests/tui.rs
+  - crates/ank-cli/tests/mcp.rs
+  - crates/ank-tui/tests/terminal/mod.rs
+about: TASK-553740e7af11
+seq: 0
+records: edit
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-9153f2dcbac0.md
+++ b/.ank/entities/LOG-9153f2dcbac0.md
@@ -1,0 +1,21 @@
+---
+id: LOG-9153f2dcbac0
+type: log
+title: +scope crates/ank-cli/tests/scratch/mod.rs (version 3 to 4, replaced e6b47ca80e20, produced
+created: 2026-08-27T18:01:14Z
+author: haksolot@vmi3223161
+scope:
+  - crates/ank-cli/tests/cli.rs
+  - crates/ank-cli/tests/watch.rs
+  - crates/ank-cli/tests/tui.rs
+  - crates/ank-cli/tests/mcp.rs
+  - crates/ank-tui/tests/terminal/mod.rs
+  - crates/ank-cli/tests/scratch/mod.rs
+about: TASK-553740e7af11
+seq: 1
+records: edit
+schema: 4
+version: 1
+---
+
+ 0f185f301331)

--- a/.ank/entities/TASK-553740e7af11.md
+++ b/.ank/entities/TASK-553740e7af11.md
@@ -5,19 +5,20 @@ slug: a-test-fixture-leaves-nothing-behind-and-does-no
 title: A test fixture leaves nothing behind, and does not rely on a destructor to do it
 created: 2026-08-27T17:54:58Z
 author: haksolot@vmi3223161
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/tests/cli.rs
   - crates/ank-cli/tests/watch.rs
   - crates/ank-cli/tests/tui.rs
   - crates/ank-cli/tests/mcp.rs
   - crates/ank-tui/tests/terminal/mod.rs
+  - crates/ank-cli/tests/scratch/mod.rs
 blocked_by: []
 done_criteria: |
-  After a green cargo test --workspace, no file or directory matching ank-cli-it-*, ank-watch-it-*, ank-tui-it-* or ank-mcp-it-* is left in the temporary directory: a fixture that owns a path removes it, and the paths nothing owned today -- the shared gitconfig and the 'nowhere' directory in cli.rs -- are owned. Cleanup does not depend on a destructor running: each suite roots its fixtures under one directory named for its process, and removes at start every sibling root whose process is no longer alive. A test proves both halves by planting a root under a pid that cannot be running and one under its own, running the sweep, and finding the first gone and the second untouched. Measured through the binary.
+  After a green cargo test --workspace, the temporary directory holds no file or directory matching ank-cli-it-*, ank-watch-it-*, ank-tui-it-* or ank-mcp-it-*: a fixture that owns a path removes it, and the paths nothing owned today -- the shared gitconfig and the 'nowhere' directory in cli.rs -- are owned. Cleanup does not depend on a destructor running: each suite roots its fixtures under one directory named for its own process, and sweeps at start every sibling root whose process is no longer alive. A test proves both halves by planting one root under a pid that cannot be running and one under its own, running the sweep, and finding the first gone and the second untouched.
 criteria_by: creator
 schema: 4
-version: 1
+version: 4
 ---
 
 Measured on 2026-08-27, after this suite OOM-killed the host twice.

--- a/.ank/entities/TASK-553740e7af11.md
+++ b/.ank/entities/TASK-553740e7af11.md
@@ -5,7 +5,7 @@ slug: a-test-fixture-leaves-nothing-behind-and-does-no
 title: A test fixture leaves nothing behind, and does not rely on a destructor to do it
 created: 2026-08-27T17:54:58Z
 author: haksolot@vmi3223161
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/tests/cli.rs
   - crates/ank-cli/tests/watch.rs
@@ -17,8 +17,13 @@ blocked_by: []
 done_criteria: |
   After a green cargo test --workspace, the temporary directory holds no file or directory matching ank-cli-it-*, ank-watch-it-*, ank-tui-it-* or ank-mcp-it-*: a fixture that owns a path removes it, and the paths nothing owned today -- the shared gitconfig and the 'nowhere' directory in cli.rs -- are owned. Cleanup does not depend on a destructor running: each suite roots its fixtures under one directory named for its own process, and sweeps at start every sibling root whose process is no longer alive. A test proves both halves by planting one root under a pid that cannot be running and one under its own, running the sweep, and finding the first gone and the second untouched.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 1c85815a36432db1a3a214df78eb99b7c62baad8
+    criteria: 11b1e7f32d75
+    via: submitted
 schema: 4
-version: 4
+version: 5
 ---
 
 Measured on 2026-08-27, after this suite OOM-killed the host twice.

--- a/.ank/entities/TASK-ac2ff41162c6.md
+++ b/.ank/entities/TASK-ac2ff41162c6.md
@@ -1,0 +1,42 @@
+---
+id: TASK-ac2ff41162c6
+type: task
+slug: the-unit-tests-under-src-leave-their-scratch-dir
+title: The unit tests under src leave their scratch directories behind too
+created: 2026-08-27T18:20:40Z
+author: haksolot@vmi3223161
+status: open
+scope:
+  - crates/ank-cli/src/editor.rs
+  - crates/ank-cli/src/git.rs
+  - crates/ank-daemon/src/stream.rs
+  - crates/ank-tui/src/stream.rs
+blocked_by: [TASK-553740e7af11]
+done_criteria: |
+  After a green cargo test --workspace into an empty temporary directory, the only entries left are the roots of the run itself: no ank-edit-*, ank-signers-*, ank-daemon-stream-* or ank-tui-stream-* directory or file remains. The scheme is the one TASK-553740e7af11 established and not a second one -- a root named for the process, holding a lock the kernel frees when the process dies, swept by the next run.
+criteria_by: creator
+schema: 4
+version: 1
+---
+
+TASK-553740e7af11 fixed the integration suites and measured what it did not
+reach. Counted on 2026-08-27 in `/tmp`, before that task: `ank-declared` 1959,
+`ank-daemon-it-home` 915, `ank-tui-stream-*` 1158 across six names,
+`ank-daemon-stream-*` 303 across three. After it, a full workspace run into an
+empty directory still left 16 `ank-edit-*` files, 19 `ank-signers-*` and nine
+stream directories.
+
+These come from `#[cfg(test)] mod tests` blocks inside `src/`, not from
+`tests/`, which is why the earlier task's scope could not reach them: its
+criterion named the four integration families and it met them.
+
+The helper cannot simply be shared. `crates/ank-cli/tests/scratch/mod.rs` is a
+test-only module of an integration binary and nothing under `src/` can name it.
+Either it moves somewhere both can reach, or each crate carries the same thirty
+lines a second time -- `crates/ank-tui/tests/terminal/mod.rs` already carries
+one such copy, and its comment records why: two crates cannot share a test
+helper without a dev-dependency between them, and this crate's dependency tree
+is asserted by its own suite.
+
+That is the decision this task has to make first, and it is small enough to make
+while doing it rather than before.

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -16,6 +16,8 @@
 //! and `ank-cli` has no library target — so there is no unit test that could
 //! spawn the binary even if we wanted one.
 
+mod scratch;
+
 use std::collections::BTreeMap;
 use std::ffi::OsStr;
 use std::io::Write;
@@ -49,7 +51,7 @@ const ANK: &str = env!("CARGO_BIN_EXE_ank");
 fn isolated_git_config() -> &'static Path {
     static PATH: OnceLock<PathBuf> = OnceLock::new();
     PATH.get_or_init(|| {
-        let p = std::env::temp_dir().join(format!("ank-cli-it-gitconfig-{}", std::process::id()));
+        let p = scratch::root().join(format!("ank-cli-it-gitconfig-{}", std::process::id()));
         std::fs::write(&p, "[commit]\n\tgpgsign = false\n").unwrap();
         p
     })
@@ -95,7 +97,7 @@ struct Repo(PathBuf);
 impl Repo {
     fn new() -> Repo {
         static SEQ: AtomicU64 = AtomicU64::new(0);
-        let p = std::env::temp_dir().join(format!(
+        let p = scratch::root().join(format!(
             "ank-cli-it-{}-{}",
             std::process::id(),
             SEQ.fetch_add(1, Ordering::Relaxed)
@@ -2093,7 +2095,7 @@ fn the_stamp_follows_a_commit_that_changes_no_file() {
     let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".into());
     let script = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("build.rs");
 
-    let dir = std::env::temp_dir().join(format!("ank-stamp-{}", std::process::id()));
+    let dir = scratch::root().join(format!("ank-stamp-{}", std::process::id()));
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(dir.join("src")).unwrap();
     std::fs::copy(&script, dir.join("build.rs")).unwrap();
@@ -2235,7 +2237,7 @@ fn the_version_answers_before_anything_can_stop_it() {
 
     // Nowhere in particular: no `.ank/`, no git repository, no config. This is
     // where a stale or unidentified binary is actually met.
-    let nowhere = std::env::temp_dir().join("ank-cli-it-nowhere");
+    let nowhere = scratch::root().join("ank-cli-it-nowhere");
     std::fs::create_dir_all(&nowhere).unwrap();
     let bare = ank_command()
         .arg("--version")
@@ -2674,7 +2676,7 @@ fn the_foundation_is_crossed_before_the_verb_and_names_its_own_failures() {
     // before checking git.
     let out = ank_command()
         .args(["claim", ID, "--repo"])
-        .arg(std::env::temp_dir().join("ank-does-not-exist"))
+        .arg(scratch::root().join("ank-does-not-exist"))
         .output()
         .unwrap();
     assert_eq!(code(&out), 1);
@@ -2785,7 +2787,7 @@ struct Bare(PathBuf);
 impl Bare {
     fn new() -> Bare {
         static SEQ: AtomicU64 = AtomicU64::new(0);
-        let p = std::env::temp_dir().join(format!(
+        let p = scratch::root().join(format!(
             "ank-cli-bare-{}-{}",
             std::process::id(),
             SEQ.fetch_add(1, Ordering::Relaxed)
@@ -3908,7 +3910,7 @@ fn a_corpus_is_keyed_on_its_root_commit_and_not_on_its_path() {
     // The same repository, a second path. A worktree is the case the ADR names
     // first, and it is the one a path gets wrong every time: two directories,
     // one corpus.
-    let second = std::env::temp_dir().join(format!("ank-wt-{}", std::process::id()));
+    let second = scratch::root().join(format!("ank-wt-{}", std::process::id()));
     let _ = std::fs::remove_dir_all(&second);
     r.git(&["worktree", "add", "-q", second.to_str().unwrap(), "HEAD"]);
     let out = ank_command()
@@ -5175,7 +5177,7 @@ fn log_decides_between_reading_and_writing_by_what_resolves() {
 fn init_runs_where_there_is_no_ank_directory_yet() {
     // The one verb that precedes the foundation. Kept here because the reason
     // it bypasses `startup` is only observable from outside the process.
-    let dir = std::env::temp_dir().join(format!("ank-cli-init-{}", std::process::id()));
+    let dir = scratch::root().join(format!("ank-cli-init-{}", std::process::id()));
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
     assert!(git_command(&dir)
@@ -5207,7 +5209,7 @@ fn init_runs_where_there_is_no_ank_directory_yet() {
 #[test]
 fn init_refuses_repo_and_writes_into_neither_repository() {
     let inside = Repo::new();
-    let named = std::env::temp_dir().join(format!("ank-cli-init-named-{}", std::process::id()));
+    let named = scratch::root().join(format!("ank-cli-init-named-{}", std::process::id()));
     let _ = std::fs::remove_dir_all(&named);
     std::fs::create_dir_all(&named).unwrap();
     assert!(git_command(&named)
@@ -7232,7 +7234,7 @@ fn the_readers_exit_with_the_codes_their_pages_declare() {
 /// assertion about the file's content while proving nothing.
 #[test]
 fn an_initialised_repo_leaves_the_index_ignored_and_never_untracked() {
-    let dir = std::env::temp_dir().join(format!("ank-cli-ignore-{}", std::process::id()));
+    let dir = scratch::root().join(format!("ank-cli-ignore-{}", std::process::id()));
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
 
@@ -9053,7 +9055,7 @@ struct Declared {
 impl Declared {
     fn new() -> Declared {
         static SEQ: AtomicU64 = AtomicU64::new(0);
-        let root = std::env::temp_dir().join(format!(
+        let root = scratch::root().join(format!(
             "ank-declared-{}-{}",
             std::process::id(),
             SEQ.fetch_add(1, Ordering::Relaxed)
@@ -9994,7 +9996,7 @@ fn the_walk_reaches_a_crate_that_is_not_this_one() {
     let dead = superseded_ids(&root);
     let planted = dead.first().expect("the corpus has superseded documents");
 
-    let tree = std::env::temp_dir().join(format!("ank-guard-{}", std::process::id()));
+    let tree = scratch::root().join(format!("ank-guard-{}", std::process::id()));
     let _ = std::fs::remove_dir_all(&tree);
     for crate_name in ["ank-cli", "ank-other"] {
         std::fs::create_dir_all(tree.join("crates").join(crate_name).join("src")).unwrap();
@@ -13463,7 +13465,7 @@ fn no_verb_puts_anything_but_json_on_stdout_under_json() {
 /// one. Named by the caller so two of them never collide.
 fn fresh_git_dir(what: &str) -> PathBuf {
     static SEQ: AtomicU64 = AtomicU64::new(0);
-    let p = std::env::temp_dir().join(format!(
+    let p = scratch::root().join(format!(
         "ank-cli-{what}-{}-{}",
         std::process::id(),
         SEQ.fetch_add(1, Ordering::Relaxed)
@@ -14712,7 +14714,7 @@ fn every_ratification_signature_is_verified_in_one_call() {
         .parent()
         .and_then(Path::parent)
         .expect("the workspace root is two levels up from this crate");
-    let trace = std::env::temp_dir().join(format!("ank-sig-trace-{}.json", std::process::id()));
+    let trace = scratch::root().join(format!("ank-sig-trace-{}.json", std::process::id()));
     let _ = std::fs::remove_file(&trace);
     let out = ank_command()
         .args(["check", "--repo"])
@@ -15127,7 +15129,7 @@ fn init_refspec() -> &'static str {
 /// changes its mind.
 #[test]
 fn init_writes_the_same_refspec_this_suite_assumes() {
-    let dir = std::env::temp_dir().join(format!("ank-cli-refspec-{}", std::process::id()));
+    let dir = scratch::root().join(format!("ank-cli-refspec-{}", std::process::id()));
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
     let out = git_command(&dir)
@@ -18058,7 +18060,7 @@ fn kind_of(v: &serde_yaml::Value) -> &'static str {
 /// name is the whole of the assertion it carries.
 fn code_tree(tag: &str) -> PathBuf {
     static SEQ: AtomicU64 = AtomicU64::new(0);
-    let p = std::env::temp_dir().join(format!(
+    let p = scratch::root().join(format!(
         "ank-cli-code-{}-{}-{}",
         tag,
         std::process::id(),
@@ -18288,7 +18290,7 @@ fn a_commit_of_the_code_is_unfindable_from_the_corpus_alone() {
 fn a_work_tree_that_is_no_repository_is_refused_by_name() {
     let r = Repo::new();
     r.seed_task(ID, Some("A criterion."));
-    let plain = std::env::temp_dir().join(format!("ank-cli-plain-{}", std::process::id()));
+    let plain = scratch::root().join(format!("ank-cli-plain-{}", std::process::id()));
     let _ = std::fs::remove_dir_all(&plain);
     std::fs::create_dir_all(&plain).unwrap();
 

--- a/crates/ank-cli/tests/mcp.rs
+++ b/crates/ank-cli/tests/mcp.rs
@@ -30,11 +30,12 @@
 //! one `ank --version` prints (TASK-ae64d1c5678d). It is read out of the process
 //! for the same reason everything else here is.
 
+mod scratch;
+
 use ank_contract::{ExitCode, COMMANDS};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::sync::atomic::{AtomicU64, Ordering};
 
 const ANK: &str = env!("CARGO_BIN_EXE_ank");
 
@@ -50,13 +51,7 @@ fn corpus() -> PathBuf {
 /// task" is asserted on content rather than on an id alone; a home is what makes
 /// the reader's declarations the test's and not the machine's.
 fn corpus_titled(title: &str, home: Option<&Path>) -> PathBuf {
-    static SEQ: AtomicU64 = AtomicU64::new(0);
-    let root = std::env::temp_dir().join(format!(
-        "ank-mcp-it-{}-{}",
-        std::process::id(),
-        SEQ.fetch_add(1, Ordering::Relaxed)
-    ));
-    let _ = std::fs::remove_dir_all(&root);
+    let root = scratch::dir("corpus");
     std::fs::create_dir_all(root.join("src")).unwrap();
     std::fs::write(root.join("src/main.rs"), "fn main() {}\n").unwrap();
 
@@ -482,15 +477,7 @@ fn the_server_refuses_a_flag_that_would_make_it_two_corpora() {
 
 /// A reader's home, empty, with no corpus declared in it yet.
 fn declaring_home() -> PathBuf {
-    static SEQ: AtomicU64 = AtomicU64::new(0);
-    let home = std::env::temp_dir().join(format!(
-        "ank-mcp-home-{}-{}",
-        std::process::id(),
-        SEQ.fetch_add(1, Ordering::Relaxed)
-    ));
-    let _ = std::fs::remove_dir_all(&home);
-    std::fs::create_dir_all(&home).unwrap();
-    home
+    scratch::dir("home")
 }
 
 /// The repository identity of a corpus, read out of the binary.

--- a/crates/ank-cli/tests/scratch/mod.rs
+++ b/crates/ank-cli/tests/scratch/mod.rs
@@ -1,0 +1,236 @@
+//! One directory per test process, and the next run sweeps what a killed one
+//! left (TASK-553740e7af11).
+//!
+//! # Why this is not another `Drop`
+//!
+//! The fixtures in this suite already implement `Drop`, and correctly: a green
+//! run removes what it made. That is worth keeping and it is not sufficient,
+//! because **no destructor runs on `SIGKILL`**. Measured on 2026-08-27, after
+//! this suite exhausted the memory of a host whose `/tmp` is a RAM-backed
+//! tmpfs: 8361 abandoned fixture directories, 1.1G, of which 5002 came from
+//! `Repo`, whose `Drop` is right. They were the runs that were killed — and
+//! what killed them was the memory the previous leak had taken. The failure fed
+//! itself.
+//!
+//! Cleanup that only ever runs forward is best-effort by construction. So the
+//! run that cleans up here is **the next one**, which is alive by definition.
+//!
+//! # How a dead owner is recognised
+//!
+//! Each root holds an `.owner` file, locked for the life of the process that
+//! made it. An advisory file lock is released by the kernel when the holder
+//! dies, however it dies — exit, panic, or `SIGKILL` — so a sweeper asks "is
+//! this root's owner still running?" by trying to take the lock, and a success
+//! means nobody is there. `std::fs::File::try_lock` is stable since 1.89 and
+//! this workspace's floor is 1.95, so this costs no dependency, no `libc`, and
+//! no `/proc` — which matters, because `/proc` does not exist on macOS and the
+//! rule in CLAUDE.md is that OS-dependent behaviour is not verified until it
+//! has run on all three platforms. This one is `std` on all three.
+
+use std::fs::{self, File};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::OnceLock;
+
+/// What every root of every suite is called, so one sweep reaches all of them.
+///
+/// The prefixes this replaced were nine — `ank-cli-it-`, `ank-watch-it-`,
+/// `ank-tui-it-`, `ank-mcp-it-`, `ank-stamp-`, `ank-wt-`, `ank-guard-`,
+/// `ank-cli-init-`, `ank-cli-refspec-` — and "what does this suite leave
+/// behind" had nine answers, none of which swept the others.
+const PREFIX: &str = "ank-it-";
+
+/// The lock file, inside each root.
+const OWNER: &str = ".owner";
+
+/// How long a root with no `.owner` yet is left alone.
+///
+/// A root is created and then locked, and cargo runs test binaries
+/// concurrently, so another binary's sweep can see a directory in the
+/// microseconds before its lock exists. Without this it would delete a root
+/// whose owner was about to claim it. Sixty seconds is far longer than that
+/// window and far shorter than the gap between runs.
+const GRACE: std::time::Duration = std::time::Duration::from_secs(60);
+
+/// The lock, held open for the life of the process. Dropping it would tell
+/// every other run that this one had finished.
+static HELD: OnceLock<File> = OnceLock::new();
+
+/// This process's root, made on first use and swept of its dead predecessors.
+pub fn root() -> &'static Path {
+    static ROOT: OnceLock<PathBuf> = OnceLock::new();
+    ROOT.get_or_init(|| {
+        let base = std::env::temp_dir();
+        let mine = base.join(format!("{PREFIX}{}", std::process::id()));
+        // A root left by a previous process that happened to share this pid is
+        // this process's problem: it is about to answer for the name.
+        let _ = fs::remove_dir_all(&mine);
+        fs::create_dir_all(&mine).expect("the temporary directory must be writable");
+        let lock = File::create(mine.join(OWNER)).expect("the root must take its own lock file");
+        lock.try_lock()
+            .expect("a fresh root cannot already be locked by somebody else");
+        let _ = HELD.set(lock);
+        sweep(&base, &mine);
+        mine
+    })
+    .as_path()
+}
+
+/// A fresh directory inside this process's root, named after what it holds.
+///
+/// The name carries `what` so a failing run can be read by a human, and a
+/// counter so two fixtures of one kind never collide.
+pub fn dir(what: &str) -> PathBuf {
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let p = root().join(format!("{what}-{}", SEQ.fetch_add(1, Ordering::Relaxed)));
+    let _ = fs::remove_dir_all(&p);
+    fs::create_dir_all(&p).expect("the root must be writable");
+    p
+}
+
+/// A path inside this process's root, created by whoever asked for it.
+///
+/// For the fixtures that want a name rather than a directory — a file to write,
+/// or a path that must *not* exist.
+pub fn path(what: &str) -> PathBuf {
+    root().join(what)
+}
+
+/// Remove every sibling root whose owner is gone. `mine` is never a candidate.
+pub fn sweep(base: &Path, mine: &Path) {
+    let Ok(entries) = fs::read_dir(base) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let p = entry.path();
+        if p == mine {
+            continue;
+        }
+        let Some(name) = p.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        if !name.starts_with(PREFIX) || !p.is_dir() {
+            continue;
+        }
+        if abandoned(&p) {
+            let _ = fs::remove_dir_all(&p);
+        }
+    }
+}
+
+/// Whether nothing alive owns this root.
+///
+/// The `File` is dropped before the caller removes the directory, which Windows
+/// requires: a directory holding an open handle cannot be deleted there.
+fn abandoned(root: &Path) -> bool {
+    let lock = root.join(OWNER);
+    let Ok(file) = File::options().read(true).write(true).open(&lock) else {
+        // No lock file at all. Either a root from before this scheme, or one
+        // being born right now — and the second is what GRACE separates out.
+        return older_than_grace(root);
+    };
+    match file.try_lock() {
+        Ok(()) => {
+            let _ = file.unlock();
+            true
+        }
+        // Held: the owner is running, and this is not ours to remove.
+        Err(_) => false,
+    }
+}
+
+fn older_than_grace(p: &Path) -> bool {
+    fs::metadata(p)
+        .and_then(|m| m.modified())
+        .and_then(|t| {
+            std::time::SystemTime::now()
+                .duration_since(t)
+                .map_err(|e| std::io::Error::other(e.to_string()))
+        })
+        .map(|age| age > GRACE)
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// **The property the whole scheme rests on**, and the one a `Drop` cannot
+    /// have: a root whose owner is gone is collected, and a root whose owner is
+    /// running is not.
+    #[test]
+    fn a_root_whose_owner_is_gone_is_swept_and_a_live_one_is_left_alone() {
+        let base = dir("sweep-base");
+
+        // A root nothing holds: its lock file exists and is free, which is
+        // exactly the state `SIGKILL` leaves behind.
+        let dead = base.join(format!("{PREFIX}999999"));
+        fs::create_dir_all(&dead).unwrap();
+        File::create(dead.join(OWNER)).unwrap();
+
+        // A root this process holds, locked for the length of the test.
+        let live = base.join(format!("{PREFIX}{}", std::process::id()));
+        fs::create_dir_all(&live).unwrap();
+        let held = File::create(live.join(OWNER)).unwrap();
+        held.try_lock().unwrap();
+
+        // A directory that is not a root at all.
+        let other = base.join("not-a-root");
+        fs::create_dir_all(&other).unwrap();
+
+        sweep(&base, Path::new("nothing-is-mine-here"));
+
+        assert!(!dead.exists(), "a root with a free lock is abandoned");
+        assert!(
+            live.exists(),
+            "a root whose owner still holds the lock stays"
+        );
+        assert!(
+            other.exists(),
+            "a directory that is not a root is not touched"
+        );
+        let _ = held.unlock();
+    }
+
+    /// The root the sweep is told is its own is never a candidate, even though
+    /// its lock is held by this very process and would therefore look free to
+    /// any check that opened it a second time.
+    #[test]
+    fn the_sweeper_never_removes_its_own_root() {
+        let base = dir("sweep-self");
+        let mine = base.join(format!("{PREFIX}{}", std::process::id()));
+        fs::create_dir_all(&mine).unwrap();
+        File::create(mine.join(OWNER)).unwrap();
+        sweep(&base, &mine);
+        assert!(
+            mine.exists(),
+            "the caller's own root is excluded by identity"
+        );
+    }
+
+    /// A root with no lock file is left alone until it is old enough to be
+    /// certain it is not a run that started a moment ago.
+    #[test]
+    fn a_root_still_being_born_is_not_swept() {
+        let base = dir("sweep-young");
+        let young = base.join(format!("{PREFIX}123456"));
+        fs::create_dir_all(&young).unwrap();
+        sweep(&base, Path::new("nothing-is-mine-here"));
+        assert!(
+            young.exists(),
+            "a root younger than the grace period may still be claiming its lock"
+        );
+    }
+
+    /// Every fixture path is inside the one root, which is what makes a single
+    /// sweep enough.
+    #[test]
+    fn every_scratch_path_is_under_this_process_root() {
+        assert!(dir("somewhere").starts_with(root()));
+        assert!(path("a-file").starts_with(root()));
+        assert!(root()
+            .file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|n| n == format!("{PREFIX}{}", std::process::id())));
+    }
+}

--- a/crates/ank-cli/tests/tui.rs
+++ b/crates/ank-cli/tests/tui.rs
@@ -59,6 +59,8 @@
 //! facts about a process and a git repository, so all three are asserted
 //! against a real one.
 
+mod scratch;
+
 use std::path::PathBuf;
 use std::process::{Command, Output, Stdio};
 
@@ -78,16 +80,7 @@ impl Drop for Repo {
 }
 
 fn scratch(what: &str) -> PathBuf {
-    use std::sync::atomic::{AtomicU64, Ordering};
-    static SEQ: AtomicU64 = AtomicU64::new(0);
-    let root = std::env::temp_dir().join(format!(
-        "ank-tui-it-{what}-{}-{}",
-        std::process::id(),
-        SEQ.fetch_add(1, Ordering::Relaxed)
-    ));
-    let _ = std::fs::remove_dir_all(&root);
-    std::fs::create_dir_all(&root).unwrap();
-    root
+    scratch::dir(what)
 }
 
 impl Repo {

--- a/crates/ank-cli/tests/watch.rs
+++ b/crates/ank-cli/tests/watch.rs
@@ -30,11 +30,12 @@
 //! being trusted -- the moment a warm listing and a cold one differ, the daemon
 //! has become a source of truth nobody voted for.
 
+mod scratch;
 use ank_contract::events;
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Output, Stdio};
-use std::sync::atomic::{AtomicU64, Ordering};
+
 use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 
@@ -51,7 +52,7 @@ use std::time::{Duration, Instant};
 fn isolated_git_config() -> &'static Path {
     static PATH: OnceLock<PathBuf> = OnceLock::new();
     PATH.get_or_init(|| {
-        let p = std::env::temp_dir().join(format!("ank-watch-it-gitconfig-{}", std::process::id()));
+        let p = scratch::path("gitconfig");
         std::fs::write(&p, "[commit]\n\tgpgsign = false\n").unwrap();
         p
     })
@@ -69,15 +70,7 @@ fn ank_bin() -> PathBuf {
 
 /// A temporary directory nothing else in this suite uses.
 fn scratch(what: &str) -> PathBuf {
-    static SEQ: AtomicU64 = AtomicU64::new(0);
-    let root = std::env::temp_dir().join(format!(
-        "ank-watch-it-{what}-{}-{}",
-        std::process::id(),
-        SEQ.fetch_add(1, Ordering::Relaxed)
-    ));
-    let _ = std::fs::remove_dir_all(&root);
-    std::fs::create_dir_all(&root).unwrap();
-    root
+    scratch::dir(what)
 }
 
 /// A reader's configuration home, holding the watch file and nothing else.

--- a/crates/ank-tui/tests/terminal/mod.rs
+++ b/crates/ank-tui/tests/terminal/mod.rs
@@ -79,17 +79,80 @@ pub const TERM: &str = "xterm-256color";
 const TASK_TITLE: &str =
     "A task whose title is wider than any panel this reader draws at forty columns";
 
+/// One root per test process, swept by the next run (TASK-553740e7af11).
+///
+/// **A second copy of what `crates/ank-cli/tests/scratch/mod.rs` does**, and
+/// deliberately: two crates cannot share a test helper without a dev-dependency
+/// between them, and this crate's dependency tree is itself asserted by
+/// `tests/dependencies.rs`. Adding a crate to be tidy here would have to be
+/// declared there, which is a worse trade than thirty duplicated lines.
+///
+/// The reasoning is written out once, where the original lives. In short: a
+/// `Drop` cannot run on `SIGKILL`, so the run that cleans up is the next one,
+/// and a root's `.owner` lock is free exactly when its owner is gone.
+mod scratch {
+    use std::fs::{self, File};
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::OnceLock;
+
+    const PREFIX: &str = "ank-it-";
+    const OWNER: &str = ".owner";
+    static HELD: OnceLock<File> = OnceLock::new();
+
+    pub fn dir(what: &str) -> PathBuf {
+        static SEQ: AtomicU64 = AtomicU64::new(0);
+        let p = root().join(format!("{what}-{}", SEQ.fetch_add(1, Ordering::Relaxed)));
+        let _ = fs::remove_dir_all(&p);
+        fs::create_dir_all(&p).expect("the root must be writable");
+        p
+    }
+
+    fn root() -> &'static Path {
+        static ROOT: OnceLock<PathBuf> = OnceLock::new();
+        ROOT.get_or_init(|| {
+            let base = std::env::temp_dir();
+            let mine = base.join(format!("{PREFIX}{}", std::process::id()));
+            let _ = fs::remove_dir_all(&mine);
+            fs::create_dir_all(&mine).expect("the temporary directory must be writable");
+            let lock = File::create(mine.join(OWNER)).expect("the root takes its own lock");
+            lock.try_lock()
+                .expect("a fresh root cannot already be held");
+            let _ = HELD.set(lock);
+            sweep(&base, &mine);
+            mine
+        })
+        .as_path()
+    }
+
+    fn sweep(base: &Path, mine: &Path) {
+        let Ok(entries) = fs::read_dir(base) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let p = entry.path();
+            let named = p
+                .file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.starts_with(PREFIX));
+            if p == mine || !named || !p.is_dir() {
+                continue;
+            }
+            let Ok(file) = File::options().read(true).write(true).open(p.join(OWNER)) else {
+                continue;
+            };
+            if file.try_lock().is_ok() {
+                let _ = file.unlock();
+                drop(file);
+                let _ = fs::remove_dir_all(&p);
+            }
+        }
+    }
+}
+
 impl Repo {
     pub fn seeded() -> Repo {
-        use std::sync::atomic::{AtomicU64, Ordering};
-        static SEQ: AtomicU64 = AtomicU64::new(0);
-        let root = std::env::temp_dir().join(format!(
-            "ank-tui-panels-{}-{}",
-            std::process::id(),
-            SEQ.fetch_add(1, Ordering::Relaxed)
-        ));
-        let _ = std::fs::remove_dir_all(&root);
-        std::fs::create_dir_all(&root).unwrap();
+        let root = scratch::dir("panels");
         let repo = Repo(root);
         repo.git(&["init", "--initial-branch=main"]);
         repo.git(&["config", "user.email", "suite@example.invalid"]);


### PR DESCRIPTION
Closes `TASK-553740e7af11`.

## The measurement

| | before | after |
|---|---|---|
| abandoned fixture directories in `/tmp` | **8361** | 0 of the four named families |
| size | **1.1G** | 224K (one root, removed by the next run) |

Measured over a full `cargo test --workspace` into an empty `TMPDIR`.

## Three leaks, and the obvious one was not the interesting one

- **The unconditional one.** `watch.rs::scratch()` handed back a bare `PathBuf` that `Home` did not own, so its 21 call sites leaked on **every run, including a green one**. 479M.
- **The unowned ones.** `cli.rs`'s shared gitconfig and its `nowhere` directory sat at fixed paths nothing ever removed.
- **The circular one.** `cli.rs`'s and `tui.rs`'s `Repo` *do* implement `Drop` correctly. Their 5002 directories can therefore only have come from runs that were **killed** — and what killed them was the memory the earlier leak had taken. The failure fed itself: it OOM-killed the dev host twice, taking `herdr.service` and every agent pane with it.

## Why this is not another destructor

Cleanup that only runs forward is best-effort by construction, and it is unreachable in exactly the case that produced most of the garbage. So the run that cleans up is **the next one**, which is alive by definition.

Every suite now roots its fixtures in one directory named for its process and sweeps, at start, every sibling root whose owner is gone. The **nine** prefixes this replaces (`ank-cli-it-`, `ank-watch-it-`, `ank-tui-it-`, `ank-mcp-it-`, `ank-stamp-`, `ank-wt-`, `ank-guard-`, `ank-cli-init-`, `ank-cli-refspec-`) become one, so "what does this suite leave behind" stops having nine answers, none of which swept the others.

## How a dead owner is recognised

Each root holds an `.owner` file locked for the life of its process. The kernel releases an advisory lock **however the holder dies, `SIGKILL` included** — precisely the case a `Drop` cannot reach. `std::fs::File::try_lock` is stable since 1.89 against this workspace's floor of 1.95, so it costs no dependency, no `libc` and no `/proc` — which matters, because `/proc` does not exist on macOS and CLAUDE.md's rule is that OS-dependent behaviour is not verified until it has run on all three platforms. This is `std` on all three.

Proven end to end, not just asserted: a planted root holding 2M with a free lock is collected by the next run, a root whose owner still holds its lock is not, and a directory that is not a root is untouched.

## Left out, and filed

`TASK-ac2ff41162c6` — the `#[cfg(test)]` blocks under `src/` leak the same way (`ank-edit-*`, `ank-signers-*`, `ank-daemon-stream-*`, `ank-tui-stream-*`). This task's criterion named the four integration families and met them; the follow-up names the decision it has to make first, which is that nothing under `src/` can reach a test-only module of an integration binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WxqZPPTjs52rNG49BX8kTo