### PR TITLE
The temp-file follow-up stops waiting on the task it unblocks

### DIFF
--- a/.ank/entities/LOG-74e62d615490.md
+++ b/.ank/entities/LOG-74e62d615490.md
@@ -1,0 +1,15 @@
+---
+id: LOG-74e62d615490
+type: log
+title: "-blocked_by TASK-ac2ff41162c6 (version 1 to 2, replaced 6600eb2e335b, produced 0214ae6a51b4)"
+created: 2026-08-28T22:13:54Z
+author: haksolot@vmi3223161
+scope:
+  - crates/ank-cli/tests/cli.rs
+  - crates/ank-cli/src/human.rs
+about: TASK-02350943e2b1
+seq: 0
+records: edit
+schema: 4
+version: 1
+---

--- a/.ank/entities/TASK-02350943e2b1.md
+++ b/.ank/entities/TASK-02350943e2b1.md
@@ -9,12 +9,12 @@ status: open
 scope:
   - crates/ank-cli/tests/cli.rs
   - crates/ank-cli/src/human.rs
-blocked_by: [TASK-ac2ff41162c6]
+blocked_by: []
 done_criteria: |
   After a green cargo test --workspace into an empty temporary directory, the only entries left are the ank-it-* roots of the run itself: no ank-edit-* and no ank-signers-* file remains. The editor's scratch file still survives a failed edit and is still named in the refusal -- what changes is where the child looks for a temporary directory, not what ank does with one.
 criteria_by: creator
 schema: 4
-version: 1
+version: 2
 ---
 
 TASK-ac2ff41162c6 fixed the families born in cfg(test) blocks under src/ and measured the two it could not reach from its scope.


### PR DESCRIPTION
TASK-ac2ff41162c6 and TASK-02350943e2b1 could not both move. ac2f's
criterion asks that no ank-edit-*, ank-signers-*, ank-daemon-stream-* or
ank-tui-stream-* survive a green run, and its scope reaches neither of the
first two: ank-edit-* is written by the ank binary the integration harness
spawns, and ank-signers-* by signers_for_git in human.rs. 0235 carries
exactly that half, with the scope it needs, and it was blocked_by ac2f.

So ac2f could not close until 0235 landed, and 0235 could not start until
ac2f closed. The DAG had no cycle and the deadlock was real anyway. The
holder of ac2f saw it, released rather than softening a frozen criterion,
and said widening the scope was not its call. This is that call.

0235 goes first. ac2f's own half is already merged, so its criterion becomes
satisfiable the moment 0235 lands, and it keeps its value as the checkpoint
that verifies all four families at once.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CwtHQ93fqgQP24UATUo5Ut
