### PR TITLE
The premise that no pull request stood in front of accept is retired

### DIFF
--- a/.ank/entities/ADR-3b6ba766a42e.md
+++ b/.ank/entities/ADR-3b6ba766a42e.md
@@ -20,7 +20,7 @@ verified:
   - by: haksolot@vmi3223161
     at: 2026-08-26T00:07:29Z
 schema: 4
-version: 2
+version: 3
 ---
 
 `accept` already computes this. It walks the tracked files, skips every `.ank/`
@@ -44,10 +44,20 @@ tool.
 
 `accept` is the one verb that writes into history rather than into the working
 tree, and it is authoritative the instant it exists, on the branch where it
-exists. There is no pull request between it and the default branch and no CI in
-front of it -- which is exactly why the branch precondition is a refusal and not
+exists -- which is exactly why the branch precondition is a refusal and not
 advice. The condition here has the same shape: something must be true *before*
-the commit, because after it there is nothing to review and no gate left to fail.
+the commit.
+
+This paragraph used to add "there is no pull request between it and the default
+branch and no CI in front of it", and that has stopped being true: since
+2026-08-28 the default branch takes no direct push, and a ratification reaches it
+through a pull request like every other change. The conclusion is unchanged, and
+the reason it survives is worth stating rather than assuming. A gate in front of
+the merge would catch a stale citation, but it would catch it *after* the
+signature: the ratification commit already exists, already carries the anchor,
+and `accept` refuses a second one on the same entity, so the repair is not a
+second attempt but a supersession. A pull request can reject a branch. It cannot
+un-sign what is on it.
 
 A warning cannot be the answer for the same reason. It arrives after the fact,
 and it is silenced by a flag somebody running in a script has every reason to

--- a/.ank/entities/LOG-d447b8effc84.md
+++ b/.ank/entities/LOG-d447b8effc84.md
@@ -1,0 +1,15 @@
+---
+id: LOG-d447b8effc84
+type: log
+title: body (version 2 to 3, replaced 39f54b13aeb6, produced 693d6b4274a8)
+created: 2026-08-28T17:26:11Z
+author: haksolot@vmi3223161
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-contract/src/verbs.rs
+about: ADR-3b6ba766a42e
+seq: 0
+records: edit
+schema: 4
+version: 1
+---

--- a/crates/ank-cli/src/human.rs
+++ b/crates/ank-cli/src/human.rs
@@ -4548,13 +4548,22 @@ pub fn accept(
 /// somebody remembered. That is the shape of a rule that belongs in the tool.
 ///
 /// **`accept` is the one verb that writes into history**, authoritative the
-/// instant it exists, on the branch where it exists — no pull request between it
-/// and the default branch, and no CI in front of it. That is why the branch
+/// instant it exists, on the branch where it exists. That is why the branch
 /// precondition is a refusal and not advice, and this condition has the same
-/// shape: it must be true *before* the commit, because after it there is
-/// nothing to review and no gate left to fail. A warning also arrives silenced
-/// by a flag somebody running in a script has every reason to pass, which is
-/// exactly how `ank accept -q` broke the default branch without saying a word.
+/// shape: it must be true *before* the commit.
+///
+/// This paragraph used to end "no pull request between it and the default
+/// branch, and no CI in front of it", and that stopped being true on
+/// 2026-08-28: the default branch takes no direct push, and a ratification
+/// reaches it through a pull request like every other change. The conclusion
+/// survives the premise, which is worth saying rather than leaving to be
+/// rediscovered. A gate in front of the merge catches a stale citation *after*
+/// the signature: the commit exists, it carries the anchor, and [`accept`]
+/// refuses a second one on the same entity, so the repair is a supersession and
+/// not another attempt. A pull request can reject a branch; it cannot un-sign
+/// what is on it. A warning also arrives silenced by a flag somebody running in
+/// a script has every reason to pass, which is exactly how `ank accept -q` broke
+/// the default branch without saying a word.
 ///
 /// **The order this makes mandatory**: re-point the citations, then sign. A
 /// citation naming a proposed successor is provisional and honest — `ank show`


### PR DESCRIPTION
ADR-3b6ba766a42e argued its refusal from a premise that stopped being true
on 2026-08-28: the default branch now takes no direct push, and a
ratification reaches it through a pull request with CI in front of it.

The conclusion survives the premise, and the body now says why rather than
leaving it to be rediscovered. A gate in front of the merge catches a stale
citation after the signature: the commit exists, it carries the anchor, and
accept refuses a second one on the same entity, so the repair is a
supersession and not another attempt. A pull request can reject a branch; it
cannot un-sign what is on it.

Only the body moved. constraint and scope are what the anchor hashes, both
are untouched, and ratified: 67e3a44bb66f still verifies, so this needed no
supersession.

git.rs's is_ancestor comment was on the same list and is left alone: it
speaks about pruning a completion ref, which none of this touched.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CwtHQ93fqgQP24UATUo5Ut
