### PR TITLE
Plan the process cost of a verb: one decision and one task

### DIFF
--- a/.ank/entities/ADR-cc65f1388a71.md
+++ b/.ank/entities/ADR-cc65f1388a71.md
@@ -1,0 +1,68 @@
+---
+id: ADR-cc65f1388a71
+type: adr
+slug: a-plane-is-read-in-one-batch-and-a-verb-s-proces
+title: A plane is read in one batch, and a verb's process count does not grow with the corpus
+created: 2026-08-29T22:33:15Z
+author: haksolot@vmi3223161
+status: proposed
+scope:
+  - crates/ank-cli/**
+constraint: |
+  A verb asks git a question once, and a plane it reads is one batch however many entities that plane holds. What a verb may not do is start one process per item where one batch answers the same question.
+  
+  The rule is invariance and not a ceiling. A verb's git process count does not grow with the number of entities, ratifications or coordination refs the corpus carries. What a verb legitimately reads it goes on reading: `check` reads the corpus because reading the corpus is its answer, and nothing here asks it to read less. A ceiling would have to be revised at every change and would be silenced within a month; invariance is the property that actually holds.
+  
+  The count is established by counting processes and never by timing. A wall in milliseconds measures the runner: process creation costs about 25ms on a Windows runner against 2-3ms on Linux, and the same commit has measured 376ms and then 612ms on two runs of one image. It is counted with `GIT_TRACE` pointed at an absolute path, which prints one line per process, and never with a shim on the PATH: a shim is a script, and `Command::new("git")` on Windows does not find one.
+schema: 4
+version: 1
+---
+
+Measured on this corpus on 2026-08-30, with `GIT_TRACE` and the release binary:
+
+    ank graph --json      1 git process
+    ank find --json       4
+    ank show <id> --json  4
+    ank context .         5
+    ank status --json     8
+    ank check --json     64
+    ank review --json    64
+
+Six of the seven are small and fixed. The two that are not spend forty-seven of
+their sixty-four on one `cat-file commit` per ratification, forty-seven distinct
+object names, one process each. That is `commit_carries_signature`
+(`crates/ank-cli/src/human.rs:5312`), which reads a commit to see whether it
+carries a `gpgsig` header. The answer it wants is one bit per ratification, and
+`cat-file --batch` already answers exactly that shape twice in the same run
+(`git.rs:911`, `git.rs:1041`).
+
+Forty-seven is not a constant. It is the number of ratifications this corpus can
+reach, and it goes up every time a decision is ratified.
+
+## Why this is a decision and not a task
+
+TASK-5690eae1e008 fixed the same shape on the coordination plane two days ago:
+`ank status --json` spent thirteen fixed processes plus two per coordination ref,
+which was 2023 of them on a corpus carrying five hundred claims, and it now spends
+seven whatever the plane holds. That fix was correct and it wrote nothing down.
+
+While it was being written, this second instance was already in the tree, in
+another file, on another plane, in the same shape. Nothing connected them and
+nothing would have. A third will arrive the same way, because process count is
+invisible in a diff: no reviewer sees it, no test names it, and the only surface
+that reports it is a runner in another operating system going slowly for reasons
+nobody can act on.
+
+## What this does not say
+
+It does not say verbs must be fast, and it does not reopen what
+ADR-f3d1dea65d84 settled. That decision governs what a verb *reads*: a summary
+does not re-derive the corpus, and it exempts `check` by name, because reading the
+corpus is what `check` answers. This one governs how many processes a read costs,
+which is a different axis and is why `check` can be both exempt there and bound
+here. `check` may go on reading every ratification; it may not go on starting a
+process for each.
+
+Nor is it a rule about git plumbing in general. The daemon spawns git too
+(`crates/ank-daemon`, four sites), to fetch `refs/ank/*` over the network. That is
+a cost of a different nature, paid once, and it is outside this perimeter.

--- a/.ank/entities/TASK-fc0334201ccf.md
+++ b/.ank/entities/TASK-fc0334201ccf.md
@@ -1,0 +1,25 @@
+---
+id: TASK-fc0334201ccf
+type: task
+slug: the-signature-of-every-ratification-is-read-in-o
+title: The signature of every ratification is read in one batch
+created: 2026-08-29T22:33:39Z
+author: haksolot@vmi3223161
+status: open
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/src/git.rs
+  - crates/ank-cli/tests/status.rs
+blocked_by: []
+done_criteria: |
+  `ank check --json` and `ank review --json` each start a number of git processes that does not grow with the number of ratifications the corpus carries. Counted with `GIT_TRACE` pointed at an absolute path, one `trace: built-in: git` line per process, never with a shim on the PATH. Asserted on two fixtures whose ratification counts differ by at least a factor of three: the two counts are equal.
+  
+  Measured on this corpus on 2026-08-30, before: 64 processes for each verb, 47 of them a `cat-file commit` on 47 distinct object names, one per ratification, from `commit_carries_signature` at crates/ank-cli/src/human.rs:5312. After, that call site asks git once for all of them, the way `git.rs:911` and `git.rs:1041` already do with `cat-file --batch`.
+  
+  The verdicts do not move. Every entity this repository's own corpus reports as Trusted, Absent, Invalid or Undeclared today is reported the same afterwards, asserted through the binary rather than on the function. A commit git cannot read is still `false` and still weakens to Absent rather than erroring.
+  
+  cargo test --workspace green, cargo fmt --check clean, and ank check reports no new fault.
+criteria_by: creator
+schema: 4
+version: 1
+---


### PR DESCRIPTION
Measured with GIT_TRACE on this corpus: ank check --json and ank review
--json each start 64 git processes, and 47 of those are a cat-file commit on
47 distinct object names, one per ratification. That is
commit_carries_signature reading a commit to see whether it carries a gpgsig
header, which is one bit per ratification, asked one process at a time, while
cat-file --batch answers exactly that shape twice in the same run.

Forty-seven is not a constant. It is how many ratifications this corpus can
reach, and it rises with every decision ratified.

TASK-5690eae1e008 fixed the same shape on the coordination plane two days ago
and wrote no rule down. This second instance was already in the tree while
that one was being fixed, in another file, on another plane. Nothing
connected them and nothing would have, because process count is invisible in
a diff: no reviewer sees it and no test named it.

So ADR-cc65f1388a71 states the rule as invariance rather than as a ceiling. A
ceiling on check would be arbitrary, since reading the corpus is what check
answers, and it would be revised at every change until somebody silenced it.
Invariance is the property that holds: the count does not grow with what the
corpus carries. Counted, never timed, because a millisecond wall measures the
Windows runner rather than the verb.

It is proposed, and binds nobody until it is ratified.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CwtHQ93fqgQP24UATUo5Ut
