### PR TITLE
The ank-cli sources and CONTRIBUTING cite the proposed successors, not the six documents they retire

### DIFF
--- a/.ank/entities/LOG-3d8c539633bb.md
+++ b/.ank/entities/LOG-3d8c539633bb.md
@@ -1,0 +1,26 @@
+---
+id: LOG-3d8c539633bb
+type: log
+title: "After count, measured the same way: 0 citations of the six retired ids across the six files in this"
+created: 2026-08-31T04:45:38Z
+author: claude-code/opus-5+citB
+scope:
+  - crates/ank-cli/src/commands.rs
+  - crates/ank-cli/src/entries.rs
+  - crates/ank-cli/src/git.rs
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/src/paint.rs
+  - CONTRIBUTING.md
+about: TASK-cd229a2cd06f
+seq: 1
+schema: 4
+version: 1
+---
+
+ perimeter, down from 11. Ten sites were re-pointed and one was dropped. Dropped: commands.rs log_write, which read '(ADR-ff294eff4d1a, carried forward by ADR-25f977377fa0)' -- ADR-67a4ac10c534 is itself the reconciliation of those two documents, so naming the retired one alongside its successor said nothing the successor does not say and would have gone on blocking accept. It now reads '(ADR-67a4ac10c534, which moves the log's address and carries this clause forward from its predecessor word for word)', with the history left to ank show.
+
+Two sites needed prose and not only an id. paint.rs attributed 'show returns the entity byte for byte' to ADR-01b6dd05f0db, whose body says exactly that; ADR-e45e1a29fe91's body drops the sentence, so the guarantee is now stated as section 4's -- which the module's first line already cites -- and the ADR is cited for the rule that rests on it. CONTRIBUTING.md listed show, find and context as the routes into .ank/, which is the enumeration ADR-e45e1a29fe91 exists to correct; the sentence now names scope, graph, status, review, check and the read form of log too, and says the ADR carries the whole list on each side.
+
+human.rs was read before assuming: the .ank/log/ walk and the 'previous layout' migrate signal at lines 380-403 implement exactly the move ADR-67a4ac10c534 records, and .ank/log/<id>.md at line 1816 is reached only on the legacy path store.log_path_of, so both are correct as they stand and neither carries a citation. The retired ids appear in no string the binary prints in this perimeter: commands.rs:3224 and git.rs:2428 are assert messages inside mod tests, so no golden moved and the scope did not have to be amended. cargo test --workspace green, cargo fmt --check green, ank check ok with 0 faults and 457 signals.
+
+The remaining sites repo-wide, 79 across 24 files, all sit in the two perimeters held by other agents.

--- a/.ank/entities/LOG-c2b30d4f3540.md
+++ b/.ank/entities/LOG-c2b30d4f3540.md
@@ -1,0 +1,18 @@
+---
+id: LOG-c2b30d4f3540
+type: log
+title: done, proof test:local/602bb324a0b2@6efc0c5 test:local/e3b0c44298fc@6efc0c5
+created: 2026-08-31T04:50:43Z
+author: claude-code/opus-5+citB
+scope:
+  - crates/ank-cli/src/commands.rs
+  - crates/ank-cli/src/entries.rs
+  - crates/ank-cli/src/git.rs
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/src/paint.rs
+  - CONTRIBUTING.md
+about: TASK-cd229a2cd06f
+seq: 2
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-c525427de12e.md
+++ b/.ank/entities/LOG-c525427de12e.md
@@ -1,0 +1,20 @@
+---
+id: LOG-c525427de12e
+type: log
+title: "Before count, measured: 11 citations of the six retired ids across the six files in this perimeter"
+created: 2026-08-31T04:31:34Z
+author: claude-code/opus-5+citB
+scope:
+  - crates/ank-cli/src/commands.rs
+  - crates/ank-cli/src/entries.rs
+  - crates/ank-cli/src/git.rs
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/src/paint.rs
+  - CONTRIBUTING.md
+about: TASK-cd229a2cd06f
+seq: 0
+schema: 4
+version: 1
+---
+
+ -- CONTRIBUTING.md 1, commands.rs 4, entries.rs 1, git.rs 1, human.rs 3, paint.rs 1. Three of the six ids are cited here at all: ADR-01b6dd05f0db (7), ADR-ff294eff4d1a (3), ADR-85e6bbb195b8 (1). ADR-a22cd3196529, ADR-9f03438f5422 and SPEC-fe8bdb84faca are cited nowhere in this perimeter -- the spec is reached by section number, never by id. ank check reports 0 faults today: the six successors are proposed, so no citation fault exists yet, which is exactly the window ADR-3b6ba766a42e opens for the sweep.

--- a/.ank/entities/TASK-cd229a2cd06f.md
+++ b/.ank/entities/TASK-cd229a2cd06f.md
@@ -19,7 +19,7 @@ done_criteria: |
 criteria_by: creator
 verify: [cargo-test, fmt-check]
 schema: 4
-version: 2
+version: 4
 ---
 
 Six supersessions were merged to main as proposals. ADR-3b6ba766a42e refuses a ratification while any tracked file outside .ank/ still cites the retired document, and names the two repairs: point the citation at the successor, or drop it and leave the history to ank show. A citation naming a proposed successor is the state that refusal exists to produce.

--- a/.ank/entities/TASK-cd229a2cd06f.md
+++ b/.ank/entities/TASK-cd229a2cd06f.md
@@ -1,0 +1,29 @@
+---
+id: TASK-cd229a2cd06f
+type: task
+slug: the-cli-source-and-contributing-cite-the-propose
+title: The CLI source and CONTRIBUTING cite the proposed successors, not the six documents they retire
+created: 2026-08-31T04:30:41Z
+author: claude-code/opus-5+citB
+status: in_progress
+scope:
+  - crates/ank-cli/src/commands.rs
+  - crates/ank-cli/src/entries.rs
+  - crates/ank-cli/src/git.rs
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/src/paint.rs
+  - CONTRIBUTING.md
+blocked_by: []
+done_criteria: |
+  git grep -nF over the six retired identifiers -- ADR-a22cd3196529, ADR-01b6dd05f0db, ADR-9f03438f5422, ADR-ff294eff4d1a, SPEC-fe8bdb84faca, ADR-85e6bbb195b8 -- restricted to the six tracked files in this scope returns zero hits, and ank check names no citation fault against any of the six from those files. Every site is either re-pointed to the proposed successor whose text supports the sentence it stands in, with the surrounding prose changed where the successor changed the substance, or dropped with the reason recorded in an ank log entry. Both counts, before and after, are measured through git grep and recorded with ank log while the claim is held.
+criteria_by: creator
+verify: [cargo-test, fmt-check]
+schema: 4
+version: 2
+---
+
+Six supersessions were merged to main as proposals. ADR-3b6ba766a42e refuses a ratification while any tracked file outside .ank/ still cites the retired document, and names the two repairs: point the citation at the successor, or drop it and leave the history to ank show. A citation naming a proposed successor is the state that refusal exists to produce.
+
+This task sweeps one perimeter of that repair -- the five ank-cli source files and CONTRIBUTING.md. Two other perimeters (the daemon, tui, contract/events.rs and cli/context/status.rs; and the tests, contract/verbs.rs, the manifests and NOTICE) are held elsewhere and are not touched here.
+
+The sweep is read site by site and never by substitution. Three of the six successors moved substance and not only the id: ADR-e45e1a29fe91 re-enumerated the routes into .ank/ to match what dispatches, ADR-67a4ac10c534 moved the log's address to .ank/entities/LOG-<ID>.md, and ADR-f8f1ea7fd2bb states the naming rule as the prefix ank-<part> instead of enumerating two crates. Where a sentence cited the retired document precisely for what that document said, the sentence changes with the id or the citation goes.

--- a/.ank/entities/TASK-cd229a2cd06f.md
+++ b/.ank/entities/TASK-cd229a2cd06f.md
@@ -5,7 +5,7 @@ slug: the-cli-source-and-contributing-cite-the-propose
 title: The CLI source and CONTRIBUTING cite the proposed successors, not the six documents they retire
 created: 2026-08-31T04:30:41Z
 author: claude-code/opus-5+citB
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/src/commands.rs
   - crates/ank-cli/src/entries.rs
@@ -18,8 +18,21 @@ done_criteria: |
   git grep -nF over the six retired identifiers -- ADR-a22cd3196529, ADR-01b6dd05f0db, ADR-9f03438f5422, ADR-ff294eff4d1a, SPEC-fe8bdb84faca, ADR-85e6bbb195b8 -- restricted to the six tracked files in this scope returns zero hits, and ank check names no citation fault against any of the six from those files. Every site is either re-pointed to the proposed successor whose text supports the sentence it stands in, with the surrounding prose changed where the successor changed the substance, or dropped with the reason recorded in an ank log entry. Both counts, before and after, are measured through git grep and recorded with ank log while the claim is held.
 criteria_by: creator
 verify: [cargo-test, fmt-check]
+proof:
+  - type: test
+    ref: local/602bb324a0b2@6efc0c5
+    tree: scope/87bf44e69ff8
+    criteria: 8e08b9bbe913
+    verifier: cargo-test@f14aeab36e1b
+    via: verifier
+  - type: test
+    ref: local/e3b0c44298fc@6efc0c5
+    tree: scope/87bf44e69ff8
+    criteria: 8e08b9bbe913
+    verifier: fmt-check@5ca6d10bcd55
+    via: verifier
 schema: 4
-version: 4
+version: 5
 ---
 
 Six supersessions were merged to main as proposals. ADR-3b6ba766a42e refuses a ratification while any tracked file outside .ank/ still cites the retired document, and names the two repairs: point the citation at the successor, or drop it and leave the history to ank show. A citation naming a proposed successor is the state that refusal exists to produce.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,9 +56,12 @@ produces a task that claims to be finished with nothing behind the claim, and an
 agent, or a human, that grades its own work can simply be wrong.
 
 **`.ank/` is reached through the CLI, not by opening the files**
-(ADR-01b6dd05f0db). `ank show <id>` gives an entity whole, `ank find` lists,
-`ank context` binds. This constrains agents, not people: a human with an editor
-keeps every power they had, and `ank check` remains what notices.
+(ADR-e45e1a29fe91). `ank show <id>` gives an entity whole, `ank find` lists,
+`ank context` binds, and `scope`, `graph`, `status`, `review`, `check` and the
+read form of `log` answer the rest. That ADR enumerates every route on each
+side, because a short list gets read as the whole one. This constrains agents,
+not people: a human with an editor keeps every power they had, and `ank check`
+remains what notices.
 
 ## Ratifying a decision
 

--- a/crates/ank-cli/src/commands.rs
+++ b/crates/ank-cli/src/commands.rs
@@ -828,9 +828,10 @@ fn resolve_blockers(store: &Store, ids: &[EntityId], hint: &str) -> Result<()> {
 ///
 /// It names the command that declares one rather than the file to open
 /// (ADR-e64dfaafd578): a hint telling an agent to edit `.ank/config.yml` is the
-/// tool instructing it to do what ADR-01b6dd05f0db forbids. The names already
-/// declared come first when there are any, because a typo is the likelier of
-/// the two mistakes and the list settles it in one line.
+/// tool instructing it to do what ADR-e45e1a29fe91 forbids — `ank config` is
+/// the route that writes that file, and that ADR is where it is named as one.
+/// The names already declared come first when there are any, because a typo is
+/// the likelier of the two mistakes and the list settles it in one line.
 fn undeclared_verifier(name: &str, cfg: &Config) -> CliError {
     let mut known: Vec<&str> = cfg.verifiers.keys().map(|s| s.as_str()).collect();
     known.sort_unstable();
@@ -2054,7 +2055,7 @@ fn budget_for_whole_log(entries: &[Entry], spent: usize) -> usize {
 /// identifier stayed wrong permanently (TASK-c34392707a7b).
 ///
 /// **Writing one settles nothing, which is what makes it safe.** An entry is a
-/// file of its own (ADR-ff294eff4d1a): the task file is not opened for writing,
+/// file of its own (ADR-67a4ac10c534): the task file is not opened for writing,
 /// no frontmatter moves, `version` does not bump and `status` does not change.
 /// A closed task stays closed and a done task stays done with its proof intact.
 /// No verb refuses on the log, so nothing downstream reads a new entry as a
@@ -2126,10 +2127,11 @@ fn log_write(
     warn_before_acting(inv, &warnings);
 
     let loaded_for_log = store.load(&id)?;
-    // **An entry is not a transition** (ADR-ff294eff4d1a, carried forward by
-    // ADR-25f977377fa0). The entity the entry is about is not opened for
-    // writing at all: no frontmatter, no version bump, and nothing touched that
-    // carries a frozen field. What lands is one new file.
+    // **An entry is not a transition** (ADR-67a4ac10c534, which moves the log's
+    // address and carries this clause forward from its predecessor word for
+    // word). The entity the entry is about is not opened for writing at all: no
+    // frontmatter, no version bump, and nothing touched that carries a frozen
+    // field. What lands is one new file.
     let entry = entries::record(
         store,
         &Index::open(&repo.ank)?,
@@ -3221,7 +3223,7 @@ mod tests {
             err.hint.as_deref(),
             Some("ank config verifiers.nope.run \"<command>\""),
             "a hint that names the file is the tool telling an agent to do \
-             what ADR-01b6dd05f0db forbids"
+             what ADR-e45e1a29fe91 forbids"
         );
 
         // With verifiers already declared, the names come first -- a typo is

--- a/crates/ank-cli/src/entries.rs
+++ b/crates/ank-cli/src/entries.rs
@@ -307,7 +307,7 @@ fn write_entry(
 /// newline gained on the way through an editor does not read as a different
 /// past.
 ///
-/// It anchors nothing, which is what ADR-ff294eff4d1a requires of the log: no
+/// It anchors nothing, which is what ADR-67a4ac10c534 requires of the log: no
 /// verb consults it, no hash chains over it, and deleting the entry that
 /// carries it changes no answer the tool gives.
 pub fn replaced_hash(before: &Entity) -> String {

--- a/crates/ank-cli/src/git.rs
+++ b/crates/ank-cli/src/git.rs
@@ -2425,7 +2425,7 @@ mod tests {
         assert!(hint.contains("git remote set-head origin -a"), "{hint}");
         // The second fix names the command, not the file to open: telling an
         // agent to edit .ank/config.yml is the tool instructing it to do what
-        // ADR-01b6dd05f0db forbids (ADR-e64dfaafd578).
+        // ADR-e45e1a29fe91 forbids (ADR-e64dfaafd578).
         assert!(hint.contains("ank config default_branch <name>"), "{hint}");
         assert!(
             !hint.contains(".ank/config.yml"),

--- a/crates/ank-cli/src/human.rs
+++ b/crates/ank-cli/src/human.rs
@@ -1825,7 +1825,7 @@ fn check_task(
     // not inside the loop.
     //
     // Read on the entry, it was a finding nobody could act on. §3 makes the
-    // proof list append-only and ADR-85e6bbb195b8 forbids rewriting an entry to
+    // proof list append-only and ADR-f8f1ea7fd2bb forbids rewriting an entry to
     // make history look better, so a task closed before `ank done` existed could
     // never clear it: the assertion has to stay, and the assertion was what
     // fired. A line every reader learns to skip is worse than no line.
@@ -2745,7 +2745,7 @@ fn evidenced_writes(entity: &Entity) -> Option<u64> {
 ///
 /// **A signal and never a fault**, and the exit code is the whole argument: an
 /// entity whose arithmetic does not close was written outside the CLI, which is
-/// legal, is what a human with an editor does, and is what ADR-01b6dd05f0db
+/// legal, is what a human with an editor does, and is what ADR-e45e1a29fe91
 /// permits a human while asking it of no agent. What the signal says is that it
 /// happened, not that it was wrong.
 ///
@@ -4182,7 +4182,7 @@ pub fn review(
     let index = Index::open(&repo.ank)?;
     let files = tracked_files(&repo.worktree);
     // Who may ratify, read here because nowhere else serves it: `.ank/` is
-    // closed to a direct read (ADR-01b6dd05f0db) and `allowed_signers` is not
+    // closed to a direct read (ADR-e45e1a29fe91) and `allowed_signers` is not
     // an entity, so before this the one file the format asks a human to edit by
     // hand was the one file no verb could show (TASK-8a80b590b356). It belongs
     // on this verb rather than on a new one: §4 calls `review` the ratification

--- a/crates/ank-cli/src/paint.rs
+++ b/crates/ank-cli/src/paint.rs
@@ -1,7 +1,8 @@
 //! The entity `show` prints, lit for a reader at a terminal (§4).
 //!
 //! `show` is the one command that does not summarise: it returns the entity
-//! byte for byte (ADR-01b6dd05f0db). This module keeps that true and still
+//! byte for byte, which is the guarantee ADR-e45e1a29fe91 rests on when it
+//! closes `.ank/` to a direct read. This module keeps that true and still
 //! gives a human hierarchy, by emitting nothing but escape sequences. An escape
 //! occupies no column, so stripping the escapes from what this writes yields
 //! the byte sequence `show` wrote before it existed — same characters, same


### PR DESCRIPTION
Six supersessions landed on `main` as proposals. ADR-3b6ba766a42e refuses a ratification while any tracked file outside `.ank/` still cites the document it retires, and names the two repairs: point the citation at the successor, or drop it and leave the history to `ank show`. A citation naming a proposed successor is the state that refusal exists to produce.

This sweeps one perimeter of that repair — the five `crates/ank-cli/src` files and `CONTRIBUTING.md`. The daemon, tui, contract and tests perimeters are held elsewhere and are untouched here.

**11 citations before, 0 after.** Ten re-pointed, one dropped.

| file | before |
| --- | --- |
| `CONTRIBUTING.md` | 1 |
| `crates/ank-cli/src/commands.rs` | 4 |
| `crates/ank-cli/src/entries.rs` | 1 |
| `crates/ank-cli/src/git.rs` | 1 |
| `crates/ank-cli/src/human.rs` | 3 |
| `crates/ank-cli/src/paint.rs` | 1 |

Only three of the six ids were cited in this perimeter at all: ADR-01b6dd05f0db (7), ADR-ff294eff4d1a (3), ADR-85e6bbb195b8 (1). The spec is reached by section number here, never by id.

## Where the prose moved with the id

- **`paint.rs`** attributed "`show` returns the entity byte for byte" to ADR-01b6dd05f0db, whose body says exactly that. ADR-e45e1a29fe91's body drops the sentence, so swapping the id alone would have attributed to it something it does not say. The guarantee is now stated as §4's — which the module's first line already cites — and ADR-e45e1a29fe91 is cited for the rule that rests on it.
- **`CONTRIBUTING.md`** listed `show`, `find` and `context` as the routes into `.ank/`. That short list is the enumeration ADR-e45e1a29fe91 exists to correct, so the sentence now names `scope`, `graph`, `status`, `review`, `check` and the read form of `log` too, and says the ADR carries the whole list on each side.
- **`commands.rs::log_write`** is the one dropped citation. It read `(ADR-ff294eff4d1a, carried forward by ADR-25f977377fa0)`. ADR-67a4ac10c534 is itself the reconciliation of those two documents, so naming the retired one beside its successor said nothing the successor does not say, and would have gone on blocking `accept`. It now names ADR-67a4ac10c534 and leaves the history to `ank show`.

## What was read rather than assumed

`human.rs`'s walk of `.ank/log/` and its `ank migrate` signal implement exactly the move ADR-67a4ac10c534 records; `.ank/log/<id>.md` at line 1816 is reached only on the legacy path through `store.log_path_of`. Both are correct as they stand and neither carries a citation, so neither was touched.

No string the binary prints was changed: `commands.rs:3224` and `git.rs:2428` are `assert!` messages inside `mod tests`. No golden moved and the scope did not have to be amended.

## Proof

TASK-cd229a2cd06f, closed by `ank done` with the verifiers it declared: `cargo-test` ok (282.5s) and `fmt-check` ok (3.1s). `ank check` ok, 0 faults.

**Nothing is ratified by this.** The six successors stay proposed until a human signs them on the default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UkwDcD37aALzp8NnvDpSyr