### PR TITLE
0.7.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ank",
   "description": "Tasks and architecture decisions in your repo, behind one CLI any coding agent can call.",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "author": {
     "name": "haksolot",
     "url": "https://github.com/haksolot"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "ank-cli"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "ank-contract",
  "ank-core",
@@ -39,7 +39,7 @@ version = "0.3.0"
 
 [[package]]
 name = "ank-core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "globset",
  "hex",

--- a/crates/ank-cli/Cargo.toml
+++ b/crates/ank-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ank-cli"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 # Measured on 2026-08-01 by walking toolchains upward against this tree, which
 # is the only way this number means anything: 1.78, 1.91, 1.92, 1.93 and 1.94

--- a/crates/ank-core/Cargo.toml
+++ b/crates/ank-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ank-core"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 # Measured, not assumed: see the note in ank-cli's manifest. This crate's own
 # code needs far less, but the workspace resolves one lockfile and builds as a

--- a/npm/ank-darwin-arm64/package.json
+++ b/npm/ank-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haksolot/ank-darwin-arm64",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "The ank binary for macOS on Apple silicon.",
   "license": "Apache-2.0",
   "author": "Sean Lamet",

--- a/npm/ank-linux-x64-musl/package.json
+++ b/npm/ank-linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haksolot/ank-linux-x64-musl",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "The ank binary for Linux x86_64, statically linked against musl.",
   "license": "Apache-2.0",
   "author": "Sean Lamet",

--- a/npm/ank-win32-x64/package.json
+++ b/npm/ank-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haksolot/ank-win32-x64",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "The ank binary for Windows x86_64.",
   "license": "Apache-2.0",
   "author": "Sean Lamet",

--- a/npm/ank/package.json
+++ b/npm/ank/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haksolot/ank",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "The stupid coordination tool: tasks and architecture decisions in your repo, behind one CLI any coding agent can call.",
   "license": "Apache-2.0",
   "author": "Sean Lamet",
@@ -42,8 +42,8 @@
     "node": ">=18"
   },
   "optionalDependencies": {
-    "@haksolot/ank-darwin-arm64": "0.6.0",
-    "@haksolot/ank-linux-x64-musl": "0.6.0",
-    "@haksolot/ank-win32-x64": "0.6.0"
+    "@haksolot/ank-darwin-arm64": "0.7.0",
+    "@haksolot/ank-linux-x64-musl": "0.7.0",
+    "@haksolot/ank-win32-x64": "0.7.0"
   }
 }


### PR DESCRIPTION
Every manifest a release gates on, and the three pins inside `npm/ank`, moved together. `check-version.sh` compares ten literals and names every one that disagrees, so they move in one commit or the tag is refused:

```
$ bash .github/scripts/check-version.sh 0.7.0
version 0.7.0 agrees with all 10 version literals
```

Nothing else is in this diff — 10 insertions, 10 deletions, plus `Cargo.lock`.

## What 0.7.0 carries

All of it landed today.

**The installers draw the mark.** `install.sh` and `install.ps1` render the shape of `assets/ank.svg` in `U+2588` where the reader's encoding is *measured* to carry it and in `#` where it is not — a round trip through the console encoding on Windows, the locale under sh. The old code refused the block on the belief that codepage 437 renders it as a question mark; 437 carries it at `0xDB`, best-fits `U+2713` to a square root, and 1252 best-fits the block to a broken bar. None produces a question mark.

The mark takes no colour of its own — it is drawn in the terminal's own foreground, matching `ank.svg` at `#1f2328` and `ank-dark.svg` at `#e6edf3` — and the animation runs on dim against normal, the one axis that survives not knowing the background.

**A task is born with the verifiers the repository declares** (ADR-443590981e41). `ank new task` seeds `verify:` from the verifiers `config.yml` marks `default: true`; `--no-verify` declines them out loud. `ank done` is untouched and reads no default at close time, so SPEC-88e1 stands: a task that declares none still requires `--proof`.

**The config reader refuses on the schema**, not on the first field it does not know — the rule `docs/format.md` already stated for entities, now obeyed by the config.

**CLAUDE.md's Proof section stops teaching the unverified close**, with a test that fails if it drifts back.

**Housekeeping:** a doc comment reunited with the test it describes (the `duplicated attribute` warning is gone), and nine fixture sites that no longer leave git maintenance running under the suite.

## Why now

`ank` 0.6.0 cannot read a corpus that declares `default:` under a verifier. Its parser is field-first and it is shipped, so nothing in this release reaches it — upgrading is the only repair, and anyone installing today through the documented `curl | sh` gets the version that breaks.

## After the merge

Tag `v0.7.0` on `main`. `release.yml` takes its version from the tag and refuses before building anything if the manifests disagree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AG9JGEXdoxahULZMskASSK