### PR TITLE
TASK-ac2ff41162c6: all four temporary-file families are gone, measured

### DIFF
--- a/.ank/entities/LOG-58e74b9d6ba9.md
+++ b/.ank/entities/LOG-58e74b9d6ba9.md
@@ -1,0 +1,16 @@
+---
+id: LOG-58e74b9d6ba9
+type: log
+title: done, proof commit:3c24874
+created: 2026-08-29T02:31:40Z
+author: claude-code/opus-5+temp-files-closed
+scope:
+  - crates/ank-cli/src/editor.rs
+  - crates/ank-cli/src/git.rs
+  - crates/ank-daemon/src/stream.rs
+  - crates/ank-tui/src/stream.rs
+about: TASK-ac2ff41162c6
+seq: 3
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-ba6c07473376.md
+++ b/.ank/entities/LOG-ba6c07473376.md
@@ -1,0 +1,28 @@
+---
+id: LOG-ba6c07473376
+type: log
+title: Measured, not read, and on a second run of its own rather than on the one TASK-02350943e2b1 used.
+created: 2026-08-29T02:31:32Z
+author: claude-code/opus-5+temp-files-closed
+scope:
+  - crates/ank-cli/src/editor.rs
+  - crates/ank-cli/src/git.rs
+  - crates/ank-daemon/src/stream.rs
+  - crates/ank-tui/src/stream.rs
+about: TASK-ac2ff41162c6
+seq: 2
+schema: 4
+version: 1
+---
+
+ TMPDIR, TMP and TEMP all pointed at a fresh empty directory on disk, cargo test --workspace green (exit 0, 40 test targets, no failures), then the directory listed.
+
+After: one entry, ank-it-1855056, holding only its own .owner lock. Zero ank-edit-*, zero ank-signers-*, zero ank-daemon-stream-*, zero ank-tui-stream-*, at the top level and recursively inside the root. Zero ank-git-*, ank-nogit-*, ank-common-* and ank-declared-* as well, the families the earlier measurements named in passing. All four families this criterion names are gone, and no line of code changed here to make it so.
+
+The counts this criterion was written against, from LOG-ffa337f1fcc6: 16 ank-edit-*, 19 ank-signers-*, 3 ank-daemon-stream-*, 6 ank-tui-stream-*.
+
+What closed it, in order. 7bb9316 gave crates/ank-cli/src/git.rs, crates/ank-daemon/src/stream.rs and crates/ank-tui/src/stream.rs the scheme TASK-553740e7af11 established, which took both stream families and the git fixtures to zero and is where this task's own scope ends. The two families outside that scope followed: fbde0e6 (PR #330) pointed every process crates/ank-cli/tests/cli.rs spawns at the suite's own root and gave signers_for_git a guard whose last holder removes the filtered copy, and 3c24874 (PR #333) did the same for crates/ank-tui/tests/terminal/mod.rs, closing the last ank-edit-*. That is the proof: it is the commit after which this criterion is true.
+
+The second clause holds too, and it is one scheme and not a second one. Five copies of it exist -- crates/ank-cli/tests/scratch/mod.rs, crates/ank-cli/src/git.rs, crates/ank-daemon/src/stream.rs, crates/ank-tui/src/stream.rs, crates/ank-tui/tests/terminal/mod.rs -- and every one of them is the same three facts on the same ank-it- prefix: a root named std::process::id(), an .owner file the process holds an advisory lock on for its whole life, and a sweep at startup that removes any sibling root whose lock can be taken, because a lock that can be taken is a lock the kernel released when its holder died. One prefix means one sweep collects what any of them left, whichever crate ran last. The copies are copies because two crates cannot share a test helper without a dev-dependency between them, and ank-tui asserts its own dependency tree.
+
+The invariant the earlier holders protected is intact. editor::scratch_path still writes ank-edit-* under whatever the process calls temporary, editor::kept still names that path in the refusal, and nothing sweeps it there. What changed was only what a spawned child calls temporary, and what_a_spawned_child_calls_temporary_is_this_runs_own_root asserts through the binary that the kept file still holds the text the editor saved.

--- a/.ank/entities/TASK-ac2ff41162c6.md
+++ b/.ank/entities/TASK-ac2ff41162c6.md
@@ -5,7 +5,7 @@ slug: the-unit-tests-under-src-leave-their-scratch-dir
 title: The unit tests under src leave their scratch directories behind too
 created: 2026-08-27T18:20:40Z
 author: haksolot@vmi3223161
-status: open
+status: done
 scope:
   - crates/ank-cli/src/editor.rs
   - crates/ank-cli/src/git.rs
@@ -15,8 +15,13 @@ blocked_by: [TASK-553740e7af11]
 done_criteria: |
   After a green cargo test --workspace into an empty temporary directory, the only entries left are the roots of the run itself: no ank-edit-*, ank-signers-*, ank-daemon-stream-* or ank-tui-stream-* directory or file remains. The scheme is the one TASK-553740e7af11 established and not a second one -- a root named for the process, holding a lock the kernel frees when the process dies, swept by the next run.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 3c24874
+    criteria: df268be2bd49
+    via: submitted
 schema: 4
-version: 3
+version: 5
 ---
 
 TASK-553740e7af11 fixed the integration suites and measured what it did not


### PR DESCRIPTION
`ank done` on TASK-ac2ff41162c6, the last link of the temporary-file chain. No code change: the criterion was already met by code on `main`, and this PR carries the corpus write plus the measurement that establishes it.

## What was measured

A run of its own, not the one PR #336 used. `TMPDIR`, `TMP` and `TEMP` all pointed at a fresh empty directory on disk, then `cargo test --workspace`.

- exit 0, 40 test targets, no failures
- the directory afterwards holds **one entry**: `ank-it-1855056`, containing only its own `.owner` lock

| family | before (LOG-ffa337f1fcc6) | now |
|---|---|---|
| `ank-edit-*` | 16 | **0** |
| `ank-signers-*` | 19 | **0** |
| `ank-daemon-stream-*` | 3 | **0** |
| `ank-tui-stream-*` | 6 | **0** |

Zero at the top level and zero recursively inside the root. `ank-git-*`, `ank-nogit-*`, `ank-common-*` and `ank-declared-*` are zero too.

## What closed it

- `7bb9316` — the scheme in `crates/ank-cli/src/git.rs`, `crates/ank-daemon/src/stream.rs` and `crates/ank-tui/src/stream.rs`; both stream families to zero. That is where this task's scope ends.
- `fbde0e6` (PR #330) and `3c24874` (PR #333) — the two families outside that scope, which is why this task was released rather than closed at the time. `3c24874` is the recorded proof: the commit after which the criterion is true.

## One scheme, not a second one

Five copies exist — `crates/ank-cli/tests/scratch/mod.rs`, `crates/ank-cli/src/git.rs`, `crates/ank-daemon/src/stream.rs`, `crates/ank-tui/src/stream.rs`, `crates/ank-tui/tests/terminal/mod.rs` — and each is the same three facts on the same `ank-it-` prefix: a root named `std::process::id()`, an `.owner` file the process holds an advisory lock on for its whole life, and a startup sweep that removes any sibling root whose lock can be taken. One prefix, so one sweep collects what any of them left.

## The invariant

`editor::scratch_path` still writes `ank-edit-*` under whatever the process calls temporary, `editor::kept` still names that path in the refusal, and nothing sweeps it there. Only what a *spawned child* calls temporary moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011zkdgut2zWvbyazyXHjDMq