### PR TITLE
Drift audit: eight findings, measured against ank 0.7.0

### DIFF
--- a/.ank/entities/LOG-22416106a51c.md
+++ b/.ank/entities/LOG-22416106a51c.md
@@ -1,0 +1,15 @@
+---
+id: LOG-22416106a51c
+type: log
+title: drift audit, re-measured and holds; no finding. Counted with GIT_TRACE pointed at an absolute path,
+created: 2026-08-31T03:11:37Z
+author: claude-code/opus-5+drift
+scope:
+  - crates/ank-cli/**
+about: ADR-cc65f1388a71
+seq: 0
+schema: 4
+version: 1
+---
+
+ one line per process, never by timing. Corpora built to isolate the dimension: three throwaway repositories with 2, 8 and 20 tasks whose scopes were then deleted by a commit, so the dead-scope history walk ADR-3094538d831e requires had 2, 8 and 20 items to answer for. ank check spawned 6 git processes in all three, and the walk is one batch -- process 5 is a single 'rev-list HEAD -- :(literal)src/f1.rs :(literal)src/f2.rs ...' followed by one 'diff-tree --stdin -r -M -z --name-status'. On this corpus, 354 tasks and 79 ADRs, check spawned 18 and every one is a distinct question: the dual-layout probes cat-file -p main:.ank/entities, :.ank/tasks and :.ank/adr, one 'rev-list --full-history' for ratifications, one 'config --get-regexp ^gpg\.', three 'cat-file --batch'. Eighteen against six is the corpus having ratifications and a remote, not a count that grows with entities. status 7, find 4, context 5, graph 4 on the big corpus against 8, 4, 5, 4 on a one-task corpus.

--- a/.ank/entities/LOG-3076d8794621.md
+++ b/.ank/entities/LOG-3076d8794621.md
@@ -1,0 +1,18 @@
+---
+id: LOG-3076d8794621
+type: log
+title: drift audit, measured not read. The constraint says 'The binary is ank, the crates are ank-core and
+created: 2026-08-31T03:11:20Z
+author: claude-code/opus-5+drift
+scope:
+  - crates/**
+  - docs/**
+  - skill/**
+  - README.md
+about: ADR-85e6bbb195b8
+seq: 0
+schema: 4
+version: 1
+---
+
+ ank-cli'. Measured on this tree at 50f4b39: ls crates/ prints six -- ank-cli, ank-contract, ank-core, ank-daemon, ank-mcp, ank-tui -- and four of them the sentence does not name. Each was created by a later accepted decision: ADR-559eebf5c6f5 scopes crates/ank-tui/**, ADR-fd98f4bc6dea scopes crates/ank-mcp/**, and the contract crate is what ADR-6fd69efb629c's 'one crate that every surface consumes' names. So the corpus has decided four times that these crates exist while this constraint, which ank context hands to anyone touching crates/**, still says there are two. Every other clause was re-measured and holds: the binary is ank, the state directory is .ank/, ank claim wrote refs/ank/claims/<id>, the identity variable is ANK_AGENT, and grep -ri ankor over the tracked tree outside .ank/ returns nothing.

--- a/.ank/entities/LOG-359a4cb8cf08.md
+++ b/.ank/entities/LOG-359a4cb8cf08.md
@@ -1,0 +1,15 @@
+---
+id: LOG-359a4cb8cf08
+type: log
+title: "probe: does an entry on an ADR need a claim"
+created: 2026-08-31T03:10:22Z
+author: claude-code/opus-5+drift
+scope:
+  - crates/ank-cli/src/claim.rs
+  - .github/workflows/ci.yml
+  - docs/ank-spec-v1.1.md
+about: ADR-af533e7a3e03
+seq: 0
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-4d599a144892.md
+++ b/.ank/entities/LOG-4d599a144892.md
@@ -1,0 +1,15 @@
+---
+id: LOG-4d599a144892
+type: log
+title: "drift audit, measured not read. Section 4 states: 'mcp and watch are on that list and the binary"
+created: 2026-08-31T03:11:06Z
+author: claude-code/opus-5+drift
+scope:
+  - crates/ank-cli/**
+about: SPEC-fe8bdb84faca
+seq: 0
+schema: 4
+version: 1
+---
+
+ does not answer to them yet, which is the form this block already uses for a verb the specification has decided on before the code moves.' Measured on ank 0.7.0 (50f4b39): ank help --json carries 26 verbs and both are among them; piping an initialize and a tools/list into ank mcp returned 26 tools, ank_accept through ank_watch, one per verb and no curated subset; ank watch --where printed /home/haksolot/.config/ank/watch.yml. The suite's own marker agrees the gap is closed -- crates/ank-cli/tests/skill.rs line 262 reads 'const NOT_YET_DISPATCHED: [&str; 0] = [];' -- so the sentence in the ratified document is the only place that still says the verbs are unimplemented. Everything else measured in this section holds: the short-form table is exactly the eleven pairs the binary declares, no letter carries two long flags, and ADR-3e6ce108edcd's rule that a --json listing answers whole was re-measured at total 105, shown 105 on ank scope.

--- a/.ank/entities/LOG-61d74d54d820.md
+++ b/.ank/entities/LOG-61d74d54d820.md
@@ -1,0 +1,16 @@
+---
+id: LOG-61d74d54d820
+type: log
+title: drift audit, measured not read. This constraint declares its perimeter as
+created: 2026-08-31T03:10:52Z
+author: claude-code/opus-5+drift
+scope:
+  - crates/ank-cli/src/index.rs
+  - docs/**
+about: ADR-a22cd3196529
+seq: 1
+schema: 4
+version: 1
+---
+
+ crates/ank-cli/src/index.rs and docs/**. Measured on ank 0.7.0 (50f4b39): the daemon is implemented in crates/ank-daemon/, seven files including fetch.rs, warm.rs, declare.rs and stream.rs, and ank context crates/ank-daemon/src/fetch.rs answers 'CONSTRAINTS (3 active)' -- ADR-9f03, ADR-85e6, ADR-d3a8 -- and names this decision in none of them. ank scope crates/ank-daemon/src/lib.rs lists four ADRs and this is not one. So the clause that matters most, 'the only thing it writes into a repository is a fetch of refs/ank/* into a tracking namespace of its own', is handed to nobody working on the code that performs the fetch. An accepted ADR's scope is hashed into its ratification commit and amend refuses it, so the repair is a successor and not an edit.

--- a/.ank/entities/LOG-6ed3ea2c66ae.md
+++ b/.ank/entities/LOG-6ed3ea2c66ae.md
@@ -1,0 +1,15 @@
+---
+id: LOG-6ed3ea2c66ae
+type: log
+title: drift audit, re-measured and holds; no finding. The risk this constraint names is a cache whose key
+created: 2026-08-31T03:11:37Z
+author: claude-code/opus-5+drift
+scope:
+  - crates/ank-cli/**
+about: ADR-f3d1dea65d84
+seq: 0
+schema: 4
+version: 1
+---
+
+ is wrong making the verb lie, so the key was exercised on both halves. In a throwaway corpus: ank status --json and ank check --json both answered faults 0, signals 18; ank new task then changed the files and both answered 20; ank claim then changed refs/ank/* alone and both still answered 20. On this corpus ank status reports 0 faults and 428 signals and ank check reports the same, while status spawns 7 git processes against check's 18. No counter is absent, optional or null under --json.

--- a/.ank/entities/LOG-79a7e6c55ef8.md
+++ b/.ank/entities/LOG-79a7e6c55ef8.md
@@ -1,0 +1,15 @@
+---
+id: LOG-79a7e6c55ef8
+type: log
+title: "drift audit, measured not read. The constraint enumerates the routes: 'Reading is ank show, ank"
+created: 2026-08-31T03:10:52Z
+author: claude-code/opus-5+drift
+scope:
+  - .ank/**
+about: ADR-01b6dd05f0db
+seq: 0
+schema: 4
+version: 1
+---
+
+ find and ank context; writing is ank new, claim, log, done, release, attest, close and accept.' Measured on ank 0.7.0 (50f4b39) in a throwaway corpus, hashing every file under .ank/ except index.db before and after each verb: ank read, ank amend --scope, ank edit --title and ank config context_budget each changed those bytes and each exited 0. None of the four is in the writing list. On the reading side the binary dispatches 26 verbs, and scope, graph, status, review, check and the read form of log all answer out of the corpus without appearing in the reading list. The rule this ADR states still holds -- the CLI is the route, the human keeps the editor -- and the two lists no longer name the routes.

--- a/.ank/entities/LOG-b357fe6223d7.md
+++ b/.ank/entities/LOG-b357fe6223d7.md
@@ -1,0 +1,17 @@
+---
+id: LOG-b357fe6223d7
+type: log
+title: drift audit, measured not read. The constraint says the log of an entity is '.ank/log/<ID>.md,
+created: 2026-08-31T03:10:40Z
+author: claude-code/opus-5+drift
+scope:
+  - crates/ank-core/**
+  - crates/ank-cli/**
+  - docs/**
+about: ADR-ff294eff4d1a
+seq: 0
+schema: 4
+version: 1
+---
+
+ append-only, one timestamped line per entry'. Measured on ank 0.7.0 (50f4b39) in a fresh corpus: ank init announces 'created .ank/entities .ank/log'; after new task, claim and log, find .ank -type f returns .ank/config.yml, .ank/entities/TASK-13cfb68d9545.md and .ank/entities/LOG-c75377afc8ab.md, and .ank/log is still empty (ls -la shows two entries, . and ..). ADR-25f977377fa0, accepted four days later, retired that address and supersedes nothing, so two accepted decisions state different addresses and the binary follows the later one. The second and third paragraphs of this constraint -- a task file changes only on a transition, the log anchors nothing -- were re-measured and hold: amend and edit wrote LOG entries carrying 'version 2 to 3, replaced 76c50fa06431, produced 3d0984e9adc4' and did not move status.

--- a/.ank/entities/LOG-b9a7d78c875f.md
+++ b/.ank/entities/LOG-b9a7d78c875f.md
@@ -1,0 +1,23 @@
+---
+id: LOG-b9a7d78c875f
+type: log
+title: drift audit, measured not read. The constraint says 'Every channel that declares a licence declares
+created: 2026-08-31T03:11:06Z
+author: claude-code/opus-5+drift
+scope:
+  - LICENSE
+  - README.md
+  - CLAUDE.md
+  - crates/**
+  - npm/**
+  - Formula/**
+  - bucket/**
+  - packaging/**
+  - package.json
+about: ADR-9f03438f5422
+seq: 0
+schema: 4
+version: 1
+---
+
+ that one -- the npm packages, the Homebrew formula, the Scoop manifest, the winget locale'. Measured on this tree at 50f4b39: ls -d Formula bucket packaging returns 'No such file or directory' for all three, which are also three of this ADR's nine declared scopes and three of the dead scopes ank check reports. ADR-221aa5da440a, accepted two days after this one, states 'No package-manager channel ships: no Homebrew tap, no Scoop bucket, no apt repository, no winget manifest, no AUR package', so this enumeration names three channels a later accepted decision abolished. The licence rule itself was re-measured and holds: no superseded identifier is cited by any tracked file outside .ank/, and ank check reports 0 faults.

--- a/.ank/entities/LOG-e817dbebe222.md
+++ b/.ank/entities/LOG-e817dbebe222.md
@@ -1,0 +1,17 @@
+---
+id: LOG-e817dbebe222
+type: log
+title: drift audit, measured not read. The constraint says 'Which of the two a verb is, its help says; a
+created: 2026-08-31T03:10:40Z
+author: claude-code/opus-5+drift
+scope:
+  - crates/ank-cli/src/claim.rs
+  - .github/workflows/ci.yml
+  - docs/ank-spec-v1.1.md
+about: ADR-af533e7a3e03
+seq: 1
+schema: 4
+version: 1
+---
+
+ caller never has to infer it from what the verb happens to touch.' Measured against ank 0.7.0 (50f4b39): of the eight coordinating verbs -- claim, log, done, release, close, attest, accept, check -- the summary, notes and refusals ank help --json carries mention a push, a remote, a clone or unreachability for attest alone. The other seven say nothing. Behaviour itself is right where I could reach it: in a clone whose origin points at a path that does not exist, ank claim printed 'warning: claim not pushed: it holds in this clone only' and exited 0, which is the degrading class the constraint allows because claim also writes the task file (status open -> in_progress, version bumped). The exit code is correct and the help does not say so, which is exactly the inference the constraint forbids.

--- a/.ank/entities/LOG-f740f080e484.md
+++ b/.ank/entities/LOG-f740f080e484.md
@@ -1,0 +1,17 @@
+---
+id: LOG-f740f080e484
+type: log
+title: drift audit, measured not read. This constraint holds in the binary and ank init still carries the
+created: 2026-08-31T03:11:20Z
+author: claude-code/opus-5+drift
+scope:
+  - crates/ank-core/**
+  - crates/ank-cli/**
+  - docs/**
+about: ADR-25f977377fa0
+seq: 0
+schema: 4
+version: 1
+---
+
+ address it retired. Measured on ank 0.7.0 (50f4b39): a fresh ank init in an empty repository prints 'created .ank/entities .ank/log', find .ank -type d then returns .ank, .ank/entities and .ank/log, and after new task, claim and log the entry is at .ank/entities/LOG-c75377afc8ab.md while .ank/log holds nothing. So every corpus this binary creates is born with a directory no verb ever writes into, which is the state ADR-c9f9d0d6f05d rules out in as many words: 'No directory means anything, and none is added to make one mean something.' The entity half of this decision was re-measured and holds: entries are allocated an id, written once, and ank log <id> reads them back newest first without a claim -- including on an ADR, where no claim arbitrates.

--- a/.ank/entities/TASK-335c6a01bfa7.md
+++ b/.ank/entities/TASK-335c6a01bfa7.md
@@ -1,0 +1,18 @@
+---
+id: TASK-335c6a01bfa7
+type: task
+slug: a-proposed-successor-to-adr-ff294eff4d1a-states
+title: A proposed successor to ADR-ff294eff4d1a states the log address the binary writes
+created: 2026-08-31T03:12:01Z
+author: claude-code/opus-5+drift
+status: open
+scope:
+  - .ank/entities/**
+blocked_by: []
+done_criteria: |
+  `ank find --type adr --status proposed --json` lists exactly one entity whose `supersedes` is ADR-ff294eff4d1a, and `ank show` of it prints a constraint naming `.ank/entities/LOG-<ID>.md` and naming `.ank/log/` nowhere. ADR-ff294eff4d1a is accepted and states the log lives at `.ank/log/<ID>.md`, one timestamped line per entry; ADR-25f977377fa0 is accepted, four days younger, retired that address and supersedes nothing, so two accepted decisions give two addresses. Measured: the binary writes .ank/entities/LOG-<id>.md and leaves .ank/log empty. The successor carries forward unchanged the two paragraphs re-measured as true -- a task file changes only on a transition, and nothing authoritative is anchored in the log. Nothing is accepted by this task: accept is a human act.
+criteria_by: creator
+verify: [cargo-test, fmt-check]
+schema: 4
+version: 1
+---

--- a/.ank/entities/TASK-34938bfc6b84.md
+++ b/.ank/entities/TASK-34938bfc6b84.md
@@ -1,0 +1,18 @@
+---
+id: TASK-34938bfc6b84
+type: task
+slug: the-licence-decision-stops-enumerating-three-cha
+title: The licence decision stops enumerating three channels a later decision abolished
+created: 2026-08-31T03:12:34Z
+author: claude-code/opus-5+drift
+status: open
+scope:
+  - .ank/entities/**
+blocked_by: []
+done_criteria: |
+  `ank find --type adr --status proposed --json` lists an entity whose `supersedes` is ADR-9f03438f5422; its constraint names no Homebrew formula, Scoop manifest or winget locale; and `ank check` reports no dead scope against it. Measured on this tree: ls -d Formula bucket packaging fails for all three, and those three are declared scopes of ADR-9f03438f5422 and among the dead scopes check reports. ADR-221aa5da440a, accepted two days younger, states 'No package-manager channel ships: no Homebrew tap, no Scoop bucket, no apt repository, no winget manifest, no AUR package', so the older accepted ADR requires a licence declaration from three channels the corpus has forbidden. The Apache-2.0 rule and the prospective-relicensing paragraph carry forward unchanged. Nothing is accepted by this task.
+criteria_by: creator
+verify: [cargo-test, fmt-check]
+schema: 4
+version: 1
+---

--- a/.ank/entities/TASK-53a95782ae5c.md
+++ b/.ank/entities/TASK-53a95782ae5c.md
@@ -1,0 +1,18 @@
+---
+id: TASK-53a95782ae5c
+type: task
+slug: the-rule-closing-ank-to-agents-names-the-routes
+title: The rule closing .ank to agents names the routes the binary actually dispatches
+created: 2026-08-31T03:12:26Z
+author: claude-code/opus-5+drift
+status: open
+scope:
+  - .ank/entities/**
+blocked_by: []
+done_criteria: |
+  `ank find --type adr --status proposed --json` lists an entity whose `supersedes` is ADR-01b6dd05f0db, and its constraint names amend, edit, config and read among the writing routes and scope, graph, status, review, check and the read form of log among the reading ones. Measured on ank 0.7.0, hashing every file under .ank/ except index.db before and after each verb in a throwaway corpus: ank read, ank amend --scope, ank edit --title and ank config each changed those bytes and each exited 0, and ADR-01b6dd05f0db lists none of the four, its writing list being 'ank new, claim, log, done, release, attest, close and accept'. The rule itself is unchanged -- the CLI is the route for an agent, a human with an editor keeps every power they had -- and only the two enumerations move. Nothing is accepted by this task.
+criteria_by: creator
+verify: [cargo-test, fmt-check]
+schema: 4
+version: 1
+---

--- a/.ank/entities/TASK-58ccbc4683ef.md
+++ b/.ank/entities/TASK-58ccbc4683ef.md
@@ -1,0 +1,18 @@
+---
+id: TASK-58ccbc4683ef
+type: task
+slug: the-naming-decision-names-the-workspace-as-it-is
+title: The naming decision names the workspace as it is, or stops enumerating it
+created: 2026-08-31T03:12:44Z
+author: claude-code/opus-5+drift
+status: open
+scope:
+  - .ank/entities/**
+blocked_by: []
+done_criteria: |
+  `ank find --type adr --status proposed --json` lists an entity whose `supersedes` is ADR-85e6bbb195b8, and its constraint either names every directory `ls crates/` prints -- six today: ank-cli, ank-contract, ank-core, ank-daemon, ank-mcp, ank-tui -- or states the naming rule with no crate enumeration at all. Measured on this tree: ADR-85e6bbb195b8 is accepted and says 'the crates are ank-core and ank-cli', ls crates/ prints six, and the four it omits were each created by a later accepted decision (ADR-559eebf5c6f5 scopes crates/ank-tui/**, ADR-fd98f4bc6dea scopes crates/ank-mcp/**), so ank context hands anyone touching crates/** a constraint that contradicts three ratified ones. Every other clause was re-measured and holds -- binary ank, directory .ank/, refs/ank/*, ANK_AGENT, no occurrence of ankor -- and carries forward unchanged. Nothing is accepted by this task.
+criteria_by: creator
+verify: [cargo-test, fmt-check]
+schema: 4
+version: 1
+---

--- a/.ank/entities/TASK-acaf2c3159dd.md
+++ b/.ank/entities/TASK-acaf2c3159dd.md
@@ -1,0 +1,19 @@
+---
+id: TASK-acaf2c3159dd
+type: task
+slug: ank-init-creates-no-directory-the-binary-never-w
+title: ank init creates no directory the binary never writes into
+created: 2026-08-31T03:11:45Z
+author: claude-code/opus-5+drift
+status: open
+scope:
+  - crates/ank-cli/src/init.rs
+  - crates/ank-cli/tests/cli.rs
+blocked_by: []
+done_criteria: |
+  Run in an empty git repository: after `ank init`, `find .ank -type d` prints exactly `.ank` and `.ank/entities`, and the line `ank init` prints names those two and no third directory. Measured today the same run prints 'created .ank/entities .ank/log' and leaves .ank/log empty for the life of the corpus, because ADR-25f977377fa0 moved entries to .ank/entities/LOG-<id>.md. A test in crates/ank-cli/tests/cli.rs drives the binary, not the function, and fails if .ank/log is created again.
+criteria_by: creator
+verify: [cargo-test, fmt-check]
+schema: 4
+version: 1
+---

--- a/.ank/entities/TASK-c4f26ad5302d.md
+++ b/.ank/entities/TASK-c4f26ad5302d.md
@@ -1,0 +1,18 @@
+---
+id: TASK-c4f26ad5302d
+type: task
+slug: the-cli-surface-stops-saying-the-binary-does-not
+title: The CLI surface stops saying the binary does not answer to mcp and watch
+created: 2026-08-31T03:12:18Z
+author: claude-code/opus-5+drift
+status: open
+scope:
+  - .ank/entities/**
+blocked_by: []
+done_criteria: |
+  `ank find --type spec --status proposed --json` lists an entity whose `supersedes` is SPEC-fe8bdb84faca, and the string 'does not answer to them yet' appears in `ank show SPEC-fe8bdb84faca` and in no proposed successor. SPEC-fe8bdb84faca is accepted and states 'mcp and watch are on that list and the binary does not answer to them yet'. Measured on ank 0.7.0: ank help --json carries 26 verbs including both; an initialize plus tools/list piped into ank mcp returned 26 tools, one per verb; ank watch --where printed the declaration path; and crates/ank-cli/tests/skill.rs declares NOT_YET_DISPATCHED as an array of length zero, so the suite that exists to name an undispatched verb names none. Nothing is accepted by this task.
+criteria_by: creator
+verify: [cargo-test, fmt-check]
+schema: 4
+version: 1
+---

--- a/.ank/entities/TASK-f3eb2695799a.md
+++ b/.ank/entities/TASK-f3eb2695799a.md
@@ -1,0 +1,19 @@
+---
+id: TASK-f3eb2695799a
+type: task
+slug: every-coordinating-verb-s-help-says-whether-its
+title: Every coordinating verb's help says whether its exit code depends on the push
+created: 2026-08-31T03:11:53Z
+author: claude-code/opus-5+drift
+status: open
+scope:
+  - crates/ank-contract/src/verbs.rs
+  - crates/ank-cli/tests/cli.rs
+blocked_by: []
+done_criteria: |
+  For each of claim, log, done, release, close, attest and accept, `ank help --json` carries a note or a refusal naming what the verb does when the push of its ref is refused: exits non-zero where the ref is the whole product, warns and exits zero where the verb also wrote to disk. Measured on ank 0.7.0: of those seven only attest says anything, so six leave a caller to infer the class from what the verb happens to touch, which ADR-af533e7a3e03 forbids in as many words. A test reads the contract table and fails when a verb that writes a ref carries no such line.
+criteria_by: creator
+verify: [cargo-test, fmt-check]
+schema: 4
+version: 1
+---

--- a/.ank/entities/TASK-f82cfa1b9344.md
+++ b/.ank/entities/TASK-f82cfa1b9344.md
@@ -1,0 +1,18 @@
+---
+id: TASK-f82cfa1b9344
+type: task
+slug: the-daemon-s-constraint-reaches-the-crate-that-i
+title: The daemon's constraint reaches the crate that implements the daemon
+created: 2026-08-31T03:12:09Z
+author: claude-code/opus-5+drift
+status: open
+scope:
+  - .ank/entities/**
+blocked_by: []
+done_criteria: |
+  `ank scope crates/ank-daemon/src/fetch.rs --json` lists an entity whose `supersedes` is ADR-a22cd3196529, and `ank context crates/ank-daemon/src/fetch.rs --json` names it under `proposed`. Measured on ank 0.7.0: ADR-a22cd3196529 declares its perimeter as crates/ank-cli/src/index.rs and docs/**, the daemon is seven files under crates/ank-daemon/, and ank context on that crate answers three active constraints -- ADR-9f03, ADR-85e6, ADR-d3a8 -- naming this decision in none of them, so the clause 'the only thing it writes into a repository is a fetch of refs/ank/* into a tracking namespace of its own' is handed to nobody working on the fetch. An accepted ADR's scope is hashed into its ratification commit and amend refuses it, so the route is a successor whose scope names crates/ank-daemon/** and whose constraint text is otherwise unchanged. Nothing is accepted by this task.
+criteria_by: creator
+verify: [cargo-test, fmt-check]
+schema: 4
+version: 1
+---


### PR DESCRIPTION
Audited the 51 accepted ADRs and 9 accepted specs against what the binary
built from this tree actually does. Every finding below rests on a run, not
on a reading; the eleven log entries carry the numbers.

Two are code:

  ank init announces "created .ank/entities .ank/log" and leaves .ank/log
  empty for the life of the corpus. ADR-25f977377fa0 moved entries to
  .ank/entities/LOG-<id>.md and ADR-c9f9d0d6f05d forbids a directory added
  to mean something.

  ADR-af533e7a3e03 says which of the two push classes a verb is, its help
  says. Of eight coordinating verbs only attest says it.

Six are the corpus outrunning its own decisions. ADR-ff294eff4d1a still
states an address ADR-25f977377fa0 retired without superseding it.
ADR-a22cd3196529's perimeter is crates/ank-cli/src/index.rs while the
daemon is seven files under crates/ank-daemon/, so ank context on the fetch
hands over none of it. SPEC-fe8b says the binary does not answer to mcp and
watch; it answers to both, and NOT_YET_DISPATCHED is empty. ADR-01b6dd05f0db
lists the routes into .ank/ and omits read, amend, edit and config, each
measured writing. ADR-9f03438f5422 requires a licence declaration from three
channels ADR-221aa5da440a abolished. ADR-85e6bbb195b8 says the crates are
ank-core and ank-cli; there are six.

Re-measured and holding, recorded as such: ADR-cc65f1388a71 (check spawns
6 git processes against 2, 8 and 20 dead scopes alike), ADR-f3d1dea65d84
(the status cache key answers on both halves), ADR-443590981e41,
ADR-6d8736c04cfa, ADR-3b6ba766a42e, ADR-1ea31c2f3c5a, ADR-91b77f036884,
ADR-9307e5d214a7, ADR-fd98f4bc6dea and the short-form table of SPEC-fe8b.

Nothing is fixed here and nothing is claimed. No accepted entity is edited,
and no successor is written: superseding is a signature, and that is not
mine to give.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CwBAytM9JcfSaqXKqJ1T2R
