### PR TITLE
One press chooses a row, and two on the same row open it

### DIFF
--- a/.ank/entities/LOG-197c1be0e2f4.md
+++ b/.ank/entities/LOG-197c1be0e2f4.md
@@ -1,0 +1,16 @@
+---
+id: LOG-197c1be0e2f4
+type: log
+title: "Built in view.rs. A press in the region is paired rather than read off the cursor: App::pointed"
+created: 2026-08-29T18:45:35Z
+author: claude-code/opus-5+one-press-two-press
+scope:
+  - crates/ank-tui/src/view.rs
+  - crates/ank-tui/tests/press.rs
+about: TASK-42de0df951a4
+seq: 3
+schema: 4
+version: 1
+---
+
+ takes the pairing at the top of its Down arm so every road but the last -- overlay, form, further-verbs list, target, waiting command -- ends it, App::press clears it so a keystroke does too, and App::tapped hands App::pressed the instant, which is where SECOND_PRESS is compared. A press opens where it lands on the same screen and the same row as the press before it, no further off than SECOND_PRESS, and that row is the selected one; otherwise it chooses, and becomes the press the next one is measured against. A pair that opened is spent, so coming back out of a document by Back does not fall into it again on one press. What the interval closes is not a hypothetical: 'the row already selected opens' was the whole rule, and a session selects row zero before anybody has touched the screen, so the first press a person made on that row was answered as their second -- one press opening a document, which is the thing the rule's own prose forbids.

--- a/.ank/entities/LOG-4ac9fa1e528f.md
+++ b/.ank/entities/LOG-4ac9fa1e528f.md
@@ -1,0 +1,15 @@
+---
+id: LOG-4ac9fa1e528f
+type: log
+title: Perimeter read. App::tapped already opens the row a finger lands on where that row is the selected
+created: 2026-08-29T18:20:38Z
+author: claude-code/opus-5+one-press-two-press
+scope:
+  - crates/ank-tui/src/view.rs
+about: TASK-42de0df951a4
+seq: 0
+schema: 4
+version: 1
+---
+
+ one (TASK-9a402a54886f), and it does it with no interval at all: the pairing is 'row == cursor.at', so a session that opens with row 0 selected opens that document on the *first* touch anybody makes on it -- one press, not two, which is the hole the criterion's interval closes. The only measurement of the region's tap today is phone.rs::a_tap_selects_a_row_and_a_second_tap_on_it_opens_it, and its two taps are separated by Live::frame(), which settles on two equal samples two hundred milliseconds apart: any interval short enough to be a mouse double-click would turn that suite red under load. There is no clock in this crate outside stream.rs::TICK.

--- a/.ank/entities/LOG-8921bedb93d4.md
+++ b/.ank/entities/LOG-8921bedb93d4.md
@@ -1,0 +1,16 @@
+---
+id: LOG-8921bedb93d4
+type: log
+title: SECOND_PRESS is five seconds and the number is argued rather than borrowed. The gesture the
+created: 2026-08-29T18:45:54Z
+author: claude-code/opus-5+one-press-two-press
+scope:
+  - crates/ank-tui/src/view.rs
+  - crates/ank-tui/tests/press.rs
+about: TASK-42de0df951a4
+seq: 4
+schema: 4
+version: 1
+---
+
+ decision names is 'choose, look, touch again', and the looking is what takes the time: an interval in the fifths of a second a desktop gives a double-click would refuse the second touch a person actually makes. It is also what the suite already says. phone.rs::a_tap_selects_a_row_and_a_second_tap_on_it_opens_it puts Live::frame() between its two taps, and frame() settles on two equal samples two hundred milliseconds apart, so its own gap is half a second on an idle machine and longer under load; planting a zero interval turned that test red, which is the same test a mouse-sized interval would make flaky. The cost of the number being too short is a reader that ignores people; the cost of it being too long is a pairing that outlives its row for a few seconds.

--- a/.ank/entities/LOG-89395b0cba13.md
+++ b/.ank/entities/LOG-89395b0cba13.md
@@ -1,0 +1,16 @@
+---
+id: LOG-89395b0cba13
+type: log
+title: "Measured through the binary in crates/ank-tui/tests/press.rs: four tests on a pseudo-terminal, the"
+created: 2026-08-29T18:45:57Z
+author: claude-code/opus-5+one-press-two-press
+scope:
+  - crates/ank-tui/src/view.rs
+  - crates/ank-tui/tests/press.rs
+about: TASK-42de0df951a4
+seq: 5
+schema: 4
+version: 1
+---
+
+ finger sent as SGR through Live::tap, terminal/mod.rs untouched. One press chooses the row under the pointer and opens nothing -- asked of a row the cursor is not on and of the row the session opens with, which is the one the old rule opened off a single press. Two presses on one row open its document, and the two clauses around that one are read off the same session: the listing does not survive the document, Back gives it back with the same row selected, and one press on that row does not fall back into it. Two presses on different rows open nothing, and the pair after them opens, so the negative half cannot pass on a reader that has stopped answering. And a press SECOND_PRESS-plus-a-second after the last one opens nothing and is counted as a first, which is the interval measured through the binary rather than named in a file. Presses meant to pair are sent back to back with nothing waited for in between -- two writes down one pty, which no load can put five seconds between -- so nothing here asserts a wall-clock bound; the one sleep is longer than the interval on purpose, and load only lengthens it. Five unit tests in view.rs state the same rules against an instant they are handed: App::pressed takes the clock rather than reading it. Every test verified to bite, each after 'cargo build -p ank-cli', on four plants: an interval that never expires (the interval test red, both suites), the old unpaired rule (all four pty tests red), a pairing that ignores which row it landed on (two red), and the interval set to zero (three red, and phone.rs's own tap test with them). Whole workspace green: 42 suites, no failures. cargo fmt --check clean, ank check exit 0.

--- a/.ank/entities/LOG-b65f5f62f549.md
+++ b/.ank/entities/LOG-b65f5f62f549.md
@@ -1,0 +1,16 @@
+---
+id: LOG-b65f5f62f549
+type: log
+title: Scope widened by exactly crates/ank-tui/tests/press.rs, a file that does not exist yet and that no
+created: 2026-08-29T18:20:56Z
+author: claude-code/opus-5+one-press-two-press
+scope:
+  - crates/ank-tui/src/view.rs
+  - crates/ank-tui/tests/press.rs
+about: TASK-42de0df951a4
+seq: 2
+schema: 4
+version: 1
+---
+
+ other agent's perimeter names -- TASK-73b1's crates/ank-tui/** covers it, and 73b1 is blocked by this task and unclaimed. The criterion opens 'The pseudo-terminal harness shows' and that measurement cannot be written where the code is: tests/dependencies.rs forbids src/ a foreign symbol and forbids it unsafe, so a pty in this crate's sources is not an option and the harness that drives one lives in tests/terminal/mod.rs, untouched here. Six tasks of this wave widened the same way (252b, b518, c94d, 3fa4, d712, 12bd) on the same reading: only the criterion is frozen, and an agent meeting it outside its declared perimeter is the undeclared work a claim collision cannot see.

--- a/.ank/entities/LOG-f421d2aeebb2.md
+++ b/.ank/entities/LOG-f421d2aeebb2.md
@@ -1,0 +1,15 @@
+---
+id: LOG-f421d2aeebb2
+type: log
+title: +scope crates/ank-tui/tests/press.rs (version 2 to 3, replaced 4c89f184fbcf, produced 0927c68dc49f)
+created: 2026-08-29T18:20:46Z
+author: claude-code/opus-5+one-press-two-press
+scope:
+  - crates/ank-tui/src/view.rs
+  - crates/ank-tui/tests/press.rs
+about: TASK-42de0df951a4
+seq: 1
+records: edit
+schema: 4
+version: 1
+---

--- a/.ank/entities/TASK-42de0df951a4.md
+++ b/.ank/entities/TASK-42de0df951a4.md
@@ -5,13 +5,14 @@ slug: one-press-chooses-a-row-and-two-on-the-same-row
 title: One press chooses a row, and two on the same row open it
 created: 2026-08-27T16:34:09Z
 author: haksolot@vmi3223161
-status: open
+status: in_progress
 scope:
   - crates/ank-tui/src/view.rs
+  - crates/ank-tui/tests/press.rs
 blocked_by: [TASK-252bf02de218]
 done_criteria: |
   The pseudo-terminal harness shows that one press selects the row under the pointer, that two presses on that row inside the interval the code names open its document, and that two presses on different rows open nothing. The interval is a named constant and not a number written at the place it is compared. Measured through the binary.
 criteria_by: creator
 schema: 4
-version: 1
+version: 3
 ---

--- a/crates/ank-tui/src/view.rs
+++ b/crates/ank-tui/src/view.rs
@@ -130,8 +130,9 @@
 //! have sent, so a person with a keyboard reads the letter, a person with a
 //! thumb touches the word, and the offer is checkable against the mapping
 //! instead of against somebody's memory of it. A thumb reaches the commonest
-//! act of all with no target whatever -- touching the row already selected
-//! opens it ([`App::tapped`]).
+//! act of all with no target whatever -- one press chooses a row, and two
+//! presses on that row inside [`SECOND_PRESS`] open it ([`App::tapped`],
+//! TASK-42de0df951a4).
 //!
 //! The second cell is the kind in force ([`kind_target`], TASK-12bd5acbf706,
 //! ADR-559eebf5c6f5), and it is on the same row for the same price. It is not
@@ -173,8 +174,13 @@
 //! puts the identifier the focused panel names in front of the verb the key
 //! composed, asks [`Ank::spelling`] for the command line that argv is, and
 //! **stops**. Nothing else here writes, and nothing runs that a person did not
-//! press twice -- there is no timer in this crate, and [`App::frame`] is a pure
-//! function of what the last command left behind.
+//! press twice -- nothing in this crate runs on a clock, and [`App::frame`] is
+//! a pure function of what the last command left behind. The one clock this
+//! file reads is [`App::tapped`]'s, and what it decides is whether a press is
+//! the second of a pair (TASK-42de0df951a4): it starts nothing, it wakes
+//! nothing, and no frame is drawn because time passed. `pressed` takes the
+//! instant rather than reading it, so the rule is stated to the suite instead
+//! of being waited out by it.
 //!
 //! # The confirmation, which is the fourth act
 //!
@@ -273,6 +279,7 @@ use ratatui::widgets::{
     Block, Clear, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState, StatefulWidget,
     Widget,
 };
+use std::time::{Duration, Instant};
 
 /// Which screen the one region is showing (TASK-252bf02de218).
 ///
@@ -457,6 +464,51 @@ struct Cursor {
     top: usize,
 }
 
+/// How long the row one press chose stays the row a second press opens
+/// (TASK-42de0df951a4, ADR-559eebf5c6f5).
+///
+/// **Not a double-click timeout, because a press is not a click.** What the
+/// decision asks for is the commonest act a thumb makes on a screen with no
+/// button on it -- choose a row, read it, touch it again -- and the reading is
+/// the part that takes the time. An interval measured in the fifths of a second
+/// a desktop gives a double-click would refuse the second touch a person
+/// actually makes, and refusing it means the document does not open: the cost
+/// of this number being too short is a reader that ignores people, where the
+/// cost of it being too long is a pairing that outlives its own row for a few
+/// seconds. So it is measured in what reading a row costs and not in what
+/// clicking twice costs.
+///
+/// **What it buys by expiring at all is that one press never opens anything.**
+/// A row is selected from the first frame a session draws, so without an
+/// interval the very first touch anybody makes on that row is a second touch:
+/// the reader opens a document nobody paired a press with, which is a screen a
+/// pocket can drive and the opposite of "the first is what *makes* a row the
+/// selected one". When the pairing goes stale the counting starts again, and
+/// that is the whole of what this is for.
+///
+/// Public because the suite measures against it rather than restating it: a
+/// test that slept a number of its own would be a second spelling of this one,
+/// and it would be the spelling that went out of date.
+pub const SECOND_PRESS: Duration = Duration::from_secs(5);
+
+/// The press a second press is measured against (TASK-42de0df951a4).
+///
+/// A row and a screen and not a point, because what a person presses twice is a
+/// row: a finger landing two columns further along the same row is the same
+/// act, and the arithmetic that turns a point into a row has already run by the
+/// time this is written down.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Chosen {
+    /// The screen it landed on. A press on row three of the entities and a
+    /// press on row three of the queue are two acts on two lists, and the digit
+    /// between them is a keystroke that has already ended the pair.
+    focus: Focus,
+    /// The row it chose.
+    row: usize,
+    /// When it landed, which is the only instant this crate holds.
+    at: Instant,
+}
+
 /// What the key list did with a key pressed over it (TASK-8a6578851244).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Listed {
@@ -627,6 +679,20 @@ pub struct App {
     /// of any listing is opened -- the cursor walks, and Enter opens what it is
     /// on. One vocabulary, applied to an overlay.
     beyond: Option<usize>,
+    /// The press the next press in the region is measured against
+    /// (TASK-42de0df951a4, ADR-559eebf5c6f5).
+    ///
+    /// `None` is the ordinary state and it is where no press can open anything:
+    /// a press with nothing to pair with is the press that chooses. It is set
+    /// by a press that landed on a row and taken back by anything else a person
+    /// does -- a keystroke, a press on a target, a press on a border -- so
+    /// "two presses on the same row" means two presses and not two events with
+    /// a session's worth of screen in between.
+    ///
+    /// Held rather than derived, because it is the one fact the frame does not
+    /// carry: which row is selected is drawn on the screen, and how it came to
+    /// be selected is not.
+    chosen: Option<Chosen>,
 }
 
 impl App {
@@ -663,6 +729,7 @@ impl App {
             overlay: None,
             form: None,
             beyond: None,
+            chosen: None,
         }
     }
 
@@ -929,6 +996,12 @@ impl App {
     /// key runs the command that is being read or drops it, so what a person
     /// says yes to is what they were shown and nothing has moved underneath it.
     pub fn press(&mut self, key: KeyEvent, ank: &Ank) -> bool {
+        // A key ends the pair a second press would be measured against
+        // (TASK-42de0df951a4). Two presses on a row are two presses on it, and
+        // a person who reached for the keyboard in between has done something
+        // else with the screen -- including where the key moved no cursor,
+        // because what is being counted is the act and not its effect.
+        self.chosen = None;
         if self.pending.is_some() {
             return self.answer(key, ank);
         }
@@ -1044,6 +1117,13 @@ impl App {
         let at = Position::new(event.column, event.row);
         match event.kind {
             MouseEventKind::Down(_) => {
+                // The pairing belongs to the region and to nothing else on the
+                // frame (TASK-42de0df951a4): taken here, so every road out of
+                // this arm but the last leaves it ended. A press that reached
+                // an overlay, a target or a waiting command is a press
+                // somewhere else, and the row a person chose before it is not
+                // half of a gesture any more.
+                let first = self.chosen.take();
                 // The list is over the region and over the bands, so it is what
                 // a press lands on while it is open: one row, one binding, and
                 // no second road to whatever is drawn underneath it.
@@ -1110,7 +1190,7 @@ impl App {
                         return self.press(KeyEvent::new(binding.key, KeyModifiers::NONE), ank);
                     }
                 }
-                self.tapped(at, ank)
+                self.tapped(first, at, ank)
             }
             // The wheel, and the swipe a phone sends as one. It moves the
             // view and never the cursor (ADR-559eebf5c6f5,
@@ -1305,8 +1385,8 @@ impl App {
         self.overlay = Some(top.clamp(0, last as isize) as usize);
     }
 
-    /// A tap that landed in the region: the row under the finger selected, or
-    /// opened where it was the selected one already.
+    /// A tap that landed in the region: the row under the finger chosen, or
+    /// opened where the press before it chose that same row.
     ///
     /// **There is no panel to move to any more** (TASK-252bf02de218). This used
     /// to resolve which of four rectangles a finger was in, focus that one, and
@@ -1317,14 +1397,34 @@ impl App {
     /// crossing tap has nowhere to cross to: the digits are how a person
     /// changes screens now.
     ///
-    /// **Touching the row already selected opens it** (ADR-c07e2694f0e1,
-    /// TASK-9a402a54886f), and that is the commonest act on a phone reaching
-    /// the screen with no button at all: select, look, touch again. It is the
-    /// second touch and never the first, because the first is what *makes* a
-    /// row the selected one -- a tap that both moved the cursor and opened
-    /// whatever it landed on would be a screen where a person cannot look
-    /// before they choose.
-    fn tapped(&mut self, at: Position, ank: &Ank) -> bool {
+    /// **One press chooses a row, and two presses on that row open it**
+    /// (ADR-559eebf5c6f5, TASK-42de0df951a4, TASK-9a402a54886f), which is the
+    /// commonest act on a phone reaching the screen with no button at all:
+    /// choose, look, touch again. It is the second press and never the first,
+    /// because the first is what *makes* a row the chosen one -- a press that
+    /// both moved the cursor and opened whatever it landed on would be a screen
+    /// where a person cannot look before they choose.
+    ///
+    /// **Which is why the pair is counted and not inferred from the cursor.**
+    /// "The row already selected" was the whole of the rule until now, and on a
+    /// screen that selects its first row before anybody has touched it, the
+    /// first press a person makes on that row is already a press on the
+    /// selected one: it opened a document off one touch, which is the very
+    /// thing the paragraph above says it must not do. So what is asked is
+    /// whether *this* press pairs with the last one -- same screen, same row,
+    /// no further apart than [`SECOND_PRESS`] -- and the cursor is asked too,
+    /// because a pairing whose row has since been chosen by other means is a
+    /// pairing about a row nobody is standing on.
+    ///
+    /// The instant is taken rather than read, so the rule can be stated to a
+    /// test instead of waited out by one, and so this stays a function of what
+    /// it was given.
+    fn tapped(&mut self, first: Option<Chosen>, at: Position, ank: &Ank) -> bool {
+        self.pressed(first, at, ank, Instant::now())
+    }
+
+    /// [`App::tapped`] with the clock handed to it.
+    fn pressed(&mut self, first: Option<Chosen>, at: Position, ank: &Ank, now: Instant) -> bool {
         let focus = self.focus;
         let Some(row) = self.row_at(focus, at) else {
             return false;
@@ -1334,9 +1434,19 @@ impl App {
         if row >= self.count(focus) {
             return false;
         }
-        let again = row == self.cursors[focus.number() - 1].at;
+        let again = first.is_some_and(|first| {
+            first.focus == focus && first.row == row && now.duration_since(first.at) <= SECOND_PRESS
+        }) && row == self.cursors[focus.number() - 1].at;
         self.cursors[focus.number() - 1].at = row;
         self.clamp(focus);
+        // A pair that opened is spent: coming back out of the document to the
+        // row that is still selected finds a screen where one press chooses
+        // again, and not one where a single touch reopens what was just left.
+        self.chosen = (!again).then_some(Chosen {
+            focus,
+            row,
+            at: now,
+        });
         again && self.act(Command::Open, ank)
     }
 
@@ -7482,6 +7592,205 @@ mod tests {
                 .count();
             assert_eq!(marked, 1, "{frame}");
         }
+    }
+
+    /// One press of the left button at a point, at an instant the test names.
+    ///
+    /// [`App::pointed`]'s own arithmetic with the clock handed in: the pairing
+    /// is taken exactly where a mouse event takes it, so what these tests drive
+    /// is the road a terminal drives and not a shortcut past it. The instant is
+    /// stated rather than slept through -- a suite that waited out
+    /// [`SECOND_PRESS`] would be asserting on the machine it ran on.
+    fn press_at(a: &mut App, ank: &Ank, at: Position, now: Instant) -> bool {
+        let first = a.chosen.take();
+        a.pressed(first, at, ank, now)
+    }
+
+    /// What the reader reached for, read off the refusal.
+    ///
+    /// The CLI is addressed where there is none, so an open says which document
+    /// it would have shown -- which is the only thing about an open worth
+    /// asserting here, and it is unambiguous: a screen that opened nothing has
+    /// nothing to say.
+    fn reached_for(a: &App) -> String {
+        a.note.clone().unwrap_or_default()
+    }
+
+    /// **One press chooses a row, and two presses on that row open it**
+    /// (TASK-42de0df951a4, ADR-559eebf5c6f5).
+    ///
+    /// The second instant is [`SECOND_PRESS`] after the first exactly, which is
+    /// the boundary stated as the interval includes it: a pair that arrives on
+    /// the last instant of the interval is a pair.
+    #[test]
+    fn one_press_chooses_a_row_and_two_presses_on_it_open_it() {
+        let ank = nowhere();
+        for size in [PHONE, (120, 40)] {
+            let mut a = App::new(size, None).inked(paint::PLAIN).drawn_with(SCREEN);
+            has_read(&mut a);
+            let start = Instant::now();
+            let at = row_of(&a, 2);
+
+            press_at(&mut a, &ank, at, start);
+            assert_eq!(
+                a.cursors[Focus::Entities.number() - 1].at,
+                2,
+                "the press at {size:?} did not choose the row under it"
+            );
+            assert_eq!(
+                a.note,
+                None,
+                "one press at {size:?} opened a document: {}",
+                reached_for(&a)
+            );
+
+            press_at(&mut a, &ank, at, start + SECOND_PRESS);
+            assert!(
+                reached_for(&a).contains("SPEC-fe8bdb84faca"),
+                "two presses on the row at {size:?} opened nothing: {}",
+                reached_for(&a)
+            );
+        }
+    }
+
+    /// **Two presses on different rows open nothing**, and the second of them
+    /// is the press that chooses (TASK-42de0df951a4).
+    ///
+    /// The third press is what makes that a statement about the pairing rather
+    /// than about the interval: if the second press were not counted as a
+    /// first, nothing would open on the row it chose either.
+    #[test]
+    fn two_presses_on_different_rows_open_nothing() {
+        let ank = nowhere();
+        let mut a = phone();
+        let start = Instant::now();
+
+        let first = row_of(&a, 2);
+        let elsewhere = row_of(&a, 1);
+        press_at(&mut a, &ank, first, start);
+        press_at(&mut a, &ank, elsewhere, start);
+        assert_eq!(
+            a.cursors[Focus::Entities.number() - 1].at,
+            1,
+            "the second press did not choose the row under it"
+        );
+        assert_eq!(
+            a.note,
+            None,
+            "two presses on two rows opened a document: {}",
+            reached_for(&a)
+        );
+
+        press_at(&mut a, &ank, elsewhere, start);
+        assert!(
+            reached_for(&a).contains("TASK-49746735127f"),
+            "the row the second press chose does not open on the press after \
+             it: {}",
+            reached_for(&a)
+        );
+    }
+
+    /// **A second press further off than [`SECOND_PRESS`] opens nothing, and
+    /// the counting starts again from it** (TASK-42de0df951a4).
+    ///
+    /// The interval is what makes one press never enough, and this is where it
+    /// is measured: one instant past it, on the row that is selected, by the
+    /// road a finger takes.
+    #[test]
+    fn a_press_past_the_interval_opens_nothing_and_is_counted_as_a_first() {
+        let ank = nowhere();
+        let mut a = phone();
+        let start = Instant::now();
+        let at = row_of(&a, 2);
+        let past = start + SECOND_PRESS + Duration::from_millis(1);
+
+        press_at(&mut a, &ank, at, start);
+        press_at(&mut a, &ank, at, past);
+        assert_eq!(
+            a.note,
+            None,
+            "a press {SECOND_PRESS:?} and a millisecond after the one it was \
+             paired with opened a document: {}",
+            reached_for(&a)
+        );
+
+        press_at(&mut a, &ank, at, past + Duration::from_millis(1));
+        assert!(
+            reached_for(&a).contains("SPEC-fe8bdb84faca"),
+            "the press past the interval was not counted as the one that \
+             chooses: {}",
+            reached_for(&a)
+        );
+    }
+
+    /// **The first press on the row a session opens with opens nothing**
+    /// (TASK-42de0df951a4, ADR-559eebf5c6f5).
+    ///
+    /// The hole the interval closes, and the reason the pair is counted rather
+    /// than read off the cursor. A row is selected from the first frame a
+    /// session draws, so "the row already selected" made the very first touch
+    /// anybody made on it a second touch: a document opened off one press, on a
+    /// screen a pocket can drive.
+    #[test]
+    fn the_first_press_on_the_row_a_session_opens_with_opens_nothing() {
+        let ank = nowhere();
+        let mut a = phone();
+        assert_eq!(
+            a.cursors[Focus::Entities.number() - 1].at,
+            0,
+            "a session opens with no row selected, and this test is about the \
+             row it opens on"
+        );
+        let start = Instant::now();
+        let at = row_of(&a, 0);
+
+        press_at(&mut a, &ank, at, start);
+        assert_eq!(
+            a.note,
+            None,
+            "the first press on the selected row opened it: {}",
+            reached_for(&a)
+        );
+
+        press_at(&mut a, &ank, at, start);
+        assert!(
+            reached_for(&a).contains("ADR-8bd76e8d7c4e"),
+            "the second press did not open the row: {}",
+            reached_for(&a)
+        );
+    }
+
+    /// **A key between two presses ends the pair** (TASK-42de0df951a4).
+    ///
+    /// The cursor is walked away and walked back, so what is left on the screen
+    /// is the state the two presses would have found on their own: the same row
+    /// selected, inside the interval. What is different is that a person did
+    /// something else with the reader in between, and two presses with a
+    /// session's worth of keyboard between them are not two presses on a row.
+    #[test]
+    fn a_key_between_two_presses_ends_the_pair() {
+        let ank = nowhere();
+        let mut a = phone();
+        let start = Instant::now();
+        let at = row_of(&a, 1);
+
+        press_at(&mut a, &ank, at, start);
+        tap(&mut a, &ank, KeyCode::Char('j'));
+        tap(&mut a, &ank, KeyCode::Char('k'));
+        assert_eq!(
+            a.cursors[Focus::Entities.number() - 1].at,
+            1,
+            "the cursor is not back on the row the press chose"
+        );
+        a.note = None;
+
+        press_at(&mut a, &ank, at, start);
+        assert_eq!(
+            a.note,
+            None,
+            "a press paired with one a keystroke came after: {}",
+            reached_for(&a)
+        );
     }
 
     /// A press that landed on no row of a listing leaves the cursor where it

--- a/crates/ank-tui/tests/press.rs
+++ b/crates/ank-tui/tests/press.rs
@@ -1,0 +1,381 @@
+//! One press chooses a row and two presses open it, through the binary, on a
+//! real terminal (TASK-42de0df951a4, ADR-559eebf5c6f5).
+//!
+//! CLAUDE.md leaves no choice about where this is measured and the criterion
+//! opens by naming the instrument: *the pseudo-terminal harness shows*. It is
+//! the right rule here for `tests/phone.rs`'s reason and for one of this task's
+//! own. Whether a terminal reports a press at all is decided by whether this
+//! reader asked it to -- `EnableMouseCapture` on the way in -- and no unit test
+//! reaches that: `src/view.rs` can be handed a `MouseEvent` all day by a suite
+//! that constructs one, on a build whose terminal was never told to send any.
+//! And what is being counted here is *presses*, which are events arriving in an
+//! order at a running loop; a suite that called one function twice would be
+//! asserting about a function rather than about a gesture.
+//!
+//! **The interval is measured against the reader's own constant and never
+//! against a number of this file's**
+//! ([`ank_tui::view::SECOND_PRESS`]). A suite that slept six hundred
+//! milliseconds because that is what a double-click was in some other program
+//! would go on passing against a reader that had moved its interval, which is
+//! the failure mode every other suite in this crate is written against.
+//!
+//! **Nothing here asserts a wall-clock bound.** Two presses meant to pair are
+//! sent back to back, with nothing waited for in between: they are two writes
+//! down one pseudo-terminal, and no machine's load can put a five-second gap
+//! between them. The one place a clock is used at all is the press that must
+//! arrive *past* the interval, and it is a sleep and not a bound -- a loaded
+//! machine makes that gap longer, which is the direction that keeps the
+//! assertion true.
+//!
+//! `src/view.rs` states the same rules against a clock it is handed rather than
+//! one it reads, at more windows and on every platform: what the pairing is,
+//! that the instant past the interval is not in it, and that a key ends a pair.
+//! This is `ank tui`, on a terminal, answering a finger twice.
+//!
+//! `#[cfg(unix)]` for the reason the other suites give: a pseudo-terminal on
+//! Windows is ConPTY, and reaching it means the console API this workspace does
+//! not otherwise call.
+
+#![cfg(unix)]
+
+mod terminal;
+
+use ank_tui::view::SECOND_PRESS;
+use terminal::{Live, Repo};
+
+/// The windows this suite opens: a phone in portrait, and the terminal every
+/// criterion of this reader has been written for.
+///
+/// The narrow one is where the clause lives -- a thumb on a screen with no
+/// button on it -- and the wide one is where a reader that had hit-tested the
+/// phone's arrangement and no other would fail.
+const WINDOWS: [(u16, u16); 2] = [(40, 30), (80, 24)];
+
+/// A column one cell inside the region's border, which is what a finger aims at
+/// when it aims at a row rather than at a word on one.
+const INSIDE: u16 = 2;
+
+/// The region's vertical border, at either weight, as characters.
+///
+/// Read out of the reader rather than written as `|` here: the border set moved
+/// once already, and a suite carrying its own copy of the character would have
+/// gone on trimming a glyph the reader no longer draws.
+fn verticals() -> [char; 2] {
+    let of = |focused| {
+        ank_tui::view::BOXES
+            .border(focused)
+            .vertical_left
+            .chars()
+            .next()
+            .expect("a border set has a vertical")
+    };
+    [of(false), of(true)]
+}
+
+/// A line with the border it opens with taken off, so what is left starts where
+/// the region's own content does.
+fn inside(line: &str) -> &str {
+    line.trim_start_matches(verticals())
+}
+
+/// The rows of a frame that name an entity: where each is drawn, the identifier
+/// it carries, and whether the cursor is standing on it.
+///
+/// Read off the grid a person would have been looking at, which is the whole
+/// point of driving a terminal: the marker is `> ` at the head of the row's own
+/// content (ADR-559eebf5c6f5 -- where a person is standing is a character), so
+/// finding it is trimming the border and looking.
+fn rows(frame: &str) -> Vec<(u16, String, bool)> {
+    frame
+        .lines()
+        .enumerate()
+        .filter(|(_, line)| {
+            line.contains("ADR-") || line.contains("TASK-") || line.contains("SPEC-")
+        })
+        .map(|(at, line)| {
+            let id = line
+                .split_whitespace()
+                .find(|word| word.contains('-'))
+                .unwrap_or_else(|| panic!("a row names no entity:\n{frame}"))
+                .to_string();
+            (at as u16, id, inside(line).starts_with("> "))
+        })
+        .collect()
+}
+
+/// The identifier of the row the cursor is on.
+fn selected(frame: &str) -> String {
+    let marked: Vec<String> = rows(frame)
+        .into_iter()
+        .filter(|(_, _, here)| *here)
+        .map(|(_, id, _)| id)
+        .collect();
+    assert_eq!(
+        marked.len(),
+        1,
+        "the frame marks {} rows rather than one:\n{frame}",
+        marked.len()
+    );
+    marked.into_iter().next().expect("the marked row")
+}
+
+/// Where the row naming an identifier is drawn now.
+///
+/// Asked again after every press rather than remembered: a listing that
+/// scrolled under a finger would leave a remembered row pointing at whatever
+/// slid into it, and that is a defect this suite would rather catch than
+/// inherit.
+fn at(frame: &str, id: &str) -> u16 {
+    rows(frame)
+        .into_iter()
+        .find(|(_, on, _)| on == id)
+        .map(|(row, _, _)| row)
+        .unwrap_or_else(|| panic!("'{id}' is not on the frame:\n{frame}"))
+}
+
+/// The session, once the corpus has reached the screen.
+fn opened(live: &Live) -> String {
+    live.until("the session to open", |t| t.contains("2 ENTITIES"));
+    live.frame()
+}
+
+/// That no document was opened, read the way a person reads it: the listing is
+/// still the screen in the region.
+fn still_listing(frame: &str, what: &str) {
+    assert!(!frame.contains("3 BODY"), "{what}:\n{frame}");
+    assert!(
+        frame.contains("2 ENTITIES"),
+        "the listing is not the screen in the region:\n{frame}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// One press
+// ---------------------------------------------------------------------------
+
+/// **One press selects the row under the pointer**, and opens nothing
+/// (TASK-42de0df951a4, ADR-559eebf5c6f5).
+///
+/// Both rows a single press can land on, because they used to be two different
+/// readers. A press on a row the cursor is not on has always chosen it. A press
+/// on the row the cursor *is* on used to open it there and then -- and a
+/// session selects its first row before anybody has touched the screen, so the
+/// first press a person made on that row was answered as though it were their
+/// second: a document opened off one press, on a screen a pocket can drive.
+/// That is the hole the interval closes and this is where it is measured.
+#[test]
+fn one_press_chooses_the_row_under_the_pointer_and_opens_no_document() {
+    let repo = Repo::seeded();
+    for (columns, rows_high) in WINDOWS {
+        let mut live = Live::open(&repo, columns, rows_high);
+        let frame = opened(&live);
+        let here = selected(&frame);
+
+        // The row the session opened on, pressed once: it is the selected row
+        // already, and one press is still one press.
+        live.tap(INSIDE, at(&frame, &here));
+        let after = live.frame();
+        still_listing(
+            &after,
+            "one press on the row a session opens with opened its document",
+        );
+        assert_eq!(
+            selected(&after),
+            here,
+            "a press on the selected row moved the cursor off it:\n{after}"
+        );
+
+        // And a row the cursor is not on, pressed once: chosen, and no more
+        // than chosen.
+        let (row, other, _) = rows(&after)
+            .into_iter()
+            .find(|(_, id, marked)| *id != here && !*marked)
+            .unwrap_or_else(|| panic!("this corpus draws one row:\n{after}"));
+        live.tap(INSIDE, row);
+        live.until("the row under the pointer to be selected", |t| {
+            t.lines()
+                .any(|l| l.contains(&other) && inside(l).starts_with("> "))
+        });
+        let chosen = live.frame();
+        still_listing(&chosen, "one press on a row opened its document");
+        assert_eq!(selected(&chosen), other, "{chosen}");
+        live.quit();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Two presses
+// ---------------------------------------------------------------------------
+
+/// **Two presses on one row inside the interval open its document**
+/// (TASK-42de0df951a4, ADR-559eebf5c6f5).
+///
+/// Sent back to back, which is both what a person does and what keeps this
+/// suite off the clock: the two are two writes down a pseudo-terminal and the
+/// reader answers them in the order they arrive, so no load on the machine can
+/// put [`SECOND_PRESS`] between them.
+///
+/// The two clauses the decision states around this one are read off the same
+/// session, because they are what opening *is* here: the document replaces the
+/// list rather than sharing the frame with it, and leaving it gives the list
+/// back with the same row selected (TASK-252bf02de218). And then the row that
+/// is selected on the way back takes one press without reopening -- a pair that
+/// opened is spent, or a person coming out of a document would fall straight
+/// back into it.
+#[test]
+fn two_presses_on_one_row_inside_the_interval_open_its_document() {
+    let repo = Repo::seeded();
+    for (columns, rows_high) in WINDOWS {
+        let mut live = Live::open(&repo, columns, rows_high);
+        let frame = opened(&live);
+        let (row, id, _) = rows(&frame)
+            .into_iter()
+            .find(|(_, _, marked)| !*marked)
+            .unwrap_or_else(|| panic!("every row of this corpus is selected:\n{frame}"));
+
+        live.tap(INSIDE, row);
+        live.tap(INSIDE, row);
+        live.until("the document the two presses opened", |t| {
+            t.contains("3 BODY") && t.contains(&id)
+        });
+        let document = live.frame();
+        assert!(
+            !document.contains("2 ENTITIES"),
+            "the listing survived the document opening over it at \
+             {columns}x{rows_high}:\n{document}"
+        );
+
+        // Out again, by the key the table names for it. The letter and not
+        // `Esc`, on `tests/region.rs`'s reasoning: a lone escape byte is one a
+        // parser has to wait to disambiguate.
+        live.send(&ank_tui::bindings::spelling_of(
+            &ank_tui::input::Command::Back,
+        ));
+        live.until("the listing to come back", |t| t.contains("2 ENTITIES"));
+        let back = live.frame();
+        assert_eq!(
+            selected(&back),
+            id,
+            "the listing came back with a different row selected at \
+             {columns}x{rows_high}:\n{back}"
+        );
+
+        // One press on it, which is one press again and not the second of the
+        // pair that already opened.
+        live.tap(INSIDE, at(&back, &id));
+        still_listing(
+            &live.frame(),
+            "the press that opened a document was counted twice, and one press \
+             on the row it left reopened it",
+        );
+        live.quit();
+    }
+}
+
+/// **Two presses on different rows open nothing**, and the second of them is
+/// the press that chooses (TASK-42de0df951a4).
+///
+/// The pair that follows is what makes this a statement about the pairing
+/// rather than about the interval: if the press on the second row were not
+/// counted as a first, the row it chose would not open on the two presses after
+/// it either, and a reader that had simply stopped answering would pass the
+/// negative half on its own.
+#[test]
+fn two_presses_on_different_rows_open_nothing() {
+    let repo = Repo::seeded();
+    for (columns, rows_high) in WINDOWS {
+        let mut live = Live::open(&repo, columns, rows_high);
+        let frame = opened(&live);
+        let listing = rows(&frame);
+        assert!(
+            listing.len() >= 2,
+            "this corpus has one row, so two presses on two cannot be \
+             measured:\n{frame}"
+        );
+        let (first, one, _) = listing[0].clone();
+        let (second, two, _) = listing[1].clone();
+
+        live.tap(INSIDE, first);
+        live.tap(INSIDE, second);
+        live.until("the second row to be chosen", |t| {
+            t.lines()
+                .any(|l| l.contains(&two) && inside(l).starts_with("> "))
+        });
+        let after = live.frame();
+        still_listing(
+            &after,
+            "two presses on two different rows opened a document",
+        );
+        assert_eq!(
+            selected(&after),
+            two,
+            "the press on the second row did not choose it at \
+             {columns}x{rows_high}:\n{after}"
+        );
+        assert_ne!(one, two, "the two rows are the same row:\n{frame}");
+
+        // And that second press was a first: two more on the row it chose open
+        // it.
+        let row = at(&after, &two);
+        live.tap(INSIDE, row);
+        live.tap(INSIDE, row);
+        live.until("the document the pair after it opened", |t| {
+            t.contains("3 BODY") && t.contains(&two)
+        });
+        live.quit();
+    }
+}
+
+/// **A press further from the one before it than the interval opens nothing,
+/// and is counted as the press that chooses** (TASK-42de0df951a4).
+///
+/// The interval measured through the binary, which is what makes it an interval
+/// and not a number in a file: a reader that named [`SECOND_PRESS`] and
+/// compared nothing to it would pass every other test in this suite.
+///
+/// The wait is [`SECOND_PRESS`] and a second, taken from the reader's own
+/// constant so that a moved interval moves this with it. It is a sleep and not
+/// a bound: what is asserted is that a press this far from the last one opens
+/// nothing, and a loaded machine only makes the gap longer.
+///
+/// One window, because what is being measured is a duration and not a layout,
+/// and this is the one test in the crate that spends real seconds.
+#[test]
+fn a_press_past_the_interval_opens_nothing_and_is_counted_as_a_first() {
+    let repo = Repo::seeded();
+    let (columns, rows_high) = WINDOWS[0];
+    let mut live = Live::open(&repo, columns, rows_high);
+    let frame = opened(&live);
+    let (row, id, _) = rows(&frame)
+        .into_iter()
+        .find(|(_, _, marked)| !*marked)
+        .unwrap_or_else(|| panic!("every row of this corpus is selected:\n{frame}"));
+
+    live.tap(INSIDE, row);
+    live.until("the row to be chosen", |t| {
+        t.lines()
+            .any(|l| l.contains(&id) && inside(l).starts_with("> "))
+    });
+    std::thread::sleep(SECOND_PRESS + std::time::Duration::from_secs(1));
+
+    let waited = live.frame();
+    live.tap(INSIDE, at(&waited, &id));
+    let after = live.frame();
+    still_listing(
+        &after,
+        "a press more than the interval after the one before it opened a \
+         document",
+    );
+    assert_eq!(
+        selected(&after),
+        id,
+        "the press past the interval did not leave its row chosen:\n{after}"
+    );
+
+    // And it was a first: the press after it is a second, and opens.
+    live.tap(INSIDE, at(&after, &id));
+    live.until("the document the pair opened", |t| {
+        t.contains("3 BODY") && t.contains(&id)
+    });
+    live.quit();
+}


### PR DESCRIPTION
TASK-42de0df951a4, ADR-559eebf5c6f5 (proposed). The last blocker of TASK-73b1.

A press in the region is paired now rather than read off the cursor: it opens
where it lands on the same screen and the same row as the press before it, no
further off than `SECOND_PRESS`, and that row is the selected one. Otherwise it
chooses the row and becomes the press the next one is measured against. The
pairing is taken at the top of `App::pointed`'s `Down` arm, so a press that
reached an overlay, a form, a target or a waiting command ends it; `App::press`
clears it, so a keystroke does too.

`App::tapped` reads the clock and hands the instant to `App::pressed`, which is
the one place the interval is compared. Nothing runs on that clock and
`App::frame` stays a pure function of what the last command left behind.

**What the interval closes is not hypothetical.** "Touching the row already
selected opens it" was the whole rule, and a session selects its first row
before anybody has touched the screen -- so the first press a person made on
that row was answered as their second: a document opened off one press.

**Five seconds, argued rather than borrowed.** The gesture the decision names is
choose, look, touch again, and the looking takes the time. It is also what the
suite already said: `tests/phone.rs` puts `Live::frame()` between its two taps,
which settles on two samples 200ms apart, and a zero interval planted there
turns that test red.

Measured through the binary in `crates/ank-tui/tests/press.rs` -- four tests on
a pseudo-terminal, the finger sent as SGR through `Live::tap`, `terminal/mod.rs`
untouched. Five unit tests in `view.rs` state the same rules against an instant
they are handed. All verified to bite on four plants: an interval that never
expires, the old unpaired rule, a pairing that ignores the row, and the interval
set to zero.

`cargo test --workspace` green (42 suites), `cargo fmt --check` clean, `ank
check` exit 0.

Scope was widened by exactly `crates/ank-tui/tests/press.rs`, a file that did
not exist and that no other agent's perimeter names, on the reading six tasks of
this wave used: the criterion says the pseudo-terminal harness shows it, and
`tests/dependencies.rs` forbids `src/` the means to drive one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013SSDXf3bYdzCAirRK1TgwS