### PR TITLE
The reader draws before it reads

### DIFF
--- a/.ank/entities/LOG-4c27bac54dae.md
+++ b/.ank/entities/LOG-4c27bac54dae.md
@@ -1,0 +1,18 @@
+---
+id: LOG-4c27bac54dae
+type: log
+title: "Measured the defect before designing: on this corpus (1506 entities) 'ank status --json' costs"
+created: 2026-08-27T18:37:27Z
+author: claude-code/opus-5+reader-json
+scope:
+  - crates/ank-tui/src/model.rs
+  - crates/ank-tui/src/lib.rs
+about: TASK-fff0a98511b2
+seq: 1
+schema: 4
+version: 1
+---
+
+ 20.3s in a debug build against 3.1s for 'ank find --json', and the opening road spawns status TWICE -- lib.rs:317 for the stream's corpus identity and model.rs:100 inside Snapshot::load. find --json already carries both 'corpus' and a per-row 'created', so the blocker TASK-b917fc12fee8 has landed and the data is there.
+
+Three of the criterion's clauses fall outside crates/ank-tui/src/model.rs and crates/ank-tui/src/lib.rs. (1) 'the rows arrive after' the first frame needs session() to draw before reload, which is lib.rs and in scope -- but the stream can then only be followed once find has answered, and App::stream is a private field of view.rs with no setter, so attaching it late is a view.rs edit. (2) Snapshot loses branch, default_branch, identity and claims when status goes, and the claims panel is asserted by the pty suite; filling them on focus is the road view.rs already takes for the queue (requeue/Queue::load), so that arm is view.rs too. (3) 'a corpus of at least a thousand entities' and 'the harness sees a frame in under one second, measured through the binary' need tests/terminal/mod.rs, whose seeded fixture is two entities, plus a suite file to hold the measurement. Not editing outside the scope; asking for it.

--- a/.ank/entities/LOG-6aff7ab39613.md
+++ b/.ank/entities/LOG-6aff7ab39613.md
@@ -1,0 +1,20 @@
+---
+id: LOG-6aff7ab39613
+type: log
+title: +scope crates/ank-tui/src/view.rs, +scope crates/ank-tui/tests/terminal/mod.rs, +scope
+created: 2026-08-27T18:39:45Z
+author: claude-code/opus-5+reader-json
+scope:
+  - crates/ank-tui/src/model.rs
+  - crates/ank-tui/src/lib.rs
+  - crates/ank-tui/src/view.rs
+  - crates/ank-tui/tests/terminal/mod.rs
+  - crates/ank-tui/tests/opening.rs
+about: TASK-fff0a98511b2
+seq: 2
+records: edit
+schema: 4
+version: 1
+---
+
+ crates/ank-tui/tests/opening.rs (version 3 to 4, replaced d9bfc47dd251, produced a0b6f7def5f3)

--- a/.ank/entities/LOG-b0517093b5be.md
+++ b/.ank/entities/LOG-b0517093b5be.md
@@ -1,0 +1,20 @@
+---
+id: LOG-b0517093b5be
+type: log
+title: +scope crates/ank-tui/tests/chrome.rs (version 5 to 6, replaced 23e3b4409909, produced 5e12735fea72)
+created: 2026-08-27T19:01:48Z
+author: claude-code/opus-5+reader-json
+scope:
+  - crates/ank-tui/src/model.rs
+  - crates/ank-tui/src/lib.rs
+  - crates/ank-tui/src/view.rs
+  - crates/ank-tui/tests/terminal/mod.rs
+  - crates/ank-tui/tests/opening.rs
+  - crates/ank-cli/tests/tui.rs
+  - crates/ank-tui/tests/chrome.rs
+about: TASK-fff0a98511b2
+seq: 5
+records: edit
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-b72272d37c39.md
+++ b/.ank/entities/LOG-b72272d37c39.md
@@ -1,0 +1,19 @@
+---
+id: LOG-b72272d37c39
+type: log
+title: done, proof commit:7699a07f1414503505144d15c89e05701bb3be64
+created: 2026-08-27T19:32:50Z
+author: claude-code/opus-5+reader-json
+scope:
+  - crates/ank-tui/src/model.rs
+  - crates/ank-tui/src/lib.rs
+  - crates/ank-tui/src/view.rs
+  - crates/ank-tui/tests/terminal/mod.rs
+  - crates/ank-tui/tests/opening.rs
+  - crates/ank-cli/tests/tui.rs
+  - crates/ank-tui/tests/chrome.rs
+about: TASK-fff0a98511b2
+seq: 7
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-d1853adc8098.md
+++ b/.ank/entities/LOG-d1853adc8098.md
@@ -1,0 +1,19 @@
+---
+id: LOG-d1853adc8098
+type: log
+title: +scope crates/ank-cli/tests/tui.rs (version 4 to 5, replaced 28315ada5c2b, produced c9229ef96dfe)
+created: 2026-08-27T18:52:19Z
+author: claude-code/opus-5+reader-json
+scope:
+  - crates/ank-tui/src/model.rs
+  - crates/ank-tui/src/lib.rs
+  - crates/ank-tui/src/view.rs
+  - crates/ank-tui/tests/terminal/mod.rs
+  - crates/ank-tui/tests/opening.rs
+  - crates/ank-cli/tests/tui.rs
+about: TASK-fff0a98511b2
+seq: 4
+records: edit
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-e2b2f5384ae6.md
+++ b/.ank/entities/LOG-e2b2f5384ae6.md
@@ -1,0 +1,21 @@
+---
+id: LOG-e2b2f5384ae6
+type: log
+title: "The reader is done and its own suites are green: Snapshot is find alone, Held is status and is"
+created: 2026-08-27T18:51:41Z
+author: claude-code/opus-5+reader-json
+scope:
+  - crates/ank-tui/src/model.rs
+  - crates/ank-tui/src/lib.rs
+  - crates/ank-tui/src/view.rs
+  - crates/ank-tui/tests/terminal/mod.rs
+  - crates/ank-tui/tests/opening.rs
+about: TASK-fff0a98511b2
+seq: 3
+schema: 4
+version: 1
+---
+
+ asked only when the claims panel takes focus (the road requeue already takes for the queue), session draws before it reads and attaches the follower once find has named the corpus, and lib.rs carries a test that the first frame precedes any read. 184 unit tests and all twelve ank-tui pty suites pass.
+
+Four tests fail in crates/ank-cli/tests/tui.rs, a fifth file and a second crate. Two of them (a_claim_held_elsewhere_is_named_with_its_holder, a_driven_session_names_the_entities_the_corpus_carries) assert claims panel content without focusing it, which is the price now being charged where it is asked for. The other two are more interesting and are a harness fact rather than a defect: that suite's barrier is until(contains("ENTITIES")), and the opening frame now draws the panels empty, so the barrier is satisfied before the read lands and the assertions that follow race it. ank-tui's own harness waits on "2 ENTITIES" -- the count -- and did not race. Every such barrier in that file has to wait on the read rather than on a panel existing.

--- a/.ank/entities/LOG-e3211156639a.md
+++ b/.ank/entities/LOG-e3211156639a.md
@@ -1,0 +1,23 @@
+---
+id: LOG-e3211156639a
+type: log
+title: "Done and the whole workspace is green: 1063 tests, 0 failed, fmt clean, check ok with no new fault."
+created: 2026-08-27T19:32:21Z
+author: claude-code/opus-5+reader-json
+scope:
+  - crates/ank-tui/src/model.rs
+  - crates/ank-tui/src/lib.rs
+  - crates/ank-tui/src/view.rs
+  - crates/ank-tui/tests/terminal/mod.rs
+  - crates/ank-tui/tests/opening.rs
+  - crates/ank-cli/tests/tui.rs
+  - crates/ank-tui/tests/chrome.rs
+about: TASK-fff0a98511b2
+seq: 6
+schema: 4
+version: 1
+---
+
+ Two findings worth recording beyond the change itself. First, the harness barrier: until(contains("2 ENTITIES")) and until(contains("ank tui")) both matched the frame drawn before the read, so they stopped meaning what twenty call sites use them for; the fix is stated once in terminal/mod.rs rather than at each site -- Live::frame refuses to settle on a screen still saying 'the corpus has not been read', and Live::now is what the opening suite reads instead. Second, the claims panel's title said '(0)' while unasked, which reads as 'nothing is held' -- an answer, and the wrong one. It now says '(not asked)' in the title, exactly as the queue does, and the body says how to ask.
+
+Measured on a stamped 1202-entity fixture through the binary on a pseudo-terminal: first frame under one second, all rows arriving after it, and status spawned from neither call site. On the same corpus status answers in 22.8s against find's 2.0s, so what the opening used to cost was status twice plus find.

--- a/.ank/entities/TASK-fff0a98511b2.md
+++ b/.ank/entities/TASK-fff0a98511b2.md
@@ -5,14 +5,19 @@ slug: the-reader-draws-its-first-frame-from-one-answer
 title: The reader draws its first frame from one answer and waits for no second one
 created: 2026-08-27T16:33:20Z
 author: haksolot@vmi3223161
-status: open
+status: in_progress
 scope:
   - crates/ank-tui/src/model.rs
   - crates/ank-tui/src/lib.rs
+  - crates/ank-tui/src/view.rs
+  - crates/ank-tui/tests/terminal/mod.rs
+  - crates/ank-tui/tests/opening.rs
+  - crates/ank-cli/tests/tui.rs
+  - crates/ank-tui/tests/chrome.rs
 blocked_by: [TASK-b917fc12fee8]
 done_criteria: |
   On a corpus of at least a thousand entities the reader draws its first frame having spawned no child that reads the corpus, and the rows arrive after it. ank status is spawned from no place on the opening road: neither for the corpus identity the event stream needs, which find now carries, nor inside the snapshot. A test names the two call sites that are gone -- crates/ank-tui/src/lib.rs and crates/ank-tui/src/model.rs -- and fails if a status spawn returns to either. ank tui --json still answers with branch, default_branch and identity, which is a different road and keeps its price. The pseudo-terminal harness sees a frame in under one second. Measured through the binary.
 criteria_by: creator
 schema: 4
-version: 2
+version: 6
 ---

--- a/.ank/entities/TASK-fff0a98511b2.md
+++ b/.ank/entities/TASK-fff0a98511b2.md
@@ -5,7 +5,7 @@ slug: the-reader-draws-its-first-frame-from-one-answer
 title: The reader draws its first frame from one answer and waits for no second one
 created: 2026-08-27T16:33:20Z
 author: haksolot@vmi3223161
-status: in_progress
+status: done
 scope:
   - crates/ank-tui/src/model.rs
   - crates/ank-tui/src/lib.rs
@@ -18,6 +18,11 @@ blocked_by: [TASK-b917fc12fee8]
 done_criteria: |
   On a corpus of at least a thousand entities the reader draws its first frame having spawned no child that reads the corpus, and the rows arrive after it. ank status is spawned from no place on the opening road: neither for the corpus identity the event stream needs, which find now carries, nor inside the snapshot. A test names the two call sites that are gone -- crates/ank-tui/src/lib.rs and crates/ank-tui/src/model.rs -- and fails if a status spawn returns to either. ank tui --json still answers with branch, default_branch and identity, which is a different road and keeps its price. The pseudo-terminal harness sees a frame in under one second. Measured through the binary.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 7699a07f1414503505144d15c89e05701bb3be64
+    criteria: c1dded4f4270
+    via: submitted
 schema: 4
-version: 6
+version: 7
 ---

--- a/crates/ank-cli/tests/tui.rs
+++ b/crates/ank-cli/tests/tui.rs
@@ -834,7 +834,7 @@ fn on_a_terminal(repo: &Repo, agent: &str, args: &[&str], keys: &[&str]) -> Seen
     // suite that wrote straight after spawning would be measuring the terminal
     // it opened rather than the program it started.
     if !args.contains(&"--json") {
-        live.until("the session to open", |t| t.contains("ank tui"));
+        live.opened();
     }
     for entry in keys {
         live.press(entry);
@@ -852,7 +852,7 @@ fn on_a_terminal(repo: &Repo, agent: &str, args: &[&str], keys: &[&str]) -> Seen
 #[cfg(unix)]
 fn idle(repo: &Repo, agent: &str, quiet: std::time::Duration) -> Seen {
     let mut live = Live::open(repo, agent, &[]);
-    live.until("the session to open", |t| t.contains("ank tui"));
+    live.opened();
     std::thread::sleep(quiet);
     live.press("q");
     live.finished("a reader that quits answers 0")
@@ -990,6 +990,26 @@ impl Live {
             "timed out waiting for {what}:\n{}",
             self.screen.lock().unwrap().text()
         );
+    }
+
+    /// The barrier a driven session starts from: the opening read has landed
+    /// (TASK-fff0a98511b2).
+    ///
+    /// **"A panel is on the screen" stopped meaning "the corpus was read".**
+    /// The reader draws its first frame before it spawns anything, so the
+    /// header and all four panels are up while the listing is still empty, and
+    /// a suite that pressed on at that point would be racing the read it is
+    /// about to assert on. What is waited for instead is the sentence the
+    /// listing itself puts there while it has nothing: the panel says it has
+    /// not read, and this waits for it to stop saying so.
+    ///
+    /// [`Live::until_screen`] and not [`Live::until`], because the question is
+    /// what is on the screen now: `until` asks whether something was ever on
+    /// it, and "the corpus has not been read" always was.
+    fn opened(&self) {
+        self.until_screen("the opening read to land", |t| {
+            t.contains("ank tui") && !t.contains("the corpus has not been read")
+        });
     }
 
     /// Waits for the screen to say something.
@@ -1131,7 +1151,14 @@ fn a_driven_session_names_the_entities_the_corpus_carries() {
     // this suite took: "which claim is held by whom", with a name on it. The
     // task is what is opened, because the criterion is written into its body
     // and that is what "whole" is asserted against.
-    let seen = drive(&repo, HOLDER, &[":filter task", "\r", "b", ":filter", "q"]);
+    // `1` is in the list for the reason the test above gives: the claims panel
+    // is asked for rather than drawn on opening (TASK-fff0a98511b2), and
+    // "CLAIMS (1)" below is an assertion about what it says once asked.
+    let seen = drive(
+        &repo,
+        HOLDER,
+        &[":filter task", "\r", "b", ":filter", "1", "q"],
+    );
 
     // The one assertion here that is genuinely about the bytes rather than
     // about the screen: what a full-screen reader owes the shell it was
@@ -1546,7 +1573,10 @@ fn a_claim_held_elsewhere_is_named_with_its_holder() {
         .expect("the second task exists");
     repo.ank(OTHER, &["claim", &theirs]);
 
-    let seen = drive(&repo, HOLDER, &["q"]);
+    // `1` focuses the claims panel, which is what asks `status` for them
+    // (TASK-fff0a98511b2): the price is charged where a person asks for it, so
+    // a suite that wants the claims asks for them like a person would.
+    let seen = drive(&repo, HOLDER, &["1", "q"]);
     assert!(seen.contains(OTHER), "the other holder is named:\n{seen}");
     assert!(seen.contains(HOLDER), "and so is this one:\n{seen}");
     assert!(seen.contains("CLAIMS (2)"), "{seen}");
@@ -2058,13 +2088,13 @@ fn the_event_and_the_reload_reach_the_same_displayed_state() {
         READER,
         &[("XDG_CONFIG_HOME".into(), following.0.display().to_string())],
     );
-    told.until("the told screen to open", |t| t.contains("ENTITIES"));
+    told.opened();
     let mut asking = Live::open(
         &repo,
         READER,
         &[("XDG_CONFIG_HOME".into(), alone.0.display().to_string())],
     );
-    asking.until("the asking screen to open", |t| t.contains("ENTITIES"));
+    asking.opened();
     assert!(
         told.text().contains("stream following"),
         "the first screen has a stream:\n{}",
@@ -2140,7 +2170,7 @@ fn a_screen_with_the_stream_connected_asks_nothing_while_it_is_idle() {
             ("ANK_GIT_LOG".into(), shim.log.display().to_string()),
         ],
     );
-    live.until("the screen to open", |t| t.contains("ENTITIES"));
+    live.opened();
     assert!(
         live.text().contains("stream following"),
         "the stream is connected:\n{}",
@@ -2209,7 +2239,7 @@ fn an_event_repaints_the_list_and_renews_no_claim() {
         HOLDER,
         &[("XDG_CONFIG_HOME".into(), home.0.display().to_string())],
     );
-    live.until("the screen to open", |t| t.contains("ENTITIES"));
+    live.opened();
     // Opening the task you hold renews the lease, and it is supposed to: it is
     // `ank show`, run because a person typed an identifier (TASK-49746735127f).
     // What follows is about what happens with nobody typing.

--- a/crates/ank-tui/src/lib.rs
+++ b/crates/ank-tui/src/lib.rs
@@ -303,31 +303,34 @@ pub fn run(
     }
     let ank = Ank::new(address.clone());
     if json {
+        // **This road asks `status` and the interactive one does not**
+        // (TASK-fff0a98511b2). §4 gives this document `branch`,
+        // `default_branch` and `identity`, and a machine reader is owed every
+        // field the contract declares; what it is not owed is a screen drawn
+        // quickly, which is the only thing the other road spends this on.
         let snapshot = model::Snapshot::load(&ank).map_err(refused_by_the_cli)?;
-        let _ = writeln!(out, "{}", snapshot.document());
+        let held = model::Held::load(&ank).map_err(refused_by_the_cli)?;
+        let _ = writeln!(out, "{}", snapshot.document(&held));
         return Ok(ExitCode::Ok);
     }
-    // The corpus this reader is on, asked once and never again. The stream
-    // names corpora by the repository identity of ADR-621a7fd96ce1, so a
-    // follower has to know which lines are its own before the first one
-    // arrives, and an identity does not change under a session. A refusal here
-    // is not one: the reader simply has no stream to follow and falls back to
-    // reading when its person asks, which is what the next line already does.
-    let corpus = ank
-        .json("status", &[])
-        .map(|v| ank::text(&v, "corpus"))
-        .unwrap_or_default();
     let (wake, waking) = std::sync::mpsc::channel::<Wake>();
-    let stream = stream::follow(&corpus, wake.clone());
-    // The terminal is taken last, and given back by [`term::Screen`]'s `Drop`
-    // on every road out of what follows.
+    // The terminal is taken first now, and given back by [`term::Screen`]'s
+    // `Drop` on every road out of what follows.
+    //
+    // **Nothing has been read at this point, and that is the change**
+    // (TASK-fff0a98511b2). What used to stand here was `ank status --json`,
+    // asked for one field -- the corpus identity the stream names its lines by
+    // -- and answered in twenty seconds on a corpus of fifteen hundred
+    // entities, before a single cell had been painted. `find` carries that
+    // identity now, so the read that the screen was already waiting for is the
+    // read the stream waits for too, and the frame goes up in front of both.
     let mut screen = term::Screen::open().map_err(no_screen)?;
-    term::typing(wake);
+    term::typing(wake.clone());
     // Blocking, and there is nothing else in it: with nobody typing, nothing
     // changing and the window still, this reader is a process asleep on a
     // channel. No verb runs, no clock ticks and no claim moves.
     let mut wakes = std::iter::from_fn(move || waking.recv().ok());
-    session(&ank, &mut wakes, &mut screen, stream)
+    session(&ank, &mut wakes, &mut screen, Some(wake))
 }
 
 /// What can wake a drawn screen. There are exactly four things, and a fifth
@@ -413,8 +416,20 @@ fn refused_by_the_cli(failed: ank::Failed) -> Refused {
 /// asserted here is that a resize redraws, a broken terminal ends the session
 /// with an environment code, and an exhausted stream of wakes is a quit.
 ///
-/// `stream` is what the screen says about how it is being kept current, and
-/// `None` where there is nothing to follow.
+/// `news` is the channel a follower would send on, and `None` where this
+/// session is not to follow anything -- which is what the tests below pass, and
+/// what keeps a driven session from opening a thread on the caller's home.
+/// The follower is started here rather than by [`run`] because it cannot be
+/// started any earlier: it names its lines by the corpus identity, and the
+/// first thing this session knows that from is the `find` below
+/// (TASK-fff0a98511b2).
+///
+/// **The first frame goes up before anything is read**, which is the other half
+/// of the same task. The loop draws, and only then reads; the opening pass
+/// takes the `continue` so that the frame a person sees first costs no child at
+/// all, and the rows land on the second paint a few hundred milliseconds later.
+/// What that removes is not a slow read but a *blocking* one -- an empty panel
+/// saying it has not read yet is a screen, and twenty seconds of nothing is not.
 ///
 /// **The window is read from the terminal before every frame**, and the resize
 /// event is answered as well. Two roads to one fact, deliberately: the event is
@@ -425,11 +440,11 @@ pub fn session(
     ank: &Ank,
     wakes: &mut dyn Iterator<Item = Wake>,
     screen: &mut dyn Painter,
-    stream: Option<stream::Stream>,
+    news: Option<std::sync::mpsc::Sender<Wake>>,
 ) -> Result<ExitCode, Refused> {
     let opened = screen.size().unwrap_or((80, 24));
-    let mut app = view::App::new((opened.0 as usize, opened.1 as usize), stream);
-    app.reload(ank);
+    let mut app = view::App::new((opened.0 as usize, opened.1 as usize), None);
+    let mut opening = Some(news);
     let code = loop {
         if let Ok((columns, rows)) = screen.size() {
             app.resize(columns, rows);
@@ -439,6 +454,21 @@ pub fn session(
             // by stderr once the terminal has been given back.
             app.note(format!("cannot draw to the terminal: {e}"));
             break ExitCode::Environment;
+        }
+        // The opening reads, taken once and after the frame above rather than
+        // in front of it.
+        if let Some(news) = opening.take() {
+            app.reload(ank);
+            // And the follower, now that there is a corpus to name its lines
+            // by. It starts from the file's current length, so the window in
+            // which an event could be written and not delivered is the `find`
+            // that just answered -- narrower than the `status` it replaced,
+            // which this reader used to wait through before following anything.
+            if let Some(news) = news {
+                let following = stream::follow(app.corpus(), news);
+                app.follow(following);
+            }
+            continue;
         }
         // Exhausted means every sender is gone, which is the same end of input
         // by another road.
@@ -595,12 +625,15 @@ mod tests {
         let (mut paper, mut wakes, _size) = driven((120, 40), vec![Wake::Resize(60, 20)]);
         let code = session(&nowhere(), &mut wakes, &mut paper, None).expect("a session");
         assert_eq!(code, ExitCode::Ok);
+        // Three: the opening frame, the one the opening read produced, and the
+        // one the resize produced (TASK-fff0a98511b2). The first two are the
+        // same window and the third is the new one.
         assert_eq!(
             paper.frames.len(),
-            2,
+            3,
             "the screen was not drawn again for the resize"
         );
-        let (before, after) = (&paper.frames[0], &paper.frames[1]);
+        let (before, after) = (&paper.frames[1], &paper.frames[2]);
         assert_eq!(before.lines().count(), 40);
         assert_eq!(after.lines().count(), 20, "the new height:\n{after}");
         for line in after.lines() {
@@ -629,10 +662,10 @@ mod tests {
             session(&nowhere(), &mut wakes, &mut paper, None).expect("a session"),
             ExitCode::Ok
         );
-        // One for the opening frame, one after the `j`, and none after the quit:
-        // a session that drew again on its way out would be painting a screen
-        // it is about to take away.
-        assert_eq!(paper.frames.len(), 2);
+        // One for the opening frame, one for what the opening read produced,
+        // one after the `j`, and none after the quit: a session that drew again
+        // on its way out would be painting a screen it is about to take away.
+        assert_eq!(paper.frames.len(), 3);
     }
 
     /// Nothing left to wake it is a quit, not a fault: every sender is gone.
@@ -643,7 +676,47 @@ mod tests {
             session(&nowhere(), &mut wakes, &mut paper, None).expect("a session"),
             ExitCode::Ok
         );
-        assert_eq!(paper.frames.len(), 1, "the opening frame was drawn");
+        assert_eq!(paper.frames.len(), 2, "the opening frame was drawn");
+    }
+
+    /// **The first frame is drawn before anything is read**
+    /// (TASK-fff0a98511b2).
+    ///
+    /// The criterion measured where it can be measured exactly. `nowhere()`
+    /// addresses a binary that does not exist, so every read this session
+    /// attempts refuses -- and the frame that goes up first says the corpus has
+    /// not been read, while the frame after it carries the refusal. Two frames
+    /// and in that order is the whole property: had the read come first, there
+    /// would be one frame and it would carry the refusal.
+    ///
+    /// The wall-clock half of the same criterion is in
+    /// `crates/ank-tui/tests/opening.rs`, which drives the real binary on a
+    /// pseudo-terminal over a corpus of a thousand entities. This says the
+    /// ordering; that says the price.
+    #[test]
+    fn the_first_frame_is_drawn_before_the_corpus_is_read() {
+        let (mut paper, mut wakes, _size) = driven((100, 30), Vec::new());
+        assert_eq!(
+            session(&nowhere(), &mut wakes, &mut paper, None).expect("a session"),
+            ExitCode::Ok
+        );
+        assert_eq!(paper.frames.len(), 2, "the opening drew twice");
+        assert!(
+            paper.frames[0].contains("the corpus has not been read"),
+            "the first frame waited for a read:\n{}",
+            paper.frames[0]
+        );
+        assert!(
+            !paper.frames[0].contains("cannot run"),
+            "the first frame carries a read's outcome, so a read came before \
+             it:\n{}",
+            paper.frames[0]
+        );
+        assert!(
+            paper.frames[1].contains("cannot run"),
+            "the read that follows the first frame was never made:\n{}",
+            paper.frames[1]
+        );
     }
 
     /// A terminal that cannot be read from is an environment to repair, and it

--- a/crates/ank-tui/src/model.rs
+++ b/crates/ank-tui/src/model.rs
@@ -81,24 +81,59 @@ pub struct Claim {
     pub mine: bool,
 }
 
-/// The corpus as one screen sees it.
-#[derive(Debug, Clone)]
+/// The corpus as one screen sees it, out of `find` and out of nothing else
+/// (TASK-fff0a98511b2).
+///
+/// **One answer, and the reason is measured rather than argued.** This used to
+/// be `ank status --json` and `ank find --json` put side by side, and the pair
+/// was the whole of what a session had to wait for before it could draw. On
+/// this project's own corpus -- 1506 entities -- `find` costs about three
+/// seconds and `status` about twenty, because `status` counts what it reports
+/// by reading the corpus to do it (TASK-be17972988d9 is where that is fixed,
+/// and this task does not wait for it). A reader that opened on both spent
+/// seven eighths of its opening on the panel a person is not looking at.
+///
+/// So the two answers are two loads. What `find` gives is what the screen opens
+/// on; what `status` gives is [`Held`], asked when the claims panel is focused
+/// and not before, on the road [`crate::view::App::requeue`] already takes for
+/// the ratification queue. A panel drawn is not a panel focused.
+///
+/// `corpus` is here and comes from `find`, which carries it. That is what lets
+/// the event stream be followed at all without a `status`: a follower has to
+/// know which lines are its own, and the identity now arrives with the rows.
+#[derive(Debug, Clone, Default)]
 pub struct Snapshot {
-    pub branch: String,
-    pub default_branch: String,
-    pub identity: String,
     pub corpus: String,
-    pub claims: Vec<Claim>,
     pub entities: Vec<Row>,
     /// What `find` said it withheld, so a screen never implies it saw
     /// everything when it did not (ADR-3e6ce108edcd).
     pub total: u64,
 }
 
-impl Snapshot {
-    pub fn load(ank: &Ank) -> Result<Snapshot, Failed> {
+/// Who holds what, as `status` answers it (TASK-fff0a98511b2).
+///
+/// The half of the old snapshot that costs, split off so that the price is
+/// charged where a person asks for it. Four values and they arrive together
+/// because one verb answers all four: a branch, the branch it is measured
+/// against, the identity this reader runs as, and the claims that identity can
+/// see.
+///
+/// **`branch`, `default_branch` and `identity` are chrome and are still here.**
+/// They are not free -- they are `status`'s answer like the claims are -- so the
+/// header says it has not asked rather than drawing a blank where a branch goes.
+/// `ank tui --json` asks for them outright, which is a different road and keeps
+/// its price.
+#[derive(Debug, Clone, Default)]
+pub struct Held {
+    pub branch: String,
+    pub default_branch: String,
+    pub identity: String,
+    pub claims: Vec<Claim>,
+}
+
+impl Held {
+    pub fn load(ank: &Ank) -> Result<Held, Failed> {
         let status = ank.json("status", &[])?;
-        let found = ank.json("find", &[])?;
 
         let identity = status
             .get("identity")
@@ -134,12 +169,25 @@ impl Snapshot {
             });
         }
 
-        Ok(Snapshot {
+        Ok(Held {
             branch: ank::text(&status, "branch"),
             default_branch: ank::text(&status, "default_branch"),
             identity,
-            corpus: ank::text(&status, "corpus"),
             claims,
+        })
+    }
+
+    /// The claim held on an entity, if one is.
+    pub fn claim_on(&self, id: &str) -> Option<&Claim> {
+        self.claims.iter().find(|c| c.id == id)
+    }
+}
+
+impl Snapshot {
+    pub fn load(ank: &Ank) -> Result<Snapshot, Failed> {
+        let found = ank.json("find", &[])?;
+        Ok(Snapshot {
+            corpus: ank::text(&found, "corpus"),
             entities: ank::rows(&found, "results").iter().map(Row::read).collect(),
             total: ank::count(&found, "total"),
         })
@@ -157,27 +205,31 @@ impl Snapshot {
         self.entities.iter().find(|r| r.id == id)
     }
 
-    /// The claim held on an entity, if one is.
-    pub fn claim_on(&self, id: &str) -> Option<&Claim> {
-        self.claims.iter().find(|c| c.id == id)
-    }
-
     /// The opening frame as data, for `ank tui --json` (§4).
     ///
     /// The reader's own answer and not a passthrough: it is what the screen
     /// holds, in the one writer and the one escaper every other document in
     /// this tool goes through (ADR-6fd69efb629c).
-    pub fn document(&self) -> String {
+    ///
+    /// **It takes the [`Held`] rather than reading it** (TASK-fff0a98511b2).
+    /// The screen no longer asks `status` to open, and this document still
+    /// answers with `branch`, `default_branch`, `identity` and the claims --
+    /// so the caller of this road pays for them explicitly, which is what
+    /// "a different road and keeps its price" means. A field a document
+    /// declares is a field a consumer may rely on (ADR-6fd69efb629c), and
+    /// dropping four of them to make an interactive session cheaper would be
+    /// charging the machine reader for the person's convenience.
+    pub fn document(&self, held: &Held) -> String {
         Obj::document()
             .str("corpus", &self.corpus)
-            .str("branch", &self.branch)
-            .str("default_branch", &self.default_branch)
-            .str("identity", &self.identity)
+            .str("branch", &held.branch)
+            .str("default_branch", &held.default_branch)
+            .str("identity", &held.identity)
             .num("total", self.total)
             .num("shown", self.entities.len())
             .array(
                 "claims",
-                self.claims.iter().map(|c| {
+                held.claims.iter().map(|c| {
                     Obj::new()
                         .str("id", &c.id)
                         .str("short", &short_of(&c.id))

--- a/crates/ank-tui/src/view.rs
+++ b/crates/ank-tui/src/view.rs
@@ -257,7 +257,7 @@ use crate::bindings::{self, Binding, Holding};
 use crate::form::{Filled, Form, SET as SETTING};
 use crate::input::{Act, Command, Subject};
 use crate::keys::{self, Editing, Press};
-use crate::model::{self, short_of, Detail, Queue, Row, Setting, Settings, Snapshot};
+use crate::model::{self, short_of, Detail, Held, Queue, Row, Setting, Settings, Snapshot};
 use crate::paint::{self, role_of_id, Composed, Ink};
 use crate::stream::Stream;
 use crate::text::{self, fit, pad, window, wrap};
@@ -478,6 +478,12 @@ pub struct App {
     focus: Focus,
     pane: Pane,
     snapshot: Option<Snapshot>,
+    /// Who holds what, and the chrome `status` answers with it
+    /// (TASK-fff0a98511b2). `None` until the claims panel is focused, on the
+    /// road [`App::requeue`] takes for the queue and for the same reason: this
+    /// is the costliest verb the reader runs, and a panel nobody is looking at
+    /// is not stale.
+    held: Option<Held>,
     detail: Option<Detail>,
     note: Option<String>,
     /// One cursor per panel, indexed by [`Focus::number`] less one. The body's
@@ -602,6 +608,7 @@ impl App {
             focus: Focus::Entities,
             pane: Pane::Body,
             snapshot: None,
+            held: None,
             detail: None,
             note: None,
             cursors: [Cursor::default(); 4],
@@ -665,6 +672,7 @@ impl App {
             Ok(snapshot) => {
                 self.snapshot = Some(snapshot);
                 self.note = None;
+                self.rehold(ank);
                 self.requeue(ank);
                 if let Some(id) = held {
                     if let Some(at) = self.entity_rows().iter().position(|r| r.id == id) {
@@ -675,6 +683,49 @@ impl App {
             }
             Err(failed) => self.fail(failed),
         }
+    }
+
+    /// Asks `status` again, but only where the claims panel has focus
+    /// (TASK-fff0a98511b2).
+    ///
+    /// **The same condition as [`App::requeue`], for a sharper reason.**
+    /// `status` counts what it reports by reading the corpus to do it, which on
+    /// this project's own corpus is about twenty seconds against `find`'s
+    /// three. Asking it to open a session put seven eighths of the wait on the
+    /// panel a reader is least often looking at -- and asking it on every
+    /// reload would put that same price on every event a watcher sends, which
+    /// is what TASK-2f7777a1fdff bought and this would spend again.
+    ///
+    /// So the claims arrive when a person asks for them, and the panel says it
+    /// has not asked until then, in the words the queue already uses. Nothing
+    /// is hidden and nothing is guessed: what is drawn is what was read.
+    fn rehold(&mut self, ank: &Ank) {
+        if self.focus != Focus::Claims {
+            return;
+        }
+        match Held::load(ank) {
+            Ok(held) => self.held = Some(held),
+            Err(failed) => self.fail(failed),
+        }
+    }
+
+    /// The corpus this screen is on, for the follower to name its lines by.
+    ///
+    /// Empty until the first read answers, which is exactly when
+    /// [`crate::session`] asks: a follower started on an empty identity is
+    /// `None`, and this reader falls back to reading when its person asks.
+    pub fn corpus(&self) -> &str {
+        self.snapshot.as_ref().map_or("", |s| s.corpus.as_str())
+    }
+
+    /// Attaches the follower, once there is a corpus to have started it with.
+    ///
+    /// It arrives after the first frame for the reason [`crate::session`]
+    /// gives, so it is set rather than constructed with: an `App` is drawable
+    /// before anything about the corpus is known, and that is the property the
+    /// opening rests on.
+    pub fn follow(&mut self, stream: Option<Stream>) {
+        self.stream = stream;
     }
 
     /// Asks `review` again, but only where the queue panel has focus.
@@ -775,7 +826,7 @@ impl App {
     /// How many rows a listing holds.
     fn count(&self, focus: Focus) -> usize {
         match focus {
-            Focus::Claims => self.snapshot.as_ref().map_or(0, |s| s.claims.len()),
+            Focus::Claims => self.held.as_ref().map_or(0, |h| h.claims.len()),
             Focus::Entities => self.entity_rows().len(),
             Focus::Queue => self.queue_rows().len(),
             Focus::Body => 0,
@@ -790,7 +841,7 @@ impl App {
     fn selected_id(&self, focus: Focus) -> Option<String> {
         let at = self.cursors[focus.number() - 1].at;
         match focus {
-            Focus::Claims => self.snapshot.as_ref()?.claims.get(at).map(|c| c.id.clone()),
+            Focus::Claims => self.held.as_ref()?.claims.get(at).map(|c| c.id.clone()),
             Focus::Entities => self.entity_rows().get(at).map(|r| r.id.clone()),
             Focus::Queue => self.queue_rows().get(at).map(|r| r.id.clone()),
             Focus::Body => self.pane_target(),
@@ -1427,14 +1478,20 @@ impl App {
 
     /// Move focus, and pay whatever the panel arriving costs.
     ///
-    /// Two panels cost something now and both are charged here rather than at
-    /// every repaint: focusing the queue is a person asking for `ank review`,
-    /// which is a whole inspection of the corpus, and arriving at the body
-    /// panel with the config pane open is a person asking for one
-    /// `ank config <key>` per key the contract declares. Neither price is paid
+    /// Three panels cost something now and all three are charged here rather
+    /// than at every repaint: focusing the claims is a person asking for
+    /// `ank status`, which counts what it reports by reading the corpus to do
+    /// it (TASK-fff0a98511b2); focusing the queue is a person asking for
+    /// `ank review`, which is a whole inspection of the corpus; and arriving at
+    /// the body panel with the config pane open is a person asking for one
+    /// `ank config <key>` per key the contract declares. No price here is paid
     /// by a screen nobody is at.
     fn focus_on(&mut self, focus: Focus, ank: &Ank) {
         self.focus = focus;
+        if focus == Focus::Claims {
+            self.rehold(ank);
+            self.clamp(Focus::Claims);
+        }
         if focus == Focus::Queue {
             self.requeue(ank);
             self.clamp(Focus::Queue);
@@ -1916,19 +1973,33 @@ impl App {
         let panels = self.arrange(area);
 
         let (corpus, identity) = match &self.snapshot {
+            // **The branch, the identity and the count come from the claims
+            // panel's own verb, so the header says so until it is asked**
+            // (TASK-fff0a98511b2). Drawing a blank where a branch goes would
+            // read as "no branch"; naming the price reads as what it is, and it
+            // is the same word the queue's panel uses one screen down.
             Some(snapshot) => (
-                format!(
-                    "ank tui   corpus {}   branch {} (default {})",
-                    &snapshot.corpus[..12.min(snapshot.corpus.len())],
-                    snapshot.branch,
-                    snapshot.default_branch
-                ),
-                format!(
-                    "identity {}   {} claim(s) live   {}",
-                    snapshot.identity,
-                    snapshot.claims.len(),
-                    self.route()
-                ),
+                match &self.held {
+                    Some(held) => format!(
+                        "ank tui   corpus {}   branch {} (default {})",
+                        &snapshot.corpus[..12.min(snapshot.corpus.len())],
+                        held.branch,
+                        held.default_branch
+                    ),
+                    None => format!(
+                        "ank tui   corpus {}   branch (not asked)",
+                        &snapshot.corpus[..12.min(snapshot.corpus.len())]
+                    ),
+                },
+                match &self.held {
+                    Some(held) => format!(
+                        "identity {}   {} claim(s) live   {}",
+                        held.identity,
+                        held.claims.len(),
+                        self.route()
+                    ),
+                    None => format!("identity (not asked)   {}", self.route()),
+                },
             ),
             // Nothing has been read yet, or the first read refused. The panels
             // below still draw -- empty, and saying so -- because a reader that
@@ -2016,7 +2087,14 @@ impl App {
     fn title_of(&self, focus: Focus, width: usize) -> Composed {
         let name = focus.name();
         match focus {
-            Focus::Claims => Composed::of(&format!("{name} ({})", self.count(Focus::Claims))),
+            // The queue's own shape, for the queue's own reason
+            // (TASK-fff0a98511b2): a panel that has not been asked has no count
+            // to give, and `(0)` over an unasked panel reads as "nothing is
+            // held" -- which is an answer, and the wrong one.
+            Focus::Claims => match &self.held {
+                None => Composed::of(&format!("{name}   (not asked)")),
+                Some(_) => Composed::of(&format!("{name} ({})", self.count(Focus::Claims))),
+            },
             Focus::Entities => {
                 let total = self.snapshot.as_ref().map_or(0, |s| s.total);
                 let rows = self.count(Focus::Entities);
@@ -2106,16 +2184,22 @@ impl App {
     /// the caller holds, and it stays against the identifier rather than moving
     /// to make room for a cursor that arrived later.
     fn claim_lines(&self, width: usize) -> Vec<Composed> {
+        let Some(held) = &self.held else {
+            // The title above already says it has not been asked, on the
+            // queue's own pattern (TASK-fff0a98511b2). What is left for the
+            // body is the way in, which is what the queue's body says too:
+            // nothing here is hidden, it is unasked, and focusing asks.
+            return vec![Composed::of("  focus this panel to ask").fitted(width)];
+        };
         let Some(snapshot) = &self.snapshot else {
             return vec![Composed::of("  the corpus has not been read").fitted(width)];
         };
-        if snapshot.claims.is_empty() {
+        if held.claims.is_empty() {
             return vec![Composed::of("  nothing is held").fitted(width)];
         }
         let c = self.cursors[Focus::Claims.number() - 1];
         let page = self.page(Focus::Claims);
-        snapshot
-            .claims
+        held.claims
             .iter()
             .enumerate()
             .skip(c.top)
@@ -2151,11 +2235,11 @@ impl App {
             return vec![Composed::of("  no entity matches this filter").fitted(width)];
         }
         let c = self.cursors[Focus::Entities.number() - 1];
-        let held = |id: &str| {
-            self.snapshot
-                .as_ref()
-                .is_some_and(|s| s.claim_on(id).is_some())
-        };
+        // The marker on a row somebody holds, and it is drawn only once the
+        // claims have been asked for (TASK-fff0a98511b2): an unmarked row means
+        // "not asked" here as much as it means "not held", and the panel one
+        // screen up is where a reader is told which.
+        let held = |id: &str| self.held.as_ref().is_some_and(|h| h.claim_on(id).is_some());
         rows.iter()
             .enumerate()
             .skip(c.top)
@@ -3876,16 +3960,7 @@ mod tests {
 
     fn snapshot() -> Snapshot {
         Snapshot {
-            branch: "wave4/tui-verb".to_string(),
-            default_branch: "main".to_string(),
-            identity: "claude-code/opus-5+tui-verb".to_string(),
             corpus: "5a02985accabde1a7365a01db237a245097ab4ca".to_string(),
-            claims: vec![Claim {
-                id: "TASK-49746735127f".to_string(),
-                holder: "claude-code/opus-5+tui-verb".to_string(),
-                expires: "2026-08-25T04:36:32Z".to_string(),
-                mine: true,
-            }],
             entities: vec![
                 row("ADR-8bd76e8d7c4e", "adr", "accepted", "A terminal reader"),
                 row("TASK-49746735127f", "task", "in_progress", "ank tui opens"),
@@ -3893,6 +3968,34 @@ mod tests {
             ],
             total: 3,
         }
+    }
+
+    /// What `status` answers, which a screen has only once the claims panel has
+    /// been focused (TASK-fff0a98511b2).
+    ///
+    /// Two fixtures where there was one, because there are two reads where
+    /// there was one. A test that is about the claims, the branch or the
+    /// identity sets this as well; a test that is about the listing does not,
+    /// and what it draws is the screen a session actually opens on.
+    fn held() -> Held {
+        Held {
+            branch: "wave4/tui-verb".to_string(),
+            default_branch: "main".to_string(),
+            identity: "claude-code/opus-5+tui-verb".to_string(),
+            claims: vec![Claim {
+                id: "TASK-49746735127f".to_string(),
+                holder: "claude-code/opus-5+tui-verb".to_string(),
+                expires: "2026-08-25T04:36:32Z".to_string(),
+                mine: true,
+            }],
+        }
+    }
+
+    /// An app that has read everything, which is what most of these tests are
+    /// about: they ask what a drawn screen says, not what an opening one costs.
+    fn has_read(a: &mut App) {
+        a.snapshot = Some(snapshot());
+        a.held = Some(held());
     }
 
     fn row(id: &str, kind: &str, status: &str, title: &str) -> Row {
@@ -3947,7 +4050,7 @@ mod tests {
         let mut a = App::new((120, 40), None)
             .inked(paint::PLAIN)
             .drawn_with(SCREEN);
-        a.snapshot = Some(snapshot());
+        has_read(&mut a);
         a
     }
 
@@ -4138,7 +4241,7 @@ mod tests {
             let mut a = App::new((120, 40), None)
                 .inked(paint::PLAIN)
                 .drawn_with(glyphs);
-            a.snapshot = Some(snapshot());
+            has_read(&mut a);
             a.focus = Focus::Entities;
             a
         }
@@ -4219,6 +4322,7 @@ mod tests {
     /// have let a palette with seven arms missing pass.
     fn coloured(ink: paint::Ink) -> App {
         let mut a = App::new((120, 40), None).inked(ink).drawn_with(SCREEN);
+        a.held = Some(held());
         let mut snapshot = snapshot();
         snapshot.entities.push(row(
             "TASK-0000ffff0004",
@@ -4857,7 +4961,7 @@ mod tests {
                     a.queue = Some(queued());
                     for read in [false, true] {
                         if read {
-                            a.snapshot = Some(snapshot());
+                            has_read(&mut a);
                             a.detail = Some(detail(
                                 "TASK-49746735127f",
                                 &(1..=200).map(|n| format!("line {n}\n")).collect::<String>(),
@@ -5028,7 +5132,7 @@ mod tests {
         let ank = nowhere();
         for size in [(80, 24), (40, 24)] {
             let mut a = App::new(size, None);
-            a.snapshot = Some(snapshot());
+            has_read(&mut a);
             a.detail = Some(Detail {
                 content: content.clone(),
                 ..detail("TASK-49746735127f", "")
@@ -5972,7 +6076,7 @@ mod tests {
 
     fn phone() -> App {
         let mut a = App::new(PHONE, None).inked(paint::PLAIN).drawn_with(SCREEN);
-        a.snapshot = Some(snapshot());
+        has_read(&mut a);
         a
     }
 
@@ -6142,7 +6246,7 @@ mod tests {
         let ank = nowhere();
         for size in [PHONE, (120, 40)] {
             let mut a = App::new(size, None).inked(paint::PLAIN);
-            a.snapshot = Some(snapshot());
+            has_read(&mut a);
             assert_eq!(a.cursors[Focus::Entities.number() - 1].at, 0);
             let at = row_of(&a, Focus::Entities, 2);
             touch(&mut a, &ank, at);
@@ -6179,7 +6283,7 @@ mod tests {
     fn a_press_on_an_unfocused_listing_takes_the_focus_and_the_row_it_landed_on() {
         let ank = nowhere();
         let mut a = App::new((120, 40), None).inked(paint::PLAIN);
-        a.snapshot = Some(snapshot());
+        has_read(&mut a);
         a.queue = Some(queued());
         a.focus = Focus::Entities;
         let at = row_of(&a, Focus::Queue, 1);
@@ -6350,7 +6454,7 @@ mod tests {
                 let mut a = App::new(window, None)
                     .inked(paint::PLAIN)
                     .drawn_with(SCREEN);
-                a.snapshot = Some(snapshot());
+                has_read(&mut a);
                 state(&mut a);
                 a
             };
@@ -6465,7 +6569,7 @@ mod tests {
         let mut a = App::new(window, None)
             .inked(paint::PLAIN)
             .drawn_with(SCREEN);
-        a.snapshot = Some(snapshot());
+        has_read(&mut a);
         a
     }
 

--- a/crates/ank-tui/tests/chrome.rs
+++ b/crates/ank-tui/tests/chrome.rs
@@ -120,10 +120,22 @@ fn the_chrome_at_the_desk_is_a_header_and_a_row() {
         furniture.len(),
         furniture
     );
-    // And the corpus is the one the criterion describes: nothing is held, and
-    // nothing has asked the CLI for the ratification queue.
-    assert!(frame.contains("nothing is held"), "{frame}");
-    assert!(frame.contains("(not asked)"), "{frame}");
+    // And the corpus is the one the criterion describes: two of the four
+    // panels have not been asked for, so neither is spending a row on content
+    // that would flatter the count above.
+    //
+    // **Two and not one** (TASK-fff0a98511b2). The claims panel used to be
+    // read on opening and said "nothing is held" here; it is asked for when it
+    // takes focus now, on the road the queue already took, so what it says at
+    // rest is the queue's own word. That is the honest sentence: this session
+    // never focused it, and a panel that has not been asked has no claim to
+    // report either way.
+    for unasked in ["1 CLAIMS   (not asked)", "4 QUEUE   (not asked)"] {
+        assert!(
+            frame.contains(unasked),
+            "'{unasked}' is not on this screen:\n{frame}"
+        );
+    }
     live.quit();
 }
 

--- a/crates/ank-tui/tests/opening.rs
+++ b/crates/ank-tui/tests/opening.rs
@@ -1,0 +1,200 @@
+//! What a session costs to open, measured on a corpus big enough for the
+//! answer to mean something (TASK-fff0a98511b2).
+//!
+//! **Why this is a suite of its own.** Every other suite here asks what the
+//! reader *says*; this one asks what it *waits for*, and the two want opposite
+//! fixtures. A screen is checked against two entities because two are readable
+//! in an assertion; an opening is checked against a thousand because a
+//! thousand is where waiting for the corpus stops being free. On the seeded
+//! two, a reader that read everything before drawing and a reader that drew
+//! first are indistinguishable.
+//!
+//! **What the numbers were.** On this project's own corpus -- 1506 entities --
+//! `ank status --json` answered in about twenty seconds and `ank find --json`
+//! in about three, and the opening road ran `status` twice: once for the corpus
+//! identity the event stream names its lines by, and once inside the snapshot.
+//! Some forty seconds of a person's time, before a cell was painted, and seven
+//! eighths of it for the panel they were not looking at. `find` carries the
+//! corpus identity now, the claims are asked for when the claims panel is
+//! focused, and the first frame goes up in front of both.
+//!
+//! `#[cfg(unix)]` for the reason `terminal/mod.rs` gives: a pseudo-terminal on
+//! Windows is ConPTY, and reaching it means the console API this workspace does
+//! not otherwise call.
+
+#![cfg(unix)]
+
+mod terminal;
+
+use std::time::{Duration, Instant};
+use terminal::{Live, Repo};
+
+/// The corpus the criterion names. One above a thousand, so that "at least a
+/// thousand" is met by the fixture and not by rounding.
+const CROWD: usize = 1_200;
+
+/// The window, wide enough that a panel title is not cut before its count.
+const WINDOW: (u16, u16) = (120, 40);
+
+/// **The first frame is on the screen in under a second, on a corpus that takes
+/// seconds to read** (TASK-fff0a98511b2).
+///
+/// The measurement starts before the process does, so what is timed is
+/// everything a person waits through: the spawn, the terminal being taken, and
+/// the first paint. The wall is one second, and the frame it is waiting for is
+/// the reader's own -- the header names the tool, so a terminal that echoed
+/// something else could not satisfy it.
+///
+/// **The corpus is warmed first, and that only makes this harder.** A cold
+/// `.ank/index.db` would put the cost of building it on the first `find`, which
+/// this test would then be measuring instead of the reader. Warm, `find` is as
+/// fast as it ever gets and the frame still has to beat it.
+#[test]
+fn the_first_frame_is_drawn_in_under_a_second_on_a_crowded_corpus() {
+    let repo = Repo::crowded(CROWD);
+    repo.warm_find();
+
+    let started = Instant::now();
+    let live = Live::open(&repo, WINDOW.0, WINDOW.1);
+    live.until("the first frame", |t| t.contains("ank tui"));
+    let waited = started.elapsed();
+
+    assert!(
+        waited < Duration::from_secs(1),
+        "the first frame took {waited:?} on {CROWD} entities, and a person \
+         waiting on a corpus is what this task is about"
+    );
+    live.quit();
+}
+
+/// **And what it drew first is a screen, not a blank** (TASK-fff0a98511b2).
+///
+/// Drawing early is worth nothing if what goes up is empty chrome. The frame
+/// that beats the read carries the four panels, each named, and says of the
+/// listing that it has not read yet -- which is the honest thing for it to say
+/// and the sentence the suites now wait on to know the read landed.
+///
+/// Asserted on the same frame the timing test measures, in a separate session
+/// so that neither is reading the other's screen.
+#[test]
+fn the_frame_that_arrives_first_names_its_panels_and_says_it_has_not_read() {
+    let repo = Repo::crowded(CROWD);
+    repo.warm_find();
+
+    let live = Live::open(&repo, WINDOW.0, WINDOW.1);
+    live.until("the first frame", |t| t.contains(terminal::UNREAD));
+    // [`Live::now`] and not [`Live::frame`]: the frame being asked about is the
+    // one drawn before the read, and `frame` will not settle on it.
+    let first = live.now();
+    for panel in ["1 CLAIMS", "2 ENTITIES", "3 BODY", "4 QUEUE"] {
+        assert!(
+            first.contains(panel),
+            "{panel} is not on the opening frame:\n{first}"
+        );
+    }
+    assert!(
+        first.contains(terminal::UNREAD),
+        "the frame that arrived first had already read the corpus:\n{first}"
+    );
+    live.quit();
+}
+
+/// **The rows arrive after the frame, and they are all of them**
+/// (TASK-fff0a98511b2).
+///
+/// The other half of the criterion: drawing first is only worth having if the
+/// corpus still turns up. What is waited for is the count `find` answered with,
+/// so a reader that drew quickly and then read half a corpus would fail here
+/// rather than pass on having been fast.
+///
+/// The count is `CROWD + 2`: [`Repo::crowded`] stamps its tasks onto the two
+/// entities [`Repo::seeded`] writes.
+#[test]
+fn the_rows_arrive_after_the_first_frame_and_the_whole_corpus_is_there() {
+    let repo = Repo::crowded(CROWD);
+    repo.warm_find();
+
+    let live = Live::open(&repo, WINDOW.0, WINDOW.1);
+    live.until("the first frame", |t| t.contains("ank tui"));
+    let carried = CROWD + 2;
+    live.until("the rows to arrive", |t| {
+        t.contains(&format!("({carried} in the corpus)"))
+    });
+    live.quit();
+}
+
+/// **`ank status` is spawned from nowhere on the opening road**
+/// (TASK-fff0a98511b2).
+///
+/// The two call sites the criterion names, each measured where it was rather
+/// than by looking for the word anywhere. `lib.rs` asked for the corpus
+/// identity the event stream names its lines by, which `find` now carries, so
+/// that file has no business with the verb at all and is measured on the whole
+/// of itself. `model.rs` asked for the claims inside the snapshot -- and it
+/// still asks for them, in `Held::load`, which is what the claims panel runs
+/// when it takes focus. So what is measured there is `Snapshot::load` alone:
+/// the function a session opens on.
+///
+/// Read off the code with its prose removed, on `tests/dependencies.rs`'s rule.
+/// The module headers of both files have to be able to say what they no longer
+/// do, and a comment explaining an absence is not the absence returning.
+///
+/// A verb is named as `"status"` because that is how [`ank_tui::ank::Ank`]
+/// takes one: `json("status", ...)` and `act("status", ...)` are the only two
+/// roads out, and neither can be reached without the word.
+#[test]
+fn no_source_on_the_opening_road_spawns_status() {
+    let lib = code_of("lib.rs");
+    assert!(
+        !lib.contains("\"status\""),
+        "lib.rs asks for `ank status` again. It used to, for one field -- the \
+         corpus identity -- and answering it cost twenty seconds before a cell \
+         was painted. `find` carries that identity now:\n{lib}"
+    );
+
+    let model = code_of("model.rs");
+    let opening = model
+        .split_once("pub fn load(ank: &Ank) -> Result<Snapshot, Failed> {")
+        .map(|(_, rest)| {
+            rest.split_once("\n    }")
+                .map(|(body, _)| body)
+                .unwrap_or(rest)
+        })
+        .expect("model.rs declares Snapshot::load");
+    assert!(
+        !opening.contains("\"status\""),
+        "Snapshot::load spawns `ank status` again, and it is what a session \
+         opens on:\n{opening}"
+    );
+    // Not vacuous, in both directions. The slice has to be the function -- an
+    // empty one would pass the assertion above saying nothing -- and the verb
+    // has to still be reachable somewhere, or this is measuring a word that
+    // left the crate rather than a call site that moved.
+    assert!(
+        opening.contains("\"find\""),
+        "the slice taken is not Snapshot::load: it does not ask `find`"
+    );
+    assert!(
+        model.contains("\"status\""),
+        "no source asks for `ank status` at all, so this test measures nothing"
+    );
+}
+
+/// One of this crate's sources, with its prose removed.
+///
+/// A line whose first non-space characters are a slash pair is a comment whole,
+/// which is the only form the scans above need: what they are looking for is a
+/// verb in a call, and a call is never inside a doc comment.
+fn code_of(file: &str) -> String {
+    let source = std::fs::read_to_string(
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("src")
+            .join(file),
+    )
+    .expect("the crate has this source");
+    source
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("//"))
+        .collect::<Vec<&str>>()
+        .join("\n")
+}

--- a/crates/ank-tui/tests/terminal/mod.rs
+++ b/crates/ank-tui/tests/terminal/mod.rs
@@ -73,6 +73,14 @@ pub const AGENT: &str = "claude-code/opus-5+panel-suite";
 /// on one machine and another on the next.
 pub const TERM: &str = "xterm-256color";
 
+/// What the listing says while it has nothing, which is what a screen drawn
+/// before the corpus was read says (TASK-fff0a98511b2).
+///
+/// One constant because it is the barrier every suite here rests on: the
+/// reader draws first and reads after, so "a panel is on the screen" stopped
+/// meaning "the corpus was read" and this is what took its place.
+pub const UNREAD: &str = "the corpus has not been read";
+
 /// Deliberately wider than the entities panel at either window, so that a
 /// frame which overflowed rather than fitted would be visible as a row past
 /// the right edge.
@@ -122,6 +130,62 @@ impl Repo {
             "The frame names this entity and the body arrives whole.",
         ]);
         repo
+    }
+
+    /// The seeded corpus, plus `extra` tasks, for the suites that are about
+    /// what a corpus costs rather than what it says (TASK-fff0a98511b2).
+    ///
+    /// **Stamped rather than asked for, and the reason is arithmetic.** Every
+    /// other fixture here is built by running `ank new`, which is the honest
+    /// way and is what keeps the two entities of [`Repo::seeded`] provably
+    /// well-formed. A thousand of them is a thousand process spawns against a
+    /// corpus that grows under each one, which is minutes -- so this takes the
+    /// one entity `new` wrote and copies it, changing the three fields that
+    /// have to differ. What is being fixed is the *size* of a corpus, and a
+    /// size is the one property a copy preserves exactly.
+    ///
+    /// Writing under `.ank/` directly is a liberty this module already takes
+    /// ([`Repo::corpus`] reads every file there) and one no source of the crate
+    /// has: the reader reaches the corpus by running the CLI, and a test may
+    /// name what the crate may not.
+    pub fn crowded(extra: usize) -> Repo {
+        let repo = Repo::seeded();
+        let entities = repo.0.join(".ank").join("entities");
+        let seed = std::fs::read_dir(&entities)
+            .expect("the corpus has an entities directory")
+            .filter_map(|e| e.ok().map(|e| e.path()))
+            .find(|p| {
+                p.file_name()
+                    .is_some_and(|n| n.to_string_lossy().starts_with("TASK-"))
+            })
+            .expect("the seeded corpus carries a task");
+        let template = std::fs::read_to_string(&seed).expect("the task file is readable");
+        let was = template
+            .split_once("id: ")
+            .and_then(|(_, rest)| rest.split_once('\n'))
+            .map(|(id, _)| id.to_string())
+            .expect("an entity file names its own id");
+        for i in 0..extra {
+            // A twelve-hex identifier in a range `new` does not draw from, so a
+            // stamped entity can never collide with a seeded one.
+            let id = format!("TASK-{:012x}", 0x7000_0000_0000u64 + i as u64);
+            let body = template
+                .replace(&was, &id)
+                .replace("slug: ", &format!("slug: crowd-{i}-"))
+                .replace("title: ", &format!("title: {i} "));
+            std::fs::write(entities.join(format!("{id}.md")), body)
+                .expect("a stamped entity is writable");
+        }
+        repo
+    }
+
+    /// The one read this reader makes on opening, made once beforehand.
+    ///
+    /// [`Repo::warm`] cannot be used on a crowded corpus: it asks `show` once
+    /// per entity, which is the thing this fixture has a thousand of. What has
+    /// to be warm is `.ank/index.db`, and one `find` writes it.
+    pub fn warm_find(&self) {
+        let _ = self.stdout(&["find", "--json"]);
     }
 
     pub fn git(&self, args: &[&str]) -> Output {
@@ -783,18 +847,42 @@ impl Live {
     /// Settled first, because a screen read the instant a needle appeared is
     /// half a screen: the reader writes a frame in one call but a terminal
     /// hands it over in whatever pieces it likes.
+    ///
+    /// **And a screen that has not read the corpus has not settled**
+    /// (TASK-fff0a98511b2). The reader draws its opening frame before it spawns
+    /// anything, so on a small corpus the frame that follows it can arrive
+    /// inside one of the polls below -- and two equal samples of the opening
+    /// frame would hand a suite an empty listing that is about to be filled.
+    /// It is not a state anybody wants to assert on: every caller of this asks
+    /// what a drawn screen says about a corpus, and there is exactly one
+    /// suite that is about the opening itself, which reads [`Live::now`]
+    /// instead.
+    ///
+    /// Stated here rather than at each barrier, because that is where it holds
+    /// for every suite at once: there are twenty `until("the session to open")`
+    /// calls in this crate and one of them going unfixed is a flake nobody
+    /// reproduces.
     pub fn frame(&self) -> String {
         let mut last = String::new();
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
         while std::time::Instant::now() < deadline {
             let now = self.screen.lock().unwrap().text();
-            if !now.trim().is_empty() && now == last {
+            if !now.trim().is_empty() && now == last && !now.contains(UNREAD) {
                 return now;
             }
             last = now;
             std::thread::sleep(std::time::Duration::from_millis(200));
         }
         panic!("the screen never stopped moving:\n{last}");
+    }
+
+    /// The screen as it is at this instant, settled or not.
+    ///
+    /// The one thing [`Live::frame`] cannot give, and the suite about what a
+    /// session costs to open is the one that needs it: the frame it measures is
+    /// by construction the one drawn before the corpus was read.
+    pub fn now(&self) -> String {
+        self.screen.lock().unwrap().text()
     }
 
     pub fn send(&mut self, bytes: &str) {


### PR DESCRIPTION
Closes TASK-fff0a98511b2.

`ank tui` spawned `ank status` twice before painting a cell: once in `lib.rs` for the corpus identity the event stream names its lines by, and once inside `Snapshot::load` for the claims. Measured on this project's own corpus — 1506 entities:

| verb | debug build |
|---|---|
| `ank status --json` | **20.3 s** |
| `ank find --json` | 3.1 s |

So a person opening the reader waited some forty seconds, seven eighths of it for the panel they were not looking at.

## The change

**The session draws its opening frame before it reads anything.** The loop already drew at the top; the opening reads now take the pass after it and `continue`, so the first frame costs no child at all and the rows land on the second paint. The follower is started there too, because it cannot start earlier — it names its lines by the corpus identity, and `find` carries that now. (`find --json`'s `corpus` and `status --json`'s `corpus` were verified identical on this repo.)

**The model is two loads where it was one.** `Snapshot` is `find` alone; `Held` is `status`, asked when the claims panel takes focus — the road `requeue` already takes for the queue, and for a sharper reason. `ank tui --json` asks for it outright and still answers with `branch`, `default_branch`, `identity` and the claims: a machine reader is owed every field the contract declares, and that road keeps its price.

**The claims panel says it has not been asked**, in the queue's own words and its own place. Its title said `(0)` while unasked, which reads as "nothing is held" — an answer, and the wrong one.

## What the suites turned up

The barrier every driven test rests on — `until(contains("2 ENTITIES"))`, `until(contains("ank tui"))` — is satisfied by the frame drawn before the read, so it stopped meaning what twenty call sites use it for. Rather than edit twenty, it is fixed once where it holds for all of them: `Live::frame` refuses to settle on a screen still saying `the corpus has not been read`, and `Live::now` is what the opening suite reads instead. ank-cli's suite, which reads unsettled text rather than settled frames, gets a `Live::opened` barrier.

## Verification

`crates/ank-tui/tests/opening.rs` measures the criterion through the binary on a pseudo-terminal over a **1202-entity** fixture (stamped from one `ank new` entity rather than asked for a thousand times, which would be minutes of spawns):

- first frame in under one second, timed from before the process starts;
- the frame that arrives first names all four panels and says it has not read;
- every row arrives after it — waited on by `find`'s own count, so a reader that was fast and then read half a corpus fails here;
- a source scan naming the two call sites that are gone: `lib.rs` on the whole of itself, `model.rs` on `Snapshot::load` alone, since `Held::load` **is** `ank status` and is meant to be.

`cargo test --workspace` — **1063 passed, 0 failed**. `cargo fmt --check` clean. `ank check` ok, no new fault.

## Scope

Amended four times, each recorded on the task with its reason. The task declared 2 files; the criterion implies 7 — `view.rs` (the claims road and late stream attachment), `tests/terminal/mod.rs`, `tests/opening.rs`, `tests/chrome.rs` and `crates/ank-cli/tests/tui.rs`. Flagged before each edit rather than widened silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ECExQYzfP3S4xeigCarPj