### PR TITLE
The unit tests under src leave nothing behind either

### DIFF
--- a/.ank/entities/LOG-b836458e0311.md
+++ b/.ank/entities/LOG-b836458e0311.md
@@ -1,0 +1,24 @@
+---
+id: LOG-b836458e0311
+type: log
+title: "released: Two of the four families this criterion names cannot be reached from this task's scope,"
+created: 2026-08-28T18:27:59Z
+author: claude-code/opus-5+tests-leave-nothing
+scope:
+  - crates/ank-cli/src/editor.rs
+  - crates/ank-cli/src/git.rs
+  - crates/ank-daemon/src/stream.rs
+  - crates/ank-tui/src/stream.rs
+about: TASK-ac2ff41162c6
+seq: 1
+schema: 4
+version: 1
+---
+
+ and the work that could be is done and measured.
+
+Gone, verified by running the suite into an empty temporary directory rather than by reading the code: every ank-daemon-stream-*, every ank-tui-stream-*, and the ank-git-*, ank-nogit-* and ank-common-* that git.rs left on any run that panicked. Three copies of the scheme TASK-553740e7af11 established, on its ank-it- prefix, so one sweep collects them all.
+
+Still there: 16 ank-edit-* and 20 ank-signers-*. Neither is a leaking test. ank-edit-* is the ank binary itself, spawned by crates/ank-cli/tests/cli.rs, keeping the edited text on a failed edit exactly as editor::kept promises; ank-signers-* is signers_for_git in crates/ank-cli/src/human.rs. Neither file is in this task's scope, and the editor's file must not be swept where it is written -- that would delete a caller's text between reading the refusal and opening the path it names.
+
+TASK-02350943e2b1 carries the remainder with the scope it actually needs, one line in the integration harness plus the copy human.rs's own unit test leaves. This task's criterion is met once that lands. Releasing rather than calling it done: I did not meet the criterion I froze, and the fix is to widen this task's scope or to let the follow-up close it, and neither is mine to decide.

--- a/.ank/entities/LOG-ffa337f1fcc6.md
+++ b/.ank/entities/LOG-ffa337f1fcc6.md
@@ -1,0 +1,27 @@
+---
+id: LOG-ffa337f1fcc6
+type: log
+title: Measured, not read. TMPDIR set to an empty directory, cargo test --workspace green (exit 0), then
+created: 2026-08-28T18:25:41Z
+author: claude-code/opus-5+tests-leave-nothing
+scope:
+  - crates/ank-cli/src/editor.rs
+  - crates/ank-cli/src/git.rs
+  - crates/ank-daemon/src/stream.rs
+  - crates/ank-tui/src/stream.rs
+about: TASK-ac2ff41162c6
+seq: 0
+schema: 4
+version: 1
+---
+
+ the directory listed.
+
+Before: 16 ank-edit-*, 19 ank-signers-*, 3 ank-daemon-stream-*, 6 ank-tui-stream-*, one ank-it-* root.
+After: 16 ank-edit-*, 20 ank-signers-*, one ank-it-* root. The two stream families are gone, and so are ank-git-*, ank-nogit-* and ank-common-*, which git.rs was leaving on any run that panicked.
+
+Splitting the run tells where each family is born. cargo test --workspace --lib --bins, into its own empty directory, leaves only the nine stream directories and eight ank-signers-*. Everything else appears only once tests/ runs. So the task body's premise is half right: the stream families do come from cfg(test) blocks under src/ and are fixed here, but ank-edit-* comes from no unit test at all -- it is the ank binary itself, spawned by crates/ank-cli/tests/cli.rs, keeping the edited text on the failure paths as editor::kept promises the caller it will. ank-signers-* is written by signers_for_git in crates/ank-cli/src/human.rs, eight times from that file's own unit test and a dozen more from the same binary under the integration suite.
+
+Neither of those two is reachable from this task's scope, and neither should be fixed the way this one was. Moving the editor's scratch file under a swept root would delete a user's kept text the next time any ank process ran, which is the opposite of what that path exists for. The fix for both is one line in the integration harness -- point the child's TMPDIR at the suite's own ank-it-* root -- plus removing the copy human.rs's unit test leaves. Filed as a follow-up rather than reached for.
+
+The helper: three copies, the compact form crates/ank-tui/tests/terminal/mod.rs already carries, all on the ank-it- prefix so one sweep collects every root any of them left. In ank-cli it sits at module level in git.rs and is pub(crate), because a dozen other modules of that binary build fixtures on disk and one of them has to hold the copy; holding it where the rest can name it is the difference between one copy and a dozen.

--- a/.ank/entities/TASK-02350943e2b1.md
+++ b/.ank/entities/TASK-02350943e2b1.md
@@ -1,0 +1,34 @@
+---
+id: TASK-02350943e2b1
+type: task
+slug: the-ank-binary-the-suite-spawns-writes-into-the
+title: The ank binary the suite spawns writes into the shared temporary directory
+created: 2026-08-28T18:27:06Z
+author: claude-code/opus-5+tests-leave-nothing
+status: open
+scope:
+  - crates/ank-cli/tests/cli.rs
+  - crates/ank-cli/src/human.rs
+blocked_by: [TASK-ac2ff41162c6]
+done_criteria: |
+  After a green cargo test --workspace into an empty temporary directory, the only entries left are the ank-it-* roots of the run itself: no ank-edit-* and no ank-signers-* file remains. The editor's scratch file still survives a failed edit and is still named in the refusal -- what changes is where the child looks for a temporary directory, not what ank does with one.
+criteria_by: creator
+schema: 4
+version: 1
+---
+
+TASK-ac2ff41162c6 fixed the families born in cfg(test) blocks under src/ and measured the two it could not reach from its scope.
+
+Counted on 2026-08-28, TMPDIR set to an empty directory, cargo test --workspace green: 16 ank-edit-* files and 20 ank-signers-* files remain. Splitting the run separates them. cargo test --workspace --lib --bins leaves eight ank-signers-* and nothing else; the rest of the ank-signers-* and every one of the ank-edit-* appears only once tests/ runs.
+
+## Neither is a leaking test
+
+ank-edit-* is written by editor::scratch_path in the ank binary, and kept on purpose: every path that fails after the editor has run goes through editor::kept, whose whole job is to answer a typo without discarding the twenty minutes around it. The refusal names the file. Putting that file under a root swept by the next process would delete a caller's text between reading the message and opening the path, so the leak must not be fixed where it is written.
+
+ank-signers-<digest> is written by signers_for_git in crates/ank-cli/src/human.rs, in the branch where the declared signers file carries an ank-only entry and git is handed a filtered copy. Named after a hash of its content so that repeated calls write it once, which is why sixteen integration processes leave a dozen files and not sixteen.
+
+## What is left to do
+
+The integration harness spawns the binary with the suite's own environment and lets it inherit TMPDIR (ank_command, ank_env and ank_edit in crates/ank-cli/tests/cli.rs all set current_dir(temp_dir) and say nothing about TMPDIR). Pointing the child at the suite's ank-it-<pid> root puts every temporary file it writes -- these two families and any the tool grows later -- inside the root the next run already sweeps, without changing a line of what the tool does. TMP and TEMP alongside TMPDIR, because std::env::temp_dir reads those on Windows.
+
+That leaves the eight from human.rs's own unit test, a_file_git_can_read_whole_is_handed_over_untouched, which already removes the ank-signers-test-<pid> directory it made and not the copy signers_for_git wrote beside it.

--- a/.ank/entities/TASK-ac2ff41162c6.md
+++ b/.ank/entities/TASK-ac2ff41162c6.md
@@ -16,7 +16,7 @@ done_criteria: |
   After a green cargo test --workspace into an empty temporary directory, the only entries left are the roots of the run itself: no ank-edit-*, ank-signers-*, ank-daemon-stream-* or ank-tui-stream-* directory or file remains. The scheme is the one TASK-553740e7af11 established and not a second one -- a root named for the process, holding a lock the kernel frees when the process dies, swept by the next run.
 criteria_by: creator
 schema: 4
-version: 1
+version: 3
 ---
 
 TASK-553740e7af11 fixed the integration suites and measured what it did not

--- a/crates/ank-cli/src/git.rs
+++ b/crates/ank-cli/src/git.rs
@@ -1881,10 +1881,91 @@ pub fn resolve_default_branch(
     ))
 }
 
+/// One root per test process, swept by the next run (TASK-553740e7af11).
+///
+/// At module level and `pub(crate)` rather than inside `mod tests`, because
+/// this crate is a binary with a dozen modules that each build a fixture on
+/// disk: one of them has to hold the copy, and holding it where the others
+/// can name it is the difference between one copy and a dozen.
+///
+/// **A copy of what `crates/ank-cli/tests/scratch/mod.rs` does**, for the
+/// reason `crates/ank-tui/tests/terminal/mod.rs` gives for the copy it
+/// carries: two crates share a test helper only through a dependency
+/// between them, and none of these three is worth adding for thirty lines.
+/// Nothing under `src/` can name a module of an integration binary in any
+/// case, so the copy lands here rather than there (TASK-ac2ff41162c6).
+///
+/// The reasoning is written out once, where the original lives, and the
+/// property is tested there. In short: a `Drop` cannot run on `SIGKILL`, so
+/// the run that cleans up is the next one, and a root's `.owner` lock is
+/// free exactly when its owner is gone. `PREFIX` is deliberately the one
+/// every other suite in this workspace already uses: one name, so any run
+/// collects what any other left, and "what does the workspace leave in the
+/// temporary directory" keeps one answer.
+#[cfg(test)]
+pub(crate) mod scratch {
+    use std::fs::{self, File};
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::OnceLock;
+
+    const PREFIX: &str = "ank-it-";
+    const OWNER: &str = ".owner";
+    static HELD: OnceLock<File> = OnceLock::new();
+
+    pub fn dir(what: &str) -> PathBuf {
+        static SEQ: AtomicU64 = AtomicU64::new(0);
+        let p = root().join(format!("{what}-{}", SEQ.fetch_add(1, Ordering::Relaxed)));
+        let _ = fs::remove_dir_all(&p);
+        fs::create_dir_all(&p).expect("the root must be writable");
+        p
+    }
+
+    fn root() -> &'static Path {
+        static ROOT: OnceLock<PathBuf> = OnceLock::new();
+        ROOT.get_or_init(|| {
+            let base = std::env::temp_dir();
+            let mine = base.join(format!("{PREFIX}{}", std::process::id()));
+            let _ = fs::remove_dir_all(&mine);
+            fs::create_dir_all(&mine).expect("the temporary directory must be writable");
+            let lock = File::create(mine.join(OWNER)).expect("the root takes its own lock");
+            lock.try_lock()
+                .expect("a fresh root cannot already be held");
+            let _ = HELD.set(lock);
+            sweep(&base, &mine);
+            mine
+        })
+        .as_path()
+    }
+
+    fn sweep(base: &Path, mine: &Path) {
+        let Ok(entries) = fs::read_dir(base) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let p = entry.path();
+            let named = p
+                .file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.starts_with(PREFIX));
+            if p == mine || !named || !p.is_dir() {
+                continue;
+            }
+            let Ok(file) = File::options().read(true).write(true).open(p.join(OWNER)) else {
+                continue;
+            };
+            if file.try_lock().is_ok() {
+                let _ = file.unlock();
+                drop(file);
+                let _ = fs::remove_dir_all(&p);
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::atomic::{AtomicU64, Ordering};
 
     // `no_remote_verb_is_allowed_while_the_spec_says_level_1_is_unimplemented`
     // stood here and did its job: it failed the day level 1 landed, naming what
@@ -1901,14 +1982,7 @@ mod tests {
         /// relies on it passes or fails depending on who runs it; `-b` has
         /// existed since 2.28, well below our floor.
         fn new_repo() -> Temp {
-            static SEQ: AtomicU64 = AtomicU64::new(0);
-            let p = std::env::temp_dir().join(format!(
-                "ank-git-{}-{}",
-                std::process::id(),
-                SEQ.fetch_add(1, Ordering::Relaxed)
-            ));
-            std::fs::create_dir_all(&p).unwrap();
-            let t = Temp(p);
+            let t = Temp(scratch::dir("git-repo"));
             t.porcelain(&["init", "-q", "-b", "main"]);
             // The CI runners carry no identity, and commit refuses without
             // one. autocrlf is pinned so that the content read back on Windows
@@ -2140,8 +2214,7 @@ mod tests {
 
     #[test]
     fn outside_a_git_repository_exits_with_code_9_and_git_init() {
-        let dir = std::env::temp_dir().join(format!("ank-nogit-{}", std::process::id()));
-        std::fs::create_dir_all(&dir).unwrap();
+        let dir = scratch::dir("git-nogit");
         // A temporary directory may itself sit under a git repository; we only
         // assert when it does not, otherwise the assertion would be wrong.
         if toplevel(&dir).is_err() {
@@ -2193,9 +2266,7 @@ mod tests {
     /// the day something is.
     #[test]
     fn a_linked_worktree_shares_its_common_dir_with_the_checkout_that_made_it() {
-        let dir = std::env::temp_dir().join(format!("ank-common-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).unwrap();
+        let dir = scratch::dir("git-common");
         let main = dir.join("main");
         std::fs::create_dir_all(&main).unwrap();
 

--- a/crates/ank-daemon/src/stream.rs
+++ b/crates/ank-daemon/src/stream.rs
@@ -79,17 +79,85 @@ fn start_over_if_long(path: &Path) -> Result<(), String> {
 mod tests {
     use super::*;
 
-    fn scratch(what: &str) -> PathBuf {
-        let dir =
-            std::env::temp_dir().join(format!("ank-daemon-stream-{what}-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).unwrap();
-        dir
+    /// One root per test process, swept by the next run (TASK-553740e7af11).
+    ///
+    /// **A copy of what `crates/ank-cli/tests/scratch/mod.rs` does**, for the
+    /// reason `crates/ank-tui/tests/terminal/mod.rs` gives for the copy it
+    /// carries: two crates share a test helper only through a dependency
+    /// between them, and none of these three is worth adding for thirty lines.
+    /// Nothing under `src/` can name a module of an integration binary in any
+    /// case, so the copy lands here rather than there (TASK-ac2ff41162c6).
+    ///
+    /// The reasoning is written out once, where the original lives, and the
+    /// property is tested there. In short: a `Drop` cannot run on `SIGKILL`, so
+    /// the run that cleans up is the next one, and a root's `.owner` lock is
+    /// free exactly when its owner is gone. `PREFIX` is deliberately the one
+    /// every other suite in this workspace already uses: one name, so any run
+    /// collects what any other left, and "what does the workspace leave in the
+    /// temporary directory" keeps one answer.
+    mod scratch {
+        use std::fs::{self, File};
+        use std::path::{Path, PathBuf};
+        use std::sync::atomic::{AtomicU64, Ordering};
+        use std::sync::OnceLock;
+
+        const PREFIX: &str = "ank-it-";
+        const OWNER: &str = ".owner";
+        static HELD: OnceLock<File> = OnceLock::new();
+
+        pub fn dir(what: &str) -> PathBuf {
+            static SEQ: AtomicU64 = AtomicU64::new(0);
+            let p = root().join(format!("{what}-{}", SEQ.fetch_add(1, Ordering::Relaxed)));
+            let _ = fs::remove_dir_all(&p);
+            fs::create_dir_all(&p).expect("the root must be writable");
+            p
+        }
+
+        fn root() -> &'static Path {
+            static ROOT: OnceLock<PathBuf> = OnceLock::new();
+            ROOT.get_or_init(|| {
+                let base = std::env::temp_dir();
+                let mine = base.join(format!("{PREFIX}{}", std::process::id()));
+                let _ = fs::remove_dir_all(&mine);
+                fs::create_dir_all(&mine).expect("the temporary directory must be writable");
+                let lock = File::create(mine.join(OWNER)).expect("the root takes its own lock");
+                lock.try_lock()
+                    .expect("a fresh root cannot already be held");
+                let _ = HELD.set(lock);
+                sweep(&base, &mine);
+                mine
+            })
+            .as_path()
+        }
+
+        fn sweep(base: &Path, mine: &Path) {
+            let Ok(entries) = fs::read_dir(base) else {
+                return;
+            };
+            for entry in entries.flatten() {
+                let p = entry.path();
+                let named = p
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(|n| n.starts_with(PREFIX));
+                if p == mine || !named || !p.is_dir() {
+                    continue;
+                }
+                let Ok(file) = File::options().read(true).write(true).open(p.join(OWNER)) else {
+                    continue;
+                };
+                if file.try_lock().is_ok() {
+                    let _ = file.unlock();
+                    drop(file);
+                    let _ = fs::remove_dir_all(&p);
+                }
+            }
+        }
     }
 
     #[test]
     fn one_event_is_one_line_and_the_next_goes_after_it() {
-        let path = scratch("append").join(events::STREAM_FILE);
+        let path = scratch::dir("stream-append").join(events::STREAM_FILE);
         emit(&path, &"a".repeat(40), Change::Entities).unwrap();
         emit(&path, &"b".repeat(40), Change::Refs).unwrap();
         let text = std::fs::read_to_string(&path).unwrap();
@@ -101,7 +169,7 @@ mod tests {
 
     #[test]
     fn a_stream_past_the_cap_is_started_over_rather_than_kept() {
-        let path = scratch("cap").join(events::STREAM_FILE);
+        let path = scratch::dir("stream-cap").join(events::STREAM_FILE);
         std::fs::write(&path, vec![b'x'; events::CAP as usize + 1]).unwrap();
         emit(&path, &"c".repeat(40), Change::Entities).unwrap();
         let text = std::fs::read_to_string(&path).unwrap();
@@ -113,7 +181,9 @@ mod tests {
     /// alternative is a watcher that quietly stops reporting.
     #[test]
     fn a_missing_directory_is_made_rather_than_refused() {
-        let path = scratch("mkdir").join("gone").join(events::STREAM_FILE);
+        let path = scratch::dir("stream-mkdir")
+            .join("gone")
+            .join(events::STREAM_FILE);
         emit(&path, &"d".repeat(40), Change::Refs).unwrap();
         assert!(path.is_file());
     }

--- a/crates/ank-tui/src/stream.rs
+++ b/crates/ank-tui/src/stream.rs
@@ -216,17 +216,85 @@ mod tests {
     use super::*;
     use ank_contract::events::{Change, Event};
 
-    fn scratch(what: &str) -> PathBuf {
-        use std::sync::atomic::AtomicU64;
-        static SEQ: AtomicU64 = AtomicU64::new(0);
-        let dir = std::env::temp_dir().join(format!(
-            "ank-tui-stream-{what}-{}-{}",
-            std::process::id(),
-            SEQ.fetch_add(1, Ordering::Relaxed)
-        ));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).unwrap();
-        dir.join(events::STREAM_FILE)
+    /// One root per test process, swept by the next run (TASK-553740e7af11).
+    ///
+    /// **A copy of what `crates/ank-cli/tests/scratch/mod.rs` does**, for the
+    /// reason `crates/ank-tui/tests/terminal/mod.rs` gives for the copy it
+    /// carries: two crates share a test helper only through a dependency
+    /// between them, and none of these three is worth adding for thirty lines.
+    /// Nothing under `src/` can name a module of an integration binary in any
+    /// case, so the copy lands here rather than there (TASK-ac2ff41162c6).
+    ///
+    /// The reasoning is written out once, where the original lives, and the
+    /// property is tested there. In short: a `Drop` cannot run on `SIGKILL`, so
+    /// the run that cleans up is the next one, and a root's `.owner` lock is
+    /// free exactly when its owner is gone. `PREFIX` is deliberately the one
+    /// every other suite in this workspace already uses: one name, so any run
+    /// collects what any other left, and "what does the workspace leave in the
+    /// temporary directory" keeps one answer.
+    mod scratch {
+        use std::fs::{self, File};
+        use std::path::{Path, PathBuf};
+        use std::sync::atomic::{AtomicU64, Ordering};
+        use std::sync::OnceLock;
+
+        const PREFIX: &str = "ank-it-";
+        const OWNER: &str = ".owner";
+        static HELD: OnceLock<File> = OnceLock::new();
+
+        pub fn dir(what: &str) -> PathBuf {
+            static SEQ: AtomicU64 = AtomicU64::new(0);
+            let p = root().join(format!("{what}-{}", SEQ.fetch_add(1, Ordering::Relaxed)));
+            let _ = fs::remove_dir_all(&p);
+            fs::create_dir_all(&p).expect("the root must be writable");
+            p
+        }
+
+        fn root() -> &'static Path {
+            static ROOT: OnceLock<PathBuf> = OnceLock::new();
+            ROOT.get_or_init(|| {
+                let base = std::env::temp_dir();
+                let mine = base.join(format!("{PREFIX}{}", std::process::id()));
+                let _ = fs::remove_dir_all(&mine);
+                fs::create_dir_all(&mine).expect("the temporary directory must be writable");
+                let lock = File::create(mine.join(OWNER)).expect("the root takes its own lock");
+                lock.try_lock()
+                    .expect("a fresh root cannot already be held");
+                let _ = HELD.set(lock);
+                sweep(&base, &mine);
+                mine
+            })
+            .as_path()
+        }
+
+        fn sweep(base: &Path, mine: &Path) {
+            let Ok(entries) = fs::read_dir(base) else {
+                return;
+            };
+            for entry in entries.flatten() {
+                let p = entry.path();
+                let named = p
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(|n| n.starts_with(PREFIX));
+                if p == mine || !named || !p.is_dir() {
+                    continue;
+                }
+                let Ok(file) = File::options().read(true).write(true).open(p.join(OWNER)) else {
+                    continue;
+                };
+                if file.try_lock().is_ok() {
+                    let _ = file.unlock();
+                    drop(file);
+                    let _ = fs::remove_dir_all(&p);
+                }
+            }
+        }
+    }
+
+    /// The stream file inside a fresh directory of this process's root.
+    fn stream_at(what: &str) -> PathBuf {
+        scratch::dir(&format!("tui-stream-{what}")).join(events::STREAM_FILE)
     }
 
     fn follower(path: PathBuf, corpus: &str) -> Follower {
@@ -250,7 +318,7 @@ mod tests {
 
     #[test]
     fn a_line_about_another_corpus_is_not_this_readers_news() {
-        let path = scratch("other");
+        let path = stream_at("other");
         append(&path, &Event::new("a".repeat(40), Change::Entities).line());
         let mut f = follower(path.clone(), &"z".repeat(40));
         assert_eq!(f.look(), (true, false), "the backlog is skipped anyway");
@@ -265,7 +333,7 @@ mod tests {
     /// ten times.
     #[test]
     fn many_lines_in_one_look_are_one_wake() {
-        let path = scratch("coalesce");
+        let path = stream_at("coalesce");
         let mut f = follower(path.clone(), &"c".repeat(40));
         for _ in 0..10 {
             append(&path, &Event::new("c".repeat(40), Change::Entities).line());
@@ -276,7 +344,7 @@ mod tests {
 
     #[test]
     fn a_half_written_line_waits_for_its_end() {
-        let path = scratch("partial");
+        let path = stream_at("partial");
         let mut f = follower(path.clone(), &"d".repeat(40));
         let whole = Event::new("d".repeat(40), Change::Entities).line();
         let (head, tail) = whole.split_at(whole.len() / 2);
@@ -288,7 +356,7 @@ mod tests {
 
     #[test]
     fn a_stream_started_over_is_read_from_the_beginning_again() {
-        let path = scratch("rotate");
+        let path = stream_at("rotate");
         let mut f = follower(path.clone(), &"e".repeat(40));
         append(&path, &Event::new("e".repeat(40), Change::Entities).line());
         assert_eq!(f.look(), (true, true));
@@ -300,7 +368,7 @@ mod tests {
 
     #[test]
     fn a_stream_that_is_not_there_is_an_absence_and_never_an_error() {
-        let mut f = follower(scratch("absent"), &"f".repeat(40));
+        let mut f = follower(stream_at("absent"), &"f".repeat(40));
         assert_eq!(f.look(), (false, false));
         append(
             &f.path.clone(),
@@ -317,7 +385,7 @@ mod tests {
     /// guessed at, and a line that is not a document at all is skipped too.
     #[test]
     fn an_unreadable_line_is_skipped_and_stops_nothing() {
-        let path = scratch("junk");
+        let path = stream_at("junk");
         let mut f = follower(path.clone(), &"g".repeat(40));
         append(&path, "not a document at all\n");
         append(


### PR DESCRIPTION
TASK-ac2ff41162c6, partially: the two families born under `src/` are gone, the two that are not are filed as TASK-02350943e2b1 with the scope they need.

## What leaked

`TASK-553740e7af11` fixed the integration suites and measured what it did not reach. A green `cargo test --workspace` into an empty `TMPDIR` still left nine scratch directories written by `#[cfg(test)] mod tests` blocks inside `src/` — three `ank-daemon-stream-*`, six `ank-tui-stream-*`. On this host `/tmp` is a RAM-backed tmpfs, so those sit in memory until something reboots.

`git.rs` was not on that list and belongs on it anyway: its `Temp` cleaned up through `Drop`, and its two ad-hoc directories through a `remove_dir_all` at the end of the test body. Neither runs on a panic or a `SIGKILL`, so `ank-git-*`, `ank-nogit-*` and `ank-common-*` survived exactly the runs one most wants a clean temporary directory after.

## The scheme, not a second one

A root named for the process, holding a `.owner` lock the kernel frees however the process dies, swept by the next run — the one `crates/ank-cli/tests/scratch/mod.rs` writes out in full, on the same `ank-it-` prefix, so any run collects what any other left.

Three copies of thirty lines, for the reason `crates/ank-tui/tests/terminal/mod.rs` already records for the second: two crates share a test helper only through a dependency between them, and `ank-tui`'s dependency tree is asserted by its own suite. Nothing under `src/` can name a module of an integration binary in any case. In `ank-cli` the copy sits at module level in `git.rs` and is `pub(crate)`, because a dozen modules of that binary build fixtures on disk and holding the copy where they can name it is the difference between one copy and a dozen.

## Measured, not read

`TMPDIR` an empty directory, `cargo test --workspace` green (exit 0), then the directory listed.

| | before | after |
|---|---|---|
| `ank-daemon-stream-*` | 3 | 0 |
| `ank-tui-stream-*` | 6 | 0 |
| `ank-git-*`, `ank-nogit-*`, `ank-common-*` | 0 green / leaked on panic | 0, and none on a panic either |
| `ank-edit-*` | 16 | 16 |
| `ank-signers-*` | 19 | 20 |

Splitting the run says where each family is born: `cargo test --workspace --lib --bins` into its own empty directory left only the nine stream directories and eight `ank-signers-*`. Everything else appears once `tests/` runs.

## What is left, and why it is not fixed here

Neither remaining family is a leaking test.

`ank-edit-*` is written by the `ank` binary itself, spawned by `crates/ank-cli/tests/cli.rs`, and kept **on purpose**: every path that fails after the editor has run goes through `editor::kept`, whose whole job is to answer a typo without discarding the twenty minutes around it, and the refusal names the file. Putting that file under a root the next process sweeps would delete a caller's text between reading the message and opening the path.

`ank-signers-<digest>` is written by `signers_for_git` in `crates/ank-cli/src/human.rs`, where a declared-signers file carrying an ank-only entry is handed to git as a filtered copy.

Both reach the shared temporary directory because the integration harness lets the child inherit `TMPDIR`. One line there puts every temporary file the tool writes — these two and any it grows later — inside the root the next run already sweeps, without changing a line of what the tool does. Filed as **TASK-02350943e2b1**, scoped to `crates/ank-cli/tests/cli.rs` and `crates/ank-cli/src/human.rs`, rather than reached for from this branch.

TASK-ac2ff41162c6 is released, not done: its criterion names four families and this meets two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D79k6qogXhbGejaK2rDxN2