### PR TITLE
Every process the TUI suite spawns writes inside the run's own root

### DIFF
--- a/.ank/entities/LOG-5340474da9b5.md
+++ b/.ank/entities/LOG-5340474da9b5.md
@@ -1,0 +1,21 @@
+---
+id: LOG-5340474da9b5
+type: log
+title: Measured, not read. TMPDIR pointed at an empty directory, cargo test --workspace green (exit 0),
+created: 2026-08-29T00:28:01Z
+author: claude-code/opus-5+tui-spawn-tmpdir
+scope:
+  - crates/ank-tui/tests/terminal/mod.rs
+about: TASK-ec85b1561855
+seq: 0
+schema: 4
+version: 1
+---
+
+ twice: one entry left in the base, the ank-it-<pid> root of the run itself. Zero ank-edit-*, zero ank-signers-*. The 16 and 20 the chain started from are gone.
+
+Attributed, too, rather than assumed: cargo test -p ank-tui --test entity alone into its own empty directory leaves ank-it-<pid>/ank-edit-<pid>-0-TASK-795b3d144257.md inside the root, holding the 24 lines the fake $EDITOR saved. Still written, still kept, still named by editor::kept's refusal ('the edited text is kept at ...'). Only the directory the child calls temporary moved, into the one the next run already sweeps -- across the whole crate the file is not even in the base at the end, because the next target's root() sweeps the previous target's root.
+
+One helper, in_this_runs_root, at both spawn sites for the binary: Repo::tried and the pty Live builder. TMPDIR, TMP and TEMP together, because std::env::temp_dir reads the last two on Windows. Set before the caller's own env pairs, so a suite that wants to say something else about the environment still wins. scratch::root became pub for it; nothing about the root's lifetime, its .owner lock or the sweep changed.
+
+Nothing was renamed. The content-addressed ank-signers-* name TASK-1b3d7b61dc8f's git::batched memo depends on lives in crates/ank-cli/src/human.rs, outside this scope and untouched.

--- a/.ank/entities/LOG-f101b513ec6e.md
+++ b/.ank/entities/LOG-f101b513ec6e.md
@@ -1,0 +1,13 @@
+---
+id: LOG-f101b513ec6e
+type: log
+title: done, proof commit:3c24874
+created: 2026-08-29T00:28:25Z
+author: claude-code/opus-5+tui-spawn-tmpdir
+scope:
+  - crates/ank-tui/tests/terminal/mod.rs
+about: TASK-ec85b1561855
+seq: 1
+schema: 4
+version: 1
+---

--- a/.ank/entities/TASK-ec85b1561855.md
+++ b/.ank/entities/TASK-ec85b1561855.md
@@ -5,15 +5,20 @@ slug: the-tui-suite-s-spawn-helper-lets-the-binary-inh
 title: The TUI suite's spawn helper lets the binary inherit the machine's temporary directory
 created: 2026-08-28T23:10:35Z
 author: claude-code/opus-5+child-temp-dir
-status: in_progress
+status: done
 scope:
   - crates/ank-tui/tests/terminal/mod.rs
 blocked_by: []
 done_criteria: |
   After a green cargo test -p ank-tui into an empty temporary directory, the only entry left is the ank-it-* root of the run itself: no ank-edit-* file remains beside it. The editor's scratch file is still written and still kept -- what changes is where the child looks for a temporary directory.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 3c24874
+    criteria: 9a493fe06a59
+    via: submitted
 schema: 4
-version: 2
+version: 3
 ---
 
 TASK-02350943e2b1 pointed every process `crates/ank-cli/tests/cli.rs` spawns at

--- a/.ank/entities/TASK-ec85b1561855.md
+++ b/.ank/entities/TASK-ec85b1561855.md
@@ -5,7 +5,7 @@ slug: the-tui-suite-s-spawn-helper-lets-the-binary-inh
 title: The TUI suite's spawn helper lets the binary inherit the machine's temporary directory
 created: 2026-08-28T23:10:35Z
 author: claude-code/opus-5+child-temp-dir
-status: open
+status: in_progress
 scope:
   - crates/ank-tui/tests/terminal/mod.rs
 blocked_by: []
@@ -13,7 +13,7 @@ done_criteria: |
   After a green cargo test -p ank-tui into an empty temporary directory, the only entry left is the ank-it-* root of the run itself: no ank-edit-* file remains beside it. The editor's scratch file is still written and still kept -- what changes is where the child looks for a temporary directory.
 criteria_by: creator
 schema: 4
-version: 1
+version: 2
 ---
 
 TASK-02350943e2b1 pointed every process `crates/ank-cli/tests/cli.rs` spawns at

--- a/crates/ank-tui/tests/terminal/mod.rs
+++ b/crates/ank-tui/tests/terminal/mod.rs
@@ -116,7 +116,9 @@ mod scratch {
         p
     }
 
-    fn root() -> &'static Path {
+    /// Public because the two places this suite spawns the binary hand it to
+    /// the child as what "temporary" means (TASK-ec85b1561855).
+    pub fn root() -> &'static Path {
         static ROOT: OnceLock<PathBuf> = OnceLock::new();
         ROOT.get_or_init(|| {
             let base = std::env::temp_dir();
@@ -156,6 +158,36 @@ mod scratch {
             }
         }
     }
+}
+
+/// Tell a child of this suite that "temporary" means this run's own root
+/// (TASK-ec85b1561855).
+///
+/// The same one line `crates/ank-cli/tests/cli.rs::spawn` grew for the same
+/// reason, on the same scheme (TASK-553740e7af11): a child that inherits the
+/// machine's temporary directory writes beside every other run on it, and
+/// nothing collects what it leaves. Measured on 2026-08-29, `cargo test
+/// --workspace` into an empty temporary directory left one file that no run
+/// sweeps -- the scratch file `ank new task` keeps when the fake `$EDITOR`
+/// this suite spawns hands back something invalid.
+///
+/// **What is not being fixed is that the file is written.** `editor::kept`
+/// answers a typo without discarding the twenty minutes around it, and the
+/// refusal names the path: a file swept between the caller reading that
+/// message and opening it would be the promise broken. It is still written,
+/// still kept, still named. Only the directory the child calls temporary
+/// moves, into the root the next run already collects.
+///
+/// All three names, because `std::env::temp_dir` reads `TMP` and `TEMP` on
+/// Windows and `TMPDIR` everywhere else: setting one of the three would leave
+/// the child on the runner's own temporary directory on the platform where
+/// this suite runs last.
+fn in_this_runs_root(command: &mut Command) {
+    let root = scratch::root();
+    command
+        .env("TMPDIR", root)
+        .env("TMP", root)
+        .env("TEMP", root);
 }
 
 impl Repo {
@@ -373,6 +405,7 @@ impl Repo {
             .current_dir(&self.0)
             .env("ANK_AGENT", AGENT)
             .env("NO_COLOR", "1");
+        in_this_runs_root(&mut command);
         for (name, value) in env {
             command.env(name, value);
         }
@@ -852,6 +885,7 @@ impl Live {
             .current_dir(&repo.0)
             .env("ANK_AGENT", AGENT)
             .env("TERM", term);
+        in_this_runs_root(&mut command);
         match colour {
             true => command.env_remove("NO_COLOR"),
             false => command.env("NO_COLOR", "1"),


### PR DESCRIPTION
The last of the three files `cargo test --workspace` into an empty temporary directory used to leave behind. TASK-ac2ff41162c6 named the families, TASK-02350943e2b1 took the workspace from 16 `ank-edit-*` and 20 `ank-signers-*` down to one `ank-edit-*` and none, and that last one is this crate's: `crates/ank-tui/tests/entity.rs` runs `ank new task` with a fake `$EDITOR` through the spawn helper in `crates/ank-tui/tests/terminal/mod.rs`, which built the child with `Command::new(ank())` and said nothing about where temporary is.

The same one line `crates/ank-cli/tests/cli.rs::spawn` grew in #330, on the scheme TASK-553740e7af11 established, at both of this suite's spawn sites for the binary — `Repo::tried` and the pty session. `TMPDIR`, `TMP` and `TEMP` together, because `std::env::temp_dir` reads the last two on Windows and setting one of the three would leave the child on the runner's own temporary directory on the platform where this suite runs last. Set before the caller's own environment pairs, so a suite asking about the environment still wins.

**What is not being fixed is that the file is written.** `editor::kept` still writes it, the refusal still names it, and it still holds what was typed: sweeping it where it is written would delete a caller's text between reading the message and opening the path. Nothing was renamed either — the content-addressed name `git::batched` memoises on lives in `crates/ank-cli/src/human.rs`, outside this scope and untouched.

## Measured, not read

`TMPDIR` pointed at an empty directory, `cargo test --workspace` green (exit 0), twice: one entry left in the base, the `ank-it-<pid>` root of the run itself. Zero `ank-edit-*`, zero `ank-signers-*`.

Attributed rather than assumed: `cargo test -p ank-tui --test entity` alone into its own empty directory leaves `ank-it-<pid>/ank-edit-<pid>-0-TASK-795b3d144257.md` **inside** the root, holding the 24 lines the fake editor saved — moved, not swept.

Closes TASK-ec85b1561855, which unblocks TASK-02350943e2b1 and makes TASK-ac2ff41162c6 satisfiable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SHmDD4LqAQNA8g86pz84EB