### PR TITLE
The workspace cites the decision that binds it, and the supersession can land

### DIFF
--- a/.ank/entities/LOG-6044be03967f.md
+++ b/.ank/entities/LOG-6044be03967f.md
@@ -1,0 +1,19 @@
+---
+id: LOG-6044be03967f
+type: log
+title: "The head diagram of view.rs was a drawing and every line of it was wrong: ASCII borders where the"
+created: 2026-08-29T20:08:46Z
+author: claude-code/opus-5+cite-what-binds
+scope:
+  - crates/ank-tui/**
+  - crates/ank-cli/tests/tui.rs
+  - crates/ank-contract/src/verbs.rs
+about: TASK-73b1eea6cecb
+seq: 1
+schema: 4
+version: 1
+---
+
+ reader draws box-drawing, one [?] where the header now carries [f all ][?], no scrollbar thumb, a '+- 2 ENTITIES' title the reader spells '2 ENTITIES' hard against the corner, and a note band shown carrying a sentence when it is blank at rest. What is there now is a transcription: ank tui driven through tests/terminal's pseudo-terminal at 72x10 on this repository's own corpus, read off the master side. Held to a second driven session afterwards -- every structural character agrees (widths, border set, chrome rule, both targets, the thumb in the region's own right border, the blank last row); only the corpus data differs, which is what it is.
+
+Cost of learning it: tests/terminal/mod.rs's Repo is a tuple struct with a public field and a Drop that ran remove_dir_all on whatever it held. Handing it this worktree's path to capture a real frame deleted the worktree. The Drop is now fenced to scratch::root() -- a path from anywhere else is left where it is. Recovered by replaying the edit scripts from the scratchpad; nothing was lost but the time.

--- a/.ank/entities/LOG-9ba4fe768177.md
+++ b/.ank/entities/LOG-9ba4fe768177.md
@@ -1,0 +1,17 @@
+---
+id: LOG-9ba4fe768177
+type: log
+title: 126 citations of the retired document across 25 files, re-pointed or rewritten; none left outside
+created: 2026-08-29T20:08:32Z
+author: claude-code/opus-5+cite-what-binds
+scope:
+  - crates/ank-tui/**
+  - crates/ank-cli/tests/tui.rs
+  - crates/ank-contract/src/verbs.rs
+about: TASK-73b1eea6cecb
+seq: 0
+schema: 4
+version: 1
+---
+
+ .ank/. The judgement was per citation, not per identifier: where the successor carries the clause forward the identifier moved, and where the succession made the sentence false the sentence was rewritten. What was false: the panel layout in the manifest's list of what ratatui and crossterm buy (it is one region, a scrollbar and the wheel now); paint.rs's 'the heavier rule and the > in the title of the panel with the focus' (nothing has focus, the marker on the row carries it); Glyphs::border's 'the focus is carried by the weight of the rule' (border(true) is what every drawing path passes now, and border(false) is only the chrome's horizontal); term.rs's 'the three things that wake a drawn screen' (four -- a key, a tap, a resize and the stream -- and the successor's first clause is where the wheel is stated). Where the retired document's *body* held a measurement the successor does not restate -- the 80x24 and 40x30 windows, the thirteen rows on furniture, the five parallel key tables, the omissions of the old trailer -- the fact was kept and the attribution dropped, because re-pointing it would have sourced those numbers to a document that does not carry them.

--- a/.ank/entities/TASK-73b1eea6cecb.md
+++ b/.ank/entities/TASK-73b1eea6cecb.md
@@ -5,7 +5,7 @@ slug: the-workspace-cites-the-decision-that-binds-it-a
 title: The workspace cites the decision that binds it, and the supersession can land
 created: 2026-08-27T16:35:42Z
 author: haksolot@vmi3223161
-status: open
+status: in_progress
 scope:
   - crates/ank-tui/**
   - crates/ank-cli/tests/tui.rs
@@ -15,5 +15,5 @@ done_criteria: |
   No tracked file outside .ank/ names ADR-c07e2694f0e1, and every sentence that quoted one of its clauses says what the clause replacing it says rather than being deleted with the identifier. The count is a hundred and thirty-two citations across twenty-five files at the time this was written, in crates/ank-tui, crates/ank-cli/tests/tui.rs and crates/ank-contract/src/verbs.rs. The diagram at the head of view.rs is the frame the binary actually draws, checked against a session on a pseudo-terminal and not against a drawing. cargo test is green, ank check reports no new fault, and ank graph shows no cycle and no orphan.
 criteria_by: creator
 schema: 4
-version: 1
+version: 2
 ---

--- a/crates/ank-cli/tests/tui.rs
+++ b/crates/ank-cli/tests/tui.rs
@@ -1,5 +1,5 @@
 //! `ank tui` through the binary (TASK-49746735127f, ADR-8bd76e8d7c4e,
-//! ADR-c07e2694f0e1).
+//! ADR-559eebf5c6f5).
 //!
 //! CLAUDE.md leaves no choice about where this suite lives: a criterion that
 //! talks about the binary is tested through the binary, and twice in this
@@ -24,7 +24,7 @@
 //! the engine whole.
 //!
 //! **How the session is driven did move, twice.** A command is a key now
-//! (ADR-c07e2694f0e1), so a list of lines became a list of keystrokes, with the
+//! (ADR-559eebf5c6f5), so a list of lines became a list of keystrokes, with the
 //! four verbs that carry a message, a reason, a proof or a flag spelled into
 //! the one line `/` opens -- see [`on_a_terminal`] for what an entry of one
 //! of those lists is.
@@ -377,7 +377,7 @@ fn json_does_not_exempt_a_caller_from_the_terminal() {
 /// nothing is added to the link line either.
 ///
 /// **The window is set here and it has to be.** The reader asks the terminal
-/// how big it is (ADR-c07e2694f0e1), and a pseudo-terminal nobody sized is nought
+/// how big it is (ADR-559eebf5c6f5), and a pseudo-terminal nobody sized is nought
 /// by nought -- so a suite that skipped this would be asserting what a reader
 /// draws into no window at all. It is also what makes the resize measurable:
 /// setting it again while a session is running is exactly what a person
@@ -1278,7 +1278,7 @@ fn a_driven_session_names_the_entities_the_corpus_carries() {
 /// has (ADR-c9f9d1a05b23).
 ///
 /// **Both ends of the window are taken in characters and never in bytes**
-/// (ADR-c07e2694f0e1). The frames carry box-drawing glyphs now and a glyph is
+/// (ADR-559eebf5c6f5). The frames carry box-drawing glyphs now and a glyph is
 /// three bytes, so the two byte offsets this used to take are both a slice
 /// through a code point -- which is a panic and not a failure. `rfind`
 /// answers the byte index a character *starts* at, so the old `i + 1` landed
@@ -1372,7 +1372,7 @@ fn the_frames_carry_no_identifier_the_corpus_does_not() {
 }
 
 /// A terminal made narrower, then wider, redraws to its new size with nobody
-/// typing (TASK-4fa385c1772d, ADR-c07e2694f0e1).
+/// typing (TASK-4fa385c1772d, ADR-559eebf5c6f5).
 ///
 /// **The whole of the assertion is that no key was pressed.** The window is
 /// changed on the master side, exactly as a terminal emulator changes it, and
@@ -1949,7 +1949,7 @@ fn a_session_left_idle_renews_no_claim() {
 /// firmer ground.** It used to carry one task around the loop by spelling a
 /// tail after each word -- a message, a glob, a reason, a proof -- and to
 /// assert the corpus afterwards. There is no line to spell a tail on now
-/// (ADR-c07e2694f0e1: input is a keystroke), so a press composes the verb and
+/// (ADR-559eebf5c6f5: input is a keystroke), so a press composes the verb and
 /// the identifier and nothing else, and three of the five reach a verb that
 /// wants something the reader cannot yet give it.
 ///

--- a/crates/ank-contract/src/verbs.rs
+++ b/crates/ank-contract/src/verbs.rs
@@ -1129,7 +1129,7 @@ pub const COMMANDS: &[CommandSpec] = &[
             "it reaches the corpus only by running this binary with --json, and writes nothing on its own",
             // "a short word and Enter" stood here while the reader took a line,
             // and stopped being true when input became a keystroke
-            // (ADR-c07e2694f0e1); TASK-1a415107fd56 gave the writing verbs
+            // (ADR-559eebf5c6f5); TASK-1a415107fd56 gave the writing verbs
             // their own letters too. A help line narrower or wider than the
             // binary is read as the binary refusing, which is the failure §9
             // exists to prevent.
@@ -1142,7 +1142,7 @@ pub const COMMANDS: &[CommandSpec] = &[
             // of a list is a note the list cannot be held to, so this one is
             // stated over the whole of them: what is true of every verb the
             // reader spells is that none of them writes unconfirmed
-            // (ADR-c07e2694f0e1).
+            // (ADR-559eebf5c6f5).
             //
             // **The names are §4's own order, and they are measured rather
             // than remembered.** `crates/ank-tui` reads this note back through

--- a/crates/ank-tui/Cargo.toml
+++ b/crates/ank-tui/Cargo.toml
@@ -13,21 +13,22 @@ license = "Apache-2.0"
 description = "The Ank terminal reader: it draws what the CLI prints, and reaches the corpus only by running it."
 
 # **The dependency list is the constraint made mechanical** (ADR-8bd76e8d7c4e,
-# ADR-c07e2694f0e1). `ank-core` is absent and must stay absent, and so is every
+# ADR-559eebf5c6f5). `ank-core` is absent and must stay absent, and so is every
 # git library: this crate reaches the corpus by running `ank ... --json` and by
 # nothing else, so the refusals it shows are the refusals the binary gave and
 # there is no second dispatch path to keep in step. `tests/dependencies.rs`
 # reads the graph back out of cargo and fails when either arrives, holds this
 # list to what is declared below, and reads the sources for the `extern` block
-# ADR-c07e2694f0e1 forbids on any platform.
+# ADR-559eebf5c6f5 forbids on any platform.
 [dependencies]
 # The exit codes, read out of the contract rather than typed as numbers
 # (ADR-6fd69efb629c). This is what `ank-daemon` takes from it and for the same
 # reason: this crate dispatches no verb, so the verb table is not its business.
 ank-contract = { path = "../ank-contract" }
 # **The two the decision spends, and the whole of what they buy**
-# (ADR-c07e2694f0e1). The reader is a full-screen application: raw mode, the
-# alternate buffer, a keystroke, a resize, and a layout with panels to come.
+# (ADR-559eebf5c6f5). The reader is a full-screen application: raw mode, the
+# alternate buffer, a keystroke, a resize, mouse events including the wheel,
+# and one full-screen region with a scrollbar over it.
 # Every one of those is two implementations of one behaviour -- `tcsetattr` and
 # `SetConsoleMode`, an `ioctl` and a console call, a byte and a key record --
 # and CLAUDE.md's rule is that OS-dependent behaviour is not verified until it

--- a/crates/ank-tui/src/bindings.rs
+++ b/crates/ank-tui/src/bindings.rs
@@ -1,4 +1,4 @@
-//! Every binding of the reader, declared once (ADR-c07e2694f0e1).
+//! Every binding of the reader, declared once (ADR-559eebf5c6f5).
 //!
 //! **One table, and the surfaces are computed from it.** [`keys::typed`] reads
 //! a keystroke out of it, [`crate::view::App::actions`] draws the offer out of
@@ -22,7 +22,7 @@
 //!
 //! # Every binding has a key, and the writing half has one too
 //!
-//! TASK-1a415107fd56 is where that became true (ADR-c07e2694f0e1: *a key is the
+//! TASK-1a415107fd56 is where that became true (ADR-559eebf5c6f5: *a key is the
 //! verb it runs*). The six verbs used to be rows with no key, reached by
 //! spelling the word into a prompt, and the table said so in an `Option`. There
 //! is no prompt for a verb any more and no row without a key, so [`Binding::key`]
@@ -55,7 +55,7 @@
 //! command: raw mode has taken the line discipline's interrupt, and this is the
 //! way out of a program that took the terminal. `q` is the binding, and it
 //! reaches the same place with no modifier -- which is what
-//! ADR-c07e2694f0e1's "no command anywhere requires a modifier chord" asks for
+//! ADR-559eebf5c6f5's "no command anywhere requires a modifier chord" asks for
 //! and what the table in `keys.rs` measures over every key there is. Every
 //! other row is reached bare and only bare: a letter that writes must not also
 //! be a letter something was holding a modifier over.
@@ -79,7 +79,7 @@ pub struct Binding {
     /// The key that runs it.
     ///
     /// Not an `Option` any more (TASK-1a415107fd56). It was one for exactly as
-    /// long as the writing half had no letters, and ADR-c07e2694f0e1 ends that:
+    /// long as the writing half had no letters, and ADR-559eebf5c6f5 ends that:
     /// a key is the verb it runs, and every row of this table now carries one.
     ///
     /// What the type buys is that no surface has to ask. A target is drawn for
@@ -334,7 +334,7 @@ pub enum Holding {
 /// same order is not a coincidence to be maintained -- it is one list.
 pub static BINDINGS: &[Binding] = &[
     // -----------------------------------------------------------------------
-    // What moves the screen (ADR-c07e2694f0e1: every one of them is one key)
+    // What moves the screen (ADR-559eebf5c6f5: every one of them is one key)
     // -----------------------------------------------------------------------
     Binding {
         key: KeyCode::Char('j'),
@@ -355,8 +355,8 @@ pub static BINDINGS: &[Binding] = &[
         verb: None,
     },
     // Space and the two named keys, and no letter: `n` and `p` went to the
-    // verbs' side of the ledger (ADR-c07e2694f0e1 prices that loss and takes
-    // it). Space is what a reader who has used `less` presses first and the
+    // verbs' side of the ledger (ADR-559eebf5c6f5: navigation takes what is
+    // left). Space is what a reader who has used `less` presses first and the
     // one paging key a phone keyboard shows without a second layer, so it is
     // the key rather than the third alias it used to be.
     Binding {
@@ -400,7 +400,7 @@ pub static BINDINGS: &[Binding] = &[
     // `s` and no longer `c`, which is `claim`'s now. The letter is not a
     // leftover: what this draws is `ank scope`'s answer over the open
     // document's globs, so the reader binds the initial of the verb whose
-    // answer it is showing -- ADR-c07e2694f0e1's rule about the letters, on a
+    // answer it is showing -- ADR-559eebf5c6f5's rule about the letters, on a
     // command that reads rather than writes.
     Binding {
         key: KeyCode::Char('s'),
@@ -592,7 +592,7 @@ pub static BINDINGS: &[Binding] = &[
     // -----------------------------------------------------------------------
     // What moves the corpus, one letter each (TASK-1a415107fd56).
     //
-    // The verb's own initial, which is ADR-c07e2694f0e1's rule and the whole of
+    // The verb's own initial, which is ADR-559eebf5c6f5's rule and the whole of
     // why these letters and not others: a person who knows `ank claim` knows
     // `c` here, and a person who learns `c` here has learned something the
     // shell takes. `m` for `amend` is the one that is not an initial, because
@@ -683,7 +683,7 @@ pub static BINDINGS: &[Binding] = &[
     // -----------------------------------------------------------------------
     // What changes what an entity says (TASK-e8da6a00564a)
     //
-    // `e` is `edit`'s own initial, which is ADR-c07e2694f0e1's rule and the
+    // `e` is `edit`'s own initial, which is ADR-559eebf5c6f5's rule and the
     // same reason the six above have theirs; the letter was free.
     //
     // It is `Runs::Form` and not `Runs::Compose`, and that is the whole of the
@@ -710,7 +710,7 @@ pub static BINDINGS: &[Binding] = &[
     // -----------------------------------------------------------------------
     // What makes an entity (TASK-d832452630d2)
     //
-    // `n` is `new`'s own initial, which is ADR-c07e2694f0e1's rule and the same
+    // `n` is `new`'s own initial, which is ADR-559eebf5c6f5's rule and the same
     // reason the six above have theirs -- and the letter was free: paging went
     // to Space and the two named keys when TASK-1a415107fd56 priced `n` and `p`
     // out of movement, so the verb takes a key nothing else wanted.
@@ -735,7 +735,7 @@ pub static BINDINGS: &[Binding] = &[
     // -----------------------------------------------------------------------
     // What the corpus is configured to do (TASK-b08d090f699c)
     //
-    // `o` and not `c`, which is `claim`'s. ADR-c07e2694f0e1 binds a verb's own
+    // `o` and not `c`, which is `claim`'s. ADR-559eebf5c6f5 binds a verb's own
     // initial where the initial is free, and `m` for `amend` is already the row
     // that shows what happens when it is not: the letter goes to the verb whose
     // hand a person's should go to, and the other takes what is left of its own
@@ -959,7 +959,7 @@ pub fn offered(holding: Holding) -> impl Iterator<Item = &'static Binding> {
 /// The reverse of [`Binding::press`], and it exists for the two callers that
 /// have a command and need the key: a sentence that names a letter, and a
 /// drawn target that has to hand [`crate::view::App::press`] the very key a
-/// keyboard would have sent (ADR-c07e2694f0e1).
+/// keyboard would have sent (ADR-559eebf5c6f5).
 pub fn of_command(command: &Command) -> Option<&'static Binding> {
     BINDINGS
         .iter()
@@ -972,7 +972,8 @@ pub fn of_command(command: &Command) -> Option<&'static Binding> {
 /// says how the screen is being kept current and names the key that reads the
 /// corpus again, and it said `r` -- which TASK-1a415107fd56 gave to `release`.
 /// A sentence carrying its own copy of a letter is one of the five parallel
-/// tables ADR-c07e2694f0e1 was written against, in prose.
+/// tables this one replaced, in prose -- the drift ADR-559eebf5c6f5 forbids by
+/// reading what the reader offers out of the contract's own verb table.
 ///
 /// The empty string where no binding runs it, which no caller has: a sentence
 /// naming a key that does not exist would be worse than one naming none.
@@ -1058,7 +1059,7 @@ const NARROWING_NOTE: &str = "   (the list narrows as it is typed -- there is no
 /// **A line is a list of rows and never a sentence with keys in it.** That is
 /// what lets the whole list be held to the table -- every binding is on exactly
 /// one line, and a line names nothing that is not a binding -- which is the
-/// claim ADR-c07e2694f0e1 found the old trailer failing.
+/// claim the old trailer was found failing.
 struct Line {
     /// What the key list calls the rows under it, on the heading over them.
     ///
@@ -1266,8 +1267,9 @@ fn lines() -> Vec<Line> {
 }
 
 // `screen_line` and `write_line` stood here (TASK-9a402a54886f). They were the
-// two lines of the trailer, drawn under every frame at every window, and
-// ADR-c07e2694f0e1 records what they cost the reader they were meant to serve.
+// two lines of the trailer, drawn under every frame at every window, and what
+// they cost the reader they were meant to serve is why no offer is drawn at
+// rest now (ADR-559eebf5c6f5).
 // The rows they named are on the key list, whole, one to a row, and nothing
 // else renders them now.
 
@@ -1349,7 +1351,7 @@ pub struct Beyond {
 /// confirmation, since §4 gives it no flag at all.
 ///
 /// Read out of the contract's own table, name, positional and flags alike, so
-/// a form drawn here is a form `ank` takes (ADR-c07e2694f0e1: what the reader
+/// a form drawn here is a form `ank` takes (ADR-559eebf5c6f5: what the reader
 /// offers is read out of the verb table rather than transcribed beside it).
 /// One row per verb and not one line carrying all three: a row is a rectangle a
 /// finger fits in, which is what the key list's overlay bought and what makes
@@ -1484,7 +1486,7 @@ mod tests {
     }
 
     /// **The gate is measured against the table and never generated from it**
-    /// (TASK-4d2eb2b4e193, ADR-c07e2694f0e1).
+    /// (TASK-4d2eb2b4e193, ADR-559eebf5c6f5).
     ///
     /// The dependency runs this way round on purpose. If `ank.rs` built its
     /// list from the rows above, a row added here would widen what this reader
@@ -1574,8 +1576,8 @@ mod tests {
     /// does not** (TASK-4d2eb2b4e193).
     ///
     /// Both halves, because either alone is half a claim. A list that omitted
-    /// `v` is what ADR-c07e2694f0e1 was written against -- the reader's own
-    /// trailer taught a vocabulary the reader did not have -- and a list
+    /// `v` is what this table was declared against -- the reader's own trailer
+    /// taught a vocabulary the reader did not have -- and a list
     /// carrying a key nobody bound would be worse: it reads as an offer and
     /// behaves as nothing.
     ///

--- a/crates/ank-tui/src/form.rs
+++ b/crates/ank-tui/src/form.rs
@@ -1,5 +1,5 @@
 //! The form a verb with flags is filled in on, and the whole of why it cannot
-//! open an editor (TASK-d832452630d2, TASK-e8da6a00564a, ADR-c07e2694f0e1).
+//! open an editor (TASK-d832452630d2, TASK-e8da6a00564a, ADR-559eebf5c6f5).
 //!
 //! **Five verbs and one form.** It arrived carrying `ank new` alone,
 //! TASK-e8da6a00564a put `ank edit`, `ank close` and `ank attest` on it, and
@@ -26,9 +26,9 @@
 //! declares what each verb takes, [`ank_contract::verbs`] is where that
 //! declaration lives, and [`Form::fields`] is that list read in its own order.
 //! Nothing here writes a flag name down: this crate has already been burned
-//! once by five parallel key tables (ADR-c07e2694f0e1 records what they cost),
-//! and a parallel flag table would be the same mistake one surface further
-//! along. A flag `new` gains is a row of this form the day it is declared, and
+//! once by five parallel key tables, and a parallel flag table would be the
+//! same mistake one surface further along -- the drift ADR-559eebf5c6f5 forbids
+//! by reading what the reader offers out of the contract's own table. A flag `new` gains is a row of this form the day it is declared, and
 //! a flag it loses is a row that goes.
 //!
 //! The kinds are read the same way, out of the verb's own `subcommands`: `ank
@@ -597,7 +597,7 @@ impl Form {
     /// [`crate::keys::narrowing`] gives: a field being typed into cannot also
     /// be a key table.
     ///
-    /// **No command here is a chord** (ADR-c07e2694f0e1). Control-C is the way
+    /// **No command here is a chord** (ADR-559eebf5c6f5). Control-C is the way
     /// out of a program that took the terminal and it closes the form, and
     /// Control-U clears the field, which is what the search does with it.
     ///
@@ -1110,13 +1110,13 @@ mod tests {
     }
 
     /// **The fields are the flags the contract declares and no others**
-    /// (TASK-d832452630d2, ADR-c07e2694f0e1).
+    /// (TASK-d832452630d2, ADR-559eebf5c6f5).
     ///
     /// Both halves, over every kind. A form short of a flag is a form that
     /// cannot say what the shell can, and a form carrying one the verb does not
     /// declare is this reader teaching a command line the binary refuses --
-    /// which is the drift ADR-c07e2694f0e1 was written against, one surface
-    /// along from the key tables it names.
+    /// which is the drift ADR-559eebf5c6f5 forbids, one surface along from the
+    /// key tables.
     ///
     /// The contract declares one flag set for `ank new` and not one per
     /// subcommand, so the three kinds carry the same rows; which of them a kind
@@ -1480,7 +1480,8 @@ mod tests {
         }
     }
 
-    /// The lone dash never reaches an argv (ADR-c07e2694f0e1's null stdin).
+    /// The lone dash never reaches an argv (the null stdin `Ank::spawn` gives
+    /// every child, ADR-8bd76e8d7c4e).
     #[test]
     fn a_lone_dash_is_refused_rather_than_handed_to_a_child_with_no_stdin() {
         let mut form = form();
@@ -1513,7 +1514,7 @@ mod tests {
     }
 
     /// **Every printable key is a character here and no printable key is a
-    /// command** (TASK-1a415107fd56, ADR-c07e2694f0e1).
+    /// command** (TASK-1a415107fd56, ADR-559eebf5c6f5).
     ///
     /// A form is where words are typed, so a letter that closed it or composed
     /// it would be a letter nobody could put in a title. The whole of the

--- a/crates/ank-tui/src/keys.rs
+++ b/crates/ank-tui/src/keys.rs
@@ -1,5 +1,5 @@
 //! One key per command, and the three regimes a keystroke is read in
-//! (ADR-c07e2694f0e1, ADR-559eebf5c6f5).
+//! (ADR-559eebf5c6f5).
 //!
 //! The table is one of them and the other two are modal: [`confirming`], which
 //! is what stands in front of every spawned write, and [`narrowing`], which is
@@ -17,7 +17,7 @@
 //! **Every command is a key, and the verbs are keys too**
 //! (TASK-1a415107fd56). `c` claims, `l` logs, `d` finishes, `r` releases, `m`
 //! amends, `a` ratifies, `n` makes and `e` edits -- the initial the CLI already
-//! spells, which is ADR-c07e2694f0e1's rule and the whole of why these letters. What only moves
+//! spells, which is ADR-559eebf5c6f5's rule and the whole of why these letters. What only moves
 //! the screen takes what is left: `j` and `k` move, Space pages, `g` goes to
 //! the top, Enter opens, `b` goes back, `s` shows the constraints, `v` opens
 //! the queue, `o` shows what `ank config` declares, `u` reads the corpus again,
@@ -27,18 +27,20 @@
 //! never read the key line still has hands.
 //!
 //! **`h`, `l`, `n` and `p` move nothing**, which is what the letters cost.
-//! ADR-c07e2694f0e1 prices it outright and takes it: `j`, `k`, the arrows, Tab
-//! and the digits are what a reader reaches for first and none of them moved.
+//! ADR-559eebf5c6f5 takes that price outright -- navigation takes what is left
+//! -- and it is a small one: `j`, `k`, the arrows, Tab and the digits are what
+//! a reader reaches for first and none of them moved.
 //!
-//! **And focus is a key too** (TASK-bb43cfe2192b). `Tab` walks the four panels
-//! in a ring, `1` to `4` reach one directly, and Left and Right cross between
-//! the two columns. Three ways to the same place, deliberately: the digit is
-//! what the panel's own title carries, so a reader who can see `3` on the queue
-//! never has to remember which key opens it; the arrows are what a hand reaches
+//! **And the screen in the region is a key too** (TASK-bb43cfe2192b). `Tab`
+//! walks the four screens in a ring, `1` to `4` reach one directly, and Left
+//! and Right cross between a listing and the document it opens. Three ways to
+//! the same place, deliberately: the digit is what the screen's own title
+//! carries, so a reader who can see `3` on the queue never has to remember
+//! which key opens it; the arrows are what a hand reaches
 //! for with nothing read at all; and `Tab` is what a person who has used one of
 //! these before will press first.
 //!
-//! **No command requires a modifier chord**, which ADR-c07e2694f0e1 asks for and
+//! **No command requires a modifier chord**, which ADR-559eebf5c6f5 asks for and
 //! a phone makes literal: a terminal keyboard on a phone has no comfortable
 //! Control. Control-C is the one exception and it is not a command -- it is the
 //! way out of a program that has taken the terminal, which raw mode has stopped
@@ -91,7 +93,7 @@
 //!
 //! **It was never the length of the road** (TASK-d4a882345837). Under a line
 //! reader a slipped finger typed nothing, because a command was a word and
-//! Enter, and that asymmetry is what ADR-c07e2694f0e1 spends: `c` is one
+//! Enter, and that asymmetry is what ADR-559eebf5c6f5 spends: `c` is one
 //! keystroke and it composes a claim. What stands in front of the spawn is
 //! [`confirming`], which never depended on how the verb was reached: the
 //! composed argv is on the screen, [`CONFIRM`] runs it, and **every other key
@@ -104,7 +106,7 @@
 //! keystroke that dismisses the confirmation runs anything" is true of the
 //! whole keyboard rather than of a list somebody has to keep complete.
 //!
-//! `y` is a letter and not a chord, which ADR-c07e2694f0e1 requires and a
+//! `y` is a letter and not a chord, which ADR-559eebf5c6f5 requires and a
 //! phone makes literal, and it is not Enter: Enter opens the row under the
 //! cursor, and a confirmation answered by the key a person was already pressing
 //! is a confirmation a repeated keypress walks straight through. Nor is it any
@@ -166,7 +168,7 @@ pub enum Answer {
 ///
 /// The modifiers are read and not ignored, in the strict direction: a `y` with
 /// anything held is not the `y` this asks for. So no chord runs a verb, which
-/// is ADR-c07e2694f0e1's rule applied to the one keystroke in this reader that
+/// is ADR-559eebf5c6f5's rule applied to the one keystroke in this reader that
 /// can move a corpus, and Control-C over a confirmation dismisses it rather
 /// than doing the thing the person was interrupting.
 pub fn confirming(key: KeyEvent) -> Answer {
@@ -180,9 +182,10 @@ pub fn confirming(key: KeyEvent) -> Answer {
 ///
 /// **The mapping is a lookup and no longer a `match`** (TASK-4d2eb2b4e193).
 /// What was here was one arm per key, written beside three other renderings of
-/// the same list, and ADR-c07e2694f0e1 -- the decision this wave is built on --
-/// records what that cost: a key list that omitted `v`, Space, every arrow and
-/// the whole of the ring. The table is now
+/// the same list, and what that cost is on the record: a key list that omitted
+/// `v`, Space, every arrow and the whole of the ring. What the reader offers is
+/// read out of the contract's own verb table now (ADR-559eebf5c6f5). The table
+/// is
 /// the single declaration and this reads it, so a key that moves moves on every
 /// surface at once.
 ///
@@ -318,8 +321,8 @@ mod tests {
         typed(key(KeyCode::Char(c)), focus)
     }
 
-    /// Every command that only moves the screen is one key, in every panel
-    /// (ADR-c07e2694f0e1).
+    /// Every command that only moves the screen is one key, on every screen
+    /// (ADR-559eebf5c6f5).
     #[test]
     fn a_reading_command_is_one_key_and_the_named_keys_agree_with_the_letters() {
         for view in Focus::ALL {
@@ -352,12 +355,12 @@ mod tests {
         }
     }
 
-    /// **Each of the six verbs is its own letter, in every panel**
-    /// (TASK-1a415107fd56, ADR-c07e2694f0e1).
+    /// **Each of the six verbs is its own letter, on every screen**
+    /// (TASK-1a415107fd56, ADR-559eebf5c6f5).
     ///
     /// What the key composes is the verb and nothing else: the identifier is
-    /// the view's, because the panel a person is standing in is what says which
-    /// entity they mean, and there is no tail because there is no longer a line
+    /// the view's, because the screen a person is standing on is what says
+    /// which entity they mean, and there is no tail because there is no longer a line
     /// to type one on.
     #[test]
     fn each_verb_that_writes_is_its_own_letter_and_composes_that_verb() {
@@ -401,11 +404,12 @@ mod tests {
 
     /// **`h`, `l`, `n` and `p` move nothing** (TASK-1a415107fd56).
     ///
-    /// The price ADR-c07e2694f0e1 puts on the letters, stated as what it is: a
-    /// person pressing `l` for "right" or `n` for "next page" gets no movement,
-    /// and `l` gets the log confirmation instead. What the four do *instead* is
-    /// what the verbs made of them, and the claim this holds is about movement:
-    /// none of them steps a cursor, pages a body or crosses a panel.
+    /// The price ADR-559eebf5c6f5 takes on the letters -- navigation takes what
+    /// is left -- stated as what it is: a person pressing `l` for "right" or
+    /// `n` for "next page" gets no movement, and `l` gets the log confirmation
+    /// instead. What the four do *instead* is what the verbs made of them, and
+    /// the claim this holds is about movement: none of them steps a cursor,
+    /// pages a body or crosses to another screen.
     ///
     /// `n` stopped being one of the three that reach nothing at all
     /// (TASK-d832452630d2): it is `new`'s own initial, and what it opens is the
@@ -436,7 +440,7 @@ mod tests {
     }
 
     /// No command is a chord, and the one that is is the way out rather than a
-    /// command (ADR-c07e2694f0e1: no command anywhere requires a modifier).
+    /// command (ADR-559eebf5c6f5: no command anywhere requires a modifier).
     ///
     /// Over every modifier and not over Control alone (TASK-1a415107fd56): `c`
     /// composes a claim now, so "a letter with something held is not that
@@ -469,7 +473,7 @@ mod tests {
     /// produce a [`Command::Act`] at all. That was worth having because
     /// reaching a verb took a key *and* a word -- a slipped finger typed
     /// nothing, because there was no `d` -- and the asymmetry is what
-    /// ADR-c07e2694f0e1 spends: TASK-1a415107fd56 gives the six their letters,
+    /// ADR-559eebf5c6f5 spends: TASK-1a415107fd56 gives the six their letters,
     /// and the old assertion would then be a rule against the decision rather
     /// than a rule the decision keeps.
     ///
@@ -554,7 +558,7 @@ mod tests {
     }
 
     /// Focus moves by key, three ways, and none of the three is a chord
-    /// (TASK-bb43cfe2192b, ADR-c07e2694f0e1).
+    /// (TASK-bb43cfe2192b, ADR-559eebf5c6f5).
     #[test]
     fn focus_moves_by_key_in_a_ring_by_digit_and_across_the_columns() {
         // The ring, forward from every panel and back again.
@@ -694,7 +698,7 @@ mod tests {
     }
 
     /// And no chord runs one either: the key that writes is the bare letter
-    /// (ADR-c07e2694f0e1, which forbids a command requiring a modifier -- and
+    /// (ADR-559eebf5c6f5, which forbids a command requiring a modifier -- and
     /// this is the one command that moves a corpus).
     #[test]
     fn no_modifier_held_over_the_confirming_key_still_runs_it() {
@@ -740,7 +744,7 @@ mod tests {
 /// The whole key table, stated as a domain rather than as a list of the likely
 /// keys (TASK-dd9747e5e305).
 ///
-/// ADR-c07e2694f0e1's rule is that **no command anywhere requires a modifier
+/// ADR-559eebf5c6f5's rule is that **no command anywhere requires a modifier
 /// chord**, and a phone makes it literal: a terminal keyboard on a phone has no
 /// comfortable Control, and a command reachable only with one is a command that
 /// reader cannot run at all. What was here before was that rule checked by
@@ -933,7 +937,7 @@ mod table {
         assert!(every_modifier().contains(&KeyModifiers::NONE));
     }
 
-    /// **No command anywhere requires a modifier chord** (ADR-c07e2694f0e1),
+    /// **No command anywhere requires a modifier chord** (ADR-559eebf5c6f5),
     /// over the whole table.
     ///
     /// Kept beside the rule under it, which is stronger, because they are not
@@ -986,7 +990,7 @@ mod table {
     }
 
     /// **No keystroke in the whole domain reaches a command with a modifier
-    /// held, except the way out** (TASK-1a415107fd56, ADR-c07e2694f0e1).
+    /// held, except the way out** (TASK-1a415107fd56, ADR-559eebf5c6f5).
     ///
     /// This is the rule above turned round, and the turn is what
     /// TASK-1a415107fd56 buys. "Nothing is *only* a chord" leaves a chord free

--- a/crates/ank-tui/src/lib.rs
+++ b/crates/ank-tui/src/lib.rs
@@ -1,5 +1,5 @@
 //! The `tui` verb: a full-screen reader over one corpus (ADR-8bd76e8d7c4e, §4),
-//! drawn with ratatui over crossterm (ADR-c07e2694f0e1).
+//! drawn with ratatui over crossterm (ADR-559eebf5c6f5).
 //!
 //! **It reaches the corpus by running the CLI, and by nothing else.** Every row
 //! of corpus data on the screen arrives as a `--json` document written by
@@ -52,8 +52,9 @@
 //!
 //! # The engine
 //!
-//! Raw mode, on the alternate buffer, drawn by ratatui and woken by three
-//! things: a key, a resize, and the change stream. That is [`term`], and the
+//! Raw mode, on the alternate buffer, drawn by ratatui and woken by four
+//! things: a key, a tap, a resize, and the change stream. That is [`term`], and
+//! the
 //! reason it may exist is stated there -- raw mode and the window are two
 //! implementations of one behaviour on the platforms this project ships to,
 //! crossterm is that implementation, and taking it puts no `extern` block in
@@ -72,7 +73,7 @@
 //! a person is on included: `Tab` walks the ring, `1` to `4` name one, and Left
 //! and Right cross between the listing and the document it opens.
 //! **And so is every verb that writes**
-//! (TASK-1a415107fd56, ADR-c07e2694f0e1: a key *is* the verb it runs): `c`
+//! (TASK-1a415107fd56, ADR-559eebf5c6f5: a key *is* the verb it runs): `c`
 //! claims, `l` logs, `d` finishes, `r` releases, `m` amends, `a` ratifies, and
 //! `n` makes one. What each of them is bound to is [`bindings`], declared once,
 //! and every surface -- the mapping, the offer, the key list -- is computed
@@ -104,7 +105,7 @@
 //! replaced it.** Under a line reader a slipped finger typed nothing, because a
 //! command was a word and Enter and no word was one letter. Under a keystroke
 //! reader the guarantee is the confirmation that shows the argv before anything
-//! is spawned, which ADR-c07e2694f0e1 requires and TASK-d4a882345837 built: a
+//! is spawned, which ADR-559eebf5c6f5 requires and TASK-d4a882345837 built: a
 //! submitted line composes the command and shows it spelled as a shell would
 //! have to spell it, `y` runs that command, and every other key on the keyboard
 //! dismisses it. What writes is a person reading an argv and saying yes to it,
@@ -170,7 +171,7 @@
 //! a place a keyboard cannot: [`view::App::actions`] draws what the screen
 //! offers with the key beside the word, so the two roads carry one vocabulary.
 //!
-//! **No command anywhere requires a modifier chord** (ADR-c07e2694f0e1), and
+//! **No command anywhere requires a modifier chord** (ADR-559eebf5c6f5), and
 //! that is now measured rather than reviewed: `keys`'s own table walks every
 //! key a terminal can report against every way a modifier can be held and holds
 //! this reader to it. It is what turned `Tab` and Shift-`Tab` into the screen
@@ -627,7 +628,7 @@ mod tests {
     }
 
     /// A terminal made narrower redraws to its new size, with nobody typing
-    /// (TASK-4fa385c1772d, ADR-c07e2694f0e1).
+    /// (TASK-4fa385c1772d, ADR-559eebf5c6f5).
     ///
     /// The only wake in the session is the resize, so a second frame existing at
     /// all is the reader answering the window rather than a command. What is

--- a/crates/ank-tui/src/paint.rs
+++ b/crates/ank-tui/src/paint.rs
@@ -33,10 +33,9 @@
 //! for its rendering under [`PLAIN`] comes back as one unstyled span, so there
 //! is no path by which half a style reaches a cell -- and every distinction the
 //! screen makes is still on it, because the distinctions are characters:
-//! the `> ` on the row a cursor is on, the `*` on a claim its reader holds, the
-//! heavier rule and the `> ` in the title of the panel with the focus, and the
-//! status spelled as a word in its own column. Colour repeats those; it carries
-//! none of them alone.
+//! the `> ` on the row a cursor is on, the `*` on a claim its reader holds, and
+//! the status spelled as a word in its own column. Colour repeats those; it
+//! carries none of them alone.
 //!
 //! **And the characters do not move when the paint is taken away.** That is
 //! what [`declared_dumb`] is for: the glyph set `view` draws its structure with
@@ -44,7 +43,7 @@
 //! probe. `NO_COLOR` reaches the ink alone, so the frame drawn with the paint
 //! and the frame drawn without it are the same characters -- which is the only
 //! way "nothing is carried by colour alone" can be measured at all
-//! (ADR-c07e2694f0e1).
+//! (ADR-559eebf5c6f5).
 //!
 //! # Composing a row, and what is deliberately left alone
 //!
@@ -168,7 +167,7 @@ impl Ink {
 /// The terminal's own declaration that it can render nothing rich.
 ///
 /// **One probe, read by two fields, which is the whole of what makes the
-/// degradation honest** (ADR-c07e2694f0e1). A terminal that says `dumb` is
+/// degradation honest** (ADR-559eebf5c6f5). A terminal that says `dumb` is
 /// saying it can draw neither the colours [`Ink`] would paint nor the
 /// box-drawing glyphs `view`'s borders are made of, and it gets one answer to
 /// that rather than two: the plain palette *and* the ASCII rules, from this

--- a/crates/ank-tui/src/term.rs
+++ b/crates/ank-tui/src/term.rs
@@ -1,5 +1,5 @@
-//! The engine: raw mode, the alternate screen, and the three things that wake a
-//! drawn screen (ADR-c07e2694f0e1).
+//! The engine: raw mode, the alternate screen, and the four things that wake a
+//! drawn screen (ADR-559eebf5c6f5).
 //!
 //! **No `extern` block enters this workspace for any of it, and that is the
 //! whole of why this file may exist at all.** Raw mode is `tcsetattr` on Unix

--- a/crates/ank-tui/src/text.rs
+++ b/crates/ank-tui/src/text.rs
@@ -106,10 +106,10 @@ pub fn wrap(line: &str, width: usize) -> Vec<String> {
 /// A run of one character, the width of the window.
 ///
 /// The character is the caller's, because which one it is is a decision about
-/// the terminal rather than about the arithmetic: a screen ruling its panels
+/// the terminal rather than about the arithmetic: a screen ruling its region
 /// with box-drawing glyphs rules its chrome with the same horizontal, and one
 /// that has been told the terminal is dumb rules both with `-`
-/// (ADR-c07e2694f0e1). [`crate::view::Glyphs`] is what answers it,
+/// (ADR-559eebf5c6f5). [`crate::view::Glyphs`] is what answers it,
 /// once, when the screen opens.
 pub fn rule(width: usize, of: &str) -> String {
     of.repeat(width)

--- a/crates/ank-tui/src/view.rs
+++ b/crates/ank-tui/src/view.rs
@@ -11,20 +11,47 @@
 //! # One region, and what happened to the panels
 //!
 //! One bordered region, and whatever has been asked for is drawn in it. Above
-//! it the header, under it the note; nothing else on the frame has a rule
-//! around it at any width.
+//! it the header -- the corpus line, the identity line and the rule under them
+//! -- and under it the note band; nothing else on the frame has a rule around
+//! it at any width.
+//!
+//! **What follows is a transcription and not a drawing.** It is `ank tui`
+//! driven through `crates/ank-tui/tests/terminal`'s pseudo-terminal at
+//! seventy-two columns by ten rows, on this repository's own corpus, read back
+//! off the master side. The corpus hash, the branch, the identity and the
+//! counts are that session's; every other character is what the reader put on
+//! the screen. Take it again the same way rather than editing it by eye -- a
+//! diagram nobody has run against a terminal is exactly the drift this file
+//! spends its length arguing against.
 //!
 //! ```text
-//! ank tui   corpus ...   branch main (default main)  [?]  <- chrome
-//! identity ...   0 claim(s) live   stream none            <- chrome
-//! ------------------------------------------------------  <- chrome
-//! +- 2 ENTITIES 1-17 of 41   (41 in the corpus) ------+
-//! |>     1  ADR-8bd7  accepted~   The reader reaches  |
-//! |      2  ADR-c072  superseded  The reader spends   |
-//! |                                                   |
-//! +---------------------------------------------------+
-//! whatever the reader is being told, or the search line   <- chrome
+//! ank tui   corpus 5a02985accab   branch wave33/cite-what-bind~[f all ][?]
+//! identity claude-code/opus-5+panel-suite   1 claim(s) live   stream none~
+//! ────────────────────────────────────────────────────────────────────────
+//! ┏2 ENTITIES 1-4 of 455   (1584 in the corpus)━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+//! ┃>     1  TASK-73b1   in_progress   The workspace cites the decision t~█
+//! ┃      2  TASK-def2   open          The filter is computed once for a ~┃
+//! ┃      3  ADR-559e    proposed      The reader is one list and one doc~┃
+//! ┃      4  TASK-ec85   done          The TUI suite's spawn helper lets ~┃
+//! ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+//!
 //! ```
+//!
+//! Six things on it are each a clause somewhere below. The header's right edge
+//! carries both targets and no band carries any ([`kind_target`],
+//! [`help_target`]). The structure is box-drawing, and the chrome's own rule
+//! is the lighter horizontal of that same set ([`Glyphs`]); the terminal that
+//! declares it can render neither glyphs nor colour gets `+`, `-`, `|` and `=`
+//! here instead, and nothing else on the frame moves. The bar is a thumb drawn
+//! *into* the region's own right border -- no track, no arrow heads
+//! ([`App::bar`]). A row that cannot afford its title drops it from the right
+//! and says so with `~`, and the identifier and the marker are what it never
+//! drops. The order is the work that is alive, then what waits for a
+//! signature, then what moved last, which is why an `in_progress` task is
+//! first and no identifier sorted anything (TASK-b5185df7aa44). And the last
+//! row is the note band, blank at rest: a refusal, a confirmation or the
+//! search line goes there, and it costs nothing until there is something to
+//! say.
 //!
 //! **What was four panels is four screens** (ADR-559eebf5c6f5). lazygit shows
 //! four planes of one repository that a person compares by eye, and comparison
@@ -123,7 +150,7 @@
 //! resolve before the cursor moves, because there is nowhere to cross to.
 //!
 //! **And what a screen offers is reachable by a finger without being drawn at
-//! rest** (TASK-9a402a54886f, ADR-c07e2694f0e1). What stands there is two cells
+//! rest** (TASK-9a402a54886f, ADR-559eebf5c6f5). What stands there is two cells
 //! of the header ([`App::help_line`]), and behind one of them the key list,
 //! every row of which is the key it names. The vocabulary is unchanged and that
 //! is the point: a target hands [`App::press`] the very key a keyboard would
@@ -151,7 +178,7 @@
 //!
 //! **The borders are box-drawing glyphs, and drop to `-`, `|`, `+` and `=` on
 //! the terminal that declares it can render neither those nor colour**
-//! (ADR-c07e2694f0e1). [`Glyphs`] is that choice, and it is a field of its own
+//! (ADR-559eebf5c6f5). [`Glyphs`] is that choice, and it is a field of its own
 //! beside the ink rather than a part of it: the probe is the terminal's own
 //! word and never `NO_COLOR`, because refusing colour is not refusing glyphs
 //! and a frame whose characters moved when the paint went would leave "nothing
@@ -185,9 +212,9 @@
 //! # The confirmation, which is the fourth act
 //!
 //! **No verb that writes is spawned without the exact command line having been
-//! on the screen first** (TASK-d4a882345837, ADR-c07e2694f0e1). What
+//! on the screen first** (TASK-d4a882345837, ADR-559eebf5c6f5). What
 //! [`App::propose`] leaves behind is a `Pending`: the verb, the argv, and the
-//! line spelled as a shell would have to spell it. The band under the panels
+//! line spelled as a shell would have to spell it. The band under the region
 //! shows that line, `y` runs it and every other key on the keyboard drops it
 //! ([`keys::confirming`]). So the road from a key to a moved corpus is two
 //! deliberate acts -- press the verb's own letter, and say yes to what it
@@ -369,7 +396,7 @@ impl Focus {
 /// person with a keyboard reads the letter, a person with a thumb touches the
 /// word, and neither is using a feature the other has not got.
 ///
-/// None of the keys named here is a chord, which is ADR-c07e2694f0e1's rule
+/// None of the keys named here is a chord, which is ADR-559eebf5c6f5's rule
 /// showing on the screen rather than only in `keys`: a target offering
 /// Control-something would be an offer a phone cannot take.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -614,7 +641,7 @@ pub struct App {
     /// screen whose answer could differ between two rows of one frame.
     ink: Ink,
     /// Which characters this screen draws its structure with, decided once
-    /// when it opens (ADR-c07e2694f0e1).
+    /// when it opens (ADR-559eebf5c6f5).
     ///
     /// **Beside the ink and never inside it.** The two are decided from one
     /// probe and they are two fields, so taking the paint away moves no
@@ -631,7 +658,8 @@ pub struct App {
     /// where the region was squeezed to make room for it.
     ///
     /// A row and not a flag, because the list is longer than the window at both
-    /// of the windows ADR-c07e2694f0e1 measures this reader on. The alternative
+    /// of the windows this reader is measured on, eighty by twenty-four and
+    /// forty by thirty. The alternative
     /// to scrolling it is cutting it, and a key list that stops at the bottom of
     /// the screen is the omission that decision was written against.
     overlay: Option<usize>,
@@ -1143,7 +1171,7 @@ impl App {
                 // The list `x` opened is over the region and over the bands
                 // like the other two, and a touch on a row of it opens that row
                 // -- which is what Enter does on it, and the whole of what
-                // ADR-c07e2694f0e1 asks of an offer: a thumb reaches it.
+                // ADR-559eebf5c6f5 asks of an offer: a thumb reaches it.
                 if self.beyond.is_some() {
                     let Some(verb) = self.beyond_at(at) else {
                         return false;
@@ -1172,7 +1200,7 @@ impl App {
                 // resolved here rather than above the two modal states on
                 // purpose: what a touch does while a command is waiting is
                 // dismiss it, and a target that opened a list from under a
-                // confirmation would be the second road ADR-c07e2694f0e1
+                // confirmation would be the second road ADR-559eebf5c6f5
                 // forbids.
                 if self.help_rect(self.area()).contains(at) {
                     if let Some(binding) = bindings::of_command(&Command::Help) {
@@ -2256,7 +2284,7 @@ impl App {
             .thumb_symbol(self.glyphs.thumb())
             // The track is the border the block has already drawn, and the
             // ends are nothing: an arrow head is an offer, and this reader
-            // draws no offer at rest (ADR-c07e2694f0e1).
+            // draws no offer at rest (ADR-559eebf5c6f5).
             .track_symbol(None)
             .begin_symbol(None)
             .end_symbol(None)
@@ -2764,11 +2792,12 @@ impl App {
     /// row of the same block because a person asking "what is this" is asking
     /// both halves at once.
     ///
-    /// **What the block buys is the screen this panel was spending on text a
-    /// person had to read as YAML.** That is the ground ADR-c07e2694f0e1 stands
-    /// on -- the reader spends its screen on the corpus -- and it is ratified,
-    /// so the argument this block was built on and the decision that binds it
-    /// are one document rather than two that happened to agree.
+    /// **What the block buys is the rows this screen was spending on text a
+    /// person had to read as YAML.** That is the ground ADR-559eebf5c6f5 stands
+    /// on -- a frame's rows go to the corpus, and text nobody has parsed is not
+    /// yet the corpus -- so the argument this block was built on and the
+    /// decision binding it are one document rather than two that happened to
+    /// agree.
     fn block(&self, width: usize) -> Vec<(Composed, Option<String>)> {
         let Some(detail) = &self.detail else {
             return Vec::new();
@@ -3116,11 +3145,11 @@ impl App {
     /// rectangle -- so [`App::arrange`] may ask it for its height.
     ///
     /// **And it is empty unless a command is waiting** (TASK-9a402a54886f).
-    /// The band was drawn at rest on every frame and at every window, and
-    /// ADR-c07e2694f0e1 priced it: four rows of the twenty-four the reader it
-    /// was written for has. What replaced it is the key list behind one
-    /// permanently visible target ([`App::help_line`]), which costs a cell
-    /// rather than a band. The confirmation keeps its two, and that is the one
+    /// The band was drawn at rest on every frame and at every window, and it
+    /// was priced at four rows of the twenty-four the reader it was written for
+    /// has -- the measurement behind ADR-559eebf5c6f5's "no offer is drawn at
+    /// rest". What replaced it is the key list behind a permanently visible
+    /// target ([`App::help_line`]), which costs a cell rather than a band. The confirmation keeps its two, and that is the one
     /// screen where knowing the key is not optional: a person being asked
     /// whether to run something must be able to say no without having learnt a
     /// letter first.
@@ -3196,7 +3225,7 @@ impl App {
 
     // -----------------------------------------------------------------------
     // The targets that are always there
-    // (ADR-c07e2694f0e1, ADR-559eebf5c6f5)
+    // (ADR-559eebf5c6f5)
     // -----------------------------------------------------------------------
 
     /// What the header's first row carries on its right edge, and the whole of
@@ -3228,12 +3257,14 @@ impl App {
     /// The header's first row, with those targets on the end of it.
     ///
     /// **This is what the band of targets was traded for** (TASK-9a402a54886f).
-    /// ADR-c07e2694f0e1 asks for one permanently visible target that opens the
-    /// key list, and it costs a cell of a row the header was drawing anyway --
-    /// against four rows of twenty-four, on the window the clause was written
-    /// to protect. ADR-559eebf5c6f5 puts the kind in force beside it on the
-    /// same terms and the same row (TASK-12bd5acbf706): the header is three
-    /// rows before this and three rows after it.
+    /// ADR-559eebf5c6f5 asks that every action a screen offers be reachable by
+    /// touch through permanently visible targets carved out of the header the
+    /// reader draws anyway, so that they cost no row: the key list's own target
+    /// is one of them, and the kind in force is the other, on the same terms
+    /// and the same row (TASK-12bd5acbf706). A cell of a row already being
+    /// drawn, against the four rows of twenty-four the band cost on the window
+    /// the clause was written to protect -- and the header is three rows before
+    /// this and three rows after it.
     ///
     /// The corpus line is padded rather than fitted so the targets land on the
     /// right edge at every width, and the corpus line is what gives way where
@@ -3352,7 +3383,7 @@ impl App {
     /// One row of the key list, pressed. `true` means the session is over.
     ///
     /// **A row is the key it names, and it reaches it by pressing it**
-    /// (ADR-c07e2694f0e1). The same reasoning [`Action`] carries: a tap on a
+    /// (ADR-559eebf5c6f5). The same reasoning [`Action`] carries: a tap on a
     /// word hands [`App::press`] the very [`KeyEvent`] that word names, so
     /// there is one vocabulary on this screen rather than a second road that
     /// happens to agree.
@@ -3640,7 +3671,7 @@ impl App {
 /// Which characters this reader draws its structure with.
 ///
 /// **A second field beside [`paint::Ink`], and never the ink itself**
-/// (ADR-c07e2694f0e1). The two share one probe -- [`paint::declared_dumb`],
+/// (ADR-559eebf5c6f5). The two share one probe -- [`paint::declared_dumb`],
 /// the terminal's own word that it can render nothing rich -- and nothing
 /// else: `NO_COLOR` reaches the ink and reaches no glyph. That separation is
 /// not tidiness. "Nothing on this screen is carried by colour alone" is
@@ -3662,11 +3693,12 @@ pub struct Glyphs {
 /// Box-drawing. What an ordinary terminal gets.
 pub const BOXES: Glyphs = Glyphs { rich: true };
 /// `+`, `-`, `|` and `=`. What a terminal that has declared itself dumb gets,
-/// and what this reader drew everywhere before ADR-c07e2694f0e1.
+/// and what this reader drew everywhere before the glyphs arrived
+/// (LOG-ed57116ba141).
 pub const ASCII: Glyphs = Glyphs { rich: false };
 
 impl Glyphs {
-    /// The glyph half of ADR-c07e2694f0e1, evaluated once when the screen
+    /// The glyph half of ADR-559eebf5c6f5, evaluated once when the screen
     /// opens.
     ///
     /// The whole of it is [`paint::declared_dumb`]. There is deliberately no
@@ -3680,13 +3712,16 @@ impl Glyphs {
         }
     }
 
-    /// The border of a panel, focused or not.
+    /// The border, at either weight.
     ///
-    /// **The focus is carried by the weight of the rule**, which is a
-    /// character in both sets: heavy against rounded where the terminal draws
-    /// glyphs, `=` against `-` where it does not. Every set here is one column
-    /// wide on every side, so two panels sharing a row are the same one column
-    /// of characters apart whichever of them has the focus.
+    /// **The weight is a character in both sets**: heavy against rounded where
+    /// the terminal draws glyphs, `=` against `-` where it does not. Nothing
+    /// chooses between the two any more -- there is one region and nothing to
+    /// tell it apart from, so the frame is drawn at the heavier weight
+    /// everywhere and where a person is standing is the marker on the row
+    /// (ADR-559eebf5c6f5). The lighter set is what [`Glyphs::rule`] takes the
+    /// chrome's own horizontal from. Every set here is one column wide on every
+    /// side.
     pub const fn border(self, focused: bool) -> border::Set<'static> {
         match (self.rich, focused) {
             (true, false) => border::ROUNDED,
@@ -3723,11 +3758,10 @@ impl Glyphs {
     }
 }
 
-/// The border of a panel nobody is in, on a terminal that declared itself
-/// dumb.
+/// The lighter ASCII border, on a terminal that declared itself dumb.
 ///
 /// Kept to the character, and it is what this reader drew everywhere before
-/// ADR-c07e2694f0e1: LOG-ed57116ba141's reasoning was that structure is text
+/// the glyphs arrived: LOG-ed57116ba141's reasoning was that structure is text
 /// emitted identically to every reader on every platform, and for the terminal
 /// that has said it can render neither glyphs nor colour that reasoning still
 /// holds.
@@ -3775,7 +3809,7 @@ struct Panels {
     ///
     /// **Zero rows on every frame but one** (TASK-9a402a54886f). It is drawn
     /// while a command is waiting to be answered and never otherwise, because
-    /// that is the one screen ADR-c07e2694f0e1 still requires an offer on: a
+    /// that is the one screen ADR-559eebf5c6f5 still requires an offer on: a
     /// person deciding whether to run something must not have to know a letter
     /// to say no. Everywhere else the offer is the key list, which costs
     /// nothing until it is asked for.
@@ -3797,9 +3831,9 @@ const HEADER: u16 = 3;
 /// bordered box with nothing in it is a reader that has stopped answering.
 const REGION: u16 = 3;
 
-/// The label of the one target drawn on every frame: the key that opens the
-/// key list, in the brackets every target on this screen wears
-/// (ADR-c07e2694f0e1).
+/// The label of the target drawn on every frame: the key that opens the key
+/// list, in the brackets every target on this screen wears
+/// (ADR-559eebf5c6f5).
 ///
 /// **The letter is the table's and not this file's.** It is `?` today and the
 /// whole of what TASK-4d2eb2b4e193 bought is that a key which moved would move
@@ -3845,8 +3879,8 @@ fn cycle_binding() -> Option<&'static Binding> {
 /// this screen wears (ADR-559eebf5c6f5).
 ///
 /// **It is information first and a target second, and that ordering is the
-/// whole argument.** ADR-c07e2694f0e1 took away a band of offers because it
-/// cost four rows of twenty-four, and this does not buy any of it back: which
+/// whole argument.** A band of offers was taken away because it cost four rows
+/// of twenty-four, and this does not buy any of it back: which
 /// kind a person is looking at has to be written somewhere regardless -- a
 /// listing that has silently dropped three quarters of a corpus and says so
 /// nowhere is the reader answering a question nobody asked -- so writing it in
@@ -4314,11 +4348,11 @@ pub const CONFIG_ABOUT: &str =
 /// What the config pane says a row of it costs.
 ///
 /// **Both keys are read out of the table and the shape out of the contract**
-/// (ADR-c07e2694f0e1). The key that opens a row is whatever runs
+/// (ADR-559eebf5c6f5). The key that opens a row is whatever runs
 /// [`Command::Open`], the key that runs a composed command is [`keys::CONFIRM`],
 /// and the command line is the verb's own usage. A sentence carrying its own
-/// copy of any of the three would be one of the five parallel tables that
-/// decision was written against, in prose.
+/// copy of any of the three would be a key table transcribed beside the
+/// contract's own, in prose, which is the drift that clause forbids.
 fn config_offer() -> String {
     let shape = crate::form::spec_of(SETTING)
         .map(|spec| spec.positional_help)
@@ -4559,9 +4593,11 @@ fn next_row_kind(kind: Option<&str>) -> Option<String> {
 pub const SEARCH: &str = "/";
 // `KEYS`, `PANEL_KEYS`, `ACT_KEYS` and `RATIFY_KEY` stood here
 // (TASK-4d2eb2b4e193). Four sentences about a key table, written beside two
-// other renderings of the same table, and ADR-c07e2694f0e1 records what they
-// cost: the trailer taught a vocabulary the reader did not have, and left out
-// `v`, Space, every arrow and the whole of the ring. The trailer itself went
+// other renderings of the same table, and what they cost is on the record:
+// the trailer taught a vocabulary the reader did not have, and left out `v`,
+// Space, every arrow and the whole of the ring. What the reader offers is read
+// out of the contract's own verb table now (ADR-559eebf5c6f5). The trailer
+// itself went
 // with them (TASK-9a402a54886f): `?` answers with `bindings::listing`, and
 // `bindings::ratify_line` is the one sentence of it the note band kept -- both
 // generated from the rows they describe, so what the reader teaches is what the
@@ -4664,11 +4700,12 @@ mod tests {
     /// the reader is drawn for; the test that is about the fallback says so.
     const SCREEN: Glyphs = BOXES;
 
-    /// How many of a line's characters are a panel's vertical border, at
+    /// How many of a line's characters are the region's vertical border, at
     /// either weight.
     ///
     /// Read off [`SCREEN`] rather than written as a character here: the border
-    /// set moved once already (ADR-c07e2694f0e1), and a suite carrying its own
+    /// set is a probe's answer and never a constant (ADR-559eebf5c6f5), it has
+    /// moved once already, and a suite carrying its own
     /// copy of `|` would have gone on counting a glyph the reader no longer
     /// draws -- which is a test that quietly stops testing rather than one that
     /// fails.
@@ -4934,7 +4971,7 @@ mod tests {
     }
 
     /// Structure is box-drawing, and the ASCII rules are what a terminal that
-    /// declared itself dumb gets back (ADR-c07e2694f0e1).
+    /// declared itself dumb gets back (ADR-559eebf5c6f5).
     ///
     /// Both sets on one test, because either alone is half of it: a reader
     /// that had gone to glyphs and taken the fallback with it would pass the
@@ -4945,7 +4982,7 @@ mod tests {
     /// ordinary characters of an identity, an identifier and the line of act
     /// forms, and a test that banned them from the whole screen would be
     /// asserting something the reader was never supposed to do. What `ank tui`
-    /// puts on a real terminal at each of the two is `tests/panels.rs`, on the
+    /// puts on a real terminal at each of the two is `tests/region.rs`, on the
     /// rule CLAUDE.md states: a criterion about the binary is measured through
     /// the binary.
     #[test]
@@ -7851,12 +7888,14 @@ mod tests {
 
     /// **The band of targets is zero rows on every screen but the
     /// confirmation, and there it draws its own two**
-    /// (TASK-9a402a54886f, ADR-c07e2694f0e1).
+    /// (TASK-9a402a54886f, ADR-559eebf5c6f5).
     ///
     /// The clause it used to answer -- every action of the focused pane drawn
-    /// as a visible target at rest -- is the one ADR-c07e2694f0e1 replaced, and
-    /// it names what the band cost: four rows of the twenty-four the reader it
-    /// was written for has. The confirmation is what stayed, because a person
+    /// as a visible target at rest -- is gone, and two supersessions have been
+    /// over it since; `ank show ADR-559eebf5c6f5` walks back to it. What stands
+    /// in its place is "no offer is drawn at rest", and what the band cost is
+    /// four rows of the twenty-four the reader it was written for has. The
+    /// confirmation is what stayed, because a person
     /// being asked whether to run something must be able to say no without
     /// having learnt a letter first.
     ///
@@ -7924,7 +7963,7 @@ mod tests {
     }
 
     /// **The key list is one touch away on every frame**
-    /// (TASK-9a402a54886f, ADR-c07e2694f0e1).
+    /// (TASK-9a402a54886f, ADR-559eebf5c6f5).
     ///
     /// This is what the band of targets was traded for, and it is what makes
     /// the trade honest: the offer is complete and free at rest rather than
@@ -7935,7 +7974,7 @@ mod tests {
     /// The two modal states are the exception and they are asserted as one: a
     /// touch there answers the thing that is waiting, which is the modal rule
     /// this reader holds everywhere. A target that opened a list from under a
-    /// confirmation would be the second road ADR-c07e2694f0e1 forbids.
+    /// confirmation would be the second road ADR-559eebf5c6f5 forbids.
     #[test]
     fn the_key_list_is_one_touch_away_on_every_frame() {
         let ank = nowhere();
@@ -8513,7 +8552,7 @@ mod tests {
     }
 
     /// The terminal that declared itself dumb is told where the view sits in
-    /// the alphabet it has (ADR-c07e2694f0e1).
+    /// the alphabet it has (ADR-559eebf5c6f5).
     #[test]
     fn the_bar_drops_to_ascii_where_the_terminal_says_it_is_dumb() {
         let mut a = crowded();
@@ -8605,7 +8644,7 @@ mod tests {
     ///
     /// The second half is the one the overlay exists for. A list the layout had
     /// to find rows for cost the panels those rows -- thirteen of twenty-four
-    /// on furniture is what ADR-c07e2694f0e1 measured -- and giving them back
+    /// went on furniture on the frame that was measured -- and giving them back
     /// afterwards is a second arrangement that has to agree with the first.
     /// Nothing moved to make room, so nothing has to move back, and the
     /// cheapest way to say so is that the two frames are the same characters.
@@ -8655,8 +8694,9 @@ mod tests {
     /// The key list's own claim, applied to the second overlay: nothing moved
     /// to make room for it, so nothing has to move back, and the five rows of
     /// chrome TASK-9a402a54886f left the reader are untouched by a form being
-    /// open. Measured at the windows ADR-c07e2694f0e1 measures this reader on
-    /// and at one too short for the form, which is where an overlay the layout
+    /// open. Measured at eighty by twenty-four and at forty by thirty, the two
+    /// windows this reader is held to, and at one too short for the form, which
+    /// is where an overlay the layout
     /// had been asked for would have shown.
     #[test]
     fn the_form_covers_the_panels_and_gives_the_frame_back_when_it_closes() {
@@ -8732,10 +8772,11 @@ mod tests {
 
     /// **Every row of the list that names a binding is reached by a press on
     /// it, and every row that names none reaches nothing**
-    /// (TASK-8a6578851244, ADR-c07e2694f0e1).
+    /// (TASK-8a6578851244, ADR-559eebf5c6f5).
     ///
     /// Over every row rather than over the one the criterion names, because
-    /// "every line of that list is a target" is a claim about all of them: a
+    /// "every action a screen offers is reachable by touch" is a claim about
+    /// all of them: a
     /// hit test off by one would answer the row above for thirty-odd of these
     /// and still pass a test that only pressed `claim`. The headings are in
     /// here for the same reason from the other side -- a sentence about the

--- a/crates/ank-tui/tests/bindings.rs
+++ b/crates/ank-tui/tests/bindings.rs
@@ -9,11 +9,12 @@
 //! that the thing a person presses `?` on shows it, and between those two
 //! there is a dispatch, a note band, a wrap, a `fit` and a terminal.
 //!
-//! **Twice, that being the whole of the point.** ADR-c07e2694f0e1, the
-//! decision this wave is built on, was written because the reader's own
-//! trailer taught a vocabulary the reader did not have
+//! **Twice, that being the whole of the point.** This table was declared
+//! because the reader's own trailer taught a vocabulary the reader did not have
 //! -- `?` omitted `v`, Space, every arrow, the way out and the whole of the
-//! ring -- and a suite that asserted the list contains `q quit` would have
+//! ring -- and what the reader offers is read out of the contract's own verb
+//! table now (ADR-559eebf5c6f5). A suite that asserted the list contains
+//! `q quit` would have
 //! passed on that screen. So this reads the drawn rows back and holds them to
 //! the table both ways: nothing the table declares is missing, and nothing that
 //! is drawn is absent from the table.
@@ -166,17 +167,17 @@ fn the_key_the_list_is_named_after_draws_every_binding_and_no_other() {
     live.quit();
 }
 
-/// The window ADR-c07e2694f0e1 measures this reader's frame on.
+/// The window this reader's frame is measured on.
 const EIGHTY: (u16, u16) = (80, 24);
 
 /// **The key list fits the window it is asked for on** (TASK-4d2eb2b4e193).
 ///
 /// The list is longer than the three sentences it replaces, and it has to be:
 /// naming every binding is the criterion, and the omissions of the old one are
-/// what ADR-c07e2694f0e1 was written against. What it must not do is break the
-/// screen it is drawn on. So the note band grows to hold what it is given, the
-/// panels give way to it, and the frame is still the window's own size, row for
-/// row and column for column.
+/// what this list was written against. What it must not do is break the screen
+/// it is drawn on. So the list is drawn over the frame, nothing under it moves,
+/// and the frame is still the window's own size, row for row and column for
+/// column.
 ///
 /// The rows it costs used to be real: the list was a note the layout had to
 /// find room for, and the panels were squeezed to give it. TASK-8a6578851244

--- a/crates/ank-tui/tests/chrome.rs
+++ b/crates/ank-tui/tests/chrome.rs
@@ -1,14 +1,14 @@
 //! What the frame spends on furniture, through the binary, at the five windows
 //! the criterion names (TASK-9a402a54886f).
 //!
-//! ADR-c07e2694f0e1 was written against a measurement and this suite is that
+//! The frame was redrawn against a measurement and this suite is that
 //! measurement, kept: at eighty columns and twenty-four rows the reader spent
 //! three rows on a header, one on a note band, one on a band of touch targets
 //! and two on key lines cut with `~` before they finished -- and the two lines
 //! teaching the keys did not fit on the screen they were taught from. The
-//! decision's answer was to take the offer out of the frame and put it behind
-//! one permanently visible target, and the number it has to hold to afterwards
-//! is [`CHROME`].
+//! answer was to take the offer out of the frame and put it behind a
+//! permanently visible target carved out of the header (ADR-559eebf5c6f5), and
+//! the number it has to hold to afterwards is [`CHROME`].
 //!
 //! **Counted through the binary, on a pseudo-terminal, at every window the
 //! criterion states.** CLAUDE.md leaves no choice about that: a criterion that
@@ -95,7 +95,7 @@ fn grid(frame: &str) -> Vec<&str> {
 
 /// **At eighty by twenty-four, with no claim held and the queue never asked
 /// for, at most five rows are not a panel's own content**
-/// (TASK-9a402a54886f, ADR-c07e2694f0e1).
+/// (TASK-9a402a54886f, ADR-559eebf5c6f5).
 ///
 /// The corpus is the seeded one, which holds no claim and is opened on a
 /// session that never presses the key that asks for the queue -- so what is

--- a/crates/ank-tui/tests/colour.rs
+++ b/crates/ank-tui/tests/colour.rs
@@ -69,13 +69,13 @@ static ONE_AT_A_TIME: Mutex<()> = Mutex::new(());
 /// the middle both draw rows, which is where the painted fields are.
 const WINDOW: (u16, u16) = (110, 30);
 
-/// The rule the focused panel is drawn with, read out of the reader rather
-/// than written here (ADR-c07e2694f0e1).
+/// The rule the region is drawn with, read out of the reader rather than
+/// written here (ADR-559eebf5c6f5).
 ///
 /// It is a *character* and that is the point of naming it in this file: the
 /// glyph set is a second field beside the ink and no `NO_COLOR` reaches it, so
 /// this rule is on the frame of every session below whether it painted or not.
-const FOCUSED_RULE: &str = ank_tui::view::BOXES.border(true).horizontal_top;
+const REGION_RULE: &str = ank_tui::view::BOXES.border(true).horizontal_top;
 
 /// A closed task, so that a role the table renders as an *attribute* rather
 /// than as a colour is on the screen.
@@ -286,7 +286,7 @@ fn with_no_color_set_the_screen_still_says_everything_it_has_to_say() {
         "the region does not name the screen in it:\n{frame}"
     );
     assert!(
-        frame.contains(&FOCUSED_RULE.repeat(10)),
+        frame.contains(&REGION_RULE.repeat(10)),
         "the region has no rule at all:\n{frame}"
     );
     assert!(

--- a/crates/ank-tui/tests/config.rs
+++ b/crates/ank-tui/tests/config.rs
@@ -83,8 +83,9 @@ fn digit_of_body() -> String {
 /// The note and not this suite's memory of it: the page is rendered from the
 /// contract's own constant, which is what the reader's pane reads and what
 /// `ank-cli`'s closed key set is. A suite carrying its own copy of the eight
-/// would agree with a pane that had drifted, which is the whole failure
-/// ADR-c07e2694f0e1 was written against.
+/// would agree with a pane that had drifted, which is the drift
+/// ADR-559eebf5c6f5 forbids by reading what the reader offers out of the
+/// contract's own table.
 fn declared(repo: &Repo) -> Vec<String> {
     let page = String::from_utf8_lossy(&repo.ank(&["help", "config"]).stdout).to_string();
     let line = page

--- a/crates/ank-tui/tests/dependencies.rs
+++ b/crates/ank-tui/tests/dependencies.rs
@@ -1,9 +1,9 @@
-//! The constraint made mechanical (ADR-8bd76e8d7c4e, ADR-c07e2694f0e1).
+//! The constraint made mechanical (ADR-8bd76e8d7c4e, ADR-559eebf5c6f5).
 //!
 //! ADR-8bd76e8d7c4e forbids the terminal reader from linking `ank-core`, from
 //! reading `.ank/` and from touching `refs/ank/*`, so that the refusals it shows
 //! are the refusals the CLI gave and there is no second dispatch path to keep in
-//! step. ADR-c07e2694f0e1 adds one of the same kind on the other side: the
+//! step. ADR-559eebf5c6f5 adds one of the same kind on the other side: the
 //! reader is drawn with ratatui over crossterm, and **no FFI enters this tree
 //! for any of it, on any platform**. A rule that lives only in prose is a rule
 //! the second contributor breaks for a good reason, on a Tuesday, in a commit
@@ -183,7 +183,7 @@ fn the_graph_carries_neither_ank_core_nor_git() {
 /// `serde_json` is what reads the CLI's `--json`, and is the crate this list
 /// gained when `serde_yaml` left it (TASK-f0c6372d8dc0) -- the argument for
 /// spending it is in the manifest beside the declaration, where
-/// ADR-c07e2694f0e1's first clause puts it; `ratatui` and `crossterm` are what
+/// ADR-559eebf5c6f5's first clause puts it; `ratatui` and `crossterm` are what
 /// that decision spends and the whole of what it spends; the rest is what those
 /// four bring with them and nothing this crate chose.
 #[test]
@@ -208,7 +208,7 @@ fn the_crate_takes_nothing_the_tree_did_not_already_carry() {
     );
 }
 
-/// No `extern` block, on any platform (ADR-c07e2694f0e1).
+/// No `extern` block, on any platform (ADR-559eebf5c6f5).
 ///
 /// **This is the assertion the whole decision rests on.** What sent the reader
 /// to a line discipline in the first place was that raw mode is `tcsetattr` on
@@ -230,7 +230,7 @@ fn no_foreign_symbol_is_declared_in_this_tree() {
                 !text.contains(forbidden),
                 "{file} declares {forbidden}: the reader reaches raw mode, the \
                  window and a keystroke through crossterm, which is what \
-                 ADR-c07e2694f0e1 bought and the only reason it was worth \
+                 ADR-559eebf5c6f5 bought and the only reason it was worth \
                  buying"
             );
         }
@@ -325,7 +325,7 @@ fn one_function_in_this_crate_spawns_a_verb_that_writes() {
 /// This is the half of `keys::no_bare_key_can_write` that survives the wave.
 /// That test said no bare key could produce a [`ank_tui::input::Command::Act`]
 /// at all, and it was worth having because reaching a verb took a key *and* a
-/// word. ADR-c07e2694f0e1 spends that asymmetry: TASK-1a415107fd56 gives the
+/// word. ADR-559eebf5c6f5 spends that asymmetry: TASK-1a415107fd56 gives the
 /// six their own letters, and the rule that has to hold afterwards is not that
 /// an act is unreachable by a key -- it is that *however* an act is reached, it
 /// is composed and shown rather than run.

--- a/crates/ank-tui/tests/edit.rs
+++ b/crates/ank-tui/tests/edit.rs
@@ -521,7 +521,7 @@ fn the_three_verbs_the_list_opens_reach_the_confirmation_and_dismissing_writes_n
 }
 
 /// **A row of that list is a target a thumb reaches, and confirming one runs
-/// the verb** (TASK-e8da6a00564a, ADR-c07e2694f0e1).
+/// the verb** (TASK-e8da6a00564a, ADR-559eebf5c6f5).
 ///
 /// Two halves that belong together. The touch, because the decision asks that
 /// every action the reader offers be reachable by a finger and this list is

--- a/crates/ank-tui/tests/entity.rs
+++ b/crates/ank-tui/tests/entity.rs
@@ -18,8 +18,9 @@
 //! list written here: `ank help new` says which flags are the verb's own and
 //! `ank help new --json` says the same thing as a document, and the rows the
 //! form draws are held to both. A suite carrying its own copy of the flag set
-//! would agree with a form that had drifted, which is the whole failure
-//! ADR-c07e2694f0e1 was written against.
+//! would agree with a form that had drifted, which is the drift
+//! ADR-559eebf5c6f5 forbids by reading what the reader offers out of the
+//! contract's own table.
 //!
 //! The terminal, the corpus and the driven session are `terminal/mod.rs`, which
 //! `tests/confirmation.rs` declares too.

--- a/crates/ank-tui/tests/kind.rs
+++ b/crates/ank-tui/tests/kind.rs
@@ -222,8 +222,9 @@ fn the_header_names_the_kind_in_force_through_the_whole_cycle_at_every_width() {
 /// Three, which is what it was: the corpus line, the identity line, and the
 /// rule under them. The cell is carved out of a row the reader was already
 /// drawing, which is the whole of ADR-559eebf5c6f5's argument for it -- it is
-/// information made touchable, not an offer drawn at rest, and ADR-c07e2694f0e1
-/// removed a band of offers precisely because it cost four rows of twenty-four.
+/// information made touchable, not an offer drawn at rest, and the band of
+/// offers it replaced was removed precisely because it cost four rows of
+/// twenty-four.
 ///
 /// Asserted at every stop of the cycle and at every window, because the failure
 /// this guards against is not a header that starts too tall: it is one that
@@ -326,10 +327,12 @@ fn a_finger_on_the_cell_walks_the_same_cycle_as_the_key() {
 /// A press beside the cell reaches nothing.
 ///
 /// The other half of "the cell is a target", and the one a reader gets wrong by
-/// being generous: a header that answered a press anywhere on its first row
-/// would be a screen a pocket can drive, which is what ADR-c07e2694f0e1's rule
-/// about chrome is for. The column tested is the left end of the corpus line,
-/// which is as far from the cell as that row goes.
+/// being generous while reaching for a screen a pocket can drive: a header that
+/// answered a press anywhere on its first row would hand a person a press they
+/// aimed at nothing. ADR-559eebf5c6f5 carves the target out of the header the
+/// reader draws anyway, and a cell carved out of a row is a cell and not the
+/// row. The column tested is the left end of the corpus line, which is as far
+/// from the cell as that row goes.
 #[test]
 fn a_press_on_the_rest_of_the_header_advances_nothing() {
     let repo = corpus();

--- a/crates/ank-tui/tests/note.rs
+++ b/crates/ank-tui/tests/note.rs
@@ -170,7 +170,7 @@ fn the_help_page_names_exactly_the_verbs_the_reader_spells() {
 }
 
 /// **The sentence the note ends on is stated over the whole of them**
-/// (ADR-c07e2694f0e1).
+/// (ADR-559eebf5c6f5).
 ///
 /// This is the half a list alone cannot carry, and it is the half that made
 /// this task: the note used to say the verbs *act on the entity the focused

--- a/crates/ank-tui/tests/overlay.rs
+++ b/crates/ank-tui/tests/overlay.rs
@@ -12,9 +12,9 @@
 //! layout, a hit test, a dispatch and a confirmation.
 //!
 //! **Both windows, every time.** The two are not two runs of one test: eighty
-//! by twenty-four is the desk ADR-c07e2694f0e1 measured the old chrome on and
-//! found it spending thirteen rows of twenty-four on furniture, and forty by
-//! thirty is the phone the decision was written for. The list is longer than
+//! by twenty-four is the desk the old chrome was measured on, where it spent
+//! thirteen rows of twenty-four on furniture, and forty by thirty is the phone
+//! ADR-559eebf5c6f5 was written for. The list is longer than
 //! either of them, which is why it scrolls, and the row reading `claim` is
 //! below the fold at both -- so a suite that only pressed at the top would be
 //! asserting on the one part of the list a window happens to hold.
@@ -43,8 +43,8 @@ use terminal::{Live, Repo};
 /// `tests/bindings.rs` carries the same lock for the same reason.
 static ONE_AT_A_TIME: Mutex<()> = Mutex::new(());
 
-/// The desk ADR-c07e2694f0e1 measures this reader's frame on, and the phone it
-/// was written for.
+/// The desk this reader's frame is measured on, and the phone it was written
+/// for.
 const WINDOWS: [(u16, u16); 2] = [(80, 24), (40, 30)];
 
 /// What the confirmation says above the command line, and what it says once
@@ -226,7 +226,7 @@ fn list_at_claim(live: &mut Live) -> (u16, u16) {
 }
 
 /// **`?` draws a bordered list over the panels, and never a note under them**
-/// (TASK-8a6578851244, ADR-c07e2694f0e1), at both windows.
+/// (TASK-8a6578851244, ADR-559eebf5c6f5), at both windows.
 ///
 /// The negative is the half that matters and it is why the panels are read
 /// first. A list drawn *into* the note band is what this replaces: it was on
@@ -293,7 +293,7 @@ fn the_key_list_is_a_bordered_overlay_over_the_panels_at_both_windows() {
 }
 
 /// **A press on the row reading `claim` raises the claim confirmation**
-/// (TASK-8a6578851244, ADR-c07e2694f0e1), at both windows.
+/// (TASK-8a6578851244, ADR-559eebf5c6f5), at both windows.
 ///
 /// This is the whole of "a line of the list is the key it names", and it is
 /// stated through the wire because that is the only place it can be: whether a

--- a/crates/ank-tui/tests/phone.rs
+++ b/crates/ank-tui/tests/phone.rs
@@ -60,7 +60,7 @@ fn claim() -> String {
 const PHONE: (u16, u16) = (40, 30);
 
 /// The region's vertical border, at either weight, as characters
-/// (ADR-c07e2694f0e1).
+/// (ADR-559eebf5c6f5).
 ///
 /// Both weights, though the reader draws one: a second bordered region arriving
 /// in the lighter set is exactly what [`shared`] counts, and a suite that only
@@ -173,7 +173,7 @@ fn at_a_phone_sized_window_the_frame_is_one_region_and_every_screen_is_reachable
 }
 
 /// **A press on a row selects it, and a press on the row already selected
-/// opens it** (TASK-dd9747e5e305, TASK-9a402a54886f, ADR-c07e2694f0e1),
+/// opens it** (TASK-dd9747e5e305, TASK-9a402a54886f, ADR-559eebf5c6f5),
 /// through the binary at a phone-sized window.
 ///
 /// The criterion's own sentence, driven: a tap lands on a row of the listing
@@ -183,11 +183,11 @@ fn at_a_phone_sized_window_the_frame_is_one_region_and_every_screen_is_reachable
 /// grid, so what is asserted is what a person would have been looking at.
 ///
 /// **The second half used to be a tap on the target reading `[Enter open]`**,
-/// and that band is gone (TASK-9a402a54886f): ADR-c07e2694f0e1 priced four rows
-/// of standing targets on the twenty-four-row screen the clause was written to
-/// protect, and what it asks for instead is exactly this -- the commonest act
-/// on a phone, read this document, reached with no button to press. So the
-/// suite asks for it the way the decision states it.
+/// and that band is gone (TASK-9a402a54886f): four rows of standing targets on
+/// the twenty-four-row screen the clause was written to protect were priced and
+/// taken away, and what ADR-559eebf5c6f5 asks for instead is exactly this --
+/// the commonest act on a phone, read this document, reached with no button to
+/// press. So the suite asks for it the way the decision states it.
 #[test]
 fn a_tap_selects_a_row_and_a_second_tap_on_it_opens_it() {
     let repo = Repo::seeded();

--- a/crates/ank-tui/tests/region.rs
+++ b/crates/ank-tui/tests/region.rs
@@ -34,7 +34,7 @@ mod terminal;
 use terminal::{Live, Repo};
 
 /// The border set an ordinary terminal is drawn with, read out of the reader
-/// rather than written here (ADR-c07e2694f0e1).
+/// rather than written here (ADR-559eebf5c6f5).
 ///
 /// A suite carrying its own copy of a glyph would go on asserting about a
 /// character the reader had stopped drawing, which is a test that quietly
@@ -339,7 +339,7 @@ fn marked(frame: &str) -> String {
 }
 
 /// Structure is box-drawing, and ASCII where the terminal declares itself
-/// dumb (TASK-e900637aeac4, ADR-c07e2694f0e1).
+/// dumb (TASK-e900637aeac4, ADR-559eebf5c6f5).
 ///
 /// **Through the binary, because the probe is the environment of a process.**
 /// `src/view.rs` asserts the same property of the render function, which is

--- a/crates/ank-tui/tests/terminal/mod.rs
+++ b/crates/ank-tui/tests/terminal/mod.rs
@@ -5,7 +5,7 @@
 //! crate, so two of them share nothing that is not in a library -- and a
 //! pseudo-terminal in `ank-tui`'s own `src/` is not an option:
 //! `tests/dependencies.rs` forbids this crate a foreign symbol and forbids it
-//! `unsafe`, which is the whole of what ADR-c07e2694f0e1 bought by taking
+//! `unsafe`, which is the whole of what ADR-559eebf5c6f5 bought by taking
 //! crossterm. A test may name what the crate may not, and that file's
 //! `sources()` reads only `src/`, which is exactly the exemption it is written
 //! to give. So the smallest terminal that can answer these questions lives in a
@@ -58,8 +58,16 @@ pub fn ank() -> PathBuf {
 pub struct Repo(pub PathBuf);
 
 impl Drop for Repo {
+    /// **Only ever under [`scratch::root`], and the check is not a formality.**
+    /// The field is public, so any path at all can be put in one -- and a
+    /// `Drop` that removed whatever it was handed took a working tree off this
+    /// machine while this suite was being read (LOG, TASK-73b1eea6cecb). What
+    /// this type is for is a corpus this suite made, so the removal is stated
+    /// over that and a path from anywhere else is left exactly where it is.
     fn drop(&mut self) {
-        let _ = std::fs::remove_dir_all(&self.0);
+        if self.0.starts_with(scratch::root()) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
     }
 }
 
@@ -839,7 +847,7 @@ impl Live {
     }
 
     /// A session on a terminal that has declared it can render nothing rich
-    /// (ADR-c07e2694f0e1).
+    /// (ADR-559eebf5c6f5).
     ///
     /// `TERM=dumb` is the whole of the declaration, and it is what puts the
     /// reader on its ASCII border set and its plain palette at once -- one

--- a/crates/ank-tui/tests/verbs.rs
+++ b/crates/ank-tui/tests/verbs.rs
@@ -208,8 +208,8 @@ fn each_of_the_six_verbs_is_a_letter_that_spells_the_panels_entity_and_waits() {
 
 /// **`h`, `l`, `n` and `p` move nothing** (TASK-1a415107fd56).
 ///
-/// The price ADR-c07e2694f0e1 puts on the letters, measured on the screen a
-/// person is looking at. Three of the four reach nothing at all and the frame
+/// The price ADR-559eebf5c6f5 takes on the letters -- navigation takes what is
+/// left -- measured on the screen a person is looking at. Three of the four reach nothing at all and the frame
 /// is identical character for character; `l` is `log`, so it raises a
 /// confirmation -- and the rows underneath it do not move, which is what the
 /// clause is about. A key that quietly moved a cursor while asking about a


### PR DESCRIPTION
Last blocker on `ank accept ADR-559eebf5c6f5`. Closes TASK-73b1eea6cecb.

126 citations of `ADR-c07e2694f0e1` stood across 25 files in `crates/ank-tui`, `crates/ank-cli/tests/tui.rs` and `crates/ank-contract/src/verbs.rs`. None is left outside `.ank/`, and no sentence was deleted with the identifier it carried.

## Not a substitution

Six of ADR-559eebf5c6f5's eight clauses carry the retired document forward, three word for word. Where a clause survives — input is a keystroke, a key is the verb it runs, no command requires a modifier chord, the confirmation stated over the verbs that write, the glyph set on the terminal's own probe, no offer drawn at rest — the identifier moved and the sentence stands.

Where the succession made the sentence false, the sentence was rewritten:

| where | what it said | what is true |
|---|---|---|
| `ank-tui/Cargo.toml` | ratatui and crossterm buy "a layout with panels to come" | one region, a scrollbar over it, the wheel |
| `src/paint.rs` | colour repeats "the heavier rule and the `> ` in the title of the panel with the focus" | nothing has focus, no title carries a marker; the marker on the row carries it |
| `src/view.rs` `Glyphs::border` | "the focus is carried by the weight of the rule" | every drawing path passes `true`; the lighter set is only the chrome's horizontal |
| `src/term.rs` | "the three things that wake a drawn screen" | four — a key, a tap, a resize and the stream; its own body already said so |

Where the retired document's **body** held a measurement the successor does not restate — the two windows, the thirteen rows on furniture, the five parallel key tables, the omissions of the old trailer — the fact was kept and the attribution dropped. Re-pointing those would have sourced numbers to a document that does not carry them: sourced-looking and wrong, and no grep finds it again.

## The diagram

The diagram at the head of `view.rs` was a drawing, and every line of it was wrong: ASCII borders where the reader draws box-drawing, one `[?]` where the header now carries `[f all ][?]`, no scrollbar thumb, a `+- 2 ENTITIES` title the reader spells hard against the corner, and a note band drawn carrying a sentence it is blank of at rest.

It is now a transcription of `ank tui` driven through `tests/terminal`'s pseudo-terminal at 72×10 on this repository's own corpus, read off the master side — and it was held to a second driven session afterwards: widths, border set, chrome rule, both header targets, the thumb in the region's own right border and the blank last row all agree. Only the corpus data differs.

## One thing beyond the criterion

`tests/terminal/mod.rs`'s `Repo` is a tuple struct with a public field whose `Drop` ran `remove_dir_all` on whatever path it held. Handing it a real path while capturing a frame deleted a working tree off this machine. It is fenced to `scratch::root()` now; a path from anywhere else is left where it is.

## Verification

- `cargo test --workspace`: **1141 passed, 0 failed**. The suite caught one of my own rewrites — `no_superseded_document_is_cited_in_the_workspace` refused a citation of `ADR-0b55983421dd`, which is the rule this task exists to enforce, working.
- `ank check`: **0 faults, 417 signals** — identical to `main`.
- `ank graph`: **344 tasks, 232 roots**, no cycle, no orphan.
- `cargo fmt --check`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GSJ1uKgzwFSiZSrQWuBo3m