### PR TITLE
The wheel moves the view, and the bar is drawn where there is overrun

### DIFF
--- a/.ank/entities/LOG-1a0ab09f614f.md
+++ b/.ank/entities/LOG-1a0ab09f614f.md
@@ -1,0 +1,16 @@
+---
+id: LOG-1a0ab09f614f
+type: log
+title: Built in view.rs. The wheel is App::wheeled -> App::scrolled, which moves the window and leaves the
+created: 2026-08-29T00:28:50Z
+author: claude-code/opus-5+wheel-moves-the-view
+scope:
+  - crates/ank-tui/src/view.rs
+  - crates/ank-tui/src/text.rs
+about: TASK-d712d7f9a326
+seq: 0
+schema: 4
+version: 1
+---
+
+ cursor's index untouched and unclamped: what a person scrolling comes back to is the row they left, and the row that scrolls off takes its marker with it -- nothing on the frame says where they are standing in any other alphabet. The bar is ratatui's Scrollbar drawn on the region's right border, thumb only, track left to the border already under it, so it costs no column of content at any width and appears and vanishes without a row underneath it being composed twice. Its state is spelled in scroll positions rather than rows (content_length = total - page + 1): passed the row count, the widget's own arithmetic leaves the thumb short of the bottom on a view with nothing more to show, which is a bar that says 'there is more' at the end of a list. Drawn only while total > page, so a listing that fits keeps the plain border it always had. Glyphs::thumb answers the same probe rule() does, so the terminal that declared itself dumb gets '#'. Eight unit tests; two verified to bite by planting the old behaviour (wheel moves the cursor: three red) and an always-drawn bar (thirty-six red, because a full track overwrites the border). text.rs is in scope and untouched: the arithmetic here is the widget's and there was nothing for it to owe.

--- a/.ank/entities/LOG-cd13f8cabe6a.md
+++ b/.ank/entities/LOG-cd13f8cabe6a.md
@@ -1,0 +1,16 @@
+---
+id: LOG-cd13f8cabe6a
+type: log
+title: +scope crates/ank-tui/tests/wheel.rs (version 2 to 3, replaced 2d481b79e2e9, produced ff297ca5cd47)
+created: 2026-08-29T00:29:20Z
+author: claude-code/opus-5+wheel-moves-the-view
+scope:
+  - crates/ank-tui/src/view.rs
+  - crates/ank-tui/src/text.rs
+  - crates/ank-tui/tests/wheel.rs
+about: TASK-d712d7f9a326
+seq: 1
+records: edit
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-ee3869e3b22c.md
+++ b/.ank/entities/LOG-ee3869e3b22c.md
@@ -1,0 +1,17 @@
+---
+id: LOG-ee3869e3b22c
+type: log
+title: Scope widened by exactly crates/ank-tui/tests/wheel.rs, a file that does not exist yet and that no
+created: 2026-08-29T00:29:22Z
+author: claude-code/opus-5+wheel-moves-the-view
+scope:
+  - crates/ank-tui/src/view.rs
+  - crates/ank-tui/src/text.rs
+  - crates/ank-tui/tests/wheel.rs
+about: TASK-d712d7f9a326
+seq: 2
+schema: 4
+version: 1
+---
+
+ other agent's perimeter names. The criterion says 'Measured through the binary' and that measurement cannot be written where the code is: tests/dependencies.rs forbids src/ a foreign symbol and forbids it unsafe, which is what ADR-c07e2694f0e1 bought by taking crossterm, so a pseudo-terminal in this crate's sources is not an option and the harness that drives one lives in tests/terminal/mod.rs. That module is being edited by another agent in this wave and is not touched here: the wheel is spelled from this file with Live::send, because SGR is the encoding the reader asked the terminal for and its wheel is '\x1b[<65;col;row M' -- decimal text a suite can write by hand, which is the same reason Live::tap could be written at all. Four tasks of this wave widened their scope the same way (252b, b518, c94d, 3fa4); only the criterion is frozen, and an agent meeting it outside its declared perimeter is the undeclared work claim collision cannot see.

--- a/.ank/entities/TASK-d712d7f9a326.md
+++ b/.ank/entities/TASK-d712d7f9a326.md
@@ -5,14 +5,15 @@ slug: the-wheel-moves-the-view-and-not-the-cursor-and
 title: The wheel moves the view and not the cursor, and a bar appears only where the content overruns
 created: 2026-08-27T16:34:09Z
 author: haksolot@vmi3223161
-status: open
+status: in_progress
 scope:
   - crates/ank-tui/src/view.rs
   - crates/ank-tui/src/text.rs
+  - crates/ank-tui/tests/wheel.rs
 blocked_by: [TASK-252bf02de218]
 done_criteria: |
   A wheel event over a list longer than the region changes which row is drawn first and leaves the selected row where it was. A bar saying where the view sits is drawn while the content is longer than the region and not otherwise, and it is drawn in characters: the frame with paint and the frame without it stay identical character for character. Measured through the binary.
 criteria_by: creator
 schema: 4
-version: 1
+version: 3
 ---

--- a/crates/ank-tui/src/view.rs
+++ b/crates/ank-tui/src/view.rs
@@ -262,7 +262,10 @@ use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseEvent, Mou
 use ratatui::layout::{Position, Rect};
 use ratatui::symbols::border;
 use ratatui::text::{Line, Text};
-use ratatui::widgets::{Block, Clear, Paragraph, Widget};
+use ratatui::widgets::{
+    Block, Clear, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState, StatefulWidget,
+    Widget,
+};
 
 /// Which screen the one region is showing (TASK-252bf02de218).
 ///
@@ -1090,11 +1093,14 @@ impl App {
                 }
                 self.tapped(at, ank)
             }
-            // A swipe, which is what a phone sends for a scroll. It moves the
-            // cursor of whatever has the focus, which is what `j` and `k` do:
-            // one command, two ways of asking for it.
-            MouseEventKind::ScrollDown => self.moved(1, ank),
-            MouseEventKind::ScrollUp => self.moved(-1, ank),
+            // The wheel, and the swipe a phone sends as one. It moves the
+            // view and never the cursor (ADR-559eebf5c6f5,
+            // TASK-d712d7f9a326): `j` and `k` are how a person chooses a row,
+            // and a wheel that chose one would move the subject of every verb
+            // on the screen while somebody was only looking further down the
+            // list.
+            MouseEventKind::ScrollDown => self.wheeled(1),
+            MouseEventKind::ScrollUp => self.wheeled(-1),
             // A release, a drag, a mouse crossing the window: no command, and
             // nothing drawn differently either.
             _ => false,
@@ -1103,7 +1109,14 @@ impl App {
 
     /// A scroll, where a scroll means anything: under an open search or a
     /// confirmation nothing moves, which is the modal rule again.
-    fn moved(&mut self, by: isize, ank: &Ank) -> bool {
+    ///
+    /// **What it moves is the view** (ADR-559eebf5c6f5, TASK-d712d7f9a326).
+    /// The three overlays under it are the exception and they are not one:
+    /// none of them draws a window a cursor can leave -- the key list *is* a
+    /// window with no cursor at all, and the form and the list `x` opens are
+    /// as long as their rows, so what a finger over them can mean is the only
+    /// thing it ever meant there.
+    fn wheeled(&mut self, by: isize) -> bool {
         if self.pending.is_some() || self.needle.is_some() {
             return false;
         }
@@ -1129,7 +1142,56 @@ impl App {
             self.scroll_list(by);
             return false;
         }
-        self.act(Command::Move(by), ank)
+        self.scrolled(by)
+    }
+
+    /// The window over the screen in the region, moved by this many rows, with
+    /// the row that is selected left exactly where it was
+    /// (TASK-d712d7f9a326).
+    ///
+    /// **The cursor is not dragged along and not clamped back into view.**
+    /// That is the whole of the decision: a person scrolling is reading, and
+    /// what they come back to has to be the row they left -- the identifier
+    /// every verb on this screen is composed against. So the selected row may
+    /// be off the top or off the bottom of what is drawn, and it is the
+    /// listing's own marker that says where it is, which is exactly what the
+    /// marker is for: a row that is not on the screen has no marker on the
+    /// screen, and none of the four screens says where a person is standing in
+    /// any other alphabet.
+    ///
+    /// [`App::scroll_list`]'s arithmetic, on the region's own window: never
+    /// above the first row and never past the last screenful, so the last
+    /// press that does anything is the one that puts the end of the list on
+    /// the bottom row. A window that scrolled into blank rows would answer a
+    /// wheel with a screen that showed nothing, which reads as a reader that
+    /// has stopped listening.
+    fn scrolled(&mut self, by: isize) -> bool {
+        let (total, _) = self.paging(self.focus);
+        let last = total.saturating_sub(self.page(self.focus)) as isize;
+        let moved = |from: usize| (from as isize + by).clamp(0, last.max(0)) as usize;
+        match self.focus {
+            Focus::Body => self.offset = moved(self.offset),
+            listing => {
+                let c = &mut self.cursors[listing.number() - 1];
+                c.top = moved(c.top);
+            }
+        }
+        false
+    }
+
+    /// What the region is a window onto: how many rows the screen in it holds,
+    /// and which of them is drawn first.
+    ///
+    /// One answer for the four screens, because "is there more of this than
+    /// the region can show" is one question -- and it is asked twice, by the
+    /// wheel and by the bar that says where the wheel has got to. Two
+    /// arithmetics for that would be two things that can disagree about
+    /// whether a bar is drawn at all.
+    fn paging(&self, focus: Focus) -> (usize, usize) {
+        match focus {
+            Focus::Body => (self.pane_lines().len(), self.offset),
+            listing => (self.count(listing), self.cursors[listing.number() - 1].top),
+        }
     }
 
     /// What one key does to the key list that is open under it
@@ -2019,6 +2081,57 @@ impl App {
             Focus::Body => self.body_lines(width, inside.height as usize),
         };
         painted(&lines, self.ink).render(inside, buf);
+        self.bar(focus, area, buf);
+    }
+
+    /// Where the view sits in the screen the region is showing, drawn on the
+    /// region's right border -- and drawn only while there is more of that
+    /// screen than the region can hold (ADR-559eebf5c6f5, TASK-d712d7f9a326).
+    ///
+    /// **A rule around emptiness is what this must not be.** A track drawn
+    /// down a listing that fits would be a bar saying "there is more" over a
+    /// screen where there is not, which is the same defect as a border with
+    /// nothing inside it: furniture a person has to learn to disregard. So a
+    /// window holding everything it has gets the plain border it always had,
+    /// and the bar arrives exactly when a wheel has somewhere to go.
+    ///
+    /// **The thumb is the whole of it and the track is the border itself.**
+    /// The bar costs no column of content at any width -- which is what lets
+    /// it appear and vanish without a row underneath it being composed twice
+    /// -- and it is characters, so the frame drawn with the paint and the
+    /// frame drawn without it are the same characters here as everywhere else:
+    /// nothing below sets a style.
+    ///
+    /// **The state is spelled in scroll positions and not in rows**, which is
+    /// the one thing about the widget worth saying twice. `content_length` is
+    /// how many places the window can stand, `position` is which of them it is
+    /// standing in: passed the row count instead, the arithmetic leaves the
+    /// thumb short of the bottom on a view that has nothing more to show, and
+    /// a bar that says "there is more" at the end of a list is a bar that
+    /// lies.
+    fn bar(&self, focus: Focus, area: Rect, buf: &mut Buffer) {
+        let (total, first) = self.paging(focus);
+        let page = self.page(focus);
+        if total <= page {
+            return;
+        }
+        let inside = inside(area);
+        // The rows the screen in the region is paging, on the column the
+        // block's own right border is drawn in. `page` is measured off that
+        // same rectangle, so this is the border and never a row beyond it.
+        let track = Rect::new(area.right() - 1, inside.y, 1, page as u16);
+        let mut state = ScrollbarState::new(total - page + 1)
+            .position(first)
+            .viewport_content_length(page);
+        Scrollbar::new(ScrollbarOrientation::VerticalRight)
+            .thumb_symbol(self.glyphs.thumb())
+            // The track is the border the block has already drawn, and the
+            // ends are nothing: an arrow head is an offer, and this reader
+            // draws no offer at rest (ADR-c07e2694f0e1).
+            .track_symbol(None)
+            .begin_symbol(None)
+            .end_symbol(None)
+            .render(track, buf, &mut state);
     }
 
     /// What a panel's title says after its number: its name, and the state of
@@ -3413,6 +3526,24 @@ impl Glyphs {
     /// the header does not sit over a frame drawn in a different alphabet.
     pub fn rule(self) -> &'static str {
         self.border(false).horizontal_top
+    }
+
+    /// The character the scrollbar's thumb is drawn with
+    /// (ADR-559eebf5c6f5, TASK-d712d7f9a326).
+    ///
+    /// **A scrollbar is characters or it is not drawn**, so this is the whole
+    /// of the bar: the track is the region's own right border, already under
+    /// it, and what says where the view sits is these cells and not a colour
+    /// on them. It is read off the same probe the border set and the palette
+    /// are, so a terminal that has said it can render neither glyphs nor
+    /// colour is told where it is standing in ASCII rather than told nothing:
+    /// U+2588 FULL BLOCK where the reader draws glyphs, `#` where it does
+    /// not.
+    pub const fn thumb(self) -> &'static str {
+        match self.rich {
+            true => "\u{2588}",
+            false => "#",
+        }
     }
 }
 
@@ -7440,28 +7571,395 @@ mod tests {
         assert!(a.pending.is_some(), "a swipe answered a command");
     }
 
-    /// A swipe moves the cursor of whatever has the focus, which is what `j`
-    /// and `k` do.
-    #[test]
-    fn a_swipe_moves_the_cursor_the_way_the_keys_do() {
-        let ank = nowhere();
-        let mut a = phone();
-        for (kind, expected) in [
-            (MouseEventKind::ScrollDown, 1),
-            (MouseEventKind::ScrollDown, 2),
-            (MouseEventKind::ScrollUp, 1),
-        ] {
+    // -----------------------------------------------------------------------
+    // The wheel, and the bar that says where it has got to
+    // (TASK-d712d7f9a326, ADR-559eebf5c6f5)
+    // -----------------------------------------------------------------------
+
+    /// A corpus longer than any window this suite opens.
+    ///
+    /// Sixty rows against the twenty-four the narrowest of them holds, so
+    /// every window below overruns and there is no width at which "the
+    /// content is longer than the region" quietly stops being true.
+    fn crowd(rows: usize) -> Snapshot {
+        Snapshot {
+            corpus: "5a02985accabde1a7365a01db237a245097ab4ca".to_string(),
+            entities: (0..rows)
+                .map(|n| {
+                    row(
+                        &format!("TASK-{n:012x}"),
+                        "task",
+                        "open",
+                        &format!("the {n}th task of a list nothing can hold"),
+                    )
+                })
+                .collect(),
+            total: rows as u64,
+        }
+    }
+
+    /// A screen with that corpus on it.
+    fn crowded() -> App {
+        let mut a = App::new((80, 24), None)
+            .inked(paint::PLAIN)
+            .drawn_with(SCREEN);
+        a.snapshot = Some(crowd(60));
+        a
+    }
+
+    /// One notch of the wheel over the region.
+    fn wheel(a: &mut App, ank: &Ank, by: isize) {
+        let kind = match by < 0 {
+            true => MouseEventKind::ScrollUp,
+            false => MouseEventKind::ScrollDown,
+        };
+        for _ in 0..by.abs() {
             a.pointed(
                 MouseEvent {
                     kind,
                     column: 2,
-                    row: 8,
+                    row: inside(a.region(a.area())).y,
                     modifiers: KeyModifiers::NONE,
                 },
-                &ank,
+                ank,
             );
-            assert_eq!(a.cursors[Focus::Entities.number() - 1].at, expected);
         }
+    }
+
+    /// The rows the region is drawing, as characters, borders taken off.
+    fn region_rows(a: &App) -> Vec<String> {
+        let inside = inside(a.region(a.area()));
+        let frame = a.frame();
+        frame
+            .lines()
+            .skip(inside.y as usize)
+            .take(inside.height as usize)
+            .map(|l| {
+                l.chars()
+                    .skip(inside.x as usize)
+                    .take(inside.width as usize)
+                    .collect()
+            })
+            .collect()
+    }
+
+    /// The column the bar is drawn in, one character per row inside the
+    /// region.
+    ///
+    /// The region's right border and not a column of content: the bar costs
+    /// no width, so this is where the track already was.
+    fn bar_column(a: &App) -> Vec<String> {
+        let region = a.region(a.area());
+        let inside = inside(region);
+        let frame = a.frame();
+        frame
+            .lines()
+            .skip(inside.y as usize)
+            .take(inside.height as usize)
+            .map(|l| {
+                l.chars()
+                    .nth(region.right() as usize - 1)
+                    .map(String::from)
+                    .unwrap_or_default()
+            })
+            .collect()
+    }
+
+    /// **The wheel moves the view and leaves the selected row where it was**
+    /// (TASK-d712d7f9a326, ADR-559eebf5c6f5).
+    ///
+    /// Both halves in one test because either alone is the wrong reader: one
+    /// that moved nothing would pass the second, and one that moved the cursor
+    /// with the view -- which is what a swipe did before this -- would pass
+    /// the first. What the criterion protects is the identifier every verb on
+    /// this screen is composed against: a person scrolling is reading, and a
+    /// wheel that chose a row would change the subject of `claim` while
+    /// somebody was only looking further down.
+    ///
+    /// And it comes back. The frame after a notch down and a notch up is the
+    /// frame before them, character for character, which says the view moved
+    /// and nothing else did.
+    #[test]
+    fn the_wheel_moves_the_view_and_not_the_cursor() {
+        let ank = nowhere();
+        for window in [(80, 24), (40, 30), (120, 40), (150, 24)] {
+            let mut a = crowded();
+            a.resize(window.0, window.1);
+            a.cursors[Focus::Entities.number() - 1].at = 2;
+            let before = a.frame();
+            let selected = a.selected_id(Focus::Entities);
+            let first = region_rows(&a)[0].clone();
+
+            wheel(&mut a, &ank, 3);
+            assert_eq!(
+                a.cursors[Focus::Entities.number() - 1].at,
+                2,
+                "the wheel moved the cursor at {window:?}"
+            );
+            assert_eq!(
+                a.selected_id(Focus::Entities),
+                selected,
+                "the wheel changed which entity the screen names at {window:?}"
+            );
+            assert_ne!(
+                region_rows(&a)[0],
+                first,
+                "the wheel drew the same row first at {window:?}:\n{}",
+                a.frame()
+            );
+            assert_eq!(
+                a.cursors[Focus::Entities.number() - 1].top,
+                3,
+                "three notches are not three rows at {window:?}"
+            );
+
+            wheel(&mut a, &ank, -3);
+            assert_eq!(
+                a.frame(),
+                before,
+                "the view did not come back at {window:?}"
+            );
+        }
+    }
+
+    /// The row the cursor is on may leave the screen, and the marker is the
+    /// only thing that ever said where it was (ADR-559eebf5c6f5).
+    ///
+    /// The consequence of the criterion rather than a second decision: a
+    /// cursor that is not dragged along is a cursor that can be scrolled past,
+    /// and the honest frame then carries no marker at all. Nothing else on it
+    /// says where a person is standing -- not a colour, and not a border --
+    /// so this asserts the marker goes and comes back with the row.
+    #[test]
+    fn a_row_scrolled_off_takes_its_marker_with_it_and_gets_it_back() {
+        let ank = nowhere();
+        let mut a = crowded();
+        a.focus = Focus::Entities;
+        assert!(
+            region_rows(&a).iter().any(|l| l.starts_with(text::CURSOR)),
+            "the first frame marks no row:\n{}",
+            a.frame()
+        );
+        wheel(&mut a, &ank, 5);
+        assert!(
+            !region_rows(&a).iter().any(|l| l.starts_with(text::CURSOR)),
+            "a row scrolled off the top is still marked:\n{}",
+            a.frame()
+        );
+        assert_eq!(a.cursors[Focus::Entities.number() - 1].at, 0);
+        wheel(&mut a, &ank, -5);
+        assert!(
+            region_rows(&a).iter().any(|l| l.starts_with(text::CURSOR)),
+            "the row came back unmarked:\n{}",
+            a.frame()
+        );
+    }
+
+    /// The view stops at both ends, and the last notch that does anything is
+    /// the one that puts the last row on the bottom.
+    ///
+    /// A window that scrolled into the blank past the end would answer a wheel
+    /// with a screen showing nothing, which reads as a reader that has stopped
+    /// listening.
+    #[test]
+    fn the_view_never_scrolls_above_the_first_row_or_past_the_last() {
+        let ank = nowhere();
+        let mut a = crowded();
+        wheel(&mut a, &ank, -4);
+        assert_eq!(
+            a.cursors[Focus::Entities.number() - 1].top,
+            0,
+            "the view scrolled above the first row"
+        );
+        let page = a.page(Focus::Entities);
+        let total = a.count(Focus::Entities);
+        wheel(&mut a, &ank, total as isize + 10);
+        assert_eq!(
+            a.cursors[Focus::Entities.number() - 1].top,
+            total - page,
+            "the view scrolled past the last screenful"
+        );
+        let rows = region_rows(&a);
+        assert!(
+            rows.iter().all(|l| !l.trim().is_empty()),
+            "the wheel reached blank rows:\n{}",
+            a.frame()
+        );
+        assert!(
+            rows.last()
+                .is_some_and(|l| l.contains(&short_of(&crowd(60).entities[total - 1].id))),
+            "the last row of the list is not on the bottom row:\n{}",
+            a.frame()
+        );
+    }
+
+    /// **A bar is drawn while the content is longer than the region and not
+    /// otherwise** (TASK-d712d7f9a326, ADR-559eebf5c6f5).
+    ///
+    /// The second half is the one that costs something to keep: a track drawn
+    /// down a listing that fits is a rule around emptiness, saying "there is
+    /// more" over a screen where there is not. So the listing of three is
+    /// asked about at every width, and so is the same listing narrowed by a
+    /// filter until it fits.
+    #[test]
+    fn the_bar_is_drawn_where_the_content_overruns_and_nowhere_else() {
+        let thumb = SCREEN.thumb();
+        for width in 40..=150u16 {
+            let mut short = app();
+            short.resize(width, 24);
+            assert!(
+                !short.frame().contains(thumb),
+                "a listing that fits its region carries a bar at {width}:\n{}",
+                short.frame()
+            );
+
+            let mut long = crowded();
+            long.resize(width, 24);
+            assert!(
+                bar_column(&long).iter().any(|c| c == thumb),
+                "a listing longer than its region carries no bar at {width}:\n{}",
+                long.frame()
+            );
+            // And it goes when the filter takes the overrun away.
+            long.search = Some("the 7th".to_string());
+            assert!(
+                !long.frame().contains(thumb),
+                "the bar survived the filter that made the list fit at \
+                 {width}:\n{}",
+                long.frame()
+            );
+        }
+    }
+
+    /// The bar says where the view sits: at the top when the first row is
+    /// drawn first, and at the bottom when the last row is on the screen.
+    ///
+    /// Both ends, because a bar that never reaches the bottom is a bar that
+    /// says "there is more" at the end of a list.
+    #[test]
+    fn the_bar_says_where_the_view_sits() {
+        let ank = nowhere();
+        let thumb = SCREEN.thumb();
+        let mut a = crowded();
+        let at_top = bar_column(&a);
+        assert_eq!(
+            at_top.first().map(String::as_str),
+            Some(thumb),
+            "the bar is not at the top of a view that is:\n{}",
+            a.frame()
+        );
+        assert_ne!(
+            at_top.last().map(String::as_str),
+            Some(thumb),
+            "the bar fills the track of a view showing part of the list:\n{}",
+            a.frame()
+        );
+
+        let rows = a.count(Focus::Entities) as isize;
+        wheel(&mut a, &ank, rows);
+        let at_end = bar_column(&a);
+        assert_eq!(
+            at_end.last().map(String::as_str),
+            Some(thumb),
+            "the bar is short of the bottom on a view with nothing more to \
+             show:\n{}",
+            a.frame()
+        );
+        assert_ne!(
+            at_end.first().map(String::as_str),
+            Some(thumb),
+            "the bar stayed at the top of a view that moved:\n{}",
+            a.frame()
+        );
+    }
+
+    /// **The bar is characters**, so the frame drawn with the paint and the
+    /// frame drawn without it are identical character for character
+    /// (ADR-559eebf5c6f5).
+    ///
+    /// The crate already asserts that of every frame it draws; what is added
+    /// here is the fixture that overruns, because the frames that test
+    /// compares all fit their region and a bar it never drew is a bar it never
+    /// measured.
+    #[test]
+    fn the_painted_bar_and_the_plain_one_are_the_same_characters() {
+        let ank = nowhere();
+        let ash = |ink| {
+            let mut a = App::new((80, 24), None).inked(ink).drawn_with(SCREEN);
+            a.snapshot = Some(crowd(60));
+            a
+        };
+        let (mut painted, mut plain) = (ash(paint::COLOUR), ash(paint::PLAIN));
+        for a in [&mut painted, &mut plain] {
+            wheel(a, &ank, 4);
+        }
+        for width in 40..=150u16 {
+            painted.resize(width, 24);
+            plain.resize(width, 24);
+            assert!(
+                plain.frame().contains(SCREEN.thumb()),
+                "the fixture draws no bar at {width}, so nothing is being \
+                 measured:\n{}",
+                plain.frame()
+            );
+            assert_eq!(
+                painted.frame(),
+                plain.frame(),
+                "the painted bar says something the plain one does not, at \
+                 {width} columns"
+            );
+        }
+    }
+
+    /// The terminal that declared itself dumb is told where the view sits in
+    /// the alphabet it has (ADR-c07e2694f0e1).
+    #[test]
+    fn the_bar_drops_to_ascii_where_the_terminal_says_it_is_dumb() {
+        let mut a = crowded();
+        a.glyphs = ASCII;
+        let column = bar_column(&a);
+        assert!(
+            column.iter().any(|c| c == ASCII.thumb()),
+            "the dumb terminal gets no bar:\n{}",
+            a.frame()
+        );
+        assert!(
+            !a.frame().contains(BOXES.thumb()),
+            "a box-drawing glyph reached a terminal that cannot render one:\n{}",
+            a.frame()
+        );
+    }
+
+    /// The document is a window like any other: the wheel moves it, and the
+    /// row Enter would open stays where it was.
+    #[test]
+    fn the_wheel_moves_the_document_and_not_its_cursor() {
+        let ank = nowhere();
+        let mut a = app();
+        let body: String = (0..80)
+            .map(|n| format!("line {n} of a document\n"))
+            .collect();
+        a.detail = Some(detail("TASK-49746735127f", &body));
+        a.focus = Focus::Body;
+        let at = a.cursors[Focus::Body.number() - 1].at;
+        let first = region_rows(&a)[0].clone();
+        assert!(
+            bar_column(&a).iter().any(|c| c == SCREEN.thumb()),
+            "a document longer than the region carries no bar:\n{}",
+            a.frame()
+        );
+        wheel(&mut a, &ank, 5);
+        assert_eq!(a.offset, 5, "the wheel did not move the document");
+        assert_eq!(
+            a.cursors[Focus::Body.number() - 1].at,
+            at,
+            "the wheel moved the document's cursor"
+        );
+        assert_ne!(
+            region_rows(&a)[0],
+            first,
+            "the document drew the same row first"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/crates/ank-tui/tests/wheel.rs
+++ b/crates/ank-tui/tests/wheel.rs
@@ -1,0 +1,466 @@
+//! The wheel and the bar, through the binary (TASK-d712d7f9a326,
+//! ADR-559eebf5c6f5).
+//!
+//! CLAUDE.md leaves no choice about where this is measured and the criterion
+//! ends by naming the instrument: *measured through the binary*. It is the
+//! right rule here twice over. A wheel event is not a function call: it is a
+//! byte sequence a terminal sends, that crossterm has to recognise as a wheel
+//! rather than as a press, that has to reach a reader in raw mode on the
+//! alternate screen -- and every one of those steps is outside the render
+//! function `src/view.rs` asserts on. And "drawn in characters" is a claim
+//! about what arrives at a terminal, which is the one thing a `Buffer` cannot
+//! answer: a bar carried by a colour would be identical to a bar carried by a
+//! glyph in every unit test this crate has, because [`ank_tui::view::App`]'s
+//! own frame is the symbol out of each cell and nothing else.
+//!
+//! So `src/view.rs` walks the arithmetic at every width from forty to a hundred
+//! and fifty and on every platform -- where the view stops, which row is drawn
+//! first, where the thumb sits at either end of a list -- and this drives `ank
+//! tui` on a pseudo-terminal, reading the frame the way a person reads it and
+//! reading the bytes the way the terminal gets them.
+//!
+//! **The wheel is spelled here rather than added to the harness.** SGR is the
+//! encoding the reader asked the terminal for (`?1006`, which
+//! `EnableMouseCapture` turns on), and its coordinates and its button are
+//! decimal text: a wheel is `\x1b[<65;col;rowM`, which is one `Live::send` and
+//! needs nothing of `terminal/mod.rs` that `Live::tap` did not already need.
+//! Sixty-four is the wheel bit; the button number crossterm reads out of it is
+//! four for up and five for down.
+//!
+//! **Nothing here asserts a wall-clock bound.** What is waited for is a frame
+//! that says something, through [`Live::until`], and the assertions compare
+//! frames with frames.
+//!
+//! `#[cfg(unix)]` for the reason the other suites give: a pseudo-terminal on
+//! Windows is ConPTY, and reaching it means the console API this workspace does
+//! not otherwise call. What runs on all three platforms is the scroll, the
+//! arithmetic and the render, in `src/view.rs`.
+
+#![cfg(unix)]
+
+mod terminal;
+
+use terminal::{Live, Repo};
+
+/// Wide enough that a row keeps its identifier and its title, and twenty-four
+/// rows because that is the window every criterion of this reader has been
+/// written for.
+const WINDOW: (u16, u16) = (100, 24);
+
+/// Tasks stamped beside the two the corpus is seeded with, which puts
+/// forty-two rows against the eighteen the region of that window holds.
+///
+/// Enough that the view can be moved several times and still have somewhere to
+/// go, which is what makes "the selected row is off the screen" a state this
+/// suite can actually reach.
+const CROWD: usize = 40;
+
+/// The character the bar's thumb is drawn with, read out of the reader rather
+/// than written here (ADR-559eebf5c6f5).
+///
+/// A suite carrying its own copy of a glyph would go on asserting about a
+/// character the reader had stopped drawing, which is a test that quietly stops
+/// testing rather than one that fails.
+const THUMB: &str = ank_tui::view::BOXES.thumb();
+
+/// How many entities the corpus below carries: the crowd, and the two the
+/// seeding writes.
+const TOTAL: usize = CROWD + 2;
+
+/// The identifier of the nth stamped row, in the twelve hex every identifier
+/// here is spelled in.
+///
+/// **The four hex a listing prints are the four that differ.** `Repo::crowded`
+/// stamps a range `ank new` does not draw from and puts its counter in the low
+/// digits, which is right for a fixture about what a corpus *costs* and wrong
+/// for one about which row is on the screen: every one of its rows is drawn as
+/// the same short identifier. Here the counter is in the leading digits, so a
+/// row says which row it is, and the range is still one nothing else mints.
+fn stamped(nth: usize) -> String {
+    format!("TASK-{:04x}{:08x}", 0x1000 + nth, nth)
+}
+
+/// A corpus longer than the region of any window this suite opens, every row of
+/// it saying who it is.
+///
+/// Stamped rather than asked for, on `Repo::crowded`'s own reasoning: forty
+/// `ank new` calls against a corpus that grows under each one is a fixture
+/// priced in seconds, and what is being fixed here is the *length* of a list,
+/// which is the one property a copy preserves exactly. Writing under `.ank/`
+/// directly is a liberty a test has and this crate's sources do not, and
+/// `tests/ordering.rs` takes the same one for the same reason.
+fn corpus() -> Repo {
+    let repo = Repo::seeded();
+    let entities = repo.0.join(".ank").join("entities");
+    let seeded = repo.only(&["--type", "task"]);
+    let template = std::fs::read_to_string(entities.join(format!("{seeded}.md")))
+        .expect("the seeded task is readable");
+    for nth in 0..CROWD {
+        let id = stamped(nth);
+        let body = template
+            .replace(&seeded, &id)
+            .replace("slug: ", &format!("slug: crowd-{nth}-"))
+            .replace("title: ", &format!("title: row {nth} of "));
+        std::fs::write(entities.join(format!("{id}.md")), body)
+            .expect("a stamped entity is writable");
+    }
+    repo.warm_find();
+    repo
+}
+
+/// A panel's vertical border, at either weight, as characters.
+fn verticals() -> [char; 2] {
+    let of = |focused| {
+        ank_tui::view::BOXES
+            .border(focused)
+            .vertical_left
+            .chars()
+            .next()
+            .expect("a border set has a vertical")
+    };
+    [of(false), of(true)]
+}
+
+/// The lines of a frame that are rows of the region, border and all.
+fn region_lines(frame: &str) -> Vec<&str> {
+    frame
+        .lines()
+        .filter(|line| {
+            line.chars()
+                .next()
+                .is_some_and(|c| verticals().contains(&c))
+        })
+        .collect()
+}
+
+/// The numbers the listing draws beside its rows, in the order they are drawn.
+///
+/// What a row *is* on this fixture: the stamped tasks share a title and a short
+/// identifier, and the number is the position in the list the reader itself
+/// printed. So "which row is drawn first" is read off the frame in the reader's
+/// own words rather than inferred from the order of anything.
+fn numbers(frame: &str) -> Vec<usize> {
+    region_lines(frame)
+        .iter()
+        .filter_map(|l| number(l))
+        .collect()
+}
+
+/// The number on one row, past the border and past the marker.
+fn number(line: &str) -> Option<usize> {
+    let row: String = line.chars().skip(1).collect();
+    let past_marker = row
+        .strip_prefix(ank_tui::text::CURSOR)
+        .or_else(|| row.strip_prefix(ank_tui::text::PLAIN))?;
+    past_marker.split_whitespace().next()?.parse().ok()
+}
+
+/// The line the cursor marks, where that row is on the screen.
+///
+/// `None` is a real answer and the criterion is why: the wheel does not drag
+/// the cursor along, so a view scrolled past the selected row is a frame with
+/// no marker on it -- and the marker is the only thing that ever said where a
+/// person was standing.
+fn marked(frame: &str) -> Option<&str> {
+    region_lines(frame).into_iter().find(|line| {
+        let mut chars = line.chars();
+        chars.next();
+        chars.as_str().starts_with(ank_tui::text::CURSOR)
+    })
+}
+
+/// The short identifier on the row the cursor marks.
+fn marked_id(frame: &str) -> Option<String> {
+    first_id(marked(frame)?)
+}
+
+/// The first `TASK-xxxx` on a line, if it carries one.
+fn first_id(line: &str) -> Option<String> {
+    let at = line.find("TASK-")? + "TASK-".len();
+    let hex: String = line[at..]
+        .chars()
+        .take_while(|c| c.is_ascii_hexdigit())
+        .collect();
+    match hex.len() >= 4 {
+        true => Some(format!("TASK-{}", &hex[..4])),
+        false => None,
+    }
+}
+
+/// One notch of the wheel, over the middle of the region.
+///
+/// The press and no release: a wheel sends one event, which is what separates
+/// this from [`Live::tap`] rather than a shortcut taken here.
+fn wheel(live: &mut Live, down: bool, notches: usize) {
+    let button = match down {
+        true => 65,
+        false => 64,
+    };
+    for _ in 0..notches {
+        live.send(&format!(
+            "\x1b[<{button};{};{}M",
+            WINDOW.0 / 2,
+            WINDOW.1 / 2
+        ));
+    }
+}
+
+/// The session, once the corpus has reached the screen.
+fn opened(live: &Live) {
+    live.until("the corpus to arrive", |t| {
+        t.contains(&format!("({TOTAL} in the corpus)"))
+    });
+}
+
+// ---------------------------------------------------------------------------
+// The wheel
+// ---------------------------------------------------------------------------
+
+/// **A wheel event over a list longer than the region changes which row is
+/// drawn first and leaves the selected row where it was**
+/// (TASK-d712d7f9a326, ADR-559eebf5c6f5).
+///
+/// Both halves, because either alone is the wrong reader: one that answered the
+/// wheel with nothing would pass the second, and one that moved the cursor with
+/// the view -- which is what a swipe did before this decision -- would pass the
+/// first.
+///
+/// **The selected row is proved by opening it.** The cursor is moved off the
+/// first row, the view is then scrolled until that row is off the screen
+/// entirely, and Enter is pressed: the document that opens is the entity the
+/// cursor was on before the wheel touched anything. That is the fact the
+/// criterion protects, said in the reader's own terms -- the identifier every
+/// verb on this screen is composed against did not move while somebody was
+/// reading further down the list.
+#[test]
+fn the_wheel_moves_the_view_and_leaves_the_selected_row_where_it_was() {
+    let repo = corpus();
+    let mut live = Live::open(&repo, WINDOW.0, WINDOW.1);
+    opened(&live);
+
+    // Off the first row, so that a reader which reset the cursor and one which
+    // kept it are distinguishable at the end.
+    live.send("j");
+    live.until("the cursor to move off the first row", |t| {
+        marked(t).and_then(number) == Some(2)
+    });
+    let before = live.frame();
+    let selected =
+        marked_id(&before).unwrap_or_else(|| panic!("the marked row names no entity:\n{before}"));
+    let first = *numbers(&before)
+        .first()
+        .unwrap_or_else(|| panic!("the region draws no numbered row:\n{before}"));
+
+    wheel(&mut live, true, 6);
+    live.until("the view to move", |t| {
+        numbers(t).first().is_some_and(|n| *n != first)
+    });
+    let after = live.frame();
+    assert_ne!(
+        numbers(&after).first(),
+        Some(&first),
+        "the wheel drew the same row first:\n{after}"
+    );
+    assert!(
+        !numbers(&after).contains(&2),
+        "six notches did not carry the selected row off the screen, so what \
+         follows would pass on a reader that had dragged the cursor \
+         along:\n{after}"
+    );
+    assert!(
+        marked(&after).is_none(),
+        "a row is marked on a view the selected row is not on:\n{after}"
+    );
+
+    // And the row a person left is the row every verb still names.
+    live.send("\r");
+    live.until("the document to open", |t| t.contains("3 BODY"));
+    let document = live.frame();
+    assert!(
+        document.contains(&selected),
+        "the wheel moved what the screen names: Enter opened something other \
+         than '{selected}':\n{document}"
+    );
+    live.quit();
+}
+
+/// The view comes back, and comes back to exactly the frame it left.
+///
+/// The cheapest way to say that a wheel moved the window and nothing else: a
+/// reader that had also moved a cursor, a filter or a focus would give back a
+/// different screen from the one it was asked to give back.
+#[test]
+fn the_view_goes_down_and_comes_back_character_for_character() {
+    let repo = corpus();
+    let mut live = Live::open(&repo, WINDOW.0, WINDOW.1);
+    opened(&live);
+    let before = live.frame();
+    let first = *numbers(&before).first().expect("the region draws rows");
+
+    wheel(&mut live, true, 4);
+    live.until("the view to move", |t| {
+        numbers(t).first().is_some_and(|n| *n != first)
+    });
+    wheel(&mut live, false, 4);
+    live.until("the view to come back", |t| {
+        numbers(t).first().is_some_and(|n| *n == first)
+    });
+    assert_eq!(
+        live.frame(),
+        before,
+        "the view did not come back to the frame it left"
+    );
+
+    // And it stops there: the wheel at the top of a list has nowhere to go.
+    wheel(&mut live, false, 4);
+    assert_eq!(
+        live.frame(),
+        before,
+        "the view scrolled above the first row of the list"
+    );
+    live.quit();
+}
+
+// ---------------------------------------------------------------------------
+// The bar
+// ---------------------------------------------------------------------------
+
+/// **A bar saying where the view sits is drawn while the content is longer
+/// than the region and not otherwise, and it is drawn in characters**
+/// (TASK-d712d7f9a326, ADR-559eebf5c6f5).
+///
+/// The negative half is measured on the corpus every other suite here uses,
+/// which carries two entities and cannot overrun any window this harness
+/// opens: a bar over it would be a rule drawn around emptiness, saying "there
+/// is more" over a screen where there is not.
+///
+/// The bar is also asserted to be on the last column of the frame, which is the
+/// region's own right border. That is what says it costs no column of content
+/// at any width: a row of this listing is composed against the same width
+/// whether the bar is there or not, so the bar can arrive and go without
+/// anything underneath it being drawn twice.
+#[test]
+fn the_bar_is_drawn_where_the_content_overruns_and_nowhere_else() {
+    let short = Repo::seeded();
+    short.warm_find();
+    let live = Live::open(&short, WINDOW.0, WINDOW.1);
+    live.until("the session to open", |t| t.contains("(2 in the corpus)"));
+    let fits = live.frame();
+    assert!(
+        !fits.contains(THUMB),
+        "a listing that fits its region carries a bar:\n{fits}"
+    );
+    live.quit();
+
+    let repo = corpus();
+    let live = Live::open(&repo, WINDOW.0, WINDOW.1);
+    opened(&live);
+    let frame = live.frame();
+    let carrying: Vec<&str> = frame.lines().filter(|l| l.contains(THUMB)).collect();
+    assert!(
+        !carrying.is_empty(),
+        "a listing longer than its region carries no bar:\n{frame}"
+    );
+    assert!(
+        carrying.len() < region_lines(&frame).len(),
+        "the bar fills its whole track, so it says nothing about where the \
+         view sits:\n{frame}"
+    );
+    for line in &carrying {
+        assert!(
+            line.ends_with(THUMB),
+            "the bar is drawn somewhere other than the region's own border, \
+             so it costs a column of content:\n{frame}"
+        );
+    }
+    live.quit();
+}
+
+/// The bar moves with the view, and reaches the bottom when the list does.
+///
+/// A bar that never reached the end of its track would be a bar saying "there
+/// is more below" on a view with nothing more to show, which is the same
+/// untruth as a bar drawn over a listing that fits.
+#[test]
+fn the_bar_moves_with_the_view_and_reaches_the_end_of_its_track() {
+    let repo = corpus();
+    let mut live = Live::open(&repo, WINDOW.0, WINDOW.1);
+    opened(&live);
+    let at_top = live.frame();
+    let rows = region_lines(&at_top).len();
+    let thumb_rows = |frame: &str| -> Vec<usize> {
+        region_lines(frame)
+            .iter()
+            .enumerate()
+            .filter(|(_, l)| l.contains(THUMB))
+            .map(|(n, _)| n)
+            .collect()
+    };
+    assert_eq!(
+        thumb_rows(&at_top).first(),
+        Some(&0),
+        "the bar is not at the top of a view that is:\n{at_top}"
+    );
+
+    // Past the end of the list, so the view is wherever it stops.
+    wheel(&mut live, true, CROWD + 10);
+    live.until("the view to reach the end of the list", |t| {
+        thumb_rows(t).last() == Some(&(rows - 1))
+    });
+    let at_end = live.frame();
+    assert!(
+        !thumb_rows(&at_end).contains(&0),
+        "the bar stayed at the top of a view that moved:\n{at_end}"
+    );
+    // The bar itself is not content: a row carrying nothing but a thumb is a
+    // blank row, and the wheel must not have reached one.
+    let thumb = THUMB.chars().next().expect("the thumb is a character");
+    assert!(
+        region_lines(&at_end).iter().all(|l| !l
+            .trim_matches(|c: char| { c.is_whitespace() || c == thumb || verticals().contains(&c) })
+            .is_empty()),
+        "the wheel scrolled into blank rows:\n{at_end}"
+    );
+    live.quit();
+}
+
+/// **The frame with the paint and the frame without it stay identical
+/// character for character** (TASK-d712d7f9a326, ADR-559eebf5c6f5).
+///
+/// `tests/colour.rs` asserts this of the reader at rest; what is added here is
+/// the fixture that overruns and the view moved off its first row, because a
+/// bar that was never drawn is a bar that was never measured. Where a person is
+/// standing and where their view is are both characters on this screen or the
+/// screen has failed.
+///
+/// One corpus for both sessions, and warmed before either: a second corpus
+/// would mint different identifiers, and the frames would differ for a reason
+/// that has nothing to do with colour.
+#[test]
+fn the_painted_bar_and_the_plain_one_are_the_same_characters() {
+    let repo = corpus();
+    let driven = |mut live: Live| {
+        opened(&live);
+        let first = *numbers(&live.frame())
+            .first()
+            .expect("the region draws rows");
+        wheel(&mut live, true, 5);
+        live.until("the view to move", |t| {
+            numbers(t).first().is_some_and(|n| *n != first)
+        });
+        let frame = live.frame();
+        live.quit();
+        frame
+    };
+    let plain = driven(Live::open(&repo, WINDOW.0, WINDOW.1));
+    let painted = driven(Live::painting(&repo, WINDOW.0, WINDOW.1));
+    assert!(
+        plain.contains(THUMB),
+        "the fixture drew no bar, so nothing here is being measured:\n{plain}"
+    );
+    assert_eq!(
+        painted, plain,
+        "the painted screen and the plain one are not the same characters, so \
+         something on this frame is carried by colour alone"
+    );
+}


### PR DESCRIPTION
TASK-d712d7f9a326, on the proposed ADR-559eebf5c6f5.

**The wheel moves the view and not the cursor.** It moved the cursor before, on the reading that a swipe and `j` are one command asked for two ways. It moves the window now and leaves the selected row where it is, unclamped: a person scrolling is reading, and the identifier every verb on the screen is composed against must not move while they look further down a list. A row scrolled off takes its marker with it, which is the honest frame — where somebody is standing is the marker on the row, never a colour and never a border.

**A scrollbar is characters or it is not drawn.** It is ratatui's `Scrollbar` on the region's own right border, thumb only: the track is the border already under it, so the bar costs no column of content at any width and can arrive and vanish without a row underneath it being composed twice. It is drawn while the content is longer than the region and not otherwise — a track down a listing that fits is a rule around emptiness. Its state is spelled in scroll positions rather than rows, because passed the row count the widget's own arithmetic leaves the thumb short of the bottom on a view with nothing more to show. `Glyphs::thumb` answers the same probe the border set does, so a terminal that declared itself dumb gets `#`.

**Measured through the binary.** `crates/ank-tui/tests/wheel.rs` drives `ank tui` on a pseudo-terminal and spells the wheel as SGR through `Live::send`, touching `tests/terminal/mod.rs` not at all; `src/view.rs` walks the same arithmetic at every width from forty to a hundred and fifty and on every platform. Both suites were verified to bite by planting the cursor-moving wheel and an always-drawn bar, with the binary rebuilt first (ADR-93d8fc25e94e).

`cargo test --workspace` green, `cargo fmt --check` clean, `ank check` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012y2GCq1pakt5hWs1Pdpbr8