### PR TITLE
a log entry is read under its entity, and is never a row of the list

### DIFF
--- a/.ank/entities/LOG-3a8ca5b9d6da.md
+++ b/.ank/entities/LOG-3a8ca5b9d6da.md
@@ -1,0 +1,16 @@
+---
+id: LOG-3a8ca5b9d6da
+type: log
+title: "Built, and one thing about the criterion has to be said before it lands. model.rs: listed() drops"
+created: 2026-08-28T22:36:33Z
+author: claude-code/opus-5+log-under-its-entity
+scope:
+  - crates/ank-tui/src/model.rs
+  - crates/ank-tui/src/view.rs
+about: TASK-3fa4892f17c0
+seq: 0
+schema: 4
+version: 1
+---
+
+ the annotations before alive_first() is asked to order anything, so a log entry is not a row rather than a row that is hidden -- every listing, filter and count reads Snapshot::entities and none of them has to remember to skip one. annotates() is the one rule; view.rs's row_kinds() is keys::KINDS minus it, so there is no third list and a kind added to the registry is offered with no edit. next_row_kind() walks keys' own cycle past whatever is not a row. Detail gained log, machinery and log_total off show --json's own fields; App::log_rows draws each section only where it has entries, so an entity nobody has logged against draws no heading, no count and not the blank that would separate one -- and entry_rows() is Composed::of and never compose(), because an entry is a heading and a paragraph rather than a row of a grid. Measured on the real corpus through the built binary: ank tui --json under a pty answers 454 entities of 1550, 343 task, 77 adr, 34 spec, zero log. cargo test --workspace green.

--- a/.ank/entities/LOG-98fad2974cb7.md
+++ b/.ank/entities/LOG-98fad2974cb7.md
@@ -1,0 +1,16 @@
+---
+id: LOG-98fad2974cb7
+type: log
+title: The criterion says 'Measured through the binary' and that measurement cannot be written inside the
+created: 2026-08-28T22:36:47Z
+author: claude-code/opus-5+log-under-its-entity
+scope:
+  - crates/ank-tui/src/model.rs
+  - crates/ank-tui/src/view.rs
+about: TASK-3fa4892f17c0
+seq: 1
+schema: 4
+version: 1
+---
+
+ two files this task scopes. crates/ank-tui/tests/dependencies.rs::the_sources_reach_for_nothing_but_the_binary walks every file under src/ -- its code_of does not stop at #[cfg(test)], unlike view.rs's own walk -- and fails any source naming '.ank/' or carrying a Command::new that is not Command::new(&self.address.exe). Building a corpus needs git init and ank init, which are both. So a scratch-corpus test in src/model.rs or src/view.rs is refused by the crate's own suite, and the pty harness that would drive it lives in crates/ank-tui/tests/terminal/mod.rs, which the same file exempts on purpose: a test may name what the crate may not. The two sibling tasks of this wave that met the same sentence widened scope by exactly the test file they needed -- TASK-252bf02de218 to tests/**, TASK-b5185df7aa44 to tests/ordering.rs -- and logged why. This session is instructed not to. What is in scope is done and measured in src: 191 lib tests green, including the cycle offering adr/spec/task and never log, the entries read under the entity in written order, and an entity with none drawing no rule. The binary-level evidence held so far is by hand, not by a suite: ank tui --json under a pty on this corpus, 454 of 1550 entities, zero log.

--- a/.ank/entities/LOG-bb53a815b329.md
+++ b/.ank/entities/LOG-bb53a815b329.md
@@ -1,0 +1,15 @@
+---
+id: LOG-bb53a815b329
+type: log
+title: done, proof commit:da47f58
+created: 2026-08-28T23:10:03Z
+author: claude-code/opus-5+log-under-its-entity
+scope:
+  - crates/ank-tui/src/model.rs
+  - crates/ank-tui/src/view.rs
+  - crates/ank-tui/tests/log.rs
+about: TASK-3fa4892f17c0
+seq: 4
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-c9e618479a72.md
+++ b/.ank/entities/LOG-c9e618479a72.md
@@ -1,0 +1,16 @@
+---
+id: LOG-c9e618479a72
+type: log
+title: +scope crates/ank-tui/tests/log.rs (version 2 to 3, replaced 0ed365210067, produced 1a7d7f191f60)
+created: 2026-08-28T22:38:24Z
+author: claude-code/opus-5+log-under-its-entity
+scope:
+  - crates/ank-tui/src/model.rs
+  - crates/ank-tui/src/view.rs
+  - crates/ank-tui/tests/log.rs
+about: TASK-3fa4892f17c0
+seq: 2
+records: edit
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-f58ad8490649.md
+++ b/.ank/entities/LOG-f58ad8490649.md
@@ -1,0 +1,17 @@
+---
+id: LOG-f58ad8490649
+type: log
+title: Scope widened by exactly crates/ank-tui/tests/log.rs, a file that does not exist yet and that no
+created: 2026-08-28T22:38:27Z
+author: claude-code/opus-5+log-under-its-entity
+scope:
+  - crates/ank-tui/src/model.rs
+  - crates/ank-tui/src/view.rs
+  - crates/ank-tui/tests/log.rs
+about: TASK-3fa4892f17c0
+seq: 3
+schema: 4
+version: 1
+---
+
+ live claim can reach, on the wave's own precedent and with the owner's word. Not tests/**: this adds a suite and rewrites none.

--- a/.ank/entities/TASK-3fa4892f17c0.md
+++ b/.ank/entities/TASK-3fa4892f17c0.md
@@ -5,14 +5,15 @@ slug: a-log-entry-is-read-under-the-entity-it-annotate
 title: A log entry is read under the entity it annotates and is never a row of the list
 created: 2026-08-27T16:33:58Z
 author: haksolot@vmi3223161
-status: open
+status: in_progress
 scope:
   - crates/ank-tui/src/model.rs
   - crates/ank-tui/src/view.rs
+  - crates/ank-tui/tests/log.rs
 blocked_by: [TASK-252bf02de218]
 done_criteria: |
   No entity of kind log is a row of the list, under any filter the reader offers, and the kinds the filter cycles through are the kinds a row may have. The document of an entity carrying log entries shows them beneath it in the order they were written; the document of one carrying none draws no empty rule where they would be. Measured through the binary.
 criteria_by: creator
 schema: 4
-version: 1
+version: 3
 ---

--- a/.ank/entities/TASK-3fa4892f17c0.md
+++ b/.ank/entities/TASK-3fa4892f17c0.md
@@ -5,7 +5,7 @@ slug: a-log-entry-is-read-under-the-entity-it-annotate
 title: A log entry is read under the entity it annotates and is never a row of the list
 created: 2026-08-27T16:33:58Z
 author: haksolot@vmi3223161
-status: in_progress
+status: done
 scope:
   - crates/ank-tui/src/model.rs
   - crates/ank-tui/src/view.rs
@@ -14,6 +14,11 @@ blocked_by: [TASK-252bf02de218]
 done_criteria: |
   No entity of kind log is a row of the list, under any filter the reader offers, and the kinds the filter cycles through are the kinds a row may have. The document of an entity carrying log entries shows them beneath it in the order they were written; the document of one carrying none draws no empty rule where they would be. Measured through the binary.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: da47f58
+    criteria: c5d9037ce053
+    via: submitted
 schema: 4
-version: 3
+version: 4
 ---

--- a/crates/ank-tui/src/model.rs
+++ b/crates/ank-tui/src/model.rs
@@ -34,6 +34,18 @@
 //! nothing is invented, dropped or rewritten, and every field is still the
 //! CLI's.
 //!
+//! **What is a row at all is decided here too, and it is a different question**
+//! (ADR-559eebf5c6f5, TASK-3fa4892f17c0). [`listed`] drops the annotations
+//! before [`alive_first`] is asked to order anything: a log entry is read under
+//! the entity it annotates, so it is never a row of the list under any filter,
+//! and [`annotates`] is the one rule the filter reads to know which kinds it
+//! may offer. `find` hands this project's own corpus 1550 rows and 1096 of them
+//! are log entries, which is the measurement the decision was taken on.
+//!
+//! [`Detail`] is the other half of the same clause: `show --json` already
+//! carries the entries about an entity, so folding them under it is a field
+//! this reader reads rather than a query it composes.
+//!
 //! [`frontmatter`] is that walk and there is one of it. [`declared_scopes`] is
 //! it asked for the `scope` field, and the reader's field block is it asked for
 //! all of them: `content` stays the bytes `show` printed either way, because
@@ -197,7 +209,7 @@ impl Snapshot {
         let found = ank.json("find", &[])?;
         Ok(Snapshot {
             corpus: ank::text(&found, "corpus"),
-            entities: alive_first(ank::rows(&found, "results")),
+            entities: alive_first(listed(ank::rows(&found, "results"))),
             total: ank::count(&found, "total"),
         })
     }
@@ -262,6 +274,43 @@ impl Snapshot {
             )
             .finish()
     }
+}
+
+/// The kind an entity carries when it annotates another one, in the registry's
+/// own word (ADR-c9f9d1a05b23).
+pub const ANNOTATION: &str = "log";
+
+/// Whether a kind annotates an entity rather than being one a list shows
+/// (ADR-559eebf5c6f5, TASK-3fa4892f17c0).
+///
+/// **One predicate and every surface asks it.** A log entry is read under the
+/// entity it annotates, which makes "is this a row" a question with one answer
+/// -- so [`listed`] drops these before the order is decided, and the filter is
+/// offered the kinds that are left rather than the registry. Two places
+/// deciding it separately would be a filter offering a kind the list cannot
+/// hold, which is the state this replaces.
+pub fn annotates(kind: &str) -> bool {
+    kind == ANNOTATION
+}
+
+/// The rows of `find` that a list may show: everything that is not an
+/// annotation (ADR-559eebf5c6f5, TASK-3fa4892f17c0).
+///
+/// **Dropped here rather than filtered downstream**, which is the difference
+/// between a row that is hidden and a row that does not exist. Every listing
+/// this reader draws, every filter it offers and every count it prints reads
+/// [`Snapshot::entities`], so a log entry that never enters it cannot come back
+/// out of one of them -- where a renderer that skipped them would leave the
+/// next listing to remember to skip them too.
+///
+/// **It is not a narrowing of the corpus and does not pretend to be.**
+/// [`Snapshot::total`] stays what `find` said, and the entities title reads it
+/// as "in the corpus": the corpus does hold them, and the reader shows each of
+/// them under the entity it is about.
+fn listed(results: &[ank::Value]) -> impl Iterator<Item = &ank::Value> {
+    results
+        .iter()
+        .filter(|value| !annotates(&ank::text(value, "kind")))
 }
 
 /// Where a row stands in the order the reader opens on
@@ -340,9 +389,13 @@ impl Band {
 /// the field sorts to the end of its band and keeps its arrival order there:
 /// `created` reached `find --json` after the reader existed, and an older `ank`
 /// on the PATH should cost the order its recency, never its bands.
-fn alive_first(results: &[ank::Value]) -> Vec<Row> {
+///
+/// **It orders what [`listed`] handed it and decides no membership.** Which
+/// rows exist is the other clause of the same decision and is answered one
+/// function up, so this one cannot quietly drop a row while claiming to sort.
+fn alive_first<'a>(results: impl IntoIterator<Item = &'a ank::Value>) -> Vec<Row> {
     let mut rows: Vec<(Band, String, Row)> = results
-        .iter()
+        .into_iter()
         .map(|value| {
             (
                 Band::of(&ank::text(value, "status"), &ank::text(value, "state")),
@@ -488,6 +541,34 @@ impl Settings {
     }
 }
 
+/// One log entry, under the entity it annotates (ADR-559eebf5c6f5,
+/// TASK-3fa4892f17c0).
+///
+/// The four fields `show --json` gives one, and nothing derived from them. It
+/// is a `LOG-` entity like any other -- `ank show LOG-049cde` prints it whole --
+/// and this is the form in which it reaches the person who is reading the thing
+/// it is about, which is the only place the decision puts it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Entry {
+    pub id: String,
+    /// When it was written, in the corpus's own RFC 3339.
+    pub timestamp: String,
+    /// The agent that wrote it.
+    pub who: String,
+    pub message: String,
+}
+
+impl Entry {
+    fn read(value: &ank::Value) -> Entry {
+        Entry {
+            id: ank::text(value, "id"),
+            timestamp: ank::text(value, "timestamp"),
+            who: ank::text(value, "who"),
+            message: ank::text(value, "message"),
+        }
+    }
+}
+
 /// One entity, opened.
 #[derive(Debug, Clone)]
 pub struct Detail {
@@ -506,6 +587,29 @@ pub struct Detail {
     /// Shown rather than swallowed: a constraint list silently short by one is
     /// the one wrong answer a reader would act on.
     pub unresolved: Vec<String>,
+    /// What has been logged about this entity, in the order it was written
+    /// (ADR-559eebf5c6f5, TASK-3fa4892f17c0).
+    ///
+    /// **The order is `show`'s and is not re-derived here.** The verb hands the
+    /// entries oldest first, which is the order they were written in, and a
+    /// reader that sorted them again would be a second opinion about what
+    /// "written" means -- there is no `seq` on this document to sort by, and
+    /// re-reading the timestamps would answer differently the first time two
+    /// entries shared a second.
+    pub log: Vec<Entry>,
+    /// The machinery: the entries that record an edit rather than a message,
+    /// oldest first, exactly as [`Detail::log`] is.
+    ///
+    /// A list of its own because `show` gives it as one and the two are asked
+    /// different questions -- what somebody said about this, and what was done
+    /// to it. Both are log entities, and both are read here because neither is
+    /// a row of any list any more.
+    pub machinery: Vec<Entry>,
+    /// How many entries there are, where the budget showed fewer
+    /// (ADR-3e6ce108edcd). `show` says both, and a section that printed what it
+    /// held without saying what it withheld would be the one wrong answer a
+    /// person acts on by not looking further.
+    pub log_total: u64,
 }
 
 impl Detail {
@@ -546,6 +650,12 @@ impl Detail {
                 .map(Row::read)
                 .collect(),
             unresolved,
+            log: ank::rows(&shown, "log").iter().map(Entry::read).collect(),
+            machinery: ank::rows(&shown, "machinery")
+                .iter()
+                .map(Entry::read)
+                .collect(),
+            log_total: ank::count(&shown, "log_total"),
         })
     }
 }
@@ -1024,6 +1134,93 @@ mod tests {
                 "TASK-0000000000d1"
             ]
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // What is a row at all (TASK-3fa4892f17c0, ADR-559eebf5c6f5)
+    // -----------------------------------------------------------------------
+
+    /// **No entity of kind log is a row**, whatever band its status would have
+    /// put it in and wherever `find` handed it over.
+    ///
+    /// The corpus below is the shape of the real one: most of it is annotations,
+    /// they arrive interleaved with the entities, and one of them carries a
+    /// status word that would otherwise have put it in the first band. What
+    /// comes back is the entities, in the order the band and the instant give
+    /// them, and nothing else at all.
+    #[test]
+    fn no_entity_of_kind_log_is_a_row_of_the_list() {
+        let mut rows = vec![
+            found("TASK-0000000000f1", "open", "open", "2026-08-04T00:00:00Z"),
+            found(
+                "ADR-0000000000f2",
+                "proposed",
+                "proposed",
+                "2026-08-03T00:00:00Z",
+            ),
+        ];
+        for i in 0..8u32 {
+            // A log entry carries no status, which is the ordinary case, except
+            // the last -- which carries the most alive word there is, so a
+            // filter that read the band instead of the kind would put it first.
+            let (status, state) = match i {
+                7 => ("open", "claimed:claude-code/opus-5+somebody"),
+                _ => ("", ""),
+            };
+            rows.push(found(
+                &format!("LOG-0000000000e{i}"),
+                status,
+                state,
+                &format!("2026-08-0{}T00:00:00Z", i + 1),
+            ));
+        }
+        let shown: Vec<String> = alive_first(listed(&rows))
+            .iter()
+            .map(|r| r.id.clone())
+            .collect();
+        assert_eq!(shown, ["TASK-0000000000f1", "ADR-0000000000f2"]);
+        // And the eight are in the fixture, so the assertion above measured a
+        // filter rather than an empty room.
+        assert_eq!(rows.len(), 10);
+    }
+
+    /// The rule the filter reads, said of every kind the registry has.
+    ///
+    /// One kind annotates and the other three are entities somebody works on,
+    /// which is the whole of the distinction: a word this reader has never
+    /// heard of is not an annotation either, so a kind added to the corpus is a
+    /// row until somebody decides otherwise here.
+    #[test]
+    fn the_kind_that_annotates_is_the_log_and_it_is_the_only_one() {
+        assert!(annotates(ANNOTATION));
+        assert!(annotates("log"));
+        for kind in ["task", "adr", "spec", "", "epic"] {
+            assert!(!annotates(kind), "{kind} is not an annotation");
+        }
+    }
+
+    /// The entries `show` gives, in the order it gives them, with nothing
+    /// derived (TASK-3fa4892f17c0).
+    #[test]
+    fn a_log_entry_is_the_four_fields_show_states_and_no_fifth() {
+        let value = serde_json::json!({
+            "id": "LOG-049cde9e5724",
+            "timestamp": "2026-08-28T20:26:31Z",
+            "who": "claude-code/opus-5+one-row-composer",
+            "message": "Built. compose(here, fields, width) is the one assembler.",
+        });
+        assert_eq!(
+            Entry::read(&value),
+            Entry {
+                id: "LOG-049cde9e5724".to_string(),
+                timestamp: "2026-08-28T20:26:31Z".to_string(),
+                who: "claude-code/opus-5+one-row-composer".to_string(),
+                message: "Built. compose(here, fields, width) is the one assembler.".to_string(),
+            }
+        );
+        // A document missing a field is read rather than refused: the reader
+        // draws what the CLI said and never less of the rest for it.
+        assert_eq!(Entry::read(&serde_json::json!({})).message, "");
     }
 
     #[test]

--- a/crates/ank-tui/src/view.rs
+++ b/crates/ank-tui/src/view.rs
@@ -989,7 +989,7 @@ impl App {
         match keys::typed(key, self.focus) {
             Press::Run(command) => self.act(command, ank),
             Press::Cycle => {
-                let next = keys::next_kind(self.kind.as_deref());
+                let next = next_row_kind(self.kind.as_deref());
                 self.act(Command::Kind(next), ank)
             }
             // The search, started on an empty needle: there is no seed, because
@@ -1358,8 +1358,8 @@ impl App {
             // row number only ever had a refusal to offer.
             Command::Kind(kind) => {
                 if let Some(k) = &kind {
-                    if !keys::KINDS.contains(&k.as_str()) {
-                        self.note = Some(format!("no kind '{k}': {}", keys::KINDS.join(", ")));
+                    if !row_kinds().contains(&k.as_str()) {
+                        self.note = Some(format!("no kind '{k}': {}", row_kinds().join(", ")));
                         return false;
                     }
                 }
@@ -2375,6 +2375,7 @@ impl App {
             _ => {
                 let mut out = self.block(width);
                 out.extend(self.prose_rows(width).into_iter().map(|line| (line, None)));
+                out.extend(self.log_rows(width).into_iter().map(|line| (line, None)));
                 out
             }
         }
@@ -2449,6 +2450,60 @@ impl App {
             .flat_map(|l| wrap(l, width.max(1)))
             .map(|l| Composed::of(&l))
             .collect()
+    }
+
+    /// What has been logged about the open entity, under it
+    /// (ADR-559eebf5c6f5, TASK-3fa4892f17c0).
+    ///
+    /// **This is where a log entry is read, and it is the only place.** They are
+    /// no longer rows of any list -- seventy per cent of this corpus is log
+    /// entries and a list that opened on them answered a question nobody asked
+    /// -- so the entity they annotate is the one screen that has to carry them,
+    /// and it carries them whole: the entries `show` gave, in the order `show`
+    /// gave them, which is the order they were written in.
+    ///
+    /// **Nothing is drawn where there is nothing to draw.** Not a heading, not a
+    /// count and not the blank that separates a section from the prose above it:
+    /// an entity nobody has logged against draws no empty rule where the
+    /// entries would be, which is the other half of the criterion and the
+    /// reason this returns rows rather than a section that can be empty. The
+    /// field block above draws its `CONSTRAINTS` heading either way, and the
+    /// difference is not an inconsistency: a scope that nothing binds is a fact
+    /// a person came to find out, and a task nobody has written about is an
+    /// absence with nothing to say.
+    ///
+    /// **The machinery is its own section for the reason `show` makes it one.**
+    /// What somebody said about an entity and what was done to its fields are
+    /// two questions, and both are log entities -- so both are read here, and
+    /// neither of them is anywhere else any more.
+    ///
+    /// **`n of m` and never a bare count.** `show` answers within the same
+    /// attention budget every other verb does (ADR-3e6ce108edcd), so a section
+    /// that printed what it held without saying what it withheld would leave a
+    /// person to conclude from a short list that there was nothing more.
+    fn log_rows(&self, width: usize) -> Vec<Composed> {
+        let Some(detail) = &self.detail else {
+            return Vec::new();
+        };
+        let mut out = Vec::new();
+        if !detail.log.is_empty() {
+            out.push(Composed::new());
+            out.push(
+                Composed::of(&format!(
+                    "  LOG ({} of {})",
+                    detail.log.len(),
+                    detail.log_total
+                ))
+                .fitted(width),
+            );
+            out.extend(detail.log.iter().flat_map(|e| entry_rows(e, width)));
+        }
+        if !detail.machinery.is_empty() {
+            out.push(Composed::new());
+            out.push(Composed::of(&format!("  EDITS ({})", detail.machinery.len())).fitted(width));
+            out.extend(detail.machinery.iter().flat_map(|e| entry_rows(e, width)));
+        }
+        out
     }
 
     /// The field block: the entity's frontmatter as labelled rows, who holds
@@ -3989,6 +4044,46 @@ fn valued(label: &str, value: &str, role: Option<Role>, width: usize) -> Vec<Com
         .collect()
 }
 
+/// How far a log entry's message is indented under the line that heads it.
+///
+/// Two columns further in than everything else the document draws, which is the
+/// whole of what says the message belongs to the entry above it rather than to
+/// the section.
+const SAID: usize = 4;
+
+/// One log entry, as rows of the document it is read under
+/// (ADR-559eebf5c6f5, TASK-3fa4892f17c0).
+///
+/// A line naming the entry, then what it says. The identifier is on it because
+/// an entry is an entity -- `ank show LOG-049c` prints it whole -- and a person
+/// who wants to quote one needs the handle the CLI answers to; the instant and
+/// the agent are beside it because "who said this, and when" is the question a
+/// log is read with.
+///
+/// **The message is wrapped and never cut**, which is the promise the prose
+/// above it carries and it is worth more here: a log entry is where a previous
+/// holder wrote down why they stopped, and one losing its last clause to the
+/// right edge is the sentence nobody read.
+///
+/// **Not a row of a listing and so not [`compose`]'s.** There are no columns
+/// here to line up -- an entry is a heading and a paragraph, the shape
+/// [`field_rows`] and [`App::prose_rows`] already draw the document in -- and
+/// composing it as a row would be claiming a grid that the wrapped lines under
+/// it do not belong to.
+fn entry_rows(entry: &model::Entry, width: usize) -> Vec<Composed> {
+    let mut out = vec![Composed::new()
+        .plain("  ")
+        .named(&short_of(&entry.id), role_of_id(&entry.id))
+        .plain(&format!("  {}  {}", entry.timestamp, entry.who))
+        .fitted(width)];
+    out.extend(
+        wrap(&entry.message, width.saturating_sub(SAID).max(1))
+            .iter()
+            .map(|line| Composed::of(&format!("{}{line}", " ".repeat(SAID)))),
+    );
+    out
+}
+
 /// What the shared table says about a field's value.
 ///
 /// Three questions and no fourth, because there are three the table answers: a
@@ -4025,6 +4120,43 @@ fn step(at: usize, by: isize, total: usize) -> usize {
     let last = total - 1;
     let moved = at as isize + by;
     moved.clamp(0, last as isize) as usize
+}
+
+/// The kinds a row of the list may have, in the registry's own order
+/// (ADR-559eebf5c6f5, TASK-3fa4892f17c0).
+///
+/// **The registry, less the kinds no row can carry, and there is no third
+/// list.** `keys::KINDS` stays what it says it is -- the registry of
+/// ADR-c9f9d1a05b23 in the order `find --type` takes it -- and
+/// [`model::annotates`] stays the one rule about what a log entry is. This is
+/// the two of them put together, so a kind added to the registry is a kind this
+/// filter offers with no edit here, and a kind that stops being a row stops
+/// being offered the same way.
+///
+/// A filter that offered a kind the list cannot hold would be a key whose only
+/// possible answer is "no entity matches this filter", which is what
+/// ADR-559eebf5c6f5 calls a list answering a question nobody asked.
+fn row_kinds() -> Vec<&'static str> {
+    keys::KINDS
+        .iter()
+        .copied()
+        .filter(|kind| !model::annotates(kind))
+        .collect()
+}
+
+/// The kind after this one, among the kinds a row may have.
+///
+/// [`keys::next_kind`]'s cycle, walked past whatever is not a row: the step and
+/// the wrap back to every kind are the key table's and are not restated here,
+/// and what this adds is the one clause about annotations. It terminates
+/// because that cycle strictly advances and ends at `None`, which is the state
+/// a person can always get back to.
+fn next_row_kind(kind: Option<&str>) -> Option<String> {
+    let mut next = keys::next_kind(kind);
+    while next.as_deref().is_some_and(model::annotates) {
+        next = keys::next_kind(next.as_deref());
+    }
+    next
 }
 
 /// The marker the open search is drawn behind (TASK-c94d086682f3).
@@ -4208,6 +4340,30 @@ mod tests {
             blocked_by: Vec::new(),
             unblocks: Vec::new(),
             unresolved: Vec::new(),
+            // Nothing logged, which is the shape most of this suite is about:
+            // every assertion below that counts the rows of a document counts
+            // them on an entity that draws no log section at all.
+            log: Vec::new(),
+            machinery: Vec::new(),
+            log_total: 0,
+        }
+    }
+
+    /// The same entity, with entries logged against it (TASK-3fa4892f17c0).
+    fn annotated(id: &str, content: &str, said: &[&str]) -> Detail {
+        Detail {
+            log: said
+                .iter()
+                .enumerate()
+                .map(|(n, message)| model::Entry {
+                    id: format!("LOG-00a{n}00000000"),
+                    timestamp: format!("2026-08-2{}T09:00:00Z", n + 1),
+                    who: "claude-code/opus-5+log-under-its-entity".to_string(),
+                    message: (*message).to_string(),
+                })
+                .collect(),
+            log_total: said.len() as u64,
+            ..detail(id, content)
         }
     }
 
@@ -5602,6 +5758,244 @@ mod tests {
         a.act(Command::Kind(Some("epic".to_string())), &nowhere());
         assert_eq!(a.kind, None);
         assert!(a.note.unwrap().contains("no kind 'epic'"));
+    }
+
+    // -----------------------------------------------------------------------
+    // A log entry is read under its entity (TASK-3fa4892f17c0, ADR-559eebf5c6f5)
+    // -----------------------------------------------------------------------
+
+    /// **The kinds the filter cycles through are the kinds a row may have.**
+    ///
+    /// Pressed once per kind and once more, the cycle walks the registry with
+    /// the annotations left out and comes back to every kind -- so there is no
+    /// press that leaves a person looking at a filter the list can only answer
+    /// "no entity matches" to.
+    ///
+    /// The registry still declares the kind that is skipped, which is what says
+    /// this measures a filter rather than an empty room: if `log` ever stops
+    /// being in `keys::KINDS` the assertion below fails and this test has to be
+    /// re-read rather than quietly passing on nothing.
+    #[test]
+    fn the_filter_cycles_through_the_kinds_a_row_may_have_and_no_other() {
+        assert!(
+            keys::KINDS.contains(&model::ANNOTATION),
+            "the registry no longer declares the kind this skips"
+        );
+        let mut kind: Option<String> = None;
+        let mut walked = Vec::new();
+        for _ in 0..row_kinds().len() {
+            kind = next_row_kind(kind.as_deref());
+            walked.push(kind.clone().expect("a kind"));
+        }
+        assert_eq!(walked, row_kinds());
+        assert_eq!(
+            next_row_kind(kind.as_deref()),
+            None,
+            "and back to every kind"
+        );
+        assert!(
+            !walked.iter().any(|k| model::annotates(k)),
+            "the filter offered a kind no row can have: {walked:?}"
+        );
+        // The same rule from the other end: the command refuses the word, and
+        // says which kinds there are rather than which one it will not take.
+        let mut a = app();
+        a.act(
+            Command::Kind(Some(model::ANNOTATION.to_string())),
+            &nowhere(),
+        );
+        assert_eq!(a.kind, None, "the filter moved onto an annotation");
+        let said = a.note.expect("a refusal says so");
+        assert!(said.contains("no kind 'log'"), "{said}");
+        assert!(said.contains("adr, spec, task"), "{said}");
+    }
+
+    /// **The document of an entity carrying entries shows them beneath it, in
+    /// the order they were written.**
+    ///
+    /// Beneath: after the field block and after the prose, which is what "under
+    /// the entity" means on a screen that is one column. In the order `show`
+    /// gave them, which is the order they were written -- asserted as a sequence
+    /// and not as a set, because a section that held all three in the wrong
+    /// order would read as a history that did not happen.
+    #[test]
+    fn the_entries_about_an_entity_are_read_under_it_in_the_order_they_were_written() {
+        let mut a = app();
+        a.detail = Some(annotated(
+            "TASK-49746735127f",
+            "---\nid: TASK-49746735127f\n---\n\nThe body of the task.\n",
+            &[
+                "First: the perimeter is read.",
+                "Second: the thing is built.",
+                "Third: done, proof commit:abc1234.",
+            ],
+        ));
+        a.focus = Focus::Body;
+        let rows = texts(&a.pane_rows(a.body_width()));
+        let at = |needle: &str| {
+            rows.iter()
+                .position(|r| r.contains(needle))
+                .unwrap_or_else(|| panic!("{needle} is not on the document:\n{}", rows.join("\n")))
+        };
+        assert!(
+            at("LOG (3 of 3)") > at("The body of the task."),
+            "the entries are under the document, not over it:\n{}",
+            rows.join("\n")
+        );
+        assert!(
+            at("First:") < at("Second:") && at("Second:") < at("Third:"),
+            "the entries are out of the order they were written:\n{}",
+            rows.join("\n")
+        );
+        // The agent and the instant are on the line that heads an entry, and
+        // the entry's own identifier is with them: an entry is an entity, and
+        // `ank show LOG-00a0` is the road to the whole of it.
+        assert!(rows[at("First:") - 1].contains("LOG-00a0"), "{rows:?}");
+        assert!(
+            rows[at("First:") - 1].contains("2026-08-21T09:00:00Z"),
+            "{rows:?}"
+        );
+        assert!(
+            rows[at("First:") - 1].contains("claude-code/opus-5+log-under-its-entity"),
+            "{rows:?}"
+        );
+    }
+
+    /// **The document of an entity carrying none draws no empty rule where they
+    /// would be.**
+    ///
+    /// Not a heading, not a count, and not the blank line that would separate a
+    /// section from the prose above it: the rows of a document nobody has
+    /// logged against are the rows it had before any of this, exactly.
+    #[test]
+    fn an_entity_nobody_has_logged_against_draws_no_section_at_all() {
+        let content = "---\nid: TASK-49746735127f\n---\n\nThe body of the task.\n";
+        let mut bare = app();
+        bare.detail = Some(detail("TASK-49746735127f", content));
+        bare.focus = Focus::Body;
+        let rows = texts(&bare.pane_rows(bare.body_width()));
+        assert!(
+            !rows
+                .iter()
+                .any(|r| r.contains("LOG (") || r.contains("EDITS (")),
+            "a heading was drawn over nothing:\n{}",
+            rows.join("\n")
+        );
+        assert_eq!(
+            rows.last().map(|r| r.trim().to_string()),
+            Some("The body of the task.".to_string()),
+            "the document ends where its prose ends:\n{}",
+            rows.join("\n")
+        );
+
+        // And the same entity with one entry is the same rows plus the section,
+        // which is what says the rows above were not merely counted right.
+        let mut annotated_app = app();
+        annotated_app.detail = Some(annotated("TASK-49746735127f", content, &["Something."]));
+        annotated_app.focus = Focus::Body;
+        let with = texts(&annotated_app.pane_rows(annotated_app.body_width()));
+        assert_eq!(with[..rows.len()], rows[..], "the document above it moved");
+        assert_eq!(
+            with.len(),
+            rows.len() + 4,
+            "a blank, a heading, a head and a said line:\n{with:?}"
+        );
+    }
+
+    /// The machinery is a section of its own and is drawn on the same rule.
+    ///
+    /// An edit record is a log entity too, so it is read under the entity it
+    /// annotates and is nowhere else -- and an entity with entries but no edits
+    /// draws one section and not two.
+    #[test]
+    fn the_machinery_is_its_own_section_and_neither_is_drawn_empty() {
+        let content = "---\nid: TASK-49746735127f\n---\n\nbody\n";
+        let mut a = app();
+        a.detail = Some(Detail {
+            machinery: vec![model::Entry {
+                id: "LOG-0000000000b1".to_string(),
+                timestamp: "2026-08-22T10:00:00Z".to_string(),
+                who: "claude-code/opus-5+log-under-its-entity".to_string(),
+                message: "+scope crates/ank-tui/src/view.rs (version 1 to 2)".to_string(),
+            }],
+            ..annotated("TASK-49746735127f", content, &["Said."])
+        });
+        a.focus = Focus::Body;
+        let rows = texts(&a.pane_rows(a.body_width()));
+        let joined = rows.join("\n");
+        assert!(joined.contains("LOG (1 of 1)"), "{joined}");
+        assert!(joined.contains("EDITS (1)"), "{joined}");
+        assert!(
+            joined.contains("+scope crates/ank-tui/src/view.rs"),
+            "{joined}"
+        );
+
+        // With no edits, one section: the other heading is not drawn over an
+        // empty list.
+        let mut only = app();
+        only.detail = Some(annotated("TASK-49746735127f", content, &["Said."]));
+        only.focus = Focus::Body;
+        let alone = texts(&only.pane_rows(only.body_width())).join("\n");
+        assert!(alone.contains("LOG (1 of 1)"), "{alone}");
+        assert!(!alone.contains("EDITS"), "{alone}");
+    }
+
+    /// What the section says it is holding is what it holds, and what it
+    /// withheld is on the same line (ADR-3e6ce108edcd).
+    #[test]
+    fn a_section_short_of_the_whole_log_says_how_short_it_is() {
+        let mut a = app();
+        a.detail = Some(Detail {
+            log_total: 40,
+            ..annotated(
+                "TASK-49746735127f",
+                "---\nid: TASK-49746735127f\n---\n\nbody\n",
+                &["One.", "Two."],
+            )
+        });
+        a.focus = Focus::Body;
+        let joined = texts(&a.pane_rows(a.body_width())).join("\n");
+        assert!(
+            joined.contains("LOG (2 of 40)"),
+            "a budgeted section read as the whole of one:\n{joined}"
+        );
+    }
+
+    /// A message is wrapped and never cut, at the narrowest window the reader
+    /// draws -- which is the promise the prose above it carries, and it is worth
+    /// more here: an entry is where a previous holder wrote down why they
+    /// stopped.
+    #[test]
+    fn an_entry_is_wrapped_and_never_cut_at_forty_columns() {
+        let said = "A message long enough that no window this reader opens can \
+                    afford it on one row, ending in a clause that a cut would take.";
+        let mut a = App::new((40, 24), None);
+        a.snapshot = Some(snapshot());
+        a.detail = Some(annotated(
+            "TASK-49746735127f",
+            "---\nid: TASK-49746735127f\n---\n\nbody\n",
+            &[said],
+        ));
+        a.focus = Focus::Body;
+        let rows = texts(&a.pane_rows(a.body_width()));
+        let joined: String = rows
+            .iter()
+            .filter(|r| r.starts_with(&" ".repeat(SAID)))
+            .map(|r| r.trim().to_string())
+            .collect::<Vec<String>>()
+            .join(" ");
+        assert_eq!(
+            joined,
+            said.split_whitespace().collect::<Vec<&str>>().join(" "),
+            "the message was cut rather than wrapped:\n{rows:?}"
+        );
+        assert!(
+            !rows
+                .iter()
+                .filter(|r| r.starts_with(&" ".repeat(SAID)))
+                .any(|r| r.contains('~')),
+            "a row of the message was elided rather than wrapped:\n{rows:?}"
+        );
     }
 
     #[test]

--- a/crates/ank-tui/tests/log.rs
+++ b/crates/ank-tui/tests/log.rs
@@ -1,0 +1,414 @@
+//! Where a log entry is read, through the binary (TASK-3fa4892f17c0,
+//! ADR-559eebf5c6f5).
+//!
+//! CLAUDE.md leaves no choice about where this is measured, and the criterion
+//! ends by naming the instrument: *measured through the binary*. Both halves of
+//! it are claims about a screen. "No entity of kind log is a row of the list,
+//! under any filter the reader offers" is a claim about every state a person
+//! can put the list into, and the filter is a keystroke; "the document of an
+//! entity carrying log entries shows them beneath it" is a claim about rows
+//! under a document that a process paged, wrapped and painted. `src/model.rs`
+//! and `src/view.rs` assert the functions that decide both, on every platform;
+//! this asserts them of `ank tui`, on a pseudo-terminal, reading the frame the
+//! way a person reads it.
+//!
+//! **The corpus carries the annotations before anything is asserted about
+//! them.** Seventy per cent of this project's own corpus is log entries -- 1096
+//! of 1550 when the decision was taken -- and a suite whose fixture had none
+//! would report a screen with nothing to leave out. So the entries are made by
+//! running `ank log`, the entry count is asserted before the session opens, and
+//! one of them is searched for by identifier afterwards.
+//!
+//! **The kinds are held to the registry the binary declares, not to a list
+//! written here.** `ank find --type <kind>` refuses a kind the registry does
+//! not declare, which is what says that every kind the filter offers is a real
+//! one; `ank find --type log` is *accepted*, which is what says the kind the
+//! filter never offers exists and is being left out on purpose rather than
+//! having quietly disappeared. Between them there is no copy of the registry in
+//! this file to drift.
+//!
+//! **Nothing here asserts a wall-clock bound.** The instants in the fixture are
+//! the ones `ank log` stamped and are only ever compared with each other, so
+//! what this measures is a sequence and never a duration.
+//!
+//! `#[cfg(unix)]` for the reason the other suites give: a pseudo-terminal on
+//! Windows is ConPTY, and reaching it means the console API this workspace does
+//! not otherwise call. What runs on all three platforms is the filter, the
+//! ordering and the render, in `src/`.
+
+#![cfg(unix)]
+
+mod terminal;
+
+use ank_tui::bindings::{self, Runs, BINDINGS};
+use ank_tui::keys::Press;
+use terminal::{Live, Repo};
+
+/// Wide enough that a row is not cut before it is read, and tall enough that
+/// the whole of a short document -- field block, prose and the entries under it
+/// -- is on one screen. A sequence read through a page boundary is a sequence
+/// half read.
+const WINDOW: (u16, u16) = (120, 44);
+
+/// What is logged against the task, in the order it is written.
+///
+/// Three of them, each with a word no other row of this corpus carries, so that
+/// finding one on the screen is finding that entry and not a title that happens
+/// to share a phrase.
+const SAID: [&str; 3] = [
+    "Zeroth: the perimeter was read before any edit.",
+    "Umpteenth: the thing was built and the suite went green.",
+    "Ultimate: done, and the proof is a commit nobody waited for.",
+];
+
+/// The key the kind filter is cycled with, out of the reader's own table.
+///
+/// Never `f` written here. The point of the wave is that a key is the verb it
+/// runs, and a suite that typed the letter the filter happens to be bound to
+/// today would go on passing against a table that had moved it.
+fn key_of_kind() -> String {
+    let binding = BINDINGS
+        .iter()
+        .find(|b| b.runs == Runs::Press(Press::Cycle))
+        .expect("the reader binds a key to the kind filter");
+    let letter = bindings::named(binding.key);
+    assert_eq!(
+        letter.chars().count(),
+        1,
+        "the filter is named '{letter}', which is not one keystroke to send"
+    );
+    letter
+}
+
+/// The key an incremental search is opened with, out of the same table.
+fn key_of_search() -> String {
+    let binding = BINDINGS
+        .iter()
+        .find(|b| b.runs == Runs::Press(Press::Find))
+        .expect("the reader binds a key to the search");
+    bindings::named(binding.key)
+}
+
+/// A corpus carrying one entity of every kind a row may have, and annotations
+/// against one of them.
+///
+/// The seeded ADR and task are kept and a spec is added, so that every kind the
+/// filter can land on has a row to show: a filter offering a kind the fixture
+/// has no entity of would be measured against an empty list either way, and the
+/// question here is whether the offered kinds and the drawn kinds are the same
+/// set.
+///
+/// The entries are made by running `ank log`, which is the only road there is:
+/// a claim is taken first because the verb refuses to write to an open task
+/// this agent does not hold, and that refusal is what makes these entries real
+/// ones rather than files stamped beside the corpus.
+fn corpus() -> Repo {
+    let repo = Repo::seeded();
+    repo.ank(&[
+        "new",
+        "spec",
+        "--title",
+        "What the reader answers, and what it leaves out",
+        "--scope",
+        "src/**",
+    ]);
+    let task = repo.only(&["--type", "task"]);
+    repo.ank(&["claim", &task]);
+    for said in SAID {
+        repo.ank(&["log", &task, said]);
+    }
+    repo.warm_find();
+    repo
+}
+
+/// A panel's vertical border, at either weight, as characters.
+///
+/// Read out of the reader rather than written as a glyph here, for the reason
+/// `tests/phone.rs` gives: the border set has moved once already, and a suite
+/// carrying its own copy of the character would go on counting one the reader
+/// no longer draws.
+fn verticals() -> [char; 2] {
+    let of = |focused| {
+        ank_tui::view::BOXES
+            .border(focused)
+            .vertical_left
+            .chars()
+            .next()
+            .expect("a border set has a vertical")
+    };
+    [of(false), of(true)]
+}
+
+/// The short identifiers on the rows the region draws, one per row that carries
+/// one.
+///
+/// **Only the lines inside the border**, which is what makes this readable for a
+/// needle that is itself an identifier: the title's filter note and the search
+/// line both repeat whatever was typed, and a frame read whole would hand back
+/// the needle as a row nobody drew.
+fn rows(frame: &str) -> Vec<String> {
+    frame
+        .lines()
+        .filter(|line| {
+            line.chars()
+                .next()
+                .is_some_and(|c| verticals().contains(&c))
+        })
+        .filter_map(first_id)
+        .collect()
+}
+
+/// The first `KIND-xxxx` on a line, if it carries one.
+fn first_id(line: &str) -> Option<String> {
+    let kinds = ["TASK-", "ADR-", "SPEC-", "LOG-"];
+    let (at, len) = kinds
+        .iter()
+        .filter_map(|kind| line.find(kind).map(|at| (at, kind.len())))
+        .min()?;
+    let hex: String = line[at + len..]
+        .chars()
+        .take_while(|c| c.is_ascii_hexdigit())
+        .collect();
+    match hex.len() >= 4 {
+        true => Some(format!("{}{}", &line[at..at + len], &hex[..4])),
+        false => None,
+    }
+}
+
+/// The kinds the rows of a frame carry, as the identifiers spell them.
+fn kinds_drawn(frame: &str) -> Vec<String> {
+    let mut out: Vec<String> = rows(frame)
+        .iter()
+        .filter_map(|id| id.split_once('-').map(|(k, _)| k.to_ascii_lowercase()))
+        .collect();
+    out.sort();
+    out.dedup();
+    out
+}
+
+/// The kind the header says is in force, out of the filter note the entities
+/// title draws, and `None` where no filter is.
+fn kind_in_force(frame: &str) -> Option<String> {
+    let at = frame.find("[kind ")? + "[kind ".len();
+    let rest = &frame[at..];
+    Some(rest[..rest.find(']')?].trim().to_string())
+}
+
+/// Whichever entity of a kind the corpus holds one of.
+fn only(repo: &Repo, kind: &str) -> String {
+    terminal::short_of(&repo.only(&["--type", kind]))
+}
+
+// ---------------------------------------------------------------------------
+// A log entry is never a row of the list
+// ---------------------------------------------------------------------------
+
+/// **No entity of kind log is a row of the list, under any filter the reader
+/// offers, and the kinds the filter cycles through are the kinds a row may
+/// have** -- the first half of the criterion, on one session.
+///
+/// The filter is pressed until it comes back to every kind, which is the whole
+/// of what it can be put into, and at each stop two things are read off the
+/// frame: which kind the header says is in force, and which kinds the rows
+/// actually carry. The offered set and the drawn set have to be the same set,
+/// and neither may hold an annotation -- while `find --type log` answers on the
+/// same corpus, so the kind exists and this measured a filter rather than an
+/// absence.
+#[test]
+fn no_log_entry_is_a_row_under_any_filter_and_the_filter_offers_only_row_kinds() {
+    let repo = corpus();
+    let entries = terminal::ids_of(&repo.stdout(&["find", "--type", "log", "--json"]));
+    assert!(
+        entries.len() >= SAID.len(),
+        "the fixture carries {} annotations and the screen has nothing to leave out",
+        entries.len()
+    );
+
+    let mut session = Live::open(&repo, WINDOW.0, WINDOW.1);
+    let mut offered: Vec<String> = Vec::new();
+    let mut drawn: Vec<String> = Vec::new();
+    let key = key_of_kind();
+    // One press per kind and one more, bounded well above any registry so that
+    // a filter which stopped cycling fails here rather than hanging.
+    for press in 0..12 {
+        let frame = session.frame();
+        assert!(
+            !frame.contains("LOG-"),
+            "a log entry is a row of the list under {:?}:\n{frame}",
+            kind_in_force(&frame)
+        );
+        match kind_in_force(&frame) {
+            Some(kind) => offered.push(kind),
+            // Back to every kind, which is the state the cycle started in.
+            None if press > 0 => break,
+            None => drawn = kinds_drawn(&frame),
+        }
+        session.send(&key);
+    }
+    session.quit();
+
+    assert!(!offered.is_empty(), "the filter offered no kind at all");
+    assert_eq!(
+        offered, drawn,
+        "the kinds the filter cycles through are not the kinds the rows have"
+    );
+    assert!(
+        !offered.iter().any(|kind| kind == "log"),
+        "the filter offers a kind no row can have: {offered:?}"
+    );
+    // Every kind offered is one the registry declares, and the one left out is
+    // declared too: the binary answers about both, so neither half of that
+    // sentence is this file's opinion.
+    for kind in &offered {
+        repo.ank(&["find", "--type", kind, "--json"]);
+    }
+    repo.ank(&["find", "--type", "log", "--json"]);
+}
+
+/// The other filter, and the sharpest form of the same question: a person who
+/// types a log entry's own identifier at the search is told nothing matches.
+///
+/// The needle is an identifier the corpus really holds -- `show` answers about
+/// it in the same breath -- so what is being measured is a list that does not
+/// carry the row rather than a search that failed to look.
+#[test]
+fn a_search_for_an_entry_by_its_own_identifier_finds_no_row() {
+    let repo = corpus();
+    let entry = terminal::ids_of(&repo.stdout(&["find", "--type", "log", "--json"]))
+        .first()
+        .expect("the fixture logged against the task")
+        .clone();
+    let short = terminal::short_of(&entry);
+    // The CLI knows it: the reader is about to say it has no row for it, and
+    // that is a fact about the list and not about the corpus.
+    assert!(repo.stdout(&["show", &entry, "--json"]).contains(&entry));
+
+    let mut session = Live::open(&repo, WINDOW.0, WINDOW.1);
+    session.send(&key_of_search());
+    session.send(&short);
+    let frame = session.frame();
+    // The rows and not the whole frame: the needle is drawn on the search line
+    // and in the filter note, which is the reader repeating what was typed.
+    assert!(
+        rows(&frame).is_empty(),
+        "the needle is a log identifier and the list drew rows for it:\n{frame}"
+    );
+    assert!(
+        frame.contains(&short),
+        "the needle is not on the screen, so nothing was searched for:\n{frame}"
+    );
+    // The search is left before the session is: while one is open every key is
+    // a character of the needle, so a drive that asked to quit from inside it
+    // would type the letter and wait forever for a process that is still
+    // running (TASK-c94d086682f3). Enter is the way out that keeps the
+    // narrowing, which is also what leaves the assertion above standing.
+    session.send("\r");
+    session.quit();
+}
+
+// ---------------------------------------------------------------------------
+// A log entry is read under the entity it annotates
+// ---------------------------------------------------------------------------
+
+/// **The document of an entity carrying log entries shows them beneath it in
+/// the order they were written.**
+///
+/// Beneath: after the entity's own body, which is what "under it" means on a
+/// screen that is one region. In the order they were written, asserted as a
+/// sequence and not as a set -- a section holding all three in the wrong order
+/// would read as a history that did not happen.
+#[test]
+fn the_entries_are_read_under_the_entity_in_the_order_they_were_written() {
+    let repo = corpus();
+    let task = only(&repo, "task");
+    let mut session = Live::open(&repo, WINDOW.0, WINDOW.1);
+    open_row(&mut session, &task);
+    let frame = session.frame();
+
+    let at = |needle: &str| {
+        frame
+            .lines()
+            .position(|line| line.contains(needle))
+            .unwrap_or_else(|| panic!("'{needle}' is not on the document:\n{frame}"))
+    };
+    // The section is under the document and not over it: the frontmatter's own
+    // identifier row is the head of the body panel.
+    assert!(
+        at("LOG (") > at("done_criteria"),
+        "the entries are drawn over the document:\n{frame}"
+    );
+    let heads: Vec<usize> = SAID.iter().map(|said| at(head_of(said))).collect();
+    assert!(
+        heads.windows(2).all(|pair| pair[0] < pair[1]),
+        "the entries are out of the order they were written: {heads:?}\n{frame}"
+    );
+    // And the section says how many it is holding, so a budgeted one could not
+    // read as the whole of a log.
+    assert!(
+        frame.contains(&format!("LOG ({} of {})", SAID.len(), SAID.len())),
+        "the section does not say what it holds:\n{frame}"
+    );
+    session.quit();
+}
+
+/// **The document of an entity carrying none draws no empty rule where they
+/// would be.**
+///
+/// The ADR of this corpus has nothing logged against it, and what its document
+/// draws is what it drew before any of this: no heading, no count, and not the
+/// blank line that would separate a section from the body above it.
+#[test]
+fn an_entity_nobody_has_logged_against_draws_no_section_at_all() {
+    let repo = corpus();
+    let adr = only(&repo, "adr");
+    assert!(
+        terminal::ids_of(&repo.stdout(&["find", "--type", "log", "--json"])).len() >= SAID.len(),
+        "the corpus has annotations, and this one entity has none"
+    );
+
+    let mut session = Live::open(&repo, WINDOW.0, WINDOW.1);
+    open_row(&mut session, &adr);
+    let frame = session.frame();
+    assert!(
+        frame.contains(&adr),
+        "the document did not open on the decision:\n{frame}"
+    );
+    assert!(
+        !frame.contains("LOG ("),
+        "a heading was drawn over nothing:\n{frame}"
+    );
+    assert!(
+        !frame.contains("EDITS ("),
+        "a heading was drawn over nothing:\n{frame}"
+    );
+    assert!(
+        !frame.contains("LOG-"),
+        "an entry reached a document that has none:\n{frame}"
+    );
+    session.quit();
+}
+
+/// The row a listing draws for an identifier, opened.
+///
+/// The cursor is walked down to it and Enter is pressed, which is the road a
+/// person takes: nothing here reaches a document by any other means, so what is
+/// measured afterwards is what opening a row actually draws.
+fn open_row(session: &mut Live, short: &str) {
+    let at = rows(&session.frame())
+        .iter()
+        .position(|id| id == short)
+        .unwrap_or_else(|| panic!("{short} is not a row of the list:\n{}", session.frame()));
+    for _ in 0..at {
+        session.send("j");
+    }
+    session.send("\r");
+    session.until("the document to open", |frame| frame.contains("scope:"));
+}
+
+/// The head of a logged message, which is what a wrapped entry is found by.
+///
+/// The first words only: an entry is wrapped to the panel, so the whole of a
+/// sentence is several rows and no one of them carries it.
+fn head_of(said: &str) -> &str {
+    said.split_once(':').expect("each message is headed").0
+}


### PR DESCRIPTION
TASK-3fa4892f17c0, under the proposed ADR-559eebf5c6f5.

Seventy per cent of this corpus is log entries — 1096 of 1550 rows when the
decision was taken — so a list that opens on them is a list that has answered a
question nobody asked. They move to the one screen that has a reason to carry
them: the entity they annotate.

**What is a row is decided one function before what order the rows are in.**
`model::listed` drops the annotations, so a log entry does not exist as a row
rather than being a row every listing has to remember to hide; `annotates` is
the one rule, and `view::row_kinds` is the registry minus it, so there is no
third list and no filter offering a kind the list cannot hold. `Snapshot::total`
still says what `find` said, and the title still reads it as "in the corpus" —
because the corpus does hold them.

**Under the entity.** `Detail` gained `log`, `machinery` and `log_total` off
`show --json`'s own fields, in the order that verb hands them over, which is the
order they were written; nothing is re-sorted here. `App::log_rows` draws each
section only where it has entries, so an entity nobody has logged against draws
no heading, no count, and not the blank that would separate one. An entry is a
heading and a paragraph rather than a row of a grid, so it goes through
`Composed::of` and never `compose` — the one row composer TASK-d58efe37eb7b
settled is untouched, and its test still refuses a second.

**Measured through the binary.** `crates/ank-tui/tests/log.rs` drives `ank tui`
on a pseudo-terminal over a corpus whose entries were made by running `ank log`:
the filter walked to every stop with no `LOG` row under any of them and the
offered kinds equal the drawn kinds, a search on an entry's own identifier
finding nothing while `show` answers about it, the three entries read under the
task in the order they were written, and the ADR with none drawing no rule. Each
was shown to bite by planting the violation it is written against. The kinds are
held to the registry the binary declares — `find --type <kind>` refuses one it
does not — so no copy of the registry lives in the suite.

`cargo test --workspace` green, `cargo fmt --check` clean, `ank check` ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SA7sDsW8WULPTzwrZTyqDa