### PR TITLE
The kind in force is written in the header, and the cell that writes it is a target

### DIFF
--- a/.ank/entities/LOG-0852ddf92ce3.md
+++ b/.ank/entities/LOG-0852ddf92ce3.md
@@ -1,0 +1,15 @@
+---
+id: LOG-0852ddf92ce3
+type: log
+title: +scope crates/ank-tui/tests/kind.rs (version 2 to 3, replaced 5b9d149e4584, produced 205a6c4328f2)
+created: 2026-08-29T02:17:44Z
+author: claude-code/opus-5+kind-in-the-header
+scope:
+  - crates/ank-tui/src/view.rs
+  - crates/ank-tui/tests/kind.rs
+about: TASK-12bd5acbf706
+seq: 1
+records: edit
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-0c91577931df.md
+++ b/.ank/entities/LOG-0c91577931df.md
@@ -1,0 +1,16 @@
+---
+id: LOG-0c91577931df
+type: log
+title: "Measured through the binary in crates/ank-tui/tests/kind.rs: four tests on a pseudo-terminal at"
+created: 2026-08-29T02:36:56Z
+author: claude-code/opus-5+kind-in-the-header
+scope:
+  - crates/ank-tui/src/view.rs
+  - crates/ank-tui/tests/kind.rs
+about: TASK-12bd5acbf706
+seq: 4
+schema: 4
+version: 1
+---
+
+ (40,30), (80,24) and (120,40), the key sent as a keystroke and the finger as SGR through Live::tap, terminal/mod.rs untouched. The header is read as a person reads it -- first line of the frame -- and the rows it costs are counted off the frame as the lines above the region's own corner rather than read out of HEADER, because a constant would agree with itself. 'The same cycle by the same step' is measured as two sessions on one corpus walked all the way round, one by the key and one by taps, compared frame for frame: an assertion on the kind alone would have passed a reader that got there by its own call to the cycle. All four verified to bite, each after 'cargo build -p ank-cli' -- the header without the kind (three red), a kind given a row of its own with HEADER=4 (the rows test red), a cell that answers no finger (the tap test times out on a header that never names the next kind), and a header row that answers a press anywhere (the fourth red). Whole workspace green. Nothing here asserts a wall-clock bound: what is waited for is a frame that says something, through Live::until.

--- a/.ank/entities/LOG-34a92901655b.md
+++ b/.ank/entities/LOG-34a92901655b.md
@@ -1,0 +1,16 @@
+---
+id: LOG-34a92901655b
+type: log
+title: "Built in view.rs. The header's first row now ends with two targets rather than one: kind_target()"
+created: 2026-08-29T02:36:40Z
+author: claude-code/opus-5+kind-in-the-header
+scope:
+  - crates/ank-tui/src/view.rs
+  - crates/ank-tui/tests/kind.rs
+about: TASK-12bd5acbf706
+seq: 3
+schema: 4
+version: 1
+---
+
+ writes [f all] / [f adr] / [f spec] / [f task] and help_target()'s [?] stays on the right edge behind it, both carved out of App::header_tail() so that drawing them and hitting them cannot disagree about which of them is on the frame. The letter is read out of BINDINGS through cycle_binding() -- the reverse of Binding::press for the one row that is not a Command, because narrowing needs the kind in force and the table therefore spells it Press::Cycle with no command to look it up by. The word is padded to widest_kind(), and that is not cosmetic: the tail is right-aligned, so an unpadded [f all] becoming [f task] moves the cell one column left and the second press of a cycle lands on the corpus line -- a target that walks out from under the finger cycling with it. A press on the cell hands App::press the very keystroke a keyboard sends, so 'the same cycle by the same step' is a property inherited rather than reimplemented. Both cells go together where a window cannot hold them and the key list's is the last to go, since it is the only road to every key on the screen. HEADER is still 3 and filter_note() is untouched: tests/log.rs reads '[kind ' out of the region's title and takes its absence as 'back to every kind', and that file is another agent's perimeter.

--- a/.ank/entities/LOG-4c57d9238417.md
+++ b/.ank/entities/LOG-4c57d9238417.md
@@ -1,0 +1,16 @@
+---
+id: LOG-4c57d9238417
+type: log
+title: Scope widened by exactly crates/ank-tui/tests/kind.rs, a file that does not exist yet and that no
+created: 2026-08-29T02:17:48Z
+author: claude-code/opus-5+kind-in-the-header
+scope:
+  - crates/ank-tui/src/view.rs
+  - crates/ank-tui/tests/kind.rs
+about: TASK-12bd5acbf706
+seq: 2
+schema: 4
+version: 1
+---
+
+ other agent's perimeter names. The criterion ends 'Measured through the binary' and that measurement cannot be written where the code is: tests/dependencies.rs forbids src/ a foreign symbol, so a pseudo-terminal in this crate's sources is not an option and the harness that drives one lives in tests/terminal/mod.rs, which is untouched here. Five tasks of this wave widened the same way (252b, b518, c94d, 3fa4, d712) on the same reading: only the criterion is frozen, and an agent meeting it outside its declared perimeter is the undeclared work a claim collision cannot see.

--- a/.ank/entities/LOG-a2abdc1ef666.md
+++ b/.ank/entities/LOG-a2abdc1ef666.md
@@ -1,0 +1,15 @@
+---
+id: LOG-a2abdc1ef666
+type: log
+title: Perimeter read. The kind in force is written today in the entities' and the queue's panel title,
+created: 2026-08-29T02:12:49Z
+author: claude-code/opus-5+kind-in-the-header
+scope:
+  - crates/ank-tui/src/view.rs
+about: TASK-12bd5acbf706
+seq: 0
+schema: 4
+version: 1
+---
+
+ out of filter_note() -- a place the criterion cannot be met from: a title is fitted to the region's width and at forty columns it is the first thing cut, which is exactly the width 'at every width the harness opens' is about. The header is three rows (HEADER=3: the corpus line, the identity line, the rule) and its first row already ends with help_target()'s [?], carved out by help_line/help_rect. That pair is the shape the ADR names, so the kind goes beside it on the same row: [f adr] / [f all], labelled the way Action::label already labels a target, with the letter read out of BINDINGS rather than written here. filter_note() stays as it is -- tests/log.rs reads '[kind ' out of the frame and takes its absence as 'back to every kind', and that file is another agent's perimeter.

--- a/.ank/entities/TASK-12bd5acbf706.md
+++ b/.ank/entities/TASK-12bd5acbf706.md
@@ -5,13 +5,14 @@ slug: the-kind-in-force-is-written-in-the-header-and-t
 title: The kind in force is written in the header, and the cell that writes it is a target
 created: 2026-08-27T16:34:09Z
 author: haksolot@vmi3223161
-status: open
+status: in_progress
 scope:
   - crates/ank-tui/src/view.rs
+  - crates/ank-tui/tests/kind.rs
 blocked_by: [TASK-252bf02de218]
 done_criteria: |
   The kind the list is restricted to is written in the header at every width the harness opens. One keystroke advances it through the kinds a row may have and back to all of them, and a press on that cell of the header advances the same cycle by the same step. The header occupies the same number of rows after this task as before it. Measured through the binary.
 criteria_by: creator
 schema: 4
-version: 1
+version: 3
 ---

--- a/crates/ank-tui/src/view.rs
+++ b/crates/ank-tui/src/view.rs
@@ -123,15 +123,22 @@
 //! resolve before the cursor moves, because there is nowhere to cross to.
 //!
 //! **And what a screen offers is reachable by a finger without being drawn at
-//! rest** (TASK-9a402a54886f, ADR-c07e2694f0e1). What stands there is one cell
-//! of the header ([`App::help_line`]), and behind it the key list, every row of
-//! which is the key it names. The vocabulary is unchanged and that is the
-//! point: a target hands [`App::press`] the very key a keyboard would have
-//! sent, so a person with a keyboard reads the letter, a person with a thumb
-//! touches the word, and the offer is checkable against the mapping instead of
-//! against somebody's memory of it. A thumb reaches the commonest act of all
-//! with no target whatever -- touching the row already selected opens it
-//! ([`App::tapped`]).
+//! rest** (TASK-9a402a54886f, ADR-c07e2694f0e1). What stands there is two cells
+//! of the header ([`App::help_line`]), and behind one of them the key list,
+//! every row of which is the key it names. The vocabulary is unchanged and that
+//! is the point: a target hands [`App::press`] the very key a keyboard would
+//! have sent, so a person with a keyboard reads the letter, a person with a
+//! thumb touches the word, and the offer is checkable against the mapping
+//! instead of against somebody's memory of it. A thumb reaches the commonest
+//! act of all with no target whatever -- touching the row already selected
+//! opens it ([`App::tapped`]).
+//!
+//! The second cell is the kind in force ([`kind_target`], TASK-12bd5acbf706,
+//! ADR-559eebf5c6f5), and it is on the same row for the same price. It is not
+//! the band coming back: which kind a person is looking at has to be written
+//! somewhere regardless, so the cell that writes it costs the frame nothing and
+//! what is added is that a finger may press it. Information made touchable,
+//! which is the opposite of an offer drawn at rest.
 //!
 //! # Where a person is standing is a character, and never a colour
 //!
@@ -248,7 +255,7 @@
 //! it.
 
 use crate::ank::{Ank, Failed, Ran};
-use crate::bindings::{self, Binding, Holding};
+use crate::bindings::{self, Binding, Holding, Runs};
 use crate::form::{Filled, Form, SET as SETTING};
 use crate::input::{Act, Command, Subject};
 use crate::keys::{self, Narrowing, Press};
@@ -1081,13 +1088,25 @@ impl App {
                 if self.needle.is_some() {
                     return false;
                 }
-                // The one target the frame always carries, and it is resolved
-                // here rather than above the two modal states on purpose: what
-                // a touch does while a command is waiting is dismiss it, and a
-                // target that opened a list from under a confirmation would be
-                // the second road ADR-c07e2694f0e1 forbids.
+                // The two targets the frame always carries, and they are
+                // resolved here rather than above the two modal states on
+                // purpose: what a touch does while a command is waiting is
+                // dismiss it, and a target that opened a list from under a
+                // confirmation would be the second road ADR-c07e2694f0e1
+                // forbids.
                 if self.help_rect(self.area()).contains(at) {
                     if let Some(binding) = bindings::of_command(&Command::Help) {
+                        return self.press(KeyEvent::new(binding.key, KeyModifiers::NONE), ank);
+                    }
+                }
+                // The kind in force, pressed (TASK-12bd5acbf706,
+                // ADR-559eebf5c6f5). The very keystroke a keyboard sends and
+                // not a second call to the cycle: "the same cycle by the same
+                // step" is a property this hands to `App::press` rather than
+                // one it reimplements, so a filter whose step moved would move
+                // for the finger on the day it moved for the key.
+                if self.kind_rect(self.area()).contains(at) {
+                    if let Some(binding) = cycle_binding() {
                         return self.press(KeyEvent::new(binding.key, KeyModifiers::NONE), ank);
                     }
                 }
@@ -3066,39 +3085,86 @@ impl App {
     }
 
     // -----------------------------------------------------------------------
-    // The one target that is always there (ADR-c07e2694f0e1)
+    // The targets that are always there
+    // (ADR-c07e2694f0e1, ADR-559eebf5c6f5)
     // -----------------------------------------------------------------------
 
-    /// The header's first row, with the key list's own target on the end of it.
+    /// What the header's first row carries on its right edge, and the whole of
+    /// what fits there: the kind in force, then the key list's own target.
+    ///
+    /// **Both, or the key list's alone, or neither, and never half of one.**
+    /// A target cut through the middle is a target whose key nobody can read,
+    /// which is the rule this row has held since TASK-9a402a54886f; what is new
+    /// is that there are two of them, so the rule has a second step. The one
+    /// the reader has always carried is the last to go, because it is the only
+    /// road to every key on the screen and the other is one fact about a
+    /// filter.
+    ///
+    /// One function, so that [`App::help_line`] drawing them and
+    /// [`App::help_rect`] and [`App::kind_rect`] hitting them cannot disagree
+    /// about which of them is on the frame -- the reason [`App::targets`] gives
+    /// for itself, applied to the two targets that are not in that band.
+    fn header_tail(&self, width: usize) -> String {
+        let help = help_target();
+        let both = format!("{}{help}", kind_target(self.kind.as_deref()));
+        for tail in [both, help] {
+            if width > tail.chars().count() {
+                return tail;
+            }
+        }
+        String::new()
+    }
+
+    /// The header's first row, with those targets on the end of it.
     ///
     /// **This is what the band of targets was traded for** (TASK-9a402a54886f).
     /// ADR-c07e2694f0e1 asks for one permanently visible target that opens the
     /// key list, and it costs a cell of a row the header was drawing anyway --
     /// against four rows of twenty-four, on the window the clause was written
-    /// to protect. The corpus line is padded rather than fitted so the target
-    /// lands on the right edge at every width, and where the window is too
-    /// narrow to hold it at all the line is fitted as it always was: a target
-    /// half drawn would be a target whose key nobody can read.
+    /// to protect. ADR-559eebf5c6f5 puts the kind in force beside it on the
+    /// same terms and the same row (TASK-12bd5acbf706): the header is three
+    /// rows before this and three rows after it.
+    ///
+    /// The corpus line is padded rather than fitted so the targets land on the
+    /// right edge at every width, and the corpus line is what gives way where
+    /// the window is narrow -- it is a sentence a person can read the head of,
+    /// and a filter that has hidden most of a corpus is not.
     fn help_line(&self, said: &str, width: usize) -> String {
-        let label = help_target();
-        let wide = label.chars().count();
-        match width > wide {
-            true => format!("{}{label}", pad(said, width - wide)),
-            false => fit(said, width),
-        }
+        let tail = self.header_tail(width);
+        format!("{}{tail}", pad(said, width - tail.chars().count()))
     }
 
-    /// Where that target is, which is [`App::help_line`] read backwards.
+    /// Where the key list's target is, which is [`App::help_line`] read
+    /// backwards.
     ///
     /// Empty where the header has no room for it, so a press cannot resolve to
     /// a target the frame is not drawing.
     fn help_rect(&self, area: Rect) -> Rect {
         let header = self.arrange(area).header;
         let wide = help_target().chars().count() as u16;
-        if header.height == 0 || header.width <= wide {
+        let drawn = self.header_tail(header.width as usize).chars().count() as u16;
+        if header.height == 0 || wide == 0 || drawn < wide {
             return Rect::new(header.x, header.y, 0, 0);
         }
         Rect::new(header.x + header.width - wide, header.y, wide, 1)
+    }
+
+    /// Where the kind in force is written, which is the same row read backwards
+    /// one target further (TASK-12bd5acbf706, ADR-559eebf5c6f5).
+    ///
+    /// Empty on the same terms as [`App::help_rect`] and for the same reason:
+    /// where the row was too narrow to hold this cell it is not on the frame,
+    /// and a finger landing on the end of the corpus line must not advance a
+    /// filter nobody was shown.
+    fn kind_rect(&self, area: Rect) -> Rect {
+        let header = self.arrange(area).header;
+        let wide = kind_target(self.kind.as_deref()).chars().count() as u16;
+        let drawn = self.header_tail(header.width as usize).chars().count() as u16;
+        let help = help_target().chars().count() as u16;
+        if header.height == 0 || wide == 0 || drawn < wide + help {
+            return Rect::new(header.x, header.y, 0, 0);
+        }
+        Rect::new(header.x + header.width - drawn, header.y, wide, 1)
     }
 
     // -----------------------------------------------------------------------
@@ -3636,6 +3702,85 @@ fn help_target() -> String {
         Some(binding) => format!("[{}]", named(binding.key)),
         None => String::new(),
     }
+}
+
+/// What the header calls the state where the list is restricted to no kind at
+/// all.
+///
+/// The reader's own word for it: [`text::window`] says `all 40` over a listing
+/// that is showing everything it has, and a header that said `every` beside a
+/// title saying `all` would be two vocabularies for one fact. It is not a kind
+/// and no registry declares it, which is why it is written here and the kinds
+/// beside it never are.
+const EVERY_KIND: &str = "all";
+
+/// The binding the kind filter is cycled by, or `None` where no row runs it.
+///
+/// **The reverse of [`Binding::press`] for the one row that is not a
+/// [`Command`]**, which is why [`bindings::of_command`] cannot answer it:
+/// narrowing a list needs the kind in force and is therefore the screen's to
+/// compute, so the table spells it [`Press::Cycle`] and carries no command to
+/// look it up by. The lookup is the same shape all the same, and it exists for
+/// the same reason: the letter drawn on the header and the letter a keyboard
+/// sends have to be one letter, and `tests/log.rs` already reads the table this
+/// way rather than typing `f`.
+fn cycle_binding() -> Option<&'static Binding> {
+    bindings::BINDINGS
+        .iter()
+        .find(|b| b.runs == Runs::Press(Press::Cycle))
+}
+
+/// The label of the second target the header carries: the kind the list is
+/// restricted to, in the brackets and the `[key word]` shape every target on
+/// this screen wears (ADR-559eebf5c6f5).
+///
+/// **It is information first and a target second, and that ordering is the
+/// whole argument.** ADR-c07e2694f0e1 took away a band of offers because it
+/// cost four rows of twenty-four, and this does not buy any of it back: which
+/// kind a person is looking at has to be written somewhere regardless -- a
+/// listing that has silently dropped three quarters of a corpus and says so
+/// nowhere is the reader answering a question nobody asked -- so writing it in
+/// the cell that also answers a finger adds nothing to the frame. What the band
+/// cost was rows. This costs none.
+///
+/// **The word is padded to the widest thing that can stand in it, so the cell
+/// does not move.** A target that changes width when it is pressed is a target
+/// that has walked out from under the finger that pressed it: the tail is drawn
+/// on the right edge, so `[f all]` becoming `[f task]` would put the cell a
+/// column left of where somebody is still holding, and the second press of a
+/// cycle would land on the corpus line and do nothing. One space inside the
+/// brackets is what a still target costs, and the widest word is asked of
+/// [`row_kinds`] rather than counted here, so a fifth kind widens it with no
+/// edit.
+///
+/// The empty string where no row runs the cycle, on [`help_target`]'s reasoning
+/// and for a sharper reason: a cell saying which kind is in force with no key
+/// behind it would be a target that does nothing when it is pressed.
+///
+/// Public for the reason [`Glyphs::thumb`] is: the suite that drives the binary
+/// has to find this cell on a real terminal's grid, and a suite that spelled
+/// the label itself would go on asserting about a cell the reader had stopped
+/// drawing -- a test that quietly stops testing rather than one that fails.
+pub fn kind_target(kind: Option<&str>) -> String {
+    match cycle_binding() {
+        Some(binding) => format!(
+            "[{} {}]",
+            named(binding.key),
+            pad(kind.unwrap_or(EVERY_KIND), widest_kind())
+        ),
+        None => String::new(),
+    }
+}
+
+/// The columns the kind's word is drawn in: the longest of every word that can
+/// stand there, which is the kinds a row may have and [`EVERY_KIND`].
+fn widest_kind() -> usize {
+    row_kinds()
+        .into_iter()
+        .chain(std::iter::once(EVERY_KIND))
+        .map(|kind| kind.chars().count())
+        .max()
+        .unwrap_or(0)
 }
 
 /// The rectangle inside a panel's borders, which is what `Block` calls its
@@ -4267,7 +4412,11 @@ fn step(at: usize, by: isize, total: usize) -> usize {
 /// A filter that offered a kind the list cannot hold would be a key whose only
 /// possible answer is "no entity matches this filter", which is what
 /// ADR-559eebf5c6f5 calls a list answering a question nobody asked.
-fn row_kinds() -> Vec<&'static str> {
+///
+/// Public because the suites drive the binary and have to know what the cycle
+/// is a cycle of: a suite carrying its own copy of that list would agree with a
+/// registry that had moved.
+pub fn row_kinds() -> Vec<&'static str> {
     keys::KINDS
         .iter()
         .copied()
@@ -7522,6 +7671,149 @@ mod tests {
                     touched.frame(),
                     pressed.frame(),
                     "touching {label} is not pressing {key:?} at {window:?}"
+                );
+            }
+        }
+    }
+
+    /// **The kind in force is written on the header at every width and on
+    /// every screen, and the cell it is written in costs no row**
+    /// (TASK-12bd5acbf706, ADR-559eebf5c6f5).
+    ///
+    /// The header is walked through the whole cycle, at the phone's window and
+    /// at two desks, and three things are asserted at every stop: the kind is
+    /// on the header's first row in the reader's own spelling, the header is
+    /// still exactly the rows it was, and the cell has not moved. The last is
+    /// what makes the target usable twice: the tail is drawn on the right edge,
+    /// so a cell that changed width when it was pressed would walk out from
+    /// under the finger that was cycling with it.
+    ///
+    /// `all` is asserted as a stop of the cycle rather than skipped, because a
+    /// header that wrote a kind and went blank when there was none would be the
+    /// reader saying nothing exactly where a person cannot tell a filter from a
+    /// short corpus.
+    #[test]
+    fn the_kind_in_force_is_on_the_header_at_every_width_and_costs_no_row() {
+        for window in [PHONE, (80, 24), (120, 40)] {
+            let mut a = App::new(window, None)
+                .inked(paint::PLAIN)
+                .drawn_with(SCREEN);
+            has_read(&mut a);
+            let rows = a.arrange(a.area()).header.height;
+            assert_eq!(rows, HEADER, "the header is not the rows it was");
+            let cell = a.kind_rect(a.area());
+            let mut kind = None;
+            // One stop per kind and one more, which is back to every kind.
+            for _ in 0..=row_kinds().len() {
+                a.kind = kind.clone();
+                let label = kind_target(kind.as_deref());
+                let head = a.frame().lines().next().unwrap().to_string();
+                assert!(
+                    head.contains(&label),
+                    "the kind in force is not on the header at {window:?}:\n{head}"
+                );
+                assert_eq!(
+                    a.arrange(a.area()).header.height,
+                    rows,
+                    "the kind cost the header a row at {window:?}"
+                );
+                assert_eq!(
+                    a.kind_rect(a.area()),
+                    cell,
+                    "the cell moved between two presses at {window:?}:\n{head}"
+                );
+                kind = next_row_kind(kind.as_deref());
+            }
+            assert_eq!(kind, None, "the cycle did not come back to every kind");
+        }
+    }
+
+    /// **A press on that cell advances the same cycle by the same step**
+    /// (TASK-12bd5acbf706, ADR-559eebf5c6f5).
+    ///
+    /// The same shape `the_key_list_is_one_touch_away_on_every_frame` uses, for
+    /// the same reason: two screens driven from one start, one by a finger and
+    /// one by the key the cell names, compared as whole frames. A cell that
+    /// reached the next kind by its own call to the cycle would pass an
+    /// assertion about `a.kind` and fail this one on the day the step moved.
+    ///
+    /// Walked all the way round rather than pressed once, because the step this
+    /// is about is the wrap: a finger that advanced through the kinds and then
+    /// could not get back to every kind would have left a person on a listing
+    /// they cannot undo without a keyboard.
+    #[test]
+    fn touching_the_kind_is_pressing_the_key_that_cycles_it() {
+        let ank = nowhere();
+        let key = cycle_binding()
+            .expect("a row of the table cycles the kind filter")
+            .key;
+        for window in [PHONE, (80, 24), (120, 40)] {
+            let made = || {
+                let mut a = App::new(window, None)
+                    .inked(paint::PLAIN)
+                    .drawn_with(SCREEN);
+                has_read(&mut a);
+                a.focus = Focus::Entities;
+                a
+            };
+            let (mut touched, mut pressed) = (made(), made());
+            for step in 0..=row_kinds().len() {
+                let cell = touched.kind_rect(touched.area());
+                assert!(cell.width > 0, "no cell to press at {window:?}");
+                touch(&mut touched, &ank, Position::new(cell.x, cell.y));
+                pressed.press(KeyEvent::new(key, KeyModifiers::NONE), &ank);
+                assert_eq!(
+                    touched.kind, pressed.kind,
+                    "step {step} at {window:?}: the finger and the key are not \
+                     on the same kind"
+                );
+                assert_eq!(
+                    touched.frame(),
+                    pressed.frame(),
+                    "step {step} at {window:?}: touching the cell is not \
+                     pressing {key:?}"
+                );
+            }
+            assert_eq!(
+                touched.kind, None,
+                "the cycle did not come back to every kind under a finger"
+            );
+        }
+    }
+
+    /// The cell is not a target where it is not drawn.
+    ///
+    /// [`App::help_rect`]'s rule, and this row now has two things to fit rather
+    /// than one: a window too narrow for both draws the key list's target
+    /// alone, and a finger landing where the kind would have been must reach
+    /// nothing at all. The alternative is a header whose right edge runs a
+    /// command a person was never shown.
+    #[test]
+    fn a_window_too_narrow_for_the_cell_does_not_answer_a_press_on_it() {
+        let ank = nowhere();
+        let wide = kind_target(None).chars().count() + help_target().chars().count();
+        for columns in 1..=wide {
+            let mut a = App::new((columns, 24), None)
+                .inked(paint::PLAIN)
+                .drawn_with(SCREEN);
+            has_read(&mut a);
+            let head = a.frame().lines().next().unwrap().to_string();
+            assert!(
+                !head.contains(&kind_target(None)),
+                "the cell is drawn at {columns} columns, where it does not fit:\n{head}"
+            );
+            let cell = a.kind_rect(a.area());
+            assert_eq!(
+                cell.width, 0,
+                "a cell the frame is not drawing at {columns}"
+            );
+            // And every column of that row reaches no cycle.
+            for x in 0..columns as u16 {
+                touch(&mut a, &ank, Position::new(x, 0));
+                assert_eq!(
+                    a.kind, None,
+                    "a press at column {x} of {columns} advanced a filter \
+                     nobody was shown"
                 );
             }
         }

--- a/crates/ank-tui/tests/kind.rs
+++ b/crates/ank-tui/tests/kind.rs
@@ -1,0 +1,351 @@
+//! The kind in force, on the header of a real terminal (TASK-12bd5acbf706,
+//! ADR-559eebf5c6f5).
+//!
+//! CLAUDE.md leaves no choice about where this is measured and the criterion
+//! ends by naming the instrument: *measured through the binary*. It is the
+//! right rule here for the same reason `tests/phone.rs` gives about a tap.
+//! Whether a terminal reports a press on a header cell at all is decided by
+//! whether this reader asked it to -- `EnableMouseCapture` on the way in -- and
+//! no unit test reaches that: `src/view.rs` can be handed a `MouseEvent` all
+//! day by a suite that constructs one, on a build whose terminal was never told
+//! to send any. And "written in the header at every width" is a claim about
+//! what arrives on a grid a person is looking at, which is what a pseudo
+//! terminal has and a `Buffer` is a rehearsal of.
+//!
+//! So `src/view.rs` walks the arithmetic -- where the cell is, that it does not
+//! move between two presses, that a window too narrow to draw it answers no
+//! press on it -- at more widths and on every platform, and this drives `ank
+//! tui` on a pseudo-terminal, reads the header the way a person reads it and
+//! sends the finger the way a terminal sends one.
+//!
+//! **Nothing here is spelled twice.** The key is read out of `BINDINGS` the way
+//! `tests/log.rs` reads it, the label is read out of [`ank_tui::view`], and the
+//! kinds the cycle walks are [`ank_tui::view::row_kinds`]. A suite carrying its
+//! own copy of any of the three would go on passing against a reader that had
+//! moved it.
+//!
+//! **Nothing here asserts a wall-clock bound.** What is waited for is a frame
+//! that says something, through [`Live::until`], and the assertions compare
+//! frames with frames.
+//!
+//! `#[cfg(unix)]` for the reason the other suites give: a pseudo-terminal on
+//! Windows is ConPTY, and reaching it means the console API this workspace does
+//! not otherwise call. What runs on all three platforms is the layout, the
+//! hit-testing and the render, in `src/view.rs`.
+
+#![cfg(unix)]
+
+mod terminal;
+
+use ank_tui::bindings::{self, Runs, BINDINGS};
+use ank_tui::keys::Press;
+use ank_tui::view::{kind_target, row_kinds};
+use terminal::{Live, Repo};
+
+/// The windows this suite opens: a phone in portrait, a terminal at the size
+/// every criterion of this reader has been written for, and a desk.
+///
+/// The narrow one is the width the criterion is about. The corpus line is the
+/// longest thing on the header and forty columns cannot hold it, so a reader
+/// that had written the kind into that sentence rather than beside it would
+/// pass at eighty and lose the cell to a `~` here.
+const WINDOWS: [(u16, u16); 3] = [(40, 30), (80, 24), (120, 40)];
+
+/// The key the kind filter is cycled with, out of the reader's own table.
+///
+/// Never `f` written here, on `tests/log.rs`'s reasoning: the point of the wave
+/// is that a key is the verb it runs, and a suite typing the letter the filter
+/// happens to be bound to today would go on passing against a table that had
+/// moved it.
+fn key_of_kind() -> String {
+    let binding = BINDINGS
+        .iter()
+        .find(|b| b.runs == Runs::Press(Press::Cycle))
+        .expect("the reader binds a key to the kind filter");
+    let letter = bindings::named(binding.key);
+    assert_eq!(
+        letter.chars().count(),
+        1,
+        "the filter is named '{letter}', which is not one keystroke to send"
+    );
+    letter
+}
+
+/// The stops of the cycle, in order: every kind the filter can be put into, and
+/// the state a person can always get back to.
+///
+/// `None` first and `None` again at the end, because that is what the criterion
+/// says the cycle is -- through the kinds a row may have *and back to all of
+/// them* -- and a reader that walked the kinds and stranded somebody on the
+/// last one would pass a test that only listed the kinds.
+fn stops() -> Vec<Option<String>> {
+    let mut out = vec![None];
+    out.extend(row_kinds().into_iter().map(|k| Some(k.to_string())));
+    out.push(None);
+    out
+}
+
+/// A corpus with one entity of every kind a row may have, so that every stop of
+/// the cycle has something to show.
+///
+/// The seeded ADR and task are kept and a spec is added. A stop with no row
+/// under it would still say which kind is in force -- that is the header's job
+/// and it is what is being measured -- but a listing that was empty at every
+/// stop would leave "the filter narrowed the list" unmeasured beside it, and a
+/// header saying `adr` over a list of tasks is exactly the defect worth
+/// catching.
+fn corpus() -> Repo {
+    let repo = Repo::seeded();
+    repo.ank(&[
+        "new",
+        "spec",
+        "--title",
+        "What the reader answers, and what it leaves out",
+        "--scope",
+        "src/**",
+    ]);
+    repo.warm_find();
+    repo
+}
+
+/// The header's first row, which is where the criterion says the kind is.
+fn header(frame: &str) -> String {
+    frame.lines().next().unwrap_or_default().to_string()
+}
+
+/// How many rows the header takes on a drawn frame: the lines above the one
+/// region's top border.
+///
+/// Counted off the frame rather than read out of a constant, because the
+/// criterion is about the rows a person loses and a constant would agree with
+/// itself. The border is the first line carrying the region's own corner, which
+/// is read out of the reader's border set for the reason `tests/phone.rs`
+/// gives.
+fn header_rows(frame: &str) -> usize {
+    let corner = ank_tui::view::BOXES
+        .border(true)
+        .top_left
+        .chars()
+        .next()
+        .expect("a border set has a corner");
+    frame
+        .lines()
+        .position(|line| line.starts_with(corner))
+        .unwrap_or_else(|| panic!("no region on the frame:\n{frame}"))
+}
+
+/// The session, once the corpus has reached the screen.
+fn opened(live: &Live) {
+    live.until("the corpus to arrive", |t| t.contains("in the corpus)"));
+}
+
+/// Where the cell is on the header, as a column a finger can be put on.
+///
+/// Found by looking for the label the reader draws, which is how a person finds
+/// it. Counted in `char`s, because a column is a cell and not a byte.
+fn cell_at(frame: &str, kind: Option<&str>) -> u16 {
+    let head = header(frame);
+    let label = kind_target(kind);
+    let at = head
+        .find(&label)
+        .unwrap_or_else(|| panic!("'{label}' is not on the header:\n{head}"));
+    head[..at].chars().count() as u16
+}
+
+// ---------------------------------------------------------------------------
+// Written in the header, at every width
+// ---------------------------------------------------------------------------
+
+/// **The kind the list is restricted to is written in the header at every width
+/// the harness opens, and one keystroke advances it through the kinds a row may
+/// have and back to all of them** -- two thirds of the criterion, on one
+/// session per window.
+///
+/// Both halves together, because either alone is the wrong reader. One that
+/// wrote the kind and never moved would pass the first; one that cycled
+/// correctly and said so only in the region's title -- which is where this
+/// reader said it before this task -- would pass the second and lose the cell
+/// to a `~` at forty columns, which is the width the clause exists for.
+///
+/// The list under it is read too. A header that named a kind while the rows
+/// carried another would be the screen lying about what a person is looking at,
+/// and it is the one failure that looks like success on the header alone.
+#[test]
+fn the_header_names_the_kind_in_force_through_the_whole_cycle_at_every_width() {
+    let repo = corpus();
+    let key = key_of_kind();
+    for window in WINDOWS {
+        let mut live = Live::open(&repo, window.0, window.1);
+        opened(&live);
+        for (step, kind) in stops().into_iter().enumerate() {
+            if step > 0 {
+                let said = kind_target(kind.as_deref());
+                live.send(&key);
+                live.until("the header to name the next kind", |t| {
+                    header(t).contains(&said)
+                });
+            }
+            let frame = live.frame();
+            let label = kind_target(kind.as_deref());
+            assert!(
+                header(&frame).contains(&label),
+                "step {step} at {window:?}: the header does not say '{label}':\n{frame}"
+            );
+            // And the rows under it are the kind the header claims.
+            if let Some(kind) = &kind {
+                let prefix = format!("{}-", kind.to_ascii_uppercase());
+                for other in row_kinds() {
+                    if other == kind {
+                        continue;
+                    }
+                    let stray = format!("{}-", other.to_ascii_uppercase());
+                    assert!(
+                        !frame.contains(&stray),
+                        "the header says '{kind}' and a {other} row is drawn \
+                         under it at {window:?}:\n{frame}"
+                    );
+                }
+                assert!(
+                    frame.contains(&prefix),
+                    "the header says '{kind}' and no {kind} row is drawn under \
+                     it at {window:?}:\n{frame}"
+                );
+            }
+        }
+        live.quit();
+    }
+}
+
+/// **The header occupies the same number of rows after this task as before it**
+/// -- the last third of the criterion.
+///
+/// Three, which is what it was: the corpus line, the identity line, and the
+/// rule under them. The cell is carved out of a row the reader was already
+/// drawing, which is the whole of ADR-559eebf5c6f5's argument for it -- it is
+/// information made touchable, not an offer drawn at rest, and ADR-c07e2694f0e1
+/// removed a band of offers precisely because it cost four rows of twenty-four.
+///
+/// Asserted at every stop of the cycle and at every window, because the failure
+/// this guards against is not a header that starts too tall: it is one that
+/// grows when a kind with a longer name is put into it, at the width where the
+/// row was already full.
+#[test]
+fn the_header_is_three_rows_whatever_kind_is_in_force() {
+    let repo = corpus();
+    let key = key_of_kind();
+    for window in WINDOWS {
+        let mut live = Live::open(&repo, window.0, window.1);
+        opened(&live);
+        for (step, kind) in stops().into_iter().enumerate() {
+            if step > 0 {
+                let said = kind_target(kind.as_deref());
+                live.send(&key);
+                live.until("the header to name the next kind", |t| {
+                    header(t).contains(&said)
+                });
+            }
+            let frame = live.frame();
+            assert_eq!(
+                header_rows(&frame),
+                3,
+                "step {step} at {window:?}: the header is not the three rows it \
+                 was:\n{frame}"
+            );
+        }
+        live.quit();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// And the cell is a target
+// ---------------------------------------------------------------------------
+
+/// **A press on that cell of the header advances the same cycle by the same
+/// step** -- the half of the criterion a keyboard cannot answer.
+///
+/// Two sessions on one corpus, one driven by the key and one by a finger on the
+/// cell, walked all the way round and compared frame for frame. That is the
+/// strongest form of "the same cycle by the same step": a reader whose finger
+/// reached the right kind by a different road -- its own call to the cycle,
+/// a step of two, a wrap that stopped at the last kind -- gives a different
+/// sequence of screens and fails here, where an assertion on the kind alone
+/// would have passed three of those four.
+///
+/// The whole way round rather than one press, because the step this is most
+/// about is the wrap: a finger that walked the kinds and could not get back to
+/// every kind would have left a person on a listing they cannot undo without a
+/// keyboard, which is the phone ADR-559eebf5c6f5 is answering.
+#[test]
+fn a_finger_on_the_cell_walks_the_same_cycle_as_the_key() {
+    let repo = corpus();
+    let key = key_of_kind();
+    for window in WINDOWS {
+        let pressed = {
+            let mut live = Live::open(&repo, window.0, window.1);
+            opened(&live);
+            let mut frames = vec![live.frame()];
+            for kind in stops().into_iter().skip(1) {
+                let said = kind_target(kind.as_deref());
+                live.send(&key);
+                live.until("the header to name the next kind", |t| {
+                    header(t).contains(&said)
+                });
+                frames.push(live.frame());
+            }
+            live.quit();
+            frames
+        };
+
+        let mut live = Live::open(&repo, window.0, window.1);
+        opened(&live);
+        let mut touched = vec![live.frame()];
+        for (step, kind) in stops().into_iter().enumerate().skip(1) {
+            // Aimed at the cell as it is drawn now, which is where a person
+            // would be putting a thumb.
+            let shown = touched.last().expect("a frame to aim at");
+            let column = cell_at(shown, stops()[step - 1].as_deref());
+            live.tap(column, 0);
+            let said = kind_target(kind.as_deref());
+            live.until("the header to name the next kind", |t| {
+                header(t).contains(&said)
+            });
+            touched.push(live.frame());
+        }
+        live.quit();
+
+        for (step, (by_key, by_finger)) in pressed.iter().zip(touched.iter()).enumerate() {
+            assert_eq!(
+                by_finger, by_key,
+                "step {step} at {window:?}: the finger and the key are not on \
+                 the same screen"
+            );
+        }
+    }
+}
+
+/// A press beside the cell reaches nothing.
+///
+/// The other half of "the cell is a target", and the one a reader gets wrong by
+/// being generous: a header that answered a press anywhere on its first row
+/// would be a screen a pocket can drive, which is what ADR-c07e2694f0e1's rule
+/// about chrome is for. The column tested is the left end of the corpus line,
+/// which is as far from the cell as that row goes.
+#[test]
+fn a_press_on_the_rest_of_the_header_advances_nothing() {
+    let repo = corpus();
+    for window in WINDOWS {
+        let mut live = Live::open(&repo, window.0, window.1);
+        opened(&live);
+        let before = live.frame();
+        live.tap(0, 0);
+        // The second row of the header too: the identity line carries no target
+        // at all, so nothing on it may run anything.
+        live.tap(0, 1);
+        let after = live.frame();
+        assert_eq!(
+            after, before,
+            "a press on the header moved the screen at {window:?}"
+        );
+        live.quit();
+    }
+}


### PR DESCRIPTION
TASK-12bd5acbf706, under ADR-559eebf5c6f5.

The header's first row ends with two targets rather than one. `kind_target()` writes the kind the list is restricted to — `[f all]`, `[f adr]`, `[f spec]`, `[f task]` — and `help_target()`'s `[?]` keeps the right edge behind it, both carved out of `App::header_tail()` so that drawing them and hitting them cannot disagree about which of them is on the frame.

**The header is three rows before this and three rows after it.** The cell is carved out of a row the reader was already drawing, which is the ADR's whole argument: which kind a person is looking at has to be written somewhere regardless, so making that cell answer a finger adds nothing to the frame. This is not the band of targets ADR-c07e2694f0e1 removed for costing four rows of twenty-four — it is information made touchable, which is the opposite of an offer drawn at rest.

**The letter is the table's.** `cycle_binding()` is the reverse of `Binding::press` for the one row that is not a `Command`: narrowing needs the kind in force, so the table spells it `Press::Cycle` and carries no command for `of_command` to look it up by. A press on the cell hands `App::press` the very keystroke a keyboard sends, so "the same cycle by the same step" is a property inherited rather than reimplemented.

**The word is padded to the widest kind, and that is not cosmetic.** The tail is right-aligned, so an unpadded `[f all]` becoming `[f task]` moves the cell one column left and the second press of a cycle lands on the corpus line — a target that walks out from under the finger cycling with it. Both cells go together where a window cannot hold them, and the key list's is the last to go: it is the only road to every key on the screen.

`filter_note()` is untouched. `tests/log.rs` reads `[kind ` out of the region's title and takes its absence as "back to every kind", and that file is another agent's perimeter.

## Measurement

Through the binary, in `crates/ank-tui/tests/kind.rs` — four tests on a pseudo-terminal at (40,30), (80,24) and (120,40), the key sent as a keystroke and the finger as SGR through `Live::tap`, `terminal/mod.rs` untouched:

- the header names the kind through the whole cycle at every width, and the rows under it are the kind it claims;
- the header is the three rows it was, counted off the frame as the lines above the region's own corner rather than read out of `HEADER` — a constant would agree with itself;
- a finger on the cell walks the same cycle as the key, measured as two sessions on one corpus walked all the way round and compared frame for frame (an assertion on the kind alone would have passed a reader that got there by its own call to the cycle);
- a press on the rest of the header advances nothing.

All four verified to bite, each after `cargo build -p ank-cli`. Three unit tests in `src/view.rs` walk the arithmetic at every width and on every platform — where the cell is, that it does not move between two presses, that a window too narrow to draw it answers no press on it — and were verified to bite too.

Scope was widened by exactly `crates/ank-tui/tests/kind.rs`, a new file no other perimeter names, on the reading five tasks of this wave already took: `tests/dependencies.rs` forbids `src/` a foreign symbol, so a pseudo-terminal cannot live in this crate's sources.

Whole workspace green; `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TuTQw87giFDeMsiYwdzB11