### PR TITLE
Six proposed successors to decisions the tree has outgrown

### DIFF
--- a/.ank/entities/ADR-24e21cb83793.md
+++ b/.ank/entities/ADR-24e21cb83793.md
@@ -1,0 +1,89 @@
+---
+id: ADR-24e21cb83793
+type: adr
+slug: the-daemon-watches-what-it-was-declared-answers
+title: The daemon watches what it was declared, answers no verb, and fetches nothing but refs/ank/*, and the rule reaches the crate that implements it
+created: 2026-08-31T03:48:24Z
+author: claude-code/opus-5+corpus
+status: proposed
+scope:
+  - crates/ank-daemon/**
+  - crates/ank-cli/src/index.rs
+  - docs/**
+constraint: |
+  A background process may keep several corpora warm for whatever reads them, on these terms and no others. It watches only corpora declared to it, keyed on the repository identity of ADR-621a7fd96ce1 and never on a path, and it walks no filesystem looking for one. It answers no verb: it is not a second dispatch path, it exposes no query surface of its own, and a caller that wants an answer runs the CLI, which finds a cache already warm. The only thing it writes into a repository is a fetch of refs/ank/* into a tracking namespace of its own; it touches no branch, no working tree, no index of git's, and no local refs/ank/claims. It takes no claim, holds none on anybody's behalf and renews none. It emits an event when a corpus it watches changes, and an event states what changed and never what to do about it. Nothing depends on it: every verb behaves identically with the daemon absent, its absence is never an error, and no route makes running it a condition of using ank.
+supersedes: ADR-a22cd3196529
+schema: 4
+version: 1
+---
+
+The text of the constraint is ADR-a22cd3196529's, word for word. Only the scope
+moves, and it moves because the scope was wrong in a way that made the whole
+document unreachable by the people it binds.
+
+## Measured, not read
+
+On ank 0.7.0 (50f4b39), 2026-08-31:
+
+- `git ls-files crates/ank-daemon` returns eight tracked files: `Cargo.toml`,
+  six under `src/` -- `declare.rs`, `fail.rs`, `fetch.rs`, `lib.rs`,
+  `stream.rs`, `warm.rs` -- and `tests/dependencies.rs`.
+- `ank scope crates/ank-daemon/src/fetch.rs` answers four ADRs: ADR-85e6bbb195b8,
+  ADR-9f03438f5422 and ADR-d3a8dcf38817, accepted, plus ADR-1713af205186,
+  superseded. The daemon's own decision is not among them.
+
+So the sentence "the only thing it writes into a repository is a fetch of
+`refs/ank/*` into a tracking namespace of its own" is handed to nobody editing
+`fetch.rs`. `ank context` is the mechanism this project built for exactly that
+delivery, and it delivered everything except the decision the file exists to
+implement.
+
+## Why the scope was wrong, and it is worth knowing how
+
+`crates/ank-daemon/**` was in the scope at version 1 and an edit removed it at
+version 2, twelve hours before ratification, at a moment when the crate did not
+exist yet. `crates/ank-cli/src/index.rs` was left because keeping the index warm
+was the visible half of the work. The half that ended up in its own crate kept
+the constraint and lost the scope.
+
+That path is worth naming because it is the ordinary one: a scope written
+against the tree of the day is correct on the day and becomes a lie when the
+implementation lands somewhere else. A glob is confronted with the filesystem,
+which is the property that makes this checkable at all.
+
+## Why this is a successor and not an amendment
+
+An accepted ADR's scope is hashed into its ratification commit, so `ank amend`
+refuses it. That refusal is the design working: a rule whose perimeter can be
+widened after signature is a rule nobody signed. The route is a new document
+that says what the perimeter should have been and is signed on its own.
+
+## What the scope adds, and why each of the three is kept
+
+`crates/ank-daemon/**` is added: it is where the daemon is. `docs/**` is kept:
+`docs/integrating.md` cites this decision twice and describes the daemon to
+integrators. `crates/ank-cli/src/index.rs` is kept: the warm cache the daemon
+maintains is that module's, and dropping it would drop a live perimeter under
+cover of a fix. Nothing else is added, and in particular this does not reach
+`crates/ank-cli/**`, whose constraint budget `ank check` already reports at 18762
+characters against a limit of 4000.
+
+## What stands between this and a signature
+
+ADR-3b6ba766a42e: `accept` refuses a supersession while any tracked file outside
+`.ank/` still cites what it retires. Counted on the same date: 44 citations of
+ADR-a22cd3196529 across 19 tracked files, 20 of them inside `crates/ank-daemon/`
+itself and 8 in `crates/ank-daemon/tests/dependencies.rs` alone, plus
+`.github/workflows/release.yml`, `docs/integrating.md`, `crates/ank-tui/`,
+`crates/ank-contract/` and `crates/ank-cli/`.
+
+Every one must name this document, or be dropped, before a ratification is
+possible. That sweep is not performed here: the task that produced this document
+is scoped to `.ank/entities/**` and those perimeters are held by other agents.
+It is the larger of the two sweeps this corpus currently owes, and filing it as
+work is the honest next step.
+
+**Nothing is accepted by writing this.** It lands proposed and binds nobody;
+until a human signs it on the default branch, `ank context` on `fetch.rs` still
+answers with the decision that does not reach it, and lists this one as
+proposed.

--- a/.ank/entities/ADR-534c7a3e6cf8.md
+++ b/.ank/entities/ADR-534c7a3e6cf8.md
@@ -1,0 +1,109 @@
+---
+id: ADR-534c7a3e6cf8
+type: adr
+slug: ank-is-apache-2-0-whole-declared-by-the-channels
+title: Ank is Apache-2.0 whole, declared by the channels that still ship
+created: 2026-08-31T04:05:44Z
+author: claude-code/opus-5+corpus
+status: proposed
+scope:
+  - LICENSE
+  - README.md
+  - CLAUDE.md
+  - crates/**
+  - npm/**
+  - package.json
+constraint: |
+  Ank is Apache-2.0, whole. Every crate in the workspace, the binary as
+  distributed, and the licence text at the root of the repository: no part of it is
+  copyleft, and there is no format/tool split any more. Every channel that declares
+  a licence declares that one -- the channels are the ones ADR-221aa5da440a fixes,
+  which today means the npm packages and the release metadata -- and the
+  documentation states it in one place, with no second answer left anywhere else to
+  contradict it. A declaration that disagrees with this one is a defect, and grep is
+  the check.
+  
+  Relicensing is prospective and says so: a release already made under GPL-3.0
+  stays available under GPL-3.0 to whoever received it, and nothing in the tree
+  claims to withdraw that.
+supersedes: ADR-9f03438f5422
+schema: 4
+version: 1
+---
+
+The licence is ADR-9f03438f5422's and it does not move: Apache-2.0, whole,
+prospective, and that paragraph is carried across word for word. What moves is
+the list of channels the rule addresses, and the scope that followed from it.
+
+## What went wrong, measured
+
+ADR-9f03438f5422 requires a licence declaration from "the Homebrew formula, the
+Scoop manifest, the winget locale". ADR-221aa5da440a, accepted two days later,
+says: "No package-manager channel ships: no Homebrew tap, no Scoop bucket, no apt
+repository, no winget manifest, no AUR package."
+
+So one accepted decision demands a declaration from three artefacts another
+accepted decision forbids anyone to create. On this tree, 2026-08-31, ank 0.7.0
+(50f4b39):
+
+- `ls -d Formula bucket packaging` fails on all three, and `git ls-files` matches
+  zero tracked files under each;
+- all three are declared scopes of ADR-9f03438f5422;
+- `ank check` names them: `dead scope 'Formula/**'`, `dead scope 'bucket/**'`,
+  `dead scope 'packaging/**'`;
+- `npm/**` matches 8 tracked files, and `LICENSE`, `README.md`, `CLAUDE.md` and
+  `package.json` all exist.
+
+This is not a contradiction that ever printed a wrong answer, which is exactly
+why it survived: a rule about a file nobody can create is invisible until
+something walks the globs. `ank check` is that walk, and it has been saying so
+one signal at a time.
+
+## What the successor does
+
+**The three channels leave the constraint, and the enumeration stops being a
+list this document maintains.** It names the set by pointing at
+ADR-221aa5da440a, which is the decision that owns which channels exist, and adds
+what that means today. When a channel is added or removed it is a supersession of
+*that* decision -- ADR-221aa5da440a says so in its own words -- and this rule
+follows without a second edit. The two-channels-today clause is there because a
+constraint an agent meets for the first time in `ank context` has to be readable
+on its own.
+
+**The three dead globs leave the scope**, so `ank check` reports no dead scope
+against this document. Nothing else moves: `LICENSE`, `README.md`, `CLAUDE.md`,
+`crates/**`, `npm/**` and `package.json` are the predecessor's remaining scopes,
+carried as they are. In particular the perimeter is not widened -- `crates/**`
+already charges 733 characters against a `crates/ank-cli/**` budget `ank check`
+reports at 18762 against a limit of 4000, and the successor's constraint is
+written to stay near that weight rather than above it.
+
+**`NOTICE` is left out, deliberately**, though it cites this decision. It is a
+declaration at the root, not a channel, and adding a path to a scope under cover
+of a repair is the move that produced the dead globs in the first place. If it
+belongs in the perimeter that is a decision of its own.
+
+## What is not reconsidered
+
+Everything ADR-9f03438f5422 argued: the format/tool split abandoned, the copyleft
+line that moved outward within a day of being drawn, the paved road a
+reimplementer already has, the proprietary fork that becomes permitted and is not
+minimised, Apache-2.0 over MIT for the patent grant, and the accounting that
+showed there was nothing to negotiate. None of it is touched here and none of it
+is restated at length; `ank show ADR-9f03438f5422` carries it whole and stays
+readable after this is signed.
+
+## What stands between this and a signature
+
+ADR-3b6ba766a42e: `accept` refuses a supersession while any tracked file outside
+`.ank/` still cites what it retires. Twelve sites cite ADR-9f03438f5422 today, in
+seven files: `NOTICE`, `crates/ank-cli/tests/skill.rs`, and the `Cargo.toml` of
+each of `ank-cli`, `ank-contract`, `ank-daemon`, `ank-mcp` and `ank-tui`.
+
+Every one must name this document, or be dropped, before a ratification is
+possible. The sweep is not performed here: the task that produced this document
+is scoped to `.ank/entities/**`, and those files belong to other perimeters.
+
+**Nothing is accepted by writing this.** It lands proposed and binds nobody, and
+until a human signs it on the default branch the corpus goes on holding a licence
+rule that addresses three channels it also forbids.

--- a/.ank/entities/ADR-67a4ac10c534.md
+++ b/.ank/entities/ADR-67a4ac10c534.md
@@ -1,0 +1,83 @@
+---
+id: ADR-67a4ac10c534
+type: adr
+slug: the-log-is-a-file-of-its-own-addressed-as-an-ent
+title: The log is a file of its own, addressed as an entity
+created: 2026-08-31T03:41:28Z
+author: claude-code/opus-5+corpus
+status: proposed
+scope:
+  - crates/ank-core/**
+  - crates/ank-cli/**
+  - docs/**
+constraint: |
+  An entry in the log of an entity is a file of its own, .ank/entities/LOG-<ID>.md, addressed and read like every other entity. The line grammar does not change: a dash, the timestamp, the identity, an em dash, the message.
+  
+  A task file changes only on a real transition. Appending a log entry writes no frontmatter, bumps no version, and touches no file carrying a frozen field.
+  
+  The log stays a work trace and never proof. Nothing authoritative is anchored in it and no hash chains over it, which is what makes an append by a second party harmless.
+  
+  Any entity kind may carry a log, and no entry means no log, never an error.
+supersedes: ADR-ff294eff4d1a
+schema: 4
+version: 1
+---
+
+ADR-25f977377fa0 made a log entry an entity: allocated an id, written once,
+never modified, with the entity it is about a field on the entry rather than the
+directory it sits in. It supersedes nothing. So ADR-ff294eff4d1a is still
+accepted and still gives the address `.ank/log/<ID>.md`, and two accepted
+decisions offer two addresses, only one of which the binary uses.
+
+## Measured, not read
+
+In an empty repository, against ank 0.7.0 (50f4b39) on 2026-08-31: `ank init`,
+one task, one claim, one `ank log`.
+
+- The entry was written to `.ank/entities/LOG-4f1b19586ce1.md`.
+- `.ank/log/` was created by `init` and left with zero files.
+- The md5 of the task file was `9b725cd725392faf904fa1305cd5212d` both before
+  and after the append.
+
+The third measurement is the one worth keeping: the clause about transitions is
+still exactly true, and it is the address alone that has stopped being.
+
+## What this changes, and what it deliberately does not
+
+The address, and nothing else. The two paragraphs re-measured as true are
+carried forward word for word rather than rephrased, because a supersession that
+edits what it did not have to re-decide makes a reader diff two documents to
+find out what moved.
+
+That includes one word that now reads oddly. "An append by a second party" is
+kept, though ADR-25f977377fa0 has made an entry a new file and there is nothing
+left to append to. The guarantee that sentence carries -- the log anchors
+nothing, so an entry a second party writes is harmless -- holds, and holds more
+simply than when it was written. Editing the word would be rewriting a clause
+that is still doing its work.
+
+The fourth clause is one line instead of two. "A missing log file means no
+entry" was a statement about a file at the retired address; with no file per
+entity's log there is nothing to be missing, and what survives is the rule it
+existed to state: an entity with no entries is not an error.
+
+## What stands between this and a signature
+
+ADR-3b6ba766a42e: `accept` refuses a supersession while any tracked file outside
+`.ank/` still cites what it retires. Seven sites cite ADR-ff294eff4d1a today, in
+three files:
+
+    crates/ank-cli/src/commands.rs:2057, :2129
+    crates/ank-cli/src/entries.rs:310
+    crates/ank-cli/tests/cli.rs:5091, :16227, :16345, :19750
+
+Every one of them must name this document, or be dropped, before a ratification
+is possible. That sweep is not performed here: those perimeters belong to other
+agents, and the task that produced this document is scoped to
+`.ank/entities/**`. A citation naming a proposed successor is the state
+ADR-3b6ba766a42e exists to produce, and it is honest, because `ank show` answers
+`status: proposed`.
+
+**Nothing is accepted by writing this.** It lands proposed, binds nobody, and
+`ank check` reports the supersession as a signal rather than a succession until
+a human signs it on the default branch.

--- a/.ank/entities/ADR-e45e1a29fe91.md
+++ b/.ank/entities/ADR-e45e1a29fe91.md
@@ -1,0 +1,114 @@
+---
+id: ADR-e45e1a29fe91
+type: adr
+slug: the-ank-directory-is-reached-only-through-the-cl
+title: The .ank directory is reached only through the CLI, and the routes are the ones that dispatch
+created: 2026-08-31T04:01:01Z
+author: claude-code/opus-5+corpus
+status: proposed
+scope:
+  - .ank/**
+constraint: |
+  Entities in .ank/ are read and written through the ank CLI only. Reading is ank show, ank find, ank context, ank scope, ank graph, ank status, ank review, ank check and the read form of ank log; writing is ank new, claim, log, done, release, attest, close, accept, amend, edit, config and read. No agent opens, greps, lists or edits a file under .ank/ directly. This constrains the agent, not the tool: a human with an editor keeps every power they had, and check remains what notices.
+supersedes: ADR-01b6dd05f0db
+schema: 4
+version: 1
+---
+
+`.ank/` should be as opaque to an agent as `.git/` is. Nobody opens
+`.git/refs/heads/main` to read a branch; they run `git rev-parse`. The reason is
+not secrecy, it is that the tool knows things the file does not: the budget of
+section 5, the truncation notice, the freeze anchored where the file's editor
+cannot reach it, what is claimable and by whom.
+
+That rule is ADR-01b6dd05f0db's and it is unchanged here. Only its two
+enumerations move, because the binary has grown four routes since they were
+written and an agent obeying the list obeyed a smaller CLI than the one it was
+running.
+
+## Measured, not read
+
+In a throwaway corpus on ank 0.7.0 (50f4b39), 2026-08-31, counting the paths
+`git status --porcelain -- .ank` reports after each verb, with `index.db`
+ignored. Counting paths rather than hashing files is deliberate: a measurement
+of this rule should not be the thing this rule forbids.
+
+Wrote, each exiting 0:
+
+    ank read <id>                     1 path
+    ank amend <id> --scope <glob>     2 paths
+    ank amend <id> --blocked-by <id>  2 paths
+    ank edit <id> --title <t>         2 paths
+    ank config default_branch main    1 path
+
+Wrote nothing, each exiting 0: `ank scope`, `ank graph`, `ank status`,
+`ank review`, `ank check`, `ank log <id>` in its read form, and the three the
+predecessor already named -- `show`, `find`, `context`.
+
+## What the two lists gain
+
+**The writing side gains `amend`, `edit`, `config` and `read`.** The first three
+are self-evidently writes. `read` is the interesting one: it is a reading act
+that records the reading, so an agent told "reading is show, find and context"
+and handed `ank read` had no way to place it. It is on the writing side because
+the enumeration is about bytes.
+
+`config` writes `.ank/config.yml`, which is not an entity. It is listed anyway,
+because the sentence governs `.ank/` and not only the entities in it, and a
+route that writes there and appears on neither list is exactly the gap this
+successor exists to close.
+
+**The reading side gains `scope`, `graph`, `status`, `review`, `check` and the
+read form of `log`.** Every one was already the answer to a question an agent
+would otherwise answer by opening a file: what constrains this path, what is
+genuinely a root, who holds what, what awaits ratification, what is already
+known to be wrong, and what previous holders tried.
+
+## The enumeration is the part that goes stale, and it will again
+
+This is a list of verbs inside a constraint, and the tree it describes moves. It
+went stale exactly once per new route, silently, and what noticed was a drift
+audit rather than anything mechanical. That is a real cost and it is accepted
+here rather than engineered away: the alternative -- a constraint that says "the
+verbs `ank help` prints" and names none -- is unreadable to the agent who most
+needs it, which is the one meeting the rule for the first time in `ank context`.
+
+The mitigation that costs nothing is a supersession like this one, filed by the
+audit that finds it. The mitigation that would cost something -- `check`
+comparing the two lists against the dispatch table -- is worth proposing on its
+own and is not decided here.
+
+## What the predecessor said that has since come true
+
+Its closing paragraph named one act with no command: adding a `blocked_by` to a
+task that already exists. `ank amend --blocked-by` does it today, measured above,
+so the human-surface exception that paragraph carved out has closed. The rest of
+its account stands: `ank new` writes a task that needs no hand finishing,
+`ank attest` performs the one write section 3 permits after `done`,
+`ank new adr --supersedes` writes the field nothing could write, and `accept`
+performs the succession that field announces.
+
+**This is still not the CLI becoming a gatekeeper.** ADR-6b3f19e08a24 says no
+frozen field may rely on the CLI refusing a write, and nothing here changes it:
+the freezes stay anchored by hash in artifacts the file's editor does not
+control, and stay verifiable by anyone. What is constrained is the agent's
+harness.
+
+## What stands between this and a signature
+
+ADR-3b6ba766a42e: `accept` refuses a supersession while any tracked file outside
+`.ank/` still cites what it retires. Fourteen sites cite ADR-01b6dd05f0db today,
+in eight files -- `CONTRIBUTING.md`, `crates/ank-cli/src/commands.rs`,
+`crates/ank-cli/src/git.rs`, `crates/ank-cli/src/human.rs`,
+`crates/ank-cli/src/paint.rs`, `crates/ank-cli/tests/cli.rs`,
+`crates/ank-cli/tests/skill.rs` and `crates/ank-contract/src/verbs.rs`. Two of
+them are inside string literals the binary prints, so re-pointing them changes
+CLI output and the assertions over it.
+
+Every one must name this document, or be dropped, before a ratification is
+possible. The sweep is not performed here: the task that produced this document
+is scoped to `.ank/entities/**` and those perimeters are held by other agents.
+
+**Nothing is accepted by writing this.** It lands proposed and binds nobody. The
+list an agent is served by `ank context` is still the predecessor's until a human
+signs this one on the default branch.

--- a/.ank/entities/ADR-f8f1ea7fd2bb.md
+++ b/.ank/entities/ADR-f8f1ea7fd2bb.md
@@ -1,0 +1,102 @@
+---
+id: ADR-f8f1ea7fd2bb
+type: adr
+slug: the-project-is-called-ank-and-every-crate-carrie
+title: The project is called ank, and every crate carries the name
+created: 2026-08-31T04:10:34Z
+author: claude-code/opus-5+corpus
+status: proposed
+scope:
+  - crates/**
+  - docs/**
+  - skill/**
+  - README.md
+constraint: |
+  The name of the project is ank. The binary is ank, every crate in the
+  workspace is named ank-<part>, the state directory is .ank/, the ref namespace
+  is refs/ank/*, the identity variable is ANK_AGENT. No occurrence of "ankor"
+  remains, with the single exception of historical anchors that rewriting would
+  falsify: log entries already written, and proof references pointing at an
+  external artifact.
+supersedes: ADR-85e6bbb195b8
+schema: 4
+version: 1
+---
+
+Three letters, typed on every call of the agent loop and present in every path of
+the state directory. The gain is small per occurrence and the occurrence is
+constant -- the same arithmetic that froze the surface at seven verbs
+(ADR-2f8a61c04b7d). None of that is reopened. One clause of ADR-85e6bbb195b8 has
+stopped describing the tree, and it is the clause that counted.
+
+## Measured, not read
+
+On this tree, ank 0.7.0 (50f4b39), 2026-08-31:
+
+- `ls crates/` prints six directories: `ank-cli`, `ank-contract`, `ank-core`,
+  `ank-daemon`, `ank-mcp`, `ank-tui`. `cargo metadata --no-deps` names the same
+  six packages, so the listing is the workspace and not a superset of it.
+- ADR-85e6bbb195b8 says "the crates are ank-core and ank-cli". That is two of
+  six, and its scope is `crates/**`, so `ank context` hands the sentence to
+  anyone touching any of the four it does not name.
+- Every other clause holds. The binary is `ank`; `ank --version` prints
+  `ank 0.7.0 (50f4b39, skill d25cedf8fe35)`. The state directory is `.ank/`.
+  `git for-each-ref` finds 311 refs under `refs/ank/remote`, 186 under
+  `refs/ank/proof`, 148 under `refs/ank/watch` and 8 under `refs/ank/claims`.
+  `ank status` prints `identity claude-code/opus-5+corpus (ANK_AGENT)`.
+  `ankor` occurs zero times in tracked files outside `.ank/`, and inside the
+  corpus `ank find ankor` returns only log entries already written and the done
+  rename task -- the exception the constraint carves out for itself.
+
+Those clauses are carried forward word for word.
+
+## Why the enumeration goes and does not come back
+
+The obvious repair is to write six names where two are written. It would be
+correct today and wrong at the next crate, in exactly the way the two names were
+wrong: silently, in a document `ank context` serves to everyone working in
+`crates/**`, with nothing mechanical to notice. The four crates that appeared
+were each created by a later accepted decision -- ADR-559eebf5c6f5 scopes
+`crates/ank-tui/**`, ADR-fd98f4bc6dea scopes `crates/ank-mcp/**` -- so the
+corpus already contradicted this one three times over, ratification against
+ratification, and no reader was told.
+
+What the sentence is actually for is the naming rule, and the rule is a prefix:
+a crate in this workspace is named `ank-<part>`. Stated that way it binds the
+crate that does not exist yet, which is what a constraint is supposed to do, and
+it is confronted with the filesystem rather than with somebody remembering to
+update a list. That is the same argument this project makes for a glob over a
+label, applied to the text inside the glob.
+
+The cost is that the constraint no longer tells a reader which crates exist. It
+should not: `ls crates/` answers that, and it is never stale.
+
+## What is not reconsidered
+
+ADR-85e6bbb195b8's account of the rename stands and is not repeated at length
+here. The rename was a format change rather than a branding one, so the
+specification moved first, then the goldens, then the code, and the goldens
+carrying none of the three strings was itself the proof the entity format did not
+move. Two categories were deliberately not rewritten, because a rewritten anchor
+anchors nothing: log entries already written keep the identity they carried, and
+the proof reference `ci://haksolot/ankor/runs/30324400136` on TASK-ca4714f5c719
+locates an artifact at a third party rather than naming this project.
+
+Its closing paragraph is worth reading beside this document, because this
+document is the case it predicted. It rewrote the scopes and constraints of
+accepted ADRs in place, on the grounds that renaming the referent of a rule is
+not amending the rule, and said plainly that the day `accept` produced real
+ratification commits the same operation would require superseding. That day has
+come: ADR-85e6bbb195b8 carries `ratified: c0c1dc33a814`, and this is a
+supersession rather than an edit for exactly the reason it gave.
+
+## What stands between this and a signature
+
+ADR-3b6ba766a42e: `accept` refuses a supersession while any tracked file outside
+`.ank/` still cites what it retires. One site cites ADR-85e6bbb195b8 today:
+`crates/ank-cli/src/human.rs:1828`. It must name this document, or be dropped,
+before a ratification is possible. That single line is not swept here -- the task
+that produced this document is scoped to `.ank/entities/**` -- but of the sweeps
+this corpus currently owes it is by a wide margin the smallest.
+
+**Nothing is accepted by writing this.** It lands proposed and binds nobody.

--- a/.ank/entities/LOG-11bff02967be.md
+++ b/.ank/entities/LOG-11bff02967be.md
@@ -1,0 +1,15 @@
+---
+id: LOG-11bff02967be
+type: log
+title: "The predecessor's body has a third stale sentence the criterion does not name: 'One act still has"
+created: 2026-08-31T04:00:29Z
+author: claude-code/opus-5+corpus
+scope:
+  - .ank/entities/**
+about: TASK-53a95782ae5c
+seq: 1
+schema: 4
+version: 1
+---
+
+ no command -- adding a blocked_by to a task that already exists'. Measured: 'ank amend TASK-790d644770e5 --blocked-by TASK-ceb875ce5316' printed 'amended TASK-790d644770e5 +blocked_by TASK-ceb875ce5316', exited 0 and changed 2 paths. TASK-bf65e2a3b6ee's line in that body is therefore closed, and the successor says so instead of repeating it.

--- a/.ank/entities/LOG-32e27783f613.md
+++ b/.ank/entities/LOG-32e27783f613.md
@@ -1,0 +1,15 @@
+---
+id: LOG-32e27783f613
+type: log
+title: "The supersession blocker is a single line: crates/ank-cli/src/human.rs:1828 is the only tracked"
+created: 2026-08-31T04:10:45Z
+author: claude-code/opus-5+corpus
+scope:
+  - .ank/entities/**
+about: TASK-58ccbc4683ef
+seq: 1
+schema: 4
+version: 1
+---
+
+ citation of ADR-85e6bbb195b8 outside .ank/. It is in a code perimeter held by another agent and outside this task's scope, so it is recorded here rather than re-pointed. The constraint states the naming rule with no crate enumeration at all, which is the second of the two forms the criterion allows.

--- a/.ank/entities/LOG-37ce4589264a.md
+++ b/.ank/entities/LOG-37ce4589264a.md
@@ -1,0 +1,15 @@
+---
+id: LOG-37ce4589264a
+type: log
+title: "One nuance stated plainly: ADR-67a4ac10c534's constraint names .ank/log/ nowhere, as the criterion"
+created: 2026-08-31T03:42:04Z
+author: claude-code/opus-5+corpus
+scope:
+  - .ank/entities/**
+about: TASK-335c6a01bfa7
+seq: 2
+schema: 4
+version: 1
+---
+
+ requires, and its body names it three times. A successor cannot say which address it retires without writing that address down once; the criterion binds the constraint, which is the binding text.

--- a/.ank/entities/LOG-4107e8ee45e6.md
+++ b/.ank/entities/LOG-4107e8ee45e6.md
@@ -1,0 +1,13 @@
+---
+id: LOG-4107e8ee45e6
+type: log
+title: done, proof test:local/cdc0865320a7@7f546d7 test:local/e3b0c44298fc@7f546d7
+created: 2026-08-31T03:53:04Z
+author: claude-code/opus-5+corpus
+scope:
+  - .ank/entities/**
+about: TASK-f82cfa1b9344
+seq: 3
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-4f499557dd21.md
+++ b/.ank/entities/LOG-4f499557dd21.md
@@ -1,0 +1,15 @@
+---
+id: LOG-4f499557dd21
+type: log
+title: "The supersession blocker: 14 tracked citations of ADR-01b6dd05f0db outside .ank/, in 8 files --"
+created: 2026-08-31T04:01:13Z
+author: claude-code/opus-5+corpus
+scope:
+  - .ank/entities/**
+about: TASK-53a95782ae5c
+seq: 2
+schema: 4
+version: 1
+---
+
+ CONTRIBUTING.md:59, crates/ank-cli/src/commands.rs:831 and :3224, crates/ank-cli/src/git.rs:2428, crates/ank-cli/src/human.rs:2748 and :4185, crates/ank-cli/src/paint.rs:4, crates/ank-cli/tests/cli.rs:10398, :12501, :15351 and :19590, crates/ank-cli/tests/skill.rs:57 and :685, crates/ank-contract/src/verbs.rs:882. Two of them (commands.rs:3224 and verbs.rs:882) are inside string literals the binary prints, so re-pointing them moves CLI output and the assertions over it. All eight files are outside this task's scope; recorded, not swept.

--- a/.ank/entities/LOG-5af24c2fa351.md
+++ b/.ank/entities/LOG-5af24c2fa351.md
@@ -1,0 +1,19 @@
+---
+id: LOG-5af24c2fa351
+type: log
+title: Measured on ank 0.7.0 (50f4b39) in a throwaway corpus, counting changed paths with 'git status
+created: 2026-08-31T04:00:26Z
+author: claude-code/opus-5+corpus
+scope:
+  - .ank/entities/**
+about: TASK-53a95782ae5c
+seq: 0
+schema: 4
+version: 1
+---
+
+ --porcelain -- .ank' rather than hashing files, so the measurement of ADR-01b6dd05f0db does not itself do what ADR-01b6dd05f0db forbids. index.db is gitignored, so it never enters the count.
+
+Writes, each exit 0: ank read (1 path), ank amend --scope (2), ank amend --blocked-by (2), ank edit --title (2), ank config default_branch main (1). Writes nothing, each exit 0: ank scope, ank graph, ank status, ank review, ank check, ank log <id> in its read form, ank show, ank find, ank context (0 paths each). ADR-01b6dd05f0db lists none of read, amend, edit or config; its writing list is 'ank new, claim, log, done, release, attest, close and accept'.
+
+Two nuances worth recording. ank config writes .ank/config.yml, which is not an entity, and it is on the writing list because the constraint governs .ank/ and not only its entities. And ank read is a reading act that writes: it records the reading, which is why it belongs on the writing side of an enumeration about bytes.

--- a/.ank/entities/LOG-5d35db5f9a37.md
+++ b/.ank/entities/LOG-5d35db5f9a37.md
@@ -1,0 +1,15 @@
+---
+id: LOG-5d35db5f9a37
+type: log
+title: "The supersession blocker, counted: 44 citations of ADR-a22cd3196529 in 19 tracked files outside"
+created: 2026-08-31T03:47:54Z
+author: claude-code/opus-5+corpus
+scope:
+  - .ank/entities/**
+about: TASK-f82cfa1b9344
+seq: 1
+schema: 4
+version: 1
+---
+
+ .ank/, including 20 inside crates/ank-daemon/ itself and 8 in crates/ank-daemon/tests/dependencies.rs alone. ADR-3b6ba766a42e means accept refuses the succession until every one of them names the successor or is dropped. All 19 files are code, documentation and workflow perimeters outside this task's scope of .ank/entities/**, so this is recorded rather than swept.

--- a/.ank/entities/LOG-6622c7e55fc0.md
+++ b/.ank/entities/LOG-6622c7e55fc0.md
@@ -1,0 +1,15 @@
+---
+id: LOG-6622c7e55fc0
+type: log
+title: Criterion measured. ank scope crates/ank-daemon/src/fetch.rs --json now lists ADR-24e21cb83793,
+created: 2026-08-31T03:49:04Z
+author: claude-code/opus-5+corpus
+scope:
+  - .ank/entities/**
+about: TASK-f82cfa1b9344
+seq: 2
+schema: 4
+version: 1
+---
+
+ status proposed, whose supersedes is ADR-a22cd3196529 per ank show. ank context on the same path answers mode 'orientation' and names ADR-24e21cb83793 under proposed, alongside the same three active constraints the criterion recorded: ADR-9f03, ADR-85e6, ADR-d3a8. That second half is only measurable from an identity holding no claim -- under this task's own claim, context returns mode 'execution' with an empty proposed list, which is the claimed task's context and not the path's. Measured with ANK_AGENT=measure-probe, a read-only verb.

--- a/.ank/entities/LOG-76e6fc888ecf.md
+++ b/.ank/entities/LOG-76e6fc888ecf.md
@@ -1,0 +1,13 @@
+---
+id: LOG-76e6fc888ecf
+type: log
+title: done, proof test:local/b370aefb7ebc@49afa4e test:local/e3b0c44298fc@49afa4e
+created: 2026-08-31T04:14:20Z
+author: claude-code/opus-5+corpus
+scope:
+  - .ank/entities/**
+about: TASK-58ccbc4683ef
+seq: 2
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-8198ef873653.md
+++ b/.ank/entities/LOG-8198ef873653.md
@@ -1,0 +1,13 @@
+---
+id: LOG-8198ef873653
+type: log
+title: done, proof test:local/61c2616f5a1e@b4b4cdd test:local/e3b0c44298fc@b4b4cdd
+created: 2026-08-31T03:47:02Z
+author: claude-code/opus-5+corpus
+scope:
+  - .ank/entities/**
+about: TASK-335c6a01bfa7
+seq: 3
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-8230410aeb48.md
+++ b/.ank/entities/LOG-8230410aeb48.md
@@ -1,0 +1,15 @@
+---
+id: LOG-8230410aeb48
+type: log
+title: "ADR-3b6ba766a42e blocks the ratification, not this task: seven tracked sites outside .ank/ still"
+created: 2026-08-31T03:42:02Z
+author: claude-code/opus-5+corpus
+scope:
+  - .ank/entities/**
+about: TASK-335c6a01bfa7
+seq: 1
+schema: 4
+version: 1
+---
+
+ cite ADR-ff294eff4d1a -- crates/ank-cli/src/commands.rs:2057 and :2129, crates/ank-cli/src/entries.rs:310, crates/ank-cli/tests/cli.rs:5091, :16227, :16345 and :19750. All three files are code perimeters held by other agents and outside this task's scope of .ank/entities/**, so the sweep is recorded here and in ADR-67a4ac10c534's body rather than performed. Measured after writing the successor: ank check exits 0 and reports the supersession as a signal, not a fault; the fault is a condition of accept, which is a human act.

--- a/.ank/entities/LOG-9e8044458e4e.md
+++ b/.ank/entities/LOG-9e8044458e4e.md
@@ -1,0 +1,13 @@
+---
+id: LOG-9e8044458e4e
+type: log
+title: done, proof test:local/933d52cec718@052a524 test:local/e3b0c44298fc@052a524
+created: 2026-08-31T04:09:20Z
+author: claude-code/opus-5+corpus
+scope:
+  - .ank/entities/**
+about: TASK-34938bfc6b84
+seq: 2
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-a1370df7bd83.md
+++ b/.ank/entities/LOG-a1370df7bd83.md
@@ -1,0 +1,13 @@
+---
+id: LOG-a1370df7bd83
+type: log
+title: done, proof test:local/6b520d1194e8@c4c4a9a test:local/e3b0c44298fc@c4c4a9a
+created: 2026-08-31T04:04:34Z
+author: claude-code/opus-5+corpus
+scope:
+  - .ank/entities/**
+about: TASK-53a95782ae5c
+seq: 3
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-a38c7c9d24f8.md
+++ b/.ank/entities/LOG-a38c7c9d24f8.md
@@ -1,0 +1,17 @@
+---
+id: LOG-a38c7c9d24f8
+type: log
+title: "The supersession blocker, counted: 7 tracked citations of SPEC-fe8bdb84faca outside .ank/, in 3"
+created: 2026-08-31T03:55:12Z
+author: claude-code/opus-5+corpus
+scope:
+  - .ank/entities/**
+about: TASK-c4f26ad5302d
+seq: 1
+schema: 4
+version: 1
+---
+
+ files -- crates/ank-cli/tests/skill.rs:241, crates/ank-contract/src/verbs.rs:412, and five in crates/ank-tui/src/view.rs (4784, 7241, 7753, 7817, 7887). The five in the TUI are fixture rows, one of which asserts the string 'accepted' beside the id; ADR-3b6ba766a42e's walk counts a fixture like any other citation, and the fixture would in any case be asserting a status the ratification changes. All three files are perimeters outside this task's scope of .ank/entities/**, so this is recorded and not swept.
+
+The successor differs from SPEC-fe8bdb84faca by exactly one line of body, measured with difflib over the two 'ank show' outputs: paragraph 273. Everything else, frontmatter scope and the four references included, is carried across unchanged.

--- a/.ank/entities/LOG-a81f0f405090.md
+++ b/.ank/entities/LOG-a81f0f405090.md
@@ -1,0 +1,15 @@
+---
+id: LOG-a81f0f405090
+type: log
+title: "Measured on this tree, ank 0.7.0 (50f4b39): the directories Formula, bucket and packaging do not"
+created: 2026-08-31T04:05:14Z
+author: claude-code/opus-5+corpus
+scope:
+  - .ank/entities/**
+about: TASK-34938bfc6b84
+seq: 0
+schema: 4
+version: 1
+---
+
+ exist -- 'ls -d' fails on all three and git ls-files matches zero tracked files under each -- and all three are declared scopes of ADR-9f03438f5422. ank check names them one by one: 'dead scope Formula/**', 'dead scope bucket/**', 'dead scope packaging/**'. npm/** matches 8 tracked files and package.json, LICENSE, README.md and CLAUDE.md all exist, so those scopes are live. ADR-221aa5da440a, accepted, forbids the Homebrew tap, the Scoop bucket and the winget manifest by name, which is why the directories are gone; the older licence rule still demands a declaration from each of them.

--- a/.ank/entities/LOG-a8b6908d82fd.md
+++ b/.ank/entities/LOG-a8b6908d82fd.md
@@ -1,0 +1,15 @@
+---
+id: LOG-a8b6908d82fd
+type: log
+title: "Measured, not read, against ank 0.7.0 (50f4b39) in an empty repository: ank init, one task, one"
+created: 2026-08-31T03:41:05Z
+author: claude-code/opus-5+corpus
+scope:
+  - .ank/entities/**
+about: TASK-335c6a01bfa7
+seq: 0
+schema: 4
+version: 1
+---
+
+ claim, one 'ank log'. The entry was written to .ank/entities/LOG-4f1b19586ce1.md; .ank/log/ was created by init and left with zero files; the md5 of the task file was 9b725cd725392faf904fa1305cd5212d both before and after the append, so an append is still not a transition. ADR-ff294eff4d1a's address is the only clause that has stopped being true.

--- a/.ank/entities/LOG-b64a8ebe698c.md
+++ b/.ank/entities/LOG-b64a8ebe698c.md
@@ -1,0 +1,17 @@
+---
+id: LOG-b64a8ebe698c
+type: log
+title: Measured on this tree, ank 0.7.0 (50f4b39). ls crates/ prints six directories -- ank-cli,
+created: 2026-08-31T04:10:04Z
+author: claude-code/opus-5+corpus
+scope:
+  - .ank/entities/**
+about: TASK-58ccbc4683ef
+seq: 0
+schema: 4
+version: 1
+---
+
+ ank-contract, ank-core, ank-daemon, ank-mcp, ank-tui -- and cargo metadata --no-deps names exactly the same six packages, so the directory listing is not a superset of the workspace. ADR-85e6bbb195b8 says 'the crates are ank-core and ank-cli', which names two of six.
+
+Every other clause re-measured and holds: the binary is ank (ank --version prints 'ank 0.7.0 (50f4b39, skill d25cedf8fe35)'); the state directory is .ank/; git for-each-ref finds refs/ank/remote 311, refs/ank/proof 186, refs/ank/watch 148 and refs/ank/claims 8, all under refs/ank/*; the identity variable is ANK_AGENT (ank status prints 'identity claude-code/opus-5+corpus (ANK_AGENT)'); and 'ankor' occurs zero times in tracked files outside .ank/. Inside the corpus ank find ankor returns only historical anchors -- log entries already written and the done rename task -- which is the exception the constraint itself carves out.

--- a/.ank/entities/LOG-d1c1b97ba7a2.md
+++ b/.ank/entities/LOG-d1c1b97ba7a2.md
@@ -1,0 +1,13 @@
+---
+id: LOG-d1c1b97ba7a2
+type: log
+title: done, proof test:local/b326da41f074@57cbbdf test:local/e3b0c44298fc@57cbbdf
+created: 2026-08-31T03:59:10Z
+author: claude-code/opus-5+corpus
+scope:
+  - .ank/entities/**
+about: TASK-c4f26ad5302d
+seq: 2
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-e8d86c5176f6.md
+++ b/.ank/entities/LOG-e8d86c5176f6.md
@@ -1,0 +1,15 @@
+---
+id: LOG-e8d86c5176f6
+type: log
+title: "Criterion measured after writing ADR-534c7a3e6cf8: ank check reports no dead scope against it (only"
+created: 2026-08-31T04:06:01Z
+author: claude-code/opus-5+corpus
+scope:
+  - .ank/entities/**
+about: TASK-34938bfc6b84
+seq: 1
+schema: 4
+version: 1
+---
+
+ two signals, the expected 'supersedes ... not yet a succession' and 'written by an agent and read by no human'), and its constraint names Homebrew, Scoop and winget zero times. Proposed ADRs are not charged against a perimeter's constraint budget: no 'charges' line appears for it in check's over-constrained breakdown, where the accepted ADR-9f03438f5422 still charges 733. The blocker: 12 citations of ADR-9f03438f5422 in 7 tracked files outside .ank/ -- NOTICE, crates/ank-cli/tests/skill.rs, and the Cargo.toml of ank-cli, ank-contract, ank-daemon, ank-mcp and ank-tui. Outside this task's scope; recorded, not swept.

--- a/.ank/entities/LOG-ecdce8067d35.md
+++ b/.ank/entities/LOG-ecdce8067d35.md
@@ -1,0 +1,15 @@
+---
+id: LOG-ecdce8067d35
+type: log
+title: "Measured on ank 0.7.0 (50f4b39), not read. git ls-files crates/ank-daemon returns 8 tracked files:"
+created: 2026-08-31T03:47:52Z
+author: claude-code/opus-5+corpus
+scope:
+  - .ank/entities/**
+about: TASK-f82cfa1b9344
+seq: 0
+schema: 4
+version: 1
+---
+
+ Cargo.toml, six under src/ (declare.rs, fail.rs, fetch.rs, lib.rs, stream.rs, warm.rs) and tests/dependencies.rs. The criterion says seven; the number that matters is unchanged either way, since ADR-a22cd3196529's scope names none of them. ank scope crates/ank-daemon/src/fetch.rs answers four ADRs, three of them accepted -- ADR-85e6, ADR-9f03, ADR-d3a8 -- and the fourth superseded; the daemon's own decision is absent from that list.

--- a/.ank/entities/LOG-f694fa8ec298.md
+++ b/.ank/entities/LOG-f694fa8ec298.md
@@ -1,0 +1,15 @@
+---
+id: LOG-f694fa8ec298
+type: log
+title: Measured on ank 0.7.0 (50f4b39), not read. ank help --json carries 26 verbs and mcp and watch are
+created: 2026-08-31T03:54:32Z
+author: claude-code/opus-5+corpus
+scope:
+  - .ank/entities/**
+about: TASK-c4f26ad5302d
+seq: 0
+schema: 4
+version: 1
+---
+
+ both among them. An initialize plus notifications/initialized plus tools/list piped into 'ank mcp' returned 26 tools -- ank_context through ank_help, one per verb of the table. ank watch --where printed /home/haksolot/.config/ank/watch.yml and exited 0. crates/ank-cli/tests/skill.rs:262 reads 'const NOT_YET_DISPATCHED: [&str; 0] = [];', an array of length zero, so the suite that exists to name an undispatched verb names none. All four facts the criterion records still hold.

--- a/.ank/entities/SPEC-d58b3a9e4e4d.md
+++ b/.ank/entities/SPEC-d58b3a9e4e4d.md
@@ -1,0 +1,567 @@
+---
+id: SPEC-d58b3a9e4e4d
+type: spec
+slug: the-cli-surface
+title: The CLI surface
+created: 2026-08-31T03:54:41Z
+author: claude-code/opus-5+corpus
+status: proposed
+scope:
+  - crates/ank-cli/**
+references: [SPEC-a89ba4f755e9, SPEC-89070ce7f3b8, SPEC-6aed60cd3717, SPEC-88e1ba60a95d]
+supersedes: SPEC-fe8bdb84faca
+schema: 4
+version: 1
+---
+
+One of the ten documents that carry the Ank specification (ADR-5a690829388d).
+This one carries **§4 without two of its halves**: the one surface and what the
+skill teaches, the verbs, the refusals and their exit codes, the commands block,
+configuration, short forms, self-correcting errors, and the catalogue `check`
+prints.
+
+## Why two halves left, and why the rest did not
+
+§4 was the longest section in the monolith and the only one this decomposition
+splits. Two passages sitting inside it failed the test in the direction nobody
+looks for — not *this cannot be read alone*, but *this is read by documents that
+are not this one*.
+
+**The presentation grammar left.** Its alphabet and its palette are declared
+before any code uses them, they read alone, and their dependencies point away
+from the verbs: the palette is keyed on the statuses the data model declares and
+on the markers synchronisation writes, not on anything in the verb table it sat
+inside. A passage whose dependencies lie outside the document holding it is a
+passage in the wrong document.
+
+**The proof half left**, and joined §8. Proofs, named verifiers and the trust
+hierarchy answer the same question §8 answers about identity — what is a claim
+about the world worth, and who validated it. The data model reads it for the
+`proof` field, synchronisation reads it for detached proofs, and a passage two
+documents depend on should not be buried inside a third.
+
+**The catalogue of `check` stayed.** It is the strongest candidate for a document
+of its own and it fails the test cleanly: nearly every finding restates a rule
+that lives elsewhere and cites the section that states it, so read alone it is an
+index of things it does not contain. An index that cannot be read without the
+things it indexes is not a document, and this one belongs beside the verb that
+prints it.
+
+Everything else here is one subject: what the caller may type, what comes back,
+and on what state it is refused. `config` and the short-form table are part of it
+for the same reason the exit codes are — they are the surface, not a mechanism
+behind it.
+
+## What it rests on
+
+- **The data model** — every verb here acts on the fields it declares.
+- **Presentation** — the grammar of what these verbs print.
+- **Proof, anchoring and authority** — what `done` requires and why a refusal is
+  never on identity.
+- **The attention budget** — `context`'s two modes, and the over-constrained
+  finding this catalogue reports.
+
+---
+
+## 4. CLI surface
+
+**Ank exposes one surface** (ADR-e17e1bbd93ff, superseding ADR-c656cbcc33a9). Every verb is available to every caller, and the CLI refuses on state, never on identity. Git has more than a hundred commands, every one of them reachable by anybody who types it, and stays learnable because of what a newcomer is taught first — not because the porcelain sorts callers into classes. Ank borrows that shape.
+
+The memorisation budget is real; it is simply not the binary's job. It is spent on documentation, and it is enforced where it operates: what an agent is taught is a contract every session loads and one policy per activity, each anchored where it lives. What a human may type is everything.
+
+### What the skills teach, and what anchors them
+
+```
+Loop:          context → claim → show → log → done
+Off-loop:      new, find, release
+Planning:      new adr, amend, review, graph, check, find --status open
+Investigation: context <path>, scope, find, show, log <id>, status, check <path>
+```
+
+**The teaching surface is plural, and no part of it is frozen by hash any more** (ADR-91b77f036884, superseding ADR-5dd7b4a9c875, which carried the freeze forward from ADR-f61e2d2c75e8 and ADR-e17e1bbd93ff unchanged). `skill/SKILL.md` is the contract: the verbs above, grouped by the moment each is used, the model behind them, and the rules that are not negotiable. Beside it lives one skill per activity: `ank-plan` interviews a goal into entities, `ank-drift` audits accepted decisions against the code, and `ank-loop` consumes planned tasks, each loaded when its activity calls for it.
+
+**What replaced the freeze is three anchors, and they are what the freeze was actually protecting.** Every skill declares `metadata.revision`, the hash of its own body, recomputed by test so it cannot drift by being forgotten; the binary names the contract revision it was built alongside, so a stale installed copy has nothing to hide behind (§9); and `accept` stays described and never invited, in every skill that mentions it. Content now evolves under review rather than by supersession, because the lock priced every edit and the anchors price none while catching the failure that was actually measured.
+
+**A description is the trigger, and it is the one line every session pays for** whether or not the skill fires. It names the activity that should load the skill, exactly, and it does not grow without a measurement (§9). The freeze constrained the documentation and never the dispatch table, and that is unchanged: an agent that runs `ank edit` gets the editor; it was simply never told the verb existed, and being untold is not being refused.
+
+**A policy is not restated in the contract, and the contract is not restated in a policy.** A rule written in two files drifts, and the drift between an installed skill and a ratified decision is a measured failure of this project rather than a hypothetical one (TASK-b495234f192c). The contract stays self-sufficient for executing work, since it is the only skill with a broad trigger and the routes of §9 may install it alone, so it names the others as invitations and never depends on them.
+
+**Three modes, because an agent that can only execute is half an agent, and one that cannot look is working blind.** The loop is how work gets done; planning is how the work that gets done comes to exist — deciding which tasks should exist, in what order, under which constraints. ADR-c656cbcc33a9 taught the loop alone, and an agent taught by it could not propose a decision, correct a graph, or notice that the corpus had gone incoherent: `ank new adr` was never mentioned, so an agent seeing an architectural problem had no documented path from the observation to a recorded ADR. Planning is the highest-leverage activity in the corpus, and a badly shaped backlog wastes more downstream than the teaching costs upstream.
+
+**Investigation is the third, and it is the one an agent needs first.** Before choosing a task — and often instead of choosing one — the question is *what governs this file* and *where am I*. `scope <path>` answers the first and `status` the second, both shipped and neither taught, so an agent holding the skill had the question and not the verb. The read form of `log <id>` is the third: it is how the next holder learns where the last one stopped, which is the whole reason `release --reason` is mandatory. And `find --type spec` reaches the specification itself, which is an entity of the corpus since ADR-5a690829388d — the normative answer is one `show` away, from inside the tool, under the rule that closes `.ank/` to direct reads. **Every verb the mode adds is a reader**: it teaches how to arrive informed, and adds no way to change anything.
+
+**The file says why before it says how.** It opened on where the files live and went straight to the verbs, which taught the moves and not what they protect: that constraints and work are two planes joined only by scope, and that nothing here is trusted because everything is anchored. An agent that does not know what a rule protects is the one that works around it, in good faith.
+
+**The ceiling is at most 180 lines and 1500 words, now per skill**, and it stays a ceiling to notice drift rather than a target to fill. The number rests on a measurement, because a ceiling raised to accommodate what was just written is not a ceiling. What every session pays for is the **frontmatter** and not the body: `claude plugin details ank` projects `Always-on: ~282 tok` across four skills, which is their `name` and `description` lines, against `~58 tok` when there was one, and a body is read when its skill is invoked. Splitting the teaching moved cost from the invoked column to the permanent one, and bought the trade §9 states: an agent executing a task no longer loads the planning policy it will not use. The ceiling is kept for the case it was always protecting: §9's by-hand route copies whole files into whatever a harness loads, and some load all of it every session. So it bounds the worst route rather than the best one, and the `description` lines do not grow at all, being the part paid for whether or not a skill is ever used.
+
+**`accept` is described and never invited.** The skill says what it is — a human act, signed, on the default branch only — so that a planning agent knows where its own authority ends, and it never shows the command as something to run. That is the one hard authority line in the system (§8, §12), and describing it is what makes it legible rather than mysterious. `close`, `attest` and `edit` stay outside for the ordinary reason: nothing has decided they are worth what every session pays for them.
+
+That distinction is the whole revision. ADR-3859eb46bdc3 froze an *agent surface* at these same eight verbs and sent everything else to a human side, but the split it protected was never a boundary — the CLI told callers apart by `$ANK_AGENT`, a variable the caller sets itself (§8). A wall whose bricks are self-declared identity is a sign, not a wall. What the freeze actually protected was the token budget, and that protection moves here, where it holds without pretending to be a check.
+
+`show` is in the loop by that route, and the reasoning is worth keeping because it is the argument any addition to SKILL.md has to beat. It sat outside at first, as the only unbounded reader in the system. That argument was about output size, and §5 answers size with a budget and a truncation notice that says what it cut. What it did not answer is the body: `context` serves the criterion and the constraints, never the prose that justifies them, and the prose is where the reasoning an agent is supposed to inherit actually lives. With `.ank/` closed to direct reads (ADR-01b6dd05f0db), withholding it entirely was the worse trade.
+
+### The rest of the surface
+
+These verbs are the rest of the surface. Four of them — `review`, `check`, `amend` and `graph` — are what the planning mode above teaches, and the others are outside what the skill teaches rather than withheld from anyone: none of the refusals below consults who is calling, and an agent that types one gets its answer.
+
+```
+review    ratification queue, pending proposals, corpus health
+accept    promotes a proposed ADR or spec to accepted (produces the signed commit,
+          §8, §12; requires the default branch)
+check     mechanical invariants, exit code usable in CI
+close     closes a task that will never be done (--reason mandatory)
+amend     changes `blocked_by`, `scope`, and a `done_criteria` no live claim freezes
+attest    appends a proof to a finished task: the one write §3 allows after `done`
+status    where am I: branch, claim, perimeter, queue, findings
+edit      changes the content field named, or opens the entity in the editor
+graph     the `blocked_by` DAG in readable text
+scope     what covers a path
+```
+
+`review` and `accept` are not comfort features: **the entire authority model of ADRs depends on them**. Without them an agent creates in `proposed` and nothing ever becomes binding.
+
+`review` filters by default on **live scopes**; entities with a dead scope are grouped into a cleanup section with `close` suggested. An ageing corpus therefore produces an explicit closure queue rather than diffuse noise.
+
+**`accept` only runs on the default branch** (§7), and there is no way around it — no `--force`. An ADR ratified on a feature branch would be binding only on that branch: a constraint of variable geometry, and a ratification hash that depends on the reading context, which is exactly the ambiguity Ank eliminates everywhere else. The legitimate use case — introducing a constraint and the code that applies it in the same PR — is already covered by the model: the ADR is created in `proposed`, travels with the code, and is accepted only once it has reached the default branch. An unratified constraint binds nobody, so nothing is lost by waiting, and that is what makes the prohibition sustainable while strict. Off the default branch, `accept` exits with **code 7** — missing prerequisite, not illegal transition: the promotion is legal, the place is not.
+
+```
+$ ank accept 19d0
+error[7]: accept requires the default branch (current: feat/opaque-sessions, default: main)
+  -> git switch main && ank accept 19d0
+```
+
+**`read <id>` records that a person read this entity**, and it exists because the corpus asked a question nothing on this surface could answer. ADR-3877fef1d662 defines `verified:` as a list of readings, each naming a typed actor and an instant, and `check` reports an entity an agent wrote and no human has read. Exactly one place in the binary ever wrote a reading: `accept`, as a side effect of ratifying. So the signal cleared for an ADR or a spec at its ratification, cleared for nothing else, and could never clear for a task at all, since `accept` refuses a task by kind before it reads anything. On this repository's own corpus that was 186 entities, 122 of them tasks: half of every signal it carried, on a state no act could change. A finding nobody can clear is what a reader learns to skip, which is the one thing every severity rule in §4 exists to prevent.
+
+It **appends and never replaces**, which is the shape `attest` already carries: a reading is a fact about a moment, and a second reader does not overwrite the first. Two readings by one actor are two readings, because reading a document again a year later is a different act from reading it today, and deduplicating them would throw away the only thing the second one records.
+
+It **refuses a log entry** (§3, ADR-25f977377fa0). An entry is written once and never modified; a correction there is a new entry naming the one it corrects, so there is no second write for a reading to be. `check` already excludes entries from the signal for the reason that decides this one: an entry is a trace of work that happened, and there is nothing in it for a person to stand behind.
+
+**No signature, no branch precondition, and no refusal that consults who is calling.** A reading is not a ratification and does not borrow its ceremony. ADR-3877fef1d662 is explicit that the convention is a signal and not a wall: an agent can write `human:` in front of its own name exactly as it can set `$ANK_AGENT` to anything, and what the field buys is that the ordinary case becomes legible, not that the dishonest one becomes impossible. What the verb writes is the identity in effect, typed, and the instant. Judging it is the reader's work, not the tool's.
+
+It sits **beside `accept`** because that is where it was split from. The reading a ratification records is this act performed as a consequence of another, and everything `accept` cannot reach needs the act on its own.
+
+**`amend` covers the three fields a plan actually changes on**, `blocked_by`, `scope` and `done_criteria`, and covers nothing else. A subtask discovered after a task was filed is a `blocked_by` added to something that already exists; a scope found to omit the files the work must touch is a scope corrected before the task can be claimed at all. Both are ordinary, both were done by hand until this verb existed, and an edit done by hand is indistinguishable in the resulting file from any other edit done by hand — which is the argument that put `attest` on this surface too.
+
+It **adds and removes explicitly** and never takes a replacement list: a verb given the whole list silently drops whatever the caller forgot to repeat. It refuses a `done` or `closed` task, since §3 allows exactly one write after completion and that write is `attest`'s. And it refuses the `scope` of an accepted ADR or spec, whose `scope` is hashed into the ratification commit (§8) — changing a ratified decision is a succession, and succession has its own verb. The two are refused on the same terms and for the same reason, and a spec's anchor simply reaches wider: it covers the body as well, so what an ADR keeps editable after ratification a spec does not (§3).
+
+Amending the `scope` of a task under a live claim is **allowed and warned about**. The claim record anchors the hash of the constraints that scope selects (§7), so the change moves what binds the work in progress. Refusing would be wrong — a scope discovered false mid-task is exactly the situation the verb exists for — and allowing it silently would be worse.
+
+**`amend --criteria` is refused while a live claim freezes the criterion, and allowed the rest of the time.** That is the same state test `edit` already applies (below), and stating it once for both is the point: a criterion under no claim is anchored by nothing, so there is no freeze to respect and nothing for `check` to notice. Under a live claim the refusal is code 6 and names `release --reason`, which is what a criterion discovered wrong mid-work actually calls for.
+
+The route exists because a criterion can turn out **unmeasurable rather than wrong**, and that case had no continuation. Measured on this corpus: a task whose criterion ended on a clause about `gh api community/profile` reporting `issue_template`, which is `null` for any repository using an `ISSUE_TEMPLATE/` directory — the layout that task existed to produce (TASK-7c2fa14284ff). The work was finished and correct; the measurement never could be. The release was right and happened, and then the corrected criterion had two ways back in and both were wrong: a hand edit, which the tool exists to make unnecessary, or `claim --criteria`, which recorded a creator's correction as the claimer's.
+
+**`amend` does not touch `criteria_by`.** That field answers one question — was this criterion set at claim time, by the party the freeze constrains (§3) — and an amend is not a claim. Writing `claimer` there for a correction made under no claim would launder the correction into exactly the shape the signal exists to expose; writing `creator` would assert something about the caller, which no refusal and no field here does. What records the amend is the log entry, as it does for `scope` and `blocked_by`.
+
+**`claim --criteria` sets a criterion, and never replaces one.** On a task that already carries one it is refused, code 6, naming `ank amend <id> --criteria`. §3 gives the flag one job — a task cannot be claimed without a criterion, and the refusal for the empty case names the command that sets it and claims in the same call — and silently overwriting an existing one is not that job. It also keeps `criteria_by: claimer` meaning exactly one thing: nobody wrote a criterion for this task before the agent that took it.
+
+Everything else (editing fields, reordering, deleting) goes through **`ank edit`**, which is the paved road rather than a gate: it opens the same file in the same editor and validates what comes back. Below it, the direct edit remains possible, since the format is the specification and the CLI is not a gatekeeper. The actor matters there and is not decoration: ADR-01b6dd05f0db closes `.ank/` to direct reads and writes *by an agent*, and leaves **a human** with an editor every power they had. Written without the subject, that sentence reads as a general permission and hands back what the ADR withdrew.
+
+### Refusals are on state
+
+The binary refuses, and what it refuses on is always a fact about the corpus or the repository, never a fact about the caller.
+
+| Refusal | Code |
+|---|---|
+| frozen field diverged from its anchoring hash, or illegal transition | 6 |
+| claim held by another agent, or task already finished on another branch | 4 |
+| task blocked, no `done_criteria`, `accept` off the default branch, or a live claim already held by the calling identity | 7 |
+| proof missing or invalid | 5 |
+
+That list is the guarantee. A state refusal applies to every caller equally and means the same thing to all of them, which is what makes it worth writing an exit code for; a refusal conditioned on identity would mean whatever the caller declared itself to be. `$ANK_AGENT` names who acted — it goes into the log, into the claim ref and into `check`'s signals — and it is never consulted to decide whether a verb runs.
+
+**The one hard line of authority is the signed ratification commit** (§8, §12), and it holds precisely because it is not a role check: `accept` produces it, `check` verifies it against `allowed_signers`, and an anchor no key covers is reported as unverifiable. That is a proof requirement, the same shape as every other anchor in the system. Everything else that looks like permission is policy, and policy lives above the binary (§8).
+
+### Four verbs and two forms, for the reader at the keyboard
+
+With the surface no longer a boundary, verbs serving human ergonomics enter it without ceremony. None of them introduces state: each one composes what `context`, `find`, `review` and `check` already derive, or wraps a write that was being done by hand anyway.
+
+**`status`** answers *where am I* in one call: the branch, the identity in effect and where it came from, the active claim and its expiry, the constraints on the current perimeter, the ratification queue, completion refs the default branch has not caught up with (§7), and the corpus findings `check` would report. It **degrades with a warning** rather than failing when there is no remote or no determinable default branch — the parts that need neither are still worth printing. Terse `git status` register, and it ends with the next command to run, like every other output here.
+
+The identity line names its **source** and not only its value, for the reason `config` prints `8000 (default)` rather than `8000`: `$ANK_AGENT` names a session, the `<user>@<hostname>` fallback names a machine, and only the second is a trap — two sessions in one checkout that both let it fall back are one agent to every ref the tool writes. Nothing else on that path says so, since a `log` or a `done` from the wrong identity is refused on state, correctly talking about the claim somebody else holds (§8). Under `--json` the two are separate fields, `value` and `source`, on the terms `config` already set.
+
+**`edit <id>`** opens the entity in the editor named by `$EDITOR`, validates the result on save, and writes it back in canonical form (§3). **A change to a frozen field is refused by naming the command that legally performs it**: `release --reason` for a `done_criteria` frozen at claim, `new adr --supersedes` for the `constraint` of a ratified ADR. Frozen means anchored *now*: a `done_criteria` no live claim covers is not refused here, which is the same state test `amend --criteria` applies above and the reason the two agree by construction rather than by restatement. An invalid result leaves the entity untouched and says why, so a mistyped frontmatter costs a re-edit and never a corrupt file. This is the argument that put `amend` and `attest` on this surface, generalised: an edit performed by hand is indistinguishable, in the resulting file, from any other edit performed by hand, and chaperoning it through the tool strengthens the invariants instead of relaxing them.
+
+**A field may be named instead** (ADR-5bd8257dfeac): `--title`, `--body` and, on an ADR, `--constraint`, with `--body -` reading the body from stdin as `new` already does. A named edit writes only what is named, leaves every other field exactly as the file had it, and **never opens an editor** — so an unset `$EDITOR` is no failure for a caller who did not want one. With no field named, the editor opens on the whole entity, which stays the road for an edit that rewrites prose around a new argument, where a flag taking a body on stdin is the worse tool.
+
+**The refusals do not fork, and that is the load-bearing half.** A named edit meets `Freeze` where the editor path meets it, refuses with the same code and the same sentence, and differs in one thing only: the editor path adds where it kept the text that was typed, because a refusal after twenty minutes of typing must not discard them, and a flag value is still in the caller's shell. A flag naming a field the addressed kind does not carry is refused by name and nothing is written, since a caller who typed `--constraint` on a task believes they changed something and a verb answering `edited` to that would be lying about the corpus. What the surface changes is how a change is expressed, never what may be changed: `author` is unchangeable (§8), `version` is the store's, and `ratified` is `accept`'s.
+
+**`graph [<path>]`** prints the `blocked_by` DAG in readable text, restricted by an optional path the way `context` is, with `--json` for the raw edges. It **names the perimeter it drew** and says so explicitly when that perimeter holds no task. The ordering of §5 already walks these edges to count what a task unblocks, and this makes the same structure visible to a reader. `show` surfaces the narrow case from the same derivation: on a task it lists what that task **directly unblocks** alongside its blockers, one line each with status. Both are computed from the corpus at read time and stored nowhere — a stored reverse edge is a second copy of `blocked_by` that can disagree with the first.
+
+**`scope <path>`** lists every entity whose declared scope matches the path, grouped by type, one line each with its status, and says so explicitly when nothing matches. The resolution is the **same glob matching `context` uses**, resolved deterministically against the filesystem, so the answer is the one that will actually bind. It is the `check-ignore` of Ank: a dead or over-broad scope is otherwise visible only after the fact, through `check`, and this makes glob resolution observable before an entity is written wrong.
+
+**`new` without its mandatory flags opens a pre-filled template** in `$EDITOR` instead of failing, validates the result, and refuses to write an entity that would not pass validation. The `git commit` pattern: no `-m`, an editor. **The flag form is unchanged and remains the scripted path** — it is what SKILL.md teaches and what an agent uses, and nothing about the interactive form reaches it.
+
+**`log <id>` with no message reads** the entity's entries, newest first, and requires no claim. An entity nobody has logged against reads as an empty log, never as an error. `log` with a message keeps writing and renewing the claim, unchanged (§3). The disambiguation is stated rather than inferred: an argument that resolves to an entity id is a read, anything else is a message, and a message that also resolves to an id is an error naming both readings rather than picking one. This closes the one place the git intuition was betrayed — `git log` reads — without renaming the verb.
+
+**`$EDITOR` unset is an environment failure, not a task failure**: `edit` and the interactive form of `new` exit with **code 9** and name the flag form as the way through, consistent with how `sh` not found is treated below. Nothing falls back to a guessed editor.
+
+### HEAD
+
+Borrowed from git, and probably the highest-yield borrowing. `claim` sets a "current task" pointer per agent. Subsequent commands do without an ID:
+
+```
+$ ank claim 8f3a
+claimed TASK-8f3a migrate-auth-sessions -> HEAD
+
+$ ank log "jwt.verify removed from session.ts"
+$ ank done
+```
+
+The agent cannot get the identifier wrong, and every iteration saves a context round trip.
+
+**HEAD is not stored, it is derived**: it is the task on which the current agent holds an active claim. Nothing to synchronise, nothing to clean up, no state that can become inconsistent with the real claim.
+
+This assumes and enforces **one active claim at a time per agent**. That is a useful constraint in itself: an agent must finish or release before moving on, which prevents task hoarding and keeps work in progress readable by others.
+
+**Enforcing it is what `claim` does**, and for a long time this paragraph said so while the binary only warned. A `claim` made while the calling identity already holds a live claim on another task refuses with **code 7**, naming the task held, its expiry, and both ways through:
+
+```
+$ ank claim 8f3a
+error[7]: claude-code@host-3 holds a live claim on TASK-51c2 (expires in 24m)
+  -> ank release --reason "<why>"   (a second session on this machine sets its own ANK_AGENT)
+```
+
+**Code 7 and not 4.** The task asked for is available; it is the caller that is not. 4 means "take something else" and the reaction called for here is the opposite — finish or hand back what is already held — so the code that carries "missing prerequisite" is the one that says it.
+
+**The second way out is not decoration**, and it is why this hint carries a parenthetical the way the "another ready task" hints do. The default identity is `<user>@<hostname>` (§8), so two sessions in one working tree read as one agent, and the session being refused may never have claimed anything: it is being answered about somebody else's claim, and `ANK_AGENT` is the only thing that separates the two. That is also why the message names the identity rather than addressing the caller as the holder — under a shared identity, telling it "you already hold" would be false.
+
+The refusal comes **after** the refusals about the task itself — no criterion, blocked, already claimed elsewhere, illegal transition. An agent told to release the work it holds, for a task that would have refused it anyway, has been made to pay for nothing.
+
+The refusal is on state and not on identity, in the sense of the table above: what is read is the coordination plane — which refs exist and who holds them — and the answer is the same for every caller. A **lapsed** claim is not a live one, so pickup after expiry (§3) is untouched, and an agent returning to a task whose lease ran out claims it exactly as before.
+
+**It does not make the state unreachable, and nothing here assumes it does.** The CLI is not a gatekeeper (§7, §12): a ref written by hand, a claim taken by an earlier binary, or a claim that lapsed and was revived all produce one identity holding two live claims. What `log`, `release` and `done` do when they meet it is settled in §3, not here.
+
+The optional ID on `log`, `done` and `release` is therefore redundant in the nominal case: it exists for explicitness in scripts, and it **must name a task this agent holds a live claim on**, otherwise error 6. It is never a way to act on somebody else's task. Holding one claim, that is the same rule as "must match HEAD"; holding several — the state §3 describes and this section refuses to create — it is what names which of them a verb acts on.
+
+### Pickup and abandonment
+
+`release` closes a real gap: an agent that finds it cannot do the task otherwise has only TTL expiry, which means thirty minutes of dead work for everyone else.
+
+```
+$ ank release --reason "needs access to the staging Redis store"
+released TASK-8f3a -> open
+```
+
+**`--reason` is mandatory.** `release` is the delegation mechanism between agents: the reason goes into the log, and the next agent to claim the task receives the recent log in its `context`, so it resumes where the previous one stopped instead of starting from scratch. A silent release is exactly the gap this verb exists to close — the tool refuses it, with the full command as an example.
+
+### Commands
+
+```
+ank context [<path>]        [--json] [--limit N]
+ank claim <id>              [--criteria <c>: sets an absent one, never replaces] [--ttl 30m]
+ank show <id>
+ank log [<id>] [<message>]  (id alone reads; a message writes)
+ank done [<id>]             [--proof <type>:<ref>]
+ank release [<id>] --reason <r>
+ank new task --title <t> --scope <glob>... [--criteria <c>] [--blocked-by <id>...]
+ank new adr  --title <t> --scope <glob>... --constraint <c> [--supersedes <id>]
+ank new spec --title <t> --scope <glob>... [--supersedes <id>] [--reference <id>...]
+ank new task|adr|spec       (no flags: pre-filled template in $EDITOR)
+ank find <query>            [--type task|adr|spec|log] [--status ...] [--scope <path>] [--free]
+ank status                  [--remote]
+ank review [<path>]
+ank accept <id>
+ank read <id>
+ank close <id> --reason <r>
+ank amend <id>              [--blocked-by <id>...] [--drop-blocked-by <id>...]
+                            [--scope <glob>...] [--drop-scope <glob>...]
+                            [--criteria <c>]
+                            [--reference <id>...] [--drop-reference <id>...]
+ank attest <id> --proof <type>:<ref>   [--detached]
+ank edit <id>              [--title <t>] [--body <b>] [--constraint <c>]
+ank graph [<path>]
+ank scope <path>
+ank tui
+ank mcp                     (every verb of this table, over MCP on stdio, for a client that has no shell)
+ank watch                   [--list] [--once] [--interval <ms>] [--where]
+                            (keeps the corpora you declared warm, so the ank you run answers sooner)
+ank check [<path>]
+ank migrate                 (the previous log directory becomes entries; the command `check` names)
+ank config <key> [<value>]  [--unset] [--user]   (a value writes; the key alone reads)
+ank init [<path>]           [--at <path>]      (§9)
+ank help [<verb>]           (§9)
+
+ank --version               (the build itself: version, commit and skill revision, no verb, no repository)
+```
+
+**This block is the whole dispatch table**, and that is a property worth stating rather than assuming: `attest`, `init` and `help` were reachable in the binary while appearing nowhere here, so a reader comparing the two documents could not tell which one was wrong (TASK-5c868c20472f). `init` and `help` are specified in §9 and listed here only so the list is complete; `ank help` prints these verbs, minus whatever is not yet implemented, grouped by the moment each is reached for and in this order inside a group, which is what ADR-f61e2d2c75e8 requires of it. It prints one short description beside each verb rather than the verb's flag names, and the rules that description answers to are in §9.
+
+**`mcp` and `watch` are on that list and the binary answers to both**, having each been declared here before the code moved -- the form this block uses for a verb the specification decides on ahead of its landing -- and having each since landed. Measured on ank 0.7.0 (50f4b39): `ank help --json` carries 26 verbs and both are among them; an `initialize` and a `tools/list` piped into `ank mcp` return 26 tools, one per verb of this table; `ank watch --where` prints the declaration file this reader's environment names. Nothing marks either line, because there is nothing left to mark: `ank help` prints these verbs minus whatever is not yet implemented, and nothing on this list is unimplemented today -- `NOT_YET_DISPATCHED` in `crates/ank-cli/tests/skill.rs` is an array of length zero, so the suite that exists to name an undispatched verb names none. `read` and `tui` each sat here in the earlier state until the landing that shipped it, and `mcp` and `watch` have joined them.
+
+**The order is forced rather than chosen** (ADR-8bd76e8d7c4e). `crates/ank-cli/tests/skill.rs` holds every dispatched verb to this block, and it reads the *ratified* document to find it, so a verb that dispatched while its declaration was still a proposal would turn the suite red. Between the declaration and the dispatch sits a signed `accept`, which is a human act and not a step in a landing (§8, §12) -- so the declaration lands first and the implementation follows the signature instead of racing it. The declaration is carried on the other side by `NOT_YET_DISPATCHED` in that suite, which is where a verb this block lists and the binary does not answer to is named, with the task that will close the gap.
+
+**`ank tui` is the CLI drawing what it already prints**, for the one audience this surface serves worst: a human at a terminal. It opens a full-screen reader over one corpus, and it reaches that corpus only by running the CLI with `--json` -- never by linking `ank-core`, never by reading `.ank/`, never by touching `refs/ank/*` itself. So every refusal it shows is the refusal the binary gave, and there is no second dispatch path to keep in step. It writes nothing the person at the keyboard did not ask for in that session, it renews no claim on its own, and `accept` stays a signed human act it may drive and never perform unattended.
+
+It is listed **beside `graph` and `scope`** because that is the neighbourhood it belongs to, the verbs that answer *what is here* rather than change it, and the grouping `ank help` prints follows this order inside a group. A reader that also acts does not become a different kind of verb: what it acts through is `claim`, `log` and `done`, run as a shell would run them, which is what keeps ADR-052accd6e3b2 naming an intersecting claim and ADR-0bb7ea8991bc holding that a screen left open all night renews nothing.
+
+**`skill/SKILL.md` does not move for it**, and that is a decision rather than an omission (ADR-8bd76e8d7c4e). The skill teaches agents, an agent has `context`, `find` and `show`, which serve it better than any screen, and what the teaching surface costs every session is stated above.
+
+**`ank mcp` is the protocol surface, and it is a verb rather than a second executable** (ADR-fd98f4bc6dea). It exposes every verb this block carries, generated from the same table the CLI dispatches from -- no curated subset, under any protocol -- it refuses on state exactly as the CLI does and never on identity, it carries the exit codes above as the reason for a refusal, and it writes under a typed process identity (§3). It is folded into the one executable every route now carries (ADR-1ea31c2f3c5a) for the reason ADR-8bd76e8d7c4e gave for `tui`: a separate file is invisible to precisely the people it exists for, and has to be distributed, documented and discovered as a third thing.
+
+**One executable is not one process**, and that is the clause that keeps what the sibling binary bought. The verb still spawns `ank <verb> --repo <corpus> --json` per call, so what is folded here is the file and never the dispatch: linking the CLI into the surface would re-derive every refusal, and anything re-derived can differ, where spawning inherits them by construction. There is no second dispatch path, and every refusal a client sees is the refusal the binary gave.
+
+**It may speak for several corpora, and never for a merged one.** Every tool carries an optional corpus argument holding the repository identity of ADR-621a7fd96ce1; absent, the call goes to the corpus the process was addressed with at startup, the way `--repo` addresses one. The set a server may reach is what the reader declared in `corpora.yml` (ADR-96174f1ac2b7) plus that startup corpus, and nothing is discovered: a corpus argument naming an identity the reader did not declare is refused by name. Claims stay per clone and no server arbitrates across clones -- no merged claim space, no claim held on a client's behalf, no pooling of clients under one identity -- which is the ban ADR-372b82af1ec7 stated and ADR-fd98f4bc6dea carries forward in the same words.
+
+**`ank watch` is the watcher, and it answers no verb** (ADR-a22cd3196529). It keeps the corpora declared to it warm, so the `ank` a reader runs finds a cache already warm and returns sooner; it fetches `refs/ank/*` into a tracking namespace of its own and writes nothing else into a repository; and it emits an event when a corpus it watches changes, which states what changed and never what to do about it. It takes no claim, holds none on anybody's behalf and renews none. Nothing depends on it: every verb behaves identically with it stopped, its absence is never an error, and no route makes running it a condition of using ank.
+
+`--list` prints what would be watched and watches nothing, `--once` warms every declared corpus and exits, `--interval <ms>` is how often it looks, and `--where` prints the declaration file this reader's environment names. That is the whole flag surface, and the shape of it is the decision: not one of them asks the watcher a question about a corpus. A caller that wants an answer runs the CLI, which is what keeps this from being the third dispatch path in a project that has spent its history reducing to one.
+
+**Both are verbs for the same reason, and it is the reason `tui` is one.** ADR-1ea31c2f3c5a made every route carry one executable, so a surface that is not a verb is a surface that has to arrive beside the binary -- a workflow matrix, an installer branch and a rule, all of whose work is to put a second file where the first one already is. A verb cannot fail to arrive. `skill/SKILL.md` does not move for either of them, on the reading the paragraph above gives for `tui`: an agent has `context`, `find` and `show`, and teaching it a protocol it should not reach for would spend the contract to no end.
+
+**`ank context` with no argument** covers the whole repository. It is the first call an agent should make, before it even knows which path it works on — an agent launched on "fix the login bug" does not yet know its perimeter.
+
+**`context` with an active claim is always in execution mode** (§5). A path argument is then ignored, with a warning line: `active claim on TASK-8f3a, execution context (release to explore elsewhere)`. Exploring another perimeter mid-task is precisely what the one-claim-per-agent rule discourages.
+
+`--limit` applies **only to tasks**, never to constraints.
+
+**`find` is subject to the same cap as `context` on the page it prints for a human**, one line per result, and it announces what it cut. A search command without a budget is a context-explosion vector at least as effective as a badly bounded `context`. `--scope <path>` filters by scope match — it is the command the truncation counters point to (§5).
+
+**The budget stops at the terminal, and `--json` is served whole** (ADR-3e6ce108edcd). The four listing verbs — `find`, `review`, `scope` and `graph` — answer with every row under `--json`, whatever `context_budget` is set to. The cap above is the human page and nothing else: what a terminal shows and what a program receives are two questions, and only one of them has a page to fill. Measured on this repository's own corpus the day the decision was taken, `ank find --type adr --json` answered `{"total":63,"shown":40,"hidden":0}` — twenty-three decisions missing from a document meant for a parser, and a caller building the set of existing entities out of it counted entities that plainly exist as absent.
+
+**In a `--json` listing `shown` equals `total` unless a filter removed rows, and `hidden` counts what a filter withheld and nothing else.** The two numbers used to disagree on a corpus nobody had filtered, which is the state that misleads a parser most: `hidden` said zero, truthfully, while the page had silently dropped a third of the corpus, so a caller comparing the three fields was told the difference was nobody's doing. `--free` is the one filter there is, and a row it never considered a candidate — a task that is not open — does not inflate `hidden` either.
+
+**No flag lifts the budget and none restores the cut.** An `--all` would put the defect behind a discoverability problem: the parser that did not know to ask still gets a short answer, and the tool can then say it was told.
+
+**`context` is the exception, and it is the verb whose answer *is* the budget.** Deciding what a reader is handed first is what `context` does, rather than a limit imposed on what it does, so the rule above does not reach it (§5).
+
+The shape does not move, so the contract version does not either (ADR-6fd69efb629c): no field is gained, lost, renamed or retyped. A parser written against contract 1 reads the same document and receives more of it.
+
+**Scope overlap is reported and never refused** (ADR-052accd6e3b2). `claim` prints one line per live claim held by another identity whose scope meets the scope of the task being taken — the holder, the task, and the ground the two have in common — and then takes the task: the exit code is 0 and the claim stands. The line names paths rather than the fact of an overlap, because `crates/ank-cli/**` against `crates/ank-cli/tests/**` overlaps on everything under the second, and "these overlap" leaves the reader exactly where they started. Where both globs are literal the answer is a path; where one is a pattern the answer is the narrower pattern, written as a glob rather than expanded into a file list that would be wrong the moment a file is added.
+
+Refusing on it is the mistake, not the omission. Scope overlap is coarse: one held task scoped `crates/ank-cli/tests/**` locks every task that touches any test, and refusing would make the glob a mutex — which pushes agents to declare narrower scopes than the truth to get past it, the one failure mode a guard must not have. A **lapsed** claim is not a live one here either, exactly as in the refusals above: the signal would otherwise fire on abandoned work forever.
+
+**Every `elsewhere` line of `status` carries the title of the task it names**, after the id. The rows are already loaded where the line is built, so the join costs nothing, and without it a reader holds an id and has to run `show` once per claim to learn what anybody is doing — which is the question the section exists to answer.
+
+**`status --remote` is the only opt-in to the network outside `claim`** (ADR-47e2ac102f58). Without it, `status` describes the plane this clone has, as §7 says every verb but `claim` does; no network call is made at all. With it, the claims namespace is read off origin with `ls-remote` — read, never fetched, because writing refs into a clone as a side effect of a question would be a reader sanitising the plane underneath everybody else. What that costs is said on the line rather than papered over: `ls-remote` carries ref names and objects, never contents, so a claim seen only on origin is named with its id and the title the corpus already carries, is marked as being only there, and is never given a holder this clone cannot read. With no remote, or one that cannot be reached, the flag **warns once and answers on the local plane** instead of failing (§2).
+
+**`status` says how far this checkout's corpus is from the default branch**, on one line, whether or not it has drifted (§4, ADR-47e2ac102f58). The count comes out of the same inspection `check` renders, so there is one answer and not two, and it is a comparison of two revisions this clone already holds — `status` without `--remote` still makes no network call. Where the question could not be asked the line is absent, which is the one case `check`'s own signal covers in words.
+
+`find --free` is the same computation for the agent choosing rather than taking: it keeps the open tasks whose scope meets no live claim, and **says how many it hid**. A filter that silently returns two candidates out of seven is a filter that will be trusted for the wrong reason. Without the flag, `find` is unchanged.
+
+**Without the flag, a listing counts the open rows a `claim` would refuse, and names it.** `--status` filters on the status the file carries and the markers come from the coordination plane (§7), so a checkout behind the default branch lists ten rows under `--status open` that all read `[finished:… on …]` — every row correct, and the whole answering a question the reader was not asking. Measured: the reader concluded the filter was broken. The markers say it one row at a time; the line says it once and names `--free`, which is the service the truncation counter and the hidden count already perform for their own filters. It counts **open tasks alone**, because that is all `--free` keeps: a `--status done` listing carries `[finished:…]` too until `check` prunes the ref, and sending that reader to `--free` would name a command answering something else — the rule §7 states for hints, applied to a listing. Nothing is dropped, which is why the word is not *hidden*: the rows were listed, and only their number is restated.
+
+**Writing to `log` requires holding the claim wherever a claim arbitrates work**; reading it requires nothing. On an `open` or `in_progress` task the log is that task's anchoring register: if anyone can write to it, it stops being a reliable trace of what the holder did. That is a state condition on the claim, not a condition on who is calling, and it is why `log <id>` with no message is a read available to everybody.
+
+**The condition has a subject, and `done` and `closed` sit outside it.** Both statuses are terminal (§3), so there is no work left to arbitrate and no holder whose register could be diluted; a claim asked for there would be a refusal on the absence of a state rather than on a state, which is the argument that already exempts an ADR and a spec (ADR-25f977377fa0). `ank log <id> "<message>"` on a settled task therefore writes the entry, takes no claim and renews none. The task has to be named, since HEAD never points at one.
+
+**What that buys is the correction the surface could not carry.** A correction is a new entry naming the one it corrects, written once and never modified (ADR-25f977377fa0), and a settled task was the one place with nowhere to put one: `log` answered `no task in progress for this agent`, a terminal task cannot be claimed, and a closure reason naming an identifier written before the task it meant existed stayed wrong for the life of the corpus (TASK-c34392707a7b).
+
+**An entry settles nothing, which is what makes it safe.** The log is a file of its own and a task file changes only on a transition (ADR-ff294eff4d1a): the entity is not opened for writing at all, no frontmatter moves, `version` does not bump and `status` does not change. A closed task stays closed and a done task stays done with its proof intact. Nothing is reopened, no second transition is introduced, and the requirement is relaxed nowhere it is still doing its job. Someone who wants to annotate a task that is still live, without holding it, edits the body of the entity, which is already the normal route for anything that is not a state transition.
+
+Commands that take a perimeter take **paths**, uniformly: `review [<path>]`, `check [<path>]` and `graph [<path>]` share the same semantics as `context`, and `scope <path>` resolves against the same globs.
+
+**A path is normalised before it is matched, and a directory has one meaning however it is typed.** Separators are unified to `/`, repeated and trailing ones collapse, `.` disappears and `..` is resolved lexically — so `docs`, `docs/`, `docs\`, `./docs`, `.\docs\` and `docs/../docs` are one perimeter. A path naming nothing inside the repository, because it is absolute or because it climbs above the root, is **refused with the command to run next**; it is never answered. Case is not folded, deliberately: `DOCS` matches nothing here and matches nothing on Linux, and folding it on Windows alone would give one corpus two meanings depending on the machine reading it.
+
+The rule is not cosmetic, and it is written down because its absence was not obvious. Measured on this repository against `docs/`, which five accepted ADRs bind: `docs` answered five, `docs\` answered **four**, `./docs` answered zero (TASK-df4c39031583). The zeros announce themselves. The four does not — it is the form Windows tab-completion produces, it looks like an answer, and it withholds a binding rule from an agent that has no way to know one is missing. A perimeter resolved two ways is a constraint set that depends on typing.
+
+**The rule is about every path and every glob a caller supplies, not about the positional ones.** It covers flag values — `find --scope`, `new --scope`, `amend --scope` and `--drop-scope` — and a glob typed into the `$EDITOR` template, on the same terms: normalised before it reaches matching or is written into an entity, refused with the command to run next when it names nothing inside the repository. A glob normalising to nothing names the repository root, which is a perimeter and not a pattern; it is refused by name, with `**` as the pattern that means what was meant.
+
+Stating it as a property rather than as a list of verbs is the correction TASK-8dd89053fa33 exists for, and the reason is instructive. TASK-df4c39031583 measured the defect, fixed it, and wrote a criterion naming four verbs where the property was general. The fix satisfied that text exactly and its proof is real; the flag values were simply never in it, and the freeze then made the enumeration authoritative. Re-measured with `docs/` present: `--scope docs` and `docs/` answered eight tasks, `docs\` answered **five**, `./docs` and `.\docs\` answered none.
+
+`new --scope` was worse than a wrong answer, because it persisted. It stored `.\docs\` verbatim into the entity, where it matches nothing on any platform for the life of the corpus, and `check` then reported the consequence as `scope '.\docs\' matches no file yet: work not started, or a typo`. It was not a typo — it was the form the caller's own shell completed, which `new` accepted without a word. **A tool that writes what it cannot read back has no way to tell the two apart later**, which is why the normalisation belongs before storage and not in the reader.
+
+Global flags, deliberately limited to four: `--json`, `--quiet`, `--repo <path>`, `--worktree <path>`. Every global flag is a memorisation cost. `--json` is available on every command without exception: full scriptability is an invariant, not an option.
+
+**`--repo <path>` names a repository that already exists**, and that is the whole of what it means: it short-circuits the walk up of §6 without ever contradicting it, so the path it is given carries a `.ank/` or the flag fails. `init` is therefore the one verb that refuses it by name (§9), because `init` is what creates the `.ank/` the flag requires — and where the target is not the current directory, `ank init <path>` is how it is said. The refusal exists because the alternative was measured: accepting it, `init` initialised the *current* repository, appended the pointer paragraph to an `AGENTS.md` the caller was not editing, reported success, and left the named directory empty (TASK-b8a12d60686d). A flag that means an existing repository on twenty verbs and a directory to create on the twenty-first is the same defect as a `-s` meaning `--status` in one verb and `--scope` in another: not a saving, a silent wrong answer.
+
+**`--worktree <path>` names the tree the corpus is anchored to**, which is the half of an address `--repo` does not give (ADR-9e56318631f3). A corpus is confronted with a filesystem for four things: a scope glob, the path argument of a path-taking verb, the working directory of a verifier, and the commit a `commit:` proof names. Until this flag existed all four were held against the directory that happens to hold `.ank/`, because there was only one directory to reach for. §6 carries the assignment; this is the flag that makes the second root sayable.
+
+**Absent, the work tree is the corpus's own directory.** That default is what makes the flag additive rather than a change of behaviour, and it is what keeps the layout §6 describes as usable actually usable: one `.ank/` standing above several checkouts, with scopes written `repoA/src/**`, is a corpus whose work tree is its own directory. A work tree read off the caller's current directory would have killed that layout without anybody deciding to. **The divergence is named, never derived.**
+
+The two flags imply each other in neither direction. `--repo` alone says which corpus and leaves the anchor where it was; `--worktree` alone anchors the corpus the walk found. A work tree that is not a git repository is refused **by the verb that needs git there**, and named as the work tree, so that a reader is not sent to look at a corpus that is plainly a repository. `done` and `attest` are those verbs and no others: git is required per verb and never at startup (ADR-9307e5d214a7), so `show`, `find` and `graph` answer perfectly well from a corpus anchored to a directory that is no repository at all.
+
+### Configuration
+
+**`ank init --at <path>` puts the corpus outside the tree and declares it**, in one gesture (ADR-96174f1ac2b7). It creates the corpus at that path, writes the declaration keyed on this repository's identity, and writes nothing into the working tree -- not a pointer, not a gitignore line, not a comment. The moment it did, the promise would be gone and the design would be the committed pointer that decision refused.
+
+Three refusals, and each is what makes the detachment one. A target **inside the current work tree** is refused naming the tree: a corpus under the code is what `ank init` is for, and a declaration promising otherwise would promise something it does not deliver. A tree with **no repository identity** is refused, because a declaration would have nothing to be keyed on and a fallback is not a key. And a target that is **not itself inside a git repository** is refused naming `git init`, on the terms `ank init` already refuses one: the corpus repository is where claims and proofs land (ADR-9e56318631f3), and `git init` is not on the plumbing ADR-9307e5d214a7 allows, so this verb names the command rather than running it.
+
+What that buys, end to end: a task claimed, logged and finished with its proof anchored, and `git for-each-ref refs/ank` in the code repository printing nothing at all. That is the requirement in its original words -- leave no traces -- and it is the one assertion the whole design exists to make true.
+
+`.ank/config.yml` is read and written through `ank config` (ADR-e64dfaafd578). ADR-01b6dd05f0db closed `.ank/` to agents and stopped at the configuration, which left six errors telling their caller to open a file the same tool forbids them to open. This is the verb those errors name instead.
+
+```
+$ ank config claim_ttl_max
+2h
+$ ank config context_budget
+8000 (default)
+$ ank config verifiers.cargo-test.run "cargo test --workspace"
+verifiers.cargo-test.run (unset) -> cargo test --workspace
+$ ank config --unset default_branch
+**`--user` reads and writes the reader's declarations instead** of the repository's configuration (ADR-96174f1ac2b7), and it is the same verb for the same reason: the map is where a stale entry makes a corpus vanish, and the discipline `ank config` carries is what a file like that needs. Its key set is closed and holds two, `schema` and `corpora.<identity>`; an unknown key is refused by name with the set it knows; a key that is not a repository identity is refused on the terms the map itself applies, so the two surfaces cannot disagree about what a key is; comments and key order survive a write byte for byte outside the line named; no default is materialised, and no file is created to answer a read. A write that would leave the file unreadable is refused and the file is what it was -- differential, as the repository file's is, so the verb still repairs a file that already did not parse.default_branch main -> (unset)
+```
+
+**The key set is closed**, and it is the set the parser knows:
+
+| Key | Value |
+|---|---|
+| `schema` | the format revision of the file |
+| `context_budget` | tokens, default `8000` |
+| `claim_ttl_max` | duration, default `2h` |
+| `claim_ttl_default` | duration, default `30m`; what `claim` grants without `--ttl`, capped by `claim_ttl_max` (§3) |
+| `default_branch` | branch name; unset falls back to `refs/remotes/origin/HEAD` (§7) |
+| `peers.<name>` | the path to a peer corpus's root, read and never written (§7) |
+| `verifiers.<name>.run` | the command line, §4 |
+| `verifiers.<name>.timeout` | duration, default `10m` |
+
+Nested values are addressed by dotted path, and `<name>` is any verifier name — writing `verifiers.<name>.run` for a name the file does not carry is how a verifier is declared. `peers.<name>` works the same way and is how a peer is declared, which is what keeps the closed key set closed: federation adds a key rather than removing the strictness that refuses an unknown one. `verifiers.<name>` addresses the whole block and is legal for `--unset` alone, which is what makes declaring one reversible; reading it, or writing a value to it, is refused by name with `verifiers.<name>.run` to type instead. `roles` and `identities` are keys the parser knows and this verb does not address: their values are structured, the surgery below has no safe edit for them, and they are refused by name rather than guessed at. A key the parser does not know is refused by name too, with the set it does know, and nothing is written.
+
+**Reading prints the value in effect, and marks a resolved default as one.** `context_budget` on a file that does not carry it is `8000 (default)`, not `8000` — the difference between "the tool's value" and "this repository's value" is the whole question a reader is asking, and a release that moves a default moves the first and not the second. A key with no value in effect is `(unset)`. The marker is on the human surface only: `--json` carries `value` and `source` as separate fields, which is what a script reads.
+
+**Writing is text surgery, and never a round-trip through a serializer.** The file is a repository artifact, reviewed like code: comments, blank lines, key order and quoting style survive a write untouched, and every key other than the one named is byte-identical afterwards. A serializer would return `verifiers`, `roles` and `identities` alphabetised, drop every comment, and — the reason this is not a matter of taste — write out every field carrying a default. An unset key means "follows the tool"; a written one means "pinned here", and a round-trip that materialises the defaults converts every repository that ever ran one `ank config` into one that silently pins the old values the day a default moves. **No default is ever materialised**: a key the file did not carry is still absent after a write to another key.
+
+Two edits touch a byte outside the line named, and both are the parent of the key being written rather than a byte beside it: `verifiers: {}` becomes a block mapping when the first verifier is declared into it, and a block mapping becomes `verifiers: {}` when the last one is removed. Without the first, the file `ank init` writes could never receive a verifier; without the second, `verifiers:` would be left with no children, which is not an empty map but a parse error.
+
+**A form the surgery cannot edit safely is refused by name, never rewritten.** A `run` written as a block or folded scalar — `|` or `>` — is one: its resolved string depends on line structure the replacement would flatten, and `verify::definition_hash` is taken over the resolved value, so flattening it would move a hash that anchors historical proofs. The refusal names the key and says to edit the file by hand, which a human always may. Quoting alone is safe and stays safe: the hash is over the resolved string and over the timeout in seconds, so `run: cargo test` and `run: "cargo test"` hash identically, as do `600s` and `10m`.
+
+**A write that would produce a file the parser cannot read fails, and leaves the file as it was.** The result is parsed before anything is written, so the check is not a repair after the fact. The test is differential and has to be: it refuses a write that *introduces* a parse failure, not one performed on a file that already had one. A file carrying an unknown key fails every other verb, and a repair verb that refused to run on it would refuse exactly where it is needed — so on a file that did not parse to begin with, the write goes through and the parse error is reported as a warning rather than a refusal.
+
+**`ank config` runs without a parsed configuration**, as `init` and `help` do (§9). `startup` loads `config.yml` for every other verb, so a file that does not parse fails all of them — `check` included. A verb that exists to repair the file and is disabled by exactly the file it repairs is not a verb; the caller who most needs it is the one whose configuration does not load.
+
+This constrains the agent and not the human. A human with an editor keeps every power they had, and the file stays reviewable text in the repository.
+
+### Short forms
+
+Every long flag keeps its form. Short forms are an addition and never a replacement (ADR-962c25797569): single-dash, single-letter, and this table is the whole of them.
+
+| Short | Long | Legal on |
+|---|---|---|
+| `-j` | `--json` | every verb |
+| `-q` | `--quiet` | every verb |
+| `-r` | `--repo` | every verb |
+| `-b` | `--blocked-by` | `new`, `amend` |
+| `-c` | `--criteria` | `claim`, `new`, `amend` |
+| `-l` | `--limit` | `context` |
+| `-p` | `--proof` | `done`, `attest` |
+| `-s` | `--status` | `find` |
+| `-t` | `--type` | `find` |
+| `-u` | `--unset` | `config` |
+| `-v` | `--verify` | `new` |
+
+**The letter is the first letter of the long flag, and one letter has one meaning in every verb.** Where several long flags begin with the same letter, exactly one takes it and the others keep only their long form. That is the whole rule, and it is worth the flags it costs: a `-s` meaning `--status` in `find` and `--scope` in `new` would not be a saving but a silent wrong answer, since `ank find -s open` would filter on a scope named `open` and return nothing at all. A short form is only useful if it can be typed without checking which verb it is being typed at.
+
+The long flags left without one, with the letter that would have been theirs: `--body` and `--drop-blocked-by` (`b`), `--constraint` (`c`), `--reason` (`r`), `--scope`, `--supersedes` and `--drop-scope` (`s`), `--title` and `--ttl` (`t`), `--worktree` (`w`). The three globals that carry one take their letter ahead of everything else, because they are legal on every verb and a letter they did not hold everywhere would be a letter nobody could rely on — that is what leaves `--reason` on its long form, `r` being `--repo`'s.
+
+A short form takes its value both ways, exactly as the long form does: `ank find -s open` and `ank find -s=open`.
+
+**Bundling is refused, and the refusal names the flags to type instead.** `-st` is not `-s -t`, because a parser that accepts bundling has to decide what `-sopen` means, and every answer to that is a guess about the caller's intent:
+
+```
+$ ank find bug -st task
+error[1]: '-st' bundles short flags
+  -> ank find -s <v> -t <v>
+```
+
+**A single dash is a flag, which is what makes `--` matter.** It was already the only way to write a positional beginning with a dash; short forms make it reachable rather than theoretical, since `ank log "-1 rebuilt the index"` now names a flag where it used to name a message. An argument that begins with a dash and contains whitespace is refused as what it is — no flag contains a space — and the refusal names the escape:
+
+```
+$ ank log "-1 rebuilt the index"
+error[1]: '-1 rebuilt the index' is not a flag: it contains a space
+  -> ank log -- "-1 rebuilt the index"
+```
+
+Values are untouched by any of this. A flag's value is taken verbatim, whichever form the flag was typed in, so `ank release --reason "-x"` and `ank find bug -s=-x` both pass their dash through and only a positional ever needs escaping.
+
+**Verbs are never abbreviated.** `ank cl` is not `ank claim`, and it is `unknown command 'cl'` naming the verbs. A prefix that resolves today stops resolving the day a second verb shares it, which would make a working script break on a release that added a verb.
+
+`ank help <verb>` shows both forms; `ank help` does not, and the listing is unchanged (§9). The overview buys its token economy by staying short, and the detail is one call away for the caller who wants it.
+
+**`ank --version` is not a fourth global flag**, and the limit above is untouched. The three modify a verb; this one replaces it — there is no `ank check --version`, and asking for the build while also asking for something else is not a question anyone has. It prints the crate version, the commit the binary was built from and the revision of the `skill/SKILL.md` it was built alongside, on one line, and exits 0.
+
+It answers **before the foundation**, like `help` and for a sharper reason: the caller who needs it is the one holding an artifact they cannot identify. A version that required a resolved repository, a git of 2.34 and a readable `config.yml` would fall silent in exactly the situation it exists for. Outside any git repository, in a directory with no `.ank/`, it still prints and still exits 0.
+
+The commit is embedded at build time through `rev-parse`, which §8's plumbing rule already allows, and is `unknown` when the build had no checkout to ask — a source tarball, a vendored dependency. Naming the absence beats inventing a value, and it beats the silence that made TASK-1ea38a17d854 cost an investigation to conclude that the binary in hand predated the feature being measured for.
+
+**What the stamp guarantees, and on which builds.** It names the commit the build script last ran at, and the script reruns whenever the commit moves — including a commit that changes no source file, which is the case that catches a binary quietly left behind. It does not depend on the source having changed. The files a commit moves are located through `rev-parse --git-path` rather than assumed at `.git/`, so a linked worktree and a packed ref are covered rather than hoped for; on a detached HEAD the sha lives in the HEAD file, which is watched on its own account. A release, built from a fresh checkout, is exact by construction. The stamp is not a claim about the working tree: uncommitted edits are invisible to it, and a binary built from a dirty tree names the commit it was based on, not the code it contains (TASK-0b26c8b5bfc5).
+
+**The skill revision, and what it lets a reader do offline.** The third value is `skill <rev>`, where `<rev>` is the short form of the same freeze hash that anchors a frozen `done_criteria` (§3), taken over the body of `skill/SKILL.md` — the same value that file declares under `metadata.revision`, computed at build time from the file rather than typed. An agent has both halves in hand and nothing else: the skill is loaded into its context, the binary is on its `PATH`. Comparing the two strings tells it, with no repository and no network, whether the instructions it is following predate the tool it is holding. That is the check TASK-1ea38a17d854 needed and did not have, and the case that motivated it was measured (TASK-b495234f192c): an installed `SKILL.md` two commits behind a tree that had just withdrawn the invitation to read `.ank/` by hand. The hash covers the body and not the frontmatter, so the revision the frontmatter carries does not change its own input. It is `unknown` on a build with no `skill/` to read, for the same reason and with the same honesty as the commit.
+
+
+### Exit codes
+
+The semantics are carried by the code so that the shell can route without parsing output.
+
+| Code | Meaning |
+|---|---|
+| 0 | ok |
+| 1 | generic error |
+| 2 | entity not found, or ambiguous prefix |
+| 3 | version conflict — re-read and retry |
+| 4 | task unavailable — claim held by another agent, or task already finished on another branch (§7) |
+| 5 | proof missing or invalid |
+| 6 | illegal transition, or frozen field modified (hash diverged) |
+| 7 | missing prerequisite — no criterion, task blocked, `accept` off the default branch, or a live claim already held by the calling identity |
+| 8 | `check`: invariants violated (reserved for `check`, for CI) |
+| 9 | environment unavailable — not a task failure |
+
+Codes 3 and 4 are the ones the agentic loop must know how to handle. 3 literally means "redo `context`, somebody moved". 4 means "take something else", and its two causes call for the same reaction, which is the reason for uniting them under a single code: in both cases the task is not to be taken, and the message says which one to take instead. `check` exits 0 when the corpus is healthy and 8 when it has findings — never 1, so that CI can distinguish a sick corpus from a broken tool.
+
+9 covers the environment broadly and not only the verifiers': `sh` not found (§4), git absent or older than 2.34 (§12), default branch indeterminable (§7), a detached proof whose ref never reached the remote (§7). What they have in common is that none of them is a failure of the agent's work — it is an environment to repair, and confusing it with a 1 or a 5 would send the agent to fix sound code.
+
+### Self-correcting errors
+
+Never generic help, always the exact command to run next. One well-designed error round trip costs less than three blind attempts.
+
+```
+$ ank done
+error[5]: proof required to move TASK-8f3a to done
+  done_criteria: "Auth integration tests pass, and no reference
+                  to jwt.verify remains in src/auth/"
+  -> ank done --proof commit:<sha>
+```
+
+```
+$ ank claim 8f3a
+error[4]: TASK-8f3a held by codex@host-9 (expires in 12m)
+  -> ank claim 51c2   (another ready task in this scope)
+```
+
+```
+$ ank claim 51c2
+error[7]: TASK-51c2 has no done_criteria
+  -> ank claim 51c2 --criteria "<verifiable criterion>"
+```
+
+
+### Scope of `check`
+
+Summary of the invariants and signals, all mechanical:
+
+- expired claims, `blocked_by` cycles, broken supersede chains, dead scopes (no file matched, and see below), over-constrained scopes (§5);
+- frozen fields diverging from their anchoring hash — `done_criteria` against the claim, `constraint`/`scope` against the ratification commit, and the signature on that commit against `allowed_signers` (§8): an anchor read from a commit nobody signed anchors nothing;
+- weak proofs (`assertion`, unverified), `done` tasks modified beyond appending a proof;
+- a `commit:` proof naming **no commit this clone can reach** — rebased away, a branch never fetched — reported as a signal naming the task and the reference, one line per detached reference, never a fault and never re-anchored (see the trust hierarchy above). Skipped outright where the clone cannot see: shallow, or reaching no commit at all, since a truncated clone would otherwise have every commit proof in the corpus reported at once;
+- behavioural signals, reported without being faults: blockers created by the holder after claiming (`author` of the blocker is the current holder and its `created` is later than the claim), criterion set by the claimer, verifier modified inside the task's activity window or proof hash diverging from its definition, scope test files modified by the task that invokes them, burst creation by a single identity (**more than 10 entities by one `author` within an hour**, through `created`), implausible `created` (in the future, or well before the commit that introduces the file — the field is declarative, git is the anchor), repeated claim renewals with no modification to the scope files (possible hoarding; a best-effort signal, since another agent's tree is not observable), constraint accepted after the claim of a task in progress, tasks blocked by a `closed` task;
+- a **discrepancy recorded against a frozen criterion** (§3) — a log entry whose message opens with `discrepancy:` — reported as a signal on the task, at any status, and never as a fault: it says a holder measured one part of the criterion wrong and kept the criterion anyway, which is a judgement and not a corpus defect, and a criterion that actually moved is the divergence fault above. **One finding per task, with the entries listed under it**, because the task is what is being judged; and it is worth most on a `done` one, where it is the only thing telling a reader that the proof was produced under a disagreement. A log this reading cannot parse is said out loud on the same task rather than counted as no record, since a check that reports nothing because it read nothing is the quiet failure §4 refuses everywhere else;
+- a `done` task carrying no `test` proof **that anything validated** — none at all, or only ones a caller submitted — once the **default branch** carries it as `done`: the completion rests on a local run and nothing external anchors it. Read on `via` and not on the type (see the trust hierarchy above), so a submitted reference is named in the finding rather than counted by it, and an entry predating `via` counts as it always did. A signal and never a fault — the corpus is intact, the record is thin, and exiting 8 would redden CI on the very merge that introduces the task. The gate on the default branch is what makes it actionable: before the merge there is no run to cite, and reporting there would name work the reader cannot do. The window between the merge landing and its run going green is left to fire, since the statement is true when printed and clears when someone attests; buying that quiet would cost a grace constant, and the constants below are justified for flooding alone;
+- entities predating `author`, **reported once for the corpus and never per file**: they are skipped by the two signals above, and saying so once is what keeps that fact visible. One line per file would add a line for every entity written before the field existed — the volume that teaches a reader to stop reading `check`;
+- actor values not matching the typed convention of §3, **reported once for the corpus and never per file**, on the same reasoning and for the same volume as the line above: the convention binds new writes, and the entities that predate it mean what they meant. A malformed actor is a finding here and never a parse error, or a rule would lock out the files it postdates;
+- an entity whose `author` is an agent and which carries **no reading by a `human:`** in `verified` (§3): a signal, one per entity, and never a fault. Nothing requires `verified`, and `check` derives what the fields state and nothing further — no score, no confidence, no ranking;
+- a corpus still in the previous per-kind layout, or still holding a work trace in the shape that preceded entries (§6), **reported once each**, naming the command that moves it: a signal and never a fault, since such a corpus parses, round-trips and answers every verb;
+- **a `references` entry of a spec that does not resolve** (§3, ADR-c88f99e1c16e), one line per entry. **A reference names a document and not a revision of it**, so the entry is followed through its succession and what is judged is the entity the chain ends on, whatever the chain's length. A **fault** where the corpus holds no such entity, or holds one of a kind a specification does not cite — the reader following it finds nothing, and the repair is `ank amend <spec> --drop-reference <id>`; a **signal** where the chain ends on a document that is not `accepted`, naming `ank accept` on the entity it ends on, since two documents are legitimately drafted at once; and a **signal** where it ends on a `superseded` entity that nothing replaces, which is a citation with nowhere to follow to and a corpus defect reported against that entity rather than against whoever cites it. A chain ending on an accepted document is reported by nothing at all. **Nothing is written to make a reference resolve**: the file keeps the identifier its author wrote, no version moves, and no machinery entry is deposited by a read — which is the argument that settled the alternative, where repairing citations in place would have had one `accept` write to nine entities and leave nine entries behind (ADR-16813b3bcf37). The rule it replaces let a citation off only when the citing document *also* stored the end of the chain, which is this same resolution spelled by hand, stored twice, and re-stored on every citing document after every revision. Only the declared field is read: a section number written in prose is not a reference and no finding pretends otherwise;
+- **an entity identifier written in prose that names an entity the corpus does not hold** (§3, ADR-1e6bcbf62e61), **reported once for the corpus and never once per mention**: a signal naming the first few and carrying the rest as a count, and never a fault. The prose read is the free text no verb resolves, which is a log entry's message, a task's `done_criteria` and an entity's body; a `constraint` is outside it because the rules above already read it as the declared field it is, and a title because it is a line a lister prints whole. What is collected from that prose is what an `ank new` could have produced, a prefix the registry declares followed by twelve hex characters, decided by the same reader every other surface resolves an identifier with. A shape that reader refuses is reported by nothing at all: `SPEC-42`, a bare `ADR-6b3f` short form and thirteen hex characters are not identifiers this corpus mints, so they are not identifiers it can fail to hold, and reporting them would be the tool holding an opinion about prose. **An identifier that resolves is silent whatever its status**, superseded included, and `status` is not read at all: prose is where history is written, and a `done_criteria` naming a replaced document is frozen at claim, so a finding against it would be one nobody could ever clear, which is the failure §11 names and this corpus has already refused twice. An identifier whose file exists and did not parse is left unjudged, on the same doctrine as every other resolution in this pass. **What it derives**: that a run of characters shaped like an identifier this corpus mints resolves to no entity held here, and nothing beyond that. **What it deliberately does not conclude**: that the identifier is a reference, so no succession is followed for it, nothing is ordered by it and no `--drop` repair is proposed, which leaves the rule of the bullet above untouched; that the prose is wrong, since roughly half of what this names on this corpus is a fixture identifier quoted in prose about tests and is perfectly good writing; and that anything is owed in response, since nothing is refused at write time and nothing is rewritten, no verb resolving an identifier inside a message being the state that produced the decision, and a read repairing prose in place being the churn ADR-f7dc76886db2 already settled for citations. Measured before it was decided: 1087 distinct identifiers in the prose of log entries, of which 15 resolve to nothing. That 1.4 percent is what makes one line affordable, where a rule firing on a fifth of the corpus would be the volume this document names as what teaches a reader to stop reading `check`;
+- **an entity whose content its entries cannot account for** (§3, ADR-f7dc76886db2): a signal naming both hashes, one line per entity, and never a fault. A machinery entry records the hash of the content its write produced, where content is every field a transition does not write -- `status`, `proof`, `ratified` and `verified` belong to a transition and `version` to the store -- and `check` compares the newest such entry against the entity as it stands. Equal, and the entity has not moved since the CLI last wrote it; unequal, and it has. **The comparison is what survives a claim**, and that is why it replaced a count: `claim` and `release` each write a task file and leave no durable record naming a version, so a task claimed and released five times carries ten versions no reader can evidence, and a rule counting them would fire on the most ordinary sequence in the corpus. It is also stronger where both apply -- a hand edit that does not move `version`, which is the likelier one since `version` is machinery a human has no reason to touch, is invisible to a count and caught here. **It says the write happened and never that it was wrong**: editing an entity file by hand is legal, is what ADR-01b6dd05f0db permits a human while asking it of no agent, and exiting 8 over it would redden a pipeline on an act the corpus allows. An entry carrying no produced hash is silent, and an entity carrying no entry is silent: no corpus is migrated by a rule it predates;
+
+- **an entity whose version its entries cannot account for** (§3, ADR-f7dc76886db2), which is the count kept where it closes: a signal naming both numbers, one line per entity, never a fault, and reported only where the hash above found nothing, so one write is one finding. The regime opens with an entity's first machinery entry, so everything before it is forgiven and the baseline is that entry's `version <from>`; each entry accounts for one version, and so does each write the entity's own fields evidence -- `ratified` for a ratification, `status: superseded` for the far side of a succession. A version above that total is reported. **It is not attempted for a task**, and the silence is derived rather than chosen: `claim` and `release` leave nothing an evidence count could read, which is the whole of why the hash exists. What it still catches that the hash cannot is a version moved and nothing else. **And it concludes nothing about an entry whose message it cannot read**: an entry is written once, one marked as machinery by a newer build is entitled to a message of its own shape, and the accounting steps aside rather than reporting on prose it does not own;
+- **an entry written about a task that is `done` or `closed`**: reported by nothing at all, and named in this catalogue so that the silence is a decision a reader can find rather than a gap. Those two statuses accept an entry with no claim held and none taken, because a terminal status leaves no work for a claim to arbitrate (§4); `open` and `in_progress` do not, because there the claim is still doing the job it was put there for. What follows is that the fault above for a `done` task modified beyond appending a proof is not reachable this way: an entry is a file of its own and the task file changes only on a transition (ADR-ff294eff4d1a), so a correction moves no field that fault reads, and the hash and version accountings above are handed nothing to disagree with either. The one rule that does read these entries is the `discrepancy:` signal already listed, which reads a task's entries at any status and so reads a correction written after the fact exactly as it reads one written during the work;
+- unresolved git conflict markers in `.ank/` files (§7);
+- **the corpus this checkout carries against the corpus on the default branch** (§7, ADR-47e2ac102f58), **reported once for the corpus and never per entity**: a signal naming how many entity files differ — held here and not there, there and not here, or held on both sides with different content — and the git command that closes the gap. Nothing is fetched to answer and nothing is merged: both revisions are already in this clone, and the gap is git's to close on the operator's word;
+- maintenance of the coordination plane (§7): pruning orphan refs, and completion refs whose task is `done` or `closed` on the default branch. `check` is the only command that prunes. A task carrying a completion ref for a long time without the default branch catching up is reported as a signal — that is a branch never merged, not a corpus anomaly, and the answer is human.
+
+**A dead scope git can explain is a signal, and the severity rule only ever lowers.** Structural death is reported as a signal for an open or `in_progress` task — work not started, or a typo — and as a fault for an ADR or a finished task, which claimed to touch files that are not there. On top of that, and only for the entities that would fault, a second question is asked: did git record where the path went (ADR-97beaf55e73a)? A yes lowers the fault to a signal. Nothing here raises a severity, so an open task whose dead scope git cannot explain is a signal exactly as before.
+
+The reason is that the two states are not the same fact. When git names the commit that moved the path, the corpus is not broken — it is outdated in a way the reader can see and follow, which is what the rename walk was built to show. When git cannot explain it, the reader has nothing, and that is what the fault is for. Without the split, any directory rename reddens a corpus permanently: `amend` refuses a `done` task, so such a task gets the rename named and no repair command (§3), and a fault nobody can clear is a finding readers learn to skip.
+
+**A history that cannot answer is a third state, and it is not a fault.** A shallow clone holds no commit that could record where a path went, so the question the paragraph above asks has three answers and not two: git names the rename, git has the history and records none, or git has no history to consult. The last is reported as a signal saying so, naming the command that deepens the clone, and it is never rendered as a rename that did not happen nor as a defect in the corpus. This is the answer §3 already gives for a ratification anchor a shallow clone cannot verify, and for the same reason — a check that cries divergence over the shape of a clone is a check people learn to ignore. It follows that a pipeline running `check` must check out the history the walk needs, or it reports that it cannot verify and verifies nothing, which is worse than the failure it replaces because it is quiet.
+
+**The walk serves a glob through its literal prefix.** `rev-list` answers about a path and has no answer for "where did `src/**` go", so a glob is asked about the part of it before the first wildcard, truncated at the last separator: `.ank/adr/**` asks about `.ank/adr`. A prefix whose files git records as renamed into one directory is explained by that directory, and the repair proposal keeps the wildcard tail — `.ank/adr/**` becomes `.ank/entities/**`. Sources landing in more than one destination, or under a rename that also changed a file's name, produce no explanation: silence is never evidence, and "the prefix moved mostly there" is not a statement this document authorises anyone to print.
+
+**Drift is counted in entity files, never in commits.** How far this corpus has drifted from the default branch is a question about two trees, and `rev-list` answers a different one: a default branch can move ten times without touching `.ank/`, so a count in commits would fire on every merge and mean nothing. What is counted is entity files that differ, which is what a reader can act on — and it is one line for the corpus rather than one per file, the volume rule this section has already applied twice above.
+
+**Unable to compare is not "nothing has moved", and the two are never printed the same way.** The question is skipped in silence where it cannot be asked at all: no repository (the coordination half already says so once), or no resolvable default branch (the line about pruning already says so once). It is said out loud where it was asked and refused — a `default_branch` naming no commit in this clone — because a mistyped branch name rendered as silence is a reader told the corpus is level by a check that never looked. A repository with no commit at all is neither: that is the nominal state of one freshly `ank init`-ed, there is nothing to compare against yet, and it is silent.
+
+**The same fact reaches `status` on one line**, out of the same inspection pass rather than computed a second way, because two answers able to disagree is the defect that surface exists to avoid. `status` prints it whether or not there is drift — a reader who has to tell "level" from "not asked" by the absence of a line is reading silence, which is the thing this section refuses everywhere else.
+
+**The two signals that need `author`, and why they are signals.** A blocker written by the agent currently holding the task is the shape of an agent building itself an excuse — but it is also the shape of an agent doing exactly what §3 asks, since a discovered subtask *is* a new task with a `blocked_by`. Only a reader knows which, so it is reported and never refused. Burst creation is the same argument at the corpus scale: §3 accepts task flooding without a quota, on the grounds that the defence is visibility rather than restriction, and this is that visibility.
+
+**The numbers are constants, not configuration.** More than 10 entities by one `author` within an hour: a threshold high enough that a session filing the four tasks of a plan passes in silence, low enough that a runaway loop is named within minutes. They live in the tool rather than in `config.yml` because a repository that can raise its own flooding threshold has a flooding threshold that will be raised the first time it fires — and the signal costs nothing to ignore, which is what makes it safe to leave unadjustable.

--- a/.ank/entities/TASK-335c6a01bfa7.md
+++ b/.ank/entities/TASK-335c6a01bfa7.md
@@ -5,7 +5,7 @@ slug: a-proposed-successor-to-adr-ff294eff4d1a-states
 title: A proposed successor to ADR-ff294eff4d1a states the log address the binary writes
 created: 2026-08-31T03:12:01Z
 author: claude-code/opus-5+drift
-status: open
+status: done
 scope:
   - .ank/entities/**
 blocked_by: []
@@ -13,6 +13,19 @@ done_criteria: |
   `ank find --type adr --status proposed --json` lists exactly one entity whose `supersedes` is ADR-ff294eff4d1a, and `ank show` of it prints a constraint naming `.ank/entities/LOG-<ID>.md` and naming `.ank/log/` nowhere. ADR-ff294eff4d1a is accepted and states the log lives at `.ank/log/<ID>.md`, one timestamped line per entry; ADR-25f977377fa0 is accepted, four days younger, retired that address and supersedes nothing, so two accepted decisions give two addresses. Measured: the binary writes .ank/entities/LOG-<id>.md and leaves .ank/log empty. The successor carries forward unchanged the two paragraphs re-measured as true -- a task file changes only on a transition, and nothing authoritative is anchored in the log. Nothing is accepted by this task: accept is a human act.
 criteria_by: creator
 verify: [cargo-test, fmt-check]
+proof:
+  - type: test
+    ref: local/61c2616f5a1e@b4b4cdd
+    tree: scope/1f459e2e13ed
+    criteria: 23be941425ab
+    verifier: cargo-test@f14aeab36e1b
+    via: verifier
+  - type: test
+    ref: local/e3b0c44298fc@b4b4cdd
+    tree: scope/1f459e2e13ed
+    criteria: 23be941425ab
+    verifier: fmt-check@5ca6d10bcd55
+    via: verifier
 schema: 4
-version: 1
+version: 3
 ---

--- a/.ank/entities/TASK-34938bfc6b84.md
+++ b/.ank/entities/TASK-34938bfc6b84.md
@@ -5,7 +5,7 @@ slug: the-licence-decision-stops-enumerating-three-cha
 title: The licence decision stops enumerating three channels a later decision abolished
 created: 2026-08-31T03:12:34Z
 author: claude-code/opus-5+drift
-status: open
+status: done
 scope:
   - .ank/entities/**
 blocked_by: []
@@ -13,6 +13,19 @@ done_criteria: |
   `ank find --type adr --status proposed --json` lists an entity whose `supersedes` is ADR-9f03438f5422; its constraint names no Homebrew formula, Scoop manifest or winget locale; and `ank check` reports no dead scope against it. Measured on this tree: ls -d Formula bucket packaging fails for all three, and those three are declared scopes of ADR-9f03438f5422 and among the dead scopes check reports. ADR-221aa5da440a, accepted two days younger, states 'No package-manager channel ships: no Homebrew tap, no Scoop bucket, no apt repository, no winget manifest, no AUR package', so the older accepted ADR requires a licence declaration from three channels the corpus has forbidden. The Apache-2.0 rule and the prospective-relicensing paragraph carry forward unchanged. Nothing is accepted by this task.
 criteria_by: creator
 verify: [cargo-test, fmt-check]
+proof:
+  - type: test
+    ref: local/933d52cec718@052a524
+    tree: scope/9c6303bd2e88
+    criteria: d001856654cd
+    verifier: cargo-test@f14aeab36e1b
+    via: verifier
+  - type: test
+    ref: local/e3b0c44298fc@052a524
+    tree: scope/9c6303bd2e88
+    criteria: d001856654cd
+    verifier: fmt-check@5ca6d10bcd55
+    via: verifier
 schema: 4
-version: 1
+version: 3
 ---

--- a/.ank/entities/TASK-53a95782ae5c.md
+++ b/.ank/entities/TASK-53a95782ae5c.md
@@ -5,7 +5,7 @@ slug: the-rule-closing-ank-to-agents-names-the-routes
 title: The rule closing .ank to agents names the routes the binary actually dispatches
 created: 2026-08-31T03:12:26Z
 author: claude-code/opus-5+drift
-status: open
+status: done
 scope:
   - .ank/entities/**
 blocked_by: []
@@ -13,6 +13,19 @@ done_criteria: |
   `ank find --type adr --status proposed --json` lists an entity whose `supersedes` is ADR-01b6dd05f0db, and its constraint names amend, edit, config and read among the writing routes and scope, graph, status, review, check and the read form of log among the reading ones. Measured on ank 0.7.0, hashing every file under .ank/ except index.db before and after each verb in a throwaway corpus: ank read, ank amend --scope, ank edit --title and ank config each changed those bytes and each exited 0, and ADR-01b6dd05f0db lists none of the four, its writing list being 'ank new, claim, log, done, release, attest, close and accept'. The rule itself is unchanged -- the CLI is the route for an agent, a human with an editor keeps every power they had -- and only the two enumerations move. Nothing is accepted by this task.
 criteria_by: creator
 verify: [cargo-test, fmt-check]
+proof:
+  - type: test
+    ref: local/6b520d1194e8@c4c4a9a
+    tree: scope/ef643b18d00c
+    criteria: d2969ef9a3f4
+    verifier: cargo-test@f14aeab36e1b
+    via: verifier
+  - type: test
+    ref: local/e3b0c44298fc@c4c4a9a
+    tree: scope/ef643b18d00c
+    criteria: d2969ef9a3f4
+    verifier: fmt-check@5ca6d10bcd55
+    via: verifier
 schema: 4
-version: 1
+version: 3
 ---

--- a/.ank/entities/TASK-58ccbc4683ef.md
+++ b/.ank/entities/TASK-58ccbc4683ef.md
@@ -5,7 +5,7 @@ slug: the-naming-decision-names-the-workspace-as-it-is
 title: The naming decision names the workspace as it is, or stops enumerating it
 created: 2026-08-31T03:12:44Z
 author: claude-code/opus-5+drift
-status: open
+status: done
 scope:
   - .ank/entities/**
 blocked_by: []
@@ -13,6 +13,19 @@ done_criteria: |
   `ank find --type adr --status proposed --json` lists an entity whose `supersedes` is ADR-85e6bbb195b8, and its constraint either names every directory `ls crates/` prints -- six today: ank-cli, ank-contract, ank-core, ank-daemon, ank-mcp, ank-tui -- or states the naming rule with no crate enumeration at all. Measured on this tree: ADR-85e6bbb195b8 is accepted and says 'the crates are ank-core and ank-cli', ls crates/ prints six, and the four it omits were each created by a later accepted decision (ADR-559eebf5c6f5 scopes crates/ank-tui/**, ADR-fd98f4bc6dea scopes crates/ank-mcp/**), so ank context hands anyone touching crates/** a constraint that contradicts three ratified ones. Every other clause was re-measured and holds -- binary ank, directory .ank/, refs/ank/*, ANK_AGENT, no occurrence of ankor -- and carries forward unchanged. Nothing is accepted by this task.
 criteria_by: creator
 verify: [cargo-test, fmt-check]
+proof:
+  - type: test
+    ref: local/b370aefb7ebc@49afa4e
+    tree: scope/379f61721509
+    criteria: e3ca4e8739cf
+    verifier: cargo-test@f14aeab36e1b
+    via: verifier
+  - type: test
+    ref: local/e3b0c44298fc@49afa4e
+    tree: scope/379f61721509
+    criteria: e3ca4e8739cf
+    verifier: fmt-check@5ca6d10bcd55
+    via: verifier
 schema: 4
-version: 1
+version: 3
 ---

--- a/.ank/entities/TASK-c4f26ad5302d.md
+++ b/.ank/entities/TASK-c4f26ad5302d.md
@@ -5,7 +5,7 @@ slug: the-cli-surface-stops-saying-the-binary-does-not
 title: The CLI surface stops saying the binary does not answer to mcp and watch
 created: 2026-08-31T03:12:18Z
 author: claude-code/opus-5+drift
-status: open
+status: done
 scope:
   - .ank/entities/**
 blocked_by: []
@@ -13,6 +13,19 @@ done_criteria: |
   `ank find --type spec --status proposed --json` lists an entity whose `supersedes` is SPEC-fe8bdb84faca, and the string 'does not answer to them yet' appears in `ank show SPEC-fe8bdb84faca` and in no proposed successor. SPEC-fe8bdb84faca is accepted and states 'mcp and watch are on that list and the binary does not answer to them yet'. Measured on ank 0.7.0: ank help --json carries 26 verbs including both; an initialize plus tools/list piped into ank mcp returned 26 tools, one per verb; ank watch --where printed the declaration path; and crates/ank-cli/tests/skill.rs declares NOT_YET_DISPATCHED as an array of length zero, so the suite that exists to name an undispatched verb names none. Nothing is accepted by this task.
 criteria_by: creator
 verify: [cargo-test, fmt-check]
+proof:
+  - type: test
+    ref: local/b326da41f074@57cbbdf
+    tree: scope/a34a47925bb5
+    criteria: 89079c3971ad
+    verifier: cargo-test@f14aeab36e1b
+    via: verifier
+  - type: test
+    ref: local/e3b0c44298fc@57cbbdf
+    tree: scope/a34a47925bb5
+    criteria: 89079c3971ad
+    verifier: fmt-check@5ca6d10bcd55
+    via: verifier
 schema: 4
-version: 1
+version: 3
 ---

--- a/.ank/entities/TASK-f82cfa1b9344.md
+++ b/.ank/entities/TASK-f82cfa1b9344.md
@@ -5,7 +5,7 @@ slug: the-daemon-s-constraint-reaches-the-crate-that-i
 title: The daemon's constraint reaches the crate that implements the daemon
 created: 2026-08-31T03:12:09Z
 author: claude-code/opus-5+drift
-status: open
+status: done
 scope:
   - .ank/entities/**
 blocked_by: []
@@ -13,6 +13,19 @@ done_criteria: |
   `ank scope crates/ank-daemon/src/fetch.rs --json` lists an entity whose `supersedes` is ADR-a22cd3196529, and `ank context crates/ank-daemon/src/fetch.rs --json` names it under `proposed`. Measured on ank 0.7.0: ADR-a22cd3196529 declares its perimeter as crates/ank-cli/src/index.rs and docs/**, the daemon is seven files under crates/ank-daemon/, and ank context on that crate answers three active constraints -- ADR-9f03, ADR-85e6, ADR-d3a8 -- naming this decision in none of them, so the clause 'the only thing it writes into a repository is a fetch of refs/ank/* into a tracking namespace of its own' is handed to nobody working on the fetch. An accepted ADR's scope is hashed into its ratification commit and amend refuses it, so the route is a successor whose scope names crates/ank-daemon/** and whose constraint text is otherwise unchanged. Nothing is accepted by this task.
 criteria_by: creator
 verify: [cargo-test, fmt-check]
+proof:
+  - type: test
+    ref: local/cdc0865320a7@7f546d7
+    tree: scope/c053a1c3e56e
+    criteria: 56932545e8ed
+    verifier: cargo-test@f14aeab36e1b
+    via: verifier
+  - type: test
+    ref: local/e3b0c44298fc@7f546d7
+    tree: scope/c053a1c3e56e
+    criteria: 56932545e8ed
+    verifier: fmt-check@5ca6d10bcd55
+    via: verifier
 schema: 4
-version: 1
+version: 3
 ---


### PR DESCRIPTION
Six drift findings, each repaired the only way an accepted decision can be: a proposed successor. **Nothing here is accepted.** `ank accept` is a human act, signed, on the default branch; every successor's body says so, and `ank check` reports each supersession as a signal ("not yet a succession") rather than a succession until it is signed.

| Task | Successor | Retires |
| --- | --- | --- |
| TASK-335c6a01bfa7 | ADR-67a4ac10c534 | ADR-ff294eff4d1a |
| TASK-f82cfa1b9344 | ADR-24e21cb83793 | ADR-a22cd3196529 |
| TASK-c4f26ad5302d | SPEC-d58b3a9e4e4d | SPEC-fe8bdb84faca |
| TASK-53a95782ae5c | ADR-e45e1a29fe91 | ADR-01b6dd05f0db |
| TASK-34938bfc6b84 | ADR-534c7a3e6cf8 | ADR-9f03438f5422 |
| TASK-58ccbc4683ef | ADR-f8f1ea7fd2bb | ADR-85e6bbb195b8 |

Every claim about the binary was measured and the numbers are in each task's log: a throwaway corpus for the log address and for which verbs write into `.ank/`, `ank help --json` and a `tools/list` through `ank mcp` for the 26 verbs, `git status --porcelain` counts rather than file hashes so the measurement of ADR-01b6dd05f0db does not do what ADR-01b6dd05f0db forbids.

## What each signature still waits on

ADR-3b6ba766a42e refuses a supersession while a tracked file outside `.ank/` still cites what it retires. Counted on this tree; **none of it is swept here**, since this work is scoped to `.ank/entities/**` and the code perimeters are held by other agents:

- ADR-a22cd3196529 — 44 citations in 19 files (20 inside `crates/ank-daemon/` itself)
- ADR-01b6dd05f0db — 14 citations in 8 files, two inside string literals the binary prints
- ADR-9f03438f5422 — 12 citations in 7 files
- ADR-ff294eff4d1a — 7 citations in 3 files
- SPEC-fe8bdb84faca — 7 citations in 3 files, five of them TUI fixture rows
- ADR-85e6bbb195b8 — 1 citation, `crates/ank-cli/src/human.rs:1828`

`ank check` on this branch: 0 faults, exit 0.