### PR TITLE
fix/until returns what it matched

### DIFF
--- a/.ank/entities/LOG-43c657dfa3af.md
+++ b/.ank/entities/LOG-43c657dfa3af.md
@@ -1,0 +1,14 @@
+---
+id: LOG-43c657dfa3af
+type: log
+title: done, proof commit:383b82657930370f2f0eba3b1792015c84c3b455
+created: 2026-08-30T01:35:02Z
+author: haksolot@vmi3223161
+scope:
+  - crates/ank-tui/tests/terminal/mod.rs
+  - crates/ank-tui/tests/opening.rs
+about: TASK-3c9e7ba257b2
+seq: 0
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-bcd47d1b7652.md
+++ b/.ank/entities/LOG-bcd47d1b7652.md
@@ -1,0 +1,14 @@
+---
+id: LOG-bcd47d1b7652
+type: log
+title: attested commit:1453b92430fa0064d1cb1391b45ecb75a7f5b110
+created: 2026-08-30T01:35:56Z
+author: haksolot@vmi3223161
+scope:
+  - crates/ank-tui/tests/terminal/mod.rs
+  - crates/ank-tui/tests/opening.rs
+about: TASK-3c9e7ba257b2
+seq: 1
+schema: 4
+version: 1
+---

--- a/.ank/entities/TASK-3c9e7ba257b2.md
+++ b/.ank/entities/TASK-3c9e7ba257b2.md
@@ -1,0 +1,29 @@
+---
+id: TASK-3c9e7ba257b2
+type: task
+slug: the-frame-a-pty-test-asserts-on-is-the-frame-its
+title: The frame a pty test asserts on is the frame its predicate matched
+created: 2026-08-30T01:22:53Z
+author: haksolot@vmi3223161
+status: done
+scope:
+  - crates/ank-tui/tests/terminal/mod.rs
+  - crates/ank-tui/tests/opening.rs
+blocked_by: []
+done_criteria: |
+  `Live::until` returns the frame on which its predicate matched, and no test asserts on a transient screen by reading the terminal a second time after it. `the_frame_that_arrives_first_names_its_screen_and_says_it_has_not_read` in crates/ank-tui/tests/opening.rs asserts on the frame `until` hands back, not on a later `now()`.
+  
+  The race, measured on 2026-08-30: the test waits for the terminal to carry `terminal::UNREAD`, then calls `live.now()` to capture it. The reader can finish its read and repaint between the two, so the captured frame carries the rows instead of the unread notice and the assertion fails on a screen that was correct when the predicate saw it. Runs 33285078069 and its neighbour failed that way on macos-latest, on two pull requests that touch neither the reader nor its tests, while main was green on its five previous runs.
+  
+  One call site is affected out of 173 uses of `until`, so this is the shape of one test and not of the harness's users: the fix is that `until` stops discarding what it matched on.
+  
+  cargo test --workspace green on all three platforms, cargo fmt --check clean, and ank check reports no new fault.
+criteria_by: creator
+proof:
+  - type: commit
+    ref: 383b82657930370f2f0eba3b1792015c84c3b455
+    criteria: 320dd6fae92d
+    via: submitted
+schema: 4
+version: 3
+---

--- a/.ank/entities/TASK-3c9e7ba257b2.md
+++ b/.ank/entities/TASK-3c9e7ba257b2.md
@@ -24,6 +24,10 @@ proof:
     ref: 383b82657930370f2f0eba3b1792015c84c3b455
     criteria: 320dd6fae92d
     via: submitted
+  - type: commit
+    ref: 1453b92430fa0064d1cb1391b45ecb75a7f5b110
+    criteria: 320dd6fae92d
+    via: submitted
 schema: 4
-version: 3
+version: 4
 ---

--- a/crates/ank-tui/tests/opening.rs
+++ b/crates/ank-tui/tests/opening.rs
@@ -88,10 +88,13 @@ fn the_frame_that_arrives_first_names_its_screen_and_says_it_has_not_read() {
     repo.warm_find();
 
     let live = Live::open(&repo, WINDOW.0, WINDOW.1);
-    live.until("the first frame", |t| t.contains(terminal::UNREAD));
-    // [`Live::now`] and not [`Live::frame`]: the frame being asked about is the
-    // one drawn before the read, and `frame` will not settle on it.
-    let first = live.now();
+    // The frame [`Live::until`] matched on, and not a second read of the
+    // terminal. What is asked about here is a state that passes: the reader
+    // finishes and repaints, so a `now()` after the wait returns the screen
+    // that came next and the assertions below fail on a frame that was correct
+    // when the predicate saw it. Measured twice on macos-latest before this
+    // returned what it matched.
+    let first = live.until("the first frame", |t| t.contains(terminal::UNREAD));
     assert!(
         first.contains("2 ENTITIES"),
         "the opening frame does not name the screen it is drawing:\n{first}"

--- a/crates/ank-tui/tests/terminal/mod.rs
+++ b/crates/ank-tui/tests/terminal/mod.rs
@@ -933,11 +933,24 @@ impl Live {
         }
     }
 
-    pub fn until(&self, what: &str, done: impl Fn(&str) -> bool) {
+    /// **Returns the frame the predicate matched on**, which is the only frame
+    /// a caller waiting for a transient state can safely assert about. Reading
+    /// the terminal again afterwards asks a second question: the screen may
+    /// have moved on between the match and the read, and the assertion then
+    /// fails on a frame that was right when it was seen. Measured on
+    /// 2026-08-30, twice on one branch: the reader finished its read between
+    /// `until` and a following `now()`, so a test waiting for the unread notice
+    /// captured the populated list instead and reported that the first frame
+    /// had already read the corpus.
+    ///
+    /// Most of the hundred and seventy-odd callers wait for a state that stays,
+    /// and drop this. It costs them nothing.
+    pub fn until(&self, what: &str, done: impl Fn(&str) -> bool) -> String {
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
         while std::time::Instant::now() < deadline {
-            if done(&self.screen.lock().unwrap().text()) {
-                return;
+            let seen = self.screen.lock().unwrap().text();
+            if done(&seen) {
+                return seen;
             }
             std::thread::sleep(std::time::Duration::from_millis(25));
         }


### PR DESCRIPTION
- **A pty test asserts on the frame its predicate matched**
- **Attest the commit that survived the amend**
