### PR TITLE
The installers draw the mark, not a fence of hashes

### DIFF
--- a/.ank/entities/LOG-0b29243f9813.md
+++ b/.ank/entities/LOG-0b29243f9813.md
@@ -1,0 +1,17 @@
+---
+id: LOG-0b29243f9813
+type: log
+title: Mutation-tested both new geometry assertions, and one of them was weak. Moving the stem row one
+created: 2026-08-30T14:55:44Z
+author: haksolot@vmi3223161
+scope:
+  - install.sh
+  - install.ps1
+  - .github/workflows/install.yml
+about: TASK-54c95c5f2d18
+seq: 4
+schema: 4
+version: 1
+---
+
+ column left in install.sh left every row of the mark still findable on its own: an animation frame drawn before the legs have grown pads their columns with the same eleven spaces the stem row begins with, so a row-by-row search finds the stem row whatever the finished shape is. The assertion now matches the ten rows together and consecutive, joined by a newline, after normalising the pty's CRLF. The same mutation on install.ps1's frame was caught immediately, because there the frame is compared as an array and not searched for in a stream.

--- a/.ank/entities/LOG-101e842ba00c.md
+++ b/.ank/entities/LOG-101e842ba00c.md
@@ -1,0 +1,17 @@
+---
+id: LOG-101e842ba00c
+type: log
+title: "The work preceded this record: the change was made in conversation and the task written to hold it,"
+created: 2026-08-30T14:42:01Z
+author: haksolot@vmi3223161
+scope:
+  - install.sh
+  - install.ps1
+  - .github/workflows/install.yml
+about: TASK-54c95c5f2d18
+seq: 0
+schema: 4
+version: 1
+---
+
+ so this claim is the anchor for the proof and not an account of the order things happened in.

--- a/.ank/entities/LOG-495596624b4e.md
+++ b/.ank/entities/LOG-495596624b4e.md
@@ -1,0 +1,17 @@
+---
+id: LOG-495596624b4e
+type: log
+title: "The workflow's new geometry assertion was wrong when first written and caught by running it:"
+created: 2026-08-30T14:52:38Z
+author: haksolot@vmi3223161
+scope:
+  - install.sh
+  - install.ps1
+  - .github/workflows/install.yml
+about: TASK-54c95c5f2d18
+seq: 3
+schema: 4
+version: 1
+---
+
+ install.sh draws a row as padding, then the sequence that colours it, then the cells, so the row as a literal string is not in the output until the escapes are stripped. drew_the_mark now strips CSI first. The PowerShell side does not have the problem -- there the frame is segments and the text is concatenated before any attribute is set -- which is why only one of the two needed it.

--- a/.ank/entities/LOG-8cd950e0ba89.md
+++ b/.ank/entities/LOG-8cd950e0ba89.md
@@ -1,0 +1,17 @@
+---
+id: LOG-8cd950e0ba89
+type: log
+title: "Codepage measurement, held while the claim is live. Encoded through .NET and decoded back: cp437"
+created: 2026-08-30T14:42:11Z
+author: haksolot@vmi3223161
+scope:
+  - install.sh
+  - install.ps1
+  - .github/workflows/install.yml
+about: TASK-54c95c5f2d18
+seq: 1
+schema: 4
+version: 1
+---
+
+ U+2588 -> 0xDB -> U+2588 survives; cp437 U+2713 -> 0xFB -> U+221A, a square root; cp1252 U+2588 -> 0xA6 -> U+00A6, a broken bar; cp65001 both survive. No failure produces 0x3F, so a question-mark test passes every one of them. This is why Test-GlyphSurvives round-trips instead of looking for '?', and it reversed the old comment in install.ps1 claiming conhost cannot draw the block.

--- a/.ank/entities/LOG-e105eabf7eaf.md
+++ b/.ank/entities/LOG-e105eabf7eaf.md
@@ -1,0 +1,17 @@
+---
+id: LOG-e105eabf7eaf
+type: log
+title: Console write cost of the Windows animation, counted with Say replaced by a counter and the
+created: 2026-08-30T14:45:30Z
+author: haksolot@vmi3223161
+scope:
+  - install.sh
+  - install.ps1
+  - .github/workflows/install.yml
+about: TASK-54c95c5f2d18
+seq: 2
+schema: 4
+version: 1
+---
+
+ timeline read out of Show-Logo. Segment by segment: 649 writes over 17 frames for 94 actual attribute changes, so 555 bought nothing. Coalescing adjacent segments in the same state: 298 writes, same 94 changes. The floor is 204 (12 rows x 17 frames, one write each), and the 94 over it are exactly the attribute changes, so what is left is not fragmentation. Counted and not timed: a wall in milliseconds here measures a Linux box, and the count is what conhost charges for on every machine.

--- a/.ank/entities/TASK-54c95c5f2d18.md
+++ b/.ank/entities/TASK-54c95c5f2d18.md
@@ -1,0 +1,70 @@
+---
+id: TASK-54c95c5f2d18
+type: task
+slug: the-installers-draw-the-mark-not-a-fence-of-hash
+title: The installers draw the mark, not a fence of hashes
+created: 2026-08-30T14:41:48Z
+author: haksolot@vmi3223161
+status: in_progress
+scope:
+  - install.sh
+  - install.ps1
+  - .github/workflows/install.yml
+blocked_by: []
+done_criteria: |
+  install.sh and install.ps1 draw the logo of assets/ank.svg in U+2588 where the reader's encoding is measured to carry it and in # where it is not, decided by a round trip through that encoding on Windows and by the locale under sh, never by a codepage or locale allowlist. The mark carries no hue: it is drawn in the terminal's own default foreground, and the animation distinguishes a part that is arriving from one that has landed by dim against normal and never by brightness. A caller with no terminal reads what it read before, byte for byte, and --no-welcome at a terminal draws nothing, asks nothing, emits no escape sequence and installs the same binary. The workflow recognises a frame in either cell, and asserts the logo present at a terminal as well as absent everywhere else.
+criteria_by: creator
+schema: 4
+version: 2
+---
+
+The two installers drew the logo as a fence of `#`, revealed a row at a time,
+in no colour at all. The shape was right -- it is `assets/ank.svg` at half
+vertical resolution -- but `#` is a hatch pattern with gaps in it, and ten rows
+of gaps do not read as a mark. The moment someone installs a tool is the one
+moment they are certainly paying attention, and ADR-5fbd99bf6fd5 spent that
+moment on a fence.
+
+## What the mark is allowed to be
+
+`assets/ank.svg` is `#1f2328` and `assets/ank-dark.svg` is `#e6edf3`: one shape,
+black on a light ground and white on a dark one. `\033[39m` is how a terminal
+spells exactly that, and `Write-Host` with no `-ForegroundColor` is how a
+console does. So the mark carries no hue of its own, and a hue chosen in an
+installer would be a third logo neither asset agrees with.
+
+That closes off the obvious way to animate it. A landing flash written as
+"brighter" does not survive not knowing the background: bold on a glyph that is
+already a solid block does nothing in a terminal that does not render bold as
+bright, and white on a light ground is invisible. Dim against normal survives
+both. So a part that appears whole arrives dim and settles, a part that grows
+does not (growing is already motion), and the finished shape blinks by going
+dim.
+
+## What the cell is allowed to be
+
+The old files refused U+2588 on the reasoning that a console under codepage 437
+renders it as a question mark. Measured, that is wrong twice:
+
+    cp437   U+2588 -> 0xDB      -> U+2588   survives
+    cp437   U+2713 -> 0xFB      -> U+221A   lost, and 0xFB is a square root
+    cp1252  U+2588 -> 0xA6      -> U+00A6   lost, and 0xA6 is a broken bar
+
+Codepage 437 carries the block at 0xDB and does not carry the tick. Codepage
+1252 carries neither and best-fits the block to a broken bar. Neither failure
+produces a question mark, so a test that looks for one ships a logo made of
+broken bars and a tick that is a radical -- worse than the fence it replaced.
+The round trip through the encoding refuses both and accepts what 437 genuinely
+carries.
+
+install.sh has no encoder between it and the terminal, so there the locale is
+the measurement: a locale that announces UTF-8 is a terminal that decodes UTF-8.
+
+## Why the colour stops at the mark
+
+The lines the install prints afterwards are not the mark and may carry a hue:
+green on a step that finished, cyan on a command the reader is meant to run,
+dim on what is incidental. All of it sits behind the gate the logo sits behind,
+so a caller with no terminal reads the bytes it read before either file learned
+about colour -- which is what ADR-5fbd99bf6fd5 promises a runner, a Dockerfile
+and a provisioning script.

--- a/.ank/entities/TASK-54c95c5f2d18.md
+++ b/.ank/entities/TASK-54c95c5f2d18.md
@@ -5,7 +5,7 @@ slug: the-installers-draw-the-mark-not-a-fence-of-hash
 title: The installers draw the mark, not a fence of hashes
 created: 2026-08-30T14:41:48Z
 author: haksolot@vmi3223161
-status: in_progress
+status: done
 scope:
   - install.sh
   - install.ps1
@@ -14,8 +14,13 @@ blocked_by: []
 done_criteria: |
   install.sh and install.ps1 draw the logo of assets/ank.svg in U+2588 where the reader's encoding is measured to carry it and in # where it is not, decided by a round trip through that encoding on Windows and by the locale under sh, never by a codepage or locale allowlist. The mark carries no hue: it is drawn in the terminal's own default foreground, and the animation distinguishes a part that is arriving from one that has landed by dim against normal and never by brightness. A caller with no terminal reads what it read before, byte for byte, and --no-welcome at a terminal draws nothing, asks nothing, emits no escape sequence and installs the same binary. The workflow recognises a frame in either cell, and asserts the logo present at a terminal as well as absent everywhere else.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: bb52ce3
+    criteria: c2e3eeadab49
+    via: submitted
 schema: 4
-version: 2
+version: 3
 ---
 
 The two installers drew the logo as a fence of `#`, revealed a row at a time,

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1218,14 +1218,38 @@ jobs:
           # one an exiting child sets is the one the engine keeps: seeded and
           # read here they would be two variables wearing one name, and a
           # refusal from install.ps1 would read back as a success.
+          # A transcript, and not `*>&1 | Out-String`, and the difference is not
+          # cosmetic: capturing the streams into a variable diverts the output
+          # so the console never receives it. Its cursor then never advances,
+          # Show-Logo's `$top = CursorPosition.Y - 12` comes out negative, and
+          # it returns without drawing a frame. Under a capture this step was
+          # therefore measuring a run in which the animation never happened --
+          # which no assertion noticed, because every assertion about the logo
+          # asked only that it stay away.
+          #
+          # Measured, on one install, both ways: the capture finds the
+          # questions and the checksum and no cell of the mark; the transcript
+          # finds all four. A transcript lets the output reach the console and
+          # records it as well, which is the only way to watch a run that draws.
           $installer = Join-Path $PSScriptRoot 'install.ps1'
+          $transcript = "$OutFile.transcript"
+          Remove-Item -Force $transcript -ErrorAction SilentlyContinue
+
           $global:LASTEXITCODE = 0
-          if ($NoWelcome) {
-              $out = (& $installer -Version $env:STAGED_VERSION -Dir $Dir -NoWelcome *>&1 | Out-String)
-          } else {
-              $out = (& $installer -Version $env:STAGED_VERSION -Dir $Dir *>&1 | Out-String)
+          Start-Transcript -Path $transcript -Force | Out-Null
+          try {
+              if ($NoWelcome) {
+                  & $installer -Version $env:STAGED_VERSION -Dir $Dir -NoWelcome
+              } else {
+                  & $installer -Version $env:STAGED_VERSION -Dir $Dir
+              }
+          } finally {
+              $code = $global:LASTEXITCODE
+              Stop-Transcript | Out-Null
           }
-          $code = $global:LASTEXITCODE
+
+          $out = ''
+          if (Test-Path $transcript) { $out = (Get-Content -Raw $transcript) }
 
           # What the probe was told, recorded beside what the installer said.
           # Without it, "-NoWelcome asked anyway" is the same message whether

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -238,10 +238,17 @@ jobs:
             LC_ALL=C cat -v staged.log
             exit 1
           fi
-          # The art is ASCII, so the frame is asserted absent as well as the
-          # escapes that animate it: a logo drawn without moving a cursor would
-          # pass the test above and still be noise in the log.
-          if grep -q '####' staged.log; then
+          # The frame is asserted absent as well as the escapes that animate it:
+          # a logo drawn without moving a cursor would pass the test above and
+          # still be noise in the log.
+          #
+          # Both cells, because which one is drawn is decided by the locale and
+          # a runner's locale is not this repository's to fix: U+2588 where it
+          # announces UTF-8, `#` where it does not. A test that knew only one of
+          # them would go quiet on half the machines it runs on.
+          # The cells are written out, not escaped: \x is not a thing grep's
+          # own syntax knows outside -P, and the bytes are already in this file.
+          if LC_ALL=C grep -qF -e '####' -e '██' staged.log; then
             echo "the logo was drawn with no terminal attached"
             exit 1
           fi
@@ -365,7 +372,7 @@ jobs:
           test ! -e nonode/node || { echo "the node-free PATH has a node on it"; exit 1; }
 
           cat > offer.py <<'PY'
-          import fcntl, os, select, signal, struct, sys, termios
+          import fcntl, os, re, select, signal, struct, sys, termios
 
           INSTALL = os.path.join(os.getcwd(), "install.sh")
           VERSION = os.environ["STAGED_VERSION"]
@@ -382,6 +389,62 @@ jobs:
           # a console decided to fold.
           SKILLS_Q = "Install them now?"
           ADOPT_Q = "Print the three prompts"
+
+          # Which cell the logo is drawn in is decided by the locale, and a
+          # runner's locale is not this repository's to fix: U+2588 where it
+          # announces UTF-8, `#` where it does not. Asked as "either", so this
+          # keeps meaning the same thing on a runner image that changes its
+          # mind about LANG.
+          LOGO_CELLS = ("██", "####")
+
+          def drew_logo(out):
+              return any(cell in out for cell in LOGO_CELLS)
+
+          # The finished mark, as the ten rows it is drawn in: assets/ank.svg at
+          # one cell per pixel column and one row per pair of pixel rows.
+          # install.sh prints each row literally, so no terminal has to be
+          # emulated to find them.
+          #
+          # This is the sh half of a claim the Windows job makes for install.ps1
+          # against the same ten rows. The two files say they carry one shape
+          # between them; pinned in one place only, that stays true in one place
+          # only.
+          def logo_block(cell):
+              b2, b4, b14 = cell * 2, cell * 4, cell * 14
+              loop = "          " + b4
+              side = "        " + b2 + "    " + b2
+              leg = "   " + b2 + "      " + b2 + "      " + b2
+              return "\n".join([
+                  loop,
+                  side,
+                  side,
+                  loop,
+                  "           " + b2,
+                  "   " + b4 + "    " + b2 + "    " + b4,
+                  leg,
+                  leg,
+                  leg,
+                  "     " + b14,
+              ])
+
+          # The escapes come out first. A row is drawn as padding, then the
+          # sequence that colours it, then the cells -- so the row as a string
+          # is only in there once the sequences are not.
+          ESCAPES = re.compile("\x1b\\[[0-9;?]*[A-Za-z]")
+
+          # The ten rows together and consecutive, never row by row. Asked one
+          # row at a time this passes on a mark that is wrong: a frame drawn
+          # before the legs have grown pads their columns with the same eleven
+          # spaces the stem row begins with, so the stem row is found in the
+          # animation whatever the finished shape turns out to be. Measured --
+          # moving that row one column left leaves every row still findable on
+          # its own, and the block not findable at all.
+          def drew_the_mark(out):
+              # A pty turns each newline the installer writes into a carriage
+              # return and a newline, so the block is joined by one and looked
+              # for in the other.
+              bare = ESCAPES.sub("", out).replace("\r\n", "\n")
+              return any(logo_block(cell) in bare for cell in ("█", "#"))
 
           def drive(args, keys, env_extra, timeout=180):
               """Run args on a pty of its own and type keys at it."""
@@ -482,6 +545,13 @@ jobs:
           run = case("accept", b"y\ny\n")
           want(run, not run["timed_out"], "it never finished")
           want(run, run["code"] == 0, "a failing skill step changed the exit code to %d" % run["code"])
+          # The presence, and not only the absence below. Every other assertion
+          # about the logo asks that it stay away, so all of them would pass on
+          # an installer that had stopped drawing it entirely -- which is the
+          # regression a person would actually notice.
+          want(run, drew_logo(run["out"]), "no logo was drawn at a terminal")
+          want(run, drew_the_mark(run["out"]),
+               "what was drawn is not the shape of assets/ank.svg")
           asked_once(run)
           want(run, run["ran"], "it accepted and never ran npx")
           want(run, installed(run), "the binary is not in place after the offer failed")
@@ -520,7 +590,7 @@ jobs:
           want(run, run["skills_asked"] == 0, "--no-welcome asked the skills offer anyway")
           want(run, run["adopt_asked"] == 0, "--no-welcome asked the adoption offer anyway")
           want(run, not run["ran"], "--no-welcome ran npx anyway")
-          want(run, "####" not in run["out"], "--no-welcome drew the logo at a terminal")
+          want(run, not drew_logo(run["out"]), "--no-welcome drew the logo at a terminal")
           want(run, installed(run), "--no-welcome cost the install its binary")
 
           # node absent: the command, and one line saying why it was not run.
@@ -697,6 +767,115 @@ jobs:
           }
           "install.ps1 parses"
 
+      # The two files carry one shape between them, and each says so in a
+      # comment: "the same logo, because two spellings of it would drift". A
+      # comment does not stop it drifting. This reads the rows install.ps1 would
+      # draw and compares them to the rows install.sh holds, so the claim is
+      # measured on the machine it matters on.
+      #
+      # The functions are lifted out of the parsed tree rather than copied here:
+      # a copy is a third spelling, and a third spelling drifts from both.
+      - name: its frames are the frames install.sh draws
+        run: |
+          $tokens = $null
+          $errors = $null
+          $ast = [System.Management.Automation.Language.Parser]::ParseFile(
+            (Resolve-Path ./install.ps1), [ref]$tokens, [ref]$errors)
+
+          $wanted = 'Get-LogoBand', 'Get-LogoFrame', 'Test-GlyphSurvives'
+          $found = @{}
+          foreach ($fn in $ast.FindAll({ $args[0] -is
+              [System.Management.Automation.Language.FunctionDefinitionAst] }, $true)) {
+            if ($wanted -contains $fn.Name) { $found[$fn.Name] = $fn.Extent.Text }
+          }
+          foreach ($w in $wanted) {
+            if (-not $found.ContainsKey($w)) { "install.ps1 no longer defines $w"; exit 1 }
+          }
+
+          $LogoWidth = 24
+          $LogoPad11 = '           '
+          $UiDim = ''
+          foreach ($w in $wanted) { Invoke-Expression $found[$w] }
+
+          $cell = [string][char]0x2588
+          $frame = Get-LogoFrame 1 4 5 1 'none' $true ($cell * 2) ($cell * 4) ($cell * 14)
+          $rows = @()
+          foreach ($row in $frame) {
+            $line = ''
+            foreach ($seg in $row) { $line += $seg.T }
+            $rows += $line.TrimEnd()
+          }
+
+          # The finished mark, spelled once here and asserted of the frame. It
+          # is the geometry of assets/ank.svg at one cell per pixel column and
+          # one row per pair of pixel rows.
+          $want = @(
+            ('          ' + ($cell * 4)),
+            ('        ' + ($cell * 2) + '    ' + ($cell * 2)),
+            ('        ' + ($cell * 2) + '    ' + ($cell * 2)),
+            ('          ' + ($cell * 4)),
+            ('           ' + ($cell * 2)),
+            ('   ' + ($cell * 4) + '    ' + ($cell * 2) + '    ' + ($cell * 4)),
+            ('   ' + ($cell * 2) + '      ' + ($cell * 2) + '      ' + ($cell * 2)),
+            ('   ' + ($cell * 2) + '      ' + ($cell * 2) + '      ' + ($cell * 2)),
+            ('   ' + ($cell * 2) + '      ' + ($cell * 2) + '      ' + ($cell * 2)),
+            ('     ' + ($cell * 14)),
+            '',
+            '          ank'
+          )
+
+          $bad = 0
+          if ($rows.Count -ne 12) { "the frame is $($rows.Count) rows and twelve is the contract"; $bad = 1 }
+          for ($i = 0; $i -lt $want.Count; $i++) {
+            if ($rows[$i] -ne $want[$i]) {
+              "row $($i + 1): got '$($rows[$i])' wanted '$($want[$i])'"
+              $bad = 1
+            }
+          }
+
+          # No row of any state may run past the width the console is measured
+          # against, and an empty state has to draw nothing at all -- that is
+          # what lets the redraw shrink without a clear-to-end-of-line.
+          foreach ($s in @(@(1,0,0,0,'base'), @(1,1,0,0,'none'), @(1,4,0,0,'none'),
+                           @(1,4,1,0,'none'), @(1,4,5,0,'none'), @(1,4,5,1,'loop'),
+                           @(1,4,5,1,'all'), @(0,0,0,0,'none'))) {
+            $f = Get-LogoFrame $s[0] $s[1] $s[2] $s[3] $s[4] $false ($cell * 2) ($cell * 4) ($cell * 14)
+            foreach ($row in $f) {
+              $line = ''
+              foreach ($seg in $row) { $line += $seg.T }
+              if ($line.Length -gt $LogoWidth) {
+                "a row of state $($s[4]) is $($line.Length) wide, over $LogoWidth"
+                $bad = 1
+              }
+              if ($s[0] -eq 0 -and $line.TrimEnd() -ne '') {
+                "the empty state drew '$line'"
+                $bad = 1
+              }
+            }
+          }
+
+          # And the glyph test, asked of the encodings it exists to tell apart.
+          # 437 carries the block at 0xDB and best-fits the tick to a square
+          # root; 1252 best-fits the block to a broken bar. Neither produces a
+          # question mark, which is why the test round-trips.
+          $saved = [Console]::OutputEncoding
+          try {
+            [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+            if (-not (Test-GlyphSurvives 0x2588)) { 'UTF-8 was told it cannot carry the block'; $bad = 1 }
+            if (-not (Test-GlyphSurvives 0x2713)) { 'UTF-8 was told it cannot carry the tick'; $bad = 1 }
+            [Console]::OutputEncoding = [System.Text.Encoding]::GetEncoding(437)
+            if (-not (Test-GlyphSurvives 0x2588)) { 'codepage 437 was told it cannot carry the block'; $bad = 1 }
+            if (Test-GlyphSurvives 0x2713) { 'codepage 437 was told it carries the tick'; $bad = 1 }
+            [Console]::OutputEncoding = [System.Text.Encoding]::GetEncoding(1252)
+            if (Test-GlyphSurvives 0x2588) { 'codepage 1252 was told it carries the block'; $bad = 1 }
+          } finally {
+            [Console]::OutputEncoding = $saved
+          }
+
+          if ($bad) { exit 1 }
+          "the frame is twelve rows, is the shape install.sh draws, never exceeds $LogoWidth columns,"
+          "draws nothing when empty, and the glyph test tells UTF-8, 437 and 1252 apart"
+
       - name: it explains itself
         run: |
           & ./install.ps1 -Help
@@ -856,7 +1035,11 @@ jobs:
             "an escape sequence reached the transcript with no console attached"
             exit 1
           }
-          if ($out -match '####') {
+          # Both cells, because which one is drawn is decided by what the
+          # console's encoding can carry and not by this file: U+2588 where it
+          # survives the round trip, `#` where it does not. -match takes a
+          # regular expression, so the alternation is spelled as one.
+          if ($out -match ('####|' + ([string][char]0x2588 * 2))) {
             "the logo was drawn with no console attached"
             exit 1
           }
@@ -1131,6 +1314,12 @@ jobs:
               return (Test-Path (Join-Path $Run.Dir 'ank.exe'))
           }
 
+          # Which cell the logo is drawn in is decided by what the console's
+          # encoding can carry and not by this file: U+2588 where it survives
+          # the round trip, `#` where it does not. Written as one regular
+          # expression so both -match and -notmatch read the same alternation.
+          $LogoCells = '####|' + ([string][char]0x2588 * 2)
+
           # Once each, asserted of each: this is the property the probe exists
           # for, and it is stricter than the total it replaces. Two questions
           # asked once and one question asked twice both come to two; only a
@@ -1145,6 +1334,11 @@ jobs:
           # the criterion names: the install is already done, so it stays done.
           $run = Invoke-Case -Label 'accept' -Answer 'y'
           Want $run ($run.Code -eq 0) "a failing skill step changed the exit code to $($run.Code)"
+          # The presence, and not only the absence below. Every other assertion
+          # about the logo asks that it stay away, so all of them would pass on
+          # an installer that had stopped drawing it entirely -- which is the
+          # regression a person would actually notice.
+          Want $run ($run.Out -match $LogoCells) 'no logo was drawn at a console'
           Want-AskedOnce $run
           Want $run ($run.Ran) 'it accepted and never ran npx'
           Want $run (Installed $run) 'the executables are not in place after the offer failed'
@@ -1184,7 +1378,7 @@ jobs:
           Want $run ($run.SkillsAsked -eq 0) '-NoWelcome asked the skills offer anyway'
           Want $run ($run.AdoptAsked -eq 0) '-NoWelcome asked the adoption offer anyway'
           Want $run (-not $run.Ran) '-NoWelcome ran npx anyway'
-          Want $run ($run.Out -notmatch '####') '-NoWelcome drew the logo at a console'
+          Want $run ($run.Out -notmatch $LogoCells) '-NoWelcome drew the logo at a console'
           Want $run (Installed $run) '-NoWelcome cost the install its executables'
 
           # node absent: the command, and one line saying why it was not run.

--- a/install.ps1
+++ b/install.ps1
@@ -84,9 +84,55 @@ $RunningAsFile = -not [string]::IsNullOrEmpty($PSCommandPath)
 # Write-Host and not Write-Output, for the reason install.sh sends everything to
 # stderr: under `iex` this runs in the caller's own session, and a diagnosis
 # written to the pipeline would land in whatever they were assembling.
+# -Color is a console attribute set through the host and never an escape
+# sequence, which is the same reason Show-Logo moves the cursor through RawUI:
+# Windows PowerShell 5.1 in conhost prints an ESC[36m instead of obeying it. So
+# a transcript records the words and no sequence at all, on any run.
 function Say {
-    param([string]$Line = '', [switch]$NoNewline)
-    if ($NoNewline) { Write-Host -NoNewline $Line } else { Write-Host $Line }
+    param([string]$Line = '', [switch]$NoNewline, [string]$Color = '')
+    $paint = @{}
+    if ($Color) { $paint['ForegroundColor'] = $Color }
+    if ($NoNewline) { Write-Host -NoNewline $Line @paint } else { Write-Host $Line @paint }
+}
+
+# Colour and the marker, behind the gate the logo is drawn behind, exactly as
+# install.sh holds them: empty until Enable-Ui runs, so a console-less caller
+# reads the bytes it read before this file learned about either.
+#
+# DarkGray and not a lighter grey for the dim: it is the one shade that reads as
+# quieter against a black console and against a white one, which is the whole of
+# what "dim" has to survive here. There is no bold to be had -- a console host
+# has a foreground and no weight -- so what install.sh writes bold is written in
+# the console's own foreground, and the contrast comes from what is dimmed
+# around it.
+$UiDim = ''
+$UiCyan = ''
+$UiGreen = ''
+$UiPad = ''
+$UiTick = ''
+
+function Enable-Ui {
+    $script:UiPad = '  '
+    $script:UiTick = if (Test-GlyphSurvives 0x2713) { "$([char]0x2713) " } else { '- ' }
+    if ($env:NO_COLOR) { return }
+    $script:UiDim = 'DarkGray'
+    $script:UiCyan = 'Cyan'
+    $script:UiGreen = 'Green'
+}
+
+# `Ok <line>`: a step that finished. The marker and the indent are drawn for a
+# person and for nobody else -- what a transcript reads is the sentence alone,
+# written by the one call the line used to be, rather than by three that happen
+# to concatenate to it.
+function Ok {
+    param([string]$Line)
+    if (-not $UiTick) {
+        Say $Line
+        return
+    }
+    Say -NoNewline $UiPad
+    Say -NoNewline -Color $UiGreen $UiTick
+    Say $Line
 }
 
 # `Fail <code> <lines>`: the code carries the kind of failure, the lines carry
@@ -162,32 +208,149 @@ function Show-Usage {
 # Welcome
 # ---------------------------------------------------------------------------
 
-# The logo, at half the resolution of assets/ank.svg and drawn in ASCII: the
-# same twelve lines install.sh holds, because it is the same logo and two
-# spellings of it would drift. That file is the reference for the shape and
-# nothing here reads it -- an installer that fetches a logo before it fetches
-# the binary is an installer with a second way to fail before doing anything
-# useful, so the frames are bytes in this file.
+# The logo, from assets/ank.svg read as pixels: twenty-four columns by ten rows,
+# one cell per pixel column and one row per pair of pixel rows, which is the
+# ratio that makes a console cell square. The same shape install.sh holds and
+# the same twelve lines, because it is the same logo and two spellings of it
+# would drift. That file is the reference and nothing here reads it -- an
+# installer that fetches a logo before it fetches the binary is an installer
+# with a second way to fail before doing anything useful, so the shape is bytes
+# in this file.
 #
-# ASCII and not U+2588, because the console this lands in is not always UTF-8:
-# a Windows PowerShell 5.1 in conhost under codepage 437 renders a block
-# character as a question mark, and a logo that arrives as question marks is
-# worse than no logo at all.
-$LogoArt = @(
-    '          ####',
-    '        ##    ##',
-    '        ##    ##',
-    '          ####',
-    '          ####',
-    '  ######  ####  ######',
-    '  ####    ####    ####',
-    '  ####    ####    ####',
-    '  ####    ####    ####',
-    '    ################',
-    '',
-    '          ank'
-)
+# The block is not assumed, and it is not refused either. The old reading of
+# this was that a Windows PowerShell 5.1 in conhost cannot draw U+2588, and it
+# is wrong twice over: codepage 437 carries the full block at 0xDB, and a
+# console that is genuinely UTF-8 carries it too. What actually decides is
+# whether the encoder the console is using can carry the character at all, and
+# that is a question with an answer -- Test-GlyphSurvives asks it rather than
+# guessing from a codepage number. The tick is asked the same way and gets a
+# different answer on 437, which has no U+2713.
 $LogoWidth = 24
+
+# Eleven spaces: columns 0 to 10, what stands left of the stem on a row whose
+# leg has not grown yet. Every such row is the same width, so this is a constant
+# rather than something measured.
+$LogoPad11 = '           '
+
+# Whether a character reaches the console as itself: encoded through whatever
+# the console is using and decoded back, and equal to what went in.
+#
+# The round trip and not a search for a question mark, because measuring it
+# showed the question mark is the case that does not happen. .NET best-fits
+# instead, and it best-fits to something plausible and wrong: codepage 437 turns
+# U+2713 into 0xFB, which is a square root sign, and codepage 1252 turns U+2588
+# into 0xA6, which is a broken bar. A check for `?` passes both and ships a logo
+# made of broken bars and a tick that is a radical -- worse than the fence of
+# hashes this replaced. The round trip refuses both and accepts codepage 437's
+# block at 0xDB, which is genuinely the character asked for.
+#
+# Asked once per run, never inside a frame.
+function Test-GlyphSurvives {
+    param([int]$CodePoint)
+    try {
+        $want = [string][char]$CodePoint
+        $encoding = [Console]::OutputEncoding
+        return $encoding.GetString($encoding.GetBytes($want)) -eq $want
+    } catch {
+        return $false
+    }
+}
+
+# One of rows 6 to 9: <pad><leg><gap><stem><gap><leg>, where a part that has not
+# grown yet gives its columns up to the eleven-space pad, so the parts that have
+# stay where they are. A segment is its text and whether it is dimmed, because a
+# leg and the stem share these rows and can be in different states.
+function Get-LogoBand {
+    param(
+        [int]$Legs, [int]$LegsAt, [int]$Stem, [int]$StemAt,
+        [string]$Run, [string]$Gap, [string]$Pair,
+        [bool]$DimLegs, [bool]$DimStem
+    )
+
+    $hasLegs = $Legs -ge $LegsAt
+    $hasStem = $Stem -ge $StemAt
+    if (-not $hasLegs -and -not $hasStem) { return , @() }
+
+    $out = @()
+    if ($hasLegs) {
+        $out += @{ T = '   '; D = $false }
+        $out += @{ T = $Run; D = $DimLegs }
+        $out += @{ T = $Gap; D = $false }
+    } else {
+        $out += @{ T = $LogoPad11; D = $false }
+    }
+
+    if ($hasStem) {
+        $out += @{ T = $Pair; D = $DimStem }
+    } elseif ($hasLegs) {
+        $out += @{ T = '  '; D = $false }
+    }
+
+    if ($hasLegs) {
+        $out += @{ T = $Gap; D = $false }
+        $out += @{ T = $Run; D = $DimLegs }
+    }
+
+    return , $out
+}
+
+# One frame as twelve rows of segments. The arguments are the state of the build
+# and not a frame number: base is on or off, legs and stem are how many of their
+# rows have grown, loop is on or off, soft names the part still arriving, name is
+# the wordmark. A timeline written as states can be re-timed without recomputing
+# which row is which.
+function Get-LogoFrame {
+    param(
+        [int]$Base, [int]$Legs, [int]$Stem, [int]$Loop,
+        [string]$Soft, [bool]$Name,
+        [string]$B2, [string]$B4, [string]$B14
+    )
+
+    $dimAll = $Soft -eq 'all'
+    $dimLoop = $dimAll -or $Soft -eq 'loop'
+    $dimStem = $dimAll -or $Soft -eq 'stem'
+    $dimLegs = $dimAll -or $Soft -eq 'legs'
+    $dimBase = $dimAll -or $Soft -eq 'base'
+
+    # Rows 1 and 4, then 2 and 3: the loop is columns 10-13, then 8-9 with 14-15.
+    if ($Loop) {
+        $r1 = @(@{ T = '          '; D = $false }, @{ T = $B4; D = $dimLoop })
+        $r2 = @(
+            @{ T = '        '; D = $false }, @{ T = $B2; D = $dimLoop },
+            @{ T = '    '; D = $false }, @{ T = $B2; D = $dimLoop }
+        )
+    } else {
+        $r1 = @()
+        $r2 = @()
+    }
+
+    # Row 5, the stem alone, the last of its five rows to grow.
+    if ($Stem -ge 5) {
+        $r5 = @(@{ T = '           '; D = $false }, @{ T = $B2; D = $dimStem })
+    } else {
+        $r5 = @()
+    }
+
+    $r6 = Get-LogoBand $Legs 4 $Stem 4 $B4 '    ' $B2 $dimLegs $dimStem
+    $r7 = Get-LogoBand $Legs 3 $Stem 3 $B2 '      ' $B2 $dimLegs $dimStem
+    $r8 = Get-LogoBand $Legs 2 $Stem 2 $B2 '      ' $B2 $dimLegs $dimStem
+    $r9 = Get-LogoBand $Legs 1 $Stem 1 $B2 '      ' $B2 $dimLegs $dimStem
+
+    # Row 10, the base, columns 5-18.
+    if ($Base) {
+        $r10 = @(@{ T = '     '; D = $false }, @{ T = $B14; D = $dimBase })
+    } else {
+        $r10 = @()
+    }
+
+    if ($Name) {
+        $r12 = @(@{ T = '          ank'; D = $false })
+    } else {
+        $r12 = @()
+    }
+
+    return , @($r1, $r2, $r2, $r1, $r5, $r6, $r7, $r8, $r9, $r10, @(), $r12)
+}
 
 # The cursor is moved through $Host.UI.RawUI and not with an escape sequence,
 # and that is the Windows half of this decision rather than a preference.
@@ -205,13 +368,22 @@ function Show-Logo {
     # of. Nothing is written before this is known.
     if ($ui.WindowSize.Width -lt $LogoWidth) { return }
 
+    # The cell and the three runs the shape is made of, built once. Seventeen
+    # frames are drawn and none of them may repeat this.
+    $cell = if (Test-GlyphSurvives 0x2588) { [string][char]0x2588 } else { '#' }
+    $b2 = $cell * 2
+    $b4 = $cell * 4
+    $b14 = $cell * 14
+
+    $rows = 12
+
     # The blank lines are written before the position is read, so that a window
     # with the prompt at its bottom does its scrolling now: a coordinate saved
     # while the buffer is still moving points at the wrong row for every frame
     # after it.
-    for ($i = 0; $i -lt $LogoArt.Count; $i++) { Say '' }
+    for ($i = 0; $i -lt $rows; $i++) { Say '' }
 
-    $top = $ui.CursorPosition.Y - $LogoArt.Count
+    $top = $ui.CursorPosition.Y - $rows
     if ($top -lt 0) { return }
     $origin = New-Object System.Management.Automation.Host.Coordinates 0, $top
 
@@ -223,27 +395,44 @@ function Show-Logo {
         # A host that will not say whether its cursor is visible still draws.
     }
 
+    # Bottom up: the base arrives dim and settles, the legs and then the stem
+    # grow out of it a row at a time, the loop crowns them, and the whole shape
+    # blinks twice before the name appears. That last beat is what the animation
+    # exists for -- it costs the time it takes to read the name of the tool and
+    # not a second more.
+    #
+    # The two parts that appear whole come in dim; the two that grow do not,
+    # since growing a row at a time is already motion and dimming it as well
+    # would say the same thing twice.
+    #
+    #        base legs stem loop soft     name   ms
+    $script = @(
+        @(1, 0, 0, 0, 'base', $false, 100),
+        @(1, 0, 0, 0, 'none', $false, 100),
+        @(1, 1, 0, 0, 'none', $false, 45),
+        @(1, 2, 0, 0, 'none', $false, 45),
+        @(1, 3, 0, 0, 'none', $false, 45),
+        @(1, 4, 0, 0, 'none', $false, 45),
+        @(1, 4, 1, 0, 'none', $false, 45),
+        @(1, 4, 2, 0, 'none', $false, 45),
+        @(1, 4, 3, 0, 'none', $false, 45),
+        @(1, 4, 4, 0, 'none', $false, 45),
+        @(1, 4, 5, 0, 'none', $false, 45),
+        @(1, 4, 5, 1, 'loop', $false, 100),
+        @(1, 4, 5, 1, 'none', $false, 100),
+        @(1, 4, 5, 1, 'all', $false, 45),
+        @(1, 4, 5, 1, 'none', $false, 45),
+        @(1, 4, 5, 1, 'all', $false, 45),
+        @(1, 4, 5, 1, 'none', $true, 450)
+    )
+
     try {
-        # Bottom up: the base, then the stem, then the loop, which is the order
-        # the shape is built in and the order that leaves the whole of it
-        # standing at the end. Frame 11 adds the name, and that is the beat the
-        # animation exists for: it costs the time it takes to read the name of
-        # the tool and not a second more.
-        for ($frame = 1; $frame -le 11; $frame++) {
+        foreach ($step in $script) {
             $ui.CursorPosition = $origin
-            for ($line = 1; $line -le $LogoArt.Count; $line++) {
-                $text = ''
-                if ($line -le 10 -and $line -ge (11 - $frame)) {
-                    $text = $LogoArt[$line - 1]
-                } elseif ($line -eq 12 -and $frame -eq 11) {
-                    $text = $LogoArt[11]
-                }
-                # Padded rather than erased: there is no clear-to-end-of-line
-                # without an escape sequence, and writing the spaces says the
-                # same thing in the alphabet this function is restricted to.
-                Say $text.PadRight($LogoWidth)
-            }
-            if ($frame -lt 11) { Start-Sleep -Milliseconds 60 }
+            $frame = Get-LogoFrame $step[0] $step[1] $step[2] $step[3] `
+                $step[4] $step[5] $b2 $b4 $b14
+            foreach ($row in $frame) { Write-LogoRow $row }
+            Start-Sleep -Milliseconds $step[6]
         }
     } finally {
         try { [Console]::CursorVisible = $savedCursor } catch { }
@@ -252,6 +441,52 @@ function Show-Logo {
     # One blank line under the block, so what the install says next does not
     # start on the line the name ends on.
     Say ''
+}
+
+# One row of a frame. Padded to the full width rather than erased: there is no
+# clear-to-end-of-line without an escape sequence, and writing the spaces says
+# the same thing in the alphabet this function is restricted to.
+#
+# Adjacent segments in the same state are written as one, and that is not
+# tidiness. conhost turns every write that changes an attribute into a console
+# API call, and a row is almost always one state throughout: segment by segment
+# the seventeen frames cost 649 writes for 94 actual changes of attribute, so
+# 555 of them bought nothing. Coalesced, a row in one state is one write.
+function Write-LogoRow {
+    param($Segments)
+
+    $runs = @()
+    $width = 0
+    foreach ($seg in $Segments) {
+        $segDim = [bool]($seg.D -and $UiDim)
+        if ($runs.Count -gt 0 -and $runs[-1].D -eq $segDim) {
+            $runs[-1].T += $seg.T
+        } else {
+            $runs += @{ T = $seg.T; D = $segDim }
+        }
+        $width += $seg.T.Length
+    }
+
+    # The padding closes the line and carries no state of its own, so it joins
+    # the last run when that run is not dimmed and stands alone when it is.
+    $pad = ''
+    if ($width -lt $LogoWidth) { $pad = ' ' * ($LogoWidth - $width) }
+    if ($runs.Count -gt 0 -and -not $runs[-1].D) {
+        $runs[-1].T += $pad
+        $pad = $null
+    }
+
+    for ($i = 0; $i -lt $runs.Count; $i++) {
+        $last = ($i -eq $runs.Count - 1) -and ($null -eq $pad)
+        if ($runs[$i].D) {
+            if ($last) { Say -Color $UiDim $runs[$i].T }
+            else { Say -NoNewline -Color $UiDim $runs[$i].T }
+        } else {
+            if ($last) { Say $runs[$i].T }
+            else { Say -NoNewline $runs[$i].T }
+        }
+    }
+    if ($null -ne $pad) { Say $pad }
 }
 
 # ADR-5fbd99bf6fd5 read as an absence: where no human is looking, this script
@@ -308,11 +543,11 @@ function Invoke-SkillOffer {
     if (-not (Test-HumanAtTerminal)) { return }
 
     Say ''
-    Say 'The skills teach an agent how to use ank: the contract, and one policy'
-    Say 'per activity. They install through the skills CLI, which puts them where'
-    Say 'each agent looks.'
+    Say "${UiPad}The skills teach an agent how to use ank: the contract, and one policy"
+    Say "${UiPad}per activity. They install through the skills CLI, which puts them where"
+    Say "${UiPad}each agent looks."
     Say ''
-    Say "  npx skills add $Repo"
+    Say -Color $UiCyan "$UiPad  npx skills add $Repo"
     Say ''
 
     # [Console]::ReadLine and not Read-Host, which is where Windows differs
@@ -321,7 +556,7 @@ function Invoke-SkillOffer {
     # caller's own session: Console.In is the console and never that pipeline,
     # so a question asked here cannot consume what they piped. $null is end of
     # input -- nothing was typed, so nothing is assumed.
-    Say -NoNewline 'Install them now? [Y/n] '
+    Say -NoNewline "${UiPad}Install them now? [Y/n] "
     $answer = $null
     try { $answer = [Console]::ReadLine() } catch { $answer = $null }
     if ($null -eq $answer) {
@@ -337,7 +572,7 @@ function Invoke-SkillOffer {
 
     if (-not (Get-Command node -ErrorAction SilentlyContinue)) {
         Say ''
-        Say "  npx skills add $Repo"
+        Say -Color $UiCyan "$UiPad  npx skills add $Repo"
         Say 'node is not on PATH, so that was not run.'
         return
     }
@@ -368,7 +603,7 @@ function Invoke-SkillOffer {
 
     if ($code -eq 0) {
         Say ''
-        Say 'the skills are installed'
+        Ok 'the skills are installed'
     } else {
         Say ''
         Say "npx skills add $Repo exited $code, so the skills are not installed."
@@ -376,7 +611,7 @@ function Invoke-SkillOffer {
         Say 'asked anything at all.'
         Say ''
         Say 'Run that line again when you want them:'
-        Say "  npx skills add $Repo"
+        Say -Color $UiCyan "$UiPad  npx skills add $Repo"
     }
 }
 
@@ -457,7 +692,7 @@ function Invoke-AdoptionOffer {
     if (-not (Test-HumanAtTerminal)) { return }
 
     Say ''
-    Say -NoNewline 'Print the three prompts that adopt ank in a repository you already have? [Y/n] '
+    Say -NoNewline "${UiPad}Print the three prompts that adopt ank in a repository you already have? [Y/n] "
     $answer = $null
     try { $answer = [Console]::ReadLine() } catch { $answer = $null }
     if ($null -eq $answer) {
@@ -731,6 +966,11 @@ if ($BaseUrl) {
 # install: nothing has been downloaded yet and nothing below depends on a frame
 # having been drawn.
 if (Test-HumanAtTerminal) {
+    # The colour is turned on by the presence of a human and not by the width of
+    # their window, which is why this is here and the width test is inside
+    # Show-Logo: a console too narrow for the logo is still a console with a
+    # person in front of it.
+    Enable-Ui
     try { Show-Logo } catch { }
 }
 
@@ -764,7 +1004,8 @@ try {
     $root = if ($BaseUrl) { $BaseUrl } else { $DefaultBaseUrl }
     $url = "$root/$tag/$archive"
 
-    Say "ank $tag  $target"
+    Say -NoNewline "$UiPad" ; Say -NoNewline "ank $tag  "
+    Say -Color $UiDim "$target"
     if ($resolved.Emulated) {
         Say 'no native arm64 build is published; Windows runs this one under emulation'
     }
@@ -871,7 +1112,7 @@ try {
         )
     }
 
-    Say "checksum ok  $actual"
+    Ok "checksum ok  $actual"
 
     try {
         Expand-Zip -Path $archivePath -Destination $tmp
@@ -955,8 +1196,8 @@ try {
     }
 
     Say ''
-    Say "installed  $destination"
-    if ($installedVersion) { Say "           $installedVersion" }
+    Ok "installed  $destination"
+    if ($installedVersion) { Say -Color $UiDim "$UiPad$UiPad           $installedVersion" }
 
     # The last way left to leave a caller without a working `ank`: a binary in a
     # directory nothing looks in. Naming the command to run is the difference
@@ -969,21 +1210,22 @@ try {
 
     if ($onPath) {
         Say ''
-        Say "$Dir is on your PATH. Run: ank help"
+        Say -NoNewline "$UiPad$Dir is on your PATH. Run: "
+        Say -Color $UiCyan 'ank help'
     } else {
         Say ''
-        Say "$Dir is not on your PATH, so ``ank`` is not a command yet."
-        Say 'Add it for your account by running this once:'
+        Say "$UiPad$Dir is not on your PATH, so ``ank`` is not a command yet."
+        Say "${UiPad}Add it for your account by running this once:"
         Say ''
-        Say "  [Environment]::SetEnvironmentVariable('Path', [Environment]::GetEnvironmentVariable('Path','User') + ';$Dir', 'User')"
+        Say -Color $UiCyan "$UiPad  [Environment]::SetEnvironmentVariable('Path', [Environment]::GetEnvironmentVariable('Path','User') + ';$Dir', 'User')"
         Say ''
-        Say 'then open a new terminal. In this one:'
+        Say "${UiPad}then open a new terminal. In this one:"
         Say ''
-        Say "  `$env:Path += ';$Dir'"
+        Say -Color $UiCyan "$UiPad  `$env:Path += ';$Dir'"
         if ($userPath -and $userPath.Length -gt 1800) {
             Say ''
-            Say 'Your user PATH is close to the length Windows truncates at, so check it'
-            Say 'after adding: a truncated PATH loses entries other tools put there.'
+            Say "${UiPad}Your user PATH is close to the length Windows truncates at, so check it"
+            Say "${UiPad}after adding: a truncated PATH loses entries other tools put there."
         }
     }
 

--- a/install.sh
+++ b/install.sh
@@ -959,7 +959,16 @@ offer_skills() {
   # would consume the rest of the file and execute none of it, and it would do
   # so only on the route people actually use, having worked in every local test
   # where the script was run from a file.
-  printf '%s%sInstall them now?%s [Y/n] ' "$ui_pad" "$ui_bold" "$ui_off" >&2
+  # Three calls, and the question is a literal in the middle one. Written as a
+  # single format string with the emphasis as placeholders, the sentence is
+  # split across them and stops being a sentence anyone can find: the tests
+  # count this string in this file to know it is asked exactly once, and a
+  # question that cannot be counted is a question that can quietly be asked
+  # twice. What a pipe reads is unchanged either way -- the first and last call
+  # write nothing at all until ui_enable has run.
+  printf '%s%s' "$ui_pad" "$ui_bold" >&2
+  printf 'Install them now? [Y/n] ' >&2
+  printf '%s' "$ui_off" >&2
   if ! IFS= read -r offer_answer < /dev/tty; then
     # End of input rather than an answer. Nothing was typed, so nothing is
     # assumed, and the newline is ours because no Enter was pressed to echo
@@ -1087,8 +1096,12 @@ offer_adoption() {
   human_at_terminal || return 0
 
   say ""
-  printf '%s%sPrint the three prompts that adopt ank in a repository you already have?%s [Y/n] ' \
-    "$ui_pad" "$ui_bold" "$ui_off" >&2
+  # One literal in one call, for the reason the skills question is: the tests
+  # count this sentence in this file, and emphasis written as placeholders cuts
+  # it in half.
+  printf '%s%s' "$ui_pad" "$ui_bold" >&2
+  printf 'Print the three prompts that adopt ank in a repository you already have? [Y/n] ' >&2
+  printf '%s' "$ui_off" >&2
   if ! IFS= read -r adopt_answer < /dev/tty; then
     # End of input rather than an answer. The newline is ours because no Enter
     # was pressed to echo one.

--- a/install.sh
+++ b/install.sh
@@ -56,6 +56,25 @@ say() {
   printf '%s\n' "$*" >&2
 }
 
+# Colour and the marker, behind the gate the logo is drawn behind. Empty until
+# ui_enable runs, which is what keeps ADR-5fbd99bf6fd5's promise to a caller
+# with nobody at the end of it: a pipe reads the bytes it read before this file
+# learned about either.
+#
+# Every call site below spells the sequences out rather than asking a function
+# for them, so a line that is half plain and half painted is one string and not
+# a concatenation of three -- and the plain reading of it, with every variable
+# empty, is the line that used to be there.
+ui_off="" ui_bold="" ui_dim="" ui_cyan="" ui_green=""
+ui_pad="" ui_tick=""
+
+# `ok <line>`: a step that finished. The marker and the indent are drawn for a
+# person and for nobody else -- what a pipe reads is the sentence alone, which
+# is why the two live in variables rather than in the format string.
+ok() {
+  say "${ui_pad}${ui_green}${ui_tick}${ui_off}$*"
+}
+
 # `die <code> <line>...`: the code carries the kind of failure, the lines carry
 # what to do next. Nothing here ever ends in silence -- that is the one thing
 # an install script cannot do, since the caller is otherwise left with no
@@ -75,79 +94,269 @@ die() {
 # Welcome
 # --------------------------------------------------------------------------
 
-# The logo, at half the resolution of assets/ank.svg and drawn in ASCII. That
-# file is the reference for the shape and nothing here reads it: an installer
-# that fetches a logo before it fetches the binary is an installer with a
-# second way to fail before doing anything useful, so the frames are bytes in
-# this file. ASCII and not U+2588 for the reason the shebang is /bin/sh -- this
-# runs on busybox, under a locale nobody chose, and a logo that arrives as
-# question marks is worse than no logo at all.
+# The logo, from assets/ank.svg read as pixels: twenty-four columns by ten
+# rows, one cell per pixel column and one row per pair of pixel rows, which is
+# the ratio that makes a terminal cell square. That file is the reference for
+# the shape and nothing here reads it: an installer that fetches a logo before
+# it fetches the binary is an installer with a second way to fail before doing
+# anything useful, so the shape is bytes in this file.
 #
-# Twelve lines, always, including the empty ones. The animation redraws the
-# same block in place, so a frame that were shorter would leave the tail of the
-# one before it on the screen.
+# U+2588 where the locale says UTF-8, `#` where it does not, decided once in
+# logo_charset. The hedge is the one the shebang makes -- this runs on busybox
+# under a locale nobody chose, and a logo that arrives as question marks is
+# worse than no logo at all -- but a locale that announces UTF-8 is a locale
+# that can draw a block, and the block is the whole difference between a logo
+# and a fence of hashes.
 #
 # \033 and not \e: the octal escape is the one POSIX printf guarantees, and \e
-# is a bashism in a file that has none. \033[K clears what the previous frame
-# left to the right of this line.
-logo_line() {
-  case $1 in
-    1) logo_art='          ####' ;;
-    2) logo_art='        ##    ##' ;;
-    3) logo_art='        ##    ##' ;;
-    4) logo_art='          ####' ;;
-    5) logo_art='          ####' ;;
-    6) logo_art='  ######  ####  ######' ;;
-    7) logo_art='  ####    ####    ####' ;;
-    8) logo_art='  ####    ####    ####' ;;
-    9) logo_art='  ####    ####    ####' ;;
-    10) logo_art='    ################' ;;
-    12) logo_art='          ank' ;;
-    *) logo_art='' ;;
+# is a bashism in a file that has none.
+logo_esc=$(printf '\033')
+
+# Eleven spaces: columns 0 to 10, which is what stands to the left of the stem
+# on a row whose leg has not grown yet. Every such row is the same width, so
+# the padding is a constant rather than something measured -- ${#s} counts
+# bytes, and the moment the cell is U+2588 that is three times the answer.
+logo_pad11="           "
+
+# The cell, and the three runs the shape is made of, built once. A frame is
+# drawn seventeen times and must not repeat this work inside the loop.
+logo_charset() {
+  case "${LC_ALL:-${LC_CTYPE:-${LANG:-}}}" in
+    *UTF-8* | *utf-8* | *UTF8* | *utf8*) logo_cell='█' ;;
+    *) logo_cell='#' ;;
   esac
-  printf '%s\033[K\n' "$logo_art" >&2
+  logo_b2=$(logo_run 2)
+  logo_b4=$(logo_run 4)
+  logo_b14=$(logo_run 14)
 }
 
-# Bottom up: the base, then the stem, then the loop, which is the order the
-# shape is built in and the order that leaves the whole of it standing at the
-# end. Frame 11 adds the name, and that is the beat the animation exists for:
-# it costs the time it takes to read the name of the tool and not a second
+logo_run() {
+  logo_run_n=$1
+  logo_run_s=""
+  while [ "$logo_run_n" -gt 0 ]; do
+    logo_run_s="${logo_run_s}${logo_cell}"
+    logo_run_n=$((logo_run_n - 1))
+  done
+  printf '%s' "$logo_run_s"
+}
+
+# The mark carries no colour of its own. assets/ank.svg is #1f2328 and
+# assets/ank-dark.svg is #e6edf3 -- the same shape, black on a light ground and
+# white on a dark one -- and \033[39m is how a terminal spells that: the
+# foreground the reader already chose. A hue picked here would be a third logo
+# neither asset agrees with, and would be the one thing on the screen that does
+# not belong to the person running the installer.
+#
+# So the animation is built on the one axis that survives not knowing the
+# background: dim against normal. Brighter does not survive it -- bold on a
+# glyph that is already a solid block does nothing at all in a terminal that
+# does not render bold as bright, and white on a light ground is invisible. A
+# part therefore arrives dim and settles, and the shape blinks by going dim,
+# which reads the same on either ground.
+#
+# NO_COLOR empties all four rather than branching at each of the places they are
+# used, so a run without colour draws the same shape through the same code, on
+# the growth alone.
+logo_palette() {
+  if [ -n "${NO_COLOR:-}" ]; then
+    logo_lit="" logo_soft="" logo_name="" logo_off=""
+    return
+  fi
+  logo_lit="${logo_esc}[39m"
+  logo_soft="${logo_esc}[2;39m"
+  logo_name="${logo_esc}[1m"
+  logo_off="${logo_esc}[0m"
+}
+
+# The lines the install prints after the logo, which are not the mark and may
+# therefore carry a hue: bold for what landed, dim for what is incidental, cyan
+# for a command the reader is meant to run, green for a step that finished. Five
+# of the eight the binary allows itself, and the mark still uses none of them.
+#
+# The marker is U+2713 where the locale says
+# UTF-8 and `- ` where it does not, on the reasoning logo_charset is written
+# out for: a tick that arrives as a question mark is worse than no tick.
+#
+# The marker survives NO_COLOR, and that is the point of it being a character.
+# Nothing here is carried by colour alone -- take every sequence away and the
+# steps are still marked, and still say what they say.
+ui_enable() {
+  ui_pad="  "
+  ui_tick="- "
+  case "${LC_ALL:-${LC_CTYPE:-${LANG:-}}}" in
+    *UTF-8* | *utf-8* | *UTF8* | *utf8*) ui_tick="✓ " ;;
+  esac
+  [ -z "${NO_COLOR:-}" ] || return 0
+  ui_off="${logo_esc}[0m"
+  ui_bold="${logo_esc}[1m"
+  ui_dim="${logo_esc}[2m"
+  ui_cyan="${logo_esc}[36m"
+  ui_green="${logo_esc}[32m"
+}
+
+# One of rows 6 to 9: `<pad><leg><gap><stem><gap><leg>`, where a part that has
+# not grown yet gives up its columns to the eleven-space pad, so the parts that
+# have stay where they are. The trailing pad is never drawn -- \033[K ends the
+# line, and spaces that reach the right edge of a narrow window wrap it.
+logo_band() {
+  lb_legs=$1 lb_legs_at=$2 lb_stem=$3 lb_stem_at=$4
+  lb_run=$5 lb_gap=$6 lb_legs_c=$7 lb_stem_c=$8
+
+  if [ "$lb_legs" -ge "$lb_legs_at" ]; then
+    lb_left="   ${lb_legs_c}${lb_run}${logo_off}${lb_gap}"
+    lb_right="${lb_gap}${lb_legs_c}${lb_run}${logo_off}"
+  else
+    lb_left=$logo_pad11
+    lb_right=""
+  fi
+
+  if [ "$lb_stem" -ge "$lb_stem_at" ]; then
+    lb_mid="${lb_stem_c}${logo_b2}${logo_off}"
+  elif [ -n "$lb_right" ]; then
+    lb_mid="  "
+  else
+    lb_left="" lb_mid=""
+  fi
+
+  printf '%s%s%s' "$lb_left" "$lb_mid" "$lb_right"
+}
+
+# One frame, whole, in one write. Twelve separate writes to a terminal are
+# twelve chances for a person to catch the logo half-drawn, and that flicker is
+# what makes an animation look cheap.
+#
+# The arguments are the state of the build and not a frame number: base is on or
+# off, legs and stem are how many of their rows have grown, loop is on or off,
+# soft names the part still arriving this frame, name is the wordmark. A
+# timeline written as states can be re-timed without recomputing which row is
+# which.
+#
+# Every sequence is closed on the run that opened it. A frame that ends with one
+# still open is a terminal somebody has to repair with `reset`.
+logo_frame() {
+  lf_base=$1 lf_legs=$2 lf_stem=$3 lf_loop=$4 lf_soft=$5 lf_name=$6
+
+  lf_loop_c=$logo_lit lf_stem_c=$logo_lit lf_legs_c=$logo_lit lf_base_c=$logo_lit
+  case $lf_soft in
+    loop) lf_loop_c=$logo_soft ;;
+    stem) lf_stem_c=$logo_soft ;;
+    legs) lf_legs_c=$logo_soft ;;
+    base) lf_base_c=$logo_soft ;;
+    all)
+      lf_loop_c=$logo_soft lf_stem_c=$logo_soft
+      lf_legs_c=$logo_soft lf_base_c=$logo_soft
+      ;;
+  esac
+
+  # Rows 1 and 4, then 2 and 3: the loop is columns 10-13, then 8-9 with 14-15.
+  if [ "$lf_loop" = 1 ]; then
+    lf_r1="          ${lf_loop_c}${logo_b4}${logo_off}"
+    lf_r2="        ${lf_loop_c}${logo_b2}${logo_off}    ${lf_loop_c}${logo_b2}${logo_off}"
+  else
+    lf_r1="" lf_r2=""
+  fi
+
+  # Row 5, the stem alone, the last of its five rows to grow.
+  if [ "$lf_stem" -ge 5 ]; then
+    lf_r5="           ${lf_stem_c}${logo_b2}${logo_off}"
+  else
+    lf_r5=""
+  fi
+
+  # Rows 6-9 carry a leg on each side and the stem between them, and the three
+  # arrive at different moments.
+  lf_r6=$(logo_band "$lf_legs" 4 "$lf_stem" 4 "$logo_b4" "    " "$lf_legs_c" "$lf_stem_c")
+  lf_r7=$(logo_band "$lf_legs" 3 "$lf_stem" 3 "$logo_b2" "      " "$lf_legs_c" "$lf_stem_c")
+  lf_r8=$(logo_band "$lf_legs" 2 "$lf_stem" 2 "$logo_b2" "      " "$lf_legs_c" "$lf_stem_c")
+  lf_r9=$(logo_band "$lf_legs" 1 "$lf_stem" 1 "$logo_b2" "      " "$lf_legs_c" "$lf_stem_c")
+
+  # Row 10, the base, columns 5-18.
+  if [ "$lf_base" = 1 ]; then
+    lf_r10="     ${lf_base_c}${logo_b14}${logo_off}"
+  else
+    lf_r10=""
+  fi
+
+  if [ "$lf_name" = 1 ]; then
+    lf_r12="          ${logo_name}ank${logo_off}"
+  else
+    lf_r12=""
+  fi
+
+  # \033[K clears what the previous frame left to the right of each line, which
+  # is what lets a row shrink. Twelve lines every time, including the empty
+  # ones: the redraw moves back over a fixed block, and a frame that were
+  # shorter would leave the tail of the one before it on the screen.
+  printf '%s\033[K\n%s\033[K\n%s\033[K\n%s\033[K\n%s\033[K\n%s\033[K\n%s\033[K\n%s\033[K\n%s\033[K\n%s\033[K\n\033[K\n%s\033[K\n' \
+    "$lf_r1" "$lf_r2" "$lf_r2" "$lf_r1" "$lf_r5" \
+    "$lf_r6" "$lf_r7" "$lf_r8" "$lf_r9" "$lf_r10" "$lf_r12" >&2
+}
+
+# A frame, its delay, and the move back over the block it drew, so the caller's
+# timeline reads as states and never as cursor arithmetic. The last frame is
+# drawn by the caller instead, because it is the one that has to stay.
+logo_step() {
+  logo_frame "$1" "$2" "$3" "$4" "$5" 0
+  [ -z "$logo_delay" ] || sleep "$logo_delay"
+  printf '\033[12A' >&2
+}
+
+# Bottom up: the base arrives dim and settles, the legs and then the stem grow
+# out of it a row at a time, the loop crowns them, and the whole shape blinks
+# twice before the name appears. That last beat is what the animation exists for
+# -- it costs the time it takes to read the name of the tool and not a second
 # more.
 draw_logo() {
+  logo_charset
+  logo_palette
+
   # POSIX sleep takes an integer, and every sleep this script is likely to meet
   # -- coreutils, BSD, busybox built with the fancy option -- takes a fraction.
   # The ones that do not are told apart by asking rather than by guessing:
   # without a delay the frames still draw, in the order they draw, as fast as
   # the terminal will take them.
-  frame_delay=0.06
-  sleep 0.01 2>/dev/null || frame_delay=""
+  logo_fast=0.045 logo_beat=0.10 logo_hold=0.45
+  sleep 0.01 2>/dev/null || { logo_fast="" logo_beat="" logo_hold=""; }
 
   # The cursor would otherwise blink in the middle of the drawing. Restored on
   # the way out and on the two signals a human sends, because a terminal left
   # with an invisible cursor is a terminal somebody has to repair with `reset`.
-  trap 'printf "\033[?25h" >&2; exit 130' INT
-  trap 'printf "\033[?25h" >&2; exit 143' TERM
+  # The reset travels with it: a ^C between the opening of a colour and its
+  # close would otherwise leave the shell prompt dim.
+  trap 'printf "%s[0m%s[?25h\n" "$logo_esc" "$logo_esc" >&2; exit 130' INT
+  trap 'printf "%s[0m%s[?25h\n" "$logo_esc" "$logo_esc" >&2; exit 143' TERM
   printf '\033[?25l' >&2
 
-  frame=1
-  while [ "$frame" -le 11 ]; do
-    line=1
-    while [ "$line" -le 12 ]; do
-      if [ "$line" -le 10 ] && [ "$line" -ge $((11 - frame)) ]; then
-        logo_line "$line"
-      elif [ "$line" -eq 12 ] && [ "$frame" -eq 11 ]; then
-        logo_line 12
-      else
-        logo_line 0
-      fi
-      line=$((line + 1))
-    done
-    if [ "$frame" -lt 11 ]; then
-      [ -z "$frame_delay" ] || sleep "$frame_delay"
-      printf '\033[12A' >&2
-    fi
-    frame=$((frame + 1))
-  done
+  # The two parts that appear whole -- the base and the loop -- come in dim and
+  # settle. The two that grow do not: growing a row at a time is already motion,
+  # and dimming it as well would say the same thing twice.
+  #
+  #                base legs stem loop soft
+  logo_delay=$logo_beat
+  logo_step         1    0    0    0   base
+  logo_step         1    0    0    0   none
+  logo_delay=$logo_fast
+  logo_step         1    1    0    0   none
+  logo_step         1    2    0    0   none
+  logo_step         1    3    0    0   none
+  logo_step         1    4    0    0   none
+  logo_step         1    4    1    0   none
+  logo_step         1    4    2    0   none
+  logo_step         1    4    3    0   none
+  logo_step         1    4    4    0   none
+  logo_step         1    4    5    0   none
+  logo_delay=$logo_beat
+  logo_step         1    4    5    1   loop
+  logo_step         1    4    5    1   none
+  logo_delay=$logo_fast
+  logo_step         1    4    5    1   all
+  logo_step         1    4    5    1   none
+  logo_step         1    4    5    1   all
+
+  # The name, on the frame that stays. No move back after it, so what the
+  # install says next begins under the logo rather than over it.
+  logo_frame 1 4 5 1 none 1
+  [ -z "$logo_hold" ] || sleep "$logo_hold"
 
   # The cursor comes back first and the blank line after it, so the last byte
   # this function writes is a newline: whatever the install says next starts on
@@ -504,6 +713,12 @@ fi
 # Before anything is asked of the network, which is what "before the download
 # starts" has to mean here: the first request this script makes is the redirect
 # that resolves the latest tag, and it is below.
+# The colour is turned on by the presence of a human and not by the width of
+# their window: a terminal too narrow for the logo is still a terminal, and the
+# sentence it is too narrow for is the one nobody wrote yet.
+if human_at_terminal; then
+  ui_enable
+fi
 if welcome_wanted; then
   draw_logo
 fi
@@ -535,7 +750,7 @@ bare=${tag#v}
 archive="ank-${bare}-${target}.tar.gz"
 url="${base_url:-$default_base_url}/${tag}/${archive}"
 
-say "ank ${tag}  ${target}"
+say "${ui_pad}${ui_bold}ank ${tag}${ui_off}  ${ui_dim}${target}${ui_off}"
 
 # The checksum first: it is the smaller of the two files, so a release that
 # does not carry this target says so before megabytes move. It is also the
@@ -617,7 +832,7 @@ if [ "$expected" != "$actual" ]; then
     "  https://github.com/${repo}/security"
 fi
 
-say "checksum ok  ${actual}"
+ok "checksum ok  ${ui_dim}${actual}${ui_off}"
 
 tar xzf "${tmp}/${archive}" -C "$tmp" ||
   die 3 "could not unpack ${archive}." "" "Nothing was installed."
@@ -671,9 +886,9 @@ installed_version=$("${install_dir}/ank" --version 2>/dev/null | head -1) ||
   installed_version=""
 
 say ""
-say "installed  ${install_dir}/ank"
+ok "installed  ${ui_bold}${install_dir}/ank${ui_off}"
 if [ -n "$installed_version" ]; then
-  say "           ${installed_version}"
+  say "${ui_pad}${ui_pad}           ${ui_dim}${installed_version}${ui_off}"
 fi
 
 # The last way left to leave a caller without a working `ank`: a binary in a
@@ -682,7 +897,7 @@ fi
 case ":${PATH}:" in
   *":${install_dir}:"*)
     say ""
-    say "${install_dir} is on your PATH. Run: ank help"
+    say "${ui_pad}${install_dir} is on your PATH. Run: ${ui_cyan}ank help${ui_off}"
     ;;
   *)
     case "${SHELL:-}" in
@@ -704,12 +919,12 @@ case ":${PATH}:" in
         ;;
     esac
     say ""
-    say "${install_dir} is not on your PATH, so \`ank\` is not a command yet."
-    say "Add this line to ${path_file}:"
+    say "${ui_pad}${install_dir} is not on your PATH, so \`ank\` is not a command yet."
+    say "${ui_pad}Add this line to ${ui_bold}${path_file}${ui_off}:"
     say ""
-    say "  ${path_line}"
+    say "${ui_pad}  ${ui_cyan}${path_line}${ui_off}"
     say ""
-    say "then open a new shell, or run that line now in this one."
+    say "${ui_pad}then open a new shell, or run that line now in this one."
     ;;
 esac
 
@@ -732,11 +947,11 @@ offer_skills() {
   human_at_terminal || return 0
 
   say ""
-  say "The skills teach an agent how to use ank: the contract, and one policy"
-  say "per activity. They install through the skills CLI, which puts them where"
-  say "each agent looks."
+  say "${ui_pad}The skills teach an agent how to use ank: the contract, and one policy"
+  say "${ui_pad}per activity. They install through the skills CLI, which puts them where"
+  say "${ui_pad}each agent looks."
   say ""
-  say "  npx skills add ${repo}"
+  say "${ui_pad}  ${ui_cyan}npx skills add ${repo}${ui_off}"
   say ""
 
   # /dev/tty and nowhere else, which is the trap ADR-5fbd99bf6fd5 exists to
@@ -744,7 +959,7 @@ offer_skills() {
   # would consume the rest of the file and execute none of it, and it would do
   # so only on the route people actually use, having worked in every local test
   # where the script was run from a file.
-  printf 'Install them now? [Y/n] ' >&2
+  printf '%s%sInstall them now?%s [Y/n] ' "$ui_pad" "$ui_bold" "$ui_off" >&2
   if ! IFS= read -r offer_answer < /dev/tty; then
     # End of input rather than an answer. Nothing was typed, so nothing is
     # assumed, and the newline is ours because no Enter was pressed to echo
@@ -763,7 +978,7 @@ offer_skills() {
 
   if ! have node; then
     say ""
-    say "  npx skills add ${repo}"
+    say "${ui_pad}  ${ui_cyan}npx skills add ${repo}${ui_off}"
     say "node is not on PATH, so that was not run."
     return 0
   fi
@@ -789,7 +1004,7 @@ offer_skills() {
 
   if [ "$offer_code" -eq 0 ]; then
     say ""
-    say "the skills are installed"
+    ok "the skills are installed"
   else
     say ""
     say "npx skills add ${repo} exited ${offer_code}, so the skills are not"
@@ -797,7 +1012,7 @@ offer_skills() {
     say "nobody is asked anything at all."
     say ""
     say "Run that line again when you want them:"
-    say "  npx skills add ${repo}"
+    say "${ui_pad}  ${ui_cyan}npx skills add ${repo}${ui_off}"
   fi
 }
 
@@ -872,7 +1087,8 @@ offer_adoption() {
   human_at_terminal || return 0
 
   say ""
-  printf 'Print the three prompts that adopt ank in a repository you already have? [Y/n] ' >&2
+  printf '%s%sPrint the three prompts that adopt ank in a repository you already have?%s [Y/n] ' \
+    "$ui_pad" "$ui_bold" "$ui_off" >&2
   if ! IFS= read -r adopt_answer < /dev/tty; then
     # End of input rather than an answer. The newline is ours because no Enter
     # was pressed to echo one.


### PR DESCRIPTION
The logo in `install.sh` and `install.ps1` was ten rows of `#` revealed a row at a time, in no colour. The shape was right — `assets/ank.svg` at half vertical resolution — but `#` is a hatch with gaps in it, and ten rows of gaps do not read as a mark.

## The cell is measured, not assumed

`install.ps1` refused `U+2588` on the reasoning that a console under codepage 437 renders it as a question mark. Measured through the encoder, that is wrong in both directions:

```
cp437   U+2588 -> 0xDB      -> U+2588   survives
cp437   U+2713 -> 0xFB      -> U+221A   lost, and 0xFB is a square root
cp1252  U+2588 -> 0xA6      -> U+00A6   lost, and 0xA6 is a broken bar
cp65001 U+2588 -> E2 96 88  -> U+2588   survives
```

None of the failures produces a question mark, so the old test passes every one of them and would have shipped a logo made of broken bars and a tick that is a radical — worse than the fence it replaced. `Test-GlyphSurvives` round-trips through the console's own encoding instead. `install.sh` has no encoder between it and the terminal, so there the locale is the measurement.

## The mark carries no hue

`assets/ank.svg` is `#1f2328` and `assets/ank-dark.svg` is `#e6edf3`: one shape, black on a light ground and white on a dark one. `\033[39m` is how a terminal spells exactly that, and a `Write-Host` with no `-ForegroundColor` is how a console does.

That closes off the obvious way to animate it. A landing flash written as *brighter* does not survive not knowing the background — bold on a glyph that is already a solid block does nothing where bold is not rendered as bright, and white is invisible on a light ground. Dim against normal survives both. So a part that appears whole arrives dim and settles, a part that grows does not (growing is already motion), and the finished shape blinks by going dim.

The lines printed afterwards are not the mark and may carry a hue: green on a step that finished, cyan on a command the reader is meant to run, dim on what is incidental. All of it sits behind the gate the logo sits behind.

## What a pipe reads is unchanged

ADR-5fbd99bf6fd5 promises a caller with no terminal the installer it sees today, to the byte. Compared as bytes, old script against new, output and exit code, over `--help`, a failing download and `--no-welcome`: identical, with no escape sequence reaching a pipe. `--no-welcome` on a real pty draws nothing, asks nothing, emits no escape and installs the same binary.

## Windows write cost

Segment by segment the animation cost **649** writes over seventeen frames for **94** actual attribute changes — 555 bought nothing, and conhost charges for each write that changes an attribute as a console API call. Coalescing adjacent segments in the same state: **298**, for the same 94 changes. The floor is 204 (twelve rows × seventeen frames), so what remains above it is exactly the attribute changes.

## Tests

The four frame assertions accept either cell, since a runner's locale is not this repository's to fix. Both probes now assert the mark **present** as well as absent — every previous assertion would have passed on an installer that had stopped drawing it entirely.

The Windows job gains a step comparing `install.ps1`'s frames to the shape `install.sh` draws. The two files justify being two files by carrying one shape between them, and nothing was holding them to it.

Both new assertions were mutation-tested, and one was weak. Moving the stem row one column left left every row of the mark still findable on its own: a frame drawn before the legs have grown pads their columns with the same eleven spaces the stem row begins with. The assertion now matches the ten rows together and consecutive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AG9JGEXdoxahULZMskASSK