### PR TITLE
Four findings and eighteen constraints re-measured against the code

### DIFF
--- a/.ank/entities/LOG-01c704694763.md
+++ b/.ank/entities/LOG-01c704694763.md
@@ -1,0 +1,18 @@
+---
+id: LOG-01c704694763
+type: log
+title: +scope crates/ank-cli/tests/golden-json/**, -scope crates/ank-cli/tests/golden-json (version 1 to
+created: 2026-08-31T07:55:49Z
+author: claude-code/opus-5+drift2
+scope:
+  - crates/ank-cli/tests/schema.rs
+  - crates/ank-cli/tests/tui.rs
+  - crates/ank-cli/tests/golden-json/**
+about: TASK-49b10f02d209
+seq: 0
+records: edit
+schema: 4
+version: 1
+---
+
+ 2, replaced 94153cc67f8f, produced 701bf1037be5)

--- a/.ank/entities/LOG-1d0a800b4077.md
+++ b/.ank/entities/LOG-1d0a800b4077.md
@@ -1,0 +1,18 @@
+---
+id: LOG-1d0a800b4077
+type: log
+title: +scope crates/ank-mcp/src/**, -scope crates/ank-mcp/src (version 1 to 2, replaced 493838d8597c,
+created: 2026-08-31T07:55:49Z
+author: claude-code/opus-5+drift2
+scope:
+  - crates/ank-mcp/Cargo.toml
+  - crates/ank-cli/tests/mcp.rs
+  - crates/ank-mcp/src/**
+about: TASK-1bc1186ad9e7
+seq: 0
+records: edit
+schema: 4
+version: 1
+---
+
+ produced f4f85659ff82)

--- a/.ank/entities/LOG-1d52c7b91ae2.md
+++ b/.ank/entities/LOG-1d52c7b91ae2.md
@@ -1,0 +1,21 @@
+---
+id: LOG-1d52c7b91ae2
+type: log
+title: drift audit 2026-08-31, re-measured and holds. Every tracked .rs, .md, .sh, .ps1, .yml, .toml and
+created: 2026-08-31T07:54:27Z
+author: claude-code/opus-5+drift2
+scope:
+  - crates/**
+  - docs/**
+  - skill/**
+  - .ank/**
+  - README.md
+  - CLAUDE.md
+  - AGENTS.md
+about: ADR-d3a8dcf38817
+seq: 0
+schema: 4
+version: 1
+---
+
+ .json outside .ank/ was scanned for characters in a Unicode letter category outside ASCII. Two files carry any: crates/ank-core/src/log.rs (e-acute, at lines 367, 448 and 464) and crates/ank-tui/src/keys.rs (e-acute and a CJK ideograph, at line 870). Both are fixtures asserting a byte sequence -- control_character(), and a KeyCode::Char array -- which is the exception this constraint names. Nothing else, and no occurrence of 'ankor' outside .ank/ either (ADR-85e6bbb195b8).

--- a/.ank/entities/LOG-29f22e84ae0b.md
+++ b/.ank/entities/LOG-29f22e84ae0b.md
@@ -1,0 +1,23 @@
+---
+id: LOG-29f22e84ae0b
+type: log
+title: "drift audit 2026-08-31: one finding, written as TASK-9b82a1edd42e, and the rest holds. Every"
+created: 2026-08-31T07:54:07Z
+author: claude-code/opus-5+drift2
+scope:
+  - LICENSE
+  - README.md
+  - CLAUDE.md
+  - crates/**
+  - npm/**
+  - Formula/**
+  - bucket/**
+  - packaging/**
+  - package.json
+about: ADR-9f03438f5422
+seq: 1
+schema: 4
+version: 1
+---
+
+ manifest that declares a licence declares Apache-2.0 -- .claude-plugin/plugin.json, the six crate Cargo.toml, the four package.json, twelve in all, measured by grep over the tracked tree. No Homebrew, Scoop, winget or AUR file exists in the tree, so the channel enumeration this constraint carries is already answered by its proposed successor ADR-534c7a3e6cf8. What does not hold is the prospective half: v0.3.0 was published on 2026-08-17 declaring GPL-3.0-only in every manifest and carrying the GPL as LICENSE, and NOTICE:18 tells its recipients the GPL era ended at 0.2.0.

--- a/.ank/entities/LOG-2fa8cc375658.md
+++ b/.ank/entities/LOG-2fa8cc375658.md
@@ -1,0 +1,15 @@
+---
+id: LOG-2fa8cc375658
+type: log
+title: drift audit 2026-08-31, re-measured and holds. 'ank amend <task> --scope docs/**' wrote
+created: 2026-08-31T07:53:21Z
+author: claude-code/opus-5+drift2
+scope:
+  - crates/ank-cli/**
+about: ADR-f7dc76886db2
+seq: 1
+schema: 4
+version: 1
+---
+
+ LOG-e7a2d5d9e7c4 titled '+scope docs/** (version 1 to 2, replaced 4ce9108bc090, produced a7a954d5db8a)': the field changed, the version it moved from and to, and both hashes. Then 'title: Sample' was changed to 'title: Tampered' in the file by hand, and check reported 'content is a5eef7ff4c8c where the last write left a7a954d5db8a: it was edited outside the CLI, which is legal and leaves no entry' -- a signal naming both, and nothing refused.

--- a/.ank/entities/LOG-3319a179b1eb.md
+++ b/.ank/entities/LOG-3319a179b1eb.md
@@ -1,0 +1,17 @@
+---
+id: LOG-3319a179b1eb
+type: log
+title: drift audit 2026-08-31, re-measured and holds. Task One scoped src/**, task Two scoped src/a.rs.
+created: 2026-08-31T07:53:42Z
+author: claude-code/opus-5+drift2
+scope:
+  - crates/ank-cli/src/claim.rs
+  - crates/ank-cli/src/context.rs
+  - docs/ank-spec-v1.1.md
+about: ADR-052accd6e3b2
+seq: 0
+schema: 4
+version: 1
+---
+
+ agent/A claimed One; agent/B then claimed Two and got 'warning: agent/A holds TASK-b88f9424754a, overlapping on src/a.rs' followed by 'claimed TASK-37aea74865eb', exit 0. The live claim named, the path in common named, and the task taken regardless.

--- a/.ank/entities/LOG-3cc48dd81edf.md
+++ b/.ank/entities/LOG-3cc48dd81edf.md
@@ -1,0 +1,17 @@
+---
+id: LOG-3cc48dd81edf
+type: log
+title: drift audit 2026-08-31, re-measured and holds. Three entities were moved by hand into .ank/tasks/
+created: 2026-08-31T07:54:06Z
+author: claude-code/opus-5+drift2
+scope:
+  - crates/ank-core/**
+  - crates/ank-cli/src/store.rs
+  - docs/**
+about: ADR-c9f9d0d6f05d
+seq: 0
+schema: 4
+version: 1
+---
+
+ and .ank/adr/. The reader accepts them: 'ank find' listed all five entities across both layouts. check reports it as a signal naming the command -- '3 entities are in the previous layout: entities live in .ank/entities/ since schema 3 (git mv .ank/tasks/*.md .ank/adr/*.md .ank/entities/)'. The writer never produces the old layout: 'ank new task' in that same corpus wrote .ank/entities/TASK-d8931868daab.md while the three stayed where they were.

--- a/.ank/entities/LOG-461f1a58f755.md
+++ b/.ank/entities/LOG-461f1a58f755.md
@@ -1,0 +1,15 @@
+---
+id: LOG-461f1a58f755
+type: log
+title: "drift audit 2026-08-31: one finding, written as TASK-49b10f02d209. What holds, measured: 'ank help"
+created: 2026-08-31T07:54:44Z
+author: claude-code/opus-5+drift2
+scope:
+  - crates/ank-cli/**
+about: ADR-6fd69efb629c
+seq: 0
+schema: 4
+version: 1
+---
+
+ --json' describes 26 verbs, exactly the 26 the dispatcher names when it refuses an unknown command, and every flag named after a verb in every tracked .md, install.sh and install.ps1 is a flag that verb declares -- zero misses across the whole tree. What does not: 24 verbs declare a non-empty output and only 22 have a fixture in crates/ank-cli/tests/golden-json/. read (verbs.rs:1018) and tui (verbs.rs:1233) declare a shape that nothing pins, and the conformance test walks fixtures to verbs so it cannot see the gap.

--- a/.ank/entities/LOG-563d07bdfdde.md
+++ b/.ank/entities/LOG-563d07bdfdde.md
@@ -1,0 +1,19 @@
+---
+id: LOG-563d07bdfdde
+type: log
+title: drift audit 2026-08-31, re-measured and holds, including the half that only shows up across
+created: 2026-08-31T07:53:21Z
+author: claude-code/opus-5+drift2
+scope:
+  - crates/ank-cli/src/claim.rs
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/src/config.rs
+  - crates/ank-cli/src/git.rs
+  - docs/**
+about: ADR-6d8736c04cfa
+seq: 0
+schema: 4
+version: 1
+---
+
+ branches. done on branch feat left refs/ank/claims/<id> as a completion ref; back on main, where the task file still reads 'status: open', 'ank claim <id>' exits 4 with 'TASK-2b9056889f89 finished on another branch (commit b19f7de, branch feat), not merged here yet' -- the commit and the branch both named, as the constraint requires. The asymmetry holds the other way: 'ank close <id> --reason' printed 'the active claim was revoked' and left no ref at all, measured by for-each-ref before and after. A done task whose file on this branch already says done is refused at 6 on the transition rather than at 4, which is the earlier gate and not this one.

--- a/.ank/entities/LOG-5eba943de2f0.md
+++ b/.ank/entities/LOG-5eba943de2f0.md
@@ -1,0 +1,16 @@
+---
+id: LOG-5eba943de2f0
+type: log
+title: drift audit 2026-08-31, re-measured and holds; the write perimeter was measured rather than read. A
+created: 2026-08-31T07:53:42Z
+author: claude-code/opus-5+drift2
+scope:
+  - crates/ank-cli/src/index.rs
+  - docs/**
+about: ADR-a22cd3196529
+seq: 2
+schema: 4
+version: 1
+---
+
+ corpus with a bare origin carrying refs/heads/main and refs/ank/claims/* was declared in watch.yml under its repository identity, and 'ank watch --once' run against it. Before and after: md5sum of .git/index unchanged, 'git status --porcelain' unchanged, and for-each-ref differs by exactly one line -- refs/ank/watch/origin/claims/TASK-10645a2750d0. No branch moved, no tag, no local refs/ank/claims, no working-tree file. One ref into a tracking namespace of its own is the whole of what it wrote. The help's phrase 'that repository's own index' is ank's index and not git's: git's was byte-identical.

--- a/.ank/entities/LOG-654de73df8bb.md
+++ b/.ank/entities/LOG-654de73df8bb.md
@@ -1,0 +1,16 @@
+---
+id: LOG-654de73df8bb
+type: log
+title: "drift audit 2026-08-31: one finding, written as TASK-1bc1186ad9e7 -- the surface refuses valid"
+created: 2026-08-31T07:54:44Z
+author: claude-code/opus-5+drift2
+scope:
+  - crates/ank-cli/src/cli.rs
+  - crates/ank-mcp/**
+about: ADR-fd98f4bc6dea
+seq: 0
+schema: 4
+version: 1
+---
+
+ JSON-RPC that escapes a non-BMP character as a surrogate pair, which is what Python's json.dumps emits by default. What holds around it, measured: nothing in crates/ank-mcp names a verb, tools/list is generated from ank_contract::COMMANDS, a flag the verb does not declare is refused -32602 by name ('find takes no --<<'), a server flag is refused with the corpus argument named, and every call spawns 'ank <verb> --repo <corpus> --json' so the refusal a client sees is the binary's. corpora.rs:324 applies the schema-first refusal that config.rs does, so the two readers of corpora.yml agree.

--- a/.ank/entities/LOG-7cb1db83504f.md
+++ b/.ank/entities/LOG-7cb1db83504f.md
@@ -1,0 +1,15 @@
+---
+id: LOG-7cb1db83504f
+type: log
+title: drift audit 2026-08-31, re-measured and holds for find. 'ank find' human output ends '+1681 more,
+created: 2026-08-31T07:54:06Z
+author: claude-code/opus-5+drift2
+scope:
+  - crates/ank-cli/**
+about: ADR-3e6ce108edcd
+seq: 0
+schema: 4
+version: 1
+---
+
+ narrow with --scope <path> or --type task|adr|spec|log' -- the cut and its notice. 'ank find --json' answers total 1721, shown 1721, hidden 0 and carries 1721 rows: the budget cut the human and not the program. shown and total agree under every filter measured -- no filter 1721/1721/0, --type adr 84/84/0, --scope crates/ank-core 177/177/0, --status open 0/0/0 -- and hidden stayed 0 throughout. context --json keeps its budget as the constraint requires. One asymmetry is worth a reader's eye rather than a claim of violation: 'ank review' prints 76 dead-scope identifiers to a human, where 'review --json' carries "dead": 76 and no rows, the count being what crates/ank-contract/src/verbs.rs:944 declares (Type::Num) beside proposed and live, which are arrays. Whether that is a listing this constraint reaches or a summary counter like faults and signals is a judgement for the human; it is recorded here rather than written as a task, and closing it would retype a field within a contract version, which ADR-6fd69efb629c forbids without a version bump.

--- a/.ank/entities/LOG-8eacaa9d6b42.md
+++ b/.ank/entities/LOG-8eacaa9d6b42.md
@@ -1,0 +1,16 @@
+---
+id: LOG-8eacaa9d6b42
+type: log
+title: drift audit 2026-08-31, re-measured and holds, and the earlier reading of it was a local artefact
+created: 2026-08-31T07:54:27Z
+author: claude-code/opus-5+drift2
+scope:
+  - crates/ank-cli/**
+  - docs/ank-spec-v1.1.md
+about: ADR-493471d64ba0
+seq: 0
+schema: 4
+version: 1
+---
+
+ worth recording. A worktree cut fresh from main reported 19 'done with no test proof' signals, which reads as the attest job failing. It is not: actions/checkout does not fetch refs/ank/*, and this clone held 186 proof refs against the remote's 205. After 'git fetch origin +refs/ank/proof/*:refs/ank/proof/*' the count of that signal is 0 across 349 done tasks, and check falls from 455 signals to 436. Every finished task in this corpus is anchored by a proof ref. Four commit: proofs still name commits unreachable here, which is the rebase case the signal describes and each of those tasks also carries a test proof.

--- a/.ank/entities/LOG-91b6b61e8a65.md
+++ b/.ank/entities/LOG-91b6b61e8a65.md
@@ -1,0 +1,18 @@
+---
+id: LOG-91b6b61e8a65
+type: log
+title: "drift audit 2026-08-31, re-measured and holds. Body sizes against the 180-line, 1500-word ceiling:"
+created: 2026-08-31T07:54:26Z
+author: claude-code/opus-5+drift2
+scope:
+  - skill/**
+  - crates/ank-cli/tests/skill.rs
+  - .claude-plugin/**
+  - docs/**
+about: ADR-91b77f036884
+seq: 0
+schema: 4
+version: 1
+---
+
+ skill/SKILL.md 121 lines and 1017 words, skill/plan 67 and 425, skill/drift 47 and 274, skill/loop 56 and 388. All four declare metadata.revision. The binary names the contract skill's revision it was built alongside: 'ank --version' prints 'ank 0.7.0 (c48e002, skill d25cedf8fe35)' and skill/SKILL.md declares revision d25cedf8fe35. One source, measured with git ls-files: skill/SKILL.md plus three siblings, no second copy anywhere in the tree, and .claude-plugin/plugin.json points at the four directories by path.

--- a/.ank/entities/LOG-92ab9a49015b.md
+++ b/.ank/entities/LOG-92ab9a49015b.md
@@ -1,0 +1,15 @@
+---
+id: LOG-92ab9a49015b
+type: log
+title: drift audit 2026-08-31, re-measured and holds. Two corpora, both declared in a corpora.yml under an
+created: 2026-08-31T07:53:42Z
+author: claude-code/opus-5+drift2
+scope:
+  - crates/ank-cli/src/claim.rs
+about: ADR-ed3e14d0f991
+seq: 0
+schema: 4
+version: 1
+---
+
+ isolated XDG_CONFIG_HOME, keyed on the root commits a04c7584... and d6b9ac1a.... Identity agent/Z claimed a task in the first, then claimed one in the second: 'warning: agent/Z holds TASK-10645a2750d0 in <path to the first corpus>, until 2026-08-31T08:13:36Z', followed by 'claimed TASK-497d97e1cfb4'. The fact is stated with the corpus and the lease, and the task is taken anyway -- ADR-052accd6e3b2's rule applied across a boundary, exactly as written, and nothing refused.

--- a/.ank/entities/LOG-98844c377794.md
+++ b/.ank/entities/LOG-98844c377794.md
@@ -1,0 +1,17 @@
+---
+id: LOG-98844c377794
+type: log
+title: "drift audit 2026-08-31: the pricing works and the price is structural, which is worth recording"
+created: 2026-08-31T07:56:22Z
+author: claude-code/opus-5+drift2
+scope:
+  - crates/ank-cli/src/commands.rs
+  - crates/ank-cli/src/claim.rs
+  - crates/ank-cli/src/human.rs
+about: ADR-6e09f8a67540
+seq: 0
+schema: 4
+version: 1
+---
+
+ before the next auditor tries to narrow it away. The four tasks this audit wrote are the only open ones in the corpus, so they are the only ones charged, and all four signal over-constrained against the 4000-character limit. Measured per path with ank context --json, summing the constraint text: crates/ank-mcp/src/lib.rs 4 ADRs and 2897 chars, crates/ank-daemon/src/declare.rs 3 and 1527, npm/ank/README.md 4 and 2405, NOTICE 0 and 0 -- all under the limit. Every path under crates/ank-cli/ charges 24 ADRs and 17660 chars, whatever its narrowness: tests/mcp.rs, tests/watch.rs, tests/schema.rs and tests/tui.rs are identical to the character, and tests/skill.rs is 25 and 18667. So a task cannot both meet CLAUDE.md's rule that a criterion about the binary is tested through the binary and stay under the charge, because the test has to live under crates/ank-cli/. The scopes were left as declared: they are the smallest perimeter the work needs, and the charge is the honest price of that perimeter rather than a scope to trim.

--- a/.ank/entities/LOG-a31c46bbcaaa.md
+++ b/.ank/entities/LOG-a31c46bbcaaa.md
@@ -1,0 +1,16 @@
+---
+id: LOG-a31c46bbcaaa
+type: log
+title: drift audit 2026-08-31, re-measured and holds. Every coordinating verb run outside a git repository
+created: 2026-08-31T07:53:01Z
+author: claude-code/opus-5+drift2
+scope:
+  - crates/ank-cli/**
+  - docs/ank-spec-v1.1.md
+about: ADR-9307e5d214a7
+seq: 0
+schema: 4
+version: 1
+---
+
+ exits 9 naming 'git init': claim, log, done, release, close, accept, attest and init, eight for eight. With .git removed from a corpus that had one, find, graph, scope, context, review and status all answer at exit 0 on the files alone, and check exits 0 saying in one line 'coordination: half skipped: no git repository here, so claim refs, ratification signatures, completion refs and detached proofs were neither read nor judged (git init to coordinate)'. The plumbing discipline holds too: GIT_TRACE over eleven verbs on this corpus and six on two throwaway ones spawned cat-file, rev-parse, symbolic-ref, rev-list, for-each-ref, config, hash-object, diff-tree, update-ref and push, every one on the list, plus 'git version' -- which is 'git --version' normalised by git, is what the 2.34 floor in this same constraint requires the code to ask, and is in the code's own PLUMBING list at crates/ank-cli/src/git.rs:44 though not in the constraint's sentence. send-pack appeared once and is git's own child of push, not a call ank makes.

--- a/.ank/entities/LOG-bf8d6e41a4df.md
+++ b/.ank/entities/LOG-bf8d6e41a4df.md
@@ -1,0 +1,15 @@
+---
+id: LOG-bf8d6e41a4df
+type: log
+title: drift audit 2026-08-31, re-measured and holds; no finding. Counted with GIT_TRACE at an absolute
+created: 2026-08-31T07:53:01Z
+author: claude-code/opus-5+drift2
+scope:
+  - crates/ank-cli/**
+about: ADR-cc65f1388a71
+seq: 1
+schema: 4
+version: 1
+---
+
+ path, one line per process, never by timing. Three throwaway corpora at 2, 20 and 60 tasks (4, 40 and 120 entities, a 30x spread): find 3/3/3, review 4/4/4, graph 3/3/3, status 5/5/5, check 4/4/4, scope 3/3/3, context 4/4/4 -- constant across every one. Coordination refs measured separately, because entities and refs are two dimensions and the earlier audit only isolated entities: the 60-task corpus was claimed 60 times under 60 identities, then copied and all but one claim ref deleted with update-ref -d, so one corpus at 1 claim and 60 claims. find 4/4, review 5/5, graph 4/4, check 5/5, scope 4/4, context 5/5. status read 8 at 1 claim and 6 at 60, which is the memoised check verdict of ADR-f3d1dea65d84 warm in one and cold in the other, and is fewer rather than more. Invariance holds on both dimensions.

--- a/.ank/entities/LOG-c3df29b95095.md
+++ b/.ank/entities/LOG-c3df29b95095.md
@@ -1,0 +1,18 @@
+---
+id: LOG-c3df29b95095
+type: log
+title: drift audit 2026-08-31, re-measured and holds. In a corpus with no allowed_signers, 'ank review'
+created: 2026-08-31T07:54:44Z
+author: claude-code/opus-5+drift2
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/src/git.rs
+  - skill/**
+  - docs/**
+about: ADR-964be4d940b2
+seq: 0
+schema: 4
+version: 1
+---
+
+ prints 'no ratification key declared: permissions are advisory, not enforced (S8)' beneath the queue, and check reports the same as a signal on 'allowed_signers'. 'review --json' carries "signers": [] there against two entries here, so a program reads the regime as directly as a person does and an unsigned corpus cannot render as a signed one. In this corpus, check also says '1 ratification signature(s) could not be checked here: no public key for the signing identity, so they are not verified and not refused', which is the fourth outcome stated rather than fallen silent.

--- a/.ank/entities/LOG-c456a84abb9f.md
+++ b/.ank/entities/LOG-c456a84abb9f.md
@@ -1,0 +1,16 @@
+---
+id: LOG-c456a84abb9f
+type: log
+title: drift audit 2026-08-31, re-measured and holds. A task file was rewritten with CRLF throughout (260
+created: 2026-08-31T07:54:06Z
+author: claude-code/opus-5+drift2
+scope:
+  - crates/ank-core/**
+  - docs/**
+about: ADR-63b59c5c26f7
+seq: 0
+schema: 4
+version: 1
+---
+
+ bytes to 277, 17 CR). 'ank show' read it unchanged; 'ank amend --scope docs/**' rewrote it and left 0 CR and 272 bytes, so CRLF is read and never written and the normalisation happens on first rewrite. The field-parity half was measured too: all 24 field names the kind registry declares in crates/ank-core/src/registry.rs -- about author blocked_by constraint created criteria_by done_criteria id proof ratified records references schema scope see seq slug status supersedes title type verified verify version -- appear in the ten accepted spec documents, none with a zero count.

--- a/.ank/entities/LOG-dbe265efbdb6.md
+++ b/.ank/entities/LOG-dbe265efbdb6.md
@@ -1,0 +1,16 @@
+---
+id: LOG-dbe265efbdb6
+type: log
+title: "drift audit 2026-08-31, re-measured and holds. Structure identical to every reader: status, review,"
+created: 2026-08-31T07:53:21Z
+author: claude-code/opus-5+drift2
+scope:
+  - crates/ank-cli/src/style.rs
+  - crates/ank-contract/**
+about: ADR-1f70ce2c3eac
+seq: 0
+schema: 4
+version: 1
+---
+
+ context, show and check were each run into a pipe and again through a pseudo-terminal, and with the escape sequences stripped the two are byte-identical for all five. The paint is real and not absent: the pty run of status carried 18 SGR sequences, the pipe run 0, NO_COLOR=1 at the pty 0, and 'status --json' at the pty 0. Bundling and abbreviation hold as declared: 'ank find -st adr' exits 1 with "'-st' bundles short flags" and names the two flags to type as 'ank find -s <v> -t <v>'; 'ank status -jq' the same; 'ank stat' exits 1 with 'unknown command' and lists the 26 verbs. One letter per long flag across the whole table, no collisions: -b -c -j -l -p -q -r -s -t -u -v.

--- a/.ank/entities/LOG-de4df7a5a564.md
+++ b/.ank/entities/LOG-de4df7a5a564.md
@@ -1,0 +1,16 @@
+---
+id: LOG-de4df7a5a564
+type: log
+title: drift audit 2026-08-31, re-measured and holds. A claimed task's done_criteria was edited in the
+created: 2026-08-31T07:53:21Z
+author: claude-code/opus-5+drift2
+scope:
+  - crates/ank-core/src/freeze.rs
+  - crates/ank-cli/**
+about: ADR-6b3f19e08a24
+seq: 0
+schema: 4
+version: 1
+---
+
+ file from 'c2' to 'c2 relaxed'. 'ank done' exits 6: 'done_criteria of TASK-37aea74865eb changed since the claim (claimed 9c0abe51c6e6, now d5110950934b)', hint 'git diff -- .ank/entities/TASK-37aea74865eb.md'. 'ank check' reports the same divergence as a fault and exits 8, naming both hashes. The edit was permitted and became visible rather than effective, which is the whole of the decision.

--- a/.ank/entities/LOG-df8c951ecb59.md
+++ b/.ank/entities/LOG-df8c951ecb59.md
@@ -1,0 +1,18 @@
+---
+id: LOG-df8c951ecb59
+type: log
+title: drift audit 2026-08-31, re-measured and holds, the surgery included. A config.yml was written with
+created: 2026-08-31T07:53:42Z
+author: claude-code/opus-5+drift2
+scope:
+  - crates/ank-cli/src/config.rs
+  - crates/ank-cli/src/init.rs
+  - crates/ank-cli/src/cli.rs
+  - docs/**
+about: ADR-e64dfaafd578
+seq: 0
+schema: 4
+version: 1
+---
+
+ a top comment carrying trailing spaces, a blank line, 'context_budget:   8000' with three spaces, "claim_ttl_max: '2h'" single-quoted, 'claim_ttl_default: "45m"' double-quoted, and a trailing '# trailing comment' after a verifier's run. 'ank config context_budget 9000' produced a one-line diff: the value alone. Every comment, blank line, quoting style and the three-space alignment survived byte for byte. 'ank config nope 1' exits 1 with "unknown key 'nope'" and the list of nine keys, and leaves the file unchanged. Running without a parsed configuration holds both ways: on a file with an unknown field every other verb exits 1 refusing to parse it while 'ank config context_budget' answers 9000 at exit 0, and a write into it succeeds and warns 'still does not parse'. On genuinely malformed YAML the read falls back honestly -- 'ank config context_budget --json' answers {"key":"context_budget","value":"8000","source":"default"} where a readable line gives "source":"file", so the caller is told which it got.

--- a/.ank/entities/LOG-f9fd50c50856.md
+++ b/.ank/entities/LOG-f9fd50c50856.md
@@ -1,0 +1,16 @@
+---
+id: LOG-f9fd50c50856
+type: log
+title: drift audit 2026-08-31, re-measured and holds. All 52 superseded entities in this corpus were
+created: 2026-08-31T07:54:26Z
+author: claude-code/opus-5+drift2
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-contract/src/verbs.rs
+about: ADR-3b6ba766a42e
+seq: 1
+schema: 4
+version: 1
+---
+
+ grepped for across every tracked file outside .ank/: zero citations, so the precondition accept refuses on is clean for all six pending supersessions. The clause about a proposed successor holds visibly at the same time: check reports 4 references whose succession ends on SPEC-d58b3a9e4e4d, which is proposed, and reports them as signals and never as faults.

--- a/.ank/entities/TASK-1bc1186ad9e7.md
+++ b/.ank/entities/TASK-1bc1186ad9e7.md
@@ -1,0 +1,62 @@
+---
+id: TASK-1bc1186ad9e7
+type: task
+slug: ank-mcp-refuses-valid-json-rpc-that-escapes-a-no
+title: ank mcp refuses valid JSON-RPC that escapes a non-BMP character
+created: 2026-08-31T07:52:05Z
+author: claude-code/opus-5+drift2
+status: open
+scope:
+  - crates/ank-mcp/Cargo.toml
+  - crates/ank-cli/tests/mcp.rs
+  - crates/ank-mcp/src/**
+blocked_by: []
+done_criteria: |
+  ank mcp answers {"jsonrpc":"2.0","id":"\ud83d\ude00-alpha","method":"ping"} with a result whose id is the same string the client sent, never with -32700, and answers a request that repeats a key rather than failing to parse it; a test in crates/ank-cli/tests/mcp.rs drives the binary with both lines and fails on any -32700.
+criteria_by: creator
+verify: [cargo-test, fmt-check]
+schema: 4
+version: 2
+---
+
+Measured on 2026-08-31 by feeding lines to the binary and reading what came back.
+
+`crates/ank-mcp/src/lib.rs:158` parses every inbound JSON-RPC message with
+`serde_yaml::from_str`, on the argument the crate manifest states: "YAML 1.2 is
+a superset of JSON, so a request on one line parses as flow YAML". Measured, it
+is not. Eight requests were sent; two valid JSON documents were refused:
+
+  sent  {"jsonrpc":"2.0","id":"😀-alpha","method":"ping"}
+  got   {"jsonrpc":"2.0","id":null,"error":{"code":-32700,"message":
+        "parse error: found invalid Unicode character escape code at line 1
+        column 29, while parsing a quoted scalar at line 1 column 26"}}
+
+  sent  {"jsonrpc":"2.0","id":3,"method":"ping","id":3}
+  got   {"jsonrpc":"2.0","id":null,"error":{"code":-32700,"message":
+        "parse error: duplicate entry with key \"id\""}}
+
+The same request with the emoji as literal UTF-8 answers
+`{"jsonrpc":"2.0","id":"<emoji>-alpha","result":{}}`. The difference is the
+escape form, not the character: RFC 8259 encodes a non-BMP code point as a
+surrogate pair, and YAML's `\u` escape is a single 16-bit unit with no pairing,
+so serde_yaml rejects it. The five other cases passed -- `é`, `\t`, `\/`,
+literal UTF-8, and a `<<` key.
+
+This is not an exotic input. `json.dumps` in Python's standard library escapes
+every non-ASCII character this way by default (`ensure_ascii=True`), so a client
+written against the stdlib cannot send an emoji, a CJK character or an accented
+name through any tool this surface offers: `ank_log`, `ank_new`, `ank_close
+--reason`. ADR-fd98f4bc6dea requires the surface to refuse on state exactly as
+the CLI does; the CLI accepts these strings and this surface does not, and it
+answers `id: null`, so the client cannot even attribute the failure to its own
+request.
+
+The tree already holds the argument against this instrument: `ank-tui`'s manifest
+replaced `serde_yaml` with `serde_json` for reading `--json` precisely because
+the superset claim is about the grammar and not about the resolver. `ank-mcp`
+was not brought along. `serde_json` is already in this workspace's lockfile.
+
+Note that ank's own writer is not affected: `ank_contract::json::string`
+(crates/ank-contract/src/json.rs:32) escapes nothing above U+001F, so the
+documents the CLI emits and this crate parses back at corpora.rs:289 carry no
+surrogate pairs. The defect is on the inbound path alone.

--- a/.ank/entities/TASK-49b10f02d209.md
+++ b/.ank/entities/TASK-49b10f02d209.md
@@ -1,0 +1,59 @@
+---
+id: TASK-49b10f02d209
+type: task
+slug: two-verbs-declare-a-json-shape-that-no-golden-fi
+title: Two verbs declare a JSON shape that no golden fixture pins
+created: 2026-08-31T07:52:41Z
+author: claude-code/opus-5+drift2
+status: open
+scope:
+  - crates/ank-cli/tests/schema.rs
+  - crates/ank-cli/tests/tui.rs
+  - crates/ank-cli/tests/golden-json/**
+blocked_by: []
+done_criteria: |
+  crates/ank-cli/tests/golden-json/ holds a fixture captured from the process for every verb whose ank-contract entry declares a non-empty output, read and tui included; and a test in crates/ank-cli/tests/schema.rs walks ank_contract::COMMANDS and fails naming any such verb that has no fixture, so deleting read.json turns the suite red.
+criteria_by: creator
+verify: [cargo-test, fmt-check]
+schema: 4
+version: 2
+---
+
+Measured on 2026-08-31 by walking the contract table against the fixture
+directory, and by running the two verbs to confirm they emit a document.
+
+Twenty-six verbs; twenty-four declare a non-empty `output` in
+crates/ank-contract/src/verbs.rs. Twenty-two have a fixture in
+crates/ank-cli/tests/golden-json/. The two that do not:
+
+  read   output declared at verbs.rs:1018   golden: none
+  tui    output declared at verbs.rs:1233   golden: none
+
+`mcp` and `watch` declare `output: &[]` and correctly have none, so the gap is
+exactly two.
+
+Both emit a real document. Measured in a throwaway corpus:
+
+  $ ank read ADR-d84db27ec8f0 --json
+  {"contract":1,"entity":"ADR-d84db27ec8f0","kind":"adr","by":"human:sean",
+   "at":"2026-08-31T07:50:45Z","readings":1}
+
+which is the shape verbs.rs:1018 declares, field for field. `ank tui --json`
+refuses at exit 9 without a terminal, so its fixture has to be captured through
+the pseudo-terminal harness crates/ank-cli/tests/tui.rs already carries -- which
+is why that file is in scope.
+
+ADR-6fd69efb629c says "A golden fixture pins the output of every verb, and a
+shape that changes without its fixture changing is a failing test". The
+conformance test that enforces it,
+`every_golden_conforms_to_the_shape_its_verb_declares` at
+crates/ank-cli/tests/cli.rs:18493, walks the fixture directory and resolves each
+fixture to a verb. It cannot notice a verb with no fixture, because it never
+starts from the verb table. So the promise `ank help --json` publishes about
+`read` and `tui` is connected to nothing the binary prints, which is the
+condition that test's own doc comment says it exists to prevent: "a description
+that is wrong reads exactly like a description that is right".
+
+The coverage assertion belongs in crates/ank-cli/tests/schema.rs rather than
+beside the existing walk, so the two questions -- does every fixture match its
+shape, does every declared shape have a fixture -- stay separable.

--- a/.ank/entities/TASK-56d188a1f8b3.md
+++ b/.ank/entities/TASK-56d188a1f8b3.md
@@ -1,0 +1,61 @@
+---
+id: TASK-56d188a1f8b3
+type: task
+slug: a-watch-yml-one-schema-ahead-is-refused-on-a-fie
+title: A watch.yml one schema ahead is refused on a field, not on the version
+created: 2026-08-31T07:52:23Z
+author: claude-code/opus-5+drift2
+status: open
+scope:
+  - crates/ank-daemon/src/declare.rs
+  - crates/ank-cli/tests/watch.rs
+blocked_by: []
+done_criteria: |
+  ank watch --once on a watch.yml carrying 'schema: 2' together with a key this build does not know exits 9 with a message naming both schema numbers and saying the file is newer than this ank, and never naming the unknown key; the same file at 'schema: 1' still exits 9 naming the unknown key; a test in crates/ank-cli/tests/watch.rs drives the binary with both files and fails if the first answer names a key.
+criteria_by: creator
+verify: [cargo-test, fmt-check]
+schema: 4
+version: 1
+---
+
+Measured on 2026-08-31 by writing two files into an isolated XDG_CONFIG_HOME and
+running the binary against each.
+
+  watch.yml           corpora.yml
+  schema: 2           schema: 2
+  watch: {}           corpora: {}
+  mirrors:            mirrors:
+    - somewhere         - somewhere
+
+  $ ank watch --once
+  error[9]: .../watch.yml: unknown field `mirrors`, expected one of `schema`,
+            `fetch`, `watch` at line 3 column 1
+    -> schema: 1 and a watch: map of repository identity to the path of a
+       checkout, or to a list of them
+
+  $ ank status
+  error[9]: .../corpora.yml: schema 2, this binary reads 1: the file is newer
+            than this ank
+    -> ank --version names the build, npm install -g @haksolot/ank replaces it
+
+Same shape of file, two answers. The corpora.yml answer is the one the rule
+asks for; docs/format.md:318 states it in as many words -- "Newer is refused,
+and refused **on the version rather than on the first field it does not
+recognise**" -- and the comment at crates/ank-cli/src/config.rs:378-385 records
+why, naming `mirrors` as the very example that sent a reader looking for a typo
+in a file that had none. watch.yml still gives that answer, and its hint tells
+the reader to write `schema: 1`, which is the one thing that would not help: the
+file is not wrong, this binary is old.
+
+The cause is ordering. `crates/ank-daemon/src/declare.rs:59` derives the
+declaration with `#[serde(deny_unknown_fields)]`, so deserialization fails on
+`mirrors` before line 178 ever compares `doc.schema` against SUPPORTED_SCHEMA.
+
+Its own test cannot see this. `an_unknown_schema_is_refused_by_number` at
+declare.rs:351 feeds `schema: 7\nwatch: {}\n` -- a file one version ahead with
+no unknown field -- so the deserialize succeeds and the number check runs. The
+ordering is exercised by no test in the tree, which is why the two files drifted
+apart while both were green.
+
+Measured control: watch.yml at `schema: 1` with the same `mirrors` key answers
+`unknown field` too, and there that answer is correct.

--- a/.ank/entities/TASK-9b82a1edd42e.md
+++ b/.ank/entities/TASK-9b82a1edd42e.md
@@ -1,0 +1,52 @@
+---
+id: TASK-9b82a1edd42e
+type: task
+slug: the-relicensing-notice-names-0-2-0-where-0-3-0-w
+title: The relicensing notice names 0.2.0 where 0.3.0 was the last GPL release
+created: 2026-08-31T07:51:45Z
+author: claude-code/opus-5+drift2
+status: open
+scope:
+  - NOTICE
+  - npm/ank/README.md
+  - crates/ank-cli/tests/skill.rs
+blocked_by: []
+done_criteria: |
+  Every tracked statement outside .ank/ of when the GPL-to-Apache change took effect names 0.3.0 as the last release distributed under GPL-3.0-only and 0.4.0 as the first under Apache-2.0; NOTICE and npm/ank/README.md agree on that boundary; and a test in crates/ank-cli/tests/skill.rs fails when a tracked file states a different one.
+criteria_by: creator
+verify: [cargo-test, fmt-check]
+schema: 4
+version: 1
+---
+
+Measured on 2026-08-31 against the tags themselves, not against the prose.
+
+`git show v0.3.0:crates/ank-cli/Cargo.toml` declares `license = "GPL-3.0-only"`,
+and `git show v0.3.0:LICENSE` is the GNU General Public License version 3. So do
+`npm/ank/package.json`, the root `package.json` and `.claude-plugin/plugin.json`
+at that tag. v0.3.0 is a published release: `gh release list` dates it
+2026-08-17. v0.4.0 (2026-08-18) is the first tag whose LICENSE is the Apache
+License and whose manifests declare Apache-2.0 -- with the single exception
+`crates/ank-cli/tests/skill.rs:918` already records, `.claude-plugin/plugin.json`,
+which went on declaring GPL-3.0-only at v0.4.0 and for thirteen days after.
+
+So the last GPL-3.0-only release is 0.3.0 and the first Apache-2.0 release is
+0.4.0. Two tracked documents say otherwise:
+
+  NOTICE:18                "distributed under GPL-3.0-only up to and including 0.2.0"
+  npm/ank/README.md:33     "Ank was GPL-3.0-only until 0.3.0"
+
+Both exclude 0.3.0 from the GPL era. ADR-534c7a3e6cf8 (successor of
+ADR-9f03438f5422, which said the same) requires that the relicensing be
+prospective and say so -- "a release already made under GPL-3.0 stays available
+under GPL-3.0 to whoever received it" -- and that the documentation state the
+licence "in one place, with no second answer left anywhere else to contradict
+it". Somebody who took 0.3.0 is told by NOTICE, the licence notice at the root
+of the repository, that their release was not one of the GPL ones. It was.
+
+Nothing catches it today. `declared_licences()` in crates/ank-cli/tests/skill.rs
+walks every manifest for its `license` field, which is exactly the drift the
+list missed before; the prose boundary is a different claim and no test reads it.
+
+The two documents also disagree with each other on where the line falls, which
+is the second answer that ADR forbids on its own terms.


### PR DESCRIPTION
A drift audit of the accepted corpus against crates/, measured through the
binary rather than read off the source.

Four findings, each written as an open task with a falsifiable criterion and
both verifiers declared:

  TASK-9b82a1edd42e  NOTICE:18 says the GPL era ended at 0.2.0. v0.3.0 was
                     published on 2026-08-17 declaring GPL-3.0-only in every
                     manifest and carrying the GPL as LICENSE; v0.4.0 is the
                     first Apache-2.0 release. npm/ank/README.md draws the line
                     in a third place. The manifest walker in skill.rs reads
                     `license` fields and never the prose boundary.

  TASK-1bc1186ad9e7  `ank mcp` answers -32700 with id:null to a JSON-RPC request
                     that escapes a non-BMP character as a surrogate pair --
                     what Python's json.dumps emits by default. serde_yaml's
                     \u is a single 16-bit unit and does not pair, so the
                     superset claim in the crate manifest is false about the
                     resolver. Duplicate keys fail the same way.

  TASK-56d188a1f8b3  A watch.yml declaring `schema: 2` beside a field this build
                     does not know is refused on the field, sending its reader
                     after a typo in a file that has none. corpora.yml with the
                     same shape is refused on the version, which is the rule
                     docs/format.md:318 states. declare.rs compares the schema
                     after deny_unknown_fields has already failed, and its own
                     test feeds a file with no unknown field.

  TASK-49b10f02d209  24 verbs declare a JSON output shape; 22 have a golden
                     fixture. `read` and `tui` have none, and the conformance
                     test walks fixtures to verbs so it cannot see the gap.

Eighteen constraints were re-measured and hold: the numbers are recorded as log
entries on the ADRs themselves, so the next auditor does not repeat the work.
Process-count invariance was measured on both dimensions -- 30x entities and
60x claim refs, constant counts -- rather than on entities alone.

No code changed and no task was claimed.
