### PR TITLE
init --at leaves the target untouched when the declaration is refused

### DIFF
--- a/.ank/entities/LOG-4388ae869f68.md
+++ b/.ank/entities/LOG-4388ae869f68.md
@@ -1,0 +1,17 @@
+---
+id: LOG-4388ae869f68
+type: log
+title: Falsifiability checked, not assumed. With the fix in place the new suite is green (2 tests plus
+created: 2026-08-31T03:35:35Z
+author: claude-code/opus-5+init
+scope:
+  - crates/ank-cli/src/init.rs
+  - crates/ank-cli/src/config.rs
+  - crates/ank-cli/tests/init_at.rs
+about: TASK-0dd151b02854
+seq: 1
+schema: 4
+version: 1
+---
+
+ scratch's 4). With init_at() moved back ahead of the declaration and nothing else changed, a_refused_declaration_leaves_the_target_exactly_as_it_was_found fails on the tree comparison at init_at.rs:201, and the negative control stays green -- which is right, since the accepted path was never what broke. Measured after the fix, same fixture as LOG-8553c20beeca: exit still 1, message still 'schema 2, this binary reads 1: the file is newer than this ank', recursive listing of the target before == after (.git alone), and 'git config --local --list' in the target byte-identical, so no +refs/ank/* refspec. corpora.yml unchanged.

--- a/.ank/entities/LOG-8553c20beeca.md
+++ b/.ank/entities/LOG-8553c20beeca.md
@@ -1,0 +1,17 @@
+---
+id: LOG-8553c20beeca
+type: log
+title: Reproduced before the fix, through this worktree's target/debug/ank. Reader home holds corpora.yml
+created: 2026-08-31T03:32:54Z
+author: claude-code/opus-5+init
+scope:
+  - crates/ank-cli/src/init.rs
+  - crates/ank-cli/src/config.rs
+  - crates/ank-cli/tests/init_at.rs
+about: TASK-0dd151b02854
+seq: 0
+schema: 4
+version: 1
+---
+
+ at 'schema: 2'; source repo has one root commit; target is a fresh 'git init' holding only .git. Run: ank init --at <target>. Exit 1, message 'schema 2, this binary reads 1: the file is newer than this ank', corpora.yml left byte-identical -- the refusal is correct. The target, before: .git alone. After: .ank/config.yml, .ank/entities/, .ank/log/, AGENTS.md, .gitattributes, .gitignore, and 'fetch = +refs/ank/*:refs/ank/*' written into the target's own .git/config. Six artefacts and one foreign config mutation, with nothing declared pointing at any of them. Two more than LOG-1bf8280879af recorded: .gitattributes and the refspec.

--- a/.ank/entities/LOG-e8ad371c49d5.md
+++ b/.ank/entities/LOG-e8ad371c49d5.md
@@ -1,0 +1,15 @@
+---
+id: LOG-e8ad371c49d5
+type: log
+title: done, proof test:local/a8a9c5ee29db@87421f6 test:local/e3b0c44298fc@87421f6
+created: 2026-08-31T03:43:40Z
+author: claude-code/opus-5+init
+scope:
+  - crates/ank-cli/src/init.rs
+  - crates/ank-cli/src/config.rs
+  - crates/ank-cli/tests/init_at.rs
+about: TASK-0dd151b02854
+seq: 2
+schema: 4
+version: 1
+---

--- a/.ank/entities/TASK-0dd151b02854.md
+++ b/.ank/entities/TASK-0dd151b02854.md
@@ -5,7 +5,7 @@ slug: init-at-leaves-the-target-untouched-when-the-dec
 title: init --at leaves the target untouched when the declaration is refused
 created: 2026-08-31T03:32:38Z
 author: claude-code/opus-5+init
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/src/init.rs
   - crates/ank-cli/src/config.rs
@@ -15,8 +15,21 @@ done_criteria: |
   An 'ank init --at <dir>' run whose declaration is refused leaves <dir> exactly as it was found: no .ank/, no AGENTS.md, no .gitattributes, no .gitignore, and no refs/ank refspec added to <dir>/.git/config. Measured through the binary, against a reader's corpora.yml at a schema this build cannot read: the exit code stays 1 and the message still names the schema, and a recursive listing of <dir> taken before the run equals the one taken after. A run whose declaration is accepted still creates the corpus and still writes the declaration.
 criteria_by: creator
 verify: [cargo-test, fmt-check]
+proof:
+  - type: test
+    ref: local/a8a9c5ee29db@87421f6
+    tree: scope/717e2fc38951
+    criteria: 82783c6d1391
+    verifier: cargo-test@f14aeab36e1b
+    via: verifier
+  - type: test
+    ref: local/e3b0c44298fc@87421f6
+    tree: scope/717e2fc38951
+    criteria: 82783c6d1391
+    verifier: fmt-check@5ca6d10bcd55
+    via: verifier
 schema: 4
-version: 2
+version: 3
 ---
 
 LOG-1bf8280879af measured it and stopped rather than widen an unrelated diff:

--- a/.ank/entities/TASK-0dd151b02854.md
+++ b/.ank/entities/TASK-0dd151b02854.md
@@ -1,0 +1,57 @@
+---
+id: TASK-0dd151b02854
+type: task
+slug: init-at-leaves-the-target-untouched-when-the-dec
+title: init --at leaves the target untouched when the declaration is refused
+created: 2026-08-31T03:32:38Z
+author: claude-code/opus-5+init
+status: in_progress
+scope:
+  - crates/ank-cli/src/init.rs
+  - crates/ank-cli/src/config.rs
+  - crates/ank-cli/tests/init_at.rs
+blocked_by: []
+done_criteria: |
+  An 'ank init --at <dir>' run whose declaration is refused leaves <dir> exactly as it was found: no .ank/, no AGENTS.md, no .gitattributes, no .gitignore, and no refs/ank refspec added to <dir>/.git/config. Measured through the binary, against a reader's corpora.yml at a schema this build cannot read: the exit code stays 1 and the message still names the schema, and a recursive listing of <dir> taken before the run equals the one taken after. A run whose declaration is accepted still creates the corpus and still writes the declaration.
+criteria_by: creator
+verify: [cargo-test, fmt-check]
+schema: 4
+version: 2
+---
+
+LOG-1bf8280879af measured it and stopped rather than widen an unrelated diff:
+`run` calls `init_at(&target)` before `config::declare_corpus`, so a refused
+declaration arrives after the corpus it was supposed to authorise has already
+been written.
+
+Reproduced here before the task was written, with this worktree's binary and a
+reader whose `corpora.yml` carries `schema: 2`. The refusal is correct and the
+declarations file is left byte-identical, which is what TASK-409e4c7d8aac
+built. The target, which nothing then points at, was left holding
+`.ank/config.yml`, `.ank/entities/`, `.ank/log/`, `AGENTS.md`, `.gitignore`,
+and two the log did not record: `.gitattributes`, and a
+`fetch = +refs/ank/*:refs/ank/*` written into the target repository's own
+`.git/config`.
+
+`init.rs` already states the rule this breaks, twice. `--repo` is refused
+"before anything is written", and `detachable` is documented as "everything a
+detached corpus is refused for, before a byte is written". The declaration is
+the one refusal that escaped that ordering.
+
+The fix keeps it a refusal rather than making it a repair. `declare_corpus`
+splits into a half that decides -- home resolved, existing text read, the
+newer-schema guard, the differential parse refusal -- and a half that writes.
+`run` takes the decision before `init_at` and performs the write after it, so
+no refusal can reach the target. Every message and exit code stays what it is:
+the existing suite asserts exit 1 and a byte-identical `corpora.yml`, and this
+change must not move either.
+
+Rollback was the alternative and is worse. Undoing an `ensure_line` append to
+a file that may have pre-existed, and a refspec written into somebody else's
+repository, is new surface with its own failure modes, and a rollback that
+fails leaves state worse than the one it was called to clean. Refusing earlier
+makes the residue impossible instead of repaired.
+
+What stays out of reach: a genuine I/O failure on the final `fs::write` of
+`corpora.yml` can still leave a corpus with no declaration. That is a disk
+error, not a refusal, and buying it back costs the rollback this task declines.

--- a/crates/ank-cli/src/config.rs
+++ b/crates/ank-cli/src/config.rs
@@ -1758,15 +1758,55 @@ pub fn run_user(inv: &Invocation, out: &mut dyn Write) -> Result<ExitCode> {
     Ok(ExitCode::Ok)
 }
 
-/// Declares `path` as the corpus of the repository `identity`, and answers with
-/// the file it wrote.
+/// A declaration this binary has decided on and has not yet written.
+///
+/// **The two halves exist so the refusals can be taken first**
+/// (TASK-0dd151b02854). `init --at` writes in two places -- a corpus in the
+/// directory the caller named, and a line in the reader's declarations file --
+/// and it used to write the first before deciding whether the second was
+/// allowed. A refused declaration then arrived after the corpus it was
+/// supposed to authorise already existed, leaving a directory nothing pointed
+/// at. Every reason this file may not be written is settled by
+/// [`plan_corpus`], which touches nothing; [`PendingDeclaration::write`] is
+/// the only part that can no longer refuse.
+pub struct PendingDeclaration {
+    file: std::path::PathBuf,
+    /// The whole file as it will stand, not the line being added: the surgery
+    /// below is line-based and its result is what gets written.
+    text: String,
+}
+
+impl PendingDeclaration {
+    /// Writes the decided declaration and answers with the file it wrote.
+    ///
+    /// What is left here is filesystem failure and nothing else. A caller that
+    /// has already created the corpus this declares cannot be handed a
+    /// refusal by this function, which is the whole point of the split.
+    pub fn write(self) -> Result<std::path::PathBuf> {
+        if let Some(dir) = self.file.parent() {
+            std::fs::create_dir_all(dir).map_err(|e| {
+                CliError::new(ExitCode::Environment, format!("{}: {e}", dir.display()))
+            })?;
+        }
+        std::fs::write(&self.file, self.text).map_err(|e| {
+            CliError::new(
+                ExitCode::Environment,
+                format!("{}: {e}", self.file.display()),
+            )
+        })?;
+        Ok(self.file)
+    }
+}
+
+/// Decides the declaration naming `path` as the corpus of the repository
+/// `identity`, taking every refusal and writing nothing.
 ///
 /// **The same surgery `--user` performs**, and deliberately not a serialiser:
 /// this file is hand-edited, and a round trip through `serde_yaml` would
 /// rewrite somebody's comments and key order to add one line. `init --at` is
 /// the gesture that makes a declaration without a text editor and a printed
 /// sha; it is not a licence to reformat the file it lands in.
-pub fn declare_corpus(identity: &str, path: &str) -> Result<std::path::PathBuf> {
+pub fn plan_corpus(identity: &str, path: &str) -> Result<PendingDeclaration> {
     let Some(file) = corpora_path() else {
         return Err(CliError::new(
             ExitCode::Environment,
@@ -1812,13 +1852,7 @@ pub fn declare_corpus(identity: &str, path: &str) -> Result<std::path::PathBuf> 
         )
         .with_hint(format!("ank config --user corpora.{identity}")));
     }
-    if let Some(dir) = file.parent() {
-        std::fs::create_dir_all(dir)
-            .map_err(|e| CliError::new(ExitCode::Environment, format!("{}: {e}", dir.display())))?;
-    }
-    std::fs::write(&file, after)
-        .map_err(|e| CliError::new(ExitCode::Environment, format!("{}: {e}", file.display())))?;
-    Ok(file)
+    Ok(PendingDeclaration { file, text: after })
 }
 
 /// The declarations file parsed, for the differential refusal above.

--- a/crates/ank-cli/src/init.rs
+++ b/crates/ank-cli/src/init.rs
@@ -77,11 +77,33 @@ pub fn run(inv: &Invocation, cwd: &Path, out: &mut dyn Write) -> Result<ExitCode
         detachable(cwd, &target)?;
     }
     git::ensure_usable(&target)?;
+    // **Decided here, written after the corpus, and that ordering is the
+    // point** (TASK-0dd151b02854). `detachable` above is documented as taking
+    // everything a detached corpus is refused for before a byte is written,
+    // and the declaration was the one refusal that escaped it: `init_at` ran
+    // first, so a `corpora.yml` this binary cannot read produced a correct
+    // refusal *after* the corpus had been created. Measured: the target was
+    // left holding `.ank/config.yml`, `.ank/entities`, `.ank/log`, `AGENTS.md`,
+    // `.gitattributes`, `.gitignore` and a `+refs/ank/*` refspec written into
+    // its own `.git/config`, with no declaration anywhere pointing at any of
+    // it.
+    //
+    // Refused earlier rather than repaired afterwards. Undoing an `ensure_line`
+    // append to a file that may have pre-existed, and a refspec written into
+    // another repository, is new surface with its own failure modes, and a
+    // rollback that fails leaves worse state than the one it was called to
+    // clean. `plan_corpus` takes every refusal and touches nothing, so there is
+    // nothing left to undo.
+    let pending = match detached {
+        Some(_) => {
+            let identity = repo::identity(cwd).expect("checked by detachable");
+            Some(config::plan_corpus(&identity, &target.to_string_lossy())?)
+        }
+        None => None,
+    };
     let mut report = init_at(&target)?;
-    if detached.is_some() {
-        let identity = repo::identity(cwd).expect("checked by detachable");
-        let file = config::declare_corpus(&identity, &target.to_string_lossy())?;
-        report.declared = Some(file.to_string_lossy().to_string());
+    if let Some(pending) = pending {
+        report.declared = Some(pending.write()?.to_string_lossy().to_string());
     }
     // `--json` is available on every command without exception (§4), and this
     // verb was the exception: it printed its prose and ignored the flag. The

--- a/crates/ank-cli/tests/init_at.rs
+++ b/crates/ank-cli/tests/init_at.rs
@@ -1,0 +1,256 @@
+//! `ank init --at <dir>` writes nothing into `<dir>` when the declaration that
+//! authorises it is refused (TASK-0dd151b02854).
+//!
+//! `init.rs` states the rule twice — `--repo` is refused "before anything is
+//! written", and `detachable` is documented as taking everything a detached
+//! corpus is refused for "before a byte is written" — and the declaration was
+//! the one refusal that escaped that ordering. `init_at` ran first, so a
+//! reader's `corpora.yml` at a schema this binary cannot read produced a
+//! correct refusal *after* the corpus had been created. Measured before the
+//! fix: the target was left holding `.ank/config.yml`, `.ank/entities`,
+//! `.ank/log`, `AGENTS.md`, `.gitattributes`, `.gitignore` and a
+//! `+refs/ank/*:refs/ank/*` refspec written into its own `.git/config`, with
+//! nothing declared pointing at any of it.
+//!
+//! **Through the binary, and it has to be.** The criterion is about what a
+//! directory holds after a process exits, and the reader's home is addressed
+//! through the environment — `XDG_CONFIG_HOME`, or `APPDATA` on Windows — so
+//! nothing but a child process can say "a reader whose declarations look like
+//! this". `CARGO_BIN_EXE_ank` is defined only for an integration test, and
+//! `ank-cli` has no library target.
+//!
+//! **The refusal is asserted as a whole, not as a list of filenames.** A test
+//! naming the six artefacts would go green against a seventh. What is compared
+//! is every path under the target with its contents, plus the target
+//! repository's own local git config, taken before the run and after it.
+
+mod scratch;
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const ANK: &str = env!("CARGO_BIN_EXE_ank");
+
+/// The one schema `corpora.yml` is written at, hard-coded for the reason
+/// `tests/schema.rs` gives: `ank-cli` has no library target, so
+/// `config::SUPPORTED_SCHEMA` is not reachable from here.
+const SUPPORTED: u32 = 1;
+
+/// A reader's home holding one `corpora.yml`, and the environment pointing the
+/// binary at it.
+///
+/// **Both variables, on every platform.** `user_dir` reads `APPDATA` on Windows
+/// and `XDG_CONFIG_HOME` elsewhere; setting one and not the other would leave
+/// this suite asserting nothing on one of the three platforms CLAUDE.md
+/// requires OS-dependent behaviour to run on, and silently — the file would
+/// simply not be found.
+struct Reader {
+    home: PathBuf,
+    file: PathBuf,
+}
+
+impl Reader {
+    fn new(what: &str, corpora: &str) -> Self {
+        let home = scratch::dir(what).join("config");
+        let dir = home.join("ank");
+        fs::create_dir_all(&dir).expect("the reader's home must be creatable");
+        let file = dir.join("corpora.yml");
+        fs::write(&file, corpora).expect("corpora.yml must be writable");
+        Reader { home, file }
+    }
+
+    fn text(&self) -> String {
+        fs::read_to_string(&self.file).expect("corpora.yml must still be readable")
+    }
+
+    fn run(&self, dir: &Path, args: &[&str]) -> (i32, String) {
+        let home = self.home.to_string_lossy().into_owned();
+        let out = Command::new(ANK)
+            .args(args)
+            .current_dir(dir)
+            .env("XDG_CONFIG_HOME", &home)
+            .env("APPDATA", &home)
+            .env("HOME", "")
+            .output()
+            .expect("the binary under test must run");
+        let mut said = String::from_utf8_lossy(&out.stdout).into_owned();
+        said.push_str(&String::from_utf8_lossy(&out.stderr));
+        (
+            out.status.code().expect("the binary must not be signalled"),
+            said,
+        )
+    }
+}
+
+fn git(dir: &Path, args: &[&str]) -> String {
+    let out = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .unwrap_or_else(|e| panic!("git {args:?}: {e}"));
+    assert!(
+        out.status.success(),
+        "git {args:?}: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+/// A git repository with one commit, which is all an identity needs
+/// (ADR-621a7fd96ce1: the identity is the root commit).
+fn repo(dir: &Path) {
+    fs::create_dir_all(dir).expect("the repository must be creatable");
+    git(dir, &["init", "-q", "."]);
+    git(
+        dir,
+        &[
+            "-c",
+            "user.email=t@example.invalid",
+            "-c",
+            "user.name=t",
+            "-c",
+            "commit.gpgsign=false",
+            "commit",
+            "-q",
+            "--allow-empty",
+            "-m",
+            "root",
+        ],
+    );
+}
+
+/// Every path under `dir` with what it holds, `.git` excluded.
+///
+/// `.git` is left out and answered for separately by [`local_config`]: git
+/// rewrites its own bookkeeping for reasons that have nothing to do with this
+/// verb, and the one thing `init` writes in there is a config line, which is
+/// compared exactly.
+fn tree(dir: &Path) -> BTreeMap<String, String> {
+    fn walk(root: &Path, at: &Path, into: &mut BTreeMap<String, String>) {
+        let entries = fs::read_dir(at).unwrap_or_else(|e| panic!("{}: {e}", at.display()));
+        for entry in entries.flatten() {
+            let p = entry.path();
+            let rel = p
+                .strip_prefix(root)
+                .expect("every walked path is under the root")
+                .to_string_lossy()
+                .replace('\\', "/");
+            if rel == ".git" {
+                continue;
+            }
+            if p.is_dir() {
+                into.insert(format!("{rel}/"), String::new());
+                walk(root, &p, into);
+            } else {
+                let what = fs::read(&p).unwrap_or_else(|e| panic!("{}: {e}", p.display()));
+                into.insert(rel, String::from_utf8_lossy(&what).into_owned());
+            }
+        }
+    }
+    let mut out = BTreeMap::new();
+    walk(dir, dir, &mut out);
+    out
+}
+
+/// The target repository's own settings, which is where the `+refs/ank/*`
+/// refspec lands.
+fn local_config(dir: &Path) -> String {
+    let mut lines: Vec<String> = git(dir, &["config", "--local", "--list"])
+        .lines()
+        .map(str::to_string)
+        .collect();
+    lines.sort();
+    lines.join("\n")
+}
+
+/// A target that already holds files of its own, so "left as it was found"
+/// covers a pointer appended to an existing `AGENTS.md` as well as one created
+/// from nothing.
+fn target(dir: &Path) {
+    repo(dir);
+    fs::write(dir.join("AGENTS.md"), "The reader's own notes.\n").expect("AGENTS.md is writable");
+    fs::write(dir.join(".gitignore"), "*.tmp\n").expect(".gitignore is writable");
+}
+
+/// **The criterion.** A declaration this binary refuses leaves the directory it
+/// was pointed at exactly as it found it.
+#[test]
+fn a_refused_declaration_leaves_the_target_exactly_as_it_was_found() {
+    let reader = Reader::new(
+        "init-at-refused",
+        &format!("schema: {}\ncorpora: {{}}\n", SUPPORTED + 1),
+    );
+    let base = scratch::dir("init-at-refused");
+    let (source, detached) = (base.join("repo"), base.join("detached"));
+    repo(&source);
+    target(&detached);
+
+    let declarations = reader.text();
+    let before = tree(&detached);
+    let before_config = local_config(&detached);
+
+    let (code, said) = reader.run(&source, &["init", "--at", &detached.to_string_lossy()]);
+
+    assert_eq!(code, 1, "the declaration is refused: {said}");
+    assert!(
+        said.contains("newer than this ank"),
+        "and refused on the schema: {said}"
+    );
+    assert_eq!(
+        tree(&detached),
+        before,
+        "the target holds neither more nor less than it did"
+    );
+    assert_eq!(
+        local_config(&detached),
+        before_config,
+        "and no refspec was written into its git config"
+    );
+    assert_eq!(
+        reader.text(),
+        declarations,
+        "and the declarations file is untouched, as TASK-409e4c7d8aac left it"
+    );
+}
+
+/// **The negative control, for the ordering rather than for the message.** A
+/// refusal taken before the corpus is written would be worth nothing if it also
+/// stopped the run that is allowed: the declaration still lands, and it lands
+/// after the corpus it names.
+#[test]
+fn an_accepted_declaration_still_creates_the_corpus_and_declares_it() {
+    let reader = Reader::new(
+        "init-at-accepted",
+        &format!("schema: {SUPPORTED}\ncorpora: {{}}\n"),
+    );
+    let base = scratch::dir("init-at-accepted");
+    let (source, detached) = (base.join("repo"), base.join("detached"));
+    repo(&source);
+    target(&detached);
+    let identity = git(&source, &["rev-list", "--max-parents=0", "HEAD"]);
+
+    let (code, said) = reader.run(&source, &["init", "--at", &detached.to_string_lossy()]);
+
+    assert_eq!(code, 0, "an ordinary detached init succeeds: {said}");
+    assert!(
+        detached.join(".ank").join("config.yml").is_file(),
+        "the corpus is created at the target"
+    );
+    assert!(
+        local_config(&detached).contains("+refs/ank/*:refs/ank/*"),
+        "and carries the refspec: {}",
+        local_config(&detached)
+    );
+    let declared = reader.text();
+    assert!(
+        declared.contains(&identity),
+        "the declaration is keyed on the root commit: {declared}"
+    );
+    assert!(
+        declared.contains(&detached.to_string_lossy().replace('\\', "\\\\"))
+            || declared.contains(&*detached.to_string_lossy()),
+        "and names the corpus: {declared}"
+    );
+}


### PR DESCRIPTION
- **init --at decides the declaration before it writes the corpus**
- **done TASK-0dd151b02854**
