### PR TITLE
release and close warn when a claim deletion does not reach the remote

### DIFF
--- a/.ank/entities/LOG-36b13953e163.md
+++ b/.ank/entities/LOG-36b13953e163.md
@@ -1,0 +1,16 @@
+---
+id: LOG-36b13953e163
+type: log
+title: done, proof test:local/2c9efa235677@c48e002 test:local/e3b0c44298fc@c48e002
+created: 2026-08-31T07:41:14Z
+author: claude-code/opus-5+degrade
+scope:
+  - crates/ank-cli/src/claim.rs
+  - crates/ank-cli/src/commands.rs
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/tests/cli.rs
+about: TASK-c5c93cc8e5f8
+seq: 1
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-564e0b77a88e.md
+++ b/.ank/entities/LOG-564e0b77a88e.md
@@ -1,0 +1,49 @@
+---
+id: LOG-564e0b77a88e
+type: log
+title: Measured with the binary, not read. Two corpora differing only in an empty .ank/log directory, ank
+created: 2026-08-31T07:52:00Z
+author: claude-code/opus-5+degrade
+scope:
+  - crates/ank-cli/tests/cli.rs
+about: TASK-a33a34288e2f
+seq: 0
+schema: 4
+version: 1
+---
+
+ built from 6183dc7:
+
+  ank check, check --json, status, context ., find, find --json, review, graph,
+  scope src, config -- all ten byte-identical between the two, same exit code,
+  after normalising ids and timestamps.
+
+Routes to the state:
+  ank init                            -> config.yml and entities/ only; no log/
+  ank migrate with one log file       -> "migrated 1 entries", directory REMOVED
+  ank migrate with an empty directory -> "nothing to migrate", exit 0, survives
+  git rm of the last log file         -> git removes the directory
+  git checkout past the last log file -> git removes the directory
+  git add of an empty log/            -> 0 files tracked; git cannot carry it
+
+Decision: no change to check, and the reason is measured rather than asserted.
+I injected the rejected alternative -- firing the signal when the directory
+merely exists -- and ran the new test against it. It went red, and the line it
+printed is the argument:
+
+  signal: corpus: 0 entities keep their log in .ank/log/: an entry is an entity
+  since schema 3 (ank migrate)
+
+Zero entities keeping their log anywhere, and the remedy named is the verb that
+has just answered "nothing to migrate". A finding whose only possible effect is
+to be dismissed is the failure the comment beside that signal in human.rs
+already names. human.rs is byte-identical to before the injection; git diff
+--stat is tests/cli.rs alone, +74.
+
+What lands is the measurement pinned as a test, asserted as an equality between
+the two corpora rather than as an absence of the word "log" -- an absence would
+still pass if check stopped reporting the populated case, which is the
+regression that would actually matter. The third part of the test puts one file
+in and watches the signal appear.
+
+cargo test --workspace: 46 binaries, 0 failed. cargo fmt --check clean.

--- a/.ank/entities/LOG-638ecd6b9140.md
+++ b/.ank/entities/LOG-638ecd6b9140.md
@@ -1,0 +1,13 @@
+---
+id: LOG-638ecd6b9140
+type: log
+title: done, proof test:local/12e857b6b840@6183dc7 test:local/e3b0c44298fc@6183dc7
+created: 2026-08-31T07:55:18Z
+author: claude-code/opus-5+degrade
+scope:
+  - crates/ank-cli/tests/cli.rs
+about: TASK-a33a34288e2f
+seq: 1
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-b6b35961b8fb.md
+++ b/.ank/entities/LOG-b6b35961b8fb.md
@@ -1,0 +1,36 @@
+---
+id: LOG-b6b35961b8fb
+type: log
+title: Measured through the binary, on a scratch corpus whose origin is a bare repository moved out of the
+created: 2026-08-31T07:37:43Z
+author: claude-code/opus-5+degrade
+scope:
+  - crates/ank-cli/src/claim.rs
+  - crates/ank-cli/src/commands.rs
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/tests/cli.rs
+about: TASK-c5c93cc8e5f8
+seq: 0
+schema: 4
+version: 1
+---
+
+ way between the claim and the revocation -- the only shape where the risk is real, since a claim that never travelled cannot go stale on a remote that never had it.
+
+Before (ank built from c48e002):
+  claim, origin reachable   -> ref reaches origin, exit 0
+  release, origin gone      -> stdout "released <id> -> open", stderr 0 bytes, --json warnings [], exit 0
+  close, origin gone        -> stdout "closed <id> -> closed", stderr 0 bytes, exit 0
+  for-each-ref on origin    -> the claim ref is STILL THERE after both
+
+After:
+  release, origin gone      -> stderr "warning: claim deletion not pushed: the claim is gone in this clone only, and another clone still reads the task as held until the claim expires", exit 0
+  close, origin gone        -> the same sentence on stderr, exit 0
+  --json                    -> the document is byte-identical, warning on stderr only
+  no remote at all          -> both verbs silent, exit 0
+
+The divergence was the "warns" clause of ADR-af533e7a3e03 and nothing else: the exit code was already right and the help already declared PUSH_DEGRADES, so it was honest. The ADR is not what is wrong here -- the risk it asks to be displayed is the stale ref measured above -- so no supersession was written and no ratified text was touched.
+
+Cause: claim::delete_at did `let _ = push(...)`, discarding the result, so neither verb could see it. It now returns Deleted { existed, sync }. The sentence is a third one beside Sync::warning and Sync::proof_failure, because it is a third risk, and it names no local status: release leaves the task open and close leaves it closed. Standard error in both modes, which is where done puts the same class of warning (ADR-6fd69efb629c: stdout under --json is a parser input).
+
+Red-first, both halves independently: with only the release eprintln reverted the test fails on "release degraded in silence"; with only the close eprintln reverted it fails on "close degraded in silence". cargo test --workspace green, 334 + 327 + the rest, 0 failed. cargo fmt --check clean.

--- a/.ank/entities/TASK-a33a34288e2f.md
+++ b/.ank/entities/TASK-a33a34288e2f.md
@@ -1,0 +1,61 @@
+---
+id: TASK-a33a34288e2f
+type: task
+slug: an-empty-ank-log-stays-invisible-to-check-and-a
+title: an empty .ank/log stays invisible to check, and a test says why
+created: 2026-08-31T07:43:44Z
+author: claude-code/opus-5+degrade
+status: done
+scope:
+  - crates/ank-cli/tests/cli.rs
+blocked_by: []
+done_criteria: |
+  A test in crates/ank-cli/tests/cli.rs drives the binary against two corpora that differ only in an empty .ank/log directory and asserts that ank check produces the same exit code and the same findings on both, and that the previous-layout signal appears as soon as one file is put in that directory. check is not changed: the signal goes on counting files, and an empty directory goes on reporting nothing.
+criteria_by: creator
+verify: [cargo-test, fmt-check]
+proof:
+  - type: test
+    ref: local/12e857b6b840@6183dc7
+    tree: scope/2845b3551428
+    criteria: f121bd51d471
+    verifier: cargo-test@f14aeab36e1b
+    via: verifier
+  - type: test
+    ref: local/e3b0c44298fc@6183dc7
+    tree: scope/2845b3551428
+    criteria: f121bd51d471
+    verifier: fmt-check@5ca6d10bcd55
+    via: verifier
+schema: 4
+version: 3
+---
+
+The signal is keyed on the number of .md files under .ank/log/, so an empty
+previous-layout directory is never reported. The question is whether that is a
+defect. Measured on ank built from 6183dc7, with the CLI and never by reading:
+
+  ank init                     -> creates config.yml and entities/ only, no log/
+  ank migrate, 1 log file      -> "migrated 1 entries", and the directory is REMOVED
+  ank migrate, empty directory -> "nothing to migrate", exit 0, directory survives
+  git rm of the last log file  -> git removes the directory
+  git checkout to a branch without it -> git removes the directory
+  git add of an empty log/     -> 0 files tracked; git cannot carry the directory
+
+  check, no .ank/log     vs  check, empty .ank/log
+    check, check --json, status, context ., find, find --json, review, graph,
+    scope src, config -- all ten byte-identical after id and timestamp
+    normalisation, same exit code
+
+So: no verb behaves differently, no route through the tool produces the state,
+and git cannot propagate it. What remains is a hand-made directory in one
+working tree.
+
+Reporting it would make things worse, not better. The signal reads "N entities
+keep their log in .ank/log/ ... (ank migrate)": at N = 0 the sentence is false,
+and the command it names answers "nothing to migrate". That is a finding whose
+only effect is to be dismissed, which is the failure mode the comment beside
+that signal in human.rs already names -- the kind of finding that teaches people
+to stop reading check.
+
+So the repair is not code. It is the measurement, pinned, so the next auditor
+reads the answer instead of rediscovering the question.

--- a/.ank/entities/TASK-c5c93cc8e5f8.md
+++ b/.ank/entities/TASK-c5c93cc8e5f8.md
@@ -1,0 +1,62 @@
+---
+id: TASK-c5c93cc8e5f8
+type: task
+slug: release-and-close-warn-when-the-claim-deletion-d
+title: release and close warn when the claim deletion does not reach the remote
+created: 2026-08-31T07:29:51Z
+author: claude-code/opus-5+degrade
+status: done
+scope:
+  - crates/ank-cli/src/claim.rs
+  - crates/ank-cli/src/commands.rs
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/tests/cli.rs
+blocked_by: []
+done_criteria: |
+  Against a corpus whose origin is configured and unreachable, "ank release --reason <r>" and "ank close <id> --reason <r>" each exit 0 and emit a warning naming the claim the remote still holds; a test in crates/ank-cli/tests/cli.rs drives the binary for both verbs, asserts exit 0 and the warning text on the combined output, and asserts that a repository with no remote at all emits no such warning.
+criteria_by: creator
+verify: [cargo-test, fmt-check]
+proof:
+  - type: test
+    ref: local/2c9efa235677@c48e002
+    tree: scope/8459ebd2b571
+    criteria: a8ce54e5859e
+    verifier: cargo-test@f14aeab36e1b
+    via: verifier
+  - type: test
+    ref: local/e3b0c44298fc@c48e002
+    tree: scope/8459ebd2b571
+    criteria: a8ce54e5859e
+    verifier: fmt-check@5ca6d10bcd55
+    via: verifier
+schema: 4
+version: 3
+---
+
+ADR-af533e7a3e03 says a verb whose write survives a refused push "degrades, warns and exits zero", and verbs.rs declares PUSH_DEGRADES for both release and close, so their help already says which class they are in.
+
+Measured on ank built from c48e002, against a scratch corpus whose origin is a bare repository moved out of the way between the claim and the release:
+
+    claim   (origin reachable)    ref reaches origin              exit 0
+    release (origin gone)         stdout "released ... -> open"   exit 0
+                                  stderr 0 bytes, --json warnings []
+    close   (origin gone)         stdout "closed ... -> closed"   exit 0
+                                  stderr 0 bytes
+    ls-remote origin refs/ank/*   after the release: the claim is still there
+
+So the local ref is deleted, the remote keeps a claim nobody holds until its
+lease runs out, and neither verb says a word. claim, on the same corpus, prints
+"warning: claim not pushed: ...". The divergence is the "warns" clause and
+nothing else: the exit code is right and the help is honest.
+
+The repair is the warning, not an edit to the ADR. The risk the ADR asks to be
+displayed is real and measured above -- another clone reads the task as held --
+and a ratified constraint is superseded by a proposal a human signs, never
+edited in place.
+
+claim::delete_at discards the push result outright (let _ = push(...)), so the
+verbs cannot see it. It has to carry the Sync out, and the sentence is the
+mirror of Sync::warning rather than that sentence reused: an acquisition that
+did not travel can be taken twice, a revocation that did not travel is read as
+held. done is the precedent for where it goes -- standard error, both modes,
+because stdout under --json is a parser input (ADR-6fd69efb629c).

--- a/crates/ank-cli/src/claim.rs
+++ b/crates/ank-cli/src/claim.rs
@@ -642,6 +642,30 @@ impl Sync {
     /// no degraded mode left to fall back to and `attest --detached` exits 9.
     /// A method named `warning` returning the text of an error would be a
     /// comment that lies in the one place a reader checks first.
+    /// The same sentence for a claim being given back, and it is a third
+    /// sentence because it is a third risk. [`Sync::warning`] reports an
+    /// acquisition that did not travel, where the danger is that the task is
+    /// taken twice; this reports a *revocation* that did not travel, where the
+    /// danger is the mirror image — the claim is gone here and reads as live
+    /// everywhere else, until the lease on the stale ref runs out. Which is
+    /// why it does not name the local status: `release` leaves the task open
+    /// and `close` leaves it closed, and one sentence serves both.
+    ///
+    /// `release` and `close` are both on the degrading side of
+    /// ADR-af533e7a3e03: the hand-back is written to disk and stands whatever
+    /// the remote did, so the verb exits 0. The constraint says degrades,
+    /// *warns* and exits zero, and this is the warning half.
+    pub fn revocation_warning(&self) -> Option<String> {
+        match self {
+            Sync::Local | Sync::Pushed => None,
+            Sync::Unsynchronised(_) => Some(
+                "claim deletion not pushed: the claim is gone in this clone only, and \
+                 another clone still reads the task as held until the claim expires"
+                    .to_string(),
+            ),
+        }
+    }
+
     pub fn proof_failure(&self) -> Option<String> {
         match self {
             Sync::Local | Sync::Pushed => None,
@@ -784,23 +808,53 @@ pub fn sync_ref_from_remote(cwd: &Path, name: &str) -> Result<()> {
 /// therefore owes an answer to. The remote failing to take it is not worth
 /// failing the release over: the handback is durable state and already written,
 /// and the stale ref expires on its own.
-pub fn delete(cwd: &Path, id: &EntityId) -> Result<bool> {
+pub fn delete(cwd: &Path, id: &EntityId) -> Result<Deleted> {
     delete_at(cwd, &claim_ref(id))
 }
 
 /// The same deletion, addressed by ref. `check` prunes a proof ref through it
 /// once the file on the default branch carries the same attestation.
-pub fn delete_at(cwd: &Path, name: &str) -> Result<bool> {
+pub fn delete_at(cwd: &Path, name: &str) -> Result<Deleted> {
     let Some(witness) = current_object(cwd, name)? else {
-        return Ok(false);
+        return Ok(Deleted {
+            existed: false,
+            sync: Sync::Local,
+        });
     };
     let args = ["update-ref", "-d", name];
     let out = git::output(cwd, &args)?;
     if !out.status.success() {
         return Err(git::failed(&args, &out));
     }
-    let _ = push(cwd, name, None, Some(&witness));
-    Ok(true)
+    // **The push result is carried out, not swallowed.** It used to be dropped
+    // here, and the two verbs that delete a claim therefore had nothing to warn
+    // from: they degraded and exited 0 in complete silence, which is two of the
+    // three things ADR-af533e7a3e03 asks of a degrading verb. A failure to
+    // reach the remote is still not a failure of the verb — the hand-back is
+    // already on disk — so it leaves as a value the caller reports rather than
+    // as an error.
+    let sync = match push(cwd, name, None, Some(&witness)) {
+        Ok(written) => written.sync,
+        // The push helper itself could not run git at all. The deletion took
+        // locally, so this is the same degradation with a coarser reason.
+        Err(e) => Sync::Unsynchronised(e.to_string()),
+    };
+    Ok(Deleted {
+        existed: true,
+        sync,
+    })
+}
+
+/// What a deletion of a coordination ref did: whether there was one to delete,
+/// and how far the deletion reached.
+///
+/// Two facts and not one because the callers need both and for different
+/// reasons: `close` reports `claim_revoked` from `existed`, and both `close`
+/// and `release` owe a warning when `sync` says the remote never heard.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Deleted {
+    pub existed: bool,
+    pub sync: Sync,
 }
 
 // ---------------------------------------------------------------------------
@@ -2992,9 +3046,12 @@ mod tests {
         let task = open_task("000000000001");
         t.seed(&task);
 
-        assert!(!delete(&t.0, &task.id).unwrap(), "nothing to delete yet");
+        assert!(
+            !delete(&t.0, &task.id).unwrap().existed,
+            "nothing to delete yet"
+        );
         take(&t, &task, "claude-code@ank", DEFAULT_TTL).unwrap();
-        assert!(delete(&t.0, &task.id).unwrap());
+        assert!(delete(&t.0, &task.id).unwrap().existed);
         assert!(read(&t.0, &task.id).unwrap().is_none());
         assert!(git::ank_refs(&t.0).unwrap().is_empty());
 

--- a/crates/ank-cli/src/commands.rs
+++ b/crates/ank-cli/src/commands.rs
@@ -2280,7 +2280,19 @@ pub fn release(
     // The file first, the ref second. A ref deleted over a task still marked
     // in_progress would read as claimable and as in progress at the same time;
     // the reverse merely waits for the TTL.
-    claim::delete(&repo.corpus, &id)?;
+    let deleted = claim::delete(&repo.corpus, &id)?;
+    // A deletion that did not reach the remote leaves the task open here and
+    // held everywhere else until the lease runs out. The hand-back stands, so
+    // the exit code does not move — ADR-af533e7a3e03 puts `release` on the
+    // degrading side and `help` says so — but degrading in silence is not what
+    // that constraint allows: it says degrades, *warns* and exits zero.
+    //
+    // On standard error and in both modes, which is where `done` puts the same
+    // class of warning: it is not the answer, and `release --json` is a
+    // parser's input (ADR-6fd69efb629c).
+    if let Some(w) = deleted.sync.revocation_warning() {
+        eprintln!("{} {w}", inv.style().on_stderr().yellow("warning:"));
+    }
 
     if inv.json() {
         let doc = Obj::document()

--- a/crates/ank-cli/src/human.rs
+++ b/crates/ank-cli/src/human.rs
@@ -5575,7 +5575,16 @@ pub fn close(
     store.write(&closed, base_version)?;
     record_entry(&store, repo, &closed, identity, format!("closed: {reason}"))?;
 
-    let revoked = claim::delete(&repo.corpus, &id)?;
+    let deleted = claim::delete(&repo.corpus, &id)?;
+    let revoked = deleted.existed;
+    // The same warning `release` owes, for the same reason: `close` revokes a
+    // claim, and a revocation the remote never heard leaves the task closed
+    // here and held there. ADR-af533e7a3e03 has both verbs degrading, warning
+    // and exiting zero; the exit code was already right and this is the middle
+    // term. Standard error in both modes, beside `done`'s.
+    if let Some(w) = deleted.sync.revocation_warning() {
+        eprintln!("{} {w}", inv.style().on_stderr().yellow("warning:"));
+    }
     if inv.json() {
         let doc = Obj::document()
             .str("task", &id.to_string())

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -16760,6 +16760,80 @@ fn a_conflict_marker_in_a_log_is_a_fault_like_one_in_an_entity() {
     );
 }
 
+/// An *empty* previous-layout directory is not a previous-layout corpus, and
+/// `check` is right to say nothing about it (TASK-a33a34288e2f).
+///
+/// The signal above counts `.md` files under `.ank/log/`, so a directory with
+/// none is never reported. That is a decision and not an oversight, and this
+/// test is what stops it drifting into either an accident or a signal somebody
+/// adds later in good faith.
+///
+/// The reason it stays silent is that the sentence would be false and the
+/// remedy empty: the signal reads "N entities keep their log in .ank/log/ (ank
+/// migrate)", and at N = 0 there is no entity keeping anything and `ank migrate`
+/// answers "nothing to migrate". Measured alongside this: `init` creates no such
+/// directory, `migrate` removes it once it has emptied it, `git rm` and a
+/// `checkout` past the last log file both remove it, and `git add` of an empty
+/// one tracks nothing — git cannot carry the state to a second clone at all.
+/// What is left is a directory somebody made by hand in one working tree, and a
+/// finding whose only possible effect is to be dismissed is the kind that
+/// teaches people to stop reading `check`.
+///
+/// **Asserted as an equality, not as an absence.** "It does not mention the log"
+/// would still pass if `check` stopped reporting the populated case too, which
+/// is the regression that would actually matter. So the two corpora differ by
+/// the empty directory and nothing else, their whole output is compared, and the
+/// last third puts one file in and watches the signal appear.
+#[test]
+fn an_empty_previous_layout_directory_is_reported_by_nobody() {
+    let bare = Repo::new();
+    bare.seed_task(LOGGED, Some("A verifiable criterion."));
+    let empty = Repo::new();
+    empty.seed_task(LOGGED, Some("A verifiable criterion."));
+    let dir = empty.0.join(".ank/log");
+    std::fs::create_dir_all(&dir).unwrap();
+    assert!(
+        std::fs::read_dir(&dir).unwrap().next().is_none(),
+        "the fixture is the empty directory and nothing else"
+    );
+
+    for args in [
+        vec!["check"],
+        vec!["check", "--json"],
+        vec!["find"],
+        vec!["status"],
+    ] {
+        let without = bare.ank("claude-code@ank", &args);
+        let with = empty.ank("claude-code@ank", &args);
+        assert_eq!(
+            code(&without),
+            code(&with),
+            "ank {args:?} changed its exit code over an empty directory"
+        );
+        assert_eq!(
+            stdout(&without),
+            stdout(&with),
+            "ank {args:?} answered differently over an empty directory"
+        );
+    }
+
+    // And the moment there is something in it, the signal is there — so the
+    // silence above is about the directory being empty and not about `check`
+    // having stopped looking.
+    std::fs::write(
+        dir.join(format!("{LOGGED}.md")),
+        "- 2026-08-15T08:00Z claude-code@ank — an entry\n",
+    )
+    .unwrap();
+    let out = empty.ank("claude-code@ank", &["check"]);
+    assert_eq!(code(&out), 0, "{}{}", stdout(&out), stderr(&out));
+    let text = stdout(&out);
+    assert!(
+        text.contains("keep their log in") && text.contains("ank migrate"),
+        "one file in the previous layout is the case the signal exists for: {text}"
+    );
+}
+
 /// `log` and `show` answer under `context_budget` and say what they cut.
 ///
 /// They were the two readers in the tool with no budget and no flags, while

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -5735,6 +5735,115 @@ fn an_unreachable_remote_warns_and_the_claim_still_holds_locally() {
     );
 }
 
+/// A revocation that did not reach the remote degrades, warns and exits zero
+/// (TASK-c5c93cc8e5f8, ADR-af533e7a3e03).
+///
+/// `release` and `close` both delete the claim ref, both declare `PUSH_DEGRADES`
+/// in the verb table, and both used to do two thirds of what that class
+/// promises: the hand-back stood on disk, the exit code stayed 0, and nothing
+/// at all was said. The push result was discarded inside `claim::delete_at`, so
+/// neither verb could have warned.
+///
+/// **Measured against a remote that was reachable and then was not**, which is
+/// the only shape where the risk is real: a claim that never travelled cannot go
+/// stale on a remote that never had it. So origin is a bare repository the claim
+/// genuinely reaches, and it is moved out of the way between the claim and the
+/// revocation. The assertion at the end is the risk itself, not the sentence
+/// describing it -- origin still holds the claim, which is exactly what the
+/// warning tells the reader.
+#[test]
+fn release_and_close_warn_when_the_claim_deletion_does_not_reach_the_remote() {
+    const RELEASED: &str = "TASK-000000000d01";
+    const CLOSED: &str = "TASK-000000000d02";
+
+    /// Every claim ref the bare origin holds. Read from origin itself rather
+    /// than through `ls-remote` from the clone, so a fetch configuration cannot
+    /// stand between the question and the answer.
+    fn origin_claims(origin: &Path) -> String {
+        let out = git_command(origin)
+            .args(["for-each-ref", "--format=%(refname)", "refs/ank/claims/"])
+            .output()
+            .unwrap();
+        assert!(out.status.success(), "for-each-ref: {}", stderr(&out));
+        stdout(&out)
+    }
+
+    let r = Repo::new();
+    r.seed_task(RELEASED, Some("A verifiable criterion."));
+    r.seed_task(CLOSED, Some("A verifiable criterion."));
+    let (origin, _other) = r.cloned();
+    let moved = origin.with_extension("moved");
+
+    for (id, verb, args) in [
+        (
+            RELEASED,
+            "release",
+            vec!["release", "--reason", "origin is gone"],
+        ),
+        (
+            CLOSED,
+            "close",
+            vec!["close", CLOSED, "--reason", "origin is gone"],
+        ),
+    ] {
+        let out = r.ank("claude-code@ank", &["claim", id]);
+        assert_eq!(code(&out), 0, "claim: {}{}", stdout(&out), stderr(&out));
+        assert!(
+            origin_claims(&origin).contains(id),
+            "the claim never reached origin, so {verb} has no stale ref to warn about"
+        );
+
+        // The remote configured and gone: a URL that resolves to nothing, which
+        // is the shape a laptop off the network actually has.
+        std::fs::rename(&origin, &moved).unwrap();
+        let out = r.ank("claude-code@ank", &args);
+        assert_eq!(
+            code(&out),
+            0,
+            "{verb} is on the degrading side and must still exit zero:\n{}{}",
+            stdout(&out),
+            stderr(&out)
+        );
+        let said = format!("{}{}", stdout(&out), stderr(&out));
+        assert!(
+            said.contains("deletion not pushed") && said.contains("still reads the task as held"),
+            "{verb} degraded in silence, which is not what degrade, warn and exit zero says: {said}"
+        );
+        assert!(
+            r.claim_ref(id).is_none(),
+            "{verb} did not revoke the claim locally, which is the half that must not degrade"
+        );
+        std::fs::rename(&moved, &origin).unwrap();
+
+        // The warning is not decoration: origin is still holding the claim the
+        // reader was just told about.
+        assert!(
+            origin_claims(&origin).contains(id),
+            "the risk the warning names did not happen, so the warning is wrong"
+        );
+    }
+
+    // And with no remote at all -- level 0, the default mode -- there is no
+    // deletion to fail to push and nothing to say. A warning here would fire on
+    // every release of every solo repository.
+    let solo = Repo::new();
+    solo.seed_task(RELEASED, Some("A verifiable criterion."));
+    solo.seed_task(CLOSED, Some("A verifiable criterion."));
+    for (id, args) in [
+        (RELEASED, vec!["release", "--reason", "no remote here"]),
+        (CLOSED, vec!["close", CLOSED, "--reason", "no remote here"]),
+    ] {
+        let out = solo.ank("claude-code@ank", &["claim", id]);
+        assert_eq!(code(&out), 0, "{}{}", stdout(&out), stderr(&out));
+        let out = solo.ank("claude-code@ank", &args);
+        assert_eq!(code(&out), 0, "{}{}", stdout(&out), stderr(&out));
+        assert!(
+            !format!("{}{}", stdout(&out), stderr(&out)).contains("deletion not pushed"),
+            "level 0 is not a degradation and must stay silent"
+        );
+    }
+}
+
 /// What a holder of a claim sees of the coordination plane (TASK-dacbcae6134c).
 ///
 /// The agent best placed to notice a collision is the one currently working,


### PR DESCRIPTION
Two findings measured earlier today by other agents, worked one claim at a time.

## TASK-c5c93cc8e5f8 — release and close degraded in silence

ADR-af533e7a3e03 puts a verb whose write survives a refused push on the degrading side: it **degrades, warns and exits zero**. `verbs.rs` declares `PUSH_DEGRADES` for both `release` and `close`, so their help already says which class they are in and was honest about it.

Measured through the binary, against a bare origin the claim genuinely reaches and which is then moved out of the way — the only shape where the risk is real:

| | before | after |
|---|---|---|
| `release`, origin gone | exit 0, stderr **0 bytes** | exit 0, warning on stderr |
| `close`, origin gone | exit 0, stderr **0 bytes** | exit 0, warning on stderr |
| `for-each-ref` on origin | the claim is **still there** | unchanged — that is the risk |

Two of the three things the constraint asks for. The ADR is not what is wrong: the stale ref it asks to be displayed was measured. So no supersession was written and no ratified text touched.

`claim::delete_at` did `let _ = push(...)`, discarding the result, so neither verb could have warned. It now returns `Deleted { existed, sync }`, and `Sync` grows a third sentence beside `warning` and `proof_failure` — a revocation that did not travel is the mirror of an acquisition that did not, and it names no local status because `release` leaves the task open and `close` leaves it closed. Standard error in both modes, where `done` puts the same class of warning; `--json` documents are byte-identical, so no contract or golden change.

## TASK-a33a34288e2f — an empty `.ank/log` is invisible to check, and stays that way

`check`, `check --json`, `status`, `context`, `find`, `find --json`, `review`, `graph`, `scope` and `config` are all byte-identical between a corpus with no `.ank/log` and one with an empty one. `init` creates none, `migrate` removes it once emptied, `git rm` and `checkout` remove it, and `git add` of an empty one tracks nothing — git cannot carry the state to a second clone.

**No change to `check`.** The rejected alternative was built and run against the new test, which went red printing:

```
signal: corpus: 0 entities keep their log in .ank/log/: an entry is an entity since schema 3 (ank migrate)
```

A false count naming a verb that answers `nothing to migrate` — the finding-that-gets-dismissed the comment beside that signal already warns about. `human.rs` is byte-identical to before the injection. The measurement lands as a test instead, asserted as an *equality* between the two corpora rather than as an absence, so it also catches `check` going silent on the populated case.

## Proof

Both closed with `ank done` on their declared verifiers (`cargo-test`, `fmt-check`), never `--proof`. Both new tests verified red-first: the first fails independently with either the `release` or the `close` warning reverted; the second fails against the injected alternative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJcUDqenaCNMLqfF3JjEwt