### PR TITLE
TASK-02350943e2b1: the suite's children write inside the run's own root, measured

### DIFF
--- a/.ank/entities/LOG-8fad89294a43.md
+++ b/.ank/entities/LOG-8fad89294a43.md
@@ -1,0 +1,24 @@
+---
+id: LOG-8fad89294a43
+type: log
+title: Measured, not read. TMPDIR, TMP and TEMP all pointed at an empty directory on disk, cargo test
+created: 2026-08-29T02:13:45Z
+author: claude-code/opus-5+temp-files-closed
+scope:
+  - crates/ank-cli/tests/cli.rs
+  - crates/ank-cli/src/human.rs
+about: TASK-02350943e2b1
+seq: 4
+schema: 4
+version: 1
+---
+
+ --workspace green (exit 0, 40 test targets, no failures), then the directory listed.
+
+After: one entry, ank-it-1781679, holding only its own .owner lock. Zero ank-edit-*, zero ank-signers-*, at the top level and recursively inside the root. The criterion is met, and no line of code changed to meet it.
+
+What made it true, in order. This task's own two changes landed as PR #330, fbde0e6: spawn() in crates/ank-cli/tests/cli.rs now sets TMPDIR, TMP and TEMP to the suite's own scratch::root() for every process the suite starts, and signers_for_git in crates/ank-cli/src/human.rs returns a SignersForGit guard whose last holder removes the filtered copy. That took 16 ank-edit-* and 20 ank-signers-* down to one ank-edit-* and none. The one that remained came from crates/ank-tui/tests/entity.rs through the spawn helper in crates/ank-tui/tests/terminal/mod.rs, which was filed as the blocker TASK-ec85b1561855 and landed as 3c24874 (PR #333, merge 1c67dcd): the same three names, set the same way, on the other crate's helper. That commit is what closed the last file, so it is the proof.
+
+The invariant held. editor::scratch_path still writes the file, editor::kept still names it in the refusal, and what_a_spawned_child_calls_temporary_is_this_runs_own_root asserts through the binary that a failed edit exits 1, that the refusal names a path under this run's root, and that the path still holds the text the editor saved. Moved, not swept.
+
+Measured on disk rather than in /tmp on purpose: this host's /tmp is tmpfs, and the run that discovered this whole family is the one that filled it.

--- a/.ank/entities/LOG-fbc0c69b60a7.md
+++ b/.ank/entities/LOG-fbc0c69b60a7.md
@@ -1,0 +1,14 @@
+---
+id: LOG-fbc0c69b60a7
+type: log
+title: done, proof commit:3c24874
+created: 2026-08-29T02:13:52Z
+author: claude-code/opus-5+temp-files-closed
+scope:
+  - crates/ank-cli/tests/cli.rs
+  - crates/ank-cli/src/human.rs
+about: TASK-02350943e2b1
+seq: 5
+schema: 4
+version: 1
+---

--- a/.ank/entities/TASK-02350943e2b1.md
+++ b/.ank/entities/TASK-02350943e2b1.md
@@ -5,7 +5,7 @@ slug: the-ank-binary-the-suite-spawns-writes-into-the
 title: The ank binary the suite spawns writes into the shared temporary directory
 created: 2026-08-28T18:27:06Z
 author: claude-code/opus-5+tests-leave-nothing
-status: open
+status: done
 scope:
   - crates/ank-cli/tests/cli.rs
   - crates/ank-cli/src/human.rs
@@ -13,8 +13,13 @@ blocked_by: [TASK-ec85b1561855]
 done_criteria: |
   After a green cargo test --workspace into an empty temporary directory, the only entries left are the ank-it-* roots of the run itself: no ank-edit-* and no ank-signers-* file remains. The editor's scratch file still survives a failed edit and is still named in the refusal -- what changes is where the child looks for a temporary directory, not what ank does with one.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 3c24874
+    criteria: 6f58a3a18f04
+    via: submitted
 schema: 4
-version: 5
+version: 7
 ---
 
 TASK-ac2ff41162c6 fixed the families born in cfg(test) blocks under src/ and measured the two it could not reach from its scope.


### PR DESCRIPTION
`ank done` on TASK-02350943e2b1. No code change: the criterion was already met by code on `main`, and this PR carries the corpus write plus the measurement that establishes it.

## What was measured

`TMPDIR`, `TMP` and `TEMP` all pointed at an empty directory on disk (not `/tmp`, which is tmpfs on this host and is what the original leak filled), then `cargo test --workspace`.

- exit 0, 40 test targets, no failures
- the directory afterwards holds **one entry**: `ank-it-1781679`, containing only its own `.owner` lock
- `ank-edit-*`: **0** — `ank-signers-*`: **0**, at the top level and recursively inside the root

The task's own body recorded 16 `ank-edit-*` and 20 `ank-signers-*` before any of this.

## What closed it

Two changes, both already on `main`:

- `fbde0e6` (PR #330) — `spawn()` in `crates/ank-cli/tests/cli.rs` sets all three temporary-directory names to the suite's own `scratch::root()`, and `signers_for_git` in `crates/ank-cli/src/human.rs` returns a guard whose last holder removes the filtered copy. That left one `ank-edit-*`.
- `3c24874` (PR #333, blocker TASK-ec85b1561855) — the same three names on `crates/ank-tui/tests/terminal/mod.rs`, which wrote that last file. This is the recorded proof.

## The invariant held

`editor::scratch_path` still writes the scratch file, `editor::kept` still names it in the refusal, and `what_a_spawned_child_calls_temporary_is_this_runs_own_root` asserts through the binary that a failed edit exits 1, that the refusal names a path under this run's root, and that the path still holds the text the editor saved. Moved, not swept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011zkdgut2zWvbyazyXHjDMq