### PR TITLE
The nine remaining fixture sites leave git maintenance off

### DIFF
--- a/.ank/entities/LOG-0a4d22621c50.md
+++ b/.ank/entities/LOG-0a4d22621c50.md
@@ -1,0 +1,23 @@
+---
+id: LOG-0a4d22621c50
+type: log
+title: "Measured, not read. Before: the nine remaining fixture sites answer nothing for gc.auto and nothing"
+created: 2026-08-30T19:02:48Z
+author: claude-code/opus-5+fixtures
+scope:
+  - crates/ank-cli/src/commands.rs
+  - crates/ank-cli/src/context.rs
+  - crates/ank-cli/src/done.rs
+  - crates/ank-cli/src/git.rs
+  - crates/ank-cli/src/init.rs
+  - crates/ank-cli/tests/cli.rs
+  - crates/ank-cli/tests/mcp.rs
+  - crates/ank-cli/tests/tui.rs
+  - crates/ank-cli/tests/watch.rs
+about: TASK-4aaccc28660e
+seq: 0
+schema: 4
+version: 1
+---
+
+ for maintenance.auto, so git's own defaults apply and maintenance was on in every one. The nine new tests, added before any fix, fail on 'gc.auto ... left: None, right: Some("0")' at commands.rs, context.rs, done.rs, git.rs, init.rs, tests/cli.rs, tests/mcp.rs, tests/tui.rs and tests/watch.rs -- watch.rs failing first on origin.git, the bare remote, which the walk reached without being told about it. claim.rs and human.rs, fixed by TASK-fc6bef21e268, pass under the same helper. git 2.47.3.

--- a/.ank/entities/LOG-10d4a2ac349b.md
+++ b/.ank/entities/LOG-10d4a2ac349b.md
@@ -1,0 +1,21 @@
+---
+id: LOG-10d4a2ac349b
+type: log
+title: done, proof commit:72b5be60e51ed23946ca64fda673f8e55eb823f3
+created: 2026-08-30T19:32:55Z
+author: claude-code/opus-5+fixtures
+scope:
+  - crates/ank-cli/src/commands.rs
+  - crates/ank-cli/src/context.rs
+  - crates/ank-cli/src/done.rs
+  - crates/ank-cli/src/git.rs
+  - crates/ank-cli/src/init.rs
+  - crates/ank-cli/tests/cli.rs
+  - crates/ank-cli/tests/mcp.rs
+  - crates/ank-cli/tests/tui.rs
+  - crates/ank-cli/tests/watch.rs
+about: TASK-4aaccc28660e
+seq: 5
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-29370acfe9bb.md
+++ b/.ank/entities/LOG-29370acfe9bb.md
@@ -1,0 +1,23 @@
+---
+id: LOG-29370acfe9bb
+type: log
+title: Negative control, both bare remotes the criterion names. With the two config lines removed from
+created: 2026-08-30T19:16:28Z
+author: claude-code/opus-5+fixtures
+scope:
+  - crates/ank-cli/src/commands.rs
+  - crates/ank-cli/src/context.rs
+  - crates/ank-cli/src/done.rs
+  - crates/ank-cli/src/git.rs
+  - crates/ank-cli/src/init.rs
+  - crates/ank-cli/tests/cli.rs
+  - crates/ank-cli/tests/mcp.rs
+  - crates/ank-cli/tests/tui.rs
+  - crates/ank-cli/tests/watch.rs
+about: TASK-4aaccc28660e
+seq: 1
+schema: 4
+version: 1
+---
+
+ cli.rs cloned() and nothing else changed, cli.rs a_fixture_repository_is_not_maintained_under_the_test fails at 'gc.auto at .../ank-cli-it-3074444-0.origin.git, left: None, right: Some("0")'; with them removed from watch.rs bare() it fails at '.../unmaintained-1/origin.git'. Restored, both pass. The walk reaches a bare repository nobody enrolled, which is the whole point of finding them rather than naming them.

--- a/.ank/entities/LOG-54d35709430a.md
+++ b/.ank/entities/LOG-54d35709430a.md
@@ -1,0 +1,23 @@
+---
+id: LOG-54d35709430a
+type: log
+title: "One deliberate strengthening of the shape TASK-fc6bef21e268 established: the read is 'git"
+created: 2026-08-30T19:17:08Z
+author: claude-code/opus-5+fixtures
+scope:
+  - crates/ank-cli/src/commands.rs
+  - crates/ank-cli/src/context.rs
+  - crates/ank-cli/src/done.rs
+  - crates/ank-cli/src/git.rs
+  - crates/ank-cli/src/init.rs
+  - crates/ank-cli/tests/cli.rs
+  - crates/ank-cli/tests/mcp.rs
+  - crates/ank-cli/tests/tui.rs
+  - crates/ank-cli/tests/watch.rs
+about: TASK-4aaccc28660e
+seq: 3
+schema: 4
+version: 1
+---
+
+ --git-dir=<dir> config --local --get <key>', where the four earlier files use '--get' alone. '--get' answers from every scope, so on a machine whose global configuration already carries gc.auto=0 the assertion would pass against a fixture that sets nothing -- vacuous exactly where it is meant to bite. '--local' answers out of the repository's own config file and nowhere else. Measured: claim.rs and human.rs, fixed by the earlier task, still pass under the stricter read, so the two shapes agree wherever the earlier one was already right.

--- a/.ank/entities/LOG-5d862f6af9b4.md
+++ b/.ank/entities/LOG-5d862f6af9b4.md
@@ -1,0 +1,23 @@
+---
+id: LOG-5d862f6af9b4
+type: log
+title: "Discrepancy: the briefing for this session said TASK-4aac declares verify: [cargo-test, fmt-check]"
+created: 2026-08-30T19:32:48Z
+author: claude-code/opus-5+fixtures
+scope:
+  - crates/ank-cli/src/commands.rs
+  - crates/ank-cli/src/context.rs
+  - crates/ank-cli/src/done.rs
+  - crates/ank-cli/src/git.rs
+  - crates/ank-cli/src/init.rs
+  - crates/ank-cli/tests/cli.rs
+  - crates/ank-cli/tests/mcp.rs
+  - crates/ank-cli/tests/tui.rs
+  - crates/ank-cli/tests/watch.rs
+about: TASK-4aaccc28660e
+seq: 4
+schema: 4
+version: 1
+---
+
+ and that ank done would therefore run them and refuse --proof. Measured: 'ank done' with no flag refuses at exit 5, 'proof required to move TASK-4aaccc28660e to done -> ank done --proof commit:<sha>'; the file carries no verify field at all, and 'ank show' prints one where there is one (TASK-935f4fb886f3 shows 'verify: [cargo-test, fmt-check]'). The reason is chronology, not a defect: TASK-4aac was created 2026-08-30T04:03:19Z and the verifiers feature landed that afternoon in 4a50e48, so this task predates the field and 'ank amend' has no flag that could add it. Closing therefore takes the road CLAUDE.md keeps open for an empty verify list -- a proof already held, commit:72b5be6, of a tree whose cargo test --workspace and cargo fmt --check I ran green before committing.

--- a/.ank/entities/LOG-98a1dac8c33a.md
+++ b/.ank/entities/LOG-98a1dac8c33a.md
@@ -1,0 +1,23 @@
+---
+id: LOG-98a1dac8c33a
+type: log
+title: "Whole-suite census, measured not read: a git shim on PATH recorded every invocation of the"
+created: 2026-08-30T19:16:37Z
+author: claude-code/opus-5+fixtures
+scope:
+  - crates/ank-cli/src/commands.rs
+  - crates/ank-cli/src/context.rs
+  - crates/ank-cli/src/done.rs
+  - crates/ank-cli/src/git.rs
+  - crates/ank-cli/src/init.rs
+  - crates/ank-cli/tests/cli.rs
+  - crates/ank-cli/tests/mcp.rs
+  - crates/ank-cli/tests/tui.rs
+  - crates/ank-cli/tests/watch.rs
+about: TASK-4aaccc28660e
+seq: 2
+schema: 4
+version: 1
+---
+
+ workspace suite (23232 lines), and every repository it creates was then matched against the configuration it was given. 707 repositories built by cargo test --workspace; 707 answer gc.auto=0 and 707 answer maintenance.auto=false; 0 missing either. That is the census that says no repository-creating site was missed, in the nine files of this task or outside them -- a grep over the sources could only have said which lines exist. git 2.47.3, Linux.

--- a/.ank/entities/TASK-4aaccc28660e.md
+++ b/.ank/entities/TASK-4aaccc28660e.md
@@ -5,7 +5,7 @@ slug: the-nine-remaining-fixture-sites-still-leave-git
 title: The nine remaining fixture sites still leave git maintenance on
 created: 2026-08-30T04:03:19Z
 author: claude-code/opus-5+fixtures-not-maintained
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/src/commands.rs
   - crates/ank-cli/src/context.rs
@@ -22,6 +22,11 @@ done_criteria: |
   
   TASK-fc6bef21e268 said four sites had a git init and fixed those four. Measured on 2026-08-30 while it was held: thirteen files in this workspace build a fixture repository, and the other nine were left maintained. The failure this guards against is recorded there: git repacked a fixture between two fingerprints of it in run 33284185681 and a test asserting that a read writes nothing failed on ubuntu-latest while passing on the other two platforms.
 criteria_by: creator
+proof:
+  - type: commit
+    ref: 72b5be60e51ed23946ca64fda673f8e55eb823f3
+    criteria: ffe51142f4d3
+    via: submitted
 schema: 4
-version: 2
+version: 3
 ---

--- a/.ank/entities/TASK-4aaccc28660e.md
+++ b/.ank/entities/TASK-4aaccc28660e.md
@@ -5,7 +5,7 @@ slug: the-nine-remaining-fixture-sites-still-leave-git
 title: The nine remaining fixture sites still leave git maintenance on
 created: 2026-08-30T04:03:19Z
 author: claude-code/opus-5+fixtures-not-maintained
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/src/commands.rs
   - crates/ank-cli/src/context.rs
@@ -23,5 +23,5 @@ done_criteria: |
   TASK-fc6bef21e268 said four sites had a git init and fixed those four. Measured on 2026-08-30 while it was held: thirteen files in this workspace build a fixture repository, and the other nine were left maintained. The failure this guards against is recorded there: git repacked a fixture between two fingerprints of it in run 33284185681 and a test asserting that a read writes nothing failed on ubuntu-latest while passing on the other two platforms.
 criteria_by: creator
 schema: 4
-version: 1
+version: 2
 ---

--- a/crates/ank-cli/src/commands.rs
+++ b/crates/ank-cli/src/commands.rs
@@ -2332,6 +2332,10 @@ mod tests {
                 vec!["config", "user.email", "test@ank.local"],
                 vec!["config", "user.name", "Test"],
                 vec!["config", "core.autocrlf", "false"],
+                // Maintenance off, because git is otherwise free to repack a
+                // fixture between two reads of it (TASK-fc6bef21e268).
+                vec!["config", "gc.auto", "0"],
+                vec!["config", "maintenance.auto", "false"],
             ] {
                 assert!(Command::new("git")
                     .current_dir(&t.0)
@@ -3247,5 +3251,94 @@ mod tests {
                 .unwrap_err()
                 .hint
         );
+    }
+
+    /// Every git repository inside a fixture, found rather than listed.
+    ///
+    /// A directory holding a `HEAD` file and an `objects` directory is one,
+    /// whether it is the `.git` beside a working tree or a bare corpus. Found,
+    /// because a list would have to be maintained, and what is being guarded
+    /// against is exactly a repository nobody remembered to enrol.
+    fn repositories_under(root: &std::path::Path) -> Vec<std::path::PathBuf> {
+        let mut found = Vec::new();
+        let mut stack = vec![root.to_path_buf()];
+        while let Some(dir) = stack.pop() {
+            if dir.join("HEAD").is_file() && dir.join("objects").is_dir() {
+                found.push(dir);
+                continue;
+            }
+            let Ok(entries) = std::fs::read_dir(&dir) else {
+                continue;
+            };
+            for e in entries.flatten() {
+                if e.file_type().is_ok_and(|t| t.is_dir()) {
+                    stack.push(e.path());
+                }
+            }
+        }
+        found
+    }
+
+    /// What git answers for one key of one repository's own configuration, `None`
+    /// when the key is unset -- which is the state this asserts against, since an
+    /// unset `maintenance.auto` means maintenance is on.
+    ///
+    /// `--local`, so what comes back is the fixture's answer and never the
+    /// machine's: a contributor carrying `gc.auto` in a global configuration would
+    /// otherwise read a pass out of a repository that sets nothing.
+    fn config_of(git_dir: &std::path::Path, key: &str) -> Option<String> {
+        let out = std::process::Command::new("git")
+            .arg("--git-dir")
+            .arg(git_dir)
+            .args(["config", "--local", "--get", key])
+            .output()
+            .expect("git must be installed: it is a hard dependency");
+        out.status
+            .success()
+            .then(|| String::from_utf8_lossy(&out.stdout).trim().to_string())
+    }
+
+    /// Asserts that every repository under `root` is one git will not maintain.
+    ///
+    /// Read back out of a freshly built fixture rather than grepped out of this
+    /// file: what is under test is the configuration `git init` was actually
+    /// followed by, and a grep passes on a comment and fails on a refactor.
+    fn assert_unmaintained(root: &std::path::Path) {
+        let repos = repositories_under(root);
+        assert!(
+            !repos.is_empty(),
+            "no repository found under {}: this asserts nothing",
+            root.display()
+        );
+        for git_dir in repos {
+            let at = git_dir.display();
+            assert_eq!(
+                config_of(&git_dir, "gc.auto").as_deref(),
+                Some("0"),
+                "gc.auto at {at}"
+            );
+            assert_eq!(
+                config_of(&git_dir, "maintenance.auto").as_deref(),
+                Some("false"),
+                "maintenance.auto at {at}"
+            );
+        }
+    }
+
+    /// A fixture repository is not maintained under the test.
+    ///
+    /// Measured on 2026-08-30 in run 33284185681: git repacked a fixture between
+    /// two fingerprints of it -- `objects/maintenance.lock`, a `tmp_pack` and six
+    /// loose objects in the first, a multi-pack-index, two packs and `info/refs`
+    /// in the second -- and a test asserting that a read writes nothing failed on
+    /// one platform of three. Ank had written nothing (TASK-fc6bef21e268).
+    ///
+    /// The repositories are found by walking the fixture and not named here, so a
+    /// second one grown under it later is held to this without anyone remembering
+    /// to enrol it.
+    #[test]
+    fn a_fixture_repository_is_not_maintained_under_the_test() {
+        let t = Temp::new();
+        assert_unmaintained(&t.0);
     }
 }

--- a/crates/ank-cli/src/context.rs
+++ b/crates/ank-cli/src/context.rs
@@ -1928,6 +1928,10 @@ After a blank one."
                 // (TASK-40a972e98a9a).
                 vec!["config", "commit.gpgsign", "false"],
                 vec!["config", "tag.gpgsign", "false"],
+                // Maintenance off, because git is otherwise free to repack a
+                // fixture between two reads of it (TASK-fc6bef21e268).
+                vec!["config", "gc.auto", "0"],
+                vec!["config", "maintenance.auto", "false"],
             ] {
                 let st = Command::new("git")
                     .current_dir(&t.0)
@@ -2910,5 +2914,94 @@ The document.
         // and the first is on neither.
         assert_eq!(kept.last(), log.last());
         assert!(!kept.contains(&log[0]), "the oldest survived the cut");
+    }
+
+    /// Every git repository inside a fixture, found rather than listed.
+    ///
+    /// A directory holding a `HEAD` file and an `objects` directory is one,
+    /// whether it is the `.git` beside a working tree or a bare corpus. Found,
+    /// because a list would have to be maintained, and what is being guarded
+    /// against is exactly a repository nobody remembered to enrol.
+    fn repositories_under(root: &std::path::Path) -> Vec<std::path::PathBuf> {
+        let mut found = Vec::new();
+        let mut stack = vec![root.to_path_buf()];
+        while let Some(dir) = stack.pop() {
+            if dir.join("HEAD").is_file() && dir.join("objects").is_dir() {
+                found.push(dir);
+                continue;
+            }
+            let Ok(entries) = std::fs::read_dir(&dir) else {
+                continue;
+            };
+            for e in entries.flatten() {
+                if e.file_type().is_ok_and(|t| t.is_dir()) {
+                    stack.push(e.path());
+                }
+            }
+        }
+        found
+    }
+
+    /// What git answers for one key of one repository's own configuration, `None`
+    /// when the key is unset -- which is the state this asserts against, since an
+    /// unset `maintenance.auto` means maintenance is on.
+    ///
+    /// `--local`, so what comes back is the fixture's answer and never the
+    /// machine's: a contributor carrying `gc.auto` in a global configuration would
+    /// otherwise read a pass out of a repository that sets nothing.
+    fn config_of(git_dir: &std::path::Path, key: &str) -> Option<String> {
+        let out = std::process::Command::new("git")
+            .arg("--git-dir")
+            .arg(git_dir)
+            .args(["config", "--local", "--get", key])
+            .output()
+            .expect("git must be installed: it is a hard dependency");
+        out.status
+            .success()
+            .then(|| String::from_utf8_lossy(&out.stdout).trim().to_string())
+    }
+
+    /// Asserts that every repository under `root` is one git will not maintain.
+    ///
+    /// Read back out of a freshly built fixture rather than grepped out of this
+    /// file: what is under test is the configuration `git init` was actually
+    /// followed by, and a grep passes on a comment and fails on a refactor.
+    fn assert_unmaintained(root: &std::path::Path) {
+        let repos = repositories_under(root);
+        assert!(
+            !repos.is_empty(),
+            "no repository found under {}: this asserts nothing",
+            root.display()
+        );
+        for git_dir in repos {
+            let at = git_dir.display();
+            assert_eq!(
+                config_of(&git_dir, "gc.auto").as_deref(),
+                Some("0"),
+                "gc.auto at {at}"
+            );
+            assert_eq!(
+                config_of(&git_dir, "maintenance.auto").as_deref(),
+                Some("false"),
+                "maintenance.auto at {at}"
+            );
+        }
+    }
+
+    /// A fixture repository is not maintained under the test.
+    ///
+    /// Measured on 2026-08-30 in run 33284185681: git repacked a fixture between
+    /// two fingerprints of it -- `objects/maintenance.lock`, a `tmp_pack` and six
+    /// loose objects in the first, a multi-pack-index, two packs and `info/refs`
+    /// in the second -- and a test asserting that a read writes nothing failed on
+    /// one platform of three. Ank had written nothing (TASK-fc6bef21e268).
+    ///
+    /// The repositories are found by walking the fixture and not named here, so a
+    /// second one grown under it later is held to this without anyone remembering
+    /// to enrol it.
+    #[test]
+    fn a_fixture_repository_is_not_maintained_under_the_test() {
+        let t = Temp::new();
+        assert_unmaintained(&t.0);
     }
 }

--- a/crates/ank-cli/src/done.rs
+++ b/crates/ank-cli/src/done.rs
@@ -637,6 +637,10 @@ mod tests {
                 // (TASK-40a972e98a9a).
                 vec!["config", "commit.gpgsign", "false"],
                 vec!["config", "tag.gpgsign", "false"],
+                // Maintenance off, because git is otherwise free to repack a
+                // fixture between two reads of it (TASK-fc6bef21e268).
+                vec!["config", "gc.auto", "0"],
+                vec!["config", "maintenance.auto", "false"],
             ] {
                 assert!(Command::new("git")
                     .current_dir(&t.0)
@@ -1179,5 +1183,94 @@ mod tests {
         let second = scope_hash(&t.0, &globs).unwrap();
         std::fs::write(t.0.join("elsewhere.txt"), "noise").unwrap();
         assert_eq!(scope_hash(&t.0, &globs).unwrap(), second);
+    }
+
+    /// Every git repository inside a fixture, found rather than listed.
+    ///
+    /// A directory holding a `HEAD` file and an `objects` directory is one,
+    /// whether it is the `.git` beside a working tree or a bare corpus. Found,
+    /// because a list would have to be maintained, and what is being guarded
+    /// against is exactly a repository nobody remembered to enrol.
+    fn repositories_under(root: &std::path::Path) -> Vec<std::path::PathBuf> {
+        let mut found = Vec::new();
+        let mut stack = vec![root.to_path_buf()];
+        while let Some(dir) = stack.pop() {
+            if dir.join("HEAD").is_file() && dir.join("objects").is_dir() {
+                found.push(dir);
+                continue;
+            }
+            let Ok(entries) = std::fs::read_dir(&dir) else {
+                continue;
+            };
+            for e in entries.flatten() {
+                if e.file_type().is_ok_and(|t| t.is_dir()) {
+                    stack.push(e.path());
+                }
+            }
+        }
+        found
+    }
+
+    /// What git answers for one key of one repository's own configuration, `None`
+    /// when the key is unset -- which is the state this asserts against, since an
+    /// unset `maintenance.auto` means maintenance is on.
+    ///
+    /// `--local`, so what comes back is the fixture's answer and never the
+    /// machine's: a contributor carrying `gc.auto` in a global configuration would
+    /// otherwise read a pass out of a repository that sets nothing.
+    fn config_of(git_dir: &std::path::Path, key: &str) -> Option<String> {
+        let out = std::process::Command::new("git")
+            .arg("--git-dir")
+            .arg(git_dir)
+            .args(["config", "--local", "--get", key])
+            .output()
+            .expect("git must be installed: it is a hard dependency");
+        out.status
+            .success()
+            .then(|| String::from_utf8_lossy(&out.stdout).trim().to_string())
+    }
+
+    /// Asserts that every repository under `root` is one git will not maintain.
+    ///
+    /// Read back out of a freshly built fixture rather than grepped out of this
+    /// file: what is under test is the configuration `git init` was actually
+    /// followed by, and a grep passes on a comment and fails on a refactor.
+    fn assert_unmaintained(root: &std::path::Path) {
+        let repos = repositories_under(root);
+        assert!(
+            !repos.is_empty(),
+            "no repository found under {}: this asserts nothing",
+            root.display()
+        );
+        for git_dir in repos {
+            let at = git_dir.display();
+            assert_eq!(
+                config_of(&git_dir, "gc.auto").as_deref(),
+                Some("0"),
+                "gc.auto at {at}"
+            );
+            assert_eq!(
+                config_of(&git_dir, "maintenance.auto").as_deref(),
+                Some("false"),
+                "maintenance.auto at {at}"
+            );
+        }
+    }
+
+    /// A fixture repository is not maintained under the test.
+    ///
+    /// Measured on 2026-08-30 in run 33284185681: git repacked a fixture between
+    /// two fingerprints of it -- `objects/maintenance.lock`, a `tmp_pack` and six
+    /// loose objects in the first, a multi-pack-index, two packs and `info/refs`
+    /// in the second -- and a test asserting that a read writes nothing failed on
+    /// one platform of three. Ank had written nothing (TASK-fc6bef21e268).
+    ///
+    /// The repositories are found by walking the fixture and not named here, so a
+    /// second one grown under it later is held to this without anyone remembering
+    /// to enrol it.
+    #[test]
+    fn a_fixture_repository_is_not_maintained_under_the_test() {
+        let t = Temp::new("");
+        assert_unmaintained(&t.0);
     }
 }

--- a/crates/ank-cli/src/git.rs
+++ b/crates/ank-cli/src/git.rs
@@ -2245,6 +2245,10 @@ mod tests {
             // Signing off at creation, not at each commit (TASK-40a972e98a9a).
             t.porcelain(&["config", "commit.gpgsign", "false"]);
             t.porcelain(&["config", "tag.gpgsign", "false"]);
+            // Maintenance off, because git is otherwise free to repack a
+            // fixture between two reads of it (TASK-fc6bef21e268).
+            t.porcelain(&["config", "gc.auto", "0"]);
+            t.porcelain(&["config", "maintenance.auto", "false"]);
             t
         }
 
@@ -2535,6 +2539,10 @@ mod tests {
         // Signing off at creation, not at each commit (TASK-40a972e98a9a).
         git(&main, &["config", "commit.gpgsign", "false"]);
         git(&main, &["config", "tag.gpgsign", "false"]);
+        // Maintenance off (TASK-fc6bef21e268), here as everywhere a fixture
+        // runs `git init`.
+        git(&main, &["config", "gc.auto", "0"]);
+        git(&main, &["config", "maintenance.auto", "false"]);
         std::fs::write(main.join("seed.txt"), "x").unwrap();
         git(&main, &["add", "-A"]);
         git(&main, &["commit", "-qm", "s"]);
@@ -2563,6 +2571,8 @@ mod tests {
         git(&inner, &["init", "-q", "-b", "main"]);
         git(&inner, &["config", "commit.gpgsign", "false"]);
         git(&inner, &["config", "tag.gpgsign", "false"]);
+        git(&inner, &["config", "gc.auto", "0"]);
+        git(&inner, &["config", "maintenance.auto", "false"]);
         let from_inner = common_dir(&inner);
         assert!(from_inner.is_some());
         assert_ne!(from_inner, from_main);
@@ -2815,5 +2825,94 @@ mod tests {
     fn a_command_line_too_long_walks_everything() {
         let asked: Vec<String> = (0..1000).map(|n| format!("crates/pkg{n}/src")).collect();
         assert_eq!(narrowing(&asked), None);
+    }
+
+    /// Every git repository inside a fixture, found rather than listed.
+    ///
+    /// A directory holding a `HEAD` file and an `objects` directory is one,
+    /// whether it is the `.git` beside a working tree or a bare corpus. Found,
+    /// because a list would have to be maintained, and what is being guarded
+    /// against is exactly a repository nobody remembered to enrol.
+    fn repositories_under(root: &std::path::Path) -> Vec<std::path::PathBuf> {
+        let mut found = Vec::new();
+        let mut stack = vec![root.to_path_buf()];
+        while let Some(dir) = stack.pop() {
+            if dir.join("HEAD").is_file() && dir.join("objects").is_dir() {
+                found.push(dir);
+                continue;
+            }
+            let Ok(entries) = std::fs::read_dir(&dir) else {
+                continue;
+            };
+            for e in entries.flatten() {
+                if e.file_type().is_ok_and(|t| t.is_dir()) {
+                    stack.push(e.path());
+                }
+            }
+        }
+        found
+    }
+
+    /// What git answers for one key of one repository's own configuration, `None`
+    /// when the key is unset -- which is the state this asserts against, since an
+    /// unset `maintenance.auto` means maintenance is on.
+    ///
+    /// `--local`, so what comes back is the fixture's answer and never the
+    /// machine's: a contributor carrying `gc.auto` in a global configuration would
+    /// otherwise read a pass out of a repository that sets nothing.
+    fn config_of(git_dir: &std::path::Path, key: &str) -> Option<String> {
+        let out = std::process::Command::new("git")
+            .arg("--git-dir")
+            .arg(git_dir)
+            .args(["config", "--local", "--get", key])
+            .output()
+            .expect("git must be installed: it is a hard dependency");
+        out.status
+            .success()
+            .then(|| String::from_utf8_lossy(&out.stdout).trim().to_string())
+    }
+
+    /// Asserts that every repository under `root` is one git will not maintain.
+    ///
+    /// Read back out of a freshly built fixture rather than grepped out of this
+    /// file: what is under test is the configuration `git init` was actually
+    /// followed by, and a grep passes on a comment and fails on a refactor.
+    fn assert_unmaintained(root: &std::path::Path) {
+        let repos = repositories_under(root);
+        assert!(
+            !repos.is_empty(),
+            "no repository found under {}: this asserts nothing",
+            root.display()
+        );
+        for git_dir in repos {
+            let at = git_dir.display();
+            assert_eq!(
+                config_of(&git_dir, "gc.auto").as_deref(),
+                Some("0"),
+                "gc.auto at {at}"
+            );
+            assert_eq!(
+                config_of(&git_dir, "maintenance.auto").as_deref(),
+                Some("false"),
+                "maintenance.auto at {at}"
+            );
+        }
+    }
+
+    /// A fixture repository is not maintained under the test.
+    ///
+    /// Measured on 2026-08-30 in run 33284185681: git repacked a fixture between
+    /// two fingerprints of it -- `objects/maintenance.lock`, a `tmp_pack` and six
+    /// loose objects in the first, a multi-pack-index, two packs and `info/refs`
+    /// in the second -- and a test asserting that a read writes nothing failed on
+    /// one platform of three. Ank had written nothing (TASK-fc6bef21e268).
+    ///
+    /// The repositories are found by walking the fixture and not named here, so a
+    /// second one grown under it later is held to this without anyone remembering
+    /// to enrol it.
+    #[test]
+    fn a_fixture_repository_is_not_maintained_under_the_test() {
+        let t = Temp::new_repo();
+        assert_unmaintained(&t.0);
     }
 }

--- a/crates/ank-cli/src/init.rs
+++ b/crates/ank-cli/src/init.rs
@@ -367,10 +367,14 @@ mod tests {
                 .success();
             assert!(ok, "git init failed in {}", p.display());
             let t = Temp(p);
-            // Signing off at creation, not at each commit (TASK-40a972e98a9a).
+            // Signing off at creation, not at each commit (TASK-40a972e98a9a),
+            // and maintenance off because git is otherwise free to repack a
+            // fixture between two reads of it (TASK-fc6bef21e268).
             for args in [
                 ["config", "commit.gpgsign", "false"],
                 ["config", "tag.gpgsign", "false"],
+                ["config", "gc.auto", "0"],
+                ["config", "maintenance.auto", "false"],
             ] {
                 let st = Command::new("git")
                     .current_dir(&t.0)
@@ -502,7 +506,18 @@ blocked_by: []\nschema: 1\nversion: 1\n---\n\nBody.\n";
 
         let clone = t.0.with_extension("clone");
         let st = Command::new("git")
-            .args(["clone", "-q"])
+            // `--config` and not two `git config` runs afterwards: the clone is
+            // a repository this fixture builds too, and it is unmaintained from
+            // the moment it exists rather than shortly after
+            // (TASK-fc6bef21e268).
+            .args([
+                "clone",
+                "-q",
+                "-c",
+                "gc.auto=0",
+                "-c",
+                "maintenance.auto=false",
+            ])
             .arg(&t.0)
             .arg(&clone)
             .status()
@@ -521,5 +536,94 @@ blocked_by: []\nschema: 1\nversion: 1\n---\n\nBody.\n";
             ank_core::parse_entity(&text).is_ok(),
             "the cloned entity must parse"
         );
+    }
+
+    /// Every git repository inside a fixture, found rather than listed.
+    ///
+    /// A directory holding a `HEAD` file and an `objects` directory is one,
+    /// whether it is the `.git` beside a working tree or a bare corpus. Found,
+    /// because a list would have to be maintained, and what is being guarded
+    /// against is exactly a repository nobody remembered to enrol.
+    fn repositories_under(root: &std::path::Path) -> Vec<std::path::PathBuf> {
+        let mut found = Vec::new();
+        let mut stack = vec![root.to_path_buf()];
+        while let Some(dir) = stack.pop() {
+            if dir.join("HEAD").is_file() && dir.join("objects").is_dir() {
+                found.push(dir);
+                continue;
+            }
+            let Ok(entries) = std::fs::read_dir(&dir) else {
+                continue;
+            };
+            for e in entries.flatten() {
+                if e.file_type().is_ok_and(|t| t.is_dir()) {
+                    stack.push(e.path());
+                }
+            }
+        }
+        found
+    }
+
+    /// What git answers for one key of one repository's own configuration, `None`
+    /// when the key is unset -- which is the state this asserts against, since an
+    /// unset `maintenance.auto` means maintenance is on.
+    ///
+    /// `--local`, so what comes back is the fixture's answer and never the
+    /// machine's: a contributor carrying `gc.auto` in a global configuration would
+    /// otherwise read a pass out of a repository that sets nothing.
+    fn config_of(git_dir: &std::path::Path, key: &str) -> Option<String> {
+        let out = std::process::Command::new("git")
+            .arg("--git-dir")
+            .arg(git_dir)
+            .args(["config", "--local", "--get", key])
+            .output()
+            .expect("git must be installed: it is a hard dependency");
+        out.status
+            .success()
+            .then(|| String::from_utf8_lossy(&out.stdout).trim().to_string())
+    }
+
+    /// Asserts that every repository under `root` is one git will not maintain.
+    ///
+    /// Read back out of a freshly built fixture rather than grepped out of this
+    /// file: what is under test is the configuration `git init` was actually
+    /// followed by, and a grep passes on a comment and fails on a refactor.
+    fn assert_unmaintained(root: &std::path::Path) {
+        let repos = repositories_under(root);
+        assert!(
+            !repos.is_empty(),
+            "no repository found under {}: this asserts nothing",
+            root.display()
+        );
+        for git_dir in repos {
+            let at = git_dir.display();
+            assert_eq!(
+                config_of(&git_dir, "gc.auto").as_deref(),
+                Some("0"),
+                "gc.auto at {at}"
+            );
+            assert_eq!(
+                config_of(&git_dir, "maintenance.auto").as_deref(),
+                Some("false"),
+                "maintenance.auto at {at}"
+            );
+        }
+    }
+
+    /// A fixture repository is not maintained under the test.
+    ///
+    /// Measured on 2026-08-30 in run 33284185681: git repacked a fixture between
+    /// two fingerprints of it -- `objects/maintenance.lock`, a `tmp_pack` and six
+    /// loose objects in the first, a multi-pack-index, two packs and `info/refs`
+    /// in the second -- and a test asserting that a read writes nothing failed on
+    /// one platform of three. Ank had written nothing (TASK-fc6bef21e268).
+    ///
+    /// The repositories are found by walking the fixture and not named here, so a
+    /// second one grown under it later is held to this without anyone remembering
+    /// to enrol it.
+    #[test]
+    fn a_fixture_repository_is_not_maintained_under_the_test() {
+        let t = Temp::new_repo();
+        assert_unmaintained(&t.0);
     }
 }

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -101,6 +101,26 @@ fn spawn(program: impl AsRef<OsStr>) -> Command {
     c
 }
 
+/// Maintenance off in the repository at `dir`.
+///
+/// The sites that call this run `git init` and nothing else -- no identity, no
+/// autocrlf -- because what they are about is a repository existing, so there
+/// is no configuration block to add two lines to. Git will maintain a
+/// repository it is not told not to, and a fixture repacked between two reads
+/// of it fails a test that was right (TASK-fc6bef21e268).
+fn unmaintain(dir: &Path) {
+    for args in [
+        ["config", "gc.auto", "0"],
+        ["config", "maintenance.auto", "false"],
+    ] {
+        let out = git_command(dir)
+            .args(args)
+            .output()
+            .expect("git must be installed: it is a hard dependency");
+        assert!(out.status.success(), "git {args:?}: {}", stderr(&out));
+    }
+}
+
 /// git, run in `dir`.
 fn git_command(dir: &Path) -> Command {
     let mut c = spawn("git");
@@ -141,6 +161,10 @@ impl Repo {
         // rediscover any of this.
         r.git(&["config", "commit.gpgsign", "false"]);
         r.git(&["config", "tag.gpgsign", "false"]);
+        // Maintenance off, because git is otherwise free to repack a fixture
+        // between two reads of it (TASK-fc6bef21e268).
+        r.git(&["config", "gc.auto", "0"]);
+        r.git(&["config", "maintenance.auto", "false"]);
         std::fs::write(
             r.0.join(".ank/config.yml"),
             "schema: 1\nclaim_ttl_max: 2h\ndefault_branch: main\n",
@@ -836,6 +860,15 @@ impl Repo {
             .output()
             .unwrap();
         assert!(out.status.success(), "init --bare: {}", stderr(&out));
+        // The bare remote is a repository this fixture builds, and git will
+        // maintain one it is not told not to (TASK-fc6bef21e268).
+        for args in [
+            ["config", "gc.auto", "0"],
+            ["config", "maintenance.auto", "false"],
+        ] {
+            let out = git_command(&origin).args(args).output().unwrap();
+            assert!(out.status.success(), "{args:?}: {}", stderr(&out));
+        }
 
         self.git(&["add", "-A"]);
         self.git(&["commit", "-qm", "corpus"]);
@@ -845,6 +878,9 @@ impl Repo {
         let out = git_command(&self.0)
             .arg("clone")
             .arg("-q")
+            // Unmaintained from the moment the clone exists, rather than
+            // shortly after it (TASK-fc6bef21e268).
+            .args(["-c", "gc.auto=0", "-c", "maintenance.auto=false"])
             .arg(&origin)
             .arg(&other)
             .output()
@@ -2216,6 +2252,8 @@ fn the_stamp_follows_a_commit_that_changes_no_file() {
     // (TASK-40a972e98a9a).
     git(&["config", "commit.gpgsign", "false"]);
     git(&["config", "tag.gpgsign", "false"]);
+    git(&["config", "gc.auto", "0"]);
+    git(&["config", "maintenance.auto", "false"]);
     git(&["add", "-A"]);
     git(&["commit", "-qm", "seed"]);
 
@@ -4017,6 +4055,8 @@ default_branch: main
         vec!["config", "user.email", "test@ank.local"],
         vec!["config", "user.name", "Test"],
         vec!["config", "commit.gpgsign", "false"],
+        vec!["config", "gc.auto", "0"],
+        vec!["config", "maintenance.auto", "false"],
         vec!["add", "-A"],
         vec!["commit", "-qm", "another root"],
     ] {
@@ -5257,6 +5297,7 @@ fn init_runs_where_there_is_no_ank_directory_yet() {
         .status()
         .unwrap()
         .success());
+    unmaintain(&dir);
 
     let out = ank_command()
         .arg("init")
@@ -5289,6 +5330,7 @@ fn init_refuses_repo_and_writes_into_neither_repository() {
         .status()
         .unwrap()
         .success());
+    unmaintain(&named);
 
     // A file worth losing: `init` places its pointer in AGENTS.md, and the
     // silent write landed in exactly this file.
@@ -7317,6 +7359,7 @@ fn an_initialised_repo_leaves_the_index_ignored_and_never_untracked() {
             .expect("git must be installed: it is a hard dependency")
     };
     assert!(git(&["init", "-q", "-b", "main"]).status.success());
+    unmaintain(&dir);
 
     // A `.gitignore` the user curated first: `init` has to append to it, not
     // replace it, and that is only observable when there is something to lose.
@@ -9547,6 +9590,8 @@ impl Declared {
         d.git(&["config", "user.email", "test@ank.local"]);
         d.git(&["config", "user.name", "Test"]);
         d.git(&["config", "commit.gpgsign", "false"]);
+        d.git(&["config", "gc.auto", "0"]);
+        d.git(&["config", "maintenance.auto", "false"]);
         std::fs::write(d.tree.join("a.txt"), "hi\n").unwrap();
         d.git(&["add", "-A"]);
         d.git(&["commit", "-qm", "seed"]);
@@ -9589,6 +9634,8 @@ impl Declared {
             &["config", "user.email", "test@ank.local"][..],
             &["config", "user.name", "Test"][..],
             &["config", "commit.gpgsign", "false"][..],
+            &["config", "gc.auto", "0"][..],
+            &["config", "maintenance.auto", "false"][..],
         ] {
             let out = git_command(&self.corpus)
                 .args(args)
@@ -13408,6 +13455,8 @@ fn nest_a_repository_in(outer: &Repo) -> PathBuf {
         &["init", "-q", "-b", "main"][..],
         &["config", "user.email", "t@ank.local"][..],
         &["config", "user.name", "T"][..],
+        &["config", "gc.auto", "0"][..],
+        &["config", "maintenance.auto", "false"][..],
     ] {
         let out = git_command(&inner)
             .args(args)
@@ -13954,6 +14003,7 @@ fn fresh_git_dir(what: &str) -> PathBuf {
         .output()
         .expect("git must be installed: it is a hard dependency");
     assert!(out.status.success(), "git init: {}", stderr(&out));
+    unmaintain(&p);
     p
 }
 
@@ -14503,7 +14553,15 @@ fn clone_of(r: &Repo, depth: Option<u32>) -> PathBuf {
     let url = file_url(&r.0);
     let dest_s = dest.to_string_lossy().to_string();
     let d = depth.map(|d| d.to_string());
-    let mut args = vec!["clone", "-q"];
+    // Unmaintained from the moment the clone exists (TASK-fc6bef21e268).
+    let mut args = vec![
+        "clone",
+        "-q",
+        "-c",
+        "gc.auto=0",
+        "-c",
+        "maintenance.auto=false",
+    ];
     if let Some(d) = d.as_deref() {
         args.extend_from_slice(&["--depth", d]);
     }
@@ -15613,6 +15671,7 @@ fn init_writes_the_same_refspec_this_suite_assumes() {
         .args(["init", "-q", "-b", "main"])
         .output();
     assert!(out.unwrap().status.success());
+    unmaintain(&dir);
     // A positional and not `--repo`, which `init` refuses by name: it is the
     // verb that makes a repository, so naming an existing one is a
     // contradiction (TASK-b8a1a3d0d47c).
@@ -18552,6 +18611,8 @@ fn code_tree(tag: &str) -> PathBuf {
         vec!["config", "user.email", "test@ank.local"],
         vec!["config", "user.name", "Test"],
         vec!["config", "commit.gpgsign", "false"],
+        vec!["config", "gc.auto", "0"],
+        vec!["config", "maintenance.auto", "false"],
         vec!["add", "-A"],
         vec!["commit", "-qm", "code"],
     ] {
@@ -21528,4 +21589,99 @@ fn main() {{}}
     assert_eq!(code(&out), 0, "{}", both_streams(&out));
     let out = r.ank("human:marie", &["check"]);
     assert_eq!(code(&out), 0, "{}", both_streams(&out));
+}
+
+/// Every git repository inside a fixture, found rather than listed.
+///
+/// A directory holding a `HEAD` file and an `objects` directory is one,
+/// whether it is the `.git` beside a working tree or a bare corpus. Found,
+/// because a list would have to be maintained, and what is being guarded
+/// against is exactly a repository nobody remembered to enrol.
+fn repositories_under(root: &std::path::Path) -> Vec<std::path::PathBuf> {
+    let mut found = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        if dir.join("HEAD").is_file() && dir.join("objects").is_dir() {
+            found.push(dir);
+            continue;
+        }
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for e in entries.flatten() {
+            if e.file_type().is_ok_and(|t| t.is_dir()) {
+                stack.push(e.path());
+            }
+        }
+    }
+    found
+}
+
+/// What git answers for one key of one repository's own configuration, `None`
+/// when the key is unset -- which is the state this asserts against, since an
+/// unset `maintenance.auto` means maintenance is on.
+///
+/// `--local`, so what comes back is the fixture's answer and never the
+/// machine's: a contributor carrying `gc.auto` in a global configuration would
+/// otherwise read a pass out of a repository that sets nothing.
+fn config_of(git_dir: &std::path::Path, key: &str) -> Option<String> {
+    let out = spawn("git")
+        .arg("--git-dir")
+        .arg(git_dir)
+        .args(["config", "--local", "--get", key])
+        .output()
+        .expect("git must be installed: it is a hard dependency");
+    out.status
+        .success()
+        .then(|| String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+/// Asserts that every repository under `root` is one git will not maintain.
+///
+/// Read back out of a freshly built fixture rather than grepped out of this
+/// file: what is under test is the configuration `git init` was actually
+/// followed by, and a grep passes on a comment and fails on a refactor.
+fn assert_unmaintained(root: &std::path::Path) {
+    let repos = repositories_under(root);
+    assert!(
+        !repos.is_empty(),
+        "no repository found under {}: this asserts nothing",
+        root.display()
+    );
+    for git_dir in repos {
+        let at = git_dir.display();
+        assert_eq!(
+            config_of(&git_dir, "gc.auto").as_deref(),
+            Some("0"),
+            "gc.auto at {at}"
+        );
+        assert_eq!(
+            config_of(&git_dir, "maintenance.auto").as_deref(),
+            Some("false"),
+            "maintenance.auto at {at}"
+        );
+    }
+}
+
+/// A fixture repository is not maintained under the test.
+///
+/// Measured on 2026-08-30 in run 33284185681: git repacked a fixture between
+/// two fingerprints of it -- `objects/maintenance.lock`, a `tmp_pack` and six
+/// loose objects in the first, a multi-pack-index, two packs and `info/refs`
+/// in the second -- and a test asserting that a read writes nothing failed on
+/// one platform of three. Ank had written nothing (TASK-fc6bef21e268).
+///
+/// The repositories are found by walking the fixture and not named here, so a
+/// second one grown under it later is held to this without anyone remembering
+/// to enrol it.
+#[test]
+fn a_fixture_repository_is_not_maintained_under_the_test() {
+    let r = Repo::new();
+    // The two repositories `cloned` grows are siblings of the corpus and not
+    // children of it, so the walk is handed each root it was given rather than
+    // one that happens to hold them all.
+    let (origin, other) = r.cloned();
+    for root in [&r.0, &origin, &other] {
+        assert_unmaintained(root);
+    }
 }

--- a/crates/ank-cli/tests/mcp.rs
+++ b/crates/ank-cli/tests/mcp.rs
@@ -71,6 +71,10 @@ fn corpus_titled(title: &str, home: Option<&Path>) -> PathBuf {
     git(&["config", "user.email", "test@ank.local"]);
     git(&["config", "user.name", "Test"]);
     git(&["config", "commit.gpgsign", "false"]);
+    // Maintenance off, because git is otherwise free to repack a fixture
+    // between two reads of it (TASK-fc6bef21e268).
+    git(&["config", "gc.auto", "0"]);
+    git(&["config", "maintenance.auto", "false"]);
 
     let run = |args: &[&str]| {
         let out = ank_at(&root, home, args);
@@ -846,5 +850,95 @@ fn the_surface_reports_the_version_the_binary_prints_and_writes_under_it() {
         replies[1]
     );
 
+    let _ = std::fs::remove_dir_all(&repo);
+}
+
+/// Every git repository inside a fixture, found rather than listed.
+///
+/// A directory holding a `HEAD` file and an `objects` directory is one,
+/// whether it is the `.git` beside a working tree or a bare corpus. Found,
+/// because a list would have to be maintained, and what is being guarded
+/// against is exactly a repository nobody remembered to enrol.
+fn repositories_under(root: &std::path::Path) -> Vec<std::path::PathBuf> {
+    let mut found = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        if dir.join("HEAD").is_file() && dir.join("objects").is_dir() {
+            found.push(dir);
+            continue;
+        }
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for e in entries.flatten() {
+            if e.file_type().is_ok_and(|t| t.is_dir()) {
+                stack.push(e.path());
+            }
+        }
+    }
+    found
+}
+
+/// What git answers for one key of one repository's own configuration, `None`
+/// when the key is unset -- which is the state this asserts against, since an
+/// unset `maintenance.auto` means maintenance is on.
+///
+/// `--local`, so what comes back is the fixture's answer and never the
+/// machine's: a contributor carrying `gc.auto` in a global configuration would
+/// otherwise read a pass out of a repository that sets nothing.
+fn config_of(git_dir: &std::path::Path, key: &str) -> Option<String> {
+    let out = std::process::Command::new("git")
+        .arg("--git-dir")
+        .arg(git_dir)
+        .args(["config", "--local", "--get", key])
+        .output()
+        .expect("git must be installed: it is a hard dependency");
+    out.status
+        .success()
+        .then(|| String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+/// Asserts that every repository under `root` is one git will not maintain.
+///
+/// Read back out of a freshly built fixture rather than grepped out of this
+/// file: what is under test is the configuration `git init` was actually
+/// followed by, and a grep passes on a comment and fails on a refactor.
+fn assert_unmaintained(root: &std::path::Path) {
+    let repos = repositories_under(root);
+    assert!(
+        !repos.is_empty(),
+        "no repository found under {}: this asserts nothing",
+        root.display()
+    );
+    for git_dir in repos {
+        let at = git_dir.display();
+        assert_eq!(
+            config_of(&git_dir, "gc.auto").as_deref(),
+            Some("0"),
+            "gc.auto at {at}"
+        );
+        assert_eq!(
+            config_of(&git_dir, "maintenance.auto").as_deref(),
+            Some("false"),
+            "maintenance.auto at {at}"
+        );
+    }
+}
+
+/// A fixture repository is not maintained under the test.
+///
+/// Measured on 2026-08-30 in run 33284185681: git repacked a fixture between
+/// two fingerprints of it -- `objects/maintenance.lock`, a `tmp_pack` and six
+/// loose objects in the first, a multi-pack-index, two packs and `info/refs`
+/// in the second -- and a test asserting that a read writes nothing failed on
+/// one platform of three. Ank had written nothing (TASK-fc6bef21e268).
+///
+/// The repositories are found by walking the fixture and not named here, so a
+/// second one grown under it later is held to this without anyone remembering
+/// to enrol it.
+#[test]
+fn a_fixture_repository_is_not_maintained_under_the_test() {
+    let repo = corpus();
+    assert_unmaintained(&repo);
     let _ = std::fs::remove_dir_all(&repo);
 }

--- a/crates/ank-cli/tests/tui.rs
+++ b/crates/ank-cli/tests/tui.rs
@@ -102,6 +102,10 @@ impl Repo {
         // §8's advisory mode, which is the regime `review` then names on the
         // screen and the one both roads through `accept` take.
         repo.git(&["config", "user.signingkey", ""]);
+        // Maintenance off, because git is otherwise free to repack a fixture
+        // between two reads of it (TASK-fc6bef21e268).
+        repo.git(&["config", "gc.auto", "0"]);
+        repo.git(&["config", "maintenance.auto", "false"]);
         std::fs::create_dir_all(repo.0.join("src")).unwrap();
         std::fs::write(repo.0.join("src/lib.rs"), "// code\n").unwrap();
         repo.ank(HOLDER, &["init"]);
@@ -2817,4 +2821,93 @@ fn accept_is_refused_off_the_document_and_carries_nothing_but_it() {
         "something was ratified:\n{found}"
     );
     assert_eq!(before, corpus_files(&repo), "a file under .ank/ moved");
+}
+
+/// Every git repository inside a fixture, found rather than listed.
+///
+/// A directory holding a `HEAD` file and an `objects` directory is one,
+/// whether it is the `.git` beside a working tree or a bare corpus. Found,
+/// because a list would have to be maintained, and what is being guarded
+/// against is exactly a repository nobody remembered to enrol.
+fn repositories_under(root: &std::path::Path) -> Vec<std::path::PathBuf> {
+    let mut found = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        if dir.join("HEAD").is_file() && dir.join("objects").is_dir() {
+            found.push(dir);
+            continue;
+        }
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for e in entries.flatten() {
+            if e.file_type().is_ok_and(|t| t.is_dir()) {
+                stack.push(e.path());
+            }
+        }
+    }
+    found
+}
+
+/// What git answers for one key of one repository's own configuration, `None`
+/// when the key is unset -- which is the state this asserts against, since an
+/// unset `maintenance.auto` means maintenance is on.
+///
+/// `--local`, so what comes back is the fixture's answer and never the
+/// machine's: a contributor carrying `gc.auto` in a global configuration would
+/// otherwise read a pass out of a repository that sets nothing.
+fn config_of(git_dir: &std::path::Path, key: &str) -> Option<String> {
+    let out = std::process::Command::new("git")
+        .arg("--git-dir")
+        .arg(git_dir)
+        .args(["config", "--local", "--get", key])
+        .output()
+        .expect("git must be installed: it is a hard dependency");
+    out.status
+        .success()
+        .then(|| String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+/// Asserts that every repository under `root` is one git will not maintain.
+///
+/// Read back out of a freshly built fixture rather than grepped out of this
+/// file: what is under test is the configuration `git init` was actually
+/// followed by, and a grep passes on a comment and fails on a refactor.
+fn assert_unmaintained(root: &std::path::Path) {
+    let repos = repositories_under(root);
+    assert!(
+        !repos.is_empty(),
+        "no repository found under {}: this asserts nothing",
+        root.display()
+    );
+    for git_dir in repos {
+        let at = git_dir.display();
+        assert_eq!(
+            config_of(&git_dir, "gc.auto").as_deref(),
+            Some("0"),
+            "gc.auto at {at}"
+        );
+        assert_eq!(
+            config_of(&git_dir, "maintenance.auto").as_deref(),
+            Some("false"),
+            "maintenance.auto at {at}"
+        );
+    }
+}
+
+/// A fixture repository is not maintained under the test.
+///
+/// Measured on 2026-08-30 in run 33284185681: git repacked a fixture between
+/// two fingerprints of it -- `objects/maintenance.lock`, a `tmp_pack` and six
+/// loose objects in the first, a multi-pack-index, two packs and `info/refs`
+/// in the second -- and a test asserting that a read writes nothing failed on
+/// one platform of three. Ank had written nothing (TASK-fc6bef21e268).
+///
+/// The repositories are found by walking the fixture and not named here, so a
+/// second one grown under it later is held to this without anyone remembering
+/// to enrol it.
+#[test]
+fn a_fixture_repository_is_not_maintained_under_the_test() {
+    let repo = Repo::seeded("unmaintained");
+    assert_unmaintained(&repo.0);
 }

--- a/crates/ank-cli/tests/watch.rs
+++ b/crates/ank-cli/tests/watch.rs
@@ -145,6 +145,11 @@ impl Corpus {
         corpus.git(home, &["config", "user.email", "test@ank.local"]);
         corpus.git(home, &["config", "user.name", "Test"]);
         corpus.git(home, &["config", "commit.gpgsign", "false"]);
+        // Maintenance off, because git is otherwise free to repack a fixture
+        // between two reads of it -- and this suite reads one twice to assert
+        // that a watch touched nothing (TASK-fc6bef21e268).
+        corpus.git(home, &["config", "gc.auto", "0"]);
+        corpus.git(home, &["config", "maintenance.auto", "false"]);
         corpus.ank(home, &["init"]);
         corpus.ank(home, &["config", "default_branch", "main"]);
         corpus.ank(
@@ -279,6 +284,18 @@ fn bare(home: &Home, path: &Path) {
     home.apply(&mut c);
     let out = c.output().expect("git is a hard dependency");
     assert!(out.status.success(), "{out:?}");
+    // The bare remote is a repository this suite builds, and git maintains one
+    // it is not told not to (TASK-fc6bef21e268).
+    for args in [
+        ["config", "gc.auto", "0"],
+        ["config", "maintenance.auto", "false"],
+    ] {
+        let mut c = Command::new("git");
+        c.arg("--git-dir").arg(path).args(args);
+        home.apply(&mut c);
+        let out = c.output().expect("git is a hard dependency");
+        assert!(out.status.success(), "git {args:?}: {out:?}");
+    }
 }
 
 /// A clone of `origin`, wired the way `git clone` wires one and no further.
@@ -290,10 +307,19 @@ fn bare(home: &Home, path: &Path) {
 /// demonstrated in a clone that was already synchronising itself.
 fn clone(home: &Home, origin: &Path, into: &Path) -> Corpus {
     let mut c = Command::new("git");
-    c.args(["clone", "-q"])
-        .arg(origin)
-        .arg(into)
-        .current_dir(std::env::temp_dir());
+    // Unmaintained from the moment the clone exists, rather than shortly after
+    // it (TASK-fc6bef21e268).
+    c.args([
+        "clone",
+        "-q",
+        "-c",
+        "gc.auto=0",
+        "-c",
+        "maintenance.auto=false",
+    ])
+    .arg(origin)
+    .arg(into)
+    .current_dir(std::env::temp_dir());
     home.apply(&mut c);
     let out = c.output().expect("git is a hard dependency");
     assert!(
@@ -1563,4 +1589,101 @@ fn no_event_carries_entity_content_a_reader_would_get_from_the_cli() {
             "the stream carries '{leaked}', which is what ank show answers:\n{text}"
         );
     }
+}
+
+/// Every git repository inside a fixture, found rather than listed.
+///
+/// A directory holding a `HEAD` file and an `objects` directory is one,
+/// whether it is the `.git` beside a working tree or a bare corpus. Found,
+/// because a list would have to be maintained, and what is being guarded
+/// against is exactly a repository nobody remembered to enrol.
+fn repositories_under(root: &std::path::Path) -> Vec<std::path::PathBuf> {
+    let mut found = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        if dir.join("HEAD").is_file() && dir.join("objects").is_dir() {
+            found.push(dir);
+            continue;
+        }
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for e in entries.flatten() {
+            if e.file_type().is_ok_and(|t| t.is_dir()) {
+                stack.push(e.path());
+            }
+        }
+    }
+    found
+}
+
+/// What git answers for one key of one repository's own configuration, `None`
+/// when the key is unset -- which is the state this asserts against, since an
+/// unset `maintenance.auto` means maintenance is on.
+///
+/// `--local`, so what comes back is the fixture's answer and never the
+/// machine's: a contributor carrying `gc.auto` in a global configuration would
+/// otherwise read a pass out of a repository that sets nothing.
+fn config_of(git_dir: &std::path::Path, key: &str) -> Option<String> {
+    let out = std::process::Command::new("git")
+        .arg("--git-dir")
+        .arg(git_dir)
+        .args(["config", "--local", "--get", key])
+        .output()
+        .expect("git must be installed: it is a hard dependency");
+    out.status
+        .success()
+        .then(|| String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+/// Asserts that every repository under `root` is one git will not maintain.
+///
+/// Read back out of a freshly built fixture rather than grepped out of this
+/// file: what is under test is the configuration `git init` was actually
+/// followed by, and a grep passes on a comment and fails on a refactor.
+fn assert_unmaintained(root: &std::path::Path) {
+    let repos = repositories_under(root);
+    assert!(
+        !repos.is_empty(),
+        "no repository found under {}: this asserts nothing",
+        root.display()
+    );
+    for git_dir in repos {
+        let at = git_dir.display();
+        assert_eq!(
+            config_of(&git_dir, "gc.auto").as_deref(),
+            Some("0"),
+            "gc.auto at {at}"
+        );
+        assert_eq!(
+            config_of(&git_dir, "maintenance.auto").as_deref(),
+            Some("false"),
+            "maintenance.auto at {at}"
+        );
+    }
+}
+
+/// A fixture repository is not maintained under the test.
+///
+/// Measured on 2026-08-30 in run 33284185681: git repacked a fixture between
+/// two fingerprints of it -- `objects/maintenance.lock`, a `tmp_pack` and six
+/// loose objects in the first, a multi-pack-index, two packs and `info/refs`
+/// in the second -- and a test asserting that a read writes nothing failed on
+/// one platform of three. Ank had written nothing (TASK-fc6bef21e268).
+///
+/// The repositories are found by walking the fixture and not named here, so a
+/// second one grown under it later is held to this without anyone remembering
+/// to enrol it.
+#[test]
+fn a_fixture_repository_is_not_maintained_under_the_test() {
+    let home = Home::new();
+    let root = scratch("unmaintained");
+    // All three shapes this suite builds, under one root: a corpus with a
+    // working tree, the bare remote two clones arbitrate through, and a clone
+    // made by hand.
+    let _corpus = Corpus::new(root.join("tree"), &home);
+    let origin = root.join("origin.git");
+    bare(&home, &origin);
+    let _cloned = clone(&home, &origin, &root.join("clone"));
+    assert_unmaintained(&root);
 }


### PR DESCRIPTION
Closes TASK-4aaccc28660e.

Every git repository a fixture builds in `crates/ank-cli/src/{commands,context,done,git,init}.rs` and `crates/ank-cli/tests/{cli,mcp,tui,watch}.rs` now answers `gc.auto=0` and `maintenance.auto=false` — the bare remotes at `tests/cli.rs:834` and `tests/watch.rs:276` included, and the clones beside them through `git clone -c`, so a clone is unmaintained from the moment it exists rather than shortly after.

Each of the nine carries a test that reads the configuration back out of a freshly built fixture and finds the repositories under it by **walking for a directory holding `HEAD` and `objects`** — found and not named, because what is being guarded against is exactly a repository nobody remembered to enrol, and a grep over the source would pass on a comment and fail on a refactor. The shape is TASK-fc6bef21e268's, with one deliberate change: the read is `config --local --get`, where the four earlier files use `--get` alone. `--get` answers from every scope, so a contributor carrying `gc.auto` in a global configuration would read a pass out of a fixture that sets nothing. `claim.rs` and `human.rs` still pass under the stricter read.

## Measured, not read

**Before.** The nine tests, written before any fix, all fail on `gc.auto ... left: None, right: Some("0")` — `watch.rs` failing first on `origin.git`, the bare remote the walk reached without being told about it.

**Negative control**, on both bare remotes the criterion names. With the two config lines removed from `cloned()` in `cli.rs` and nothing else changed, that file's test fails naming `…-0.origin.git`; removed from `bare()` in `watch.rs`, it fails naming `unmaintained-1/origin.git`. Restored, both pass.

**After, whole-suite census.** A `git` shim on `PATH` recorded every invocation of `cargo test --workspace` — 23232 of them — and every repository the run creates was then matched against the configuration it was given: **707 repositories built, 707 answering `gc.auto=0`, 707 answering `maintenance.auto=false`, none missing either.** That is what says no repository-creating site was missed, in the nine files or outside them; a grep over the sources could only have said which lines exist.

`cargo test --workspace` green, `cargo fmt --check` clean, `ank check` reports no new fault.

## One thing for the maintainer

TASK-4aac carries **no `verify:` list** — it was created at 04:03 on 2026-08-30 and the verifiers feature landed that afternoon in 4a50e48, so it predates the field, and `ank amend` has no flag that could add one. `ank done` with no flag refuses at exit 5 and names `ank done --proof commit:<sha>`; the close took that road, with a proof already held over a tree whose suite and formatting were run green first. Recorded in LOG-5d862f6af9b4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LFHbhF9uj63zH2HHFqzMTa