### PR TITLE
Re-point the runtime crates' citations at the six proposed successors

### DIFF
--- a/.ank/entities/LOG-d0e0223d29bd.md
+++ b/.ank/entities/LOG-d0e0223d29bd.md
@@ -1,0 +1,28 @@
+---
+id: LOG-d0e0223d29bd
+type: log
+title: Counted before, measured not read. In this task's fourteen paths, `git grep -oE` over the six
+created: 2026-08-31T04:31:35Z
+author: claude-code/opus-5+citA
+scope:
+  - crates/ank-daemon/src/declare.rs
+  - crates/ank-daemon/src/fetch.rs
+  - crates/ank-daemon/src/lib.rs
+  - crates/ank-daemon/src/stream.rs
+  - crates/ank-daemon/src/warm.rs
+  - crates/ank-daemon/tests/dependencies.rs
+  - crates/ank-contract/src/events.rs
+  - crates/ank-tui/src/stream.rs
+  - crates/ank-tui/src/view.rs
+  - crates/ank-cli/src/cli.rs
+  - crates/ank-cli/src/context.rs
+  - crates/ank-cli/src/status.rs
+  - .github/workflows/release.yml
+  - docs/integrating.md
+about: TASK-d8448e35354e
+seq: 0
+schema: 4
+version: 1
+---
+
+ retired ids returns 37 occurrences on 37 lines: ADR-a22cd3196529 32, SPEC-fe8bdb84faca 5, and zero for ADR-01b6dd05f0db, ADR-9f03438f5422, ADR-ff294eff4d1a and ADR-85e6bbb195b8 -- those three perimeters are held elsewhere. The abbreviated pattern returns 40, which is the 37 plus two references no full-id sweep would see: `SPEC-fe8b` twice in crates/ank-tui/src/view.rs (a frame assertion and a prefix filter), and `ADR-ff29` once in crates/ank-daemon/src/stream.rs:17, an abbreviation of ADR-ff294eff4d1a.

--- a/.ank/entities/LOG-dca472145684.md
+++ b/.ank/entities/LOG-dca472145684.md
@@ -1,0 +1,26 @@
+---
+id: LOG-dca472145684
+type: log
+title: done, proof test:local/7d48e58f54fd@fa1f999 test:local/e3b0c44298fc@fa1f999
+created: 2026-08-31T05:00:11Z
+author: claude-code/opus-5+citA
+scope:
+  - crates/ank-daemon/src/declare.rs
+  - crates/ank-daemon/src/fetch.rs
+  - crates/ank-daemon/src/lib.rs
+  - crates/ank-daemon/src/stream.rs
+  - crates/ank-daemon/src/warm.rs
+  - crates/ank-daemon/tests/dependencies.rs
+  - crates/ank-contract/src/events.rs
+  - crates/ank-tui/src/stream.rs
+  - crates/ank-tui/src/view.rs
+  - crates/ank-cli/src/cli.rs
+  - crates/ank-cli/src/context.rs
+  - crates/ank-cli/src/status.rs
+  - .github/workflows/release.yml
+  - docs/integrating.md
+about: TASK-d8448e35354e
+seq: 2
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-dddfe6bbb623.md
+++ b/.ank/entities/LOG-dddfe6bbb623.md
@@ -1,0 +1,38 @@
+---
+id: LOG-dddfe6bbb623
+type: log
+title: Counted after, measured not read, on ank 0.7.0 (bdf6e82) rebuilt from this tree and re-measured
+created: 2026-08-31T04:54:46Z
+author: claude-code/opus-5+citA
+scope:
+  - crates/ank-daemon/src/declare.rs
+  - crates/ank-daemon/src/fetch.rs
+  - crates/ank-daemon/src/lib.rs
+  - crates/ank-daemon/src/stream.rs
+  - crates/ank-daemon/src/warm.rs
+  - crates/ank-daemon/tests/dependencies.rs
+  - crates/ank-contract/src/events.rs
+  - crates/ank-tui/src/stream.rs
+  - crates/ank-tui/src/view.rs
+  - crates/ank-cli/src/cli.rs
+  - crates/ank-cli/src/context.rs
+  - crates/ank-cli/src/status.rs
+  - .github/workflows/release.yml
+  - docs/integrating.md
+about: TASK-d8448e35354e
+seq: 1
+schema: 4
+version: 1
+---
+
+ after merging origin/main. Over the same fourteen paths: 0 occurrences of the six retired ids in full, and 0 of the abbreviated forms -- from 37 and 40. What stands in their place: ADR-24e21cb83793 32 times, SPEC-d58b3a9e4e4d 5 and the prefix SPEC-d58b twice, ADR-67a4ac10c534 once. Nothing was dropped: every one of the 40 references survives as a citation of the successor. ank check exits 0, 364 tasks, 84 adr, 0 fault(s), and no finding names a file in this scope. cargo test --workspace green, 0 FAILED across 42 test binaries; cargo fmt --check green.
+
+Why a swap was safe for the bulk of it: ADR-24e21cb83793's constraint is ADR-a22cd3196529's word for word -- diffed with ank show and not assumed -- and only the scope moves, widening to crates/ank-daemon/**. Every one of the 32 sites cites a clause of that constraint: answers no verb, writes nothing but the fetch into a tracking namespace, nothing depends on it, an event says what changed and never what to do about it. Each sentence is true of the successor unchanged.
+
+One site was rewritten rather than swapped, and it is the one the equal id length would have hidden. crates/ank-daemon/src/stream.rs:17 read ".ank/log/ is a work trace with a grammar and an append-only rule (ADR-ff29)". ADR-67a4ac10c534 moves an entry to .ank/entities/LOG-<ID>.md, one file per entry addressed as an entity, and drops the append-only sentence; it says so about its own wording. Measured rather than read: this task's first entry landed at .ank/entities/LOG-d0e0223d29bd.md, so the successor already describes the tree and the retired text describes nothing that exists. The sentence now reads "an entity's log is a work trace with a grammar, kept as entities of its own (ADR-67a4ac10c534)", which is the half that survives the change and the half the contrast with a bounded, thrown-away stream actually needed.
+
+That abbreviation is written out in full deliberately. "ADR-ff29" is invisible to the walk accept and check share, so it would have outlived every future sweep while reading as a citation.
+
+Nothing the binary prints changed. The only non-comment edits are five assertion messages in crates/ank-daemon/tests/dependencies.rs and seven fixture lines in crates/ank-tui/src/view.rs, so no golden and no snapshot moves and the scope needed no amendment. The TUI fixture keeps status "accepted" beside the now-proposed successor because that field is sample data and already was: the same fixture carries TASK-49746735127f as "in_progress" where the corpus says "done".
+
+Two claims were pruned under me before the branch was pushed, which is the orphan sweep another agent's ank check runs: a task commit on an unpushed branch is not reachable to them. Pushing the branch first is what made the third claim hold.

--- a/.ank/entities/TASK-d8448e35354e.md
+++ b/.ank/entities/TASK-d8448e35354e.md
@@ -1,0 +1,51 @@
+---
+id: TASK-d8448e35354e
+type: task
+slug: re-point-the-runtime-crates-citations-of-the-six
+title: Re-point the runtime crates' citations of the six retired documents at their proposed successors
+created: 2026-08-31T04:31:15Z
+author: claude-code/opus-5+citA
+status: in_progress
+scope:
+  - crates/ank-daemon/src/declare.rs
+  - crates/ank-daemon/src/fetch.rs
+  - crates/ank-daemon/src/lib.rs
+  - crates/ank-daemon/src/stream.rs
+  - crates/ank-daemon/src/warm.rs
+  - crates/ank-daemon/tests/dependencies.rs
+  - crates/ank-contract/src/events.rs
+  - crates/ank-tui/src/stream.rs
+  - crates/ank-tui/src/view.rs
+  - crates/ank-cli/src/cli.rs
+  - crates/ank-cli/src/context.rs
+  - crates/ank-cli/src/status.rs
+  - .github/workflows/release.yml
+  - docs/integrating.md
+blocked_by: []
+done_criteria: |
+  No file in this task's scope names ADR-a22cd3196529, ADR-01b6dd05f0db, ADR-9f03438f5422, ADR-ff294eff4d1a, SPEC-fe8bdb84faca or ADR-85e6bbb195b8, in full or in an abbreviated form: git grep -nE 'ADR-a22cd3196529|ADR-01b6dd05f0db|ADR-9f03438f5422|ADR-ff294eff4d1a|SPEC-fe8bdb84faca|ADR-85e6bbb195b8|ADR-a22c|ADR-01b6|ADR-9f03|ADR-ff29|SPEC-fe8b|ADR-85e6bbb' over exactly those paths returns nothing, and ank check reports no citation finding against any of the six naming a file in this scope. Every site that survives as a citation names the proposed successor and the sentence around it is true of that successor; every site that does not is dropped rather than re-pointed, and the reason is in this task's log. cargo test --workspace and cargo fmt --check are green.
+criteria_by: creator
+verify: [cargo-test, fmt-check]
+schema: 4
+version: 2
+---
+
+Six supersessions landed on `main` as proposals. ADR-3b6ba766a42e refuses
+`accept` on any of them while a tracked file outside `.ank/` still cites what
+they retire, and names the two repairs: write the successor instead, or drop the
+citation and leave the history to `ank show`. This task performs that sweep over
+the runtime crates, the release workflow and the integrator guide. Three other
+perimeters -- the rest of `crates/ank-cli/src/`, the test and contract files, the
+manifests -- are held by other agents and are deliberately not in this scope.
+
+Two of the six reach these files. `ADR-a22cd3196529 -> ADR-24e21cb83793` is the
+bulk of it: the successor's constraint is the retired text word for word, and
+only the scope moves, so a citation of any clause stays true under the new id.
+`SPEC-fe8bdb84faca -> SPEC-d58b3a9e4e4d` reaches `crates/ank-tui/src/view.rs`,
+where the id is fixture data in a snapshot row rather than an appeal to what the
+document says.
+
+The criterion covers abbreviated forms because one site carries one: an
+abbreviated citation is invisible to the walk `check` and `accept` share, so a
+sweep that only matched full ids would leave a stale reference that no verifier
+can ever find again.

--- a/.ank/entities/TASK-d8448e35354e.md
+++ b/.ank/entities/TASK-d8448e35354e.md
@@ -5,7 +5,7 @@ slug: re-point-the-runtime-crates-citations-of-the-six
 title: Re-point the runtime crates' citations of the six retired documents at their proposed successors
 created: 2026-08-31T04:31:15Z
 author: claude-code/opus-5+citA
-status: in_progress
+status: done
 scope:
   - crates/ank-daemon/src/declare.rs
   - crates/ank-daemon/src/fetch.rs
@@ -26,8 +26,21 @@ done_criteria: |
   No file in this task's scope names ADR-a22cd3196529, ADR-01b6dd05f0db, ADR-9f03438f5422, ADR-ff294eff4d1a, SPEC-fe8bdb84faca or ADR-85e6bbb195b8, in full or in an abbreviated form: git grep -nE 'ADR-a22cd3196529|ADR-01b6dd05f0db|ADR-9f03438f5422|ADR-ff294eff4d1a|SPEC-fe8bdb84faca|ADR-85e6bbb195b8|ADR-a22c|ADR-01b6|ADR-9f03|ADR-ff29|SPEC-fe8b|ADR-85e6bbb' over exactly those paths returns nothing, and ank check reports no citation finding against any of the six naming a file in this scope. Every site that survives as a citation names the proposed successor and the sentence around it is true of that successor; every site that does not is dropped rather than re-pointed, and the reason is in this task's log. cargo test --workspace and cargo fmt --check are green.
 criteria_by: creator
 verify: [cargo-test, fmt-check]
+proof:
+  - type: test
+    ref: local/7d48e58f54fd@fa1f999
+    tree: scope/89c0f25fcbb4
+    criteria: e21d532eaa94
+    verifier: cargo-test@f14aeab36e1b
+    via: verifier
+  - type: test
+    ref: local/e3b0c44298fc@fa1f999
+    tree: scope/89c0f25fcbb4
+    criteria: e21d532eaa94
+    verifier: fmt-check@5ca6d10bcd55
+    via: verifier
 schema: 4
-version: 4
+version: 5
 ---
 
 Six supersessions landed on `main` as proposals. ADR-3b6ba766a42e refuses

--- a/.ank/entities/TASK-d8448e35354e.md
+++ b/.ank/entities/TASK-d8448e35354e.md
@@ -27,7 +27,7 @@ done_criteria: |
 criteria_by: creator
 verify: [cargo-test, fmt-check]
 schema: 4
-version: 2
+version: 4
 ---
 
 Six supersessions landed on `main` as proposals. ADR-3b6ba766a42e refuses

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,7 +130,7 @@ jobs:
       # One binary, and the workspace is what makes it one: the protocol
       # surface and the watcher are libraries linked into `ank` and dispatched
       # by the verbs `mcp` and `watch` (ADR-1ea31c2f3c5a, ADR-fd98f4bc6dea,
-      # ADR-a22cd3196529). A surface built from an older table than the CLI
+      # ADR-24e21cb83793). A surface built from an older table than the CLI
       # beside it used to be a thing that could happen; one executable built
       # once cannot disagree with itself.
       - name: build

--- a/crates/ank-cli/src/cli.rs
+++ b/crates/ank-cli/src/cli.rs
@@ -855,10 +855,10 @@ fn mcp(inv: &Invocation, cwd: &std::path::Path, out: &mut dyn std::io::Write) ->
     Ok(ExitCode::Ok)
 }
 
-/// `watch`, the watcher (ADR-a22cd3196529, ADR-1ea31c2f3c5a, §4).
+/// `watch`, the watcher (ADR-24e21cb83793, ADR-1ea31c2f3c5a, §4).
 ///
 /// **It answers no verb, and being started by one does not change that.** The
-/// clause a reader meets first in ADR-a22cd3196529 is the easiest one in this
+/// clause a reader meets first in ADR-24e21cb83793 is the easiest one in this
 /// tree to read backwards, so it is worth saying in the place the reading
 /// happens: what the decision forbids is a *query surface* -- a socket, a
 /// protocol, a subset of the CLI answering out of a resident process. It says
@@ -1225,7 +1225,7 @@ fn dispatch(
         return mcp(&inv, cwd, out);
     }
     // The sixth, and it goes one step further than the two above it
-    // (ADR-a22cd3196529). `watch` resolves no corpus at all: what it keeps warm
+    // (ADR-24e21cb83793). `watch` resolves no corpus at all: what it keeps warm
     // is what the reader declared outside every repository, so there is nothing
     // in the working directory for it to need, and a `.ank/` demanded here
     // would refuse the watcher in the one place a person is most likely to

--- a/crates/ank-cli/src/context.rs
+++ b/crates/ank-cli/src/context.rs
@@ -93,7 +93,7 @@ impl Coordination {
 /// is what reports a damaged ref, and a reader must not fail for having nothing
 /// to say about one.
 /// Where the watcher mirrors the remote's `refs/ank/*`, when somebody is
-/// running one (ADR-a22cd3196529).
+/// running one (ADR-24e21cb83793).
 ///
 /// **A mirror, and never the plane itself.** `refs/ank/claims/<id>` is where a
 /// claim of this clone lives, so a background process writing there would be

--- a/crates/ank-cli/src/status.rs
+++ b/crates/ank-cli/src/status.rs
@@ -161,7 +161,7 @@ pub fn run(
         .collect();
 
     // **What a watcher mirrored, which is the same fact arriving without the
-    // round trip** (ADR-a22cd3196529). `refs/ank/claims/*` in this clone is
+    // round trip** (ADR-24e21cb83793). `refs/ank/claims/*` in this clone is
     // whatever somebody last fetched by hand, so on a parc of clones the
     // section above reports holders as of an hour ago and has no way to say so.
     // A watcher mirrors the remote's namespace on the interval its declaration

--- a/crates/ank-contract/src/events.rs
+++ b/crates/ank-contract/src/events.rs
@@ -1,5 +1,5 @@
 //! The change stream: what the watcher says happened, and where it says it
-//! (ADR-a22cd3196529, TASK-2f7777a1fdff).
+//! (ADR-24e21cb83793, TASK-2f7777a1fdff).
 //!
 //! `ank-daemon` already knows when a corpus it watches moves. Until this module
 //! that knowledge reached a person as a line on stderr and reached a program not
@@ -8,7 +8,7 @@
 //! that answer best are the verbs that renew a lease (ADR-0bb7ea8991bc).
 //!
 //! **An event says what changed, and never what to do about it.** That is the
-//! line ADR-a22cd3196529 draws to keep the watcher from becoming a third
+//! line ADR-24e21cb83793 draws to keep the watcher from becoming a third
 //! dispatch path, and it is easy to cross by kindness: an event carrying the new
 //! state of a task would save its reader a call, and would make the watcher a
 //! source of entity content that nothing generated from `COMMANDS` ever
@@ -16,7 +16,7 @@
 //! constructor that takes anything else, and the test at the foot of this file
 //! is what keeps it that way.
 //!
-//! **A file, and deliberately not a socket.** ADR-a22cd3196529 says the watcher
+//! **A file, and deliberately not a socket.** ADR-24e21cb83793 says the watcher
 //! answers no verb and exposes no query surface of its own. A socket is a place
 //! a caller connects *to*, and the first convenient question asked over one is
 //! the beginning of the surface that decision refused. A file is a place the

--- a/crates/ank-daemon/src/declare.rs
+++ b/crates/ank-daemon/src/declare.rs
@@ -1,5 +1,5 @@
 //! The declaration: which corpora this reader wants kept warm
-//! (ADR-a22cd3196529).
+//! (ADR-24e21cb83793).
 //!
 //! **Declared, never discovered.** ADR-621a7fd96ce1 says it and
 //! ADR-96174f1ac2b7 repeats it: nothing walks a filesystem looking for a

--- a/crates/ank-daemon/src/fetch.rs
+++ b/crates/ank-daemon/src/fetch.rs
@@ -1,5 +1,5 @@
 //! The one thing this process writes into somebody else's repository
-//! (ADR-a22cd3196529).
+//! (ADR-24e21cb83793).
 //!
 //! **A tracking namespace, and never the corpus's own.** `init` wires
 //! `+refs/ank/*:refs/ank/*`, so the fetch a person runs by hand lands the

--- a/crates/ank-daemon/src/lib.rs
+++ b/crates/ank-daemon/src/lib.rs
@@ -1,5 +1,5 @@
 //! `ank watch`: it keeps declared corpora warm, and that is the whole of it
-//! (ADR-a22cd3196529).
+//! (ADR-24e21cb83793).
 //!
 //! **It answers no verb.** There is no query surface here, no socket, no
 //! protocol and no subset of the CLI wearing a different name. A caller that
@@ -108,7 +108,7 @@ const DEFAULT_INTERVAL: Duration = Duration::from_millis(500);
 /// process and no search to get it wrong. There is deliberately no corpus here
 /// -- the corpora are what the reader declared in [`declare::WATCH_FILE`], and
 /// a watcher that took one from the directory it was started in would be
-/// discovering a corpus, which is the thing ADR-a22cd3196529 refuses first.
+/// discovering a corpus, which is the thing ADR-24e21cb83793 refuses first.
 pub struct Address {
     /// The binary a warming runs. `std::env::current_exe()` of the process
     /// serving the verb -- see the note on [`warm`].
@@ -284,7 +284,7 @@ fn identity_of(root: &Path) -> Option<String> {
 /// exactly as long as they were not editing -- which is most of the time, and
 /// all of the time that matters after a `git checkout`. That pass is a warming
 /// and not a change, so it says so: an event states what changed
-/// (ADR-a22cd3196529), and a first sighting is not one.
+/// (ADR-24e21cb83793), and a first sighting is not one.
 ///
 /// **Two kinds of change, because there are two things to see.** The files
 /// under `.ank/` moving is one; the mirror of somebody else's `refs/ank/*`

--- a/crates/ank-daemon/src/stream.rs
+++ b/crates/ank-daemon/src/stream.rs
@@ -1,4 +1,4 @@
-//! Putting a change onto the stream (ADR-a22cd3196529, TASK-2f7777a1fdff).
+//! Putting a change onto the stream (ADR-24e21cb83793, TASK-2f7777a1fdff).
 //!
 //! The shape of an event, where it goes and what it may carry are
 //! [`ank_contract::events`], because a stream has two ends and they must not
@@ -6,17 +6,18 @@
 //! starting it over when it has grown past what news is worth.
 //!
 //! **Writing is best-effort, in the way everything this process does is.**
-//! Nothing depends on the watcher (ADR-a22cd3196529), so a stream that cannot be
+//! Nothing depends on the watcher (ADR-24e21cb83793), so a stream that cannot be
 //! written is a stream nobody gets, exactly as if no watcher were running. A
 //! full disk, a configuration directory somebody removed, a permission somebody
 //! changed: each costs a line on stderr and the next poll, and none of them
 //! reaches the exit code of anything the person is running.
 //!
 //! **An event is not a log entry**, and the difference is why this file is
-//! allowed to be thrown away. `.ank/log/` is a work trace with a grammar and an
-//! append-only rule (ADR-ff29); this is news, nothing is anchored in it and no
-//! hash chains over it, so a reader that was not running missed what happened
-//! while it was not running, and the file is bounded rather than kept.
+//! allowed to be thrown away. An entity's log is a work trace with a grammar,
+//! kept as entities of its own (ADR-67a4ac10c534); this is news, nothing is
+//! anchored in it and no hash chains over it, so a reader that was not running
+//! missed what happened while it was not running, and the file is bounded
+//! rather than kept.
 
 use ank_contract::events::{self, Change, Event};
 use std::io::Write;
@@ -64,7 +65,7 @@ pub fn emit(path: &Path, identity: &str, change: Change) -> Result<(), String> {
 /// reader of the old bytes, nothing refers back to them, and a rotation would
 /// leave a directory of files somebody has to clean up. A follower notices
 /// because the file is suddenly shorter than the offset it holds, which
-/// ADR-a22cd3196529's reader handles by reading from the beginning again.
+/// ADR-24e21cb83793's reader handles by reading from the beginning again.
 fn start_over_if_long(path: &Path) -> Result<(), String> {
     let long = std::fs::metadata(path).map(|m| m.len() >= events::CAP);
     if !matches!(long, Ok(true)) {

--- a/crates/ank-daemon/src/warm.rs
+++ b/crates/ank-daemon/src/warm.rs
@@ -1,5 +1,5 @@
 //! Keeping a declared corpus's index current, and doing it through the CLI
-//! (ADR-a22cd3196529).
+//! (ADR-24e21cb83793).
 //!
 //! **The daemon is not a second implementation of the index.** `index.rs` is a
 //! cache the CLI rebuilds from the files at read time, comparing a content hash
@@ -10,7 +10,7 @@
 //! answers rather than fails.
 //!
 //! So this spawns `ank` and asks it for a listing. That is also what keeps
-//! ADR-a22cd3196529's first clause true by construction: a process that has to
+//! ADR-24e21cb83793's first clause true by construction: a process that has to
 //! run the CLI to learn anything is not a second dispatch path, because it has
 //! no dispatch of its own to be one. It is the rule ADR-8bd7ea0e8f2b already
 //! set for the terminal reader, applied to the one other thing that reads a

--- a/crates/ank-daemon/tests/dependencies.rs
+++ b/crates/ank-daemon/tests/dependencies.rs
@@ -1,5 +1,5 @@
 //! **The watcher is not a second implementation of anything**, made mechanical
-//! (ADR-a22cd3196529, TASK-9dd22f2b0430).
+//! (ADR-24e21cb83793, TASK-9dd22f2b0430).
 //!
 //! The file folded into `ank`; the read did not. That is the clause the decision
 //! rests its first paragraph on, and its reason is not symmetry: a process that
@@ -20,7 +20,7 @@
 //! **What this crate may do that those two may not is spawn `git`**, and the
 //! assertions below say so rather than copying a prohibition that does not
 //! belong here. Mirroring `refs/ank/*` into a tracking namespace is the one
-//! thing ADR-a22cd3196529 has this process write into somebody else's
+//! thing ADR-24e21cb83793 has this process write into somebody else's
 //! repository, and it is a fetch and nothing else -- which is a claim about
 //! *which* git commands are reachable, so that is what is asserted.
 
@@ -87,7 +87,7 @@ fn the_graph_carries_neither_the_dispatch_nor_the_core() {
     for forbidden in ["ank-cli", "ank-core"] {
         assert!(
             !names.iter().any(|n| n == forbidden),
-            "ank-daemon links {forbidden}, and ADR-a22cd3196529 forbids it: what \
+            "ank-daemon links {forbidden}, and ADR-24e21cb83793 forbids it: what \
              folded into the one binary is the file and never the read, so the \
              watcher warms the index by running `ank` or it is a second \
              implementation of one.\n{tree}"
@@ -160,7 +160,7 @@ fn the_crate_declares_a_library_and_no_binary() {
     assert!(
         declarations.contains(&"[lib]"),
         "the crate declares no library target, and the verb `ank watch` links \
-         one (ADR-a22cd3196529, ADR-1ea31c2f3c5a)"
+         one (ADR-24e21cb83793, ADR-1ea31c2f3c5a)"
     );
     assert!(
         !declarations.contains(&"[[bin]]"),
@@ -207,7 +207,7 @@ fn nothing_that_reaches_into_a_watched_checkout_opens_what_it_finds() {
                 "{file} calls {forbidden} inside a watched checkout: the \
                  watcher learns what a corpus holds by running the binary, and \
                  a second reader of these files drifts silently because a stale \
-                 cache answers rather than fails (ADR-a22cd3196529)"
+                 cache answers rather than fails (ADR-24e21cb83793)"
             );
         }
     }
@@ -237,7 +237,7 @@ fn the_only_document_this_crate_parses_is_the_declaration() {
             !text.contains("serde_yaml") && !text.contains("Deserialize"),
             "{file} parses a document, and the one document this process reads \
              is the reader's own declaration in declare.rs: what a corpus holds \
-             is what the binary answers (ADR-a22cd3196529)"
+             is what the binary answers (ADR-24e21cb83793)"
         );
     }
 }
@@ -255,7 +255,7 @@ fn the_only_document_this_crate_parses_is_the_declaration() {
 /// The git commands are enumerated rather than counted, because "we only fetch
 /// `refs/ank/*`" is a sentence that stays true right up until a second command
 /// is added beside it. A subcommand not on this list is a write into somebody's
-/// repository that ADR-a22cd3196529 did not authorise -- and the ones that are
+/// repository that ADR-24e21cb83793 did not authorise -- and the ones that are
 /// here are read-only but for the fetch, whose refspec
 /// `a_watching_cycle_moves_the_tracking_namespace_and_nothing_else` pins.
 #[test]
@@ -296,7 +296,7 @@ fn the_sources_spawn_git_and_the_binary_the_dispatch_named() {
                 "{file} runs `git {subcommand}`, which is not one of \
                  {allowed_git:?}: the one thing this process writes into a \
                  repository is a fetch into the tracking namespace \
-                 (ADR-a22cd3196529)"
+                 (ADR-24e21cb83793)"
             );
         }
     }

--- a/crates/ank-tui/src/stream.rs
+++ b/crates/ank-tui/src/stream.rs
@@ -1,4 +1,4 @@
-//! Following the watcher's change stream (TASK-2f7777a1fdff, ADR-a22cd3196529).
+//! Following the watcher's change stream (TASK-2f7777a1fdff, ADR-24e21cb83793).
 //!
 //! The corpus is a working tree and it moves under a screen left open. Until
 //! this module the only answer was `r`, and the only alternative anybody ever
@@ -11,7 +11,7 @@
 //! **Following is not asking.** Nothing here talks to the watcher, and there is
 //! nothing to talk to: the stream is a file, the watcher writes it, and several
 //! readers follow the same bytes without it knowing any of them exist. That is
-//! what keeps ADR-a22cd3196529's "answers no verb" true with a consumer
+//! what keeps ADR-24e21cb83793's "answers no verb" true with a consumer
 //! attached, and it is why the watcher's absence costs a repaint that has to be
 //! typed rather than an error.
 //!
@@ -140,7 +140,7 @@ impl Follower {
         };
         let len = meta.len();
         if len < self.offset {
-            // The watcher started the file over (ADR-a22cd3196529's stream is
+            // The watcher started the file over (ADR-24e21cb83793's stream is
             // news and is bounded, not kept). Reading from the beginning again
             // costs at most one repaint of a corpus that has certainly changed.
             self.offset = 0;

--- a/crates/ank-tui/src/view.rs
+++ b/crates/ank-tui/src/view.rs
@@ -4781,7 +4781,7 @@ mod tests {
             entities: vec![
                 row("ADR-8bd76e8d7c4e", "adr", "accepted", "A terminal reader"),
                 row("TASK-49746735127f", "task", "in_progress", "ank tui opens"),
-                row("SPEC-fe8bdb84faca", "spec", "accepted", "The CLI surface"),
+                row("SPEC-d58b3a9e4e4d", "spec", "accepted", "The CLI surface"),
             ],
             total: 3,
         }
@@ -6254,7 +6254,7 @@ mod tests {
         for expected in [
             "ADR-8bd7",
             "TASK-4974",
-            "SPEC-fe8b",
+            "SPEC-d58b",
             "accepted",
             "in_progress",
             "wave4/tui-verb",
@@ -7238,7 +7238,7 @@ mod tests {
             [2, 1, 1, 1],
             "the list did not follow the needle keystroke by keystroke"
         );
-        assert_eq!(rendered_rows(&a), ["SPEC-fe8bdb84faca"]);
+        assert_eq!(rendered_rows(&a), ["SPEC-d58b3a9e4e4d"]);
         assert_eq!(a.note, None, "narrowing said something");
 
         // A Backspace widens it again, on the keystroke, for the same reason.
@@ -7750,13 +7750,13 @@ mod tests {
             // makes a selection mean anything.
             assert_eq!(
                 a.selected_id(Focus::Entities).as_deref(),
-                Some("SPEC-fe8bdb84faca")
+                Some("SPEC-d58b3a9e4e4d")
             );
             // The mark is drawn on it, and on no other row.
             let frame = a.frame();
             let marked = frame
                 .lines()
-                .filter(|l| l.contains("> ") && l.contains("SPEC-fe8b"))
+                .filter(|l| l.contains("> ") && l.contains("SPEC-d58b"))
                 .count();
             assert_eq!(marked, 1, "{frame}");
         }
@@ -7814,7 +7814,7 @@ mod tests {
 
             press_at(&mut a, &ank, at, start + SECOND_PRESS);
             assert!(
-                reached_for(&a).contains("SPEC-fe8bdb84faca"),
+                reached_for(&a).contains("SPEC-d58b3a9e4e4d"),
                 "two presses on the row at {size:?} opened nothing: {}",
                 reached_for(&a)
             );
@@ -7884,7 +7884,7 @@ mod tests {
 
         press_at(&mut a, &ank, at, past + Duration::from_millis(1));
         assert!(
-            reached_for(&a).contains("SPEC-fe8bdb84faca"),
+            reached_for(&a).contains("SPEC-d58b3a9e4e4d"),
             "the press past the interval was not counted as the one that \
              chooses: {}",
             reached_for(&a)

--- a/docs/integrating.md
+++ b/docs/integrating.md
@@ -413,7 +413,7 @@ rebuild. It is a verb of the same one executable every route installs
 (ADR-1ea31c2f3c5a), so every installation already has it -- and running one is
 still nobody's condition for anything, which is the statement below about
 nothing depending on it. Everything else worth knowing about it as an
-integrator is what it refuses to be (ADR-a22cd3196529).
+integrator is what it refuses to be (ADR-24e21cb83793).
 
 **It is not a surface.** No socket, no protocol, no query of its own, and no
 subset of the verbs. There is nothing here to ask: a caller that wants an answer
@@ -519,7 +519,7 @@ handed; each line says which corpus it is about.
 and no entity content of any kind, and it never will: an event that carried the
 new state of a task would save you a call and would make the watcher a source of
 corpus data that nothing generated from the verb table ever validated
-(ADR-a22cd3196529). What changed is on the stream; what is now true of it is what
+(ADR-24e21cb83793). What changed is on the stream; what is now true of it is what
 the CLI answers, and `no_event_carries_entity_content_a_reader_would_get_from_the_cli`
 asserts the absence rather than promising it. An event also never says what to do
 about itself. There is one sensible thing to do, which is to read the corpus


### PR DESCRIPTION
`ADR-3b6ba766a42e` refuses `accept` on a supersession while any tracked file
outside `.ank/` still cites the document it retires. Six supersessions are
waiting proposed on `main`; this clears the runtime perimeter so they can be
signed. Three other perimeters — the rest of `crates/ank-cli/src/`, the tests
and contract, the manifests — are held by other agents and are deliberately
untouched here.

**Counted, not read.** Over the fourteen paths `TASK-d8448e35354e` scopes:
37 → 0 occurrences of the six retired ids in full, and 40 → 0 including
abbreviated forms. Nothing was dropped; every reference survives as a citation
of the successor.

| retired | successor | sites |
| --- | --- | --- |
| `ADR-a22cd3196529` | `ADR-24e21cb83793` | 32 |
| `SPEC-fe8bdb84faca` | `SPEC-d58b3a9e4e4d` | 5 + 2 prefixes |
| `ADR-ff29` (abbreviated) | `ADR-67a4ac10c534` | 1 |

The other three retired ids reach no file in this scope.

### Why the bulk is a swap

`ADR-24e21cb83793`'s constraint is `ADR-a22cd3196529`'s word for word — diffed
with `ank show`, not assumed — and only the scope moves, widening to
`crates/ank-daemon/**`. Every one of the 32 sites cites a clause of that
constraint (answers no verb, writes nothing but the tracking fetch, nothing
depends on it, an event says what changed and never what to do about it), so
each sentence is true of the successor unchanged.

The `SPEC-` sites are fixture data in the TUI view tests, not an appeal to what
the document says. The fixture keeps `"accepted"` beside the now-proposed
successor because that field is sample data and already was: the same fixture
carries `TASK-49746735127f` as `in_progress` where the corpus says `done`.

### The one site rewritten rather than swapped

`crates/ank-daemon/src/stream.rs:17` read *"`.ank/log/` is a work trace with a
grammar and an append-only rule (ADR-ff29)"*. `ADR-67a4ac10c534` moves an entry
to `.ank/entities/LOG-<ID>.md`, one file per entry addressed as an entity, and
drops the append-only sentence — it says so about its own wording. Measured:
this task's own log entries landed at `.ank/entities/LOG-*.md`, so the successor
already describes the tree and the retired text describes nothing that exists.
The sentence now names what survives the change, and it names the successor in
full: an abbreviation is invisible to the walk `accept` and `check` share, so it
would have outlived every future sweep while reading as a citation.

### Blast radius

Nothing the binary prints changed. The only non-comment edits are five assertion
messages in `crates/ank-daemon/tests/dependencies.rs` and seven fixture lines in
`crates/ank-tui/src/view.rs`, so no golden and no snapshot moves and the scope
needed no amendment.

`cargo test --workspace` and `cargo fmt --check` ran under `ank done` as the
task's declared verifiers; `ank check` exits 0 with 0 faults and no finding
naming a file in this scope.

**These six stay proposed.** `ank accept` is not run here and this branch signs
nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5C1MsjrBP89v9HbAUgC7U
