### PR TITLE
attest reads the proofs it already wrote

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,20 @@ jobs:
         with:
           fetch-depth: 0
 
+      # The proofs earlier runs already wrote. `actions/checkout` fetches
+      # history and not `refs/ank/*`, so without this the `check` below reads a
+      # corpus in which nothing is anchored and this job re-attests every
+      # finished task, on every push, forever. Measured on run 33285805350:
+      # 199 ids listed and 336 seconds spent pushing refs that were already
+      # there, against 16 genuinely unproved in a clone that carries them.
+      #
+      # One direction and read-only. Pushing this pattern back is what
+      # force-reverts the attestations (the loop below pushes one ref by name),
+      # and a refspec matching nothing is not an error, so a corpus with no
+      # proofs yet passes through here untouched.
+      - name: the proofs already recorded
+        run: git fetch origin '+refs/ank/proof/*:refs/ank/proof/*'
+
       # The binary the test job built, rather than one this job compiles. It
       # `needs` that job, so the artefact exists whenever this runs, and the two
       # cannot disagree about what they are attesting: it is the same file.


### PR DESCRIPTION
Removing the build from this job exposed what the job actually costs. On run
33285805350, the first under the new workflow:

    download the binary                1s
    the tasks this run anchors         5s
    anchor them on this run          336s

The build is gone and the anchoring is the whole job. It anchors 199 tasks,
every push, while the remote already carries 200 refs under
refs/ank/proof/*. It is re-writing what is already there.

actions/checkout fetches history and not refs/ank/*, so `check` runs against a
corpus in which no finished task is anchored and reports all of them as
"done with no test proof". Measured on the same commit: 16 tasks are reported
that way in a clone carrying the proof refs, against 199 in CI.

So the job fetches them first. The list becomes the tasks that genuinely need
anchoring, which is what it was always meant to be, and it stops growing with
the corpus.

The fetch is one direction on purpose. Pushing this pattern back is what
force-reverts the CI's own attestations; the loop below pushes one ref by name
and keeps doing so.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CwtHQ93fqgQP24UATUo5Ut
