### PR TITLE
TASK-d712d7f9a326 is done, with what the measurement found

### DIFF
--- a/.ank/entities/LOG-d98bdad31419.md
+++ b/.ank/entities/LOG-d98bdad31419.md
@@ -1,0 +1,17 @@
+---
+id: LOG-d98bdad31419
+type: log
+title: "The measurement went through the binary in crates/ank-tui/tests/wheel.rs: five tests on a"
+created: 2026-08-29T01:24:17Z
+author: claude-code/opus-5+wheel-moves-the-view
+scope:
+  - crates/ank-tui/src/view.rs
+  - crates/ank-tui/src/text.rs
+  - crates/ank-tui/tests/wheel.rs
+about: TASK-d712d7f9a326
+seq: 3
+schema: 4
+version: 1
+---
+
+ pseudo-terminal, the wheel spelled as SGR through Live::send and terminal/mod.rs untouched. Three of them bite on the cursor-moving wheel and one on an always-drawn bar, each verified by planting it -- and the plant was only informative after 'cargo build -p ank-cli': the first attempt ran 'cargo test -p ank-tui' against the binary already on disk and reported green about code that was not in it, which is exactly what ADR-93d8fc25e94e says and which arrived on this perimeter with the scope amendment. One thing to record about the fixture: Repo::crowded stamps its counter in the low hex digits, so every one of its rows draws as the same short identifier and 'which row is on the screen' is unaskable of it; this suite stamps its own crowd with the counter in the leading digits. CI: macos-latest failed twice on tests/opening.rs::the_frame_that_arrives_first_names_its_screen_and_says_it_has_not_read, which is not this task's file and whose subject is the frame drawn before the corpus is read -- a 25ms poll against a race the suite documents. The same commit passed macos-latest in the push run and passed again on a third rerun; main was green through all of it. It was timing and not this change, and it is said here rather than dropped.

--- a/.ank/entities/LOG-fcf760055e21.md
+++ b/.ank/entities/LOG-fcf760055e21.md
@@ -1,0 +1,15 @@
+---
+id: LOG-fcf760055e21
+type: log
+title: done, proof commit:70d334a
+created: 2026-08-29T01:24:25Z
+author: claude-code/opus-5+wheel-moves-the-view
+scope:
+  - crates/ank-tui/src/view.rs
+  - crates/ank-tui/src/text.rs
+  - crates/ank-tui/tests/wheel.rs
+about: TASK-d712d7f9a326
+seq: 4
+schema: 4
+version: 1
+---

--- a/.ank/entities/TASK-d712d7f9a326.md
+++ b/.ank/entities/TASK-d712d7f9a326.md
@@ -5,7 +5,7 @@ slug: the-wheel-moves-the-view-and-not-the-cursor-and
 title: The wheel moves the view and not the cursor, and a bar appears only where the content overruns
 created: 2026-08-27T16:34:09Z
 author: haksolot@vmi3223161
-status: in_progress
+status: done
 scope:
   - crates/ank-tui/src/view.rs
   - crates/ank-tui/src/text.rs
@@ -14,6 +14,11 @@ blocked_by: [TASK-252bf02de218]
 done_criteria: |
   A wheel event over a list longer than the region changes which row is drawn first and leaves the selected row where it was. A bar saying where the view sits is drawn while the content is longer than the region and not otherwise, and it is drawn in characters: the frame with paint and the frame without it stay identical character for character. Measured through the binary.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 70d334a
+    criteria: 109b86642e3d
+    via: submitted
 schema: 4
-version: 3
+version: 4
 ---


### PR DESCRIPTION
The status and the log entries for TASK-d712d7f9a326, whose code landed in #334.

Two things in the log worth reading after the fact:

- The pseudo-terminal plant is only informative once `cargo build` has replaced the binary the suite drives (ADR-93d8fc25e94e). The first mutation check here ran `cargo test -p ank-tui` and reported green about code that was not in the binary on disk; the decision arrived on this perimeter with the scope amendment, and the check was redone.
- `macos-latest` went red twice on `tests/opening.rs::the_frame_that_arrives_first_names_its_screen_and_says_it_has_not_read` — not this task's file, and a race the suite documents between the frame drawn before the corpus is read and a 25ms poll. The same commit passed `macos-latest` in the push run and again on a third rerun, and main was green throughout. It is recorded rather than dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012y2GCq1pakt5hWs1Pdpbr8