### PR TITLE
Refuse a newer watch.yml on its version, not on an unknown key

### DIFF
--- a/.ank/entities/LOG-401e94218ec6.md
+++ b/.ank/entities/LOG-401e94218ec6.md
@@ -1,0 +1,16 @@
+---
+id: LOG-401e94218ec6
+type: log
+title: "After, same binary rebuilt, same isolated home, four files measured. schema: 2 + mirrors ->"
+created: 2026-08-31T08:52:47Z
+author: claude-code/opus-5+watch
+scope:
+  - crates/ank-daemon/src/declare.rs
+  - crates/ank-cli/tests/watch.rs
+about: TASK-56d188a1f8b3
+seq: 1
+schema: 4
+version: 1
+---
+
+ error[9] 'schema 2, this binary reads 1: the file is newer than this ank', hint 'ank --version names the build...', and the word mirrors does not appear. schema: 1 + mirrors -> error[9] 'unknown field `mirrors`, expected one of `schema`, `fetch`, `watch` at line 3 column 1', unchanged, and there the key is the fault. schema: 0 -> 'schema 0 is not 1', not reported as newer: no build ever read 0. A file that is not a mapping -> 'invalid type: string ... expected struct WatchFileDoc', the diagnosis it always gave, so the probe only ever adds a refusal. Red-first: the new watch.rs test failed on its 'schema 2' assertion against the unchanged tree, printing the unknown-field sentence. The declare.rs unit test it replaces fed 'schema: 7 / watch: {}' with no unknown field, so the deserialize succeeded and the ordering was exercised by nothing; it now carries mirrors and asserts the key is never named.

--- a/.ank/entities/LOG-5c39d8096e81.md
+++ b/.ank/entities/LOG-5c39d8096e81.md
@@ -1,0 +1,14 @@
+---
+id: LOG-5c39d8096e81
+type: log
+title: done, proof test:local/71f2591b7063@702f51b test:local/e3b0c44298fc@702f51b
+created: 2026-08-31T09:14:13Z
+author: claude-code/opus-5+watch
+scope:
+  - crates/ank-daemon/src/declare.rs
+  - crates/ank-cli/tests/watch.rs
+about: TASK-56d188a1f8b3
+seq: 2
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-cc703490b972.md
+++ b/.ank/entities/LOG-cc703490b972.md
@@ -1,0 +1,16 @@
+---
+id: LOG-cc703490b972
+type: log
+title: "Before, measured through target/debug/ank into an isolated XDG_CONFIG_HOME. watch.yml 'schema: 2 /"
+created: 2026-08-31T08:50:30Z
+author: claude-code/opus-5+watch
+scope:
+  - crates/ank-daemon/src/declare.rs
+  - crates/ank-cli/tests/watch.rs
+about: TASK-56d188a1f8b3
+seq: 0
+schema: 4
+version: 1
+---
+
+ watch: {} / mirrors: [somewhere]' with 'ank watch --once': error[9] '<path>/watch.yml: unknown field `mirrors`, expected one of `schema`, `fetch`, `watch` at line 3 column 1', hint 'schema: 1 and a watch: map ...'. The same file at 'schema: 1' gives the byte-identical answer, so the version buys the reader nothing. Control, corpora.yml of the same shape with 'ank status': error[9] '<path>/corpora.yml: schema 2, this binary reads 1: the file is newer than this ank'. Two files, one rule, two answers.

--- a/.ank/entities/TASK-56d188a1f8b3.md
+++ b/.ank/entities/TASK-56d188a1f8b3.md
@@ -5,7 +5,7 @@ slug: a-watch-yml-one-schema-ahead-is-refused-on-a-fie
 title: A watch.yml one schema ahead is refused on a field, not on the version
 created: 2026-08-31T07:52:23Z
 author: claude-code/opus-5+drift2
-status: open
+status: done
 scope:
   - crates/ank-daemon/src/declare.rs
   - crates/ank-cli/tests/watch.rs
@@ -14,8 +14,21 @@ done_criteria: |
   ank watch --once on a watch.yml carrying 'schema: 2' together with a key this build does not know exits 9 with a message naming both schema numbers and saying the file is newer than this ank, and never naming the unknown key; the same file at 'schema: 1' still exits 9 naming the unknown key; a test in crates/ank-cli/tests/watch.rs drives the binary with both files and fails if the first answer names a key.
 criteria_by: creator
 verify: [cargo-test, fmt-check]
+proof:
+  - type: test
+    ref: local/71f2591b7063@702f51b
+    tree: scope/c0aba09d0ee3
+    criteria: bb221aa589f7
+    verifier: cargo-test@f14aeab36e1b
+    via: verifier
+  - type: test
+    ref: local/e3b0c44298fc@702f51b
+    tree: scope/c0aba09d0ee3
+    criteria: bb221aa589f7
+    verifier: fmt-check@5ca6d10bcd55
+    via: verifier
 schema: 4
-version: 1
+version: 3
 ---
 
 Measured on 2026-08-31 by writing two files into an isolated XDG_CONFIG_HOME and

--- a/crates/ank-cli/tests/watch.rs
+++ b/crates/ank-cli/tests/watch.rs
@@ -479,6 +479,48 @@ fn a_declaration_that_does_not_exist_refuses_to_start() {
     assert!(said.contains("watch.yml"), "{said}");
 }
 
+/// A declaration one version ahead is refused on its version, and the reader is
+/// never sent after a key.
+///
+/// **The unknown key is the point of the fixture, not decoration.** `watch.yml`
+/// is read by a shape that denies unknown fields, so a file newer than this
+/// build fails to deserialize before its `schema` is ever compared -- and the
+/// sentence the reader got named `mirrors`, a key that is not wrong, in a file
+/// that is not wrong either. `docs/format.md` legislates the opposite: "Newer
+/// is refused, and refused **on the version rather than on the first field it
+/// does not recognise**", which is the answer `corpora.yml` has given since
+/// TASK-409e4c7d8aac and `.ank/config.yml` since TASK-742cd978a806.
+///
+/// The control is the same file at `schema: 1`, where the key really is the
+/// fault and naming it is the correct answer. Both are driven through the
+/// binary because the ordering lives in a file the daemon reads at startup, and
+/// the version of this that lived in `declare.rs` alone fed a file with no
+/// unknown field and so proved nothing (TASK-56d188a1f8b3).
+#[test]
+fn a_declaration_newer_than_this_ank_is_refused_on_its_version_and_not_on_a_key() {
+    let home = Home::new();
+    home.declare("schema: 2\nwatch: {}\nmirrors:\n  - somewhere\n");
+    let out = home.daemon(&["--once"]).output().unwrap();
+    assert_eq!(out.status.code(), Some(9), "{out:?}");
+    let said = String::from_utf8_lossy(&out.stderr);
+    assert!(said.contains("schema 2"), "{said}");
+    assert!(said.contains("reads 1"), "{said}");
+    assert!(said.contains("newer than this ank"), "{said}");
+    assert!(
+        !said.contains("mirrors"),
+        "the reader is told the tool is old, never that a key is wrong: {said}"
+    );
+
+    // The same file one version back: here the key is genuinely the fault, and
+    // the refusal that names it is the one to keep.
+    home.declare("schema: 1\nwatch: {}\nmirrors:\n  - somewhere\n");
+    let out = home.daemon(&["--once"]).output().unwrap();
+    assert_eq!(out.status.code(), Some(9), "{out:?}");
+    let said = String::from_utf8_lossy(&out.stderr);
+    assert!(said.contains("mirrors"), "{said}");
+    assert!(!said.contains("newer than this ank"), "{said}");
+}
+
 #[test]
 fn the_watch_file_sits_beside_the_corpora_file() {
     let home = Home::new();

--- a/crates/ank-daemon/src/declare.rs
+++ b/crates/ank-daemon/src/declare.rs
@@ -55,6 +55,27 @@ const SUPPORTED_SCHEMA: u32 = 1;
 /// through the binary and never through the code that reads it.
 pub const ANK_DIR: &str = ".ank";
 
+/// `schema:` alone, read before anything else in the file is looked at.
+///
+/// **The one shape in this file that tolerates an unknown key**, which is the
+/// whole reason it exists. `WatchFileDoc` denies them, so a file one version
+/// newer than this build was reported as *unknown field `mirrors`* -- the
+/// reader was told a key is wrong when the truth is that the tool is old, and
+/// went hunting for a typo in a file that had none. `docs/format.md` already
+/// legislates it: "Newer is refused, and refused **on the version rather than
+/// on the first field it does not recognise**." The version has to be readable
+/// without reading the rest, or the rest refuses first and the version never
+/// gets asked.
+///
+/// Spelled here rather than shared with `ank-cli`'s copy for the reason the
+/// rest of this module is: that crate has no library target. The shape is the
+/// same one `parse()` and `newer_than_this_ank()` use there, deliberately, so
+/// `watch.yml` and `corpora.yml` answer a reader in one sentence.
+#[derive(Debug, Deserialize)]
+struct SchemaProbe {
+    schema: u32,
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct WatchFileDoc {
@@ -169,12 +190,38 @@ pub fn resolve(
     path: &Path,
     identity_of: &dyn Fn(&Path) -> Option<String>,
 ) -> Result<Declaration> {
+    // **The version first, and the fields afterwards**, which is the rule
+    // `corpora.yml` and `.ank/config.yml` already follow. Like the probe in
+    // `ank-cli`'s `parse()`, this may only ever *add* a refusal: where it
+    // cannot read a version it says nothing and the deserialize below produces
+    // exactly the diagnosis it always produced, a missing `schema` and a file
+    // that is not a mapping included.
+    if let Some(found) = serde_yaml::from_str::<SchemaProbe>(text)
+        .ok()
+        .map(|p| p.schema)
+    {
+        if found > SUPPORTED_SCHEMA {
+            return Err(Fail::new(
+                ExitCode::Environment,
+                format!(
+                    "{}: schema {found}, this binary reads {SUPPORTED_SCHEMA}: \
+                     the file is newer than this ank",
+                    path.display()
+                ),
+            )
+            .with_hint("ank --version names the build, npm install -g @haksolot/ank replaces it"));
+        }
+    }
+
     let doc: WatchFileDoc = serde_yaml::from_str(text).map_err(|e| {
         Fail::new(ExitCode::Environment, format!("{}: {e}", path.display())).with_hint(
             "schema: 1 and a watch: map of repository identity to the path of a checkout, \
              or to a list of them",
         )
     })?;
+    // Below the range rather than above it, exactly as `ank-cli` splits them:
+    // no binary ever read schema 0, so there is no older tool to name and the
+    // file is simply wrong.
     if doc.schema != SUPPORTED_SCHEMA {
         return Err(Fail::new(
             ExitCode::Environment,
@@ -347,10 +394,42 @@ mod tests {
         );
     }
 
+    /// **The unknown key is the fixture, not decoration.**
+    ///
+    /// This test used to feed `schema: 7\nwatch: {}\n` -- a file one version
+    /// ahead with no unknown field -- so the deserialize succeeded, the number
+    /// check ran, and the ordering the refusal actually depends on was
+    /// exercised by nothing. It stayed green for as long as the bug lived
+    /// (TASK-56d188a1f8b3). With `mirrors` in the file and the probe removed,
+    /// `deny_unknown_fields` answers first and the reader is sent after a typo
+    /// in a file that has none.
     #[test]
-    fn an_unknown_schema_is_refused_by_number() {
-        let err = resolve("schema: 7\nwatch: {}\n", Path::new("watch.yml"), &none).unwrap_err();
-        assert!(err.message.contains("schema 7 is not 1"), "{err:?}");
+    fn a_newer_schema_is_refused_as_newer_before_any_field_is_read() {
+        let err = resolve(
+            "schema: 7\nwatch: {}\nmirrors:\n  - somewhere\n",
+            Path::new("watch.yml"),
+            &none,
+        )
+        .unwrap_err();
+        assert_eq!(err.code, ExitCode::Environment);
+        assert!(err.message.contains("schema 7"), "{err:?}");
+        assert!(err.message.contains("reads 1"), "{err:?}");
+        assert!(err.message.contains("newer than this ank"), "{err:?}");
+        assert!(
+            !err.message.contains("mirrors"),
+            "the version is the answer, never the key: {err:?}"
+        );
+    }
+
+    /// Below the range is not "newer", and is not reported as such: no build
+    /// ever read schema 0, so there is no older tool for a reader to go and
+    /// install.
+    #[test]
+    fn a_schema_below_the_range_is_refused_by_number() {
+        let err = resolve("schema: 0\nwatch: {}\n", Path::new("watch.yml"), &none).unwrap_err();
+        assert_eq!(err.code, ExitCode::Environment);
+        assert!(err.message.contains("schema 0 is not 1"), "{err:?}");
+        assert!(!err.message.contains("newer than this ank"), "{err:?}");
     }
 
     #[test]


### PR DESCRIPTION
`declare.rs` derived its document with `deny_unknown_fields` and compared
`schema` only after the deserialize had already succeeded, so a watch.yml
one version ahead was refused with *unknown field `mirrors`* and its
reader went looking for a typo in a file that had none. corpora.yml and
.ank/config.yml answer on the version, which is what docs/format.md:318
states; watch.yml now reads `schema:` through a probe first, on the same
shape TASK-742cd978a806 and TASK-409e4c7d8aac put in ank-cli.

Below the range is still refused by number: no build ever read schema 0,
so there is no older tool to name. The probe only ever adds a refusal --
a file that is not a mapping gets the diagnosis it always got.

The unit test that covered this fed `schema: 7\nwatch: {}\n`, a file with
no unknown field, so the deserialize succeeded and the ordering was
exercised by nothing. It now carries the unknown key and asserts the key
is never named, and crates/ank-cli/tests/watch.rs drives the binary with
both files.

TASK-56d188a1f8b3

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015nEawXxQ5QKQ5D3KxmuSDE
