### PR TITLE
What a day of parallel agents taught the guide and the skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,23 @@ run id. Once the task lands on the default branch, the `attest` job records
 skipping when the proof does not reach the remote. The recipe and the contract
 it rests on are in `docs/getting-started.md`.
 
+## Landing
+
+`main` is protected and takes no direct push. Work reaches it through a pull
+request: commit on your branch, `gh pr create --fill --base main --head
+<branch>`, then `gh pr merge --merge`. Ratifying has its own recipe, in
+`CONTRIBUTING.md`, because `ank accept` runs on the default branch and its
+commit still has to arrive through a PR.
+
+**A merge commit is the only allowed method, and that is load-bearing.** A
+ratification is located by the subject of its commit, `ratify <id>`, walked with
+`rev-list --full-history` and no path restriction. A merge preserves that commit
+whole. A squash rewrites the subject to the pull request title and the anchor is
+never found again, which `check` reports as a signal at exit 0: the corpus
+quietly stops being verifiable while CI stays green. A rebase keeps the subject
+and drops the signature, which is a fault. Both are disabled on the repository
+and in its ruleset. Do not re-enable them.
+
 ## Testing
 
 A criterion that talks about the binary is tested through the binary. When a
@@ -45,3 +62,14 @@ only the function meant to produce X: twice, green unit tests covered code that
 was right on a path the binary never reached. The same rule applies to
 platforms: OS-dependent behaviour is not verified until it has run on all
 three.
+
+**A fact is measured, not read.** Establish what the code does by running it and
+counting what comes back, never by reading it and concluding: the suite into an
+empty `TMPDIR` and then list what it left behind, the binary through a
+pseudo-terminal and then compare the frames, `GIT_TRACE` at an absolute path and
+then count the processes. Prove a process cost by counting processes and never
+by timing: a wall in milliseconds measures the runner, where creating a process
+costs about 25ms on a Windows runner against 2-3ms on Linux and swings by half
+between two runs of one image. Record the numbers with `ank log` while you hold
+the claim. A task that closes with a proof and no measurement is green and
+leaves nothing behind for whoever asks later what was actually checked.

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -2,7 +2,7 @@
 name: ank
 description: Read a repository's tasks and binding constraints, claim work, and finish it with proof. Use when working in a repo that has a .ank/ directory.
 metadata:
-  revision: "c5bae2a5f350"
+  revision: "d25cedf8fe35"
 ---
 
 # ank
@@ -69,7 +69,11 @@ Execute:
 Shape:
 
     ank new task          a scope is mandatory; a discovered subtask is a new task with
-                          blocked_by, never a softened criterion
+                          blocked_by, never a softened criterion. Point the edge the way
+                          the work runs: if the new task carries part of your criterion,
+                          yours waits on it and never the reverse. Backwards, neither
+                          moves, and `graph` reports no cycle because the dependency is
+                          in the criterion's prose and not in an edge
     ank new adr           a decision the corpus is held to afterwards, not a thing to do
                           now; lands proposed, binding nobody until ratified
     ank amend <id>        blocked_by, scope and criteria, added and removed explicitly;

--- a/skill/loop/SKILL.md
+++ b/skill/loop/SKILL.md
@@ -2,7 +2,7 @@
 name: ank-loop
 description: Work through the open tasks in .ank/ without supervision, one claim at a time. Use when asked to work the backlog, chain tasks, or run autonomously in a repository with a .ank/ directory.
 metadata:
-  revision: "735328589adf"
+  revision: "8ff677f38578"
 ---
 
 # ank-loop
@@ -42,6 +42,13 @@ Do not soften the criterion.
     one clause rests on a false premise    ank log "discrepancy: <assumed> vs <measured>", finish the rest
     the whole criterion is wrong           ank release --reason "<why>", move on
     a decision is missing                  ank release --reason "<which>", flag it for planning, move on
+    it names work your scope cannot reach  do the part you can, file the rest, then
+                                           ank release --reason "<what is left, and where>"
+
+That last row is not a failure and is the commonest of the four. A criterion
+that is right about the work and wrong about who can do it is answered by
+releasing it, not by widening a scope you were not given: say what you measured,
+what you finished, and which task carries the remainder.
 
 Work you discover is a new task with blocked_by, left for a later pass. Never
 a detour in this one.

--- a/skill/plan/SKILL.md
+++ b/skill/plan/SKILL.md
@@ -2,7 +2,7 @@
 name: ank-plan
 description: Interview a goal into decisions and tasks recorded in .ank/. Use when someone brings a feature, change, or problem to plan before implementation in a repository with a .ank/ directory.
 metadata:
-  revision: "03d408e5e20f"
+  revision: "c006ab14a4df"
 ---
 
 # ank-plan
@@ -26,6 +26,12 @@ Never ask a question the repository answers. Before the first question:
 
 Then read the code the goal touches. A question answered by reading, asked
 anyway, teaches the human to stop answering.
+
+**Re-measure what you are about to plan around.** A number from an earlier
+session is a claim about a tree that has moved since, and a goal built on one is
+a goal aimed at the wrong place. Take the measurement again before the first
+question: the work may already be done, and where it is not, the shape of what
+remains is rarely the shape that was reported.
 
 ## The interview
 


### PR DESCRIPTION
Five changes, each from something that actually happened this week rather
than from a review of the prose.

CLAUDE.md gains a Landing section. main became protected yesterday and
nothing told an agent: the same paragraph about branch, PR and merge commit
was written by hand into thirteen dispatch prompts. An agent working here
without that would push to main, be refused, and improvise, and the
improvisation that matters is the merge method. A squash rewrites the subject
a ratification is found by, and check reports that as a signal at exit 0, so
the corpus stops being verifiable while CI stays green.

CLAUDE.md's Testing section gains "a fact is measured, not read". The best
work this week established facts by running: the suite into an empty TMPDIR
and then listing what it left, the binary through a pty and then comparing
frames, GIT_TRACE and then counting processes. The weakest closed with a
proof and no measurement, which is green and leaves nothing behind.

The contract gains a sentence on the direction of a blocked_by edge.
TASK-ac2ff41162c6 and TASK-02350943e2b1 deadlocked: one criterion needed work
only the other could do, and the other waited on it. graph reported no cycle,
correctly, because the dependency was in the criterion's prose.

ank-loop gains the fourth row of its table, which turned out to be the
commonest: the criterion is right about the work and wrong about who can
reach it. Four holders released for exactly that this week and every one was
right, while the table named only "the whole criterion is wrong".

ank-plan gains a line about re-measuring. Planning the git process work
started from a number two days old that TASK-5690eae1e008 had already made
false, and only recounting found it.

What is deliberately not changed: "accept is not yours to run" stays
absolute. ADR-91b77f036884 binds every skill mentioning accept to describe it
and never invite it, and a delegation given once is a fact about a session,
not about the skill.

Revisions recomputed, ceilings held, 21 skill tests green.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CwtHQ93fqgQP24UATUo5Ut
