### PR TITLE
The test suites, the contract table and the manifests cite the six proposed successors

### DIFF
--- a/.ank/entities/LOG-3a9cb6f5a787.md
+++ b/.ank/entities/LOG-3a9cb6f5a787.md
@@ -1,0 +1,24 @@
+---
+id: LOG-3a9cb6f5a787
+type: log
+title: "Baseline counted through git grep over the ten scoped files: 36 occurrences of the six retired ids"
+created: 2026-08-31T04:40:23Z
+author: claude-code/opus-5+citC
+scope:
+  - crates/ank-cli/tests/cli.rs
+  - crates/ank-cli/tests/skill.rs
+  - crates/ank-cli/tests/watch.rs
+  - crates/ank-contract/src/verbs.rs
+  - crates/ank-cli/Cargo.toml
+  - crates/ank-contract/Cargo.toml
+  - crates/ank-daemon/Cargo.toml
+  - crates/ank-mcp/Cargo.toml
+  - crates/ank-tui/Cargo.toml
+  - NOTICE
+about: TASK-435d812d66bd
+seq: 0
+schema: 4
+version: 1
+---
+
+ on 35 lines (skill.rs:241 names two of them). Per id: ADR-a22cd3196529 12, ADR-9f03438f5422 12, ADR-01b6dd05f0db 7, ADR-ff294eff4d1a 4, SPEC-fe8bdb84faca 2, ADR-85e6bbb195b8 0 -- the naming ADR is cited nowhere in this perimeter.

--- a/.ank/entities/LOG-4f3c6f0bed03.md
+++ b/.ank/entities/LOG-4f3c6f0bed03.md
@@ -1,0 +1,32 @@
+---
+id: LOG-4f3c6f0bed03
+type: log
+title: Counted after, the same way as before and through git rather than by eye. The baseline in
+created: 2026-08-31T05:07:35Z
+author: claude-code/opus-5+citC
+scope:
+  - crates/ank-cli/tests/cli.rs
+  - crates/ank-cli/tests/skill.rs
+  - crates/ank-cli/tests/watch.rs
+  - crates/ank-contract/src/verbs.rs
+  - crates/ank-cli/Cargo.toml
+  - crates/ank-contract/Cargo.toml
+  - crates/ank-daemon/Cargo.toml
+  - crates/ank-mcp/Cargo.toml
+  - crates/ank-tui/Cargo.toml
+  - NOTICE
+about: TASK-435d812d66bd
+seq: 2
+schema: 4
+version: 1
+---
+
+ LOG-3a9cb6f5a787 says 36 occurrences; that number is wrong and the correct one is 37 -- I summed the per-id counts by hand and dropped one. Recounted against origin/main with str.count over the ten files: ADR-a22cd3196529 12, ADR-9f03438f5422 12, ADR-01b6dd05f0db 7, ADR-ff294eff4d1a 4, SPEC-fe8bdb84faca 2, ADR-85e6bbb195b8 0, total 37 on 36 lines. After: 0 retired ids in the perimeter, 34 citations of the successors -- ADR-24e21cb83793 12, ADR-534c7a3e6cf8 11, ADR-e45e1a29fe91 7, ADR-67a4ac10c534 3, SPEC-d58b3a9e4e4d 1. ank check answers 'ok -- 364 tasks, 84 adr, 456 signal(s)' at exit 0, with no fault of any kind and no citation finding against the six. cargo fmt --check exits 0; cargo test --workspace exits 0 across 46 test-result blocks with no FAILED line.
+
+Three of the 37 were dropped instead of re-pointed, each because the sentence is a claim about a particular document rather than about the rule it carries, and a re-point would have made the sentence false.
+
+crates/ank-cli/tests/skill.rs, the NOT_YET_DISPATCHED doc comment: 'while SPEC-fe8bdb84faca was still proposed and the block this suite walks was its predecessor' is a dated observation, and SPEC-d58b3a9e4e4d did not exist when mcp and watch were declared. The file argues against pinning an id here in its own words sixty lines above -- 'the document is found by what it carries rather than by its id, so a supersession that replaces it keeps this test green' -- so the id went and 'the section 4 document of the day' took its place. The ADR-a22cd3196529 on the same line was re-pointed; only the SPEC id was dropped.
+
+crates/ank-cli/tests/cli.rs, over two_branches_recording_an_entry_merge_with_no_conflict: 'the case ADR-ff294eff4d1a celebrated most and the one it did not cover'. ADR-67a4ac10c534 keeps that clause word for word but argues the opposite about it -- it says the case is gone rather than uncovered, because ADR-25f977377fa0 made an entry a file. Naming the successor would have attributed to it an omission it addresses in as many words. The sentence now names the decision by what it did, and ADR-25f977377fa0 in the next clause anchors it.
+
+crates/ank-cli/tests/skill.rs, over declared_licences: 'TASK-47beb64fd204 swept the tree when ADR-9f03438f5422 relicensed it'. ADR-534c7a3e6cf8 relicenses nothing: it carries the licence verbatim and says the licence is its predecessor's and does not move, changing only the channel list. TASK-47beb64fd204 still anchors the sweep, so the id was dropped and the act named plainly.

--- a/.ank/entities/LOG-50b9144b3f31.md
+++ b/.ank/entities/LOG-50b9144b3f31.md
@@ -1,0 +1,28 @@
+---
+id: LOG-50b9144b3f31
+type: log
+title: "The first claim was pruned before any edit landed: ank new task wrote the entity, ank claim took"
+created: 2026-08-31T04:45:21Z
+author: claude-code/opus-5+citC
+scope:
+  - crates/ank-cli/tests/cli.rs
+  - crates/ank-cli/tests/skill.rs
+  - crates/ank-cli/tests/watch.rs
+  - crates/ank-contract/src/verbs.rs
+  - crates/ank-cli/Cargo.toml
+  - crates/ank-contract/Cargo.toml
+  - crates/ank-daemon/Cargo.toml
+  - crates/ank-mcp/Cargo.toml
+  - crates/ank-tui/Cargo.toml
+  - NOTICE
+about: TASK-435d812d66bd
+seq: 1
+schema: 4
+version: 1
+---
+
+ it, and the next verb answered 'no task in progress for this agent' with the file still untracked. Committing TASK-435d812d66bd and its log entry on the branch and re-claiming restored it. The lesson is the ordering, not the tool: commit the task before the first log.
+
+Read all six pairs before editing. Four supersessions carry their constraint word for word and change only the perimeter or an enumeration. ADR-24e21cb83793 is ADR-a22cd3196529's text verbatim with crates/ank-daemon/** added to the scope. ADR-534c7a3e6cf8 keeps the licence and the prospective clause verbatim and replaces the Homebrew/Scoop/winget enumeration with a pointer at ADR-221aa5da440a. ADR-e45e1a29fe91 keeps the opacity rule and re-enumerates the routes, gaining amend/edit/config/read on the writing side and scope/graph/status/review/check/log on the reading side. ADR-67a4ac10c534 keeps every clause but the address, which moves from .ank/log/<ID>.md to .ank/entities/LOG-<ID>.md. SPEC-d58b3a9e4e4d differs from SPEC-fe8bdb84faca in exactly one paragraph, the mcp/watch one. ADR-85e6bbb195b8 is cited nowhere in this perimeter.
+
+Measured the golden exposure rather than assuming it. verbs.rs carries one retired id inside a printed string, the second note on 'review'. crates/ank-cli/tests/cli.rs:18137 normalises every hex run to <HEX> before comparing, and help.json already stores that note as 'since ADR-<HEX> closes that file to a direct read'. Every re-point is length-preserving besides, ADR- ids being 16 characters and SPEC- ids 17. So no golden moves and no ank amend --scope is needed.

--- a/.ank/entities/LOG-73a904381de2.md
+++ b/.ank/entities/LOG-73a904381de2.md
@@ -1,0 +1,22 @@
+---
+id: LOG-73a904381de2
+type: log
+title: done, proof test:local/8a5b2e59eab9@454ae08 test:local/e3b0c44298fc@454ae08
+created: 2026-08-31T05:11:25Z
+author: claude-code/opus-5+citC
+scope:
+  - crates/ank-cli/tests/cli.rs
+  - crates/ank-cli/tests/skill.rs
+  - crates/ank-cli/tests/watch.rs
+  - crates/ank-contract/src/verbs.rs
+  - crates/ank-cli/Cargo.toml
+  - crates/ank-contract/Cargo.toml
+  - crates/ank-daemon/Cargo.toml
+  - crates/ank-mcp/Cargo.toml
+  - crates/ank-tui/Cargo.toml
+  - NOTICE
+about: TASK-435d812d66bd
+seq: 4
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-7f6d735b36c3.md
+++ b/.ank/entities/LOG-7f6d735b36c3.md
@@ -1,0 +1,26 @@
+---
+id: LOG-7f6d735b36c3
+type: log
+title: The golden contract files were checked rather than assumed, because verbs.rs is the generated
+created: 2026-08-31T05:07:50Z
+author: claude-code/opus-5+citC
+scope:
+  - crates/ank-cli/tests/cli.rs
+  - crates/ank-cli/tests/skill.rs
+  - crates/ank-cli/tests/watch.rs
+  - crates/ank-contract/src/verbs.rs
+  - crates/ank-cli/Cargo.toml
+  - crates/ank-contract/Cargo.toml
+  - crates/ank-daemon/Cargo.toml
+  - crates/ank-mcp/Cargo.toml
+  - crates/ank-tui/Cargo.toml
+  - NOTICE
+about: TASK-435d812d66bd
+seq: 3
+schema: 4
+version: 1
+---
+
+ machine contract's source table and the brief warned a change here can move tests/golden-json/help.json and help-verb.json. One retired id sits in a printed string: the second note on 'review', 'the signers are what .ank/allowed_signers declares; this is where they are read, since ADR-<id> closes that file to a direct read'. help.json already stores that note as 'since ADR-<HEX> closes that file to a direct read' -- cli.rs:18137 replaces every hex run with <HEX> before comparing -- so the id never reaches the golden. help-verb.json covers 'claim' alone and carries no ADR at all. git grep over crates/ank-cli/tests/golden-json/ finds none of the six ids in any of the 26 files, before or after. cargo test --workspace was green with the goldens untouched, which is the measurement rather than the reading. No ank amend --scope was needed and nothing outside the ten scoped files was edited.
+
+The other change to verbs.rs, e803e34 'Every coordinating verb's help says what a refused push does to its exit code', does not collide with this work: 'review' is coordinates: false, so it took no such note, and the four sites re-pointed in verbs.rs are three doc comments and one note string that commit did not touch.

--- a/.ank/entities/TASK-435d812d66bd.md
+++ b/.ank/entities/TASK-435d812d66bd.md
@@ -5,7 +5,7 @@ slug: re-point-the-test-suites-the-contract-table-and
 title: Re-point the test suites, the contract table and the manifests at the six proposed successors
 created: 2026-08-31T04:40:14Z
 author: claude-code/opus-5+citC
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/tests/cli.rs
   - crates/ank-cli/tests/skill.rs
@@ -22,8 +22,21 @@ done_criteria: |
   git grep -E 'ADR-a22cd3196529|ADR-01b6dd05f0db|ADR-9f03438f5422|ADR-ff294eff4d1a|SPEC-fe8bdb84faca|ADR-85e6bbb195b8' over the ten files of this scope returns no line, and ank check reports no citation fault naming any of those six ids against any file in this scope. Every site that kept its citation names the proposed successor instead, and where the successor changed the substance the surrounding sentence or assertion states what the successor says, not what the retired document said. cargo test --workspace is green and cargo fmt --check is clean.
 criteria_by: creator
 verify: [cargo-test, fmt-check]
+proof:
+  - type: test
+    ref: local/8a5b2e59eab9@454ae08
+    tree: scope/e90ef96818ca
+    criteria: 328bda0b6e29
+    verifier: cargo-test@f14aeab36e1b
+    via: verifier
+  - type: test
+    ref: local/e3b0c44298fc@454ae08
+    tree: scope/e90ef96818ca
+    criteria: 328bda0b6e29
+    verifier: fmt-check@5ca6d10bcd55
+    via: verifier
 schema: 4
-version: 3
+version: 5
 ---
 
 Six supersessions landed on main as proposals. ADR-3b6ba766a42e refuses accept while any tracked file outside .ank/ still cites a retired document, and names the repair: re-point at the proposed successor, or drop the citation and leave the history to ank show.

--- a/.ank/entities/TASK-435d812d66bd.md
+++ b/.ank/entities/TASK-435d812d66bd.md
@@ -1,0 +1,41 @@
+---
+id: TASK-435d812d66bd
+type: task
+slug: re-point-the-test-suites-the-contract-table-and
+title: Re-point the test suites, the contract table and the manifests at the six proposed successors
+created: 2026-08-31T04:40:14Z
+author: claude-code/opus-5+citC
+status: in_progress
+scope:
+  - crates/ank-cli/tests/cli.rs
+  - crates/ank-cli/tests/skill.rs
+  - crates/ank-cli/tests/watch.rs
+  - crates/ank-contract/src/verbs.rs
+  - crates/ank-cli/Cargo.toml
+  - crates/ank-contract/Cargo.toml
+  - crates/ank-daemon/Cargo.toml
+  - crates/ank-mcp/Cargo.toml
+  - crates/ank-tui/Cargo.toml
+  - NOTICE
+blocked_by: []
+done_criteria: |
+  git grep -E 'ADR-a22cd3196529|ADR-01b6dd05f0db|ADR-9f03438f5422|ADR-ff294eff4d1a|SPEC-fe8bdb84faca|ADR-85e6bbb195b8' over the ten files of this scope returns no line, and ank check reports no citation fault naming any of those six ids against any file in this scope. Every site that kept its citation names the proposed successor instead, and where the successor changed the substance the surrounding sentence or assertion states what the successor says, not what the retired document said. cargo test --workspace is green and cargo fmt --check is clean.
+criteria_by: creator
+verify: [cargo-test, fmt-check]
+schema: 4
+version: 2
+---
+
+Six supersessions landed on main as proposals. ADR-3b6ba766a42e refuses accept while any tracked file outside .ank/ still cites a retired document, and names the repair: re-point at the proposed successor, or drop the citation and leave the history to ank show.
+
+This task takes the ten files listed in scope. Three other perimeters are held by other agents and are not touched here.
+
+The pairs, retired -> proposed successor:
+  ADR-a22cd3196529 -> ADR-24e21cb83793
+  ADR-01b6dd05f0db -> ADR-e45e1a29fe91
+  ADR-9f03438f5422 -> ADR-534c7a3e6cf8
+  ADR-ff294eff4d1a -> ADR-67a4ac10c534
+  SPEC-fe8bdb84faca -> SPEC-d58b3a9e4e4d
+  ADR-85e6bbb195b8 -> ADR-f8f1ea7fd2bb
+
+A sed is not the repair. A test that cites a document is asserting what that document said; where the successor moved the substance, the assertion moves with the id or it stops being true.

--- a/.ank/entities/TASK-435d812d66bd.md
+++ b/.ank/entities/TASK-435d812d66bd.md
@@ -23,7 +23,7 @@ done_criteria: |
 criteria_by: creator
 verify: [cargo-test, fmt-check]
 schema: 4
-version: 2
+version: 3
 ---
 
 Six supersessions landed on main as proposals. ADR-3b6ba766a42e refuses accept while any tracked file outside .ank/ still cites a retired document, and names the repair: re-point at the proposed successor, or drop the citation and leave the history to ank show.

--- a/NOTICE
+++ b/NOTICE
@@ -18,4 +18,4 @@ limitations under the License.
 Ank was distributed under GPL-3.0-only up to and including 0.2.0. That change
 is prospective, and this notice does not withdraw it: a release received under
 GPL-3.0 stays available under GPL-3.0 to whoever received it
-(ADR-9f03438f5422).
+(ADR-534c7a3e6cf8).

--- a/crates/ank-cli/Cargo.toml
+++ b/crates/ank-cli/Cargo.toml
@@ -12,11 +12,13 @@ edition = "2021"
 rust-version = "1.95"
 # Apache-2.0, and this is the crate where that is a decision rather than a
 # default: the tool used to be GPL-3.0-only, on the argument that the tool was
-# precisely the part worth defending with copyleft. ADR-9f03438f5422 replaced
-# that argument and says why the trade is judged differently -- and what it gives
-# up, which is that a proprietary fork is now permitted. Prospective only: a
-# release already made under GPL-3.0 stays available under GPL-3.0 to whoever
-# received it.
+# precisely the part worth defending with copyleft. ADR-534c7a3e6cf8 is the rule
+# that holds today. The argument that replaced the copyleft one -- why the trade
+# is judged differently, and what it gives up, which is that a proprietary fork
+# is now permitted -- is the predecessor's and is not restated there, so it is
+# read by following the succession with `ank show`. Prospective only: a release
+# already made under GPL-3.0 stays available under GPL-3.0 to whoever received
+# it.
 license = "Apache-2.0"
 authors = ["Sean Lamet"]
 description = "The Ank CLI: one surface, refusing on state and never on identity."
@@ -53,7 +55,7 @@ ank-tui = { path = "../ank-tui" }
 # not one process, and `crates/ank-mcp/tests/dependencies.rs` reads the graph to
 # keep that true.
 ank-mcp = { path = "../ank-mcp" }
-# The watcher of ADR-a22cd3196529, which ships as the verb `ank watch` rather
+# The watcher of ADR-24e21cb83793, which ships as the verb `ank watch` rather
 # than as a sibling binary, on the reading ADR-8bd76e8d7c4e gave for `tui` and
 # ADR-1ea31c2f3c5a made general. The dependency points this way and only this
 # way: the watcher reaches a declared corpus by running this binary, so it does

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -5088,7 +5088,7 @@ fn log_refuses_a_message_carrying_a_control_character() {
 /// assertion on each and neither is covered by the other.
 ///
 /// **The task file is compared byte for byte**, not field by field. The
-/// guarantee is that an entry is a file of its own (ADR-ff294eff4d1a) and moves
+/// guarantee is that an entry is a file of its own (ADR-67a4ac10c534) and moves
 /// nothing on the entity it is about — no frontmatter, no `version`, no
 /// `status` — and a field-by-field assertion would pass over exactly the byte
 /// it forgot to name.
@@ -6118,7 +6118,7 @@ fn status_says_a_checkout_level_with_origin_in_one_line() {
 }
 
 /// What a watcher mirrors into `refs/ank/watch/*` reaches `status`, and reaches
-/// nothing else (ADR-a22cd3196529).
+/// nothing else (ADR-24e21cb83793).
 ///
 /// The reader's half of the watcher. `refs/ank/claims/*` in this clone is
 /// whatever somebody last fetched by hand, so on a parc of clones `status`
@@ -10548,7 +10548,7 @@ fn json_number(text: &str, name: &str) -> u64 {
 }
 
 /// The identifiers of every superseded document in a corpus, asked of the
-/// binary (ADR-01b6dd05f0db: `.ank/` is reached only through the CLI).
+/// binary (ADR-e45e1a29fe91: `.ank/` is reached only through the CLI).
 ///
 /// **Derived and never transcribed.** A list in this file protects the cases
 /// somebody remembered and no fourth: superseding an entity does not add to it,
@@ -12651,9 +12651,11 @@ fn config_is_the_one_verb_a_config_that_does_not_parse_does_not_stop() {
 
 #[test]
 fn the_errors_that_named_the_file_now_name_the_command() {
-    // ADR-01b6dd05f0db closed `.ank/` to agents and stopped at the
-    // configuration, which left these telling their caller to open a file the
-    // same tool forbids them to open (ADR-e64dfaafd578).
+    // Closing `.ank/` to agents stopped at the configuration, which left
+    // these telling their caller to open a file the same tool forbids them to
+    // open (ADR-e64dfaafd578). ADR-e45e1a29fe91 is where the gap closes in the
+    // rule as well: it lists `config` among the writing routes, on the reading
+    // that the sentence governs `.ank/` and not only the entities in it.
     let r = Repo::new();
 
     // `new`, on a --verify that matches nothing. The criterion calls the two
@@ -12818,7 +12820,7 @@ const NOT_A_PATH: [&str; 28] = [
     // is one (ADR-96174f1ac2b7).
     "--user",
     // `watch`'s four, and all four are here for one reason: not one of them
-    // names anything in a corpus (ADR-a22cd3196529). Three carry no value at
+    // names anything in a corpus (ADR-24e21cb83793). Three carry no value at
     // all, and `--interval` carries a number of milliseconds.
     //
     // `--where` is the one worth a sentence, because it is the one that looks
@@ -15501,7 +15503,7 @@ review:
 
 /// **`review` names who may ratify, and nothing else can** (TASK-8a80b590b356).
 ///
-/// ADR-01b6dd05f0db closes `.ank/` to a direct read by an agent, and
+/// ADR-e45e1a29fe91 closes `.ank/` to a direct read by an agent, and
 /// `allowed_signers` is not an entity, so `show`, `find` and `config` all pass
 /// over it: before this, the one file the format asks a human to edit by hand
 /// was the one file no command could show. `review` is where the answer belongs
@@ -16377,7 +16379,7 @@ fn the_help_of_attest_says_a_detached_proof_fails_on_an_unreachable_remote() {
 }
 
 // ---------------------------------------------------------------------------
-// The log is a file, and an append is not a transition (§3, ADR-ff294eff4d1a)
+// An entry is a file, and writing it is not a transition (§3, ADR-67a4ac10c534)
 // ---------------------------------------------------------------------------
 
 const LOGGED: &str = "TASK-00000000c10a";
@@ -16495,13 +16497,14 @@ fn repository_gitattributes() -> String {
 /// adjacent-change case (TASK-6c0463fb4319). An assertion about the contents of
 /// `.gitattributes` would have proved none of that, in either direction.
 ///
-/// That is the case ADR-ff294eff4d1a celebrated most and the one it did not
-/// cover: a second party writing to a task's log while the holder writes to it
-/// too. ADR-25f977377fa0 removes it rather than resolving it — an entry is an
-/// entity, so two concurrent entries are **two new files** and there is nothing
-/// for a three-way merge to be three-way about. The test is kept, and it is
-/// kept because the failure it caught was a text everybody believed: what makes
-/// it evidence is that git actually runs.
+/// That is the case the decision moving the log out of the task file
+/// celebrated most and the one it did not cover: a second party writing to a
+/// task's log while the holder writes to it too. ADR-25f977377fa0 removes it
+/// rather than resolving it — an entry is an entity, so two concurrent entries
+/// are **two new files** and there is nothing for a three-way merge to be
+/// three-way about. The test is kept, and it is kept because the failure it
+/// caught was a text everybody believed: what makes it evidence is that git
+/// actually runs.
 #[test]
 fn two_branches_recording_an_entry_merge_with_no_conflict() {
     let r = Repo::new();
@@ -19740,7 +19743,7 @@ fn an_entity_that_cannot_account_for_a_version_is_reported_with_both_counts() {
 
     let checked = r.ank("claude-code/1.0", &["check"]);
     // A signal and never a fault: an entity written outside the CLI is legal,
-    // and exiting 8 over it would redden a pipeline on an act ADR-01b6dd05f0db
+    // and exiting 8 over it would redden a pipeline on an act ADR-e45e1a29fe91
     // permits a human outright.
     assert_eq!(
         code(&checked),
@@ -19900,7 +19903,7 @@ fn without_edits(text: &str) -> String {
 /// code and no answer.
 ///
 /// **Asserted by deletion rather than by a comment**, which is what the
-/// criterion asks and what ADR-ff294eff4d1a requires of the log: nothing
+/// criterion asks and what ADR-67a4ac10c534 requires of the log: nothing
 /// authoritative is anchored in it. A verb that had quietly started consulting
 /// one of these entries would answer differently here, whatever its author
 /// believed.

--- a/crates/ank-cli/tests/skill.rs
+++ b/crates/ank-cli/tests/skill.rs
@@ -54,7 +54,7 @@ fn push_once(verbs: &mut Vec<String>, verb: String) {
 /// **Read through the binary, and that is the point rather than a detour.** The
 /// specification is no longer a file in `docs/` — it is ten entities of kind
 /// `spec` in `.ank/` (ADR-c88f99e1c16e) — and `.ank/` is reached through the CLI
-/// and never by opening the files (ADR-01b6dd05f0db). A test that walked the
+/// and never by opening the files (ADR-e45e1a29fe91). A test that walked the
 /// directory would be the one reader in the repository exempt from the rule the
 /// repository enforces on every agent.
 ///
@@ -238,11 +238,11 @@ fn help_order() -> Vec<String> {
 /// shipping fails until the line is gone.
 ///
 /// `mcp` and `watch` were both declared here (ADR-fd98f4bc6dea,
-/// ADR-a22cd3196529, TASK-36666e36744e), while SPEC-fe8bdb84faca was still
-/// `proposed` and the block this suite walks was its predecessor: the signed
-/// `accept` is the moment §4 gains a verb, and declaring it beforehand is what
-/// makes the ratification itself green rather than red on a human act nobody is
-/// watching. Both have now been through the round trip whole -- the document is
+/// ADR-24e21cb83793, TASK-36666e36744e), while the §4 document of the day was
+/// still `proposed` and the block this suite walks was its predecessor: the
+/// signed `accept` is the moment §4 gains a verb, and declaring it beforehand
+/// is what makes the ratification itself green rather than red on a human act
+/// nobody is watching. Both have now been through the round trip whole -- the document is
 /// ratified, TASK-e655d28c83cb dispatched `mcp` and TASK-9dd22f2b0430
 /// dispatched `watch`, and each lost its entry here in the very commit that
 /// started shipping it, because the test below fails a declared verb that has
@@ -682,9 +682,10 @@ fn declared_revision(front: &str) -> Option<String> {
 /// **A copy in the wild says which revision it is.** Measured on 2026-08-02:
 /// the SKILL.md installed at `~/.claude/skills/ank` was byte-identical to the
 /// blob at a004ac7, two commits and nine hours behind a tree that had just
-/// withdrawn the invitation to read `.ank/` by hand (ADR-01b6dd05f0db). It was
-/// not merely old, it instructed against a ratified decision -- and it carried
-/// nothing by which its reader or its owner could have noticed.
+/// withdrawn the invitation to read `.ank/` by hand -- the rule
+/// ADR-e45e1a29fe91 states today. It was not merely old, it instructed against
+/// a ratified decision -- and it carried nothing by which its reader or its
+/// owner could have noticed.
 ///
 /// The marker is a hash of the body rather than a version anyone keeps by hand,
 /// for two reasons. A hand-kept number drifts the first time somebody edits the
@@ -905,17 +906,17 @@ fn the_binary_names_the_skill_revision_it_was_built_alongside() {
 }
 
 // ---------------------------------------------------------------------------
-// The licence, discovered rather than listed (ADR-9f03438f5422)
+// The licence, discovered rather than listed (ADR-534c7a3e6cf8)
 // ---------------------------------------------------------------------------
 
 /// Every manifest in the tree that declares a licence, found by walking rather
 /// than by a list somebody keeps.
 ///
 /// **A list is what let this drift.** TASK-47beb64fd204 swept the tree when
-/// ADR-9f03438f5422 relicensed it, and its criterion was met: every one of the
-/// eleven files it enumerated said Apache-2.0. `.claude-plugin/plugin.json` was
-/// not among the eleven, so it went on declaring `GPL-3.0-only` for thirteen
-/// days, in the one place a person installing the plugin reads a licence.
+/// the relicensing landed, and its criterion was met: every one of the eleven
+/// files it enumerated said Apache-2.0. `.claude-plugin/plugin.json` was not
+/// among the eleven, so it went on declaring `GPL-3.0-only` for thirteen days,
+/// in the one place a person installing the plugin reads a licence.
 /// Nothing noticed, because nothing was looking at anything but the list.
 ///
 /// So this walks. A manifest added tomorrow is held to the same answer without
@@ -937,7 +938,7 @@ fn declared_licences() -> Vec<(String, String)> {
                 .to_string();
             // Not build output, not vendored code, and not the corpus: `.ank/`
             // records what the licence *was*, and that history is the thing the
-            // relicensing is careful to keep (ADR-9f03438f5422).
+            // relicensing is careful to keep (ADR-534c7a3e6cf8).
             if path.is_dir() {
                 if !matches!(name.as_str(), "target" | "node_modules" | ".git" | ".ank") {
                     stack.push(path);
@@ -978,7 +979,7 @@ fn declared_licences() -> Vec<(String, String)> {
     found
 }
 
-/// **Every declaration in the tree says Apache-2.0** (ADR-9f03438f5422).
+/// **Every declaration in the tree says Apache-2.0** (ADR-534c7a3e6cf8).
 #[test]
 fn every_manifest_declares_the_ratified_licence() {
     let found = declared_licences();
@@ -989,7 +990,7 @@ fn every_manifest_declares_the_ratified_licence() {
     let wrong: Vec<_> = found.iter().filter(|(_, v)| v != "Apache-2.0").collect();
     assert!(
         wrong.is_empty(),
-        "ADR-9f03438f5422 relicensed this tree to Apache-2.0 whole, and these \
+        "ADR-534c7a3e6cf8 holds this tree to Apache-2.0 whole, and these \
          still say otherwise: {wrong:#?}"
     );
 }
@@ -1001,7 +1002,8 @@ fn every_manifest_declares_the_ratified_licence() {
 /// came, the licence GitHub renders at the root of the repository asserts a
 /// copyright for nobody, in the one place most people ever look. There are four
 /// copies of the text in this tree, and they are found by walking rather than
-/// listed, for the reason ADR-9f03438f5422's own sweep gives.
+/// listed, for the reason ADR-534c7a3e6cf8 gives when it stops maintaining a
+/// list of channels of its own.
 #[test]
 fn every_licence_text_names_its_copyright_owner() {
     let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");

--- a/crates/ank-cli/tests/watch.rs
+++ b/crates/ank-cli/tests/watch.rs
@@ -3,7 +3,7 @@
 //! Driven rather than called, on the rule this repository learned twice: a
 //! criterion that talks about the binary is tested through the binary, because
 //! green unit tests have twice covered code that was right on a path the binary
-//! never reached. Every claim ADR-a22cd3196529 makes is a claim about a running
+//! never reached. Every claim ADR-24e21cb83793 makes is a claim about a running
 //! process -- what it reads, what it leaves untouched, and what stopping it
 //! changes -- and none of them can be asserted from inside a function.
 //!
@@ -516,7 +516,7 @@ fn the_watch_file_sits_beside_the_corpora_file() {
 /// one of these asks the watcher a question about a corpus: `--list` and
 /// `--where` report the declaration back and never a corpus's contents,
 /// `--once` and `--interval` say when to look. A flag that queried a running
-/// watcher is the shape ADR-a22cd3196529 refuses, and this is where its absence
+/// watcher is the shape ADR-24e21cb83793 refuses, and this is where its absence
 /// is read off the binary rather than off a promise.
 ///
 /// It is `ank help watch` and not a `--help` of the watcher's own, which is the
@@ -539,7 +539,7 @@ fn the_verb_offers_the_four_flags_of_section_4_and_no_query() {
 /// ignored.
 ///
 /// **This is the discovery ban reached from the caller's side.** Nothing walks a
-/// filesystem looking for a corpus (ADR-a22cd3196529), and the mirror image of
+/// filesystem looking for a corpus (ADR-24e21cb83793), and the mirror image of
 /// that is a caller who *names* one: `ank watch --repo <tree>` reads as "watch
 /// this", and a verb that took the flag and warmed something else would have
 /// answered a question nobody could tell it had gone unanswered. `ank help

--- a/crates/ank-contract/Cargo.toml
+++ b/crates/ank-contract/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # no dependencies at all and would compile on far less, but the workspace
 # resolves one lockfile and builds as a unit.
 rust-version = "1.95"
-# Apache-2.0, like the whole tree (ADR-9f03438f5422).
+# Apache-2.0, like the whole tree (ADR-534c7a3e6cf8).
 #
 # This crate was the first to carry it, a day before the rest, and the argument
 # it was given then is worth keeping because it is the argument that moved the

--- a/crates/ank-contract/src/verbs.rs
+++ b/crates/ank-contract/src/verbs.rs
@@ -409,7 +409,7 @@ const fn refuses(code: ExitCode, when: &'static str) -> Refusal {
 /// The refusal every path-taking verb performs, declared once and named six
 /// times.
 ///
-/// SPEC-fe8bdb84faca states it for all of them at once — a path naming nothing
+/// SPEC-d58b3a9e4e4d states it for all of them at once — a path naming nothing
 /// inside the repository, because it is absolute or because it climbs above the
 /// root, is refused with the command to run next and never answered — and the
 /// six verbs reach it through one helper, `context::normalised`. One sentence
@@ -508,7 +508,7 @@ pub struct CommandSpec {
     /// carries a `.ank/`, and `init` is what produces one. `watch` refuses
     /// `--repo` and `--worktree`: both address *a* corpus, and the watcher is
     /// told which corpora to keep warm by the reader's declaration and by
-    /// nothing else (ADR-a22cd3196529) -- a flag that looked like it named one
+    /// nothing else (ADR-24e21cb83793) -- a flag that looked like it named one
     /// would be the discovery that decision refuses, offered from the caller's
     /// side.
     ///
@@ -938,7 +938,7 @@ pub const COMMANDS: &[CommandSpec] = &[
         // kind. Found while pinning the goldens for TASK-2c12b027f805.
         notes: &[
             "exit 8 means findings, as it does for check; a signal alone leaves it 0",
-            "the signers are what .ank/allowed_signers declares; this is where they are read, since ADR-01b6dd05f0db closes that file to a direct read",
+            "the signers are what .ank/allowed_signers declares; this is where they are read, since ADR-e45e1a29fe91 closes that file to a direct read",
         ],
         refuses_globals: &[],
         output: &[one(&[f("proposed", Type::Array(&[f("id", Type::Str), f("title", Type::Str)])), f("signers", Type::Array(&[f("principal", Type::Str), f("keytype", Type::Str)])), f("live", Type::Array(&[f("id", Type::Str), f("title", Type::Str), f("files", Type::Num)])), f("dead", Type::Num), f("faults", Type::Num), f("signals", Type::Num)])],
@@ -1293,7 +1293,7 @@ pub const COMMANDS: &[CommandSpec] = &[
         name: "watch",
         group: "look around",
         // It takes no claim, holds none on anybody's behalf and renews none
-        // (ADR-a22cd3196529, §4). A lease is renewed by working, and this
+        // (ADR-24e21cb83793, §4). A lease is renewed by working, and this
         // process does not work on a task -- it warms an index
         // (ADR-0bb7ea8991bc).
         renews: Renews::Never,
@@ -1356,7 +1356,7 @@ pub const COMMANDS: &[CommandSpec] = &[
         // here, because what this verb watches is what the reader declared in
         // watch.yml -- so a caller who typed `ank watch --repo <tree>` would
         // have addressed a corpus that is not being watched and been told
-        // nothing. That is the discovery ADR-a22cd3196529 refuses, reached from
+        // nothing. That is the discovery ADR-24e21cb83793 refuses, reached from
         // the caller's side instead of the filesystem's.
         refuses_globals: &["--repo", "--worktree"],
         // **No `--json` document leaves this verb either, and the empty list is

--- a/crates/ank-daemon/Cargo.toml
+++ b/crates/ank-daemon/Cargo.toml
@@ -8,19 +8,19 @@ edition = "2021"
 # The workspace floor, for the reason ank-core's manifest gives: one lockfile,
 # one build.
 rust-version = "1.95"
-# Apache-2.0, like the whole tree (ADR-9f03438f5422).
+# Apache-2.0, like the whole tree (ADR-534c7a3e6cf8).
 license = "Apache-2.0"
 authors = ["Sean Lamet"]
 description = "The Ank watcher: it keeps declared corpora warm, answers no verb, and nothing depends on it."
 
-# **A library, and no `[[bin]]`** (ADR-a22cd3196529, ADR-1ea31c2f3c5a). The
+# **A library, and no `[[bin]]`** (ADR-24e21cb83793, ADR-1ea31c2f3c5a). The
 # watcher is the verb `ank watch`, so this crate is linked into the one
 # executable every route carries rather than shipped beside it -- the same shape
 # `ank-tui` and `ank-mcp` have, and folded for the reason ADR-8bd76e8d7c4e gave
 # there: a separate file is invisible to precisely the people it exists for, and
 # has to be distributed, documented and discovered as a third thing.
 #
-# **Being started by a verb is not answering one.** ADR-a22cd3196529's clause is
+# **Being started by a verb is not answering one.** ADR-24e21cb83793's clause is
 # that the watcher serves no verb and exposes no query surface, and it is
 # untouched by this: `ank watch` starts a process that still answers nothing.
 # The note at the top of `src/lib.rs` says it where a reader meets it.

--- a/crates/ank-mcp/Cargo.toml
+++ b/crates/ank-mcp/Cargo.toml
@@ -20,7 +20,7 @@ edition = "2021"
 # The workspace floor, for the reason ank-core's manifest gives: one lockfile,
 # one build.
 rust-version = "1.95"
-# Apache-2.0, like the whole tree (ADR-9f03438f5422).
+# Apache-2.0, like the whole tree (ADR-534c7a3e6cf8).
 license = "Apache-2.0"
 authors = ["Sean Lamet"]
 description = "The Ank protocol surface: every verb the CLI dispatches, over MCP, generated from one table."

--- a/crates/ank-tui/Cargo.toml
+++ b/crates/ank-tui/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 # The workspace floor, for the reason ank-core's manifest gives: one lockfile,
 # one build.
 rust-version = "1.95"
-# Apache-2.0, like the whole tree (ADR-9f03438f5422).
+# Apache-2.0, like the whole tree (ADR-534c7a3e6cf8).
 license = "Apache-2.0"
 authors = ["Sean Lamet"]
 description = "The Ank terminal reader: it draws what the CLI prints, and reaches the corpus only by running it."


### PR DESCRIPTION
ADR-3b6ba766a42e refuses a supersession while any tracked file outside `.ank/` still cites the document it retires. Six supersessions landed on `main` as proposals; ten files of this perimeter carried **37 citations** of what they retire, and now carry **none**.

    ADR-a22cd3196529 -> ADR-24e21cb83793
    ADR-01b6dd05f0db -> ADR-e45e1a29fe91
    ADR-9f03438f5422 -> ADR-534c7a3e6cf8
    ADR-ff294eff4d1a -> ADR-67a4ac10c534
    SPEC-fe8bdb84faca -> SPEC-d58b3a9e4e4d
    ADR-85e6bbb195b8 -> ADR-f8f1ea7fd2bb   (cited nowhere in this perimeter)

## Counted, not read

Through git over the ten files: **37 before** (a22c 12, 9f03 12, 01b6 7, ff29 4, SPEC-fe8b 2, 85e6 0), **0 after**, **34 citations of the successors**. `ank check` answers `ok — 364 tasks, 84 adr, 455 signal(s)` at exit 0, with no fault and no citation finding against the six.

## Not a sed

Four supersessions carry their constraint word for word and move only a perimeter or an enumeration, so those citations are re-pointed and the sentences around them stand unchanged. Where the successor moved the substance, the sentence moved with the id:

- `tests/cli.rs`, `the_errors_that_named_the_file_now_name_the_command` — the retired ADR *stopped at the configuration*, and ADR-e45e1a29fe91 is the document that closes that gap by listing `config` among the writing routes. Re-pointing alone would have made the comment say the opposite of what its successor does.
- `tests/cli.rs`, the section heading over the log tests — under ADR-67a4ac10c534 an *entry* is a file, not the log, and there is nothing left to append to.
- `ank-cli/Cargo.toml` — ADR-534c7a3e6cf8 relicenses nothing and restates none of the argument; it says so in as many words. The comment now names it as the rule that holds and says the argument is read by following the succession.

## Three citations dropped rather than re-pointed

Each is a claim about a particular document rather than about the rule it carries, so naming the successor would have made the sentence false.

| Site | Why |
|---|---|
| `tests/skill.rs`, `NOT_YET_DISPATCHED` | "while SPEC-fe8bdb84faca was still `proposed`" is dated: SPEC-d58b3a9e4e4d did not exist when `mcp` and `watch` were declared. The file argues against pinning an id here sixty lines above — *the document is found by what it carries rather than by its id*. Now reads "the §4 document of the day". The ADR on the same line was re-pointed. |
| `tests/cli.rs`, `two_branches_recording_an_entry_merge_with_no_conflict` | "the case ADR-ff294eff4d1a celebrated most and the one it did not cover". ADR-67a4ac10c534 keeps that clause verbatim but argues the case is *gone* rather than uncovered. Naming it would attribute an omission it addresses. ADR-25f977377fa0, already in the next clause, anchors it. |
| `tests/skill.rs`, `declared_licences` | "TASK-47beb64fd204 swept the tree when ADR-9f03438f5422 relicensed it". ADR-534c7a3e6cf8 relicensed nothing. TASK-47beb64fd204 still anchors the sweep. |

## Goldens

Measured, not assumed. `verbs.rs` carries one retired id inside a printed string — the second note on `review`. `tests/cli.rs:18137` normalises every hex run to `<HEX>` before comparing, and `help.json` already stores that note as `since ADR-<HEX> closes that file to a direct read`, so no golden moves. None of the 26 golden files contains any of the six ids, before or after. No `ank amend --scope` was needed, and nothing outside the ten scoped files was touched.

## Proof

Closed by `ank done`, which ran the declared verifiers itself against 454ae08: `cargo-test` ok (204.0s), `fmt-check` ok (1.9s). No `--proof`.

## These stay proposed

No `ank accept` was run and this must not be merged-and-ratified in one step. The six remain proposals until a human signs them on the default branch, which is exactly the state ADR-3b6ba766a42e exists to produce: a citation naming a proposed successor is honest, because `ank show` answers `status: proposed`.