### PR TITLE
Plan: a task is born with the verifiers the repository declares

### DIFF
--- a/.ank/entities/ADR-443590981e41.md
+++ b/.ank/entities/ADR-443590981e41.md
@@ -1,0 +1,81 @@
+---
+id: ADR-443590981e41
+type: adr
+slug: a-task-is-born-with-the-verifiers-the-repository
+title: A task is born with the verifiers the repository declares
+created: 2026-08-30T15:31:56Z
+author: haksolot@vmi3223161
+status: proposed
+scope:
+  - crates/ank-cli/src/commands.rs
+  - crates/ank-cli/src/config.rs
+  - crates/ank-cli/src/cli.rs
+  - crates/ank-contract/src/verbs.rs
+  - .ank/config.yml
+constraint: |
+  `ank new task` fills `verify:` with the verifiers config.yml marks `default: true`, unless `--verify` names some explicitly or `--no-verify` asks for none. A verifier is marked through `ank config verifiers.<name>.default`, a nested scalar the surgical writer already handles; the key stays absent until set, and unsetting the verifier removes it with the rest. `ank done` is unchanged and reads no default at close time: a task that declares verifiers has them run and `--proof` refused, a task whose file declares none still requires `--proof`. `verify` stays outside `ank amend`, because an agent that could drop its verifiers between the claim and the done would hold the short-circuit this mechanism exists to remove.
+schema: 4
+version: 1
+---
+
+The strongest claim this project makes is that an agent cannot declare itself
+done without proof. ADR-b6b69053a47b measured how far that had degraded and
+fixed what it could: a proof now records the route it arrived by, and a
+completion nothing external anchors is reported as such. It named, and did not
+close, the reason the degradation was possible at all:
+
+> No task in this corpus declares a `verify:` list, so `ank done` never runs a
+> verifier either.
+
+That is still true. Three verifiers are declared in `config.yml` and none of
+them has ever run under `ank done`, because running them requires a field no
+task fills in. The mechanism is built, configured, tested, and unreachable by
+default.
+
+## What it cost, once, measurably
+
+TASK-54c95c5f2d18 closed with `--proof commit:bb52ce3` while `cargo test
+--workspace` was failing on three platforms: a test counts each installer
+question as one literal string, and the change had split one across `printf`
+placeholders. `cargo-test` is declared in this repository's `config.yml`. Had
+the task carried it in `verify:`, `ank done` would have run it, refused the
+transition with code 5, and refused `--proof` outright. Nothing exotic was
+needed. The field was empty.
+
+## Why the default is seeded and not applied
+
+The obvious repair is for `done` to fall back on a configured list when a task
+declares none. SPEC-88e1 forbids it in as many words: "Without `verify` — field
+absent or empty list — `--proof` is mandatory." A fallback in `done` is a
+supersession of the proof specification, and it buys a second thing nobody
+asked for: a task whose file says it declares no verifier, and a `done` that
+runs two.
+
+Seeding at creation costs neither. The task genuinely declares what will run,
+`ank show` prints it, a reviewer reads it in the diff, and `done` behaves
+exactly as specified because the task is exactly the kind of task the
+specification already describes. One function changes -- `verifiers_of` in
+commands.rs, the single place `--verify` is resolved for both `new` and the
+editor path -- and the two modes of `done` are not touched at all.
+
+## Why the escape is at creation and not at amend
+
+`ank amend` reaches `blocked_by`, `references`, `scope` and an unfrozen
+`done_criteria`. It does not reach `verify`, and that absence is load-bearing:
+an agent that could drop its verifiers between the claim and the `done` would
+have the short-circuit this whole mechanism exists to remove. So the opt-out
+belongs to the moment the task is written, where it is a visible choice in the
+command that created it, and `amend` stays closed.
+
+A task that genuinely cannot be mechanised by the repository's verifiers is a
+real case -- the criterion that only a published release can settle, the one a
+human has to read -- and `--no-verify` says so out loud instead of arriving as
+an empty field nobody chose.
+
+## What this does not do
+
+It does not refuse a typed proof, and it does not touch what `check` reports.
+ADR-b6b69053a47b decided that a proof somebody typed in good faith is worth
+having in the record as what it is, and that stands. It does not reach the
+seventeen finished tasks that carry `done with no test proof`; they are
+reported already, and archaeology is not this decision.

--- a/.ank/entities/LOG-92144f985461.md
+++ b/.ank/entities/LOG-92144f985461.md
@@ -1,0 +1,15 @@
+---
+id: LOG-92144f985461
+type: log
+title: done, proof commit:bb52ce3
+created: 2026-08-30T14:56:30Z
+author: haksolot@vmi3223161
+scope:
+  - install.sh
+  - install.ps1
+  - .github/workflows/install.yml
+about: TASK-54c95c5f2d18
+seq: 5
+schema: 4
+version: 1
+---

--- a/.ank/entities/TASK-25d8646e5db8.md
+++ b/.ank/entities/TASK-25d8646e5db8.md
@@ -1,0 +1,54 @@
+---
+id: TASK-25d8646e5db8
+type: task
+slug: the-proof-section-of-claude-md-stops-teaching-th
+title: The Proof section of CLAUDE.md stops teaching the unverified close
+created: 2026-08-30T15:32:41Z
+author: haksolot@vmi3223161
+status: open
+scope:
+  - CLAUDE.md
+blocked_by: []
+done_criteria: |
+  The Proof section of CLAUDE.md no longer presents ank done --proof commit:<sha> as the route a task closes by, and no longer states the absence of verify: as a property of the corpus. It says instead that a task declares its verifiers when it is written, names the command that does it, and keeps --proof for the criterion no declared verifier can settle, naming that case. The string commit:<sha> occurs in CLAUDE.md only within the sentence describing that remaining case, and every verifier the section names is one .ank/config.yml declares. A test asserts both counts by reading the file, so the paragraph cannot drift back without the suite saying so.
+criteria_by: creator
+verify: [cargo-test, fmt-check]
+schema: 4
+version: 1
+---
+
+The Proof section reads:
+
+> No task in this corpus declares a `verify:` list, so `ank done` requires
+> `--proof`. Give it one you already hold, `commit:<sha>`; never wait for a CI
+> run id.
+
+Every sentence is true, and together they teach an agent to close a task on a
+proof nothing verified. It states the absence of `verify:` as a property of the
+corpus rather than as the thing to fix, and then hands over the route that
+absence forces. An agent that reads this file and follows it exactly arrives at
+a `done` with no verification behind it, which is what happened on
+TASK-54c95c5f2d18: `cargo test --workspace` was failing on three platforms and
+the task closed green on `commit:<sha>`.
+
+The repair is not to delete the paragraph. `--proof` is real and stays: some
+criteria genuinely have no verifier -- the one only a published release
+settles, the one a human has to read -- and ADR-b6b69053a47b is explicit that a
+proof somebody typed in good faith is worth having in the record as what it is.
+What has to change is which route is presented as the normal one.
+
+## Not blocked on the code
+
+`ank new task --verify cargo-test --verify fmt-check` works today. This
+paragraph can stop being wrong before ADR-443590981e41 lands, and the
+instruction it should carry is true either way: a task declares its verifiers
+when it is written. If the seeding lands, the flag stops being something to
+remember and the sentence loses a clause; that is a smaller edit than leaving
+this standing in the meantime.
+
+## Beside it
+
+The Testing section already says a fact is measured and not read, and that a
+task closing with a proof and no measurement leaves nothing behind. The Proof
+section immediately above it prescribes exactly that. Whoever writes this
+should read the two together.

--- a/.ank/entities/TASK-935f4fb886f3.md
+++ b/.ank/entities/TASK-935f4fb886f3.md
@@ -1,0 +1,53 @@
+---
+id: TASK-935f4fb886f3
+type: task
+slug: a-new-task-carries-the-verifiers-config-yml-mark
+title: A new task carries the verifiers config.yml marks, and --no-verify is how you decline them
+created: 2026-08-30T15:32:20Z
+author: haksolot@vmi3223161
+status: open
+scope:
+  - crates/ank-cli/src/commands.rs
+  - crates/ank-cli/src/config.rs
+  - crates/ank-cli/src/cli.rs
+  - crates/ank-contract/src/verbs.rs
+  - .ank/config.yml
+blocked_by: []
+done_criteria: |
+  ank new task with neither --verify nor --no-verify writes a verify list holding exactly the verifiers config.yml marks default: true, in declaration order; with --verify it writes those names and no default joins them; with --no-verify it writes no verify field at all, and --no-verify together with --verify is refused by name. ank config verifiers.<name>.default reads and writes the flag, refuses it on a verifier that is not declared the way timeout does, and ank config --unset verifiers.<name> removes it with the verifier. --no-verify appears in ank help new and in the generated machine surface, and is refused on new adr and new spec. ank done reads no default at close time: a task whose file declares no verifier still requires --proof. Every clause above is tested by invoking the binary in a scratch corpus, and .ank/config.yml marks cargo-test and fmt-check and nothing else.
+criteria_by: creator
+verify: [cargo-test, fmt-check]
+schema: 4
+version: 1
+---
+
+`verifiers_of` in commands.rs is the single place `--verify` is resolved, for
+`ank new task` and for the editor path both. It returns an empty list when the
+flag is absent, and an empty list is what makes `ank done` demand `--proof`
+instead of running anything. The change is there: an empty result becomes the
+verifiers `config.yml` marks, and `--no-verify` is how a caller asks for the
+empty one on purpose.
+
+`ank config` already refuses `verifiers.<name>.timeout` on a verifier that is
+not declared, with code 7. `default` takes the same refusal and the same
+surgery: ADR-e64dfaafd578 keeps the key set closed and refuses a form the
+writer cannot edit safely, and a nested scalar beside `run` and `timeout` is a
+form it already edits.
+
+`--no-verify` reaches the machine surface, so verbs.rs carries it: ADR-6fd6
+makes that table the generated contract, and a flag that exists in the parser
+and not in the table is a surface that disagrees with itself. It applies to
+`new task` alone -- `new adr` already refuses `--verify` by name, and refusing
+`--no-verify` there costs one more arm of the same match.
+
+## What is worth testing through the binary
+
+Three states, and the third is the one a reading would get wrong: no flag
+seeds the defaults, `--verify` names its own and the defaults do not join
+them, `--no-verify` writes no field at all. The last two are not the same
+outcome as each other for any other reason than that the code says so.
+
+And one negative, which is the whole of ADR-443590981e41's second half: a task
+file that declares no verifier still requires `--proof` at `done`. If `done`
+ever learns to read the default, the field stops meaning what it says and
+SPEC-88e1 is superseded by accident.


### PR DESCRIPTION
One proposed ADR and two tasks. Nothing here changes behaviour; the ADR binds nobody until it is ratified on `main`.

## The gap

ADR-b6b69053a47b named this and did not close it:

> No task in this corpus declares a `verify:` list, so `ank done` never runs a verifier either.

Three verifiers are declared in `.ank/config.yml` — `cargo-test`, `fmt-check`, `check-repo` — and none has ever run under `ank done`, because running them needs a field no task fills in. The mechanism is built, configured, tested, and unreachable by default.

It cost something measurable this week. TASK-54c95c5f2d18 closed with `--proof commit:bb52ce3` while `cargo test --workspace` was failing on three platforms: a test counts each installer question as one literal string, and the change had split one across `printf` placeholders. Had the task carried `cargo-test` in `verify:`, `ank done` would have run it, refused the transition with code 5, and refused `--proof` outright.

## Why the default is seeded and not applied

The obvious repair is for `done` to fall back on a configured list when a task declares none. SPEC-88e1 forbids it in as many words:

> Without `verify` — field absent or empty list — `--proof` is mandatory.

A fallback in `done` is a supersession of the proof specification, and it buys a second thing nobody asked for: a task whose file says it declares no verifier, and a `done` that runs two.

Seeding at creation costs neither. `ank new task` fills `verify:` from the verifiers `config.yml` marks `default: true`; the task genuinely declares what will run, `ank show` prints it, a reviewer reads it in the diff, and `done` behaves exactly as specified. One function changes — `verifiers_of` in commands.rs, the single place `--verify` is resolved for both `new` and the editor path.

The flag is `verifiers.<name>.default`, a nested scalar beside `run` and `timeout`. ADR-e64dfaafd578 keeps the key set closed and refuses a form the surgical writer cannot edit safely; a nested scalar is a form it already edits, where a top-level list would not be.

## Why the escape is at creation

`ank amend` reaches `blocked_by`, `references`, `scope` and an unfrozen `done_criteria`. It does not reach `verify`, and that absence is load-bearing: an agent that could drop its verifiers between the claim and the `done` would hold the short-circuit this mechanism exists to remove. So `--no-verify` belongs to the moment the task is written, and `amend` stays closed.

## What lands

| | |
|---|---|
| ADR-443590981e41 | A task is born with the verifiers the repository declares — **proposed** |
| TASK-935f4fb886f3 | `ank new task` carries the marked verifiers, and `--no-verify` declines them |
| TASK-25d8646e5db8 | The Proof section of CLAUDE.md stops teaching the unverified close |

Neither task blocks the other. `ank new task --verify cargo-test` works today, so the guidance can stop being wrong before the seeding lands.

Both tasks declare `verify: [cargo-test, fmt-check]`, which is the decision applying to itself.

## Not in scope

The seventeen finished tasks carrying `done with no test proof`. ADR-b6b69053a47b reports them already and chose report-not-refuse deliberately; retrofitting them is archaeology, not this decision. Nothing here changes what `check` reports or refuses a typed proof.

`LOG-92144f985461` travels with the plan: `ank done` wrote it for TASK-54c95c5f2d18 and the close commit missed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AG9JGEXdoxahULZMskASSK