### PR TITLE
The licence every manifest declares is the one that was ratified

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -8,7 +8,7 @@
   },
   "homepage": "https://github.com/haksolot/ank",
   "repository": "https://github.com/haksolot/ank",
-  "license": "GPL-3.0-only",
+  "license": "Apache-2.0",
   "keywords": [
     "adr",
     "architecture-decision-record",

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,21 @@
+Ank
+Copyright 2026 Sean Lamet
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+---
+
+Ank was distributed under GPL-3.0-only up to and including 0.2.0. That change
+is prospective, and this notice does not withdraw it: a release received under
+GPL-3.0 stays available under GPL-3.0 to whoever received it
+(ADR-9f03438f5422).

--- a/crates/ank-cli/Cargo.toml
+++ b/crates/ank-cli/Cargo.toml
@@ -18,6 +18,7 @@ rust-version = "1.95"
 # release already made under GPL-3.0 stays available under GPL-3.0 to whoever
 # received it.
 license = "Apache-2.0"
+authors = ["Sean Lamet"]
 description = "The Ank CLI: one surface, refusing on state and never on identity."
 
 [[bin]]

--- a/crates/ank-cli/tests/skill.rs
+++ b/crates/ank-cli/tests/skill.rs
@@ -903,3 +903,114 @@ fn the_binary_names_the_skill_revision_it_was_built_alongside() {
          the comparison this exists for would mislead its reader"
     );
 }
+
+// ---------------------------------------------------------------------------
+// The licence, discovered rather than listed (ADR-9f03438f5422)
+// ---------------------------------------------------------------------------
+
+/// Every manifest in the tree that declares a licence, found by walking rather
+/// than by a list somebody keeps.
+///
+/// **A list is what let this drift.** TASK-47beb64fd204 swept the tree when
+/// ADR-9f03438f5422 relicensed it, and its criterion was met: every one of the
+/// eleven files it enumerated said Apache-2.0. `.claude-plugin/plugin.json` was
+/// not among the eleven, so it went on declaring `GPL-3.0-only` for thirteen
+/// days, in the one place a person installing the plugin reads a licence.
+/// Nothing noticed, because nothing was looking at anything but the list.
+///
+/// So this walks. A manifest added tomorrow is held to the same answer without
+/// anyone remembering to enrol it, which is the property the list did not have.
+fn declared_licences() -> Vec<(String, String)> {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let mut found = Vec::new();
+    let mut stack = vec![root.clone()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let name = path
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .to_string();
+            // Not build output, not vendored code, and not the corpus: `.ank/`
+            // records what the licence *was*, and that history is the thing the
+            // relicensing is careful to keep (ADR-9f03438f5422).
+            if path.is_dir() {
+                if !matches!(name.as_str(), "target" | "node_modules" | ".git" | ".ank") {
+                    stack.push(path);
+                }
+                continue;
+            }
+            let text = match name.as_str() {
+                "Cargo.toml" | "package.json" | "plugin.json" => match fs::read_to_string(&path) {
+                    Ok(t) => t,
+                    Err(_) => continue,
+                },
+                _ => continue,
+            };
+            for line in text.lines() {
+                let line = line.trim();
+                // A declaration, never a comment about one: the manifests carry
+                // prose explaining what the licence used to be, and that prose
+                // is correct and stays.
+                if line.starts_with("//") || line.starts_with('#') {
+                    continue;
+                }
+                let declared = line
+                    .strip_prefix("license = \"")
+                    .or_else(|| line.strip_prefix("\"license\": \""))
+                    .and_then(|rest| rest.split('"').next());
+                if let Some(value) = declared {
+                    let shown = path
+                        .strip_prefix(&root)
+                        .unwrap_or(&path)
+                        .to_string_lossy()
+                        .to_string();
+                    found.push((shown, value.to_string()));
+                }
+            }
+        }
+    }
+    found.sort();
+    found
+}
+
+/// **Every declaration in the tree says Apache-2.0** (ADR-9f03438f5422).
+#[test]
+fn every_manifest_declares_the_ratified_licence() {
+    let found = declared_licences();
+    assert!(
+        !found.is_empty(),
+        "no licence declaration was found at all, so this test is asserting nothing"
+    );
+    let wrong: Vec<_> = found.iter().filter(|(_, v)| v != "Apache-2.0").collect();
+    assert!(
+        wrong.is_empty(),
+        "ADR-9f03438f5422 relicensed this tree to Apache-2.0 whole, and these \
+         still say otherwise: {wrong:#?}"
+    );
+}
+
+/// **And the copyright is asserted somewhere a reader can find it.**
+///
+/// Apache-2.0 propagates attribution through notices, and the licence text at
+/// the root carries the unfilled `[name of copyright owner]` of the appendix,
+/// which is the verbatim text and not a notice. `NOTICE` is where the claim
+/// lives, and it is what a redistributor is asked to keep.
+#[test]
+fn the_copyright_is_asserted_in_a_notice() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let notice = fs::read_to_string(root.join("NOTICE"))
+        .expect("NOTICE must exist: it is where the copyright is asserted");
+    assert!(
+        notice.contains("Sean Lamet"),
+        "NOTICE names no copyright owner:\n{notice}"
+    );
+    assert!(
+        notice.contains("Apache License"),
+        "NOTICE does not name the licence it notices:\n{notice}"
+    );
+}

--- a/crates/ank-contract/Cargo.toml
+++ b/crates/ank-contract/Cargo.toml
@@ -17,6 +17,7 @@ rust-version = "1.95"
 # the tool the day after, which is how a line redrawn twice in one direction
 # turned out to be a line in the wrong place.
 license = "Apache-2.0"
+authors = ["Sean Lamet"]
 description = "The Ank machine contract: the verb table, the refusals and the exit codes, consumed by every surface."
 
 # Deliberately none, and this is load-bearing rather than tidy. Every surface

--- a/crates/ank-core/Cargo.toml
+++ b/crates/ank-core/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 # unit, so a floor that holds only here would not be a floor.
 rust-version = "1.95"
 license = "Apache-2.0"
+authors = ["Sean Lamet"]
 description = "Parser and data model for the Ank format. The format is the specification; this crate is its reference implementation."
 
 [dependencies]

--- a/crates/ank-daemon/Cargo.toml
+++ b/crates/ank-daemon/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2021"
 rust-version = "1.95"
 # Apache-2.0, like the whole tree (ADR-9f03438f5422).
 license = "Apache-2.0"
+authors = ["Sean Lamet"]
 description = "The Ank watcher: it keeps declared corpora warm, answers no verb, and nothing depends on it."
 
 # **A library, and no `[[bin]]`** (ADR-a22cd3196529, ADR-1ea31c2f3c5a). The

--- a/crates/ank-mcp/Cargo.toml
+++ b/crates/ank-mcp/Cargo.toml
@@ -22,6 +22,7 @@ edition = "2021"
 rust-version = "1.95"
 # Apache-2.0, like the whole tree (ADR-9f03438f5422).
 license = "Apache-2.0"
+authors = ["Sean Lamet"]
 description = "The Ank protocol surface: every verb the CLI dispatches, over MCP, generated from one table."
 
 # **A library, and no `[[bin]]`** (ADR-fd98f4bc6dea). The surface is the verb

--- a/crates/ank-tui/Cargo.toml
+++ b/crates/ank-tui/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2021"
 rust-version = "1.95"
 # Apache-2.0, like the whole tree (ADR-9f03438f5422).
 license = "Apache-2.0"
+authors = ["Sean Lamet"]
 description = "The Ank terminal reader: it draws what the CLI prints, and reaches the corpus only by running it."
 
 # **The dependency list is the constraint made mechanical** (ADR-8bd76e8d7c4e,

--- a/crates/ank-tui/tests/opening.rs
+++ b/crates/ank-tui/tests/opening.rs
@@ -88,13 +88,17 @@ fn the_frame_that_arrives_first_names_its_screen_and_says_it_has_not_read() {
     repo.warm_find();
 
     let live = Live::open(&repo, WINDOW.0, WINDOW.1);
-    // The frame [`Live::until`] matched on, and not a second read of the
-    // terminal. What is asked about here is a state that passes: the reader
-    // finishes and repaints, so a `now()` after the wait returns the screen
-    // that came next and the assertions below fail on a frame that was correct
-    // when the predicate saw it. Measured twice on macos-latest before this
-    // returned what it matched.
-    let first = live.until("the first frame", |t| t.contains(terminal::UNREAD));
+    // [`Live::ever`] and not [`Live::until`], because this frame does not last.
+    // The reader draws it, finishes its read and repaints, and both halves of
+    // that were measured failing on macos-latest: first an assertion against a
+    // screen re-read after the wait, which by then carried the rows, and then a
+    // timeout against a session whose unread frame had come and gone inside the
+    // twenty-five millisecond sampling interval. The reader got faster this week
+    // and closed the window. `ever` reads the frames the drain recorded, so a
+    // frame that existed is answerable whether or not it is still up.
+    let first = live.ever("carried the unread notice", |t| {
+        t.contains(terminal::UNREAD)
+    });
     assert!(
         first.contains("2 ENTITIES"),
         "the opening frame does not name the screen it is drawing:\n{first}"

--- a/crates/ank-tui/tests/terminal/mod.rs
+++ b/crates/ank-tui/tests/terminal/mod.rs
@@ -825,6 +825,16 @@ pub struct Live {
     child: std::process::Child,
     writer: std::fs::File,
     screen: std::sync::Arc<std::sync::Mutex<Screen>>,
+    /// Every distinct frame this session painted, in order.
+    ///
+    /// **Sampling misses a frame that does not last.** [`Live::until`] looks at
+    /// the screen every twenty-five milliseconds, so a state the reader passes
+    /// through faster than that is never seen: measured on macos-latest, a test
+    /// waiting for the pre-read notice timed out against a screen that already
+    /// carried all 1202 rows. The reader got faster this week and the window
+    /// closed. Recorded here instead, so a frame that existed is answerable
+    /// whether or not it is still up.
+    seen: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
     drain: Option<std::thread::JoinHandle<()>>,
 }
 
@@ -909,7 +919,10 @@ impl Live {
             .expect("the binary must have been built");
 
         let screen = std::sync::Arc::new(std::sync::Mutex::new(Screen::new(columns, rows)));
+        let seen: std::sync::Arc<std::sync::Mutex<Vec<String>>> =
+            std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
         let into = std::sync::Arc::clone(&screen);
+        let recorded = std::sync::Arc::clone(&seen);
         let mut reader = master.try_clone().expect("the master side clones");
         // Drained on a thread of its own: a session that painted more than the
         // pseudo-terminal's buffer holds while nobody was reading would
@@ -921,7 +934,20 @@ impl Live {
                     // Linux answers EIO once the last slave is closed; macOS
                     // answers zero. Both mean the session is over.
                     Ok(0) | Err(_) => return,
-                    Ok(n) => into.lock().unwrap().feed(&buf[..n]),
+                    Ok(n) => {
+                        let text = {
+                            let mut screen = into.lock().unwrap();
+                            screen.feed(&buf[..n]);
+                            screen.text()
+                        };
+                        // Distinct frames only: a chunk that repaints nothing
+                        // visible is not a frame, and the history is read by a
+                        // linear search.
+                        let mut history = recorded.lock().unwrap();
+                        if history.last().map(|last| last != &text).unwrap_or(true) {
+                            history.push(text);
+                        }
+                    }
                 }
             }
         });
@@ -929,6 +955,7 @@ impl Live {
             child,
             writer: master,
             screen,
+            seen,
             drain: Some(drain),
         }
     }
@@ -945,6 +972,41 @@ impl Live {
     ///
     /// Most of the hundred and seventy-odd callers wait for a state that stays,
     /// and drop this. It costs them nothing.
+    /// The first frame this session ever painted that satisfies `done`,
+    /// whether or not it is still on screen.
+    ///
+    /// **For a state that passes.** [`Live::until`] samples, so it answers
+    /// about states that last; this reads the recorded history, so it answers
+    /// about states that happened. Use it only when the thing asked about is
+    /// transient by nature, such as the frame drawn before a read lands: for
+    /// anything that stays, `until` is the honest question, and searching
+    /// history there would match a frame from before the keystroke under test.
+    pub fn ever(&self, what: &str, done: impl Fn(&str) -> bool) -> String {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        loop {
+            if let Some(hit) = self
+                .seen
+                .lock()
+                .unwrap()
+                .iter()
+                .find(|frame| done(frame))
+                .cloned()
+            {
+                return hit;
+            }
+            if std::time::Instant::now() >= deadline {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(25));
+        }
+        panic!(
+            "no frame this session painted ever {what}; it painted {} distinct \
+             frames, the last being:\n{}",
+            self.seen.lock().unwrap().len(),
+            self.screen.lock().unwrap().text()
+        );
+    }
+
     pub fn until(&self, what: &str, done: impl Fn(&str) -> bool) -> String {
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
         while std::time::Instant::now() < deadline {

--- a/npm/ank-darwin-arm64/package.json
+++ b/npm/ank-darwin-arm64/package.json
@@ -3,6 +3,7 @@
   "version": "0.6.0",
   "description": "The ank binary for macOS on Apple silicon.",
   "license": "Apache-2.0",
+  "author": "Sean Lamet",
   "homepage": "https://github.com/haksolot/ank",
   "repository": {
     "type": "git",

--- a/npm/ank-linux-x64-musl/package.json
+++ b/npm/ank-linux-x64-musl/package.json
@@ -3,6 +3,7 @@
   "version": "0.6.0",
   "description": "The ank binary for Linux x86_64, statically linked against musl.",
   "license": "Apache-2.0",
+  "author": "Sean Lamet",
   "homepage": "https://github.com/haksolot/ank",
   "repository": {
     "type": "git",

--- a/npm/ank-win32-x64/package.json
+++ b/npm/ank-win32-x64/package.json
@@ -3,6 +3,7 @@
   "version": "0.6.0",
   "description": "The ank binary for Windows x86_64.",
   "license": "Apache-2.0",
+  "author": "Sean Lamet",
   "homepage": "https://github.com/haksolot/ank",
   "repository": {
     "type": "git",

--- a/npm/ank/package.json
+++ b/npm/ank/package.json
@@ -3,6 +3,7 @@
   "version": "0.6.0",
   "description": "The stupid coordination tool: tasks and architecture decisions in your repo, behind one CLI any coding agent can call.",
   "license": "Apache-2.0",
+  "author": "Sean Lamet",
   "homepage": "https://github.com/haksolot/ank",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "description": "Pi package manifest for the ank skill. Not published: the published package is @haksolot/ank, under npm/ank.",
   "license": "Apache-2.0",
+  "author": "Sean Lamet",
   "homepage": "https://github.com/haksolot/ank",
   "repository": {
     "type": "git",


### PR DESCRIPTION
.claude-plugin/plugin.json still said "GPL-3.0-only". ADR-9f03438f5422
relicensed this tree to Apache-2.0 whole and was ratified on 2026-08-17; that
line was written on 2026-08-08 and never moved. It is the one place a person
installing the plugin from the marketplace reads a licence, and it told them
the wrong one for thirteen days.

TASK-47beb64fd204 is titled "Every licence declaration in the tree says
Apache-2.0" and is done. Its criterion was met: every one of the eleven files
its inventory enumerated said Apache-2.0. The plugin manifest was not among
the eleven. The sweep was checked against its own list rather than against the
tree, which is how a hand-kept inventory fails and why the guard added here
walks instead of listing. Reintroducing the GPL line was measured to make it
red, naming the file and the value.

Attribution, which was asserted nowhere. The root LICENSE carries the Apache
appendix with [name of copyright owner] unfilled, and that is the verbatim
licence text rather than a notice, so it stays as it is. The claim goes in
NOTICE, which is what a redistributor is asked to keep, and into the eleven
manifests that declared a licence and no author.

What is deliberately kept: every sentence in the READMEs and the Cargo.toml
comments saying ank was GPL-3.0-only until 0.3.0 and that the change is
prospective. Those are not stale declarations, they are the statement of the
rights of somebody who received an earlier release, and ADR-9f03438f5422 is
explicit that a version distributed under GPL-3.0 stays available under it.
Deleting them would make the README lie in the other direction.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CwtHQ93fqgQP24UATUo5Ut
