### PR TITLE
wave35/signatures in one batch

### DIFF
--- a/.ank/entities/LOG-2911cf795ed9.md
+++ b/.ank/entities/LOG-2911cf795ed9.md
@@ -1,0 +1,15 @@
+---
+id: LOG-2911cf795ed9
+type: log
+title: done, proof commit:9d2a1ea253e450d185066e5fc1f9e53f569715e3
+created: 2026-08-29T23:55:37Z
+author: claude-code/opus-5+signatures-in-one-batch
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/src/git.rs
+  - crates/ank-cli/tests/status.rs
+about: TASK-fc0334201ccf
+seq: 0
+schema: 4
+version: 1
+---

--- a/.ank/entities/TASK-fc0334201ccf.md
+++ b/.ank/entities/TASK-fc0334201ccf.md
@@ -5,7 +5,7 @@ slug: the-signature-of-every-ratification-is-read-in-o
 title: The signature of every ratification is read in one batch
 created: 2026-08-29T22:33:39Z
 author: haksolot@vmi3223161
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/src/human.rs
   - crates/ank-cli/src/git.rs
@@ -20,6 +20,11 @@ done_criteria: |
   
   cargo test --workspace green, cargo fmt --check clean, and ank check reports no new fault.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 9d2a1ea253e450d185066e5fc1f9e53f569715e3
+    criteria: b7f0366e860c
+    via: submitted
 schema: 4
-version: 2
+version: 3
 ---

--- a/.ank/entities/TASK-fc0334201ccf.md
+++ b/.ank/entities/TASK-fc0334201ccf.md
@@ -5,7 +5,7 @@ slug: the-signature-of-every-ratification-is-read-in-o
 title: The signature of every ratification is read in one batch
 created: 2026-08-29T22:33:39Z
 author: haksolot@vmi3223161
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/src/human.rs
   - crates/ank-cli/src/git.rs
@@ -21,5 +21,5 @@ done_criteria: |
   cargo test --workspace green, cargo fmt --check clean, and ank check reports no new fault.
 criteria_by: creator
 schema: 4
-version: 1
+version: 2
 ---

--- a/crates/ank-cli/src/git.rs
+++ b/crates/ank-cli/src/git.rs
@@ -1821,6 +1821,70 @@ fn all_ratifications(cwd: &Path) -> Result<HashMap<String, Ratification>> {
     Ok(found)
 }
 
+/// The commit object of a ratification, out of one batch read for the whole
+/// history and kept for the process.
+///
+/// **One `cat-file --batch` where there was one `cat-file commit` per
+/// ratification** (TASK-fc0334201ccf). The caller wants one bit per
+/// ratification — whether the commit carries a `gpgsig` header — and asked git
+/// for it a process at a time: forty-seven of the sixty-four processes `check`
+/// and `review` each started on this repository, forty-seven distinct object
+/// names, one per ratification. Forty-seven is not a constant, it is the number
+/// of decisions this corpus has ratified, and it goes up with every one.
+///
+/// The names come from [`all_ratifications`], which has already walked the
+/// history and holds every ratification commit there is; the batch is the same
+/// shape [`cat_file_batch`] already answers for the coordination plane.
+///
+/// **A sha the walk does not carry is read on its own, once, and kept.** The
+/// walk is read at the first question and is not re-read, so a ratification
+/// made after it — `accept` committing and then reading back — is not in it,
+/// exactly as [`ratification_at`] describes for the anchor. That fallback
+/// cannot go stale in the direction that matters: a commit object is immutable,
+/// so a sha that answered once answers the same for ever.
+pub fn ratification_object(cwd: &Path, sha: &str) -> Option<String> {
+    static READ: OnceLock<Mutex<HashMap<PathBuf, HashMap<String, String>>>> = OnceLock::new();
+    let memo = READ.get_or_init(|| Mutex::new(HashMap::new()));
+    let known = |seen: &HashMap<PathBuf, HashMap<String, String>>| {
+        seen.get(cwd).and_then(|m| m.get(sha)).cloned()
+    };
+    let warmed = match memo.lock() {
+        Ok(seen) => {
+            if let Some(hit) = known(&seen) {
+                return Some(hit);
+            }
+            seen.contains_key(cwd)
+        }
+        Err(_) => false,
+    };
+    if !warmed {
+        // One commit ratifies both halves of a succession, so two entities can
+        // name the same object: deduplicated, because a name repeated in the
+        // input is bytes git writes twice for an answer already held.
+        let mut names: Vec<String> = all_ratifications(cwd)
+            .unwrap_or_default()
+            .into_values()
+            .map(|r| r.sha)
+            .collect();
+        names.sort();
+        names.dedup();
+        let batch = cat_file_batch(cwd, &names).unwrap_or_default();
+        if let Ok(mut seen) = memo.lock() {
+            seen.entry(cwd.to_path_buf()).or_default().extend(batch);
+            if let Some(hit) = known(&seen) {
+                return Some(hit);
+            }
+        }
+    }
+    let object = run(cwd, &["cat-file", "commit", sha]).ok()?;
+    if let Ok(mut seen) = memo.lock() {
+        seen.entry(cwd.to_path_buf())
+            .or_default()
+            .insert(sha.to_string(), object.clone());
+    }
+    Some(object)
+}
+
 fn ratification_uncached(cwd: &Path, id: &str, path: &str) -> Result<Option<Ratification>> {
     let subject = format!("ratify {id}");
     let args = ["rev-list", "--full-history", "HEAD", "--", path];

--- a/crates/ank-cli/src/human.rs
+++ b/crates/ank-cli/src/human.rs
@@ -5309,8 +5309,14 @@ fn can_sign(cwd: &Path) -> bool {
 /// A failure to read is `false`: this only ever weakens `Unchecked` back to
 /// `Absent`, which is the verdict the caller would have reached anyway, and
 /// `Unreadable` already covers a git that cannot answer at all.
+///
+/// The object comes out of [`git::ratification_object`], which reads every
+/// ratification in the history in one batch rather than one process per commit
+/// (TASK-fc0334201ccf). Nothing about the answer moves: the bytes are the same
+/// bytes `cat-file commit` wrote, and a name git cannot resolve is absent from
+/// the batch, which lands on the same `false` a failed read always did.
 fn commit_carries_signature(root: &Path, sha: &str) -> bool {
-    let Ok(object) = git::run(root, &["cat-file", "commit", sha]) else {
+    let Some(object) = git::ratification_object(root, sha) else {
         return false;
     };
     // Headers stop at the first blank line. A message body quoting `gpgsig` is

--- a/crates/ank-cli/tests/status.rs
+++ b/crates/ank-cli/tests/status.rs
@@ -59,6 +59,31 @@ const REFS: usize = 500;
 /// An expiry no run of this suite reaches, so every seeded claim is a live one.
 const LIVE: &str = "2099-01-01T00:00:00Z";
 
+/// The plane the signature measurement is over: ratified decisions, on the
+/// corpus that carries many of them.
+const RATIFICATIONS: usize = 24;
+
+/// How much smaller the other corpus is. The criterion asks for a factor of at
+/// least three between the two, because two counts that are equal over a
+/// difference of one prove nothing about a count that grows.
+const FACTOR: usize = 6;
+
+/// A `gpgsig` header no keyring produced and none can check, ending its own
+/// line so that the blank line after it is the one that opens the message.
+///
+/// A signed commit carries this header whatever the format — `gpgsig-sha256` in
+/// a SHA-256 repository, and an SSH signature uses the same key — and it is the
+/// only thing that tells a commit nobody signed apart from one this machine
+/// cannot verify. What is inside it is deliberately not decodable: the fixture
+/// is about the header being *there*, and a runner with gpg and one without
+/// reach the same verdict over bytes gpg cannot make sense of.
+const FORGED_SIGNATURE: &str = concat!(
+    "gpgsig -----BEGIN PGP SIGNATURE-----\n",
+    " \n",
+    " bm90IGEgc2lnbmF0dXJl\n",
+    " -----END PGP SIGNATURE-----\n",
+);
+
 /// What git prefixes the argument list of every process it starts with, under
 /// `GIT_TRACE`.
 const MARK: &str = "trace: built-in: git ";
@@ -275,6 +300,78 @@ impl Corpus {
         std::fs::remove_dir_all(&dir).unwrap();
     }
 
+    /// `count` ratified decisions, half of them ratified by a commit carrying a
+    /// signature header and half by a commit carrying none.
+    ///
+    /// **The commits are written as objects rather than committed**, and that
+    /// is what makes the signed half possible at all: a header no keyring can
+    /// produce on demand is one `hash-object -t commit` writes verbatim. It is
+    /// the same act `git commit` performs — a tree, a parent, the message — and
+    /// the branch is moved onto the chain at the end, over the tree it already
+    /// had, so nothing in the worktree differs from what `main` carries.
+    ///
+    /// The two halves are the two answers `commit_carries_signature` exists to
+    /// tell apart: `%G?` says `N` for both a commit nobody signed and a
+    /// signature git could not attempt, and only the object says which. The
+    /// forged block is deliberately not decodable — whether gpg is installed on
+    /// the runner, and what it makes of the bytes, decides nothing here, because
+    /// the statuses it can reach for them (`N` with the header there, `E`) are
+    /// the same verdict.
+    fn seed_ratifications(&self, count: usize) {
+        // A file the decisions' scope matches, outside the one the seeded tasks
+        // carry: a scope matching nothing is a dead scope, and a scope shared
+        // with an open task charges its constraint to that task's budget. This
+        // fixture means neither.
+        std::fs::create_dir_all(self.0.join("doc")).unwrap();
+        std::fs::write(self.0.join("doc/note.md"), "// seed\n").unwrap();
+        // Declared, or every verdict is `None`: with no key in the file, §8's
+        // advisory mode is what `signature_state` answers, and it answers it
+        // before it ever asks about a commit.
+        std::fs::write(
+            self.0.join(".ank/allowed_signers"),
+            "marie@example.org gpg 0123456789ABCDEF0123456789ABCDEF01234567\n",
+        )
+        .unwrap();
+        for n in 0..count {
+            let id = adr_id(n);
+            std::fs::write(
+                self.entity(&id),
+                format!(
+                    "---\nid: {id}\ntype: adr\nslug: example\ntitle: A decision\n\
+                     created: 2026-07-20T00:00:00Z\nstatus: accepted\nratified: {anchor}\n\
+                     scope:\n  - doc/**\nconstraint: |\n  Decision {n} binds doc.\n\
+                     schema: 1\nversion: 1\n---\n\nWhy.\n",
+                    anchor = anchor(n)
+                ),
+            )
+            .unwrap();
+        }
+        self.git(&["add", "-A"]);
+        self.git(&["commit", "-qm", "decisions"]);
+
+        // One tree for the whole chain, which is HEAD's: a ratification records
+        // the anchor in its message, and these carry no write of their own.
+        let tree = self.git(&["rev-parse", "HEAD^{tree}"]);
+        let mut parent = self.git(&["rev-parse", "HEAD"]);
+        for n in 0..count {
+            let id = adr_id(n);
+            let signed = n % 2 == 0;
+            let header = if signed { FORGED_SIGNATURE } else { "" };
+            let object = format!(
+                "tree {tree}\nparent {parent}\n\
+                 author Test <test@ank.local> 1753660800 +0000\n\
+                 committer Test <test@ank.local> 1753660800 +0000\n{header}\n\
+                 ratify {id}\n\nconstraint+scope: {anchor}\nby: human:marie\n",
+                anchor = anchor(n)
+            );
+            parent = self
+                .stdin_git(&["hash-object", "-t", "commit", "-w", "--stdin"], &object)
+                .trim()
+                .to_string();
+        }
+        self.git(&["update-ref", "refs/heads/main", &parent]);
+    }
+
     /// A git command fed on standard input, with its standard output returned.
     fn stdin_git(&self, args: &[&str], input: &str) -> String {
         let mut child = spawn("git")
@@ -358,6 +455,24 @@ impl Drop for Corpus {
 /// A well-formed identifier for the nth seeded task.
 fn id(n: usize) -> String {
     format!("TASK-{:012x}", 0x1000_0000_0000u64 + n as u64)
+}
+
+/// A well-formed identifier for the nth seeded decision.
+fn adr_id(n: usize) -> String {
+    format!("ADR-{:012x}", 0x2000_0000_0000u64 + n as u64)
+}
+
+/// The anchor the nth seeded decision claims to have been ratified with.
+///
+/// **Not the hash of its constraint**, and it cannot be: the normalisation and
+/// the hash live in the binary, this suite declares no dependency on it, and
+/// re-deriving either here would be a second implementation to keep true. So
+/// every seeded decision reads as altered since ratification, which is a fault
+/// this fixture carries deliberately. It changes nothing the measurement below
+/// asks: the freeze and the signature are two independent readings of the same
+/// commit, and it is the second one that is being counted.
+fn anchor(n: usize) -> String {
+    format!("{:012x}", 0xabc0_0000_0000u64 + n as u64)
 }
 
 /// The number that follows `name` in a JSON document.
@@ -527,6 +642,104 @@ fn status_asks_git_no_question_twice_and_reads_the_plane_in_one_batch() {
         started, single,
         "{REFS} coordination refs cost more git than one does"
     );
+}
+
+/// A ratification costs no process of its own, and the verdict is the same
+/// verdict (TASK-fc0334201ccf).
+///
+/// **Counted over two corpora, and never timed.** `check` and `review` each
+/// asked git for one commit object per ratification — forty-seven of the
+/// sixty-four processes they started on this repository, one `cat-file commit`
+/// per decision that has been ratified, and forty-seven is not a constant. The
+/// question is one bit per commit and `cat-file --batch` answers all of them at
+/// once, which is what the coordination plane already does two call sites away.
+///
+/// The claim is invariance and not a ceiling: what is asserted is that the two
+/// counts are *equal* over corpora [`FACTOR`] apart, never that either is some
+/// particular number. A ceiling would be a number to revise at every change,
+/// and a duration would be a measurement of the runner — process creation costs
+/// about 25ms on a Windows runner against 2-3ms on Linux, and the floor of one
+/// commit on one runner image has measured 376ms and then 612ms.
+///
+/// And the verdicts are asserted beside the count, on both corpora, because a
+/// batch that read the wrong bytes would be perfectly invariant and perfectly
+/// wrong: a commit carrying a `gpgsig` header nobody can check is `Unchecked`
+/// and counted for the corpus, a commit carrying none is `Absent` and a fault
+/// per entity, and the batch is the only thing that now tells them apart.
+#[test]
+fn every_ratification_signature_is_read_in_one_batch() {
+    let many = Corpus::new();
+    many.seed_ratifications(RATIFICATIONS);
+    let few = Corpus::new();
+    few.seed_ratifications(RATIFICATIONS / FACTOR);
+
+    // Warm, and both the same way: a cold run builds the index and asks git for
+    // the signatures it has no verdict for yet, and a comparison between a cold
+    // corpus and a warm one would be a comparison of two different questions.
+    for c in [&many, &few] {
+        c.json(&["check", "--json"]);
+        c.json(&["check", "--json"]);
+        c.json(&["review", "--json"]);
+    }
+
+    for verb in ["check", "review"] {
+        let (over_many, _) = many.git_processes(&[verb, "--json"]);
+        let (over_few, _) = few.git_processes(&[verb, "--json"]);
+        assert_eq!(
+            over_many.len(),
+            over_few.len(),
+            "{RATIFICATIONS} ratifications cost {verb} more git than \
+             {} do:\nmany {over_many:#?}\nfew {over_few:#?}",
+            RATIFICATIONS / FACTOR
+        );
+        assert_eq!(
+            over_many.iter().filter(|a| reads_one_commit(a)).count(),
+            0,
+            "a commit is still read on its own: {over_many:#?}"
+        );
+    }
+
+    // The verdicts, through the binary and on both corpora, so that neither the
+    // batch nor the fallback beside it can be reading bytes that say something
+    // else.
+    for (c, count) in [(&many, RATIFICATIONS), (&few, RATIFICATIONS / FACTOR)] {
+        let doc = c.json(&["check", "--json"]);
+        let unsigned = count / 2;
+        assert_eq!(
+            doc.matches("its ratification commit is not signed").count(),
+            unsigned,
+            "{unsigned} ratifications carry no signature header: {doc}"
+        );
+        for n in 0..count {
+            let ratified_by_a_signature = n % 2 == 0;
+            let named = doc.contains(&format!(
+                "\"subject\":\"{}\",\"message\":\"its ratification commit is not signed",
+                adr_id(n)
+            ));
+            assert_eq!(
+                named,
+                !ratified_by_a_signature,
+                "{} is reported by the object its ratification is: {doc}",
+                adr_id(n)
+            );
+        }
+        // The other half, counted once for the corpus rather than once per
+        // entity, which is what `check` does with a signature it cannot check.
+        assert!(
+            doc.contains(&format!(
+                "{} ratification signature(s) could not be checked here",
+                count - unsigned
+            )),
+            "the signatures that are there are counted and not refused: {doc}"
+        );
+    }
+}
+
+/// `cat-file commit <object name>`, which is one ratification read one process
+/// at a time.
+fn reads_one_commit(argv: &str) -> bool {
+    argv.strip_prefix("cat-file commit ")
+        .is_some_and(|name| name.len() == 40 && name.chars().all(|c| c.is_ascii_hexdigit()))
 }
 
 /// The corpus is keyed on its root commit, and the history is walked to find it


### PR DESCRIPTION
- **The signature of every ratification is read in one batch**
- **TASK-fc0334201ccf is done, proved by commit:9d2a1ea**
