### PR TITLE
CLAUDE.md: the Proof section stops teaching the unverified close

### DIFF
--- a/.ank/entities/LOG-037f5d23c56a.md
+++ b/.ank/entities/LOG-037f5d23c56a.md
@@ -1,0 +1,15 @@
+---
+id: LOG-037f5d23c56a
+type: log
+title: "measured: ank new --verify <name> refuses at exit 7 a name .ank/config.yml does not declare (probe"
+created: 2026-08-30T16:23:58Z
+author: claude-code/opus-5+claude-md
+scope:
+  - CLAUDE.md
+about: TASK-25d8646e5db8
+seq: 0
+schema: 4
+version: 1
+---
+
+ repo, error[7] no verifier 'cargo-test'); with cargo-test and fmt-check declared, ank new task --verify cargo-test --verify fmt-check writes verify: [cargo-test, fmt-check] and ank done --proof commit:HEAD is then refused at exit 5 'declares verifiers, so --proof is refused'

--- a/.ank/entities/LOG-13bd7e249f0f.md
+++ b/.ank/entities/LOG-13bd7e249f0f.md
@@ -1,0 +1,15 @@
+---
+id: LOG-13bd7e249f0f
+type: log
+title: +scope crates/ank-cli/tests/guide.rs (version 2 to 3, replaced 1ed870ea40d6, produced ff4f9d1fbfa2)
+created: 2026-08-30T16:24:16Z
+author: claude-code/opus-5+claude-md
+scope:
+  - CLAUDE.md
+  - crates/ank-cli/tests/guide.rs
+about: TASK-25d8646e5db8
+seq: 1
+records: edit
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-3e640c2994d9.md
+++ b/.ank/entities/LOG-3e640c2994d9.md
@@ -1,0 +1,14 @@
+---
+id: LOG-3e640c2994d9
+type: log
+title: done, proof test:local/6076ab185a52@40c799f test:local/e3b0c44298fc@40c799f
+created: 2026-08-30T16:32:08Z
+author: claude-code/opus-5+claude-md
+scope:
+  - CLAUDE.md
+  - crates/ank-cli/tests/guide.rs
+about: TASK-25d8646e5db8
+seq: 4
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-914e1062206f.md
+++ b/.ank/entities/LOG-914e1062206f.md
@@ -1,0 +1,16 @@
+---
+id: LOG-914e1062206f
+type: log
+title: "measured: each assertion in crates/ank-cli/tests/guide.rs was made to fail by mutating CLAUDE.md"
+created: 2026-08-30T16:26:12Z
+author: claude-code/opus-5+claude-md
+scope:
+  - CLAUDE.md
+  - crates/ank-cli/tests/guide.rs
+about: TASK-25d8646e5db8
+seq: 2
+schema: 4
+version: 1
+---
+
+ and passed again on restore -- reintroducing '--proof commit:<sha>' fails 3 of 5 (count, sentence, forbidden string), renaming check-repo to clippy-strict fails the declared-verifier count, restoring 'No task in this corpus declares' fails the forbidden-string test, dropping 'ank new task --verify' fails the creation test; 5 passed on the restored file

--- a/.ank/entities/LOG-c0e182d18aa2.md
+++ b/.ank/entities/LOG-c0e182d18aa2.md
@@ -1,0 +1,16 @@
+---
+id: LOG-c0e182d18aa2
+type: log
+title: "environment: ank done runs verifiers through sh -c, which does not read the login shell's PATH here"
+created: 2026-08-30T16:26:50Z
+author: claude-code/opus-5+claude-md
+scope:
+  - CLAUDE.md
+  - crates/ank-cli/tests/guide.rs
+about: TASK-25d8646e5db8
+seq: 3
+schema: 4
+version: 1
+---
+
+ -- cargo-test failed at exit 9 (shell code 127, 'cargo: not found') until PATH included ~/.cargo/bin. Exit 9 is a broken environment and not a failing test, exactly as SPEC-88e1 says.

--- a/.ank/entities/TASK-25d8646e5db8.md
+++ b/.ank/entities/TASK-25d8646e5db8.md
@@ -5,16 +5,17 @@ slug: the-proof-section-of-claude-md-stops-teaching-th
 title: The Proof section of CLAUDE.md stops teaching the unverified close
 created: 2026-08-30T15:32:41Z
 author: haksolot@vmi3223161
-status: open
+status: in_progress
 scope:
   - CLAUDE.md
+  - crates/ank-cli/tests/guide.rs
 blocked_by: []
 done_criteria: |
   The Proof section of CLAUDE.md no longer presents ank done --proof commit:<sha> as the route a task closes by, and no longer states the absence of verify: as a property of the corpus. It says instead that a task declares its verifiers when it is written, names the command that does it, and keeps --proof for the criterion no declared verifier can settle, naming that case. The string commit:<sha> occurs in CLAUDE.md only within the sentence describing that remaining case, and every verifier the section names is one .ank/config.yml declares. A test asserts both counts by reading the file, so the paragraph cannot drift back without the suite saying so.
 criteria_by: creator
 verify: [cargo-test, fmt-check]
 schema: 4
-version: 1
+version: 3
 ---
 
 The Proof section reads:

--- a/.ank/entities/TASK-25d8646e5db8.md
+++ b/.ank/entities/TASK-25d8646e5db8.md
@@ -5,7 +5,7 @@ slug: the-proof-section-of-claude-md-stops-teaching-th
 title: The Proof section of CLAUDE.md stops teaching the unverified close
 created: 2026-08-30T15:32:41Z
 author: haksolot@vmi3223161
-status: in_progress
+status: done
 scope:
   - CLAUDE.md
   - crates/ank-cli/tests/guide.rs
@@ -14,8 +14,21 @@ done_criteria: |
   The Proof section of CLAUDE.md no longer presents ank done --proof commit:<sha> as the route a task closes by, and no longer states the absence of verify: as a property of the corpus. It says instead that a task declares its verifiers when it is written, names the command that does it, and keeps --proof for the criterion no declared verifier can settle, naming that case. The string commit:<sha> occurs in CLAUDE.md only within the sentence describing that remaining case, and every verifier the section names is one .ank/config.yml declares. A test asserts both counts by reading the file, so the paragraph cannot drift back without the suite saying so.
 criteria_by: creator
 verify: [cargo-test, fmt-check]
+proof:
+  - type: test
+    ref: local/6076ab185a52@40c799f
+    tree: scope/a4ec32f3bdd7
+    criteria: 21f5a94b5bf1
+    verifier: cargo-test@f14aeab36e1b
+    via: verifier
+  - type: test
+    ref: local/e3b0c44298fc@40c799f
+    tree: scope/a4ec32f3bdd7
+    criteria: 21f5a94b5bf1
+    verifier: fmt-check@5ca6d10bcd55
+    via: verifier
 schema: 4
-version: 3
+version: 4
 ---
 
 The Proof section reads:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,9 +30,30 @@ defect; it bites only a project dogfooding ank on itself.
 
 ## Proof
 
-No task in this corpus declares a `verify:` list, so `ank done` requires
-`--proof`. Give it one you already hold, `commit:<sha>`; never wait for a CI
-run id. Once the task lands on the default branch, the `attest` job records
+A task declares its verifiers when it is written. `ank new task --verify
+cargo-test --verify fmt-check` fills `verify:`, and `ank done` then runs every
+verifier in that list, records what ran, and refuses `--proof` outright: the
+close becomes Ank's statement about the tree instead of the agent's. `--verify`
+takes a name `.ank/config.yml` declares -- `cargo-test`, `fmt-check`,
+`check-repo` -- and refuses at exit 7 anything else, so a name you misremember
+fails when you write the task rather than at the close.
+
+Declare them. A task closing on a proof nothing ran is the failure this
+paragraph exists to stop: TASK-54c95c5f2d18 closed green while `cargo test
+--workspace` was failing on three platforms, and `cargo-test` was declared in
+`config.yml` the whole time -- the list was empty, so `ank done` had nothing to
+run and took a typed proof instead.
+
+`--proof` stays, for the criterion no declared verifier can settle -- the one
+only a published release answers, the one a human has to read -- and in that
+case you give a proof you already hold, `commit:<sha>`, never a CI run id you
+would have to wait for. An empty `verify:` is that judgement and nothing else,
+made when the task is written and visible in its diff; it is not the state a
+task arrives in by default. ADR-b6b69053a47b keeps the record honest either way:
+a proof somebody typed in good faith is worth having as what it is, and `check`
+goes on saying that nothing external anchors it.
+
+Once the task lands on the default branch, the `attest` job records
 `test:<run-id>` itself, on `refs/ank/proof/<id>`, and turns red rather than
 skipping when the proof does not reach the remote. The recipe and the contract
 it rests on are in `docs/getting-started.md`.

--- a/crates/ank-cli/tests/guide.rs
+++ b/crates/ank-cli/tests/guide.rs
@@ -1,0 +1,232 @@
+//! The Proof section of `CLAUDE.md`, and the two counts that hold it in place.
+//!
+//! `CLAUDE.md` is loaded into every agent's context in this repository before
+//! it does anything, which makes its prose an instruction and not a note. The
+//! Proof section used to read that no task in this corpus declares a `verify:`
+//! list, and then hand over the route that absence forces -- `ank done --proof
+//! commit:<sha>`. Every sentence was true and the paragraph was wrong: it
+//! stated the thing to fix as a property of the corpus, and taught the close
+//! nothing verifies. TASK-54c95c5f2d18 closed green that way while `cargo test
+//! --workspace` was failing on three platforms.
+//!
+//! Two facts keep the repaired paragraph from drifting back, and neither is
+//! safe as a habit:
+//!
+//! 1. `commit:<sha>` appears **once** in the whole file, inside the sentence
+//!    naming the case that keeps `--proof` -- the criterion no declared
+//!    verifier can settle. A second occurrence is the old route returning.
+//! 2. Every verifier the section names is one `.ank/config.yml` declares.
+//!    Naming a verifier the repository does not have teaches an `ank new
+//!    --verify` that refuses at exit 7, which reads to whoever tries it as the
+//!    guide being wrong about the tool.
+//!
+//! Both are counted here rather than reviewed, because a paragraph is exactly
+//! the kind of thing a later edit walks back one sentence at a time.
+
+use std::fs;
+use std::path::PathBuf;
+
+fn repo_file(rel: &str) -> String {
+    let p = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join(rel);
+    let text = fs::read_to_string(&p).unwrap_or_else(|e| panic!("{}: {e}", p.display()));
+    // `CLAUDE.md` is not pinned to LF by `.gitattributes`, so a checkout on
+    // Windows hands this test CRLF. What is asserted here is the characters,
+    // and a line ending git chose is not one of them.
+    text.replace("\r\n", "\n")
+}
+
+fn guide() -> String {
+    repo_file("CLAUDE.md")
+}
+
+/// The body of one `##` section of `CLAUDE.md`, heading excluded.
+fn section(text: &str, heading: &str) -> String {
+    let open = format!("\n## {heading}\n");
+    let from = text
+        .find(&open)
+        .unwrap_or_else(|| panic!("CLAUDE.md has no `## {heading}` section"))
+        + open.len();
+    let rest = &text[from..];
+    let to = rest.find("\n## ").unwrap_or(rest.len());
+    rest[..to].to_string()
+}
+
+/// The verifier names `.ank/config.yml` declares, read as the keys nested one
+/// level under `verifiers:`.
+///
+/// Hand-scanned rather than parsed with a yaml crate: `ank-cli` has no yaml
+/// dependency for its tests, and the shape being read is two levels of fixed
+/// indentation that `ank config` writes and `check` validates.
+fn declared_verifiers() -> Vec<String> {
+    let text = repo_file(".ank/config.yml");
+    let mut inside = false;
+    let mut names = Vec::new();
+    for line in text.lines() {
+        if !line.starts_with(char::is_whitespace) {
+            inside = line.trim_end() == "verifiers:";
+            continue;
+        }
+        if !inside {
+            continue;
+        }
+        // A key of the block itself is indented exactly two spaces; anything
+        // deeper is `run:` or `timeout:` belonging to the verifier above it.
+        let Some(rest) = line.strip_prefix("  ") else {
+            continue;
+        };
+        if rest.starts_with(' ') {
+            continue;
+        }
+        if let Some(name) = rest.split(':').next() {
+            let name = name.trim();
+            if !name.is_empty() {
+                names.push(name.to_string());
+            }
+        }
+    }
+    assert!(
+        !names.is_empty(),
+        ".ank/config.yml declares no verifiers, so nothing below is being checked"
+    );
+    names
+}
+
+/// The whitespace-separated tokens of every backticked span in `text`.
+///
+/// A span is read token by token because the section's spans are commands:
+/// `ank new task --verify cargo-test --verify fmt-check` carries two verifier
+/// names inside one pair of backticks.
+fn code_tokens(text: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut rest = text;
+    while let Some(open) = rest.find('`') {
+        rest = &rest[open + 1..];
+        let Some(close) = rest.find('`') else { break };
+        for token in rest[..close].split_whitespace() {
+            tokens.push(token.to_string());
+        }
+        rest = &rest[close + 1..];
+    }
+    tokens
+}
+
+/// Whether a token is shaped like a verifier name: lowercase kebab-case, at
+/// least one hyphen, and nothing that makes it a path, a flag or a reference.
+///
+/// This is what makes the second count possible at all. There is no marker in
+/// the prose saying "this word is a verifier", so the shape has to do it, and
+/// the shape is the one every name in `config.yml` has and no other backticked
+/// token in the section does: `--proof` is a flag, `commit:<sha>` a reference,
+/// `.ank/config.yml` a path, `ank done` two bare words.
+fn looks_like_a_verifier(token: &str) -> bool {
+    token.contains('-')
+        && token.starts_with(|c: char| c.is_ascii_lowercase())
+        && token
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+}
+
+// ---------------------------------------------------------------------------
+// Count one: `commit:<sha>` occurs once, where the remaining case is named
+// ---------------------------------------------------------------------------
+
+#[test]
+fn commit_sha_occurs_exactly_once_in_the_guide() {
+    let text = guide();
+    let count = text.matches("commit:<sha>").count();
+    assert_eq!(
+        count, 1,
+        "CLAUDE.md names `commit:<sha>` {count} time(s); it belongs in exactly one \
+         sentence, the one describing the criterion no declared verifier can settle"
+    );
+}
+
+#[test]
+fn the_one_commit_sha_sits_in_the_sentence_that_keeps_proof() {
+    let text = guide();
+    let proof = section(&text, "Proof");
+    assert!(
+        proof.contains("commit:<sha>"),
+        "the single `commit:<sha>` has left the Proof section"
+    );
+
+    // The sentence around it, taken between the full stops that bound it. Line
+    // breaks are the paragraph's wrapping and not sentence boundaries, so the
+    // section is flattened first.
+    let flat = proof.replace('\n', " ");
+    let at = flat.find("commit:<sha>").unwrap();
+    let start = flat[..at].rfind(". ").map_or(0, |i| i + 2);
+    let end = flat[at..].find(". ").map_or(flat.len(), |i| at + i + 1);
+    let sentence = &flat[start..end];
+
+    assert!(
+        sentence.contains("--proof"),
+        "`commit:<sha>` is no longer in a sentence about `--proof`: {sentence:?}"
+    );
+    assert!(
+        sentence.contains("no declared verifier can settle"),
+        "the sentence carrying `commit:<sha>` no longer names the case that keeps \
+         `--proof` -- the criterion no declared verifier can settle: {sentence:?}"
+    );
+}
+
+#[test]
+fn the_guide_never_spells_the_close_it_stopped_teaching() {
+    let text = guide();
+    assert!(
+        !text.contains("--proof commit:"),
+        "CLAUDE.md hands `--proof commit:` back as the route a task closes by; \
+         the route is `ank done` running the verifiers the task declares"
+    );
+    assert!(
+        !text.contains("No task in this corpus declares"),
+        "CLAUDE.md states the absence of `verify:` as a property of the corpus \
+         again; it is the thing to fix, not a fact to work around"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Count two: every verifier the section names is declared
+// ---------------------------------------------------------------------------
+
+#[test]
+fn every_verifier_the_proof_section_names_is_declared_in_config() {
+    let declared = declared_verifiers();
+    let proof = section(&guide(), "Proof");
+
+    let named: Vec<String> = code_tokens(&proof)
+        .into_iter()
+        .filter(|t| looks_like_a_verifier(t))
+        .collect();
+
+    assert!(
+        !named.is_empty(),
+        "the Proof section names no verifier at all, so an agent reading it has \
+         nothing to put in `verify:`"
+    );
+
+    let undeclared: Vec<&String> = named.iter().filter(|n| !declared.contains(n)).collect();
+    assert_eq!(
+        undeclared.len(),
+        0,
+        "the Proof section names {} verifier(s) `.ank/config.yml` does not declare: \
+         {undeclared:?}; declared are {declared:?}",
+        undeclared.len()
+    );
+}
+
+#[test]
+fn the_proof_section_teaches_declaring_verifiers_at_creation() {
+    let proof = section(&guide(), "Proof");
+    assert!(
+        proof.contains("ank new task --verify"),
+        "the Proof section no longer names the command that declares a task's \
+         verifiers when it is written"
+    );
+    assert!(
+        proof.contains("ank done"),
+        "the Proof section no longer names the command that runs them"
+    );
+}


### PR DESCRIPTION
Closes TASK-25d8646e5db8.

The Proof section read that no task in this corpus declares a `verify:` list,
so `ank done` requires `--proof`, and then handed over the route that absence
forces. Every sentence was true and the whole was wrong: it stated the thing to
fix as a property of the corpus, and the Testing section immediately below it
already says that a task closing with a proof and no measurement leaves nothing
behind. TASK-54c95c5f2d18 followed it exactly and closed green while `cargo
test --workspace` was failing on three platforms.

It now says a task declares its verifiers when it is written, names `ank new
task --verify cargo-test --verify fmt-check`, and keeps `--proof` for the
criterion no declared verifier can settle — the case ADR-b6b69053a47b decided
is worth recording as what it is. It does not name `--no-verify`, which
ADR-443590981e41 has not landed yet; the instruction is true either way.

`crates/ank-cli/tests/guide.rs` counts the two facts that hold it there:
`commit:<sha>` occurs once in the file and inside the sentence naming that
remaining case, and every verifier the section names is one `.ank/config.yml`
declares. Each of the five assertions was made to fail by mutating CLAUDE.md
before it was believed — reintroducing `--proof commit:<sha>` fails three,
renaming `check-repo` to a verifier config does not declare fails the second
count, restoring the old sentence and dropping the `--verify` command fail one
each.

Closed on its own verifiers rather than on a typed proof: the task declares
`verify: [cargo-test, fmt-check]`, `ank done` ran both and refused `--proof`.

    cargo-test@f14aeab36e1b -> local/6076ab185a52@40c799f  (scope/a4ec32f3bdd7)
    fmt-check@5ca6d10bcd55  -> local/e3b0c44298fc@40c799f  (scope/a4ec32f3bdd7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012K1rTFTsSZsYhxyNxCLxLr