### PR TITLE
A run pays once for what it answers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,36 @@
 name: ci
 
+# `push` on the default branch and nowhere else, because every other push is
+# already answered: main takes no direct push, so a commit arrives through a
+# pull request and `pull_request` is the event that tests it. Listening to both
+# ran each workflow twice per commit, which cost no money on a public repository
+# and cost a reader every listing: `gh pr checks` printed twenty-four rows where
+# twelve say the same thing, in pairs pointing at different runs.
+#
+# What this gives up is CI on a branch pushed with no pull request open, which
+# is worth naming: that branch now gets its first answer when the pull request
+# exists. `attest` is unaffected and still fires, it already asked for a push on
+# the default branch.
 on:
   push:
+    branches: [main]
   pull_request:
 
 # Read-only: this workflow publishes nothing. Artifacts and tags are the
 # perimeter of release.yml (TASK-b8c9d0e1f2a3).
 permissions:
   contents: read
+
+# One run per ref, and the two halves are not symmetric. A pull request that is
+# pushed again has nothing to learn from the run it superseded, so that one is
+# cancelled. The default branch is queued instead, never cancelled, because
+# `attest` writes `refs/ank/proof/*` and two of them racing is exactly how an
+# intermediate merge commit goes red while the head of main is green: whichever
+# run got there first recorded the proofs and the other found them taken. Serial
+# runs on main make that race impossible rather than tolerable.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   test:
@@ -30,6 +53,22 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
+
+      # `actions/cache` and not one of the Rust cache actions, for the reason
+      # the next comment gives about toolchains: a first-party action is the
+      # same trust as the checkout above, where a third-party one would be a new
+      # dependency in the supply chain for something GitHub already ships. The
+      # key is the lockfile, so a dependency change misses on purpose, and the
+      # restore-key falls back to the last build of this OS rather than to none.
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+            target
+          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-test-
 
       # The Rust toolchain preinstalled on the runners is enough, rustfmt
       # included. A third-party toolchain action would be one more dependency
@@ -77,6 +116,21 @@ jobs:
       # Exit 8 means findings, and that is a failure here. Signals exit 0.
       - run: cargo run -q --bin ank -- check
 
+      # The binary the step above just built, kept for `attest`. That job used
+      # to run `cargo run` of its own and spend nine minutes, the most expensive
+      # job in this file, rebuilding what this one had compiled two hundred
+      # seconds earlier. One platform is enough: `attest` runs on ubuntu.
+      #
+      # A day, because nothing reads this after the run that made it.
+      - name: the binary this run built
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ank-ubuntu
+          path: target/debug/ank
+          retention-days: 1
+          if-no-files-found: error
+
   # `done` records what ran on the machine that ran it. That is a local claim,
   # and `check` says so on the default branch: "done with no test proof: nothing
   # external anchors it". Ten tasks in this corpus carried that signal, each one
@@ -123,11 +177,24 @@ jobs:
         with:
           fetch-depth: 0
 
+      # The binary the test job built, rather than one this job compiles. It
+      # `needs` that job, so the artefact exists whenever this runs, and the two
+      # cannot disagree about what they are attesting: it is the same file.
+      - uses: actions/download-artifact@v4
+        with:
+          name: ank-ubuntu
+          path: ${{ runner.temp }}/bin
+
+      - name: the binary is the one the tests ran
+        run: |
+          chmod +x "$RUNNER_TEMP/bin/ank"
+          "$RUNNER_TEMP/bin/ank" --version
+
       - name: the tasks this run anchors
         id: unanchored
         run: |
           code=0
-          out=$(cargo run -q --bin ank -- check --json) || code=$?
+          out=$("$RUNNER_TEMP/bin/ank" check --json) || code=$?
           # The contract, and the whole of it: 8 is findings, 9 is the
           # environment. Both are red here, and 9 says which so nobody goes
           # looking for a broken corpus.
@@ -167,7 +234,7 @@ jobs:
           fi
           failed=0
           for id in $IDS; do
-            cargo run -q --bin ank -- attest "$id" \
+            "$RUNNER_TEMP/bin/ank" attest "$id" \
               --proof "test:$GITHUB_RUN_ID" --detached --json || failed=1
           done
           [ "$failed" -eq 0 ]
@@ -296,6 +363,21 @@ jobs:
       # --locked because the lockfile is half the claim: lockfile v4 needs 1.78
       # on its own, and a resolution performed here would measure a different
       # tree from the one that ships.
+      # Keyed on the declared MSRV as well as the lockfile: each toolchain
+      # compiles its own artefacts, and a cache shared between them would hand a
+      # job objects the compiler it runs cannot read. `msrv is tight` below is
+      # deliberately left uncached, because its job is to prove that a build
+      # FAILS and a restored `target` is the one thing that could make it pass.
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+            target
+          key: ${{ runner.os }}-cargo-msrv-${{ steps.floor.outputs.declared }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-msrv-
+
       - name: build on the declared MSRV
         shell: bash
         env:

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -15,13 +15,24 @@ name: install
 # shell script, and a Windows row would share the row's name and none of its
 # steps. The two jobs assert the same properties in the two languages.
 
+# `push` on the default branch only, for the reason ci.yml gives at the same
+# place: main takes no direct push, so every other commit arrives through a pull
+# request and `pull_request` already tests it. Listening to both ran this
+# workflow twice per commit.
 on:
   push:
+    branches: [main]
   pull_request:
 
 # Read-only. This workflow publishes nothing; it reads the release page.
 permissions:
   contents: read
+
+# One run per ref. This workflow writes nothing, so unlike ci.yml there is no
+# race to protect the default branch from and a superseded run is simply waste.
+concurrency:
+  group: install-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   # The version the staged release below carries. Deliberately not a version


### PR DESCRIPTION
Measured on run 33283957391, a full green run of ci on main, seventeen
minutes wall clock:

    attest / ubuntu-latest   556s
    windows-latest           476s
    macos-latest             410s
    ubuntu-latest            201s
    msrv x3, version, tight  213s

Three things, each with its own reason.

attest was the most expensive job in the file. It ran cargo run to get a
binary the ubuntu leg of the matrix had compiled two hundred seconds earlier,
and its own comment already complained about building for two minutes to be
told there was nothing to do. It now downloads that binary as an artefact.
The artefact goes to RUNNER_TEMP and not into the checkout, because the last
step of the job asserts the working tree did not move and an untracked .bin/
would have failed it.

Nothing was cached. Every job compiled the workspace from zero, on every run.
actions/cache and not one of the Rust cache actions, because this file already
argues against a third-party action for something the image or GitHub ships:
the checkout is first-party and so is this. The msrv jobs key on the declared
toolchain as well as the lockfile, since artefacts are not shared between
compilers. `msrv is tight` is deliberately left uncached: its job is to prove
a build FAILS, and a restored target is the one thing that could make it pass.

Both workflows fired on push and on pull_request, so every commit of a pull
request ran each of them twice. On a public repository that costs no money and
it cost every listing: gh pr checks printed twenty-four rows where twelve say
the same thing. push is now the default branch only, which is where the only
push can land anyway.

And concurrency, which is not an optimisation but a fix. Two merges landing
close together ran two attest jobs at once, one lost the race to write
refs/ank/proof/*, and an intermediate merge commit went red while the head of
main was green. The standing advice was to judge main by the head run and not
to repair the red ones. Runs on the default branch are now serialised, so the
race cannot happen; pull requests cancel instead, having nothing to learn from
a run they superseded.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CwtHQ93fqgQP24UATUo5Ut
