### PR TITLE
TASK-02350943e2b1 waits on the crate its last file belongs to

### DIFF
--- a/.ank/entities/LOG-48c381a6cc30.md
+++ b/.ank/entities/LOG-48c381a6cc30.md
@@ -1,0 +1,15 @@
+---
+id: LOG-48c381a6cc30
+type: log
+title: +blocked_by TASK-ec85b1561855 (version 3 to 4, replaced 8f792a78a3da, produced 147d5f9223e2)
+created: 2026-08-28T23:29:31Z
+author: claude-code/opus-5+child-temp-dir
+scope:
+  - crates/ank-cli/tests/cli.rs
+  - crates/ank-cli/src/human.rs
+about: TASK-02350943e2b1
+seq: 2
+records: edit
+schema: 4
+version: 1
+---

--- a/.ank/entities/TASK-02350943e2b1.md
+++ b/.ank/entities/TASK-02350943e2b1.md
@@ -9,12 +9,12 @@ status: in_progress
 scope:
   - crates/ank-cli/tests/cli.rs
   - crates/ank-cli/src/human.rs
-blocked_by: []
+blocked_by: [TASK-ec85b1561855]
 done_criteria: |
   After a green cargo test --workspace into an empty temporary directory, the only entries left are the ank-it-* roots of the run itself: no ank-edit-* and no ank-signers-* file remains. The editor's scratch file still survives a failed edit and is still named in the refusal -- what changes is where the child looks for a temporary directory, not what ank does with one.
 criteria_by: creator
 schema: 4
-version: 3
+version: 4
 ---
 
 TASK-ac2ff41162c6 fixed the families born in cfg(test) blocks under src/ and measured the two it could not reach from its scope.


### PR DESCRIPTION
Follow-up to #330. After that landed, one `ank-edit-*` still stands beside the run's root, and it is written by `crates/ank-tui/tests/entity.rs` through a spawn helper outside TASK-02350943e2b1's scope — filed as TASK-ec85b1561855.

So the task records the blocker rather than sitting open and unblocked for the next holder to claim, re-measure, and rediscover. `ank check` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014m1wLBka1Efw3thegTQkAa