### PR TITLE
A search narrows as it is typed, and the line to compose goes with the grammar that read it

### DIFF
--- a/.ank/entities/LOG-06df86a7443f.md
+++ b/.ank/entities/LOG-06df86a7443f.md
@@ -1,0 +1,16 @@
+---
+id: LOG-06df86a7443f
+type: log
+title: The criterion cannot be reached from input.rs and keys.rs alone, and the blocker is one function in
+created: 2026-08-28T20:03:47Z
+author: claude-code/opus-5+search-narrows
+scope:
+  - crates/ank-tui/src/input.rs
+  - crates/ank-tui/src/keys.rs
+about: TASK-c94d086682f3
+seq: 0
+schema: 4
+version: 1
+---
+
+ view.rs. App::press holds the whole prompt regime: it owns the buffer (App::prompt), it calls keys::edit on every keystroke, and it acts only on Editing::Submit, where it calls input::parse and closes the line. The narrowing state is App::search, set in App::act, read by App::rows. So 'narrows on every keystroke with nothing to submit' is a change to view.rs:894-906, and 'Escape gives back the list unnarrowed' is one too -- Editing::Cancel closes the line today and leaves App::search where it was. Deleting parse is the same story from the other end: view.rs:903 is its only caller outside this file, so the grammar cannot leave the crate while that line stands, and a shim left behind would be the grammar not leaving. Adding a fourth Editing variant does not route around it either: the match in view.rs is exhaustive over three and stops compiling on a fourth. bindings.rs:427,1548,1675 also read Press::Prompt and keys::edit, but bindings.rs is in no live claim and tests/** is in none either, so those two widen without collision. view.rs does not: TASK-d58efe37eb7b holds it. The delta needed there is small and far from that task's rows -- press() lines 894-948 and the tests that drive them -- but it is still that file.

--- a/.ank/entities/LOG-90f8fc62aada.md
+++ b/.ank/entities/LOG-90f8fc62aada.md
@@ -1,0 +1,20 @@
+---
+id: LOG-90f8fc62aada
+type: log
+title: +scope crates/ank-tui/src/bindings.rs, +scope crates/ank-tui/src/view.rs, +scope
+created: 2026-08-28T20:05:05Z
+author: claude-code/opus-5+search-narrows
+scope:
+  - crates/ank-tui/src/input.rs
+  - crates/ank-tui/src/keys.rs
+  - crates/ank-tui/src/bindings.rs
+  - crates/ank-tui/src/view.rs
+  - crates/ank-tui/tests/**
+about: TASK-c94d086682f3
+seq: 1
+records: edit
+schema: 4
+version: 1
+---
+
+ crates/ank-tui/tests/** (version 2 to 3, replaced 9900be2ed441, produced 725b2b6588a8)

--- a/.ank/entities/LOG-a99196d67047.md
+++ b/.ank/entities/LOG-a99196d67047.md
@@ -1,0 +1,20 @@
+---
+id: LOG-a99196d67047
+type: log
+title: +scope crates/ank-cli/tests/tui.rs (version 4 to 5, replaced eb845a179341, produced 7266e19fdeb4)
+created: 2026-08-28T20:34:48Z
+author: claude-code/opus-5+search-narrows
+scope:
+  - crates/ank-tui/src/input.rs
+  - crates/ank-tui/src/keys.rs
+  - crates/ank-tui/src/bindings.rs
+  - crates/ank-tui/src/view.rs
+  - crates/ank-tui/tests/**
+  - crates/ank-tui/src/form.rs
+  - crates/ank-cli/tests/tui.rs
+about: TASK-c94d086682f3
+seq: 3
+records: edit
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-b1934013f81a.md
+++ b/.ank/entities/LOG-b1934013f81a.md
@@ -1,0 +1,19 @@
+---
+id: LOG-b1934013f81a
+type: log
+title: +scope crates/ank-tui/src/form.rs (version 3 to 4, replaced 1fc7385f8ba7, produced 44290822fca6)
+created: 2026-08-28T20:13:12Z
+author: claude-code/opus-5+search-narrows
+scope:
+  - crates/ank-tui/src/input.rs
+  - crates/ank-tui/src/keys.rs
+  - crates/ank-tui/src/bindings.rs
+  - crates/ank-tui/src/view.rs
+  - crates/ank-tui/tests/**
+  - crates/ank-tui/src/form.rs
+about: TASK-c94d086682f3
+seq: 2
+records: edit
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-b7fedca33072.md
+++ b/.ank/entities/LOG-b7fedca33072.md
@@ -1,0 +1,22 @@
+---
+id: LOG-b7fedca33072
+type: log
+title: The Escape byte is not a keystroke a drive may send mid-sequence, and it cost a hang.
+created: 2026-08-28T21:31:40Z
+author: claude-code/opus-5+search-narrows
+scope:
+  - crates/ank-tui/src/input.rs
+  - crates/ank-tui/src/keys.rs
+  - crates/ank-tui/src/bindings.rs
+  - crates/ank-tui/src/view.rs
+  - crates/ank-tui/tests/**
+  - crates/ank-tui/src/form.rs
+  - crates/ank-cli/tests/tui.rs
+  - crates/ank-tui/src/lib.rs
+about: TASK-c94d086682f3
+seq: 6
+schema: 4
+version: 1
+---
+
+ crates/ank-cli/tests/tui.rs::open composed '2 / <short> CR CR / ESC' -- narrow, keep, open, then give the list back -- and drive() writes the next entry immediately behind it, so the terminal decoder read ESC plus the following letter as an Alt chord. The search never closed, every byte after it went into the needle, q included, and the session never ended: a hang and not a failure. accept_is_refused_off_the_document_and_carries_nothing_but_it already carried the warning in a comment, about the confirmation, one wave earlier. The way out is Backspace, 0x7f, which crossterm reads as a bare KeyCode::Backspace with no prefix: a Backspace off the end of an empty needle is Narrowing::Undone, the same place Escape reaches. A suite may send Escape only where it waits for the screen before the next byte, which is what tests/search.rs and tests/verbs.rs do.

--- a/.ank/entities/LOG-be2869c40a0f.md
+++ b/.ank/entities/LOG-be2869c40a0f.md
@@ -1,0 +1,20 @@
+---
+id: LOG-be2869c40a0f
+type: log
+title: done, proof commit:eff73c14fa640d35dbc5d1c2bb9a02f8e3c9f9b7
+created: 2026-08-28T21:35:18Z
+author: claude-code/opus-5+search-narrows
+scope:
+  - crates/ank-tui/src/input.rs
+  - crates/ank-tui/src/keys.rs
+  - crates/ank-tui/src/bindings.rs
+  - crates/ank-tui/src/view.rs
+  - crates/ank-tui/tests/**
+  - crates/ank-tui/src/form.rs
+  - crates/ank-cli/tests/tui.rs
+  - crates/ank-tui/src/lib.rs
+about: TASK-c94d086682f3
+seq: 7
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-c2044854eaad.md
+++ b/.ank/entities/LOG-c2044854eaad.md
@@ -1,0 +1,21 @@
+---
+id: LOG-c2044854eaad
+type: log
+title: +scope crates/ank-tui/src/lib.rs (version 5 to 6, replaced 5ea3cf737904, produced 618404e3ca6d)
+created: 2026-08-28T20:43:36Z
+author: claude-code/opus-5+search-narrows
+scope:
+  - crates/ank-tui/src/input.rs
+  - crates/ank-tui/src/keys.rs
+  - crates/ank-tui/src/bindings.rs
+  - crates/ank-tui/src/view.rs
+  - crates/ank-tui/tests/**
+  - crates/ank-tui/src/form.rs
+  - crates/ank-cli/tests/tui.rs
+  - crates/ank-tui/src/lib.rs
+about: TASK-c94d086682f3
+seq: 4
+records: edit
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-c97a81e85912.md
+++ b/.ank/entities/LOG-c97a81e85912.md
@@ -1,0 +1,22 @@
+---
+id: LOG-c97a81e85912
+type: log
+title: "Built. The search is a regime of keys.rs and no longer a line: Press::Prompt(seed) became"
+created: 2026-08-28T21:08:50Z
+author: claude-code/opus-5+search-narrows
+scope:
+  - crates/ank-tui/src/input.rs
+  - crates/ank-tui/src/keys.rs
+  - crates/ank-tui/src/bindings.rs
+  - crates/ank-tui/src/view.rs
+  - crates/ank-tui/tests/**
+  - crates/ank-tui/src/form.rs
+  - crates/ank-cli/tests/tui.rs
+  - crates/ank-tui/src/lib.rs
+about: TASK-c94d086682f3
+seq: 5
+schema: 4
+version: 1
+---
+
+ Press::Find carrying nothing, Editing{Typing,Submit,Cancel} became Narrowing{Narrowed,Kept,Undone}, and keys::edit became keys::narrowing. Every character is a needle one longer and a Command::Search sent through App::act, so one road still narrows the list. Enter is Kept -- the search ends, the narrowing stays -- and it is not a submit: the narrowing already happened, and what Enter buys is the alphabet back, since every letter is a needle while a search is open. Escape is Undone and sends Command::Search(None), which is the half a close alone would not have met. input.rs lost parse, the word table, the letter table, IDENTIFIER_KINDS, Command::Row, Command::Select, Command::Nothing and Command::Unknown; what is left is the command type. The two commands that went are the two no key reached, and the cost is stated in the module rather than hidden: a row number and an identifier typed whole are gone, and /4974 replaces both. bindings.rs: Runs::Submit/Cancel became Keep/Undo, worded 'keep' and 'clear'; Offered::Typing and Holding::Typing became Narrowing; the key list's line is titled 'narrowing' and its note says the list narrows as it is typed and there is nothing to submit. view.rs: App::prompt is App::needle, and the marker it is drawn behind is view::SEARCH = '/' and no longer PROMPT = ': '. The writing verbs kept their confirmation untouched -- no line ever reached one, tests/dependencies.rs still holds one arm answering an act and one function spawning a verb.

--- a/.ank/entities/TASK-c94d086682f3.md
+++ b/.ank/entities/TASK-c94d086682f3.md
@@ -5,14 +5,20 @@ slug: a-search-narrows-as-it-is-typed-and-the-line-to
 title: A search narrows as it is typed, and the line to compose goes with the grammar that read it
 created: 2026-08-27T16:33:58Z
 author: haksolot@vmi3223161
-status: open
+status: in_progress
 scope:
   - crates/ank-tui/src/input.rs
   - crates/ank-tui/src/keys.rs
+  - crates/ank-tui/src/bindings.rs
+  - crates/ank-tui/src/view.rs
+  - crates/ank-tui/tests/**
+  - crates/ank-tui/src/form.rs
+  - crates/ank-cli/tests/tui.rs
+  - crates/ank-tui/src/lib.rs
 blocked_by: [TASK-252bf02de218]
 done_criteria: |
   Pressing the search key and then characters narrows the list on every keystroke with nothing to submit, and Escape gives back the list unnarrowed. The prompt grammar of input.rs is gone from the crate. Every movement that survives it is a key in the binding table, and the key list the reader draws names each of them. Measured through the binary.
 criteria_by: creator
 schema: 4
-version: 1
+version: 6
 ---

--- a/.ank/entities/TASK-c94d086682f3.md
+++ b/.ank/entities/TASK-c94d086682f3.md
@@ -5,7 +5,7 @@ slug: a-search-narrows-as-it-is-typed-and-the-line-to
 title: A search narrows as it is typed, and the line to compose goes with the grammar that read it
 created: 2026-08-27T16:33:58Z
 author: haksolot@vmi3223161
-status: in_progress
+status: done
 scope:
   - crates/ank-tui/src/input.rs
   - crates/ank-tui/src/keys.rs
@@ -19,6 +19,11 @@ blocked_by: [TASK-252bf02de218]
 done_criteria: |
   Pressing the search key and then characters narrows the list on every keystroke with nothing to submit, and Escape gives back the list unnarrowed. The prompt grammar of input.rs is gone from the crate. Every movement that survives it is a key in the binding table, and the key list the reader draws names each of them. Measured through the binary.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: eff73c14fa640d35dbc5d1c2bb9a02f8e3c9f9b7
+    criteria: 3aa536db5fa3
+    via: submitted
 schema: 4
-version: 6
+version: 7
 ---

--- a/crates/ank-cli/tests/tui.rs
+++ b/crates/ank-cli/tests/tui.rs
@@ -256,14 +256,43 @@ fn ids_of(doc: &str) -> Vec<String> {
     out
 }
 
-/// One entry of a key list that opens an entity by its identifier.
+/// Goes to the listing and opens one entity, by narrowing the listing to it.
 ///
-/// An identifier is a line by nature -- it is fourteen characters and no key
-/// spells it -- so it goes through the prompt, which is where the grammar reads
-/// one and jumps to it.
+/// **The road is the search now** (TASK-c94d086682f3, ADR-559eebf5c6f5). It was
+/// the identifier typed whole into the prompt -- `Command::Select`, which
+/// forced the listing, put the cursor on the row and opened it in one command
+/// -- and that command is gone with the line it needed. What replaces it is
+/// what a person does: the digit that reaches the listing, `/` and the short
+/// form, which narrows to the one row as it is typed; Enter, which leaves the
+/// search with that narrowing in force; and Enter again, which opens the row
+/// under the cursor. The cursor is on it because a search puts it back at the
+/// top and there is one row left.
+///
+/// `2` first for the reason the old command forced the listing: an identifier
+/// names an entity wherever the reader is standing, and a document has no rows
+/// to narrow.
+///
+/// **And the narrowing is given back once the document is open**, which is the
+/// one thing the search does that `Command::Select` did not. A needle left in
+/// force is a listing this helper's callers never asked for -- the suite that
+/// found it was the one watching a task *arrive* in the list, which a filter
+/// nobody could see had quietly excluded. So the last two keystrokes are the
+/// search opened and undone, and the reader is left on the document with the
+/// listing behind it whole again.
+///
+/// **Undone with Backspace and not with Escape, and that is about this terminal
+/// rather than about this reader.** An escape byte with another key straight
+/// behind it is an *Alt chord* to any terminal decoder, and this helper's
+/// output is followed immediately by the next entry of a drive -- so an
+/// `Escape` here would arrive as `Alt` and whatever came next, which is not a
+/// keystroke the reader answers. Backspace is `0x7F`, one byte, no prefix, and
+/// it reaches the same place: a Backspace off the end of an empty needle ends
+/// the search, which `keys::narrowing` answers with `Narrowing::Undone` exactly
+/// as it answers Escape. `accept_is_refused_off_the_document_and_carries_
+/// nothing_but_it` states the same fact for the same reason, one wave earlier.
 #[cfg(unix)]
 fn open(id: &str) -> String {
-    format!(":{}", short_of(id))
+    format!("2{FIND}{}\r\r{FIND}{BACKSPACE}", short_of(id))
 }
 
 /// The short form every listing prints: the kind, then four characters.
@@ -807,17 +836,20 @@ fn drive(repo: &Repo, agent: &str, keys: &[&str]) -> Seen {
 
 /// The same, for a call that takes flags and ends on its own.
 ///
-/// **What an entry of `keys` is.** Anything beginning with `:` is a line typed
-/// into the prompt: the key that opens it, Control-U to take the search seed
-/// off, the rest of the entry, and Enter. Anything else is the keys themselves,
-/// byte for byte -- `"q"`, `"j"`, `"\r"` for Enter.
+/// **An entry of `keys` is the keys themselves, byte for byte** -- `"q"`,
+/// `"j"`, `"\r"` for Enter (TASK-c94d086682f3).
 ///
-/// **No `:` entry names a verb any more** (TASK-1a415107fd56). Every command is
-/// one key, the six that write included, so a verb is reached by [`verb`] and
-/// what a line is still the shape for is a row number and an identifier. The
-/// letter composes the command and shows it rather than running it, so an entry
-/// that presses one is followed by [`confirm`] wherever the verb is meant to
-/// land (TASK-d4a882345837).
+/// There is no second form. An entry opening with `:` used to mean "open the
+/// line, clear the search seed, type this and submit it", which is how this
+/// suite reached the two commands no key had: `filter <kind>` and an identifier
+/// typed whole. ADR-559eebf5c6f5 ends the line, so both roads are keys now --
+/// [`kinds`] walks the filter and [`open`] narrows with the search -- and every
+/// entry here is something a person presses.
+///
+/// A verb is reached by [`verb`], one letter. The letter composes the command
+/// and shows it rather than running it, so an entry that presses one is
+/// followed by [`confirm`] wherever the verb is meant to land
+/// (TASK-d4a882345837).
 #[cfg(unix)]
 fn on_a_terminal(repo: &Repo, agent: &str, args: &[&str], keys: &[&str]) -> Seen {
     let mut live = Live::open_with(repo, agent, args, &[]);
@@ -1041,18 +1073,17 @@ impl Live {
         panic!("the screen never stopped moving:\n{last}");
     }
 
-    /// One entry of a key list: a line typed into the prompt, or the keys
-    /// themselves.
+    /// One entry of a drive: the keys themselves.
+    ///
+    /// **There is no second form any more** (TASK-c94d086682f3). An entry that
+    /// opened with `:` used to mean "open the line, clear the seed, type this
+    /// and submit it" -- which is how this suite reached `filter <kind>`, a
+    /// word of a grammar that no key spelled. ADR-559eebf5c6f5 ends the line
+    /// and the grammar with it, so every entry here is now what a person
+    /// actually presses, and [`kinds`] computes the presses for the one road
+    /// that was reached by a word.
     fn press(&mut self, entry: &str) {
-        match entry.strip_prefix(':') {
-            Some(line) => {
-                self.send(&FIND.to_string());
-                self.send(CLEAR);
-                self.send(line);
-                self.send("\r");
-            }
-            None => self.send(entry),
-        }
+        self.send(entry);
     }
 
     fn send(&mut self, bytes: &str) {
@@ -1076,25 +1107,59 @@ impl Live {
     }
 }
 
-/// The key that opens the one line this reader still takes, read out of the
-/// reader rather than typed as a letter here: a suite carrying its own copy of
-/// it would agree with a mapping that moved.
+/// Backspace, as a terminal sends it: `0x7F`, which crossterm reads as a bare
+/// `KeyCode::Backspace`.
 ///
-/// It opens a *search*, seeded with a slash (TASK-1a415107fd56). The prompt a
-/// verb used to be spelled into is gone, and the six verbs are letters now, so
-/// what a `:` entry of a key list means is "clear the seed and type the line",
-/// which is what [`Live::press`] does.
+/// The way out of an open search that gives the list back unnarrowed
+/// (TASK-c94d086682f3), and the one a suite may send in the middle of a key
+/// sequence: see [`open`] for why Escape is not.
+#[cfg(unix)]
+const BACKSPACE: &str = "\u{7f}";
+
+/// The key that starts the search, read out of the reader rather than typed as
+/// a letter here: a suite carrying its own copy of it would agree with a
+/// mapping that moved.
+///
+/// What follows it is a needle and not a line (TASK-c94d086682f3): the list
+/// narrows on every character, so a drive that sends this and then some text is
+/// looking at a shorter list before it sends anything else. `CLEAR` -- the
+/// Control-U that took the old prompt's slash seed off -- stood beside this and
+/// went with the seed.
 #[cfg(unix)]
 const FIND: char = ank_tui::keys::FIND;
 
-/// The byte a terminal sends for Control-U, which clears the open line and
-/// leaves the prompt open (`ank_tui::keys::edit`).
+/// The keystrokes that walk the kind filter from one kind to another.
 ///
-/// How a line that is not a search is reached: the seed is a slash, and this
-/// takes it off. Not Backspace, which closes the prompt on the keystroke after
-/// the line empties -- one key with one meaning is what a suite should send.
+/// Read out of the reader's own registry and its own table rather than counted
+/// here (`ank_tui::keys::next_kind`, `ank_tui::bindings::BINDINGS`): the key is
+/// a *cycle*, so how many presses reach a kind is the order the registry
+/// declares, and a suite that wrote `fff` would go on passing against a
+/// registry that gained a kind.
+///
+/// This is what replaces the `:filter <kind>` entries (TASK-c94d086682f3). The
+/// word was a road no key spelled, and the reader has one road now.
 #[cfg(unix)]
-const CLEAR: &str = "\u{15}";
+fn kinds(from: Option<&str>, to: Option<&str>) -> String {
+    use ank_tui::bindings::{Runs, BINDINGS};
+    use ank_tui::keys::{next_kind, Press, KINDS};
+
+    let binding = BINDINGS
+        .iter()
+        .find(|b| b.runs == Runs::Press(Press::Cycle))
+        .expect("a key walks the kinds");
+    let key = ank_tui::bindings::named(binding.key);
+    let mut at = from.map(str::to_string);
+    let mut out = String::new();
+    while at.as_deref() != to {
+        at = next_kind(at.as_deref());
+        out.push_str(&key);
+        assert!(
+            out.chars().count() <= KINDS.len() + 1,
+            "the cycle never reaches {to:?} from {from:?}"
+        );
+    }
+    out
+}
 
 /// The letter one verb of the writing half is bound to, out of the reader's own
 /// table (TASK-1a415107fd56).
@@ -1150,7 +1215,14 @@ fn a_driven_session_names_the_entities_the_corpus_carries() {
     let seen = drive(
         &repo,
         HOLDER,
-        &[":filter task", "\r", "b", ":filter", "1", "q"],
+        &[
+            &kinds(None, Some("task")),
+            "\r",
+            "b",
+            &kinds(Some("task"), None),
+            "1",
+            "q",
+        ],
     );
 
     // The one assertion here that is genuinely about the bytes rather than
@@ -1425,14 +1497,14 @@ fn quitting_leaves_no_file_and_no_ref_changed() {
         &[
             // Space pages and `s` opens the constraints: `n` and `c` went to
             // the verbs' side of the ledger (TASK-1a415107fd56).
-            ":filter adr",
+            &kinds(None, Some("adr")),
             "\r",
             " ",
             "s",
             "g",
             "b",
-            ":filter",
-            "/task\r",
+            &kinds(Some("adr"), None),
+            &format!("{FIND}task\r"),
             "j",
             "k",
             "q",
@@ -1471,7 +1543,7 @@ fn opening_the_task_you_hold_takes_nothing_and_creates_nothing() {
 
     let files = corpus_files(&repo);
     let names = ref_names(&repo);
-    let seen = drive(&repo, HOLDER, &[":filter task", "\r", "q"]);
+    let seen = drive(&repo, HOLDER, &[&kinds(None, Some("task")), "\r", "q"]);
     assert!(seen.contains(TAIL), "the held task was opened:\n{seen}");
 
     assert_eq!(
@@ -1780,7 +1852,13 @@ fn a_done_refused_for_a_missing_proof_leaves_the_task_untouched() {
     let seen = drive(
         &repo,
         HOLDER,
-        &[":filter task", "\r", &verb("done"), &confirm(), "q"],
+        &[
+            &kinds(None, Some("task")),
+            "\r",
+            &verb("done"),
+            &confirm(),
+            "q",
+        ],
     );
 
     let code = declared("done", "no proof");
@@ -2465,7 +2543,7 @@ fn a_document_ratified_through_the_reader_is_what_a_shell_accept_makes() {
     let seen = drive(
         &repo,
         READER,
-        &[&format!(":{by_screen}"), &verb("accept"), &confirm(), "q"],
+        &[&open(&by_screen), &verb("accept"), &confirm(), "q"],
     );
     assert!(
         seen.contains(&format!("ank accept {by_screen}")),

--- a/crates/ank-tui/src/bindings.rs
+++ b/crates/ank-tui/src/bindings.rs
@@ -151,10 +151,16 @@ pub enum Runs {
     Run,
     /// The command on the screen, dropped.
     Dismiss,
-    /// The open line, read as a command.
-    Submit,
-    /// The open line, dropped.
-    Cancel,
+    /// The open search, left with the narrowing it made
+    /// (TASK-c94d086682f3).
+    ///
+    /// It was `Submit` -- the open line, read as a command -- and there is no
+    /// line and no command to read it as. What this row names is the way out
+    /// that keeps the list narrowed; the narrowing itself happened on every
+    /// keystroke before it.
+    Keep,
+    /// The open search, ended, and the list given back unnarrowed.
+    Undo,
 }
 
 /// Which half of the reader a binding belongs to.
@@ -222,8 +228,10 @@ pub enum Offered {
     /// Only over a command waiting to be answered, which is modal: nothing else
     /// is what the rest of the keyboard does (TASK-d4a882345837).
     Waiting,
-    /// Only over an open prompt, which is modal for the same reason.
-    Typing,
+    /// Only over an open search, which is modal for the same reason: while one
+    /// is open every letter is a needle, so the two rows this offers are the
+    /// two ways out of it (TASK-c94d086682f3).
+    Narrowing,
     /// Only on a document `accept` would take: a proposal, open in the body
     /// panel. A trailer that carried the word over every open entity would be
     /// offering what the verb turns down.
@@ -306,8 +314,8 @@ pub enum Tail {
 pub enum Holding {
     /// A composed command, waiting to be answered.
     Waiting,
-    /// An open prompt.
-    Typing,
+    /// An open search.
+    Narrowing,
     /// Neither, with this panel focused.
     Panel(Focus),
 }
@@ -424,7 +432,7 @@ pub static BINDINGS: &[Binding] = &[
     Binding {
         key: KeyCode::Char(FIND),
         aliases: &[],
-        runs: Runs::Press(Press::Prompt("/")),
+        runs: Runs::Press(Press::Find),
         word: "find",
         group: Group::Screen,
         offered: Offered::Panels(&[Focus::Entities]),
@@ -781,19 +789,19 @@ pub static BINDINGS: &[Binding] = &[
     Binding {
         key: KeyCode::Enter,
         aliases: &[],
-        runs: Runs::Submit,
-        word: "run",
+        runs: Runs::Keep,
+        word: "keep",
         group: Group::Answer,
-        offered: Offered::Typing,
+        offered: Offered::Narrowing,
         verb: None,
     },
     Binding {
         key: KeyCode::Esc,
         aliases: &[],
-        runs: Runs::Cancel,
-        word: "cancel",
+        runs: Runs::Undo,
+        word: "clear",
         group: Group::Answer,
-        offered: Offered::Typing,
+        offered: Offered::Narrowing,
         verb: None,
     },
 ];
@@ -843,7 +851,7 @@ impl Binding {
     pub fn is_offered(&self, holding: Holding) -> bool {
         match (self.offered, holding) {
             (Offered::Waiting, Holding::Waiting) => true,
-            (Offered::Typing, Holding::Typing) => true,
+            (Offered::Narrowing, Holding::Narrowing) => true,
             (Offered::Anywhere, Holding::Panel(_)) => true,
             (Offered::Panels(panels), Holding::Panel(focus)) => panels.contains(&focus),
             // The ratification offer is the line the trailer draws over a
@@ -914,7 +922,7 @@ pub const OFF_THE_DOCUMENT: &str =
 ///
 /// The three groups a key press answers, the writing half included since
 /// TASK-1a415107fd56 gave it letters. What stays out is [`Group::Answer`],
-/// whose two grammars are the confirmation's and the prompt's and are modal --
+/// whose two grammars are the confirmation's and the search's and are modal --
 /// so an `Esc` here is the one that goes back, and never the one that dismisses
 /// a command that is not on the screen.
 pub fn of_key(code: KeyCode) -> Option<&'static Binding> {
@@ -1038,8 +1046,12 @@ const RATIFY_NOTE: &str =
 /// runs and the whole of the rest of the keyboard declines. The pair is what
 /// the screen *offers*; the sentence is what it does.
 const WAITING_NOTE: &str = "   (over a command waiting -- every other key dismisses it too)";
-/// What it says after the prompt's two.
-const TYPING_NOTE: &str = "   (over a line being typed)";
+/// What it says after the search's two.
+///
+/// "as it is typed" and not "then Enter", because that is the grammar
+/// (ADR-559eebf5c6f5): the list is already narrowed by the time either of these
+/// two keys is pressed, and what they choose is whether it stays that way.
+const NARROWING_NOTE: &str = "   (the list narrows as it is typed -- there is nothing to submit)";
 
 /// One line of the key list: the bindings it names, and how they are drawn.
 ///
@@ -1221,14 +1233,14 @@ fn waiting() -> Line {
     }
 }
 
-/// What an open prompt offers.
-fn typing() -> Line {
+/// What an open search offers.
+fn narrowed() -> Line {
     Line {
-        title: "typing",
-        bindings: answering(Offered::Typing),
+        title: "narrowing",
+        bindings: answering(Offered::Narrowing),
         lead: String::new(),
         between: "  ",
-        note: TYPING_NOTE.to_string(),
+        note: NARROWING_NOTE.to_string(),
     }
 }
 
@@ -1249,7 +1261,7 @@ fn lines() -> Vec<Line> {
         settings(),
         ratify(),
         waiting(),
-        typing(),
+        narrowed(),
     ]
 }
 
@@ -1545,9 +1557,9 @@ mod tests {
                     fields.push(flag);
                 }
             }
-            if let Runs::Press(Press::Prompt(seed)) = &binding.runs {
-                fields.push(seed);
-            }
+            // The seed a prompt opened on stood here (TASK-c94d086682f3). It
+            // was the last `&'static str` a row carried into a composed line,
+            // and there is no line: `Press::Find` carries nothing.
             for field in fields {
                 assert_ne!(
                     field, "-",
@@ -1650,7 +1662,7 @@ mod tests {
     /// **The two modal grammars answer the keys the table offers**
     /// (TASK-4d2eb2b4e193).
     ///
-    /// [`crate::keys::confirming`] and [`crate::keys::edit`] are stated over
+    /// [`crate::keys::confirming`] and [`crate::keys::narrowing`] are stated over
     /// the whole keyboard rather than over a list -- one key runs and every
     /// other one declines, which is a claim about every keystroke there is --
     /// so they are not generated from rows and must not be. What *can* be held
@@ -1659,7 +1671,7 @@ mod tests {
     /// answer would be a target that reads as an offer and behaves as nothing.
     #[test]
     fn the_modal_grammars_answer_the_keys_the_table_offers() {
-        use crate::keys::{confirming, edit, Answer, Editing};
+        use crate::keys::{confirming, narrowing, Answer, Narrowing};
         use ratatui::crossterm::event::{KeyEvent, KeyModifiers};
 
         let bare = |code: KeyCode| KeyEvent::new(code, KeyModifiers::NONE);
@@ -1670,13 +1682,17 @@ mod tests {
             match binding.runs {
                 Runs::Run => assert_eq!(confirming(key), Answer::Run, "{binding:?}"),
                 Runs::Dismiss => assert_eq!(confirming(key), Answer::Dismiss, "{binding:?}"),
-                Runs::Submit => {
-                    let mut line = String::from("done commit:2d9c847");
-                    assert_eq!(edit(&mut line, key), Editing::Submit, "{binding:?}");
+                Runs::Keep => {
+                    let mut needle = String::from("a needle");
+                    assert_eq!(narrowing(&mut needle, key), Narrowing::Kept, "{binding:?}");
                 }
-                Runs::Cancel => {
-                    let mut line = String::from("done commit:2d9c847");
-                    assert_eq!(edit(&mut line, key), Editing::Cancel, "{binding:?}");
+                Runs::Undo => {
+                    let mut needle = String::from("a needle");
+                    assert_eq!(
+                        narrowing(&mut needle, key),
+                        Narrowing::Undone,
+                        "{binding:?}"
+                    );
                 }
                 ref other => panic!("{other:?} is not something a modal state answers with"),
             }

--- a/crates/ank-tui/src/form.rs
+++ b/crates/ank-tui/src/form.rs
@@ -592,16 +592,16 @@ impl Form {
     /// words, so no printable character is a command here: the movement is on
     /// the named keys a terminal sends for arrows and tabs, the kind is on the
     /// two arrows that cross, Enter composes and Escape closes. That is the
-    /// same shape the confirmation and the prompt have -- a state where the
+    /// same shape the confirmation and the search have -- a state where the
     /// keyboard means something else -- and the reason is the one
-    /// [`crate::keys::edit`] gives: a line being typed into cannot also be a
-    /// key table.
+    /// [`crate::keys::narrowing`] gives: a field being typed into cannot also
+    /// be a key table.
     ///
     /// **No command here is a chord** (ADR-c07e2694f0e1). Control-C is the way
     /// out of a program that took the terminal and it closes the form, and
-    /// Control-U clears the field, which is what the prompt does with it.
+    /// Control-U clears the field, which is what the search does with it.
     ///
-    /// **And the modifiers are read the way [`crate::keys::edit`] reads them
+    /// **And the modifiers are read the way [`crate::keys::narrowing`] reads them
     /// and not the way [`crate::keys::typed`] does**, which is the one place
     /// this grammar had to part company with the key table. The table refuses a
     /// modifier held, because six letters write and a Shift still down from the
@@ -610,8 +610,8 @@ impl Form {
     /// that turned a held modifier down would be a form nobody can put a
     /// capital letter in -- which is every title in this corpus. It cost a
     /// title its first letter before the pseudo-terminal caught it. Control is
-    /// the only modifier that means anything else here, exactly as at the
-    /// prompt, and nothing under it types.
+    /// the only modifier that means anything else here, exactly as in the
+    /// search, and nothing under it types.
     pub fn press(&mut self, key: KeyEvent) -> Filled {
         if key.modifiers.contains(KeyModifiers::CONTROL) {
             return match key.code {
@@ -674,7 +674,7 @@ impl Form {
 
     fn backspace(&mut self) {
         // Backspacing an empty field does not close the form, which is where
-        // this and the prompt part company: a prompt is one line and emptying
+        // this and the search part company: a search is one needle and emptying
         // it is a person saying they did not mean to be there, and a form is
         // nine fields somebody has been typing into.
         if let Some(field) = self.fields.get_mut(self.at) {
@@ -1517,7 +1517,7 @@ mod tests {
     ///
     /// A form is where words are typed, so a letter that closed it or composed
     /// it would be a letter nobody could put in a title. The whole of the
-    /// grammar is on the named keys, and the two chords are the ones the prompt
+    /// grammar is on the named keys, and the two chords are the ones the search
     /// already answers.
     #[test]
     fn no_printable_key_is_a_command_of_the_form() {
@@ -1537,7 +1537,7 @@ mod tests {
         assert_eq!(form.fields()[0].entry, Entry::Typed("a title".to_string()));
         assert_eq!(form.press(bare(KeyCode::Enter)), Filled::Compose);
         assert_eq!(form.press(bare(KeyCode::Esc)), Filled::Close);
-        // Backspacing an empty field is not a way out: a form is not a prompt.
+        // Backspacing an empty field is not a way out: a form is not a search.
         let mut empty = Form::open(MAKE).expect("a form");
         assert_eq!(empty.press(bare(KeyCode::Backspace)), Filled::Filling);
         assert!(empty.fields()[0].entry.blank());
@@ -1573,8 +1573,8 @@ mod tests {
     }
 
     /// Control is the one modifier that means something else, and it is the way
-    /// out and the clear -- the two the prompt already answers
-    /// ([`crate::keys::edit`]).
+    /// out and the clear -- the two the search already answers
+    /// ([`crate::keys::narrowing`]).
     #[test]
     fn control_is_the_way_out_and_the_clear_and_nothing_under_it_types() {
         let held = KeyEvent::new;

--- a/crates/ank-tui/src/input.rs
+++ b/crates/ank-tui/src/input.rs
@@ -1,62 +1,74 @@
-//! The grammar of the one-line prompt, which is a search and the words that
-//! only move a screen.
+//! What a command *is*, now that nothing composes one out of words
+//! (TASK-c94d086682f3, ADR-559eebf5c6f5).
 //!
-//! **No word typed here reaches a verb** (TASK-1a415107fd56,
-//! ADR-c07e2694f0e1). The six that write have their own letters now -- `c`,
-//! `l`, `d`, `r`, `m`, `a` -- and the prompt that used to spell them whole is
-//! gone with the key that opened it. What is left is `/`, which is this
-//! grammar's search, and the words a line is the natural shape for: a row
-//! number, an identifier, a filter.
+//! **There is no grammar here any more.** This module was the reader's
+//! one-line prompt: `parse` took a string and answered a [`Command`], and
+//! around it stood a table of words, a list of the letters allowed to stand for
+//! one, a row number, an identifier and a search. All of it is gone, and what
+//! is left is the enumeration itself -- the vocabulary the key table speaks,
+//! with nothing that reads it out of prose.
 //!
-//! # Why the verbs left rather than staying as a second road
+//! # Why the line went, and not merely the verbs
 //!
-//! They could have stayed. A word is still a word, and `claim` typed whole
-//! would still have composed the same act. What that would have been is a
-//! second vocabulary for the same six commands -- one a person learns from the
-//! key list and one they learn from nowhere -- and a second road to
-//! [`Command::Act`] for every rule about reaching one to be restated on.
-//! ADR-c07e2694f0e1 asks for the opposite: a key *is* the verb it runs, and
-//! the surface a person already learned at the shell is where the letters come
-//! from. One road, and it is a keystroke.
+//! TASK-1a415107fd56 took the writing verbs out of the prompt and left the rest
+//! of the grammar standing, on the reasoning that `open`, `top`, a row number
+//! and an identifier "are lines by nature, and none of them writes". That was
+//! true and it was not the question. ADR-559eebf5c6f5 asks a different one:
+//! *a search narrows the list as it is typed and is not a line to compose and
+//! submit*, and *input is a keystroke and no longer a line*.
 //!
-//! So [`parse`] cannot produce a [`Command::Act`] at all, and that is held
-//! twice over: by the tests at the foot of this file, over every verb §4
-//! declares rather than over the six -- a grammar that had quietly kept
-//! `attest` would be exactly as much of a second road as one that kept `claim`
-//! -- and by `tests/dependencies.rs`, which reads this file's own source and
-//! finds nothing outside its tests that so much as names the variant.
+//! Once the search narrows on the keystroke there is nothing left for a line to
+//! be. `/` was the last thing anybody typed into the prompt, and it was the
+//! only one the key list ever named; `open`, `top`, `next`, `prev`,
+//! `constraints`, `filter`, `reload` and the four letters that stood for them
+//! were a second vocabulary for keys that already existed, learned from
+//! nowhere. A row number and an identifier were the two that had no key at all,
+//! and they are the two that go: **every movement that survives is a key of
+//! [`crate::bindings::BINDINGS`]**, which `crates/ank-tui/tests/commands.rs`
+//! measures over the whole enumeration.
 //!
-//! # What a line is still the right shape for
+//! # What that costs, said plainly
 //!
-//! A search, above all: `/` opens the prompt seeded with a slash and the rest
-//! of the line is the needle, spaces and all. That is the whole of what a
-//! person is offered, and it is the whole of what the key list names. What is
-//! under it is the rest of this grammar, reached by clearing the seed --
-//! Control-U, or Backspace -- and it costs nothing to keep: `open`, `top`, a
-//! row number and an identifier are lines by nature, and none of them writes.
+//! [`Command::Row`] and [`Command::Select`] were real. A person who could see
+//! `12` beside a row could type `12` and land on it, and one who knew an
+//! identifier could type it and open the entity without walking to it. Both are
+//! gone, and neither is replaced.
 //!
-//! # No letter means two things
+//! What replaces them is the search, which is why the decision is one clause
+//! and not two: a needle narrows the list to the rows that carry it on every
+//! keystroke, so reaching `TASK-4974` is `/4974` and the cursor is already
+//! there. That is fewer keys than the identifier was and it is the same key
+//! everywhere, whereas the row number only ever worked on a listing and said so
+//! with a refusal on a document. A jump by ordinal was the panel arrangement's
+//! affordance and it goes with the panels.
 //!
-//! **A single letter is a word here only where the key of that letter means the
-//! same** (TASK-1a415107fd56). `c` and `r` were `constraints` and `reload` for
-//! as long as those were what the keys did; the keys are `claim` and `release`
-//! now, and a line where `c` shows the rules while the keyboard's `c` claims a
-//! task would be two vocabularies wearing one letter -- which is the drift
-//! ADR-c07e2694f0e1 was written against, one surface further down.
+//! # The verbs kept their confirmation, and this is where that is visible
 //!
-//! So the letters that survive are the ones that agree with the table -- `q`,
-//! `g`, `b`, `v`, `?`, and `j`/`k` with a count in front -- and everything else
-//! is spelled whole. `h`, `n` and `p` are gone from here for the same reason
-//! from the other end: the decision empties those keys, and a word that filled
-//! one back in would be putting the meaning somewhere a person could still find
-//! it. `f` goes for a third reason, and it is the one that shows the rule is
-//! not about which wave moved what: the key *cycles* the kinds and the word
-//! *sets* one, so they were never the same command and the letter was standing
-//! for two things all along.
+//! [`Command::Act`] is still here, and it is still not a verb *run*
+//! (TASK-d4a882345837). The grammar leaving must not take the gate with it: a
+//! key composes the argv, [`crate::view::App`] shows it whole, and nothing is
+//! spawned until [`crate::keys::confirming`] answers. **Nothing in this module
+//! builds an [`Act`]** -- it never did -- and what changed is only that there
+//! is no longer a `parse` that could have. `tests/dependencies.rs` holds the
+//! other half over the crate's whole source: one function spawns a verb that
+//! writes, and the confirmation stands in front of it.
 
 use crate::view::Focus;
 
-/// What a typed line asks for.
+/// What the reader has been asked to do.
+///
+/// **Every one of these is reached by a key**, and that is a property the crate
+/// is answerable for rather than a habit: `crates/ank-tui/tests/commands.rs`
+/// names the whole enumeration in a total `match` -- so a variant added here
+/// stops that suite compiling -- and holds every name in it to
+/// [`crate::bindings::BINDINGS`].
+///
+/// It is stated from outside this module and not at the foot of it, because
+/// what it measures is the join between two things: the vocabulary declared
+/// here and the table declared in `bindings.rs`. `tests/dependencies.rs` reads
+/// this file's own source and requires the dispatch for an act to be answered
+/// in exactly one place, and a `match` arm in a test module here would be a
+/// second one as far as a source-walking suite can tell.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Command {
     Quit,
@@ -77,26 +89,29 @@ pub enum Command {
     /// Focus one named panel (TASK-bb43cfe2192b). A digit names one, and a
     /// digit is what the panel's own title carries.
     Panel(Focus),
-    /// An identifier, whole or abbreviated.
-    Select(String),
-    /// A row number, as the list prints them: one-based.
-    Row(usize),
     /// Show one kind only, or every kind again.
+    ///
+    /// Reached by `f`, which walks the registry: the key answers
+    /// [`crate::keys::Press::Cycle`] rather than this, because the next kind
+    /// needs the one in force and that is the screen's to know.
     Kind(Option<String>),
-    /// Show the rows whose title or identifier carries this text, or every row
-    /// again.
+    /// Narrow the list to the rows whose title or identifier carries this text,
+    /// or give it back whole.
+    ///
+    /// **One of these per keystroke** (TASK-c94d086682f3, ADR-559eebf5c6f5).
+    /// It used to arrive once, when a composed line was submitted; the search
+    /// narrows as it is typed now, so `/` opens it, every character sends
+    /// another of these, and Escape sends the `None`.
     Search(Option<String>),
     /// Show the constraints binding the open entity, or hide them for the body.
     Constraints,
     /// Show what `ank config` declares and what each key is set to, or hide it
     /// for the body (TASK-b08d090f699c).
     ///
-    /// A key and no word, like [`Command::Further`] and [`Command::Form`]. It
-    /// is a *read* -- what it opens is a pane, asked for once when it opens --
-    /// and what writes is a row of that pane, which reaches the form and then
-    /// the confirmation. So there is nothing here for a line to have carried,
-    /// and a word that spelled `config` would be the second road to a write
-    /// ADR-c07e2694f0e1 closed.
+    /// A key and nothing else, like [`Command::Further`] and [`Command::Form`].
+    /// What it opens is a *read* -- a pane, asked for once when it opens -- and
+    /// what writes is a row of that pane, which reaches the form and then the
+    /// confirmation.
     Config,
     /// Focus the ratification queue, and ask `review` for it
     /// (TASK-d90e94afca08). A read and nothing else -- `ank review` writes no
@@ -109,27 +124,28 @@ pub enum Command {
     /// view does with it is compose the argv and show it, and a person answers
     /// that (TASK-d4a882345837).
     ///
-    /// **Nothing in this module builds one** (TASK-1a415107fd56). It is
-    /// [`crate::bindings`] that composes an act, from the row whose key was
-    /// pressed, and this type is here because it is what a command *is* rather
-    /// than because a line makes one.
+    /// **Nothing in this module builds one.** It is [`crate::bindings`] that
+    /// composes an act, from the row whose key was pressed, and this type is
+    /// here because it is what a command *is*.
     Act(Act),
-    /// A line that named an act and did not give it what it needs. The reader's
-    /// own refusal and not the CLI's, and the line between the two is where the
-    /// fact lives: this one is about the line that was typed, and every refusal
-    /// on the state of the corpus stays the CLI's (ADR-8bd76e8d7c4e).
+    /// A key that named an act the screen cannot give it a subject for.
+    ///
+    /// The reader's own refusal and not the CLI's, and the line between the two
+    /// is where the fact lives: this one is about where the cursor is standing,
+    /// and every refusal on the state of the corpus stays the CLI's
+    /// (ADR-8bd76e8d7c4e). One key raises it -- `a` off the document, which is
+    /// `accept` with no proposal under it (`crate::bindings::of_key`).
+    ///
+    /// It said "a line that named an act and did not give it what it needs" for
+    /// as long as there was a line. There is none, and the fact it carries did
+    /// not need one.
     Malformed(String),
     Help,
-    /// The verbs past the six, named (TASK-1a415107fd56). `x`, and no word:
-    /// what it opens is a list of what this reader does not run, so there is
-    /// nothing for a person to have typed.
+    /// The verbs past the six, named (TASK-1a415107fd56). `x`, and nothing
+    /// else: what it opens is a list of what this reader does not run.
     Further,
-    /// The form one verb is filled in on, named
+    /// The form one verb is filled in on
     /// (TASK-d832452630d2, TASK-e8da6a00564a).
-    ///
-    /// A key and no word, like [`Command::Further`]: what it opens is a form
-    /// whose fields are read out of the contract, and a line that spelled the
-    /// verb would be the second road to a write ADR-c07e2694f0e1 closed.
     ///
     /// It carries the verb and nothing else. There are four forms now -- `new`,
     /// `edit`, `close` and `attest` -- and what differs between them is entirely
@@ -137,18 +153,7 @@ pub enum Command {
     /// [`crate::form::NEEDS`] and never an arm here. What the form *holds* is
     /// still the form's.
     Form(&'static str),
-    /// A line that asked for nothing: an empty prompt, or one carrying only
-    /// whitespace.
-    Nothing,
-    Unknown(String),
 }
-
-/// The kinds an identifier can start with, which is how a typed line is told
-/// from a command. Read off nothing: an identifier is `<KIND>-<hex>` and the
-/// kinds are a registry (ADR-c9f9), so a prefix that is not one of these is not
-/// treated as an identifier and falls through to [`Command::Unknown`], where it
-/// is named rather than swallowed.
-const IDENTIFIER_KINDS: &[&str] = &["task", "adr", "spec", "log"];
 
 /// One verb of the writing half, with the arguments the key or the form gave
 /// it.
@@ -169,300 +174,20 @@ pub struct Act {
 /// **Two answers, because there are two shapes of act and there always were.**
 /// The six that move an entity take `<id>` first, and the identifier is the
 /// view's to supply: the person at the keyboard said which entity they meant by
-/// being in the panel that names it, and a key press does not carry it. `ank
-/// new` takes a kind first, which is nothing the panels name at all -- so the
-/// act arrives carrying its own front, and the view must not put a row's
-/// identifier in front of it (TASK-d832452630d2).
+/// being on the row that names it, and a key press does not carry it. `ank new`
+/// takes a kind first, which is nothing a row names at all -- so the act
+/// arrives carrying its own front, and the view must not put a row's identifier
+/// in front of it (TASK-d832452630d2).
 ///
 /// Stated on the act rather than decided from the verb's name, so a second verb
 /// of this shape is a field on its row and never an arm somewhere that has to
 /// be remembered.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Subject {
-    /// The entity the focused panel names goes in front. What all six of the
-    /// writing half take.
+    /// The entity under the cursor goes in front. What all six of the writing
+    /// half take.
     Selected,
     /// The act already carries its own first positional, and nothing is put in
     /// front of it.
     Given,
-}
-
-pub fn parse(line: &str) -> Command {
-    let line = line.trim();
-    // A prompt opened and submitted empty asked for nothing, and answering it
-    // with the obvious next thing would be the reader choosing a command for
-    // somebody who chose none. Under the line discipline this was Enter and
-    // meant "open"; Enter is a key now, and it still does.
-    if line.is_empty() {
-        return Command::Nothing;
-    }
-    if let Some(text) = line.strip_prefix('/') {
-        return Command::Search(non_empty(text));
-    }
-    let (word, rest) = match line.split_once(char::is_whitespace) {
-        Some((w, r)) => (w, r.trim()),
-        None => (line, ""),
-    };
-    match word {
-        "q" | "quit" => Command::Quit,
-        "reload" => Command::Reload,
-        "g" | "top" => Command::Top,
-        "b" | "back" => Command::Back,
-        "constraints" => Command::Constraints,
-        "open" => Command::Open,
-        "?" | "help" => Command::Help,
-        "filter" => Command::Kind(non_empty(rest).map(|k| k.to_ascii_lowercase())),
-        // `v` and not a letter closer to the word: `q` is quit, and a queue one
-        // keystroke from the way out is a queue nobody opens twice.
-        "v" | "queue" => Command::Queue,
-        "next" => Command::Page(1),
-        "prev" => Command::Page(-1),
-        // And a word this grammar does not know is named back, whether or not
-        // it happens to be a verb. `claim` here is `Command::Unknown("claim")`
-        // and reaches nothing: the six are keys, and a second road to them is
-        // exactly what TASK-1a415107fd56 closed.
-        _ => repeated(word).unwrap_or_else(|| other(line)),
-    }
-}
-
-/// `j`, `k`, and the same with a count in front: `5j`.
-///
-/// The count is the one piece of vi a line-oriented reader can keep for free,
-/// and it is what makes a list of twelve hundred entities navigable without a
-/// scrollbar.
-fn repeated(word: &str) -> Option<Command> {
-    let (digits, letter) = word.split_at(word.len().checked_sub(1)?);
-    let step: isize = if digits.is_empty() {
-        1
-    } else {
-        digits.parse().ok()?
-    };
-    match letter {
-        "j" => Some(Command::Move(step)),
-        "k" => Some(Command::Move(-step)),
-        _ => None,
-    }
-}
-
-fn other(line: &str) -> Command {
-    if let Ok(n) = line.parse::<usize>() {
-        return Command::Row(n);
-    }
-    let kind = line
-        .split('-')
-        .next()
-        .unwrap_or_default()
-        .to_ascii_lowercase();
-    if IDENTIFIER_KINDS.contains(&kind.as_str()) {
-        return Command::Select(line.to_string());
-    }
-    Command::Unknown(line.to_string())
-}
-
-fn non_empty(s: &str) -> Option<String> {
-    let s = s.trim();
-    (!s.is_empty()).then(|| s.to_string())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn list(line: &str) -> Command {
-        parse(line)
-    }
-
-    /// A prompt submitted empty runs nothing. Enter is a key and opening a row
-    /// is what it does; a line that says nothing must not be turned into a
-    /// command nobody typed.
-    #[test]
-    fn an_empty_line_asks_for_nothing() {
-        assert_eq!(parse(""), Command::Nothing);
-        assert_eq!(parse("   "), Command::Nothing);
-    }
-
-    /// The words this grammar reads, and the letters that are allowed to stand
-    /// for one.
-    #[test]
-    fn the_short_words_and_their_long_forms_agree() {
-        for (short, long, expected) in [
-            ("q", "quit", Command::Quit),
-            ("g", "top", Command::Top),
-            ("b", "back", Command::Back),
-            ("v", "queue", Command::Queue),
-        ] {
-            assert_eq!(list(short), expected, "{short}");
-            assert_eq!(list(long), expected, "{long}");
-        }
-        for (long, expected) in [
-            ("reload", Command::Reload),
-            ("constraints", Command::Constraints),
-            ("open", Command::Open),
-            ("next", Command::Page(1)),
-            ("prev", Command::Page(-1)),
-            ("filter", Command::Kind(None)),
-        ] {
-            assert_eq!(list(long), expected, "{long}");
-        }
-    }
-
-    /// **No letter means one thing typed and another pressed**
-    /// (TASK-1a415107fd56).
-    ///
-    /// The trap this closes is `c`: it was `constraints` here while it was the
-    /// constraints key, and the key is `claim` now. A grammar that had kept the
-    /// old meaning would be a second vocabulary on the same letter, in the one
-    /// place a person is least able to tell which surface they are on.
-    ///
-    /// Stated over every letter and both ways round, rather than over the two
-    /// that moved: the letter that gets it wrong next will be the one the next
-    /// wave reassigns.
-    #[test]
-    fn a_letter_is_a_word_here_only_where_the_key_means_the_same() {
-        use crate::keys::{typed, Press};
-        use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-
-        for c in 'a'..='z' {
-            let word = parse(&c.to_string());
-            // A letter this grammar does not read is not a second meaning for
-            // it. Everything else is measured, `j` and `k` included: they are
-            // the same command typed and pressed, which is what the rule looks
-            // like when it holds.
-            if matches!(word, Command::Unknown(_)) {
-                continue;
-            }
-            let key = typed(
-                KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE),
-                Focus::Entities,
-            );
-            assert_eq!(
-                Press::Run(word.clone()),
-                key,
-                "'{c}' is {word:?} typed and {key:?} pressed"
-            );
-        }
-    }
-
-    #[test]
-    fn a_count_in_front_of_a_move_is_the_repeat() {
-        assert_eq!(list("j"), Command::Move(1));
-        assert_eq!(list("k"), Command::Move(-1));
-        assert_eq!(list("12j"), Command::Move(12));
-        assert_eq!(list("3k"), Command::Move(-3));
-        // A count with no letter is a row number, which is what the list
-        // prints beside every row.
-        assert_eq!(list("12"), Command::Row(12));
-    }
-
-    #[test]
-    fn an_identifier_selects_and_anything_else_is_named() {
-        assert_eq!(list("TASK-4974"), Command::Select("TASK-4974".to_string()));
-        assert_eq!(list("adr-8bd7"), Command::Select("adr-8bd7".to_string()));
-        // Not a kind of this corpus: named back rather than treated as an
-        // identifier that will then resolve to nothing.
-        assert_eq!(list("EPIC-0001"), Command::Unknown("EPIC-0001".to_string()));
-        assert_eq!(list("zzz"), Command::Unknown("zzz".to_string()));
-    }
-
-    #[test]
-    fn a_filter_carries_its_argument_and_an_empty_one_clears_it() {
-        assert_eq!(list("filter adr"), Command::Kind(Some("adr".to_string())));
-        assert_eq!(list("filter ADR"), Command::Kind(Some("adr".to_string())));
-        assert_eq!(list("filter"), Command::Kind(None));
-        assert_eq!(list("filter task"), Command::Kind(Some("task".to_string())));
-        // And not `f`, which is the key that walks to the *next* kind: one
-        // letter, two commands, is what this grammar no longer has.
-        assert_eq!(list("f"), Command::Unknown("f".to_string()));
-    }
-
-    /// **No word typed anywhere reaches a verb** (TASK-1a415107fd56,
-    /// ADR-c07e2694f0e1).
-    ///
-    /// The claim this module is answerable for after the wave, and it is stated
-    /// over every verb the contract declares rather than over the six: the six
-    /// are what a person is most likely to type, and a grammar that had quietly
-    /// kept `attest` or `edit` would be exactly as much of a second road as one
-    /// that kept `claim`.
-    ///
-    /// Every shape a line could carry them in, too. A bare word, a word with a
-    /// tail, a word behind its own flag: the verbs left this grammar, so none
-    /// of the three is an act and none of them is a refusal *about* an act
-    /// either -- they are words this reader does not know, and it says so.
-    #[test]
-    fn no_verb_of_the_contract_is_a_word_this_grammar_reads() {
-        for spec in ank_contract::verbs::COMMANDS {
-            for line in [
-                spec.name.to_string(),
-                format!("{} something", spec.name),
-                format!("{} --reason 'a reason'", spec.name),
-            ] {
-                assert!(
-                    !matches!(parse(&line), Command::Act(_)),
-                    "'{line}' reaches a verb, and no typed word may"
-                );
-            }
-        }
-    }
-
-    /// And the six the gate allows are named back like any other word
-    /// (TASK-1a415107fd56).
-    ///
-    /// The half above cannot see: "not an act" would also be true of a grammar
-    /// that refused them with a sentence, and a refusal reads as a road that is
-    /// closed today. What the prompt does with `claim` is what it does with
-    /// `zzz` -- it does not know the word -- because the letters are where the
-    /// verbs are and there is nothing here to explain.
-    #[test]
-    fn the_verbs_the_gate_allows_are_words_this_grammar_does_not_know() {
-        for verb in crate::ank::ACTS {
-            // `log` is the exception and it is not one: it is a *kind* of this
-            // corpus, so a bare `log` is read as the front of an identifier and
-            // selects, exactly as `task` and `adr` do. A read, and the same one
-            // it was before the verbs left.
-            let expected = match *verb {
-                "log" => Command::Select(verb.to_string()),
-                _ => Command::Unknown(verb.to_string()),
-            };
-            assert_eq!(
-                parse(verb),
-                expected,
-                "'{verb}' is still a word of this grammar"
-            );
-        }
-    }
-
-    /// No single letter writes either, which is the same claim from the other
-    /// end: the letters that write are keys, and `keys::typed` never reads one
-    /// through this grammar.
-    #[test]
-    fn no_line_of_this_grammar_can_write() {
-        for c in 'a'..='z' {
-            let line = c.to_string();
-            assert!(
-                !matches!(parse(&line), Command::Act(_)),
-                "'{line}' writes, and no line may"
-            );
-        }
-        for line in ["d", "cl", "clai", "don", "rel", "am", "acce", "close"] {
-            assert!(
-                !matches!(parse(line), Command::Act(_)),
-                "'{line}' writes, and no line may"
-            );
-        }
-    }
-
-    #[test]
-    fn a_search_takes_the_rest_of_the_line_including_its_spaces() {
-        assert_eq!(
-            list("/terminal reader"),
-            Command::Search(Some("terminal reader".to_string()))
-        );
-        assert_eq!(list("/"), Command::Search(None));
-        // A slash is not a word boundary, so a query starting with a command
-        // letter is still a query.
-        assert_eq!(list("/q"), Command::Search(Some("q".to_string())));
-        // Nor is a verb, which is the search a person looking for the six
-        // would actually type.
-        assert_eq!(list("/claim"), Command::Search(Some("claim".to_string())));
-    }
 }

--- a/crates/ank-tui/src/keys.rs
+++ b/crates/ank-tui/src/keys.rs
@@ -1,9 +1,14 @@
-//! One key per command, and the one place a line is still typed
-//! (ADR-c07e2694f0e1).
+//! One key per command, and the three regimes a keystroke is read in
+//! (ADR-c07e2694f0e1, ADR-559eebf5c6f5).
+//!
+//! The table is one of them and the other two are modal: [`confirming`], which
+//! is what stands in front of every spawned write, and [`narrowing`], which is
+//! the search. None of the three reads a line, and the last of the three
+//! stopped reading one with TASK-c94d086682f3.
 //!
 //! **The keys themselves are declared in [`crate::bindings`] and not here**
 //! (TASK-4d2eb2b4e193). What this module is now is the two grammars a table
-//! cannot state -- the modifiers, and what a line editor does with a keystroke
+//! cannot state -- the modifiers, and what the search does with a keystroke
 //! -- and the whole-domain suite at the foot of the file that measures the
 //! table over every key a terminal can report. The prose below says what the
 //! table says and is answerable to it, not the other way round: a key named
@@ -50,20 +55,37 @@
 //! keystroke this table answers. Nothing is lost, because nothing was ever
 //! *only* a chord.
 //!
-//! # Why there is still a line, and where
+//! # There is no line left, and the search is why
 //!
-//! For the search, and for nothing else (TASK-1a415107fd56). `/` opens a
-//! one-line prompt seeded with a slash and what is typed there goes through
-//! [`crate::input::parse`]; no word that grammar reads writes anything, and the
-//! prompt a verb used to be spelled into is gone with the key that opened it.
+//! **`/` narrows the list as it is typed** (TASK-c94d086682f3,
+//! ADR-559eebf5c6f5: *a search narrows the list as it is typed and is not a
+//! line to compose and submit*). What `/` opened before was a one-line prompt
+//! seeded with a slash, read by a grammar in `crate::input`, and it ran nothing
+//! until Enter. There is no grammar there now and nothing to submit here: every
+//! character is a needle one character longer and a list narrowed to it, every
+//! Backspace is the list widening again, and Escape gives it back whole.
+//!
+//! So the third regime this module carries is [`narrowing`] and no longer a
+//! line editor. It keeps the shape of one -- a buffer, a keystroke, an outcome
+//! -- because that is what typing *is*; what it no longer keeps is a state
+//! where something has been composed and not yet run.
+//!
+//! **Enter is not a submit and there is nothing for it to be one of.** The
+//! list is already narrowed by the time it is pressed, on every keystroke that
+//! came before it, so what Enter does is leave the search with the narrowing in
+//! force -- which is what gives the alphabet back to the key table, since every
+//! letter is a needle while the search is open. Escape is the other way out and
+//! it takes the narrowing with it. Two ways out, both named on the key list,
+//! neither of them a command waiting to be run.
+//!
 //! What a verb carries in a tail -- a message, a reason, a proof, a field --
-//! comes back as a form. It arrived with TASK-d832452630d2, on `ank new`, and
-//! TASK-e8da6a00564a puts `edit`, `close` and `attest` on the same one: `n` and
-//! `e` open [`crate::form`], and so does a row of the list `x` opens. Its
-//! fields are the flags the contract declares for the verb, and it is modal, so
-//! no letter typed into it is a command and no word typed into it reaches a
-//! verb -- what reaches one is Enter, and what Enter reaches is the
-//! confirmation.
+//! comes back as a form and never as a line. It arrived with TASK-d832452630d2,
+//! on `ank new`, and TASK-e8da6a00564a puts `edit`, `close` and `attest` on the
+//! same one: `n` and `e` open [`crate::form`], and so does a row of the list
+//! `x` opens. Its fields are the flags the contract declares for the verb, and
+//! it is modal, so no letter typed into it is a command and no word typed into
+//! it reaches a verb -- what reaches one is Enter, and what Enter reaches is
+//! the confirmation.
 //!
 //! # The guarantee, now that the letter is one keystroke
 //!
@@ -96,24 +118,33 @@ use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 /// What a key press asks for, once the focused panel is known.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Press {
-    /// A command of the grammar, ready to run.
+    /// A command of the table, ready to run.
     Run(Command),
     /// `f`: narrow to the next kind, which needs the one in force and is
     /// therefore the screen's to compute rather than this module's.
     Cycle,
-    /// Open the one-line prompt, seeded with this much of a line.
-    Prompt(&'static str),
+    /// `/`: start a search, which narrows the list on every keystroke after it
+    /// (TASK-c94d086682f3).
+    ///
+    /// It carries nothing. It was `Prompt(&'static str)` and the string was the
+    /// seed a line opened on -- a slash, because the grammar that read the line
+    /// told a search from a command by it. There is no grammar and so no seed:
+    /// what `/` opens is the search itself, and the needle starts empty because
+    /// an empty needle is a list narrowed by nothing, which is where a person
+    /// pressing it is standing.
+    Find,
     /// A key this screen has nothing to do with. Named as a variant rather than
-    /// answered with [`Command::Unknown`]: an unmapped key is not a person
-    /// getting a command wrong, and a note saying so on every stray arrow would
-    /// be noise where the line reader had a typo.
+    /// answered with a refusal: an unmapped key is not a person getting a
+    /// command wrong, and a note saying so on every stray arrow would be noise.
     Ignored,
 }
 
-/// The key that opens the prompt, seeded with the grammar's search.
+/// The key that starts the search.
 ///
-/// The one key that still opens a line. What it opens is a search and not a
-/// verb: `crate::input::parse` reads no verb at all (TASK-1a415107fd56).
+/// It opened a line until TASK-c94d086682f3 and opens none now: what follows it
+/// is a needle, and the list is narrowed to it on the keystroke rather than on
+/// an Enter. What Enter does here is end the search keeping that narrowing,
+/// which [`Narrowing::Kept`] says and is not a submit.
 pub const FIND: char = '/';
 /// The one key that runs a command a person has been shown
 /// (TASK-d4a882345837).
@@ -204,48 +235,73 @@ pub fn next_kind(kind: Option<&str>) -> Option<String> {
     }
 }
 
-/// What one key did to an open prompt.
+/// What one key did to an open search (TASK-c94d086682f3, ADR-559eebf5c6f5).
+///
+/// **Three outcomes and none of them is a submit.** The list is narrowed to
+/// whatever the needle says on every keystroke, so there is no state where
+/// something has been composed and is waiting to be run -- which is the whole
+/// of what this replaces. `Editing` had `Typing`, `Submit` and `Cancel`, and
+/// the middle one was the prompt's reason to exist.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Editing {
-    /// The line changed, or the key meant nothing here. Either way the prompt
-    /// stays open and nothing runs.
-    Typing,
-    /// Enter: the line is a command now.
-    Submit,
-    /// Escape, or a backspace that emptied it. The prompt closes and nothing
-    /// runs -- which is what a person who opened it by accident needs, and the
-    /// only road back out.
-    Cancel,
+pub enum Narrowing {
+    /// The needle is what it is now, and the list narrows to it. Every
+    /// character, every Backspace, and every key this regime has no other
+    /// answer for: the search stays open and the list follows the needle.
+    Narrowed,
+    /// Enter: the search ends and the list stays narrowed.
+    ///
+    /// **Not a submit**, and the difference is not a word: nothing is run here
+    /// and nothing is composed, because the narrowing this leaves in force
+    /// happened on the keystrokes before it. What it buys is the alphabet --
+    /// every letter is a needle while the search is open, so a person who has
+    /// found what they were looking for needs a way to have the keys back
+    /// without losing the list they narrowed to.
+    Kept,
+    /// Escape, Control-C, or a Backspace off the end of an empty needle: the
+    /// search ends and the list comes back unnarrowed.
+    ///
+    /// The road out for a person who opened it by accident, and the one that
+    /// undoes what the typing did. A needle deleted to nothing has already
+    /// widened the list back, so the one extra Backspace only closes what is
+    /// left.
+    Undone,
 }
 
-pub fn edit(line: &mut String, key: KeyEvent) -> Editing {
+/// One keystroke against the open search.
+///
+/// The two chords are the ones the line editor answered and they are kept for
+/// the reason they were there: neither is the only road to what it does.
+/// Control-C leaves, and so does Escape; Control-U empties the needle, and so
+/// does holding Backspace. `no_way_through_the_search_requires_a_modifier`
+/// states that over the whole table.
+pub fn narrowing(needle: &mut String, key: KeyEvent) -> Narrowing {
     if key.modifiers.contains(KeyModifiers::CONTROL) {
         return match key.code {
-            KeyCode::Char('c') => Editing::Cancel,
-            // The line, cleared: a long `log` message typed wrongly is not a
-            // reason to hold Backspace.
+            KeyCode::Char('c') => Narrowing::Undone,
+            // The needle, cleared. The list widens back on this keystroke like
+            // it does on any other: what is being typed is the narrowing.
             KeyCode::Char('u') => {
-                line.clear();
-                Editing::Typing
+                needle.clear();
+                Narrowing::Narrowed
             }
-            _ => Editing::Typing,
+            _ => Narrowing::Narrowed,
         };
     }
     match key.code {
-        KeyCode::Enter => Editing::Submit,
-        KeyCode::Esc => Editing::Cancel,
-        KeyCode::Backspace => match line.pop() {
-            // Backspacing off the end of an empty line closes the prompt. A
+        KeyCode::Enter => Narrowing::Kept,
+        KeyCode::Esc => Narrowing::Undone,
+        KeyCode::Backspace => match needle.pop() {
+            // Backspacing off the end of an empty needle ends the search. A
             // person deleting what they typed and then one more has said they
             // did not mean to be here.
-            None => Editing::Cancel,
-            Some(_) => Editing::Typing,
+            None => Narrowing::Undone,
+            Some(_) => Narrowing::Narrowed,
         },
         KeyCode::Char(c) => {
-            line.push(c);
-            Editing::Typing
+            needle.push(c);
+            Narrowing::Narrowed
         }
-        _ => Editing::Typing,
+        _ => Narrowing::Narrowed,
     }
 }
 
@@ -450,23 +506,33 @@ mod tests {
         );
     }
 
-    /// The one key that still opens a line opens it on a search, and what it
-    /// seeds is what the grammar reads (TASK-1a415107fd56).
+    /// **`/` starts the search and no key opens a line at all**
+    /// (TASK-c94d086682f3, ADR-559eebf5c6f5).
+    ///
+    /// Stated over the whole table and not over `/` alone. The claim the wave
+    /// leaves this module answerable for is that the compose-and-submit grammar
+    /// is not reachable from anywhere, and a test that only checked what `/`
+    /// does would pass on a table that had quietly kept a second key opening a
+    /// line on something else.
     #[test]
-    fn the_one_prompt_key_seeds_the_search_it_opens() {
-        assert_eq!(press(FIND, Focus::Entities), Press::Prompt("/"));
+    fn the_find_key_starts_a_search_and_no_key_opens_a_line() {
+        assert_eq!(press(FIND, Focus::Entities), Press::Find);
+        // The needle starts empty, so the first character typed is the first
+        // character of the needle: there is no seed to clear.
+        let mut needle = String::new();
         assert_eq!(
-            crate::input::parse("/a needle"),
-            Command::Search(Some("a needle".to_string()))
+            narrowing(&mut needle, key(KeyCode::Char('a'))),
+            Narrowing::Narrowed
         );
-        // And no key opens a line on nothing: the prompt a verb was spelled
-        // into is gone, so no binding of the table seeds an empty one.
+        assert_eq!(needle, "a");
+        // And `/` is the only key that starts one, from every screen.
         for code in table::every_key() {
             for view in Focus::ALL {
-                assert_ne!(
-                    typed(key(code), view),
-                    Press::Prompt(""),
-                    "{code:?} opens the prompt a verb was spelled into"
+                let starts = typed(key(code), view) == Press::Find;
+                assert_eq!(
+                    starts,
+                    code == KeyCode::Char(FIND),
+                    "{code:?} in {view:?} starts a search"
                 );
             }
         }
@@ -551,17 +617,34 @@ mod tests {
         assert_eq!(next_kind(Some("epic")), None);
     }
 
+    /// **The needle grows on the keystroke and there is nothing to submit**
+    /// (TASK-c94d086682f3).
+    ///
+    /// Every character is a needle one longer and the list narrowed to it, and
+    /// what the two ways out do is end the search: Enter with the narrowing in
+    /// force, Escape with it undone. Neither of them is the keystroke on which
+    /// the narrowing happens, which is the whole difference from the line this
+    /// replaces.
     #[test]
-    fn the_prompt_takes_a_line_and_gives_two_ways_out() {
-        let mut line = String::new();
-        for c in "claim".chars() {
-            assert_eq!(edit(&mut line, key(KeyCode::Char(c))), Editing::Typing);
+    fn the_needle_grows_on_the_keystroke_and_the_two_ways_out_end_the_search() {
+        let mut needle = String::new();
+        for (typed_so_far, c) in "task".chars().enumerate().map(|(i, c)| (i + 1, c)) {
+            assert_eq!(
+                narrowing(&mut needle, key(KeyCode::Char(c))),
+                Narrowing::Narrowed,
+                "'{c}' did not narrow"
+            );
+            assert_eq!(needle.chars().count(), typed_so_far);
         }
-        assert_eq!(line, "claim");
-        assert_eq!(edit(&mut line, key(KeyCode::Backspace)), Editing::Typing);
-        assert_eq!(line, "clai");
-        assert_eq!(edit(&mut line, key(KeyCode::Enter)), Editing::Submit);
-        assert_eq!(edit(&mut line, key(KeyCode::Esc)), Editing::Cancel);
+        assert_eq!(needle, "task");
+        assert_eq!(
+            narrowing(&mut needle, key(KeyCode::Backspace)),
+            Narrowing::Narrowed
+        );
+        assert_eq!(needle, "tas", "a Backspace widens the list back");
+        assert_eq!(narrowing(&mut needle, key(KeyCode::Enter)), Narrowing::Kept);
+        assert_eq!(needle, "tas", "Enter changed the needle");
+        assert_eq!(narrowing(&mut needle, key(KeyCode::Esc)), Narrowing::Undone);
     }
 
     /// One key runs a confirmed command, and the whole of the rest of the
@@ -633,18 +716,24 @@ mod tests {
         assert_eq!(confirming(key(KeyCode::Char('Y'))), Answer::Dismiss);
     }
 
-    /// Backspacing off the end of an empty line closes the prompt, and clearing
+    /// Backspacing off the end of an empty needle ends the search, and clearing
     /// it does not.
     #[test]
-    fn an_emptied_prompt_closes_and_a_cleared_one_stays_open() {
-        let mut line = String::from("x");
-        assert_eq!(edit(&mut line, key(KeyCode::Backspace)), Editing::Typing);
-        assert_eq!(edit(&mut line, key(KeyCode::Backspace)), Editing::Cancel);
+    fn an_emptied_needle_ends_the_search_and_a_cleared_one_stays_open() {
+        let mut needle = String::from("x");
+        assert_eq!(
+            narrowing(&mut needle, key(KeyCode::Backspace)),
+            Narrowing::Narrowed
+        );
+        assert_eq!(
+            narrowing(&mut needle, key(KeyCode::Backspace)),
+            Narrowing::Undone
+        );
 
-        let mut line = String::from("done commit:2d9c847");
+        let mut needle = String::from("a long needle");
         let cleared = KeyEvent::new(KeyCode::Char('u'), KeyModifiers::CONTROL);
-        assert_eq!(edit(&mut line, cleared), Editing::Typing);
-        assert!(line.is_empty());
+        assert_eq!(narrowing(&mut needle, cleared), Narrowing::Narrowed);
+        assert!(needle.is_empty(), "the list is not back to every row");
     }
 }
 
@@ -973,50 +1062,50 @@ mod table {
         assert_eq!(ran, 1, "exactly one keystroke in the whole table runs it");
     }
 
-    /// The prompt's table, over the same domain.
+    /// The search's table, over the same domain.
     ///
-    /// Two chords are answered there -- Control-C leaves and Control-U clears
-    /// the line -- and neither is the only road to what it does: Escape leaves,
-    /// and Backspace held down empties. So the state a chord reaches in the
-    /// prompt is a state a bare key reaches too, which is the same rule as
-    /// above wearing the prompt's clothes.
+    /// Two chords are answered there -- Control-C ends it and Control-U clears
+    /// the needle -- and neither is the only road to what it does: Escape ends
+    /// it, and Backspace held down empties the needle. So the state a chord
+    /// reaches in the search is a state a bare key reaches too, which is the
+    /// same rule as above wearing the search's clothes.
     #[test]
-    fn no_way_through_the_prompt_requires_a_modifier() {
+    fn no_way_through_the_search_requires_a_modifier() {
         for code in every_key() {
             for held in every_modifier() {
                 if held.is_empty() {
                     continue;
                 }
-                let mut line = String::from("done commit:2d9c847");
-                let outcome = edit(&mut line, KeyEvent::new(code, held));
-                // Whatever it did, a bare key does it too: Escape cancels,
-                // Enter submits, and any character is typing.
+                let mut needle = String::from("a needle");
+                let outcome = narrowing(&mut needle, KeyEvent::new(code, held));
+                // Whatever it did, a bare key does it too: Escape ends the
+                // search, Enter keeps the narrowing, and any character narrows.
                 let bare = match outcome {
-                    Editing::Cancel => KeyCode::Esc,
-                    Editing::Submit => KeyCode::Enter,
-                    Editing::Typing => KeyCode::Char('x'),
+                    Narrowing::Undone => KeyCode::Esc,
+                    Narrowing::Kept => KeyCode::Enter,
+                    Narrowing::Narrowed => KeyCode::Char('x'),
                 };
-                let mut same = String::from("done commit:2d9c847");
+                let mut same = String::from("a needle");
                 assert_eq!(
-                    edit(&mut same, KeyEvent::new(bare, KeyModifiers::NONE)),
+                    narrowing(&mut same, KeyEvent::new(bare, KeyModifiers::NONE)),
                     outcome,
                     "{code:?} with {held:?} does something no bare key does"
                 );
             }
         }
-        // And the one state a chord is a shortcut to -- an emptied line with
-        // the prompt still open -- is reached by holding Backspace, which is
+        // And the one state a chord is a shortcut to -- an emptied needle with
+        // the search still open -- is reached by holding Backspace, which is
         // what makes Control-U a convenience rather than a requirement.
-        let mut line = String::from("done");
+        let mut needle = String::from("task");
         for _ in 0..4 {
             assert_eq!(
-                edit(
-                    &mut line,
+                narrowing(
+                    &mut needle,
                     KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE)
                 ),
-                Editing::Typing
+                Narrowing::Narrowed
             );
         }
-        assert!(line.is_empty(), "the prompt empties without a chord");
+        assert!(needle.is_empty(), "the needle empties without a chord");
     }
 }

--- a/crates/ank-tui/src/lib.rs
+++ b/crates/ank-tui/src/lib.rs
@@ -89,9 +89,11 @@
 //! but one positional, so a repaint can reach the reading half and nothing that
 //! writes.
 //!
-//! What is left of the typed word is two places, and neither of them reaches a
-//! verb by being read. `/` opens the one-line prompt on a search, and
-//! [`input`]'s grammar carries no verb at all. `n` opens the form
+//! What is left of typing is two places, and neither of them reaches a verb by
+//! being read. `/` starts a search that narrows the list on every keystroke
+//! and has nothing to submit (TASK-c94d086682f3, ADR-559eebf5c6f5): there is no
+//! line there and no grammar behind it, so there is no word for a verb to be.
+//! `n` opens the form
 //! (TASK-d832452630d2), whose fields are the flags `ank help --json` declares
 //! for `ank new` and which is modal: a letter typed into it is a letter, and
 //! what reaches the verb is Enter, and what Enter reaches is the confirmation.

--- a/crates/ank-tui/src/view.rs
+++ b/crates/ank-tui/src/view.rs
@@ -227,7 +227,7 @@ use crate::ank::{Ank, Failed, Ran};
 use crate::bindings::{self, Binding, Holding};
 use crate::form::{Filled, Form, SET as SETTING};
 use crate::input::{Act, Command, Subject};
-use crate::keys::{self, Editing, Press};
+use crate::keys::{self, Narrowing, Press};
 use crate::model::{self, short_of, Detail, Held, Queue, Row, Setting, Settings, Snapshot};
 use crate::paint::{self, role_of_id, Composed, Ink};
 use crate::stream::Stream;
@@ -497,14 +497,21 @@ pub struct App {
     /// `reload`, and a pane refreshed from there would be a stream of `ank
     /// config` calls nobody asked for.
     config: Option<Settings>,
-    /// The one-line prompt, open, with what has been typed into it so far.
+    /// The open search, with the needle typed into it so far
+    /// (TASK-c94d086682f3, ADR-559eebf5c6f5).
     ///
-    /// `None` is the ordinary state and it is where every key is a command. The
-    /// prompt is what a verb carrying a message, a reason, a proof or a flag is
-    /// spelled into, and what a search is typed into; it is opened by a key,
-    /// dismissed by a key, and runs nothing until Enter -- at which point what
-    /// it produced is a [`Pending`] and still not a spawned verb.
-    prompt: Option<String>,
+    /// `None` is the ordinary state and it is where every key is a command;
+    /// `Some` is where every character is a needle. It is not a line waiting to
+    /// be read: [`App::search`] is set from it on every keystroke, so what this
+    /// holds and what the list is narrowed by are the same string for as long
+    /// as the search is open. What it carries that `search` does not is that
+    /// the search is *open*, which is what makes the state modal and what
+    /// [`App::holding`] reads.
+    ///
+    /// The two outlive each other in one direction only: Enter closes this and
+    /// leaves `search` where it is, which is how a narrowing survives the
+    /// keyboard coming back.
+    needle: Option<String>,
     /// The verb that has been composed and shown and not yet run
     /// (TASK-d4a882345837).
     ///
@@ -609,7 +616,7 @@ impl App {
             stream,
             queue: None,
             config: None,
-            prompt: None,
+            needle: None,
             pending: None,
             // The two reads of the environment this crate makes, and they
             // ask it one thing between them. A session is at a terminal by
@@ -891,17 +898,35 @@ impl App {
         if self.pending.is_some() {
             return self.answer(key, ank);
         }
-        if let Some(line) = &mut self.prompt {
-            return match keys::edit(line, key) {
-                Editing::Typing => false,
-                Editing::Cancel => {
-                    self.prompt = None;
+        // The search, which narrows on the keystroke and has nothing to submit
+        // (TASK-c94d086682f3, ADR-559eebf5c6f5). What stood here read a line
+        // into a buffer, ran nothing until Enter, and then handed the whole
+        // string to a grammar; the grammar is gone and so is the wait.
+        //
+        // The needle is applied through `act` like any other command, which is
+        // what keeps one road to `self.search`: a keystroke is a
+        // `Command::Search`, and `Command::Search` is the only thing that
+        // narrows the list.
+        if let Some(needle) = &mut self.needle {
+            return match keys::narrowing(needle, key) {
+                Narrowing::Narrowed => {
+                    let text = needle.clone();
+                    let narrowed = (!text.is_empty()).then_some(text);
+                    self.act(Command::Search(narrowed), ank)
+                }
+                // The search ends and the narrowing stays. Nothing is run:
+                // the list has been narrowed on every keystroke that came
+                // before this one, and what this gives back is the keyboard.
+                Narrowing::Kept => {
+                    self.needle = None;
                     false
                 }
-                Editing::Submit => {
-                    let line = self.prompt.take().unwrap_or_default();
-                    let command = crate::input::parse(&line);
-                    self.act(command, ank)
+                // And the list comes back whole, which is the half of the
+                // criterion a close alone would not have met: a search
+                // dismissed used to leave the narrowing it had made.
+                Narrowing::Undone => {
+                    self.needle = None;
+                    self.act(Command::Search(None), ank)
                 }
             };
         }
@@ -943,8 +968,11 @@ impl App {
                 let next = keys::next_kind(self.kind.as_deref());
                 self.act(Command::Kind(next), ank)
             }
-            Press::Prompt(seed) => {
-                self.prompt = Some(seed.to_string());
+            // The search, started on an empty needle: there is no seed, because
+            // there is no grammar left to tell a search from a command by one
+            // (TASK-c94d086682f3).
+            Press::Find => {
+                self.needle = Some(String::new());
                 false
             }
             // A key this screen does not answer to leaves everything where it
@@ -1023,7 +1051,7 @@ impl App {
                     // keystroke that is not the one key that runs.
                     return self.answer(KeyEvent::new(KeyCode::Null, KeyModifiers::NONE), ank);
                 }
-                if self.prompt.is_some() {
+                if self.needle.is_some() {
                     return false;
                 }
                 // The one target the frame always carries, and it is resolved
@@ -1049,10 +1077,10 @@ impl App {
         }
     }
 
-    /// A scroll, where a scroll means anything: under a prompt or a
+    /// A scroll, where a scroll means anything: under an open search or a
     /// confirmation nothing moves, which is the modal rule again.
     fn moved(&mut self, by: isize, ank: &Ank) -> bool {
-        if self.pending.is_some() || self.prompt.is_some() {
+        if self.pending.is_some() || self.needle.is_some() {
             return false;
         }
         // A swipe over the form walks its fields, which is what the arrows do:
@@ -1294,39 +1322,16 @@ impl App {
                 };
                 self.focus_on(to, ank);
             }
-            Command::Select(needle) => {
-                match self.entity_rows().iter().position(|r| {
-                    r.id.to_ascii_uppercase()
-                        .starts_with(&needle.to_ascii_uppercase())
-                }) {
-                    Some(at) => {
-                        self.focus = Focus::Entities;
-                        self.cursors[Focus::Entities.number() - 1].at = at;
-                        self.clamp(Focus::Entities);
-                        self.open_selected(ank);
-                    }
-                    None => {
-                        self.note = Some(format!(
-                            "no entity here matches '{needle}' (a filter is on: f, /)"
-                        ))
-                    }
-                }
-            }
-            Command::Row(n) => {
-                if !self.focus.holds_rows() {
-                    self.note = Some(format!(
-                        "a document has no row {n}: it is paged, not selected"
-                    ));
-                    return false;
-                }
-                let total = self.count(self.focus);
-                if n == 0 || n > total {
-                    self.note = Some(format!("there is no row {n}: this screen holds {total}"));
-                } else {
-                    self.cursors[self.focus.number() - 1].at = n - 1;
-                    self.clamp(self.focus);
-                }
-            }
+            // `Command::Select` and `Command::Row` stood here
+            // (TASK-c94d086682f3). They were the two commands no key reached:
+            // an identifier typed whole jumped to the entity and opened it, and
+            // a row number landed on the row the list printed it beside. Both
+            // needed a line and there is none, so both are gone from
+            // `crate::input` -- and what replaces them is one clause of
+            // ADR-559eebf5c6f5 rather than two arms: `/4974` narrows the list
+            // to the rows carrying it as it is typed, which reaches the same
+            // entity in fewer keys and reaches it from a document too, where a
+            // row number only ever had a refusal to offer.
             Command::Kind(kind) => {
                 if let Some(k) = &kind {
                     if !keys::KINDS.contains(&k.as_str()) {
@@ -1382,10 +1387,6 @@ impl App {
             // `App::filling`, and the confirmation is on that road like every
             // other (TASK-d832452630d2).
             Command::Form(verb) => self.open_form(verb),
-            Command::Nothing => {}
-            Command::Unknown(word) => {
-                self.note = Some(format!("no command '{word}'; ? for the list"))
-            }
         }
         false
     }
@@ -1857,7 +1858,7 @@ impl App {
 
     /// One frame, onto a ratatui `Frame` (TASK-4fa385c1772d).
     ///
-    /// The caret is set only where a prompt is open, which is what makes
+    /// The caret is set only where a search is open, which is what makes
     /// ratatui show a cursor at all: on every other screen this reader has
     /// nothing to point at, and a block sitting on an arbitrary row would be a
     /// promise that something there can be typed into.
@@ -2617,11 +2618,11 @@ impl App {
         self.size.0
     }
 
-    /// Where the caret goes, which is the end of the prompt or nowhere.
+    /// Where the caret goes, which is the end of the needle or nowhere.
     fn caret(&self, area: Rect) -> Option<Position> {
-        let line = self.prompt.as_ref()?;
+        let line = self.needle.as_ref()?;
         let note = self.arrange(area).note;
-        let at = PROMPT.chars().count() + line.chars().count();
+        let at = SEARCH.chars().count() + line.chars().count();
         Some(Position::new(
             note.x + (at as u16).min(note.width.saturating_sub(1)),
             note.y,
@@ -2635,15 +2636,15 @@ impl App {
     /// measured rather than assumed, and the layout pays for what it actually
     /// is.
     ///
-    /// **An open prompt is drawn here and hides whatever the note was saying.**
+    /// **An open search is drawn here and hides whatever the note was saying.**
     /// One band of the screen belongs to whatever the reader is being told or
-    /// asked, and a person typing `done commit:<sha>` needs to see the line
-    /// they are typing far more than the answer to the command before it. What
-    /// was there comes back when the prompt is dismissed, because cancelling
-    /// runs nothing and nothing clears it.
+    /// asked, and a person narrowing a list needs to see the needle it is
+    /// narrowed by far more than the answer to the command before it. What was
+    /// there comes back when the search ends, because neither way out of it
+    /// runs anything and nothing clears it.
     ///
     /// **And a confirmation is drawn here too, above both of them**
-    /// (TASK-d4a882345837). It belongs in this band for the reason the prompt
+    /// (TASK-d4a882345837). It belongs in this band for the reason the needle
     /// does -- it is what the reader is asking -- and it belongs in the *chrome*
     /// rather than in a panel or a box of its own for two reasons that outlive
     /// this task. The chrome is full width and unbordered, so the command line
@@ -2673,8 +2674,8 @@ impl App {
             .map(|l| fit(&l, width))
             .collect();
         }
-        if let Some(line) = &self.prompt {
-            return vec![fit(&format!("{PROMPT}{line}"), width)];
+        if let Some(line) = &self.needle {
+            return vec![fit(&format!("{SEARCH}{line}"), width)];
         }
         match &self.note {
             None => match self
@@ -2754,14 +2755,15 @@ impl App {
     /// the same direction: a command waiting to be answered offers the key that
     /// runs it and the key that drops it and nothing else, because nothing else
     /// is what the rest of the keyboard does (TASK-d4a882345837); and an open
-    /// prompt offers the two ways out of a line. Anything else drawn under
-    /// either would be an offer the reader would refuse.
+    /// search offers the two ways out of it, since every letter is a needle
+    /// while one is open (TASK-c94d086682f3). Anything else drawn under either
+    /// would be an offer the reader would refuse.
     fn holding(&self) -> Holding {
         if self.pending.is_some() {
             return Holding::Waiting;
         }
-        if self.prompt.is_some() {
-            return Holding::Typing;
+        if self.needle.is_some() {
+            return Holding::Narrowing;
         }
         Holding::Panel(self.focus)
     }
@@ -2975,9 +2977,9 @@ impl App {
     /// **The writing half has its letters now** (TASK-1a415107fd56), so this is
     /// one line and no longer two roads. It was written with a second arm --
     /// a row of the writing half had no key to press, so it reached the verb
-    /// through the typed grammar, and a verb wanting a message opened the
-    /// prompt with its word in it. There is no keyless row left and no typed
-    /// grammar that reads a verb, so what remains is the rule the doc above
+    /// through the typed grammar, and a verb wanting a message opened a line
+    /// with its word in it. There is no keyless row left and no typed grammar
+    /// at all, so what remains is the rule the doc above
     /// states, applied to every row: a row is the key it names, and pressing it
     /// presses that key.
     ///
@@ -3757,12 +3759,14 @@ fn step(at: usize, by: isize, total: usize) -> usize {
     moved.clamp(0, last as isize) as usize
 }
 
-/// The marker the prompt is drawn behind.
+/// The marker the open search is drawn behind (TASK-c94d086682f3).
 ///
-/// What follows it is the line the grammar will be given, byte for byte,
-/// leading slash included: a person about to press Enter is looking at exactly
-/// what will be read.
-pub const PROMPT: &str = ": ";
+/// It was `": "` and it stood in front of a line the grammar was about to be
+/// given. There is no grammar and nothing is about to happen: what follows this
+/// is the needle the list is *already* narrowed to, so the marker is the search
+/// key itself, which is what a person pressed to get here and what every other
+/// incremental search on a terminal draws.
+pub const SEARCH: &str = "/";
 // `KEYS`, `PANEL_KEYS`, `ACT_KEYS` and `RATIFY_KEY` stood here
 // (TASK-4d2eb2b4e193). Four sentences about a key table, written beside two
 // other renderings of the same table, and ADR-c07e2694f0e1 records what they
@@ -5620,20 +5624,87 @@ mod tests {
         assert!(said.contains("ADR-8bd76e8d7c4e"), "{said}");
     }
 
+    /// **The list narrows on every keystroke, and Escape gives it back**
+    /// (TASK-c94d086682f3, ADR-559eebf5c6f5).
+    ///
+    /// This stands where `a_row_number_out_of_range_is_named_rather_than_
+    /// clamped_silently` stood, which is not a coincidence: the row number was
+    /// the affordance the search replaces, and it went with the line it was
+    /// typed on.
+    ///
+    /// The narrowing is read after each character rather than at the end. A
+    /// test that typed the whole needle and then looked would pass on the
+    /// reader this replaces -- one that composes a line and narrows once, on
+    /// Enter -- which is exactly the grammar the decision ends.
     #[test]
-    fn a_row_number_out_of_range_is_named_rather_than_clamped_silently() {
+    fn the_list_narrows_on_every_keystroke_and_escape_gives_it_back() {
         let mut a = app();
         let ank = nowhere();
-        a.act(Command::Row(99), &ank);
-        assert!(a.note.clone().unwrap().contains("there is no row 99"));
-        a.act(Command::Row(2), &ank);
-        assert_eq!(a.cursors[Focus::Entities.number() - 1].at, 1);
-        a.focus = Focus::Body;
-        a.act(Command::Row(1), &ank);
-        assert!(
-            a.note.unwrap().contains("a document has no row 1"),
-            "a document is paged, not selected"
+        let whole = rendered_rows(&a);
+        assert_eq!(whole.len(), 3, "the fixture is not three rows");
+
+        tap(&mut a, &ank, KeyCode::Char(keys::FIND));
+        assert_eq!(a.needle.as_deref(), Some(""), "the search opened on a seed");
+        assert_eq!(rendered_rows(&a), whole, "`/` narrowed before a needle");
+
+        // `spec` reaches one row, and it reaches it by the letter: after `s`
+        // the list is already shorter, which is the clause.
+        let mut narrowed = Vec::new();
+        for c in "spec".chars() {
+            tap(&mut a, &ank, KeyCode::Char(c));
+            narrowed.push(rendered_rows(&a).len());
+        }
+        assert_eq!(
+            narrowed,
+            [2, 1, 1, 1],
+            "the list did not follow the needle keystroke by keystroke"
         );
+        assert_eq!(rendered_rows(&a), ["SPEC-fe8bdb84faca"]);
+        assert_eq!(a.note, None, "narrowing said something");
+
+        // A Backspace widens it again, on the keystroke, for the same reason.
+        tap(&mut a, &ank, KeyCode::Backspace);
+        assert_eq!(rendered_rows(&a).len(), 1);
+        tap(&mut a, &ank, KeyCode::Backspace);
+        tap(&mut a, &ank, KeyCode::Backspace);
+        assert_eq!(rendered_rows(&a).len(), 2, "'s' matches two rows");
+
+        // And Escape gives the list back unnarrowed, which a search that only
+        // closed would not have done.
+        tap(&mut a, &ank, KeyCode::Esc);
+        assert_eq!(a.needle, None, "Escape left the search open");
+        assert_eq!(a.search, None);
+        assert_eq!(rendered_rows(&a), whole);
+    }
+
+    /// Enter ends the search with the narrowing in force, and runs nothing
+    /// (TASK-c94d086682f3).
+    ///
+    /// The other way out, and the one that gives the keyboard back: every
+    /// letter is a needle while the search is open, so a person who has found
+    /// their row needs to leave without losing it. It is not a submit -- there
+    /// is nothing composed for it to run -- and the assertion that nothing was
+    /// said is what holds that.
+    #[test]
+    fn enter_leaves_the_search_with_the_list_still_narrowed() {
+        let mut a = app();
+        let ank = nowhere();
+        tap(&mut a, &ank, KeyCode::Char(keys::FIND));
+        for c in "task".chars() {
+            tap(&mut a, &ank, KeyCode::Char(c));
+        }
+        assert_eq!(rendered_rows(&a), ["TASK-49746735127f"]);
+
+        tap(&mut a, &ank, KeyCode::Enter);
+        assert_eq!(a.needle, None, "the search is still open");
+        assert_eq!(a.search.as_deref(), Some("task"), "the narrowing was lost");
+        assert_eq!(rendered_rows(&a), ["TASK-49746735127f"]);
+        assert_eq!(a.note, None, "Enter ran something");
+
+        // And the keys are back: `j` moves a cursor rather than lengthening a
+        // needle.
+        tap(&mut a, &ank, KeyCode::Char('j'));
+        assert_eq!(a.search.as_deref(), Some("task"), "'j' reached the needle");
     }
 
     #[test]
@@ -5679,7 +5750,7 @@ mod tests {
                 // form is one of those states now (TASK-d832452630d2), and
                 // leaving it open would send the rest of the alphabet into a
                 // title instead of into the reader.
-                a.prompt = None;
+                a.needle = None;
                 a.pending = None;
                 a.form = None;
                 let said = a.note.clone().unwrap_or_default();
@@ -5861,7 +5932,7 @@ mod tests {
             // The key did the one thing a key does here, and none of the
             // things it does everywhere else.
             assert_eq!(a.pending, None, "{code:?} left the command waiting");
-            assert_eq!(a.prompt, None, "{code:?} opened the prompt");
+            assert_eq!(a.needle, None, "{code:?} opened the needle");
             assert_eq!(a.focus, focus, "{code:?} moved the focus");
             assert_eq!(a.cursors, cursors, "{code:?} moved a cursor");
             assert_eq!(a.kind, kind, "{code:?} moved the filter");
@@ -5894,30 +5965,31 @@ mod tests {
         );
     }
 
+    /// The needle is on the screen behind the key that opened it, and the list
+    /// under it is already narrowed (TASK-c94d086682f3).
+    ///
+    /// `a_prompt_dismissed_runs_nothing` stood beside this and is folded into
+    /// `the_list_narrows_on_every_keystroke_and_escape_gives_it_back`, which
+    /// makes the stronger claim: Escape does not merely run nothing, it gives
+    /// the whole list back.
     #[test]
-    fn a_prompt_dismissed_runs_nothing() {
+    fn the_open_search_draws_its_needle_behind_the_key_that_opened_it() {
         let mut a = app();
         let ank = nowhere();
         tap(&mut a, &ank, KeyCode::Char(keys::FIND));
-        for c in "needle".chars() {
-            tap(&mut a, &ank, KeyCode::Char(c));
-        }
-        tap(&mut a, &ank, KeyCode::Esc);
-        assert_eq!(a.prompt, None);
-        assert_eq!(a.note, None, "a dismissed prompt ran something");
-    }
-
-    #[test]
-    fn the_find_key_opens_the_prompt_on_a_search() {
-        let mut a = app();
-        let ank = nowhere();
-        tap(&mut a, &ank, KeyCode::Char(keys::FIND));
-        assert_eq!(a.prompt.as_deref(), Some("/"));
+        assert_eq!(a.needle.as_deref(), Some(""));
         for c in "terminal".chars() {
             tap(&mut a, &ank, KeyCode::Char(c));
         }
-        assert!(a.frame().contains(": /terminal"), "{}", a.frame());
-        tap(&mut a, &ank, KeyCode::Enter);
+        // The marker is the search key itself, read out of the reader rather
+        // than spelled here: `/` is what a person pressed to get here.
+        assert!(
+            a.frame().contains(&format!("{SEARCH}terminal")),
+            "{}",
+            a.frame()
+        );
+        // And the list is narrowed while the needle is still being typed into,
+        // which is what makes the marker a report and not a prompt.
         assert_eq!(rendered_rows(&a), ["ADR-8bd76e8d7c4e"]);
     }
 
@@ -6156,7 +6228,7 @@ mod tests {
                 a.focus = Focus::Body;
                 a.detail = Some(detail("TASK-49746735127f", "a body\n"));
             },
-            |a| a.prompt = Some("done".to_string()),
+            |a| a.needle = Some("a needle".to_string()),
             |a| {
                 a.pending = Some(Pending {
                     verb: "log",
@@ -6281,7 +6353,7 @@ mod tests {
                     "{label} is not on the header at {window:?}:\n{}",
                     start.frame()
                 );
-                let modal = start.pending.is_some() || start.prompt.is_some();
+                let modal = start.pending.is_some() || start.needle.is_some();
                 let mut touched = made(state);
                 touch(&mut touched, &ank, at(&start));
                 assert_eq!(

--- a/crates/ank-tui/tests/commands.rs
+++ b/crates/ank-tui/tests/commands.rs
@@ -1,0 +1,189 @@
+//! Every command this reader has is a key of its table (TASK-c94d086682f3).
+//!
+//! ADR-559eebf5c6f5: *input is a keystroke and no longer a line*, and *every
+//! command that only moves the screen is one key*. Until this wave that was
+//! true of most of the vocabulary and not of all of it: `ank_tui::input`
+//! carried a grammar, and two of its commands -- a row number and an identifier
+//! -- were reachable only by typing one. There is no line left, so a command no
+//! key reaches is a command nobody can run.
+//!
+//! **A domain and not a list.** [`named`] is total over
+//! [`ank_tui::input::Command`], so a variant added to that enumeration stops
+//! this suite compiling rather than quietly arriving outside the rule. That is
+//! the shape `ank_tui::keys`'s own table suite uses over `KeyCode`, and it is
+//! the difference between a claim about every command there is and a claim
+//! about the ones somebody remembered.
+//!
+//! # Why this is a suite and not a test module beside the enumeration
+//!
+//! Two reasons, and the second is the load-bearing one.
+//!
+//! What is being measured is a *join*: the vocabulary is declared in
+//! `input.rs`, the keys are declared in `bindings.rs`, and the claim is that
+//! the first is covered by the second. Neither file owns that.
+//!
+//! And `tests/dependencies.rs` walks this crate's sources for the arm that
+//! answers a `Command::Act`, requiring exactly one, in `view.rs`, doing
+//! nothing but composing the argv and showing it -- which is one half of how
+//! the confirmation in front of every spawned write is held. A total `match`
+//! over `Command` names that variant, and a source-walking suite cannot tell a
+//! test's `match` from a dispatch's. Putting the domain here keeps that
+//! invariant at full strength rather than teaching it an exception.
+//!
+//! This one runs on all three platforms: nothing here opens a terminal. What a
+//! person *sees* of the same claim -- the key list naming every one of these
+//! keys -- is `tests/bindings.rs`, on a pseudo-terminal, and what the search
+//! itself does is `tests/search.rs`.
+
+use ank_tui::bindings::BINDINGS;
+use ank_tui::input::{Act, Command, Subject};
+use ank_tui::keys::{typed, Press};
+use ank_tui::view::Focus;
+use ratatui::crossterm::event::{KeyEvent, KeyModifiers};
+
+/// A name for every command there is.
+///
+/// **The `match` is the point and the name is the by-product.** It is total
+/// over `Command`, so a variant added there fails to compile here.
+fn named(command: &Command) -> &'static str {
+    match command {
+        Command::Quit => "quit",
+        Command::Reload => "reload",
+        Command::Move(_) => "move",
+        Command::Page(_) => "page",
+        Command::Top => "top",
+        Command::Open => "open",
+        Command::Back => "back",
+        Command::Panel(_) => "panel",
+        Command::Kind(_) => "kind",
+        Command::Search(_) => "search",
+        Command::Constraints => "constraints",
+        Command::Config => "config",
+        Command::Queue => "queue",
+        Command::Act(_) => "act",
+        Command::Malformed(_) => "malformed",
+        Command::Help => "help",
+        Command::Further => "further",
+        Command::Form(_) => "form",
+    }
+}
+
+/// Every command named above, so the domain can be held to the match.
+const COMMANDS: [&str; 18] = [
+    "quit",
+    "reload",
+    "move",
+    "page",
+    "top",
+    "open",
+    "back",
+    "panel",
+    "kind",
+    "search",
+    "constraints",
+    "config",
+    "queue",
+    "act",
+    "malformed",
+    "help",
+    "further",
+    "form",
+];
+
+/// One command of each variant, for the domain to be checked against.
+fn every_command() -> Vec<Command> {
+    vec![
+        Command::Quit,
+        Command::Reload,
+        Command::Move(1),
+        Command::Page(1),
+        Command::Top,
+        Command::Open,
+        Command::Back,
+        Command::Panel(Focus::Body),
+        Command::Kind(None),
+        Command::Search(None),
+        Command::Constraints,
+        Command::Config,
+        Command::Queue,
+        Command::Act(Act {
+            verb: "claim",
+            args: Vec::new(),
+            subject: Subject::Selected,
+        }),
+        Command::Malformed(String::new()),
+        Command::Help,
+        Command::Further,
+        Command::Form("new"),
+    ]
+}
+
+/// What a key of the table reaches, named the way [`named`] names it.
+///
+/// Two presses answer no command by themselves, and they are not exceptions to
+/// the rule: they are the two the screen has to finish, and what it finishes
+/// them into is written here rather than inferred. `Press::Cycle` needs the
+/// kind in force, which the screen knows and the table does not; `Press::Find`
+/// opens the search, and what the search sends on every keystroke after it is a
+/// `Command::Search`.
+fn reaches(press: Press) -> Option<&'static str> {
+    match press {
+        Press::Run(command) => Some(named(&command)),
+        Press::Cycle => Some(named(&Command::Kind(None))),
+        Press::Find => Some(named(&Command::Search(None))),
+        Press::Ignored => None,
+    }
+}
+
+#[test]
+fn the_domain_names_every_command_there_is() {
+    for command in every_command() {
+        let name = named(&command);
+        assert!(
+            COMMANDS.contains(&name),
+            "'{name}' is a command the rule below is not stated over"
+        );
+    }
+    assert_eq!(
+        every_command().len(),
+        COMMANDS.len(),
+        "the domain and the names have drifted apart"
+    );
+}
+
+/// **Every movement that survives the grammar is a key in the binding table**
+/// (TASK-c94d086682f3, ADR-559eebf5c6f5).
+///
+/// Stated over the whole enumeration rather than over the two variants this
+/// wave removed. `Row` and `Select` were the commands no key reached, and a
+/// rule written as "those two are gone" would be a rule about them; this one
+/// says what has to stay true, so the next command added without a key fails
+/// here rather than shipping as a road reachable only by a line that no longer
+/// exists.
+///
+/// Every key of every row is tried, aliases included, in every screen -- the
+/// same domain `keys::typed` is answerable to -- because "there is a key for
+/// it" is a claim about the table and not about the letters somebody thought of.
+#[test]
+fn every_command_is_reached_by_a_key_of_the_table() {
+    let mut reached: Vec<&str> = Vec::new();
+    for binding in BINDINGS {
+        for code in std::iter::once(binding.key).chain(binding.aliases.iter().copied()) {
+            for focus in Focus::ALL {
+                let press = typed(KeyEvent::new(code, KeyModifiers::NONE), focus);
+                if let Some(name) = reaches(press) {
+                    if !reached.contains(&name) {
+                        reached.push(name);
+                    }
+                }
+            }
+        }
+    }
+    for command in COMMANDS {
+        assert!(
+            reached.contains(&command),
+            "no key of the table reaches '{command}', and there is no line left \
+             to type it on"
+        );
+    }
+}

--- a/crates/ank-tui/tests/confirmation.rs
+++ b/crates/ank-tui/tests/confirmation.rs
@@ -100,10 +100,11 @@ fn expected(argv: &str, id: &str) -> String {
 
 /// Opens one document into the body panel and waits until it is there.
 ///
-/// By identifier and through the search, because an identifier is a line by
-/// nature and `/` is the one prompt left (TASK-1a415107fd56): the needle
-/// narrows the listing to the one row, and Enter opens the row under the
-/// cursor, which a search puts back at the top. Into the *body* panel
+/// By identifier and through the search, which is the one thing a character
+/// reaches (TASK-1a415107fd56, TASK-c94d086682f3): the needle narrows the
+/// listing to the one row as it is typed, the first Enter leaves the search
+/// with that narrowing in force, and the second opens the row under the cursor,
+/// which a search puts back at the top. Into the *body* panel
 /// deliberately, which is the only panel `accept` is a command in
 /// (TASK-d90e94afca08) and is therefore the one place all six can be reached
 /// from.

--- a/crates/ank-tui/tests/dependencies.rs
+++ b/crates/ank-tui/tests/dependencies.rs
@@ -370,24 +370,71 @@ fn one_arm_answers_an_act_and_what_it_does_is_show_it() {
     );
 }
 
-/// **The grammar of the prompt composes no act at all**
-/// (TASK-1a415107fd56, ADR-c07e2694f0e1).
+/// **The module that declares the vocabulary declares no grammar**
+/// (TASK-c94d086682f3, ADR-559eebf5c6f5: *input is a keystroke and no longer a
+/// line*).
 ///
-/// The tests in `input.rs` say that no word §4 declares reaches a verb, over
-/// every one of them. This says the same thing from the side a test cannot be
-/// forgotten on: the file that reads a typed line does not name the variant an
-/// act arrives as, so there is no line of it that could construct one and no
-/// word anybody might add later that could reach one.
+/// `input.rs` used to carry `parse`, and around it a table of words, a table of
+/// the letters allowed to stand for one, a row number and an identifier. What
+/// is left is the enumeration and the two types an act is made of -- a
+/// declaration, and nothing that reads.
 ///
-/// Stated over the code above the tests, because a test naming the variant is a
-/// test measuring its absence -- which is the file's own suite doing exactly
-/// what this asks of it.
+/// Stated as "no function above the tests" because that is what a grammar *is*:
+/// something that turns bytes nobody pressed into a command. A reader that
+/// grew one again would grow it as a function here, and it would fail here
+/// rather than arrive as a second vocabulary nobody learned from the key list.
+/// Where a keystroke is read is `keys.rs`, against the table `bindings.rs`
+/// declares, and `crates/ank-tui/tests/commands.rs` holds every command of this
+/// enumeration to that table.
 #[test]
-fn the_grammar_of_the_prompt_names_no_act() {
+fn the_module_that_declares_the_vocabulary_declares_no_grammar() {
     let (_, source) = sources()
         .into_iter()
         .find(|(file, _)| file == "input.rs")
-        .expect("the grammar is a source of this crate");
+        .expect("the command type is a source of this crate");
+    let code = code_of(&source);
+    let above = match code.find("#[cfg(test)]") {
+        Some(at) => &code[..at],
+        None => &code[..],
+    };
+    let functions: Vec<&str> = above
+        .lines()
+        .map(str::trim)
+        .filter(|line| line.starts_with("fn ") || line.starts_with("pub fn "))
+        .collect();
+    assert!(
+        functions.is_empty(),
+        "input.rs reads something, and what reads a keystroke is keys.rs:\n{}",
+        functions.join("\n")
+    );
+    // Not vacuous: the file is where the vocabulary is declared, so a scan that
+    // found nothing because it was looking at an empty source would say so.
+    assert!(
+        above.contains("pub enum Command"),
+        "input.rs is not where the vocabulary is declared any more"
+    );
+}
+
+/// **The file that declares an act composes none**
+/// (TASK-1a415107fd56, TASK-c94d086682f3, ADR-559eebf5c6f5).
+///
+/// It said "the grammar of the prompt composes no act at all" while there was a
+/// grammar, and it was worth saying: `input.rs` read a typed line, so a word
+/// added to its table could have reached a verb. There is no line and no table
+/// -- TASK-c94d086682f3 took both -- and what survives is the narrower claim
+/// underneath, which is the one that keeps the confirmation whole: the module
+/// where `Command::Act` is *declared* constructs none, so the only place an act
+/// can come from is the key table, and `one_arm_answers_an_act_and_what_it_
+/// does_is_show_it` says what happens to it there.
+///
+/// Stated over the code above the tests, because a test naming the variant is a
+/// test measuring its absence.
+#[test]
+fn the_file_that_declares_an_act_composes_none() {
+    let (_, source) = sources()
+        .into_iter()
+        .find(|(file, _)| file == "input.rs")
+        .expect("the command type is a source of this crate");
     let code = code_of(&source);
     let above = match code.find("#[cfg(test)]") {
         Some(at) => &code[..at],
@@ -399,7 +446,7 @@ fn the_grammar_of_the_prompt_names_no_act() {
         .collect();
     assert!(
         named.is_empty(),
-        "input.rs composes an act, and no typed word may reach one:\n{}",
+        "input.rs composes an act, and only the key table may:\n{}",
         named.join("\n")
     );
     // Not vacuous: the variant is declared in this very file, so a scan that

--- a/crates/ank-tui/tests/region.rs
+++ b/crates/ank-tui/tests/region.rs
@@ -97,7 +97,7 @@ const WIDTHS: [u16; 5] = [40, 46, 48, 80, 150];
 /// that are about a window rather than about a width.
 const WINDOWS: [(u16, u16); 2] = [(80, 24), (40, 24)];
 
-/// The key that opens the prompt, read out of the reader rather than typed as a
+/// The key that starts the search, read out of the reader rather than typed as a
 /// letter here: it is the one key this suite has to know, and a suite carrying
 /// its own copy of it would agree with a mapping that moved.
 ///

--- a/crates/ank-tui/tests/search.rs
+++ b/crates/ank-tui/tests/search.rs
@@ -1,0 +1,198 @@
+//! The search, through the binary, on a real terminal (TASK-c94d086682f3).
+//!
+//! ADR-559eebf5c6f5: *a search narrows the list as it is typed and is not a
+//! line to compose and submit*. Every word of that is about a running process.
+//! A unit test can show that [`ank_tui::keys::narrowing`] answers a character
+//! with `Narrowed` and that `App::press` turns it into a `Command::Search` --
+//! and ones beside both do -- but neither is the claim. The claim is that a
+//! person pressing `/` and then a letter is looking at a shorter list, and
+//! between the keystroke and that list there is a dispatch, a spawn of `ank
+//! find`, a filter, a layout and a terminal.
+//!
+//! **The measurement is taken after every keystroke and not at the end**,
+//! which is the whole of what distinguishes this reader from the one it
+//! replaces. A suite that typed a needle and then read the screen would pass
+//! against a line that composes and narrows once, on Enter -- which is the
+//! grammar the decision ends. So the count is read between characters, and no
+//! Enter is sent until the list has already reached one row.
+//!
+//! `#[cfg(unix)]` for the reason the sibling suites give: a pseudo-terminal on
+//! Windows is ConPTY, and reaching it means the console API this workspace does
+//! not otherwise call. What the search *is* -- the needle, the two ways out,
+//! the table around them -- is platform-free and its own tests run on all
+//! three.
+
+#![cfg(unix)]
+
+mod terminal;
+
+use ank_tui::view::SEARCH;
+use std::sync::Mutex;
+use terminal::{ids_of, short_of, Live, Repo};
+
+/// One pseudo-terminal open at a time, for `tests/bindings.rs`'s reason:
+/// `ptsname(3)` answers out of a static buffer, and two sessions opened at once
+/// can be handed the same path.
+static ONE_AT_A_TIME: Mutex<()> = Mutex::new(());
+
+/// Wide enough that the title's arithmetic and the needle both fit whole. What
+/// `fit` does to a line too narrow for it is a real behaviour and another
+/// suite's subject.
+const WINDOW: (u16, u16) = (110, 34);
+
+/// Escape, as a terminal sends it.
+const ESCAPE: &str = "\u{1b}";
+
+/// How many rows the listing says it is drawing, off its own title.
+///
+/// The reader's own count and not this suite's: `ENTITIES all 2` is what
+/// `crate::text::window` writes when a listing fits whole, and reading it back
+/// is how "the list narrowed" becomes a number rather than an impression.
+fn counted(frame: &str) -> usize {
+    let at = frame
+        .find("ENTITIES all ")
+        .unwrap_or_else(|| panic!("the listing is not naming its own count:\n{frame}"));
+    frame[at + "ENTITIES all ".len()..]
+        .chars()
+        .take_while(char::is_ascii_digit)
+        .collect::<String>()
+        .parse()
+        .unwrap_or_else(|_| panic!("the count is not a number:\n{frame}"))
+}
+
+/// The identifier of the seeded decision, short, which is what a listing prints
+/// and therefore what a person would search for.
+fn an_identifier(repo: &Repo) -> String {
+    let id = ids_of(&repo.stdout(&["find", "--json"]))
+        .into_iter()
+        .find(|id| id.starts_with("ADR-"))
+        .expect("the seeded corpus carries a decision");
+    short_of(&id)
+}
+
+/// **The list narrows on every keystroke, there is nothing to submit, and
+/// Escape gives it back unnarrowed** (TASK-c94d086682f3, ADR-559eebf5c6f5).
+///
+/// The criterion, whole, measured where it is claimed. The three clauses are
+/// three assertions and they are separate on purpose: a reader that narrowed
+/// only on Enter would pass the last two, and one that narrowed as it typed and
+/// left the needle in force on Escape would pass the first two.
+#[test]
+fn the_list_narrows_as_the_needle_is_typed_and_escape_gives_it_back() {
+    let _one = ONE_AT_A_TIME
+        .lock()
+        .unwrap_or_else(|held| held.into_inner());
+    let repo = Repo::seeded();
+    repo.warm();
+    let needle = an_identifier(&repo);
+    let mut live = Live::open(&repo, WINDOW.0, WINDOW.1);
+    live.until("the session to open", |t| t.contains("2 ENTITIES"));
+
+    let whole = counted(&live.frame());
+    assert_eq!(whole, 2, "the fixture is not two rows");
+
+    // The key alone narrows nothing: an empty needle is a list restricted by
+    // nothing, which is where the person pressing it is standing.
+    live.send(&ank_tui::keys::FIND.to_string());
+    live.until("the search to open", |t| t.contains(SEARCH));
+    assert_eq!(
+        counted(&live.frame()),
+        whole,
+        "the search key narrowed before anything was typed"
+    );
+
+    // And then character by character, reading the count between each one.
+    let mut typed = String::new();
+    let mut counts = Vec::new();
+    for c in needle.chars() {
+        typed.push(c);
+        live.send(&c.to_string());
+        live.until(&format!("the needle to reach '{typed}'"), |t| {
+            t.contains(&format!("{SEARCH}{typed}"))
+        });
+        counts.push(counted(&live.frame()));
+    }
+
+    // Never longer than it was, and one row by the end -- with no Enter sent,
+    // which is the "nothing to submit" half. A reader that waited for a line
+    // would still be showing two rows here.
+    for pair in counts.windows(2) {
+        assert!(
+            pair[1] <= pair[0],
+            "the list grew while the needle did: {counts:?}"
+        );
+    }
+    assert_eq!(
+        counts.last().copied(),
+        Some(1),
+        "'{needle}' never narrowed the list to the entity it names: {counts:?}"
+    );
+    assert!(
+        counts.iter().any(|&n| n < whole),
+        "nothing narrowed until the needle was whole: {counts:?}"
+    );
+
+    // Escape gives the list back, and takes the needle off the screen with it.
+    live.send(ESCAPE);
+    live.until("the list to come back whole", |t| {
+        t.contains(&format!("ENTITIES all {whole}"))
+    });
+    let back = live.frame();
+    assert!(
+        !back.contains(&format!("{SEARCH}{needle}")),
+        "Escape left the needle on the screen:\n{back}"
+    );
+    assert!(
+        !back.contains("matching"),
+        "Escape left the list narrowed:\n{back}"
+    );
+
+    live.quit();
+}
+
+/// Enter ends the search with the narrowing in force and runs nothing
+/// (TASK-c94d086682f3).
+///
+/// The other way out, and the one that gives the keyboard back: every character
+/// is a needle while the search is open, so a person who has found their row
+/// needs to leave without losing the list they narrowed to. It is not a submit
+/// -- the narrowing happened on the keystrokes before it -- and what holds that
+/// here is a corpus compared byte for byte afterwards.
+#[test]
+fn enter_ends_the_search_keeping_the_list_narrowed_and_writes_nothing() {
+    let _one = ONE_AT_A_TIME
+        .lock()
+        .unwrap_or_else(|held| held.into_inner());
+    let repo = Repo::seeded();
+    repo.warm();
+    let refs = repo.refs();
+    let before = repo.corpus();
+    let needle = an_identifier(&repo);
+    let mut live = Live::open(&repo, WINDOW.0, WINDOW.1);
+    live.until("the session to open", |t| t.contains("2 ENTITIES"));
+
+    live.send(&format!("{}{needle}", ank_tui::keys::FIND));
+    live.until("the listing to narrow to one row", |t| {
+        t.contains("ENTITIES all 1")
+    });
+
+    live.send("\r");
+    live.until("the needle to leave the screen", |t| {
+        !t.contains(&format!("{SEARCH}{needle}"))
+    });
+    let kept = live.frame();
+    assert_eq!(counted(&kept), 1, "Enter gave the whole list back:\n{kept}");
+    assert!(
+        kept.contains("matching"),
+        "the narrowing did not survive the search closing:\n{kept}"
+    );
+
+    // And the keyboard is back: `f`, which walks the kinds, is a command again
+    // rather than a longer needle.
+    live.send("f");
+    live.until("the kind filter to move", |t| t.contains("kind adr"));
+
+    live.quit();
+    assert_eq!(before, repo.corpus(), "a search moved a file under .ank/");
+    assert_eq!(refs, repo.refs(), "a search moved a ref under refs/ank/");
+}

--- a/crates/ank-tui/tests/verbs.rs
+++ b/crates/ank-tui/tests/verbs.rs
@@ -343,16 +343,21 @@ fn the_key_past_the_six_names_the_verbs_with_no_letter_of_their_own() {
     assert_eq!(refs, repo.refs(), "the list moved a ref under refs/ank/");
 }
 
-/// **The prompt a verb was spelled into is gone, and no word typed anywhere
-/// reaches a verb** (TASK-1a415107fd56, ADR-c07e2694f0e1).
+/// **No word typed anywhere reaches a verb, and there is no line to type one
+/// on** (TASK-1a415107fd56, TASK-c94d086682f3, ADR-559eebf5c6f5).
 ///
-/// Two halves, and neither is the other. The first is that the key which used
-/// to open a line on nothing opens no line: `a` is `accept` now, and on a row
-/// it says so. The second is about the line that is still there -- `/` opens a
-/// search, and a person who takes the seed off and spells a verb whole gets
-/// what any other unknown word gets, a sentence saying the reader does not know
-/// it. A grammar that had kept the six as a second road would answer that line
-/// with a confirmation, which is exactly what is asserted absent.
+/// Two halves, and neither is the other. The first is about the search, which
+/// is the only thing a character reaches now: each of the six spelled into it
+/// whole is a needle and never a verb, so what a person sees is a list narrowed
+/// to nothing rather than a command waiting for an answer.
+///
+/// The second is that no key opens a line at all. It used to be measured by
+/// looking for the prompt's marker at the head of a band; the marker is the
+/// search key itself now and a listing is full of paths, so a stronger instrument
+/// takes its place -- the keystroke *after* `a`. If `a` had opened a line, `q`
+/// would be a character of it and the session would still be up; `Live::quit`
+/// requires the process to have left with 0, so a reader that swallowed it
+/// fails here rather than passing quietly.
 #[test]
 fn no_word_typed_anywhere_reaches_a_verb() {
     let _one = ONE_AT_A_TIME
@@ -365,31 +370,12 @@ fn no_word_typed_anywhere_reaches_a_verb() {
     let mut live = Live::open(&repo, WINDOW.0, WINDOW.1);
     live.until("the session to open", |t| t.contains("2 ENTITIES"));
 
-    // `a` on a row opens no line. It is `accept`, and off the document it names
-    // the way in rather than a prompt to type into.
-    live.send("2");
-    live.until("the listing", |t| t.contains("2 ENTITIES"));
-    live.send("a");
-    live.until("the reader to answer", |t| {
-        t.contains("open it into the body")
-    });
-    let answered = live.frame();
-    // On a line that *starts* with the prompt's marker and not on the marker
-    // anywhere: the prompt is drawn at the head of the band it owns, and a
-    // colon inside a sentence is a sentence.
-    assert!(
-        !answered
-            .lines()
-            .any(|line| line.starts_with(ank_tui::view::PROMPT)),
-        "'a' opened a line to type a verb into:\n{answered}"
-    );
-
-    // And the line that is left is a search. Cleared back to empty, every one
-    // of the six is a word this reader does not know.
+    // Every one of the six, spelled whole into the search: a needle no entity
+    // carries, and never a command.
     for verb in SIX {
-        live.send(&format!("{}\u{15}{verb}\r", ank_tui::keys::FIND));
-        live.until(&format!("the reader to answer '{verb}'"), |t| {
-            t.contains(&format!("no command '{verb}'")) || t.contains("no entity here matches")
+        live.send(&format!("{}{verb}", ank_tui::keys::FIND));
+        live.until(&format!("the needle to reach '{verb}'"), |t| {
+            t.contains(&format!("{}{verb}", ank_tui::view::SEARCH))
         });
         let said = live.frame();
         assert!(
@@ -400,8 +386,22 @@ fn no_word_typed_anywhere_reaches_a_verb() {
             !said.contains(&format!("ank {verb}")),
             "'{verb}' typed whole reached the verb:\n{said}"
         );
+        // And back to the whole list, so the next needle starts where this one
+        // did.
+        live.send("\u{1b}");
+        live.until("the list to come back", |t| t.contains("ENTITIES all 2"));
     }
 
+    // `a` on a row opens no line. It is `accept`, and off the document it names
+    // the way in rather than a prompt to type into.
+    live.send("2");
+    live.until("the listing", |t| t.contains("2 ENTITIES"));
+    live.send("a");
+    live.until("the reader to answer", |t| {
+        t.contains("open it into the body")
+    });
+
+    // The instrument for "no line was opened": `q` is still the way out.
     live.quit();
     assert_eq!(
         before,


### PR DESCRIPTION
Closes TASK-c94d086682f3, proved by commit eff73c1.

ADR-559eebf5c6f5 (proposed): *a search narrows the list as it is typed and is not a line to compose and submit*, and *input is a keystroke and no longer a line*.

## What changed

`/` starts a search on an empty needle. Every character is a needle one longer and a `Command::Search` through `App::act`, so the list follows the needle keystroke by keystroke and there is nothing to submit. Escape gives the list back unnarrowed. Enter is the other way out and keeps the narrowing — not a submit, since the narrowing already happened, but what gives the alphabet back to the key table.

So `keys::edit` is `keys::narrowing`, `Editing{Typing,Submit,Cancel}` is `Narrowing{Narrowed,Kept,Undone}`, and `Press::Prompt(seed)` is `Press::Find` carrying nothing — there is no grammar left to tell a search from a command by a slash.

`input.rs` loses `parse`, the word table, the letter table, `IDENTIFIER_KINDS`, and `Command::Row`, `Select`, `Nothing` and `Unknown`. It goes from 468 lines to 193: the command type, and nothing that reads.

## What it costs, said plainly

`Row` and `Select` were real and are not replaced. A row number let you type `12` and land on row twelve; an identifier typed whole jumped to the entity and opened it. Both needed a line. What replaces them is one clause rather than two: `/4974` narrows to the row as it is typed, which is fewer keys, works from a document where a row number only ever had a refusal to offer, and is the same key everywhere.

## The verbs kept their confirmation

Untouched. No typed line ever reached one, and the two suites that hold it — one arm answering an act, one function spawning a verb — are unchanged and green.

## How each clause of the criterion is measured

| Clause | Where |
|---|---|
| narrows on every keystroke, nothing to submit; Escape gives the list back | `tests/search.rs` — pty, counts read *between* characters, no Enter sent until the list is already one row |
| the prompt grammar of `input.rs` is gone from the crate | `tests/dependencies.rs` — "no function above the tests" is a property of the source, not a fact about today's tree |
| every surviving movement is a key in the binding table | `tests/commands.rs` — total `match` over `Command`, held to `BINDINGS` over every key, alias and screen |
| the key list names each of them | `tests/bindings.rs` (pty, pre-existing) holds the drawn list to `BINDINGS` both ways |

## Scope

Amended under the claim, and why: the criterion cannot be reached from `input.rs` and `keys.rs` alone. `App::press` owned the whole prompt regime and `view.rs:903` was `parse`'s only caller, so the crate stops compiling the moment the grammar goes. The `view.rs` edit is confined to `App::press`, the two dispatch arms no key reached any more, and the field rename that follows from them; `bindings.rs`, `form.rs`, `lib.rs`, `tests/**` and `crates/ank-cli/tests/tui.rs` were in no live claim.

`crates/ank-cli/tests/tui.rs` needed the most care: its drive helpers *encoded* the two roads that were words — `:filter <kind>` and an identifier typed into the prompt. Both are keys now, computed from the reader's own registry and table rather than spelled in the suite. `open` ends its search with Backspace and not Escape, because an escape byte with another key straight behind it is an Alt chord to any terminal decoder — the trap the confirmation suite already documented one wave earlier, and which cost a hang before it was found.

## Verification

`cargo test --workspace`: 37 suites, 1084 tests, 0 failures. `cargo fmt --check` clean. `ank check` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WDoSvm5Y4ND9Hc8SV6x1F