### PR TITLE
Ratify the six supersessions the tree had outgrown

### DIFF
--- a/.ank/entities/ADR-01b6dd05f0db.md
+++ b/.ank/entities/ADR-01b6dd05f0db.md
@@ -4,14 +4,14 @@ type: adr
 slug: the-ank-directory-is-reached-only-through-the-cl
 title: The .ank directory is reached only through the CLI
 created: 2026-08-01T01:58:41Z
-status: accepted
+status: superseded
 scope:
   - .ank/**
 constraint: |
   Entities in .ank/ are read and written through the ank CLI only. Reading is ank show, ank find and ank context; writing is ank new, claim, log, done, release, attest, close and accept. No agent opens, greps, lists or edits a file under .ank/ directly. This constrains the agent, not the tool: a human with an editor keeps every power they had, and check remains what notices.
 ratified: ea7020bae33d
 schema: 1
-version: 2
+version: 3
 ---
 
 `.ank/` should be as opaque to an agent as `.git/` is. Nobody opens `.git/refs/heads/main` to read a branch; they run `git rev-parse`. The reason is not secrecy, it is that the tool knows things the file does not: the budget of section 5, the truncation notice, the freeze anchored where the file's editor cannot reach it, what is claimable and by whom.

--- a/.ank/entities/ADR-24e21cb83793.md
+++ b/.ank/entities/ADR-24e21cb83793.md
@@ -5,7 +5,7 @@ slug: the-daemon-watches-what-it-was-declared-answers
 title: The daemon watches what it was declared, answers no verb, and fetches nothing but refs/ank/*, and the rule reaches the crate that implements it
 created: 2026-08-31T03:48:24Z
 author: claude-code/opus-5+corpus
-status: proposed
+status: accepted
 scope:
   - crates/ank-daemon/**
   - crates/ank-cli/src/index.rs
@@ -13,8 +13,12 @@ scope:
 constraint: |
   A background process may keep several corpora warm for whatever reads them, on these terms and no others. It watches only corpora declared to it, keyed on the repository identity of ADR-621a7fd96ce1 and never on a path, and it walks no filesystem looking for one. It answers no verb: it is not a second dispatch path, it exposes no query surface of its own, and a caller that wants an answer runs the CLI, which finds a cache already warm. The only thing it writes into a repository is a fetch of refs/ank/* into a tracking namespace of its own; it touches no branch, no working tree, no index of git's, and no local refs/ank/claims. It takes no claim, holds none on anybody's behalf and renews none. It emits an event when a corpus it watches changes, and an event states what changed and never what to do about it. Nothing depends on it: every verb behaves identically with the daemon absent, its absence is never an error, and no route makes running it a condition of using ank.
 supersedes: ADR-a22cd3196529
+ratified: 15df779f6e20
+verified:
+  - by: claude-code/opus-5+ratify
+    at: 2026-08-31T08:12:42Z
 schema: 4
-version: 1
+version: 2
 ---
 
 The text of the constraint is ADR-a22cd3196529's, word for word. Only the scope

--- a/.ank/entities/ADR-534c7a3e6cf8.md
+++ b/.ank/entities/ADR-534c7a3e6cf8.md
@@ -5,7 +5,7 @@ slug: ank-is-apache-2-0-whole-declared-by-the-channels
 title: Ank is Apache-2.0 whole, declared by the channels that still ship
 created: 2026-08-31T04:05:44Z
 author: claude-code/opus-5+corpus
-status: proposed
+status: accepted
 scope:
   - LICENSE
   - README.md
@@ -27,8 +27,12 @@ constraint: |
   stays available under GPL-3.0 to whoever received it, and nothing in the tree
   claims to withdraw that.
 supersedes: ADR-9f03438f5422
+ratified: 11f332dddc55
+verified:
+  - by: claude-code/opus-5+ratify
+    at: 2026-08-31T08:12:42Z
 schema: 4
-version: 1
+version: 2
 ---
 
 The licence is ADR-9f03438f5422's and it does not move: Apache-2.0, whole,

--- a/.ank/entities/ADR-67a4ac10c534.md
+++ b/.ank/entities/ADR-67a4ac10c534.md
@@ -5,7 +5,7 @@ slug: the-log-is-a-file-of-its-own-addressed-as-an-ent
 title: The log is a file of its own, addressed as an entity
 created: 2026-08-31T03:41:28Z
 author: claude-code/opus-5+corpus
-status: proposed
+status: accepted
 scope:
   - crates/ank-core/**
   - crates/ank-cli/**
@@ -19,8 +19,12 @@ constraint: |
   
   Any entity kind may carry a log, and no entry means no log, never an error.
 supersedes: ADR-ff294eff4d1a
+ratified: e251c9c7df58
+verified:
+  - by: claude-code/opus-5+ratify
+    at: 2026-08-31T08:11:32Z
 schema: 4
-version: 1
+version: 2
 ---
 
 ADR-25f977377fa0 made a log entry an entity: allocated an id, written once,

--- a/.ank/entities/ADR-85e6bbb195b8.md
+++ b/.ank/entities/ADR-85e6bbb195b8.md
@@ -4,7 +4,7 @@ type: adr
 slug: the-name-is-ank
 title: The project is called ank
 created: 2026-07-29T10:40:00Z
-status: accepted
+status: superseded
 scope:
   - crates/**
   - docs/**
@@ -19,7 +19,7 @@ constraint: |
   at an external artifact.
 ratified: c0c1dc33a814
 schema: 1
-version: 3
+version: 4
 ---
 
 Three letters, typed on every call of the agent loop and present in every path

--- a/.ank/entities/ADR-9f03438f5422.md
+++ b/.ank/entities/ADR-9f03438f5422.md
@@ -5,7 +5,7 @@ slug: ank-is-apache-2-0-whole-and-the-format-tool-spli
 title: Ank is Apache-2.0 whole, and the format/tool split is abandoned
 created: 2026-08-17T19:38:57Z
 author: claude-code/2.1.233+exposition
-status: accepted
+status: superseded
 scope:
   - LICENSE
   - README.md
@@ -31,7 +31,7 @@ constraint: |
 supersedes: ADR-68018cda382c
 ratified: 40aea8956b05
 schema: 3
-version: 2
+version: 3
 ---
 
 ## What this supersedes

--- a/.ank/entities/ADR-a22cd3196529.md
+++ b/.ank/entities/ADR-a22cd3196529.md
@@ -5,7 +5,7 @@ slug: the-daemon-watches-what-it-was-declared-answers
 title: The daemon watches what it was declared, answers no verb, and fetches nothing but refs/ank/*
 created: 2026-08-24T22:02:40Z
 author: claude-code/opus-5+planning
-status: accepted
+status: superseded
 scope:
   - crates/ank-cli/src/index.rs
   - docs/**
@@ -16,7 +16,7 @@ verified:
   - by: haksolot@vmi3223161
     at: 2026-08-24T22:26:39Z
 schema: 4
-version: 3
+version: 4
 ---
 
 The request is the one git answers with `git daemon` and a fetch in the

--- a/.ank/entities/ADR-e45e1a29fe91.md
+++ b/.ank/entities/ADR-e45e1a29fe91.md
@@ -5,14 +5,18 @@ slug: the-ank-directory-is-reached-only-through-the-cl
 title: The .ank directory is reached only through the CLI, and the routes are the ones that dispatch
 created: 2026-08-31T04:01:01Z
 author: claude-code/opus-5+corpus
-status: proposed
+status: accepted
 scope:
   - .ank/**
 constraint: |
   Entities in .ank/ are read and written through the ank CLI only. Reading is ank show, ank find, ank context, ank scope, ank graph, ank status, ank review, ank check and the read form of ank log; writing is ank new, claim, log, done, release, attest, close, accept, amend, edit, config and read. No agent opens, greps, lists or edits a file under .ank/ directly. This constrains the agent, not the tool: a human with an editor keeps every power they had, and check remains what notices.
 supersedes: ADR-01b6dd05f0db
+ratified: 1f884b7a61e2
+verified:
+  - by: claude-code/opus-5+ratify
+    at: 2026-08-31T08:12:42Z
 schema: 4
-version: 1
+version: 2
 ---
 
 `.ank/` should be as opaque to an agent as `.git/` is. Nobody opens

--- a/.ank/entities/ADR-f8f1ea7fd2bb.md
+++ b/.ank/entities/ADR-f8f1ea7fd2bb.md
@@ -5,7 +5,7 @@ slug: the-project-is-called-ank-and-every-crate-carrie
 title: The project is called ank, and every crate carries the name
 created: 2026-08-31T04:10:34Z
 author: claude-code/opus-5+corpus
-status: proposed
+status: accepted
 scope:
   - crates/**
   - docs/**
@@ -19,8 +19,12 @@ constraint: |
   falsify: log entries already written, and proof references pointing at an
   external artifact.
 supersedes: ADR-85e6bbb195b8
+ratified: bd1f6317b930
+verified:
+  - by: claude-code/opus-5+ratify
+    at: 2026-08-31T08:12:43Z
 schema: 4
-version: 1
+version: 2
 ---
 
 Three letters, typed on every call of the agent loop and present in every path of

--- a/.ank/entities/ADR-ff294eff4d1a.md
+++ b/.ank/entities/ADR-ff294eff4d1a.md
@@ -5,7 +5,7 @@ slug: the-log-is-a-file-of-its-own-and-a-task-file-cha
 title: The log is a file of its own, and a task file changes only on a transition
 created: 2026-08-11T22:17:16Z
 author: claude-code@sean-laptop
-status: accepted
+status: superseded
 scope:
   - crates/ank-core/**
   - crates/ank-cli/**
@@ -26,7 +26,7 @@ constraint: |
   error.
 ratified: 79b697b2f062
 schema: 2
-version: 2
+version: 3
 ---
 
 ## Context

--- a/.ank/entities/SPEC-d58b3a9e4e4d.md
+++ b/.ank/entities/SPEC-d58b3a9e4e4d.md
@@ -5,13 +5,17 @@ slug: the-cli-surface
 title: The CLI surface
 created: 2026-08-31T03:54:41Z
 author: claude-code/opus-5+corpus
-status: proposed
+status: accepted
 scope:
   - crates/ank-cli/**
 references: [SPEC-a89ba4f755e9, SPEC-89070ce7f3b8, SPEC-6aed60cd3717, SPEC-88e1ba60a95d]
 supersedes: SPEC-fe8bdb84faca
+ratified: 427e1a351ad9
+verified:
+  - by: claude-code/opus-5+ratify
+    at: 2026-08-31T08:12:43Z
 schema: 4
-version: 1
+version: 2
 ---
 
 One of the ten documents that carry the Ank specification (ADR-5a690829388d).

--- a/.ank/entities/SPEC-fe8bdb84faca.md
+++ b/.ank/entities/SPEC-fe8bdb84faca.md
@@ -5,7 +5,7 @@ slug: the-cli-surface
 title: The CLI surface
 created: 2026-08-25T17:32:13Z
 author: claude-code/opus-5+spec-declares
-status: accepted
+status: superseded
 scope:
   - crates/ank-cli/**
 references: [SPEC-a89ba4f755e9, SPEC-89070ce7f3b8, SPEC-6aed60cd3717, SPEC-88e1ba60a95d]
@@ -15,7 +15,7 @@ verified:
   - by: haksolot@vmi3223161
     at: 2026-08-25T19:09:25Z
 schema: 4
-version: 2
+version: 3
 ---
 
 One of the ten documents that carry the Ank specification (ADR-5a690829388d).


### PR DESCRIPTION
Six successors were proposed this morning and all 85 citations of the documents they retire were re-pointed and verified at zero outside `.ank/`. `ank accept` refuses a supersession while any such citation stands, so this is the first moment these could be signed.

| retired | successor |
| --- | --- |
| `ADR-ff294eff4d1a` | `ADR-67a4ac10c534` — the log is a file of its own, addressed as an entity |
| `ADR-a22cd3196529` | `ADR-24e21cb83793` — the daemon's rule reaches the crate that implements it |
| `ADR-01b6dd05f0db` | `ADR-e45e1a29fe91` — the routes into `.ank/` are the ones that dispatch |
| `ADR-9f03438f5422` | `ADR-534c7a3e6cf8` — Apache-2.0 whole, declared by the channels that still ship |
| `ADR-85e6bbb195b8` | `ADR-f8f1ea7fd2bb` — every crate carries the name |
| `SPEC-fe8bdb84faca` | `SPEC-d58b3a9e4e4d` — the CLI surface |

Each commit keeps its `ratify <id>` subject, which is how the ratification is located afterwards: **merge commit only, never squash or rebase.**

`ank review` answers *nothing proposed for ratification*. `ank check` is ok at exit 0 — 366 tasks, 84 adr — and the signal count falls from 455 to 426 as the six "not yet a succession" signals clear.

Run by Claude Code on the repository owner's explicit instruction; the corpus records the actor as `claude-code/opus-5+ratify` on each entity rather than presenting it as a human reading.