### PR TITLE
The order is the work that is alive, then what waits for a signature, then what moved last

### DIFF
--- a/.ank/entities/LOG-34eab9564a0d.md
+++ b/.ank/entities/LOG-34eab9564a0d.md
@@ -1,0 +1,14 @@
+---
+id: LOG-34eab9564a0d
+type: log
+title: done, proof commit:a5f815da8fae97946445fd30a983e1246229b6f4
+created: 2026-08-28T20:22:22Z
+author: claude-code/opus-5+alive-first
+scope:
+  - crates/ank-tui/src/model.rs
+  - crates/ank-tui/tests/ordering.rs
+about: TASK-b5185df7aa44
+seq: 2
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-3565cb7f87db.md
+++ b/.ank/entities/LOG-3565cb7f87db.md
@@ -1,0 +1,16 @@
+---
+id: LOG-3565cb7f87db
+type: log
+title: The criterion is measured through the binary and the ordering lives in one file, so the measurement
+created: 2026-08-28T20:09:28Z
+author: claude-code/opus-5+alive-first
+scope:
+  - crates/ank-tui/src/model.rs
+  - crates/ank-tui/tests/ordering.rs
+about: TASK-b5185df7aa44
+seq: 1
+schema: 4
+version: 1
+---
+
+ needs a second: scope widened by exactly crates/ank-tui/tests/ordering.rs, a file that does not exist yet and that no live claim can reach. Not tests/** -- TASK-252bf02de218 needed the whole directory because it rewrote the suite that asserted four panels; this adds a suite and rewrites none, and three agents are in this crate. src/model.rs sorts what find handed over: three bands (alive, waiting, the rest) and the instant inside each, with no key mentioning an identifier.

--- a/.ank/entities/LOG-e08e75e63cb5.md
+++ b/.ank/entities/LOG-e08e75e63cb5.md
@@ -1,0 +1,17 @@
+---
+id: LOG-e08e75e63cb5
+type: log
+title: +scope crates/ank-tui/tests/ordering.rs (version 2 to 3, replaced f5ab99045c9e, produced
+created: 2026-08-28T20:08:16Z
+author: claude-code/opus-5+alive-first
+scope:
+  - crates/ank-tui/src/model.rs
+  - crates/ank-tui/tests/ordering.rs
+about: TASK-b5185df7aa44
+seq: 0
+records: edit
+schema: 4
+version: 1
+---
+
+ b60378d733b5)

--- a/.ank/entities/TASK-b5185df7aa44.md
+++ b/.ank/entities/TASK-b5185df7aa44.md
@@ -5,13 +5,14 @@ slug: the-order-is-the-work-that-is-alive-then-what-wa
 title: The order is the work that is alive, then what waits for a signature, then what moved last
 created: 2026-08-27T16:33:58Z
 author: haksolot@vmi3223161
-status: open
+status: in_progress
 scope:
   - crates/ank-tui/src/model.rs
+  - crates/ank-tui/tests/ordering.rs
 blocked_by: [TASK-b917fc12fee8, TASK-252bf02de218]
 done_criteria: |
   On a corpus carrying an open task, a task a live claim holds, a proposed decision and at least ten finished entities, the list opens on the open and the claimed, then the proposed, then the rest in decreasing order of created. No identifier takes part in the ordering. Two runs over an unchanged corpus put the rows in the same order. Measured through the binary.
 criteria_by: creator
 schema: 4
-version: 1
+version: 3
 ---

--- a/.ank/entities/TASK-b5185df7aa44.md
+++ b/.ank/entities/TASK-b5185df7aa44.md
@@ -5,7 +5,7 @@ slug: the-order-is-the-work-that-is-alive-then-what-wa
 title: The order is the work that is alive, then what waits for a signature, then what moved last
 created: 2026-08-27T16:33:58Z
 author: haksolot@vmi3223161
-status: in_progress
+status: done
 scope:
   - crates/ank-tui/src/model.rs
   - crates/ank-tui/tests/ordering.rs
@@ -13,6 +13,11 @@ blocked_by: [TASK-b917fc12fee8, TASK-252bf02de218]
 done_criteria: |
   On a corpus carrying an open task, a task a live claim holds, a proposed decision and at least ten finished entities, the list opens on the open and the claimed, then the proposed, then the rest in decreasing order of created. No identifier takes part in the ordering. Two runs over an unchanged corpus put the rows in the same order. Measured through the binary.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: a5f815da8fae97946445fd30a983e1246229b6f4
+    criteria: a9f083c8c7ca
+    via: submitted
 schema: 4
-version: 3
+version: 4
 ---

--- a/crates/ank-tui/src/model.rs
+++ b/crates/ank-tui/src/model.rs
@@ -26,6 +26,14 @@
 //! alternative was to ask a fifth verb for it, and there is none that answers
 //! "what does this entity declare".
 //!
+//! **What is ordered here is ordered here and nowhere else.** [`alive_first`]
+//! is the whole of the decision about what a person sees first
+//! (ADR-559eebf5c6f5): the rows arrive from `find` in the CLI's own order and
+//! leave this file in the reader's, so no renderer downstream has an opinion
+//! about it to keep in step. That is a presentation and not a derived fact --
+//! nothing is invented, dropped or rewritten, and every field is still the
+//! CLI's.
+//!
 //! [`frontmatter`] is that walk and there is one of it. [`declared_scopes`] is
 //! it asked for the `scope` field, and the reader's field block is it asked for
 //! all of them: `content` stays the bytes `show` printed either way, because
@@ -33,6 +41,7 @@
 
 use crate::ank::{self, Ank, Failed};
 use ank_contract::json::Obj;
+use ank_contract::meaning::{role_of_status, Role};
 
 /// One entity row, as `find` renders one.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -188,7 +197,7 @@ impl Snapshot {
         let found = ank.json("find", &[])?;
         Ok(Snapshot {
             corpus: ank::text(&found, "corpus"),
-            entities: ank::rows(&found, "results").iter().map(Row::read).collect(),
+            entities: alive_first(ank::rows(&found, "results")),
             total: ank::count(&found, "total"),
         })
     }
@@ -253,6 +262,99 @@ impl Snapshot {
             )
             .finish()
     }
+}
+
+/// Where a row stands in the order the reader opens on
+/// (ADR-559eebf5c6f5, TASK-b5185df7aa44).
+///
+/// Three bands and they are the decision itself: the work that is alive, then
+/// what waits for a ratification, then everything else. Declared in that order
+/// because the derived `Ord` is what sorts them, so the order of these variants
+/// is the order of the screen and there is no table repeating it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum Band {
+    /// Open, or held by a live claim: what somebody could pick up or is
+    /// already carrying.
+    Alive,
+    /// Proposed, and so waiting for a signature nobody else can give.
+    Waiting,
+    /// Finished, superseded, closed -- and the log entries, which is most of a
+    /// corpus. What is here is here because it is over, and recency is the only
+    /// thing left to say about it.
+    Rest,
+}
+
+impl Band {
+    /// **The words are the contract's and the reader holds no copy of them**
+    /// (ADR-1f70ce2c3eac). `meaning::role_of_status` is the one table that says
+    /// what a status word means -- `open` is there to be taken, `in_progress`
+    /// and `claimed:<who>` are somebody being on it, `proposed` is waiting on a
+    /// human -- so a status added to the model is a band of this screen with no
+    /// edit here, and a reader that spelled the four words itself would be the
+    /// second table that decision forbids.
+    ///
+    /// **Both fields, because a claim is one fact seen twice.** `find` gives a
+    /// row the stored `status` and the coordination plane's `state`, and which
+    /// one carries the claim depends on where the claim was taken: a task held
+    /// from another branch reads `open` in the file and `claimed:<who>` in the
+    /// plane, and one held from this one reads `in_progress` in both. Either
+    /// answer being alive is enough, so neither has to be the right one to ask.
+    ///
+    /// **A lapsed claim is alive.** `state` is then `open expired:<who>`, whose
+    /// role is [`Role::Attention`] rather than a state -- the marker says the
+    /// lease ran out and not what it ran out of -- and the stored status
+    /// underneath it still says `open`. It is the most available work in a
+    /// corpus, and a band read off the marker alone would bury it with the
+    /// finished entities.
+    fn of(status: &str, state: &str) -> Band {
+        let roles = [role_of_status(status), role_of_status(state)];
+        let any = |wanted: &[Role]| roles.iter().flatten().any(|r| wanted.contains(r));
+        match () {
+            _ if any(&[Role::Available, Role::Underway]) => Band::Alive,
+            _ if any(&[Role::Awaiting]) => Band::Waiting,
+            _ => Band::Rest,
+        }
+    }
+}
+
+/// The rows of `find`, in the order the reader shows them
+/// (ADR-559eebf5c6f5, TASK-b5185df7aa44).
+///
+/// **What is shown first is chosen here and inherited nowhere.** `find` orders
+/// by identifier -- `ank-cli/src/index.rs`, `ORDER BY id` -- and an identifier
+/// is `KIND-<hex>`, so the row a person reads as the most important one is
+/// whichever hash sorted first. That is not creation order, not recency and not
+/// relevance. The band decides, and within a band the most recently created
+/// comes first.
+///
+/// **No identifier takes part in it.** Neither key mentions one, and the sort
+/// is stable rather than total: rows the two keys cannot separate -- the same
+/// band, the same `created`, which a second's resolution makes ordinary -- stay
+/// in the order `find` handed them over in. That is what makes two runs over an
+/// unchanged corpus draw the same screen without this comparing hashes to get
+/// it: determinism is the arrival order's, and the ordering is these two keys'.
+///
+/// **`created` is compared as text, and it is an instant.** The corpus writes
+/// RFC 3339 in Zulu, which is fixed width and zero padded, so lexical order is
+/// chronological order and no clock is parsed to find that out. A row without
+/// the field sorts to the end of its band and keeps its arrival order there:
+/// `created` reached `find --json` after the reader existed, and an older `ank`
+/// on the PATH should cost the order its recency, never its bands.
+fn alive_first(results: &[ank::Value]) -> Vec<Row> {
+    let mut rows: Vec<(Band, String, Row)> = results
+        .iter()
+        .map(|value| {
+            (
+                Band::of(&ank::text(value, "status"), &ank::text(value, "state")),
+                ank::text(value, "created"),
+                Row::read(value),
+            )
+        })
+        .collect();
+    rows.sort_by(|(band, created, _), (other, theirs, _)| {
+        band.cmp(other).then_with(|| theirs.cmp(created))
+    });
+    rows.into_iter().map(|(_, _, row)| row).collect()
 }
 
 /// The ratification queue, as `review` answers it.
@@ -720,6 +822,208 @@ mod tests {
     fn the_flow_form_is_read_too_and_deduplicated() {
         let content = "---\nid: ADR-0001\nscope: [\"src/**\", 'src/**', docs/**]\n---\n\nbody\n";
         assert_eq!(declared_scopes(content), ["src/**", "docs/**"]);
+    }
+
+    // -----------------------------------------------------------------------
+    // The order the reader opens on (TASK-b5185df7aa44, ADR-559eebf5c6f5)
+    // -----------------------------------------------------------------------
+
+    /// One row of `find --json`, with the four fields the order is read from.
+    fn found(id: &str, status: &str, state: &str, created: &str) -> ank::Value {
+        serde_json::json!({
+            "id": id,
+            "kind": id.split('-').next().unwrap().to_ascii_lowercase(),
+            "status": status,
+            "state": state,
+            "title": format!("the entity {id}"),
+            "created": created,
+        })
+    }
+
+    /// A corpus carrying what the criterion names, handed over the way `find`
+    /// hands one over: `ORDER BY id`.
+    ///
+    /// **The identifiers ascend and the instants ascend with them**, which is
+    /// what makes the fixture sharp: the order this corpus is handed over in
+    /// and the order it must be shown in are reverses of each other inside
+    /// every band. A listing that kept the CLI's order, or that sorted on the
+    /// hashes itself, answers the sequence backwards rather than passing by
+    /// accident.
+    fn corpus() -> Vec<ank::Value> {
+        let mut rows = vec![
+            found(
+                "ADR-0000000000a1",
+                "proposed",
+                "proposed",
+                "2026-08-02T00:00:00Z",
+            ),
+            found("TASK-0000000000a2", "open", "open", "2026-08-01T00:00:00Z"),
+            found(
+                "TASK-0000000000a3",
+                "open",
+                "claimed:claude-code/opus-5+somebody",
+                "2026-08-03T00:00:00Z",
+            ),
+        ];
+        // Ten finished entities, the oldest first: by identifier they ascend,
+        // by instant they ascend too, so recency is their reverse.
+        for i in 0..10u32 {
+            rows.push(found(
+                &format!("TASK-0000000000b{i}"),
+                "done",
+                "done",
+                &format!("2026-07-{:02}T00:00:00Z", 10 + i),
+            ));
+        }
+        rows
+    }
+
+    /// The same thing said about the identifiers the corpus actually carries,
+    /// which is where an ordering by hash would show.
+    #[test]
+    fn the_order_is_the_bands_and_then_the_instant() {
+        let shown: Vec<String> = alive_first(&corpus())
+            .iter()
+            .map(|r| r.id.clone())
+            .collect();
+        let expected: Vec<String> = ["TASK-0000000000a3", "TASK-0000000000a2", "ADR-0000000000a1"]
+            .iter()
+            .map(|s| s.to_string())
+            // The ten finished ones, newest first, which is the reverse of the
+            // order `find` handed them over in.
+            .chain((0..10u32).rev().map(|i| format!("TASK-0000000000b{i}")))
+            .collect();
+        assert_eq!(shown, expected);
+        // And the sequence is not the one that arrived, which is what says the
+        // assertion above measured a choice rather than an inheritance.
+        let arrived: Vec<String> = corpus().iter().map(|v| ank::text(v, "id")).collect();
+        assert_ne!(shown, arrived, "the CLI's own order came through unchanged");
+    }
+
+    /// **No identifier takes part in the ordering**, and this is that sentence
+    /// made mechanical rather than asserted.
+    ///
+    /// One corpus is sorted twice with the identifiers permuted between the two
+    /// runs -- reversed, so every row's hash sorts where another's did -- and
+    /// the sequence of titles must not move. Two rows of each band share an
+    /// instant, which is what makes the test sharp: an implementation that
+    /// compared identifiers anywhere, including as the tie-break those two
+    /// invite, would answer a different sequence the second time.
+    #[test]
+    fn no_identifier_takes_part_in_the_ordering() {
+        let rows = vec![
+            found("TASK-0000000000e1", "done", "done", "2026-08-01T00:00:00Z"),
+            found("TASK-0000000000e2", "done", "done", "2026-08-01T00:00:00Z"),
+            found("TASK-0000000000e3", "open", "open", "2026-08-05T00:00:00Z"),
+            found("TASK-0000000000e4", "open", "open", "2026-08-05T00:00:00Z"),
+        ];
+        let titles =
+            |rows: &[Row]| -> Vec<String> { rows.iter().map(|r| r.title.clone()).collect() };
+        let before = titles(&alive_first(&rows));
+        assert_eq!(
+            before,
+            [
+                "the entity TASK-0000000000e3",
+                "the entity TASK-0000000000e4",
+                "the entity TASK-0000000000e1",
+                "the entity TASK-0000000000e2",
+            ],
+            "the bands, and the arrival order inside a tie"
+        );
+
+        // The same rows, the same instants, every identifier somebody else's.
+        let mut permuted = rows.clone();
+        let backwards: Vec<String> = rows.iter().rev().map(|v| ank::text(v, "id")).collect();
+        for (value, id) in permuted.iter_mut().zip(backwards) {
+            value["id"] = serde_json::Value::String(id);
+        }
+        assert_eq!(
+            before,
+            titles(&alive_first(&permuted)),
+            "the identifiers moved and the order followed them"
+        );
+    }
+
+    /// Every word the model can store, put in the band it belongs to -- the
+    /// four roles the contract's table gives them, read rather than spelled.
+    ///
+    /// A held task is alive whichever half of the corpus carries the claim: the
+    /// file says `in_progress` where it was taken and still says `open`
+    /// elsewhere, and the plane says `claimed:<who>` either way. A lapsed claim
+    /// is alive too, and it is the case a band read off the marker alone gets
+    /// wrong.
+    #[test]
+    fn a_band_is_the_role_the_contract_gives_the_status() {
+        assert_eq!(Band::of("open", "open"), Band::Alive);
+        assert_eq!(Band::of("in_progress", "in_progress"), Band::Alive);
+        assert_eq!(
+            Band::of("open", "claimed:claude-code/opus-5+somebody"),
+            Band::Alive
+        );
+        assert_eq!(
+            Band::of("in_progress", "claimed:claude-code/opus-5+somebody"),
+            Band::Alive
+        );
+        assert_eq!(
+            Band::of("open", "open expired:somebody@somewhere"),
+            Band::Alive,
+            "a lapsed claim is the most available work there is"
+        );
+        assert_eq!(Band::of("proposed", "proposed"), Band::Waiting);
+        for over in ["done", "closed", "accepted", "superseded"] {
+            assert_eq!(Band::of(over, over), Band::Rest, "{over} is not alive");
+        }
+        // A log entry carries no status at all, and a word this reader has
+        // never heard of is not invented into a band either.
+        assert_eq!(Band::of("", ""), Band::Rest);
+        assert_eq!(Band::of("nonsense", "nonsense"), Band::Rest);
+    }
+
+    /// Two runs over an unchanged corpus put the rows in the same order, and
+    /// rows the two keys cannot separate keep the order `find` gave them: a
+    /// second's resolution makes a shared instant ordinary, and a sort that
+    /// broke those ties on anything of its own would be breaking them on a
+    /// hash.
+    #[test]
+    fn what_the_keys_cannot_separate_stays_as_it_arrived() {
+        let same = vec![
+            found("TASK-0000000000c1", "done", "done", "2026-08-01T00:00:00Z"),
+            found("TASK-0000000000c2", "done", "done", "2026-08-01T00:00:00Z"),
+            found("TASK-0000000000c3", "done", "done", "2026-08-01T00:00:00Z"),
+        ];
+        let once: Vec<String> = alive_first(&same).iter().map(|r| r.id.clone()).collect();
+        let twice: Vec<String> = alive_first(&same).iter().map(|r| r.id.clone()).collect();
+        assert_eq!(once, twice, "two runs over one corpus disagreed");
+        assert_eq!(
+            once,
+            [
+                "TASK-0000000000c1",
+                "TASK-0000000000c2",
+                "TASK-0000000000c3"
+            ],
+            "an unseparable tie was reordered"
+        );
+    }
+
+    /// An `ank` too old to say when an entity was created costs the order its
+    /// recency and never its bands: the rows with nothing to compare go to the
+    /// end of the band they belong to, in the order they arrived.
+    #[test]
+    fn a_row_without_an_instant_keeps_its_band() {
+        let rows = vec![
+            found("TASK-0000000000d1", "done", "done", ""),
+            found("TASK-0000000000d2", "done", "done", "2026-08-01T00:00:00Z"),
+            found("TASK-0000000000d3", "open", "open", ""),
+        ];
+        let shown: Vec<String> = alive_first(&rows).iter().map(|r| r.id.clone()).collect();
+        assert_eq!(
+            shown,
+            [
+                "TASK-0000000000d3",
+                "TASK-0000000000d2",
+                "TASK-0000000000d1"
+            ]
+        );
     }
 
     #[test]

--- a/crates/ank-tui/tests/ordering.rs
+++ b/crates/ank-tui/tests/ordering.rs
@@ -26,6 +26,13 @@
 //! already takes and one no source of the crate has: the reader reaches the
 //! corpus by running the CLI, and a test may name what the crate may not.
 //!
+//! **A green run here is evidence only after a workspace build**
+//! (ADR-93d8fc25e94e). `CARGO_BIN_EXE_ank` is defined for `ank-cli` alone, so
+//! `cargo test -p ank-tui` drives whichever `ank` is already on disk: this
+//! suite was written against one built before the ordering existed and reported
+//! the identifier order back, which is the failure the decision describes and
+//! is also how the assertions below were shown to measure anything at all.
+//!
 //! **Nothing here asserts a wall-clock bound.** Not one instant in the fixture
 //! comes from a clock, so the sequence this measures is the same on a machine
 //! whose date is wrong as on one whose date is right.

--- a/crates/ank-tui/tests/ordering.rs
+++ b/crates/ank-tui/tests/ordering.rs
@@ -1,0 +1,295 @@
+//! What the reader opens on, through the binary (TASK-b5185df7aa44,
+//! ADR-559eebf5c6f5).
+//!
+//! CLAUDE.md leaves no choice about where the measurement happens: a criterion
+//! that talks about the binary is tested through the binary, and "the list
+//! opens on the open and the claimed, then the proposed, then the rest in
+//! decreasing order of created" is a claim about the rows a person is looking
+//! at. `src/model.rs` asserts the ordering of the function that decides it, on
+//! every platform and over the cases a corpus takes years to produce; this
+//! asserts it of `ank tui`, on a pseudo-terminal, reading the sequence off the
+//! screen the way a person reads it.
+//!
+//! **The corpus is stamped and not asked for, and the reason is the clock.**
+//! Every other fixture in this crate is built by running `ank new`, which is
+//! the honest way and is what keeps [`Repo::seeded`]'s two entities provably
+//! well-formed. It cannot answer this criterion: `new` stamps `created` from
+//! the machine's clock, so ten entities made in a row share a second and their
+//! recency is unassertable -- and the one order they would then come out in is
+//! the arrival order, which is the very thing this task removed. So the
+//! instants are chosen, written into the files, and the identifiers are chosen
+//! against them: inside every band the order this corpus is handed over in and
+//! the order it must be shown in are reverses of each other. A reader that kept
+//! `find`'s `ORDER BY id` draws this screen backwards.
+//!
+//! Writing under `.ank/` directly is a liberty this module's `Repo::crowded`
+//! already takes and one no source of the crate has: the reader reaches the
+//! corpus by running the CLI, and a test may name what the crate may not.
+//!
+//! **Nothing here asserts a wall-clock bound.** Not one instant in the fixture
+//! comes from a clock, so the sequence this measures is the same on a machine
+//! whose date is wrong as on one whose date is right.
+
+#![cfg(unix)]
+
+mod terminal;
+
+use terminal::{Live, Repo};
+
+/// The window every session here is opened on.
+///
+/// Wide enough that a title is not what runs out first, and tall enough for the
+/// fourteen rows of the fixture: what is being read is a sequence, and a
+/// sequence cut off at the tenth row is a sequence half read.
+const WINDOW: (u16, u16) = (120, 40);
+
+/// The identifiers the fixture stamps, in twelve hex like every other.
+///
+/// A range `ank new` does not draw from, as `Repo::crowded`'s is, so a stamped
+/// entity can never collide with a seeded one.
+fn stamped(first: u64, nth: u64) -> String {
+    format!("TASK-{:012x}", (first << 44) + (nth << 32))
+}
+
+/// The task that is open, and the one a live claim holds.
+///
+/// `e` sorts after `a`, and the open one is the more recent of the two: by
+/// identifier this pair arrives in one order and by instant it must be shown in
+/// the other.
+fn open_task() -> String {
+    stamped(0xe, 0)
+}
+fn held_task() -> String {
+    stamped(0xa, 0)
+}
+
+/// The ten finished entities, oldest first, which is the order their
+/// identifiers ascend in.
+fn finished(nth: u64) -> String {
+    stamped(0xb, nth)
+}
+
+/// A corpus carrying everything the criterion names: an open task, a task a
+/// live claim holds, a proposed decision, and ten finished entities.
+///
+/// The two entities [`Repo::seeded`] writes are kept and put to work -- the ADR
+/// is the proposal, and the task is retired into the finished band as its
+/// oldest member -- so that the fixture is not one entity larger than what it
+/// measures.
+fn corpus() -> (Repo, String) {
+    let repo = Repo::seeded();
+    let entities = repo.0.join(".ank").join("entities");
+
+    // The seeded task, retired: its instant is the oldest in the corpus, so it
+    // is the last row of the last band and every stamped entity has a stated
+    // place above it.
+    let seeded = repo.only(&["--type", "task"]);
+    let template = restamp(&entities, &seeded, &seeded, "done", "2026-06-02T00:00:00Z");
+    // And the seeded ADR, which is the whole of the waiting band.
+    let adr = repo.only(&["--type", "adr"]);
+    restamp(&entities, &adr, &adr, "proposed", "2026-06-01T00:00:00Z");
+
+    let write = |id: &str, status: &str, created: &str, title: &str| {
+        let body = template
+            .replace(&seeded, id)
+            .replace("slug: ", &format!("slug: {}-", id.to_ascii_lowercase()))
+            .replace("title: ", &format!("title: {title} "))
+            .replace("status: done", &format!("status: {status}"))
+            .replace(
+                "created: 2026-06-02T00:00:00Z",
+                &format!("created: {created}"),
+            );
+        std::fs::write(entities.join(format!("{id}.md")), body)
+            .expect("a stamped entity is writable");
+    };
+
+    write(
+        &open_task(),
+        "open",
+        "2026-08-05T00:00:00Z",
+        "The open task",
+    );
+    write(
+        &held_task(),
+        "open",
+        "2026-08-01T00:00:00Z",
+        "The held task",
+    );
+    for nth in 0..10 {
+        write(
+            &finished(nth),
+            "done",
+            &format!("2026-07-{:02}T00:00:00Z", 10 + nth),
+            &format!("A finished entity {nth}"),
+        );
+    }
+
+    // The claim is taken through the CLI and never written: what makes a task
+    // held is a ref in the coordination plane, and a fixture that stamped a
+    // status would be measuring a word in a file rather than a claim.
+    repo.ank(&["claim", &held_task()]);
+    repo.warm_find();
+    (repo, seeded)
+}
+
+/// One entity's file, with its status and its instant restated.
+///
+/// Answers the bytes it wrote, which is what the stamped entities are copied
+/// from: one template, read once, so a field this test does not know about is
+/// carried into every copy rather than dropped from it.
+fn restamp(entities: &std::path::Path, id: &str, was: &str, status: &str, created: &str) -> String {
+    let at = entities.join(format!("{was}.md"));
+    let text = std::fs::read_to_string(&at).expect("a seeded entity is readable");
+    let created_was = text
+        .split_once("created: ")
+        .and_then(|(_, rest)| rest.split_once('\n'))
+        .map(|(instant, _)| instant.to_string())
+        .expect("an entity file states when it was created");
+    let status_was = text
+        .split_once("status: ")
+        .and_then(|(_, rest)| rest.split_once('\n'))
+        .map(|(word, _)| word.to_string())
+        .expect("an entity file states its status");
+    let body = text
+        .replace(
+            &format!("created: {created_was}"),
+            &format!("created: {created}"),
+        )
+        .replace(
+            &format!("status: {status_was}"),
+            &format!("status: {status}"),
+        );
+    std::fs::write(entities.join(format!("{id}.md")), &body).expect("the entity is writable");
+    body
+}
+
+/// The short form every listing prints, of every identifier the fixture holds,
+/// in the order the corpus hands them over: `find`'s own `ORDER BY id`.
+fn as_they_arrive(repo: &Repo) -> Vec<String> {
+    terminal::ids_of(&repo.stdout(&["find", "--json"]))
+        .iter()
+        .map(|id| terminal::short_of(id))
+        .collect()
+}
+
+/// The identifiers on a frame, in the order the rows carry them.
+///
+/// One per line and the first on each: a row is a line, and the identifier is
+/// one of the two fields the reader never drops (ADR-559eebf5c6f5). Lines
+/// carrying none are the chrome and are passed over.
+fn rows(frame: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    for line in frame.lines() {
+        if let Some(id) = first_id(line) {
+            out.push(id);
+        }
+    }
+    out
+}
+
+/// The first `KIND-xxxx` on a line, if it carries one.
+fn first_id(line: &str) -> Option<String> {
+    let kinds = ["TASK-", "ADR-", "SPEC-", "LOG-"];
+    let at = kinds
+        .iter()
+        .filter_map(|kind| line.find(kind).map(|at| (at, kind.len())))
+        .min()?;
+    let rest = &line[at.0 + at.1..];
+    let hex: String = rest.chars().take_while(|c| c.is_ascii_hexdigit()).collect();
+    match hex.len() >= 4 {
+        true => Some(format!("{}{}", &line[at.0..at.0 + at.1], &hex[..4])),
+        false => None,
+    }
+}
+
+/// The sequence the fixture must be drawn in: the alive, the waiting, then the
+/// rest by recency.
+fn expected(repo: &Repo, retired: &str) -> Vec<String> {
+    let mut want = vec![
+        terminal::short_of(&open_task()),
+        terminal::short_of(&held_task()),
+        terminal::short_of(&repo.only(&["--type", "adr"])),
+    ];
+    want.extend((0..10).rev().map(|nth| terminal::short_of(&finished(nth))));
+    want.push(terminal::short_of(retired));
+    want
+}
+
+/// The whole criterion, on one screen (TASK-b5185df7aa44).
+///
+/// The open task and the held one, then the proposal, then the ten finished
+/// entities newest first -- and the seeded task, retired and oldest, under all
+/// of them.
+#[test]
+fn the_list_opens_on_the_alive_then_the_waiting_then_the_rest_by_recency() {
+    let (repo, retired) = corpus();
+    let session = Live::open(&repo, WINDOW.0, WINDOW.1);
+    let frame = session.frame();
+    let shown = rows(&frame);
+    let want = expected(&repo, &retired);
+
+    assert_eq!(
+        shown.len(),
+        want.len(),
+        "the fixture is fourteen rows and the screen drew {}:\n{frame}",
+        shown.len()
+    );
+    assert_eq!(shown, want, "the order is not the one chosen:\n{frame}");
+    session.quit();
+}
+
+/// **No identifier takes part in the ordering**, measured where it would show:
+/// the sequence the CLI hands the reader is the sequence by identifier, and the
+/// screen draws another one.
+///
+/// Inside every band of this fixture the two are reverses of each other, so a
+/// reader that had inherited `find`'s order -- which is what this task removed
+/// -- would draw the rows in the order asserted absent here.
+#[test]
+fn the_order_drawn_is_not_the_order_of_the_identifiers() {
+    let (repo, _) = corpus();
+    let arrived = as_they_arrive(&repo);
+    let session = Live::open(&repo, WINDOW.0, WINDOW.1);
+    let frame = session.frame();
+    let shown = rows(&frame);
+
+    assert_ne!(
+        shown, arrived,
+        "the identifiers' own order came through to the screen unchanged:\n{frame}"
+    );
+    // And the same rows are on the screen: an order that differed by having
+    // lost a row would not be an order at all.
+    let (mut sorted, mut theirs) = (shown.clone(), arrived.clone());
+    sorted.sort();
+    theirs.sort();
+    assert_eq!(sorted, theirs, "a row was dropped or invented:\n{frame}");
+    session.quit();
+}
+
+/// Two runs over an unchanged corpus put the rows in the same order.
+///
+/// Two processes and not two frames of one: what the criterion is about is
+/// whether the order is a property of the corpus, and a second reading inside
+/// one session would share whatever the first had already decided.
+#[test]
+fn two_runs_over_an_unchanged_corpus_draw_the_same_order() {
+    let (repo, _) = corpus();
+
+    let first = Live::open(&repo, WINDOW.0, WINDOW.1);
+    let once = rows(&first.frame());
+    first.quit();
+
+    let second = Live::open(&repo, WINDOW.0, WINDOW.1);
+    let twice = rows(&second.frame());
+    second.quit();
+
+    assert_eq!(once, twice, "two runs disagreed about the order");
+    // Nothing between them wrote: the reader renews no claim and runs no verb
+    // nobody asked for (ADR-8bd76e8d7c4e), and the sessions above pressed no
+    // key at all.
+    assert_eq!(
+        as_they_arrive(&repo).len(),
+        once.len(),
+        "the corpus changed size between the two runs"
+    );
+}


### PR DESCRIPTION
TASK-b5185df7aa44. `crates/ank-tui/src/model.rs`, plus one new suite.

`find` answers `ORDER BY id`, and an identifier is `KIND-<hex>`, so the row a
person read as the most important one was whichever hash sorted first: not
creation order, not recency, not relevance. What the reader shows first is
chosen here now — the work that is alive, then what waits for a ratification,
then the rest by recency — which is the clause ADR-559eebf5c6f5 proposes.

## What changed

- `Band` and `alive_first` in `model.rs`. The band is read out of
  `ank_contract::meaning`, so the reader keeps no copy of the status
  vocabulary: `open` is available, `in_progress` and `claimed:<who>` are
  underway, `proposed` is awaiting. Both the stored `status` and the
  coordination plane's `state` are asked — a claim taken on another branch
  shows in the plane while the file still says `open` — and a lapsed claim,
  whose marker is neither, stays alive because it is the most available work
  in a corpus.
- No identifier takes part in it. Neither key mentions one, and the sort is
  stable rather than total: rows the two keys cannot separate keep the order
  `find` handed them over in, which is what makes two runs agree without
  comparing hashes to get there.
- `created` is compared as text. RFC 3339 in Zulu is fixed width, so lexical
  order is chronological order; a row without the field sorts to the end of
  its band, so an older `ank` on the PATH costs the order its recency and
  never its bands.

## How the criterion is measured

`crates/ank-tui/tests/ordering.rs`, through the binary, on a pseudo-terminal:
a corpus carrying an open task, a task a live claim holds, a proposed decision
and eleven finished entities, read as the sequence of identifiers on the
frame. The instants are stamped rather than taken from a clock — ten entities
made by `ank new` in a row share a second, and their recency would be
unassertable — and the identifiers are chosen against them, so inside every
band the arrival order and the drawn order are reverses of each other. The
suite was red on a binary built before the change, which is ADR-93d8fc25e94e's
case and is what says it measures something.

`model.rs` carries the exhaustive half: every status word the model can hold,
the permutation test that reorders the identifiers and demands the sequence
not follow them, and the tie that must keep its arrival order.

## Scope

The task declared `crates/ank-tui/src/model.rs` alone. Scope was amended by
exactly one file — `crates/ank-tui/tests/ordering.rs`, which did not exist and
no live claim could reach — because a criterion phrased about the binary
cannot be measured from inside the crate. Not `tests/**`: three agents are in
this crate, and this adds a suite rather than rewriting one.

`cargo test --workspace` green (`status_answers_a_thousand_entities_in_under_a_quarter_second`
went red once under four concurrent agents and passes alone), `cargo fmt --check`
clean, `ank check` at 0 faults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MXfq9ZNnGoKmE5QnbnwpDa