### PR TITLE
TASK-42de0df951a4 is done

### DIFF
--- a/.ank/entities/LOG-b3471ed0a730.md
+++ b/.ank/entities/LOG-b3471ed0a730.md
@@ -1,0 +1,14 @@
+---
+id: LOG-b3471ed0a730
+type: log
+title: done, proof commit:8781705
+created: 2026-08-29T18:55:11Z
+author: claude-code/opus-5+one-press-two-press
+scope:
+  - crates/ank-tui/src/view.rs
+  - crates/ank-tui/tests/press.rs
+about: TASK-42de0df951a4
+seq: 6
+schema: 4
+version: 1
+---

--- a/.ank/entities/TASK-42de0df951a4.md
+++ b/.ank/entities/TASK-42de0df951a4.md
@@ -5,7 +5,7 @@ slug: one-press-chooses-a-row-and-two-on-the-same-row
 title: One press chooses a row, and two on the same row open it
 created: 2026-08-27T16:34:09Z
 author: haksolot@vmi3223161
-status: in_progress
+status: done
 scope:
   - crates/ank-tui/src/view.rs
   - crates/ank-tui/tests/press.rs
@@ -13,6 +13,11 @@ blocked_by: [TASK-252bf02de218]
 done_criteria: |
   The pseudo-terminal harness shows that one press selects the row under the pointer, that two presses on that row inside the interval the code names open its document, and that two presses on different rows open nothing. The interval is a named constant and not a number written at the place it is compared. Measured through the binary.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: "8781705"
+    criteria: 8839e712aaf5
+    via: submitted
 schema: 4
-version: 3
+version: 4
 ---


### PR DESCRIPTION
The status and the proof for the work merged in #340: `commit:8781705`, a sha
held before the push, never a CI run id. The `attest` job records `test:<run-id>`
on `refs/ank/proof/TASK-42de0df951a4` once this reaches the default branch.

With this, TASK-73b1 has no blockers left: it is the task that re-points the
citations so ADR-559eebf5c6f5 can be ratified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013SSDXf3bYdzCAirRK1TgwS