### PR TITLE
Every process the CLI suite spawns writes inside the run's own root

### DIFF
--- a/.ank/entities/LOG-70ac84a27413.md
+++ b/.ank/entities/LOG-70ac84a27413.md
@@ -1,0 +1,27 @@
+---
+id: LOG-70ac84a27413
+type: log
+title: Measured, not read. TMPDIR pointed at an empty directory, cargo test --workspace green (exit 0),
+created: 2026-08-28T23:10:14Z
+author: claude-code/opus-5+child-temp-dir
+scope:
+  - crates/ank-cli/tests/cli.rs
+  - crates/ank-cli/src/human.rs
+about: TASK-02350943e2b1
+seq: 1
+schema: 4
+version: 1
+---
+
+ twice.
+
+Before: 16 ank-edit-*, 20 ank-signers-*, one ank-it-* root, exactly the counts this task's body carries.
+After: one ank-edit-*, no ank-signers-*, one ank-it-* root.
+
+The twenty signers are gone and the sixteen editor files are down to one, and the one that remains is not written by anything in this task's scope. Attributed by running each test target into its own empty directory: crates/ank-cli/tests/cli.rs left 15 of the 16 ank-edit-* and 13 of the signers; the sixteenth is crates/ank-tui/tests/entity.rs, which runs 'ank new task' with a fake $EDITOR through the spawn helper in crates/ank-tui/tests/terminal/mod.rs and lets the child inherit the suite's TMPDIR. Same defect as cli.rs had, same one-line fix, another crate's file. Filed rather than reached for.
+
+The body's premise about the signers is half right, the way TASK-ac2ff41162c6's was. Eight do not come from human.rs's own unit test: one does, five more come from Temp fixtures reaching signers_for_git through signature_state, and the last is written by two tests at once -- human::tests::this_repositorys_own_ratifications_are_signed and cli::tests::the_foundation_is_resolved_before_the_verb_runs, both of which check this very repository, whose allowed_signers carries a gpg entry under gpg.format=ssh. That second writer is in crates/ank-cli/src/cli.rs, outside this scope, so no cleanup written in a test could make the count deterministic: whichever of the two finished last decided whether a file remained.
+
+So the copy is cleaned up where it is written instead. signers_for_git returns a guard now, and the filtered copy is removed when the last holder of it drops. The lifetime changed and nothing else did: the name is still content-addressed, because git::batched memoises every ratification under the allowed-signers path it was asked with and a per-call name would undo TASK-1b3d7b61dc8f; the process id joins the name and a count guards it inside the process, because check verifies on one thread and this crate's tests do not. It is also asked for after the signature cache rather than before, so a verdict already held writes no file at all.
+
+The editor's file is untouched in kind. editor::kept still writes it, the refusal still names it, and it still holds what was typed -- what_a_spawned_child_calls_temporary_is_this_runs_own_root asserts all three through the binary. Only the directory the child calls temporary moved, TMPDIR and TMP and TEMP together because std::env::temp_dir reads the last two on Windows.

--- a/.ank/entities/TASK-02350943e2b1.md
+++ b/.ank/entities/TASK-02350943e2b1.md
@@ -5,7 +5,7 @@ slug: the-ank-binary-the-suite-spawns-writes-into-the
 title: The ank binary the suite spawns writes into the shared temporary directory
 created: 2026-08-28T18:27:06Z
 author: claude-code/opus-5+tests-leave-nothing
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/tests/cli.rs
   - crates/ank-cli/src/human.rs
@@ -14,7 +14,7 @@ done_criteria: |
   After a green cargo test --workspace into an empty temporary directory, the only entries left are the ank-it-* roots of the run itself: no ank-edit-* and no ank-signers-* file remains. The editor's scratch file still survives a failed edit and is still named in the refusal -- what changes is where the child looks for a temporary directory, not what ank does with one.
 criteria_by: creator
 schema: 4
-version: 2
+version: 3
 ---
 
 TASK-ac2ff41162c6 fixed the families born in cfg(test) blocks under src/ and measured the two it could not reach from its scope.

--- a/.ank/entities/TASK-ec85b1561855.md
+++ b/.ank/entities/TASK-ec85b1561855.md
@@ -1,0 +1,53 @@
+---
+id: TASK-ec85b1561855
+type: task
+slug: the-tui-suite-s-spawn-helper-lets-the-binary-inh
+title: The TUI suite's spawn helper lets the binary inherit the machine's temporary directory
+created: 2026-08-28T23:10:35Z
+author: claude-code/opus-5+child-temp-dir
+status: open
+scope:
+  - crates/ank-tui/tests/terminal/mod.rs
+blocked_by: []
+done_criteria: |
+  After a green cargo test -p ank-tui into an empty temporary directory, the only entry left is the ank-it-* root of the run itself: no ank-edit-* file remains beside it. The editor's scratch file is still written and still kept -- what changes is where the child looks for a temporary directory.
+criteria_by: creator
+schema: 4
+version: 1
+---
+
+TASK-02350943e2b1 pointed every process `crates/ank-cli/tests/cli.rs` spawns at
+that suite's own `ank-it-<pid>` root, and measured what was left afterwards.
+One file survives, and it is this crate's.
+
+Measured on 2026-08-29, `TMPDIR` set to an empty directory, `cargo test
+--workspace` green, twice: one `ank-edit-*` remains and nothing else. Run per
+target into its own empty directory, it is `cargo test -p ank-tui --test
+entity` that leaves it -- `ank new task` run with a fake `$EDITOR` through
+`Live`/`Repo` in `crates/ank-tui/tests/terminal/mod.rs`, which builds the child
+with `Command::new(ank())` and says nothing about `TMPDIR`, so the binary
+writes its scratch file into whatever temporary directory the developer or the
+runner happens to have.
+
+## Not a leaking test
+
+The file is `editor::scratch_path`, kept on purpose: every path that fails
+after the editor has run goes through `editor::kept`, whose whole job is to
+answer a typo without discarding the twenty minutes around it, and the refusal
+names the file. Sweeping it where it is written would delete a caller's text
+between reading the message and opening the path. So the fix is not to remove
+it: it is to point the child at the root this suite already makes and the next
+run already sweeps.
+
+## What to do
+
+`crates/ank-tui/tests/terminal/mod.rs` has two spawn sites for the binary (the
+`Repo::ank` helper and the pty session). Set `TMPDIR`, `TMP` and `TEMP` on the
+child to this process's `scratch` root, the way
+`crates/ank-cli/tests/cli.rs::spawn` now does -- all three names, because
+`std::env::temp_dir` reads `TMP` and `TEMP` on Windows and `TMPDIR` everywhere
+else, and setting one of the three would leave the child on the runner's own
+temporary directory on the platform this suite runs last.
+
+TASK-02350943e2b1's criterion is met the day this lands, and nothing else is
+outstanding against it.

--- a/crates/ank-cli/src/human.rs
+++ b/crates/ank-cli/src/human.rs
@@ -47,6 +47,7 @@ use std::cell::OnceCell;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
 
 // ---------------------------------------------------------------------------
 // Findings
@@ -923,28 +924,96 @@ pub fn git_readable_signers(text: &str) -> String {
     out
 }
 
-/// The path to hand git, which is the file itself whenever git can read all of
-/// it and a filtered copy otherwise.
+/// The file to hand git, and how long it needs to exist.
 ///
-/// Returning the source unchanged in the ordinary case matters: a corpus that
-/// declares only SSH keys writes nothing anywhere, and the file git verifies
-/// against is the file under review. The copy is named after a hash of its own
-/// content, so repeated calls over one corpus write it once and two corpora
-/// never collide.
-fn signers_for_git(source: &Path) -> Option<PathBuf> {
+/// Where git can read the declared file whole this **is** that file and nothing
+/// is written anywhere: a corpus declaring only SSH keys verifies against the
+/// file under review rather than against a copy of it. Where it cannot, this is
+/// the filtered copy, and the copy is scratch — it exists for the one git call
+/// the caller is about to make, and the last holder to drop removes it.
+///
+/// **Removing it is the change TASK-02350943e2b1 made**, and it is a change to
+/// the lifetime and not to the content. The copy used to be left where it was
+/// written, one per distinct allowlist, for as long as the machine kept its
+/// temporary directory: twenty of them stood there after a single green
+/// `cargo test --workspace`, written by the tool itself and by no leaking test.
+/// Nothing reads the file after the call it was written for — the caller hands
+/// the path straight to git and keeps none of it — so what the old lifetime
+/// bought was one skipped write of a file smaller than the signature it helps
+/// check.
+///
+/// **The name stays content-addressed, and it has to.** `git::batched`
+/// memoises every ratification's verdict under the allowed-signers path it was
+/// asked with, so a name that changed per call would turn one `rev-list` over
+/// the whole corpus into one per ratification, which is the cost
+/// TASK-1b3d7b61dc8f removed. The process id joins it because a name two
+/// processes share is a name one can pull out from under the other, and
+/// `HELD` is that same rule inside one process: `check` verifies on one
+/// thread, this crate's own tests do not, and two of them read this very
+/// repository at once.
+struct SignersForGit {
+    path: PathBuf,
+    /// Whether the path is a copy this value owns, rather than the source.
+    scratch: bool,
+}
+
+impl SignersForGit {
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for SignersForGit {
+    fn drop(&mut self) {
+        if !self.scratch {
+            return;
+        }
+        let Ok(mut held) = held().lock() else {
+            return;
+        };
+        let Some(count) = held.get_mut(&self.path) else {
+            return;
+        };
+        *count -= 1;
+        if *count == 0 {
+            held.remove(&self.path);
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
+/// How many live `SignersForGit` values each scratch copy is answering for.
+fn held() -> &'static Mutex<HashMap<PathBuf, usize>> {
+    static HELD: OnceLock<Mutex<HashMap<PathBuf, usize>>> = OnceLock::new();
+    HELD.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn signers_for_git(source: &Path) -> Option<SignersForGit> {
     let text = std::fs::read_to_string(source).ok()?;
     let readable = git_readable_signers(&text);
     if readable == text {
-        return Some(source.to_path_buf());
+        return Some(SignersForGit {
+            path: source.to_path_buf(),
+            scratch: false,
+        });
     }
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     std::hash::Hash::hash(&readable, &mut hasher);
     let digest = std::hash::Hasher::finish(&hasher);
-    let path = std::env::temp_dir().join(format!("ank-signers-{digest:016x}"));
-    if std::fs::read_to_string(&path).ok().as_deref() != Some(readable.as_str()) {
-        std::fs::write(&path, &readable).ok()?;
+    let path =
+        std::env::temp_dir().join(format!("ank-signers-{}-{digest:016x}", std::process::id()));
+    // Counted before the write and released only by `Drop`, so a second caller
+    // arriving between the first one's git call and its removal keeps the file
+    // alive instead of finding it gone.
+    *held().lock().ok()?.entry(path.clone()).or_insert(0) += 1;
+    let guard = SignersForGit {
+        path,
+        scratch: true,
+    };
+    if std::fs::read_to_string(&guard.path).ok().as_deref() != Some(readable.as_str()) {
+        std::fs::write(&guard.path, &readable).ok()?;
     }
-    Some(path)
+    Some(guard)
 }
 
 /// What a ratification commit's signature is worth.
@@ -5062,14 +5131,6 @@ pub fn signature_state<'a>(repo: &Repo, of: impl Into<Anchored<'a>>) -> Option<S
     }
 
     let sha = ratification_of(repo, &view)?.sha;
-    // `.ok()?` here used to fold every git failure into `None`, the one verdict
-    // `check_adr` says nothing about — so a machine where the signature could
-    // not be read looked exactly like a corpus that declared no key at all
-    // (TASK-c92b7cc10f13). Failing to ask has to survive as an answer.
-    // The file git is pointed at, which is the reviewed one unless it carries
-    // entries only ank reads. Falling back to the source on a failure to write
-    // keeps the behaviour this had before the filter existed.
-    let for_git = signers_for_git(&signers).unwrap_or_else(|| signers.clone());
 
     // **The verdict already reached for this commit, under this allowlist**
     // (TASK-dbef284a166c). gpg is 4.0 of the 7.1 seconds `check` costs on this
@@ -5092,7 +5153,21 @@ pub fn signature_state<'a>(repo: &Repo, of: impl Into<Anchored<'a>>) -> Option<S
         return Some(classify_signature(&facts, &declared, carries));
     }
 
-    match git::signature_of(&repo.corpus, &sha, Some(&for_git)) {
+    // The file git is pointed at, which is the reviewed one unless it carries
+    // entries only ank reads. Asked for here and not above the cache, because
+    // it is this call that needs it and a verdict already held needs no file at
+    // all. Falling back to the source on a failure to write keeps the behaviour
+    // this had before the filter existed.
+    //
+    // `.ok()?` below used to fold every git failure into `None`, the one
+    // verdict `check_adr` says nothing about — so a machine where the signature
+    // could not be read looked exactly like a corpus that declared no key at
+    // all (TASK-c92b7cc10f13). Failing to ask has to survive as an answer.
+    let for_git = signers_for_git(&signers);
+    let handed = for_git
+        .as_ref()
+        .map_or(signers.as_path(), SignersForGit::path);
+    match git::signature_of(&repo.corpus, &sha, Some(handed)) {
         Ok(facts) => {
             signature_cache(repo, |index, key| {
                 index.remember_signature(&sha, key, facts.status, &facts.fingerprint);
@@ -8515,18 +8590,32 @@ mod tests {
         let file = dir.join("allowed_signers");
         std::fs::write(&file, source).unwrap();
         assert_eq!(
-            signers_for_git(&file).as_deref(),
-            Some(file.as_path()),
+            signers_for_git(&file).unwrap().path(),
+            file.as_path(),
             "no copy is written when none is needed"
         );
 
         std::fs::write(&file, format!("sean@example.com gpg 739A60\n{source}")).unwrap();
         let handed = signers_for_git(&file).unwrap();
         assert_ne!(
-            handed, file,
+            handed.path(),
+            file,
             "a file carrying an ank-only entry needs a copy"
         );
-        assert_eq!(std::fs::read_to_string(&handed).unwrap(), source);
+        assert_eq!(std::fs::read_to_string(handed.path()).unwrap(), source);
+
+        // And the copy is scratch: it lives for the git call it was written
+        // for and no longer (TASK-02350943e2b1). It is not inside `dir` — it
+        // is named after its own content, in the temporary directory — so
+        // removing the directory this test made would never have reached it,
+        // which is how twenty of them came to stand beside the suite's root.
+        let copy = handed.path().to_path_buf();
+        drop(handed);
+        assert!(
+            !copy.exists(),
+            "the copy outlived the value that owned it: {}",
+            copy.display()
+        );
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -68,11 +68,36 @@ fn isolated_git_config() -> &'static Path {
 /// twenty-four: the isolation is load-bearing rather than doubled by a habit,
 /// and every test in this file exercises it.
 /// `nothing_spawns_a_process_outside_the_one_door` keeps this the only door.
+///
+/// It is also where the child is told what "temporary" means, and for the same
+/// reason: a child that inherits the suite's own `TMPDIR` writes beside every
+/// other run on the machine, and nothing collects what it leaves
+/// (TASK-02350943e2b1). Measured on 2026-08-29, `cargo test --workspace` into
+/// an empty temporary directory: sixteen `ank-edit-*` and twenty
+/// `ank-signers-*` files, every one of the integration ones written by a
+/// process spawned here. Pointing the child at this run's root puts them
+/// inside the directory the next run already sweeps, and it covers the
+/// families the tool has not grown yet as well as these two.
+///
+/// **What is not being fixed is where those files are written.** The editor's
+/// scratch file is kept on purpose: `editor::kept` answers a typo without
+/// discarding the twenty minutes around it, and a file swept between the
+/// caller reading the refusal and opening the path it names would be that
+/// promise broken. It is still written, still kept, still named. Only the
+/// directory the child calls temporary moves, and this run's root outlives
+/// this run.
+///
+/// All three names, because `std::env::temp_dir` reads `TMP` and `TEMP` on
+/// Windows and `TMPDIR` everywhere else: setting one of the three would leave
+/// the child on the runner's own temporary directory on the platform where
+/// this suite runs last.
 fn spawn(program: impl AsRef<OsStr>) -> Command {
     let mut c = Command::new(program);
     let config = isolated_git_config();
     c.env("GIT_CONFIG_GLOBAL", config)
         .env("GIT_CONFIG_SYSTEM", config);
+    let root = scratch::root();
+    c.env("TMPDIR", root).env("TMP", root).env("TEMP", root);
     c
 }
 
@@ -1054,6 +1079,53 @@ fn nothing_spawns_a_process_outside_the_one_door() {
         "a process is spawned outside `spawn`, so it inherits the git \
          configuration of the machine running the suite: route it through \
          `git_command`, `ank_command` or `spawn`"
+    );
+}
+
+/// The other half of the one door: what a child of this suite calls temporary
+/// is this run's own root, and the file the editor keeps proves it.
+///
+/// Through the binary, and through the family that must *not* be swept where
+/// it is written. `an_invalid_result_leaves_the_entity_untouched_and_says_why`
+/// asserts the promise — the refusal names the file and the file holds what
+/// was typed — and this asserts where the promise is kept, which is the only
+/// thing TASK-02350943e2b1 changed. Both have to hold at once: a run that
+/// leaves nothing behind by discarding a caller's text has traded a full
+/// temporary directory for a worse defect.
+///
+/// The kept file is deliberately not removed here. It is inside the root, the
+/// next run collects the root, and a test that swept it would be asserting
+/// nothing about where it landed.
+#[test]
+fn what_a_spawned_child_calls_temporary_is_this_runs_own_root() {
+    let r = Repo::new();
+    r.seed_task(ID, Some("A verifiable criterion."));
+    let broken = "---\nid: TASK-000000000001\ntype: task\ntitle: Half a file\n";
+    let editor = r.editor_saving(broken);
+
+    let out = r.ank_edit("claude-code@ank", &["edit", ID], Some(&editor));
+    assert_eq!(code(&out), 1, "{}", stderr(&out));
+    let err = stderr(&out);
+    let kept = err
+        .split("kept at ")
+        .nth(1)
+        .and_then(|s| s.split(')').next())
+        .expect("the refusal names where the text was kept")
+        .trim()
+        .to_string();
+    let kept = Path::new(&kept);
+
+    assert!(
+        kept.starts_with(scratch::root()),
+        "the child wrote outside this run's root, where nothing collects it: \
+         {} is not under {}",
+        kept.display(),
+        scratch::root().display()
+    );
+    assert_eq!(
+        std::fs::read_to_string(kept).expect("the kept file exists"),
+        broken,
+        "moved, not swept: the text the editor saved is still there"
     );
 }
 


### PR DESCRIPTION
`cargo test --workspace` into an empty temporary directory left thirty-six files beside the one root it makes: sixteen `ank-edit-*` and twenty `ank-signers-*`. Neither family is a leaking test — both are written by ank itself, and the suite let the binary it spawns inherit whatever the developer or the runner calls temporary (TASK-02350943e2b1).

**The harness.** `spawn`, the one door every process of `crates/ank-cli/tests/cli.rs` goes through, now hands the child `TMPDIR`, `TMP` and `TEMP` pointed at this process's `ank-it-<pid>` root — all three names because `std::env::temp_dir` reads the last two on Windows. What the child writes lands in the directory the next run already sweeps.

**The editor's file is unchanged in kind.** `editor::kept` still writes it, the refusal still names it, and it still holds what was typed; sweeping it where it is written would delete a caller's text between reading the message and opening the path. `what_a_spawned_child_calls_temporary_is_this_runs_own_root` asserts all three through the binary.

**The signers copy is cleaned up where it is written**, because no test could make that count deterministic: the same file is written by `human::tests::this_repositorys_own_ratifications_are_signed` and by `cli::tests::the_foundation_is_resolved_before_the_verb_runs`, both checking this repository, and whichever finished last decided whether a file remained. `signers_for_git` returns a guard and the filtered copy is removed when the last holder drops. Only the lifetime moved: the name stays content-addressed, or `git::batched` loses the memo TASK-1b3d7b61dc8f added, and it gains the process id and a count so no other process or thread can have it pulled out from under it.

**Measured, not read.** `TMPDIR` empty, `cargo test --workspace` green, three times: no `ank-signers-*` remains and one `ank-edit-*` does. That one is `crates/ank-tui/tests/entity.rs` running `ank new task` with a fake `$EDITOR` through a spawn helper in another crate — outside this task's scope, filed as TASK-ec85b1561855, and TASK-02350943e2b1's criterion is met the day it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014m1wLBka1Efw3thegTQkAa