### PR TITLE
The licence names its owner and its year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@ APPENDIX: How to apply the Apache License to your work.
    same "printed page" as the copyright notice for easier
    identification within third-party archives.
 
-Copyright [yyyy] [name of copyright owner]
+Copyright 2026 Sean Lamet
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crates/ank-cli/LICENSE
+++ b/crates/ank-cli/LICENSE
@@ -186,7 +186,7 @@ APPENDIX: How to apply the Apache License to your work.
    same "printed page" as the copyright notice for easier
    identification within third-party archives.
 
-Copyright [yyyy] [name of copyright owner]
+Copyright 2026 Sean Lamet
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crates/ank-cli/tests/skill.rs
+++ b/crates/ank-cli/tests/skill.rs
@@ -994,6 +994,61 @@ fn every_manifest_declares_the_ratified_licence() {
     );
 }
 
+/// **Every LICENSE in the tree names the owner rather than the placeholder.**
+///
+/// The Apache appendix ships as `Copyright [yyyy] [name of copyright owner]`,
+/// which is a template for the reader to fill and not a notice. Left as it
+/// came, the licence GitHub renders at the root of the repository asserts a
+/// copyright for nobody, in the one place most people ever look. There are four
+/// copies of the text in this tree, and they are found by walking rather than
+/// listed, for the reason ADR-9f03438f5422's own sweep gives.
+#[test]
+fn every_licence_text_names_its_copyright_owner() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let mut found = Vec::new();
+    let mut stack = vec![root.clone()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let name = path
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .to_string();
+            if path.is_dir() {
+                if !matches!(name.as_str(), "target" | "node_modules" | ".git" | ".ank") {
+                    stack.push(path);
+                }
+            } else if name == "LICENSE" {
+                let text = fs::read_to_string(&path).unwrap_or_default();
+                found.push((
+                    path.strip_prefix(&root).unwrap_or(&path).to_path_buf(),
+                    text,
+                ));
+            }
+        }
+    }
+    assert!(
+        !found.is_empty(),
+        "no LICENSE was found at all, so this test is asserting nothing"
+    );
+    for (path, text) in &found {
+        assert!(
+            !text.contains("[name of copyright owner]"),
+            "{} still carries the unfilled Apache placeholder",
+            path.display()
+        );
+        assert!(
+            text.contains("Copyright 2026 Sean Lamet"),
+            "{} names no copyright owner",
+            path.display()
+        );
+    }
+}
+
 /// **And the copyright is asserted somewhere a reader can find it.**
 ///
 /// Apache-2.0 propagates attribution through notices, and the licence text at

--- a/crates/ank-contract/LICENSE
+++ b/crates/ank-contract/LICENSE
@@ -186,7 +186,7 @@ APPENDIX: How to apply the Apache License to your work.
    same "printed page" as the copyright notice for easier
    identification within third-party archives.
 
-Copyright [yyyy] [name of copyright owner]
+Copyright 2026 Sean Lamet
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crates/ank-core/LICENSE
+++ b/crates/ank-core/LICENSE
@@ -186,7 +186,7 @@ APPENDIX: How to apply the Apache License to your work.
    same "printed page" as the copyright notice for easier
    identification within third-party archives.
 
-Copyright [yyyy] [name of copyright owner]
+Copyright 2026 Sean Lamet
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
All four copies of the Apache text carried the appendix as it ships,
"Copyright [yyyy] [name of copyright owner]". That is a template for a reader
to fill, and left unfilled it means the licence GitHub renders at the root of
the repository asserts a copyright for nobody, in the one place most people
ever look.

I argued once for leaving it: the appendix is the verbatim licence text, and
the notice belongs in NOTICE. The owner asked twice, it is his copyright, and
filling it is both common and harmless to licence detection, which matches on
the body rather than the appendix. Only that line moves, in each of the four
files.

The guard added with NOTICE now covers this too, and walks rather than lists,
so a fifth copy of the text is held to the same answer. Emptying the line again
was measured to make it red, naming the file.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CwtHQ93fqgQP24UATUo5Ut
