### PR TITLE
Correct the GPL-to-Apache boundary to 0.3.0/0.4.0 in NOTICE and the npm README, and test it

### DIFF
--- a/.ank/entities/LOG-2dc4d88c02a4.md
+++ b/.ank/entities/LOG-2dc4d88c02a4.md
@@ -1,0 +1,29 @@
+---
+id: LOG-2dc4d88c02a4
+type: log
+title: Test written red-first, and made to fail four different ways before it was allowed to pass.
+created: 2026-08-31T08:56:00Z
+author: claude-code/opus-5+licence
+scope:
+  - NOTICE
+  - npm/ank/README.md
+  - crates/ank-cli/tests/skill.rs
+about: TASK-9b82a1edd42e
+seq: 1
+schema: 4
+version: 1
+---
+
+
+
+the_relicensing_boundary_is_stated_the_same_way_everywhere in crates/ank-cli/tests/skill.rs walks the tree the way declared_licences() does (target, node_modules, .git and .ank excluded, non-UTF-8 files skipped by failing to decode rather than by an extension list) and reports every line naming an N.N.N release with the word GPL within two lines either side. A window and not a whole file, measured: crates/ank-cli/Cargo.toml declares version 0.7.0 eleven lines above its licence comment and is untouched, and so are install.sh, install.ps1, release.yml and docs/getting-started.md, which name 0.2.0 as an install example. On this tree the walk returns exactly three sites and no false positive.
+
+Four measured reds, each with the rest of the fix in place:
+1. NOTICE saying 0.2.0 -> FAILED, naming NOTICE:18 and the version.
+2. NOTICE corrected, npm/ank/README.md still 'until 0.3.0' -> FAILED on the one-sided rule: a file that states the boundary must name both ends, because one release alone reads as inclusive or exclusive and the two documents were read the two different ways.
+3. A file that does not exist yet, docs/licence-mutant.md with 'GPL-3.0-only up to and including 0.2.0' -> FAILED naming it. So the check is a walk and not a list of two paths.
+4. NOTICE truncated to its Apache header -> FAILED: neither NOTICE nor npm/ank/README.md may fall silent, since an assertion over an empty walk passes.
+
+The test file is inside its own walk: a probe line '// probe 0.9.9 GPL' appended after the constants FAILED at skill.rs:1085. The two constants sit in one window with the word GPL so that this file states the boundary whole and is held to the rule it enforces.
+
+Green after: cargo test -p ank-cli --test skill, 25 passed 0 failed; cargo fmt --check clean; ank check 0 faults.

--- a/.ank/entities/LOG-59b8362b9d88.md
+++ b/.ank/entities/LOG-59b8362b9d88.md
@@ -1,0 +1,15 @@
+---
+id: LOG-59b8362b9d88
+type: log
+title: done, proof test:local/ca53baefe30c@bbdf494 test:local/e3b0c44298fc@bbdf494
+created: 2026-08-31T09:03:40Z
+author: claude-code/opus-5+licence
+scope:
+  - NOTICE
+  - npm/ank/README.md
+  - crates/ank-cli/tests/skill.rs
+about: TASK-9b82a1edd42e
+seq: 2
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-e197b307291d.md
+++ b/.ank/entities/LOG-e197b307291d.md
@@ -1,0 +1,19 @@
+---
+id: LOG-e197b307291d
+type: log
+title: "Tag facts confirmed by git, not by prose. v0.2.0 and v0.3.0: crates/ank-cli/Cargo.toml,"
+created: 2026-08-31T08:49:14Z
+author: claude-code/opus-5+licence
+scope:
+  - NOTICE
+  - npm/ank/README.md
+  - crates/ank-cli/tests/skill.rs
+about: TASK-9b82a1edd42e
+seq: 0
+schema: 4
+version: 1
+---
+
+ npm/ank/package.json, package.json and .claude-plugin/plugin.json all declare license GPL-3.0-only, and LICENSE at both tags opens 'GNU GENERAL PUBLIC LICENSE Version 3'. v0.4.0: LICENSE opens 'Apache License Version 2.0' and every manifest declares Apache-2.0 except .claude-plugin/plugin.json, still GPL-3.0-only there (the drift skill.rs:918 already records). So 0.3.0 is the last GPL release and 0.4.0 the first Apache one. Eleven tags exist, v0.1.0 through v0.7.0; none after v0.4.0 reverts.
+
+Swept every tracked file outside .ank/ for a fourth statement of the boundary: git ls-files | grep -v '^.ank/' | xargs grep -InE 'GPL|copyleft|relicens|Apache-2.0', then again for any N.N.N version token. The boundary is stated in exactly two places, NOTICE:18 and npm/ank/README.md:33. crates/ank-cli/Cargo.toml:13-21 and crates/ank-{contract,daemon,mcp,tui}/Cargo.toml carry the prospective clause and cite ADR-534c7a3e6cf8 but name no version, so they state no boundary and need no edit. Every other 0.2.0 in the tree (install.sh, install.ps1, release.yml, docs/getting-started.md) is an install-example or a release-tooling example, unrelated to the licence.

--- a/.ank/entities/TASK-9b82a1edd42e.md
+++ b/.ank/entities/TASK-9b82a1edd42e.md
@@ -5,7 +5,7 @@ slug: the-relicensing-notice-names-0-2-0-where-0-3-0-w
 title: The relicensing notice names 0.2.0 where 0.3.0 was the last GPL release
 created: 2026-08-31T07:51:45Z
 author: claude-code/opus-5+drift2
-status: in_progress
+status: done
 scope:
   - NOTICE
   - npm/ank/README.md
@@ -15,8 +15,21 @@ done_criteria: |
   Every tracked statement outside .ank/ of when the GPL-to-Apache change took effect names 0.3.0 as the last release distributed under GPL-3.0-only and 0.4.0 as the first under Apache-2.0; NOTICE and npm/ank/README.md agree on that boundary; and a test in crates/ank-cli/tests/skill.rs fails when a tracked file states a different one.
 criteria_by: creator
 verify: [cargo-test, fmt-check]
+proof:
+  - type: test
+    ref: local/ca53baefe30c@bbdf494
+    tree: scope/54b2d675a14e
+    criteria: bac966a2fa4a
+    verifier: cargo-test@f14aeab36e1b
+    via: verifier
+  - type: test
+    ref: local/e3b0c44298fc@bbdf494
+    tree: scope/54b2d675a14e
+    criteria: bac966a2fa4a
+    verifier: fmt-check@5ca6d10bcd55
+    via: verifier
 schema: 4
-version: 2
+version: 3
 ---
 
 Measured on 2026-08-31 against the tags themselves, not against the prose.

--- a/.ank/entities/TASK-9b82a1edd42e.md
+++ b/.ank/entities/TASK-9b82a1edd42e.md
@@ -5,7 +5,7 @@ slug: the-relicensing-notice-names-0-2-0-where-0-3-0-w
 title: The relicensing notice names 0.2.0 where 0.3.0 was the last GPL release
 created: 2026-08-31T07:51:45Z
 author: claude-code/opus-5+drift2
-status: open
+status: in_progress
 scope:
   - NOTICE
   - npm/ank/README.md
@@ -16,7 +16,7 @@ done_criteria: |
 criteria_by: creator
 verify: [cargo-test, fmt-check]
 schema: 4
-version: 1
+version: 2
 ---
 
 Measured on 2026-08-31 against the tags themselves, not against the prose.

--- a/NOTICE
+++ b/NOTICE
@@ -15,7 +15,8 @@ limitations under the License.
 
 ---
 
-Ank was distributed under GPL-3.0-only up to and including 0.2.0. That change
-is prospective, and this notice does not withdraw it: a release received under
-GPL-3.0 stays available under GPL-3.0 to whoever received it
-(ADR-534c7a3e6cf8).
+Ank was distributed under GPL-3.0-only up to and including 0.3.0, the last
+release made under that licence; 0.4.0 is the first released under the Apache
+License, Version 2.0. The change is prospective, and this notice does not
+withdraw it: a release received under GPL-3.0 stays available under GPL-3.0 to
+whoever received it (ADR-534c7a3e6cf8).

--- a/crates/ank-cli/tests/skill.rs
+++ b/crates/ank-cli/tests/skill.rs
@@ -1071,3 +1071,181 @@ fn the_copyright_is_asserted_in_a_notice() {
         "NOTICE does not name the licence it notices:\n{notice}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// The historical boundary, stated the same way wherever it is stated
+// (ADR-534c7a3e6cf8)
+// ---------------------------------------------------------------------------
+
+/// The boundary, measured at the tags: 0.3.0 is the last release distributed
+/// under GPL-3.0-only and 0.4.0 the first under Apache-2.0. Stated here in one
+/// window, so the walk below reads this file too and holds it to its own rule.
+const LAST_COPYLEFT_RELEASE: &str = "0.3.0";
+const FIRST_APACHE_RELEASE: &str = "0.4.0";
+
+/// Every `N.N.N` in a line, which is what a release is called in prose here.
+fn release_versions(line: &str) -> Vec<String> {
+    let bytes: Vec<char> = line.chars().collect();
+    let mut found = Vec::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        if !bytes[i].is_ascii_digit() || (i > 0 && bytes[i - 1] == '.') {
+            i += 1;
+            continue;
+        }
+        let start = i;
+        let mut dots = 0;
+        while i < bytes.len() && (bytes[i].is_ascii_digit() || bytes[i] == '.') {
+            if bytes[i] == '.' {
+                if i + 1 >= bytes.len() || !bytes[i + 1].is_ascii_digit() {
+                    break;
+                }
+                dots += 1;
+            }
+            i += 1;
+        }
+        if dots == 2 {
+            found.push(bytes[start..i].iter().collect::<String>());
+        }
+    }
+    found
+}
+
+/// Every line in the tree that names a release close enough to the word `GPL`
+/// to be read as saying when the copyleft era ended.
+///
+/// A window of two lines either side, because the sentence wraps and a
+/// paragraph is not a line. `crates/ank-cli/Cargo.toml` declares a package
+/// version eleven lines above its licence comment and is untouched by that
+/// distance, which is the point of a window rather than a whole file: a
+/// manifest names its own version for reasons that have nothing to do with
+/// this, and so do `install.sh`, `install.ps1` and `release.yml`.
+///
+/// Returned as `(path, line number, versions named, the line)`.
+fn boundary_statements() -> Vec<(String, usize, Vec<String>, String)> {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let mut found = Vec::new();
+    let mut stack = vec![root.clone()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let name = path
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .to_string();
+            // The same exclusions the licence walk above uses, and for the same
+            // reason: `.ank/` records what the licence *was*, and that history
+            // is the thing the relicensing is careful to keep.
+            if path.is_dir() {
+                if !matches!(name.as_str(), "target" | "node_modules" | ".git" | ".ank") {
+                    stack.push(path);
+                }
+                continue;
+            }
+            // Not a list of extensions: a file that is not text fails to decode
+            // and is skipped, so a format nobody thought of is still read.
+            let Ok(text) = fs::read_to_string(&path) else {
+                continue;
+            };
+            let lines: Vec<&str> = text.lines().collect();
+            for (i, line) in lines.iter().enumerate() {
+                let versions = release_versions(line);
+                if versions.is_empty() {
+                    continue;
+                }
+                let lo = i.saturating_sub(2);
+                let hi = (i + 3).min(lines.len());
+                if !lines[lo..hi].iter().any(|l| l.contains("GPL")) {
+                    continue;
+                }
+                let shown = path
+                    .strip_prefix(&root)
+                    .unwrap_or(&path)
+                    .to_string_lossy()
+                    .replace('\\', "/");
+                found.push((shown, i + 1, versions, line.trim().to_string()));
+            }
+        }
+    }
+    found.sort();
+    found
+}
+
+/// **Wherever the tree says when the copyleft era ended, it says the same
+/// thing, and it says both ends of it** (ADR-534c7a3e6cf8).
+///
+/// The sentence is not decoration. The relicensing is prospective, so a release
+/// received under the old terms stays available under them, and the notice is
+/// how its recipient learns they are owed that. A boundary drawn one release
+/// early silently writes those recipients out of a guarantee they hold.
+///
+/// It was drawn one release early. `NOTICE` put the end of the copyleft era at
+/// 0.2.0, and `npm/ank/README.md` said "until 0.3.0", which a reader cannot
+/// settle either way. Measured at the tags rather than read from the prose:
+/// `git show v0.3.0:LICENSE` is the GNU General Public License version 3, and
+/// so is v0.2.0's, while `git show v0.4.0:LICENSE` is the Apache License; every
+/// manifest at each tag agrees with its own LICENSE.
+///
+/// Nothing was looking. `declared_licences()` above walks manifests for the
+/// licence they declare *now*, which is a different claim entirely -- it would
+/// stay green with the date of the change stated wrongly in every document in
+/// the tree.
+///
+/// So both ends are required, not just the correct one. A statement naming only
+/// the last release under the old licence can be read as inclusive or exclusive
+/// of it, and the two documents that carried this were read the two different
+/// ways. Naming the first release under the new licence as well leaves no
+/// reading in which they disagree.
+#[test]
+fn the_relicensing_boundary_is_stated_the_same_way_everywhere() {
+    let statements = boundary_statements();
+
+    let wrong: Vec<_> = statements
+        .iter()
+        .filter(|(_, _, versions, _)| {
+            versions
+                .iter()
+                .any(|v| v != LAST_COPYLEFT_RELEASE && v != FIRST_APACHE_RELEASE)
+        })
+        .collect();
+    assert!(
+        wrong.is_empty(),
+        "{LAST_COPYLEFT_RELEASE} is the last release distributed under \
+         GPL-3.0-only and {FIRST_APACHE_RELEASE} the first under Apache-2.0, \
+         measured at the tags. These say otherwise: {wrong:#?}"
+    );
+
+    let mut files: Vec<String> = statements.iter().map(|(p, _, _, _)| p.clone()).collect();
+    files.sort();
+    files.dedup();
+    for file in &files {
+        let named: Vec<&str> = statements
+            .iter()
+            .filter(|(p, _, _, _)| p == file)
+            .flat_map(|(_, _, versions, _)| versions.iter().map(|v| v.as_str()))
+            .collect();
+        assert!(
+            named.contains(&LAST_COPYLEFT_RELEASE) && named.contains(&FIRST_APACHE_RELEASE),
+            "{file} says when the licence changed but names only {named:?}: a \
+             boundary given as one release can be read as including it or not, \
+             and both readings were taken. Name {LAST_COPYLEFT_RELEASE} as the \
+             last under GPL-3.0-only and {FIRST_APACHE_RELEASE} as the first \
+             under Apache-2.0."
+        );
+    }
+
+    // A recipient of a copyleft release reads one of these two, and neither is
+    // allowed to fall silent: an assertion over an empty walk passes.
+    for document in ["NOTICE", "npm/ank/README.md"] {
+        assert!(
+            files.iter().any(|f| f == document),
+            "{document} no longer states when the licence changed, so the \
+             guarantee owed to whoever received a GPL-3.0-only release is not \
+             written down there. Found statements in: {files:?}"
+        );
+    }
+}

--- a/npm/ank/README.md
+++ b/npm/ank/README.md
@@ -30,6 +30,7 @@ The skill an agent loads is a separate install, and
 specification and the source.
 
 Apache-2.0. Your `.ank/` files, the third-party tools that read or write them,
-and anything you build on top are yours. Ank was GPL-3.0-only until 0.3.0, and
-the change is prospective: a release you already received under GPL-3.0 stays
-available to you under GPL-3.0.
+and anything you build on top are yours. Ank was GPL-3.0-only up to and
+including 0.3.0, the last release made under that licence; 0.4.0 is the first
+released under Apache-2.0. The change is prospective: a release you already
+received under GPL-3.0 stays available to you under GPL-3.0.


### PR DESCRIPTION
- **State the GPL-to-Apache boundary at 0.3.0/0.4.0, and test it**
- **Close TASK-9b82a1edd42e: the relicensing boundary is 0.3.0/0.4.0**
