### PR TITLE
One redactor for every golden: cli.rs captures through tests/fixture/mod.rs

### DIFF
--- a/.ank/entities/LOG-0b182bf1c829.md
+++ b/.ank/entities/LOG-0b182bf1c829.md
@@ -1,0 +1,24 @@
+---
+id: LOG-0b182bf1c829
+type: log
+title: Folded, and measured red-first on Linux. cli.rs's copy of the redactor is deleted -- is_word_char,
+created: 2026-08-31T10:32:46Z
+author: claude-code/opus-5+redactor
+scope:
+  - crates/ank-cli/tests/cli.rs
+  - crates/ank-cli/tests/fixture/**
+about: TASK-7a9d945640e3
+seq: 1
+schema: 4
+version: 1
+---
+
+ timestamp_len_at, redact, golden, GOLDEN_DIR -- and its 16 call sites now go through fixture::pin, its conformance walk through fixture::dir(). tests/fixture/mod.rs is the one redaction all three capture paths write under: cli.rs 26 documents, schema.rs read, tui.rs tui.
+
+All 28 goldens in tests/golden-json/ are byte-identical before and after: sha256 of the 28 files compared across the change, diff empty, twice (once after the fold, once after the perturbation runs). No fixture was re-blessed. cargo test --workspace green, 46 targets ok, 0 failed; cargo fmt --check clean.
+
+Red-first, the measurement that matters. Perturbation: <TIME> -> <INSTANT> in the single redactor, cargo test --workspace --no-fail-fast --test cli --test schema --test tui. Red: 5 tests over 3 binaries -- cli json_golden_reading_verbs, json_golden_status, json_golden_writing_verbs; schema read_pins_the_document_the_binary_prints; tui the_json_frame_is_pinned_by_a_golden.
+
+The counterfactual, measured on the pre-change tree (both files restored from HEAD, same perturbation applied to cli.rs's copy alone): cli 3 failed, schema 12 passed 0 failed, tui 29 passed 0 failed. That is the gap this task closes -- an edit to one copy left read.json and tui.json green while they quietly became a file written under different masks.
+
+What now fails when the redaction drifts: every golden, because there is one redactor. What does not fail is a re-introduced second copy -- nothing in the suite forbids a new private redact in a fourth test crate; the guarantee is structural, by there being one function, not by a test that would catch two.

--- a/.ank/entities/LOG-a4ce76dfc6f2.md
+++ b/.ank/entities/LOG-a4ce76dfc6f2.md
@@ -1,0 +1,14 @@
+---
+id: LOG-a4ce76dfc6f2
+type: log
+title: done, proof test:local/88202701e38a@8e17da3 test:local/e3b0c44298fc@8e17da3
+created: 2026-08-31T10:36:48Z
+author: claude-code/opus-5+redactor
+scope:
+  - crates/ank-cli/tests/cli.rs
+  - crates/ank-cli/tests/fixture/**
+about: TASK-7a9d945640e3
+seq: 2
+schema: 4
+version: 1
+---

--- a/.ank/entities/TASK-7a9d945640e3.md
+++ b/.ank/entities/TASK-7a9d945640e3.md
@@ -5,7 +5,7 @@ slug: cli-rs-carries-its-own-copy-of-the-golden-redact
 title: cli.rs carries its own copy of the golden redactor
 created: 2026-08-31T08:57:34Z
 author: claude-code/opus-5+golden
-status: open
+status: done
 scope:
   - crates/ank-cli/tests/cli.rs
   - crates/ank-cli/tests/fixture/**
@@ -14,8 +14,21 @@ done_criteria: |
   crates/ank-cli/tests/cli.rs captures its fixtures through crates/ank-cli/tests/fixture/mod.rs, so one redaction serves every golden in tests/golden-json/ and deleting the copy in cli.rs leaves the suite green.
 criteria_by: creator
 verify: [cargo-test, fmt-check]
+proof:
+  - type: test
+    ref: local/88202701e38a@8e17da3
+    tree: scope/07adf7234de2
+    criteria: 50afdab75b8e
+    verifier: cargo-test@f14aeab36e1b
+    via: verifier
+  - type: test
+    ref: local/e3b0c44298fc@8e17da3
+    tree: scope/07adf7234de2
+    criteria: 50afdab75b8e
+    verifier: fmt-check@5ca6d10bcd55
+    via: verifier
 schema: 4
-version: 2
+version: 4
 ---
 
 Left behind by TASK-49b10f02d209, which added the two fixtures ADR-6fd69efb629c

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -16,6 +16,7 @@
 //! and `ank-cli` has no library target — so there is no unit test that could
 //! spawn the binary even if we wanted one.
 
+mod fixture;
 mod scratch;
 
 use std::collections::BTreeMap;
@@ -18258,101 +18259,18 @@ fn a_log_check_cannot_read_is_reported_rather_than_read_as_empty() {
 // The JSON goldens (TASK-2c12b027f805)
 // ---------------------------------------------------------------------------
 
-/// Where a caller's parser meets this binary, pinned one file per verb.
-///
-/// Captured from the process and never from a function. A fixture compared
-/// against what an emitter returns proves the emitter, and what §4 promises is
-/// what leaves the process — the same distinction this whole file exists for.
-///
-/// Volatile values are named rather than kept: an instant, a commit, an
-/// identifier the binary generated. A golden that changes every run pins
-/// nothing, and everything outside those three is compared byte for byte.
-///
-/// Bless a new or deliberately changed shape with
-/// `ANK_BLESS_GOLDEN=1 cargo test --test cli -- json_golden`, and read the diff
-/// before committing it: that diff is the contract changing.
-const GOLDEN_DIR: &str = "tests/golden-json";
-
-fn is_word_char(c: char) -> bool {
-    c.is_ascii_alphanumeric()
-}
-
-/// `dddd-dd-ddTdd:dd:ddZ`, the only instant the format writes.
-fn timestamp_len_at(b: &[char], i: usize) -> Option<usize> {
-    const SHAPE: &str = "nnnn-nn-nnTnn:nn:nnZ";
-    if i + SHAPE.len() > b.len() {
-        return None;
-    }
-    for (k, want) in SHAPE.chars().enumerate() {
-        let got = b[i + k];
-        let ok = match want {
-            'n' => got.is_ascii_digit(),
-            c => got == c,
-        };
-        if !ok {
-            return None;
-        }
-    }
-    Some(SHAPE.len())
-}
-
-fn redact(s: &str) -> String {
-    let b: Vec<char> = s.chars().collect();
-    let mut out = String::with_capacity(s.len());
-    let mut i = 0;
-    while i < b.len() {
-        if let Some(n) = timestamp_len_at(&b, i) {
-            out.push_str("<TIME>");
-            i += n;
-            continue;
-        }
-        if b[i].is_ascii_hexdigit() {
-            let mut j = i;
-            while j < b.len() && b[j].is_ascii_hexdigit() {
-                j += 1;
-            }
-            let word: String = b[i..j].iter().collect();
-            let whole =
-                (i == 0 || !is_word_char(b[i - 1])) && (j == b.len() || !is_word_char(b[j]));
-            // A seeded identifier is deterministic and worth pinning; the
-            // zero prefix is what the fixtures in this file use for one. Only
-            // what the binary minted itself is named away.
-            if whole && word.len() == 40 {
-                out.push_str("<SHA>");
-            } else if whole && word.len() == 12 && !word.starts_with("0000") {
-                out.push_str("<HEX>");
-            } else {
-                out.push_str(&word);
-            }
-            i = j;
-            continue;
-        }
-        out.push(b[i]);
-        i += 1;
-    }
-    out
-}
-
-fn golden(name: &str, actual: &str) {
-    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join(GOLDEN_DIR)
-        .join(format!("{name}.json"));
-    let actual = format!("{}\n", redact(actual.trim_end_matches('\n')));
-    if std::env::var_os("ANK_BLESS_GOLDEN").is_some() {
-        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
-        std::fs::write(&path, actual.as_bytes()).unwrap();
-        return;
-    }
-    let expected = std::fs::read_to_string(&path)
-        .unwrap_or_else(|e| panic!("no golden for {name} at {}: {e}", path.display()))
-        .replace("\r\n", "\n");
-    assert_eq!(
-        actual, expected,
-        "the --json document of `{name}` is not what the golden pins.\n\
-         If the contract really changed, bless it and read the diff:\n  \
-         ANK_BLESS_GOLDEN=1 cargo test --test cli -- json_golden"
-    );
-}
+// Where a caller's parser meets this binary, pinned one file per verb.
+//
+// Captured from the process and never from a function — the same distinction
+// this whole file exists for. What redacts a captured document and what compares
+// it to its fixture live in `tests/fixture/mod.rs`, because `schema.rs` and
+// `tui.rs` capture two of these documents and an integration test is a crate of
+// its own: a copy here would be a second redaction nothing holds to the first
+// (TASK-7a9d945640e3).
+//
+// Bless a new or deliberately changed shape with
+// `ANK_BLESS_GOLDEN=1 cargo test --workspace`, and read the diff before
+// committing it: that diff is the contract changing.
 
 /// A corpus with one of everything, so that a document has something to carry.
 ///
@@ -18435,8 +18353,8 @@ fn golden_repo() -> Repo {
     r
 }
 
-/// The identifiers the golden corpus is built from, zero-prefixed so that
-/// [`redact`] leaves them alone: they are seeded and deterministic, where an
+/// The identifiers the golden corpus is built from, zero-prefixed so that the
+/// redaction in `tests/fixture/mod.rs` leaves them alone: they are seeded and deterministic, where an
 /// identifier the binary minted is named away.
 /// Long enough to be measured against a budget, and that is the point of its
 /// length rather than a taste for prose: `check.findings[].charge` is the
@@ -18490,7 +18408,7 @@ fn json_golden_reading_verbs() {
             "{name} emitted no document: {}",
             stderr(&out)
         );
-        golden(name, &stdout(&out));
+        fixture::pin(name, &stdout(&out));
     }
 }
 
@@ -18511,7 +18429,7 @@ fn json_golden_status() {
     assert_eq!(code(&out), 0, "a claim by somebody else: {}", stderr(&out));
     let out = r.ank(AGENT, &["status", "--json"]);
     assert_eq!(code(&out), 0, "status: {}", stderr(&out));
-    golden("status", &stdout(&out));
+    fixture::pin("status", &stdout(&out));
 }
 
 /// The verbs that write. One fixture each: a document that depended on the
@@ -18534,19 +18452,19 @@ fn json_golden_writing_verbs() {
             "--json",
         ],
     );
-    golden("new", &stdout(&out));
+    fixture::pin("new", &stdout(&out));
 
     // claim, then the verbs that need a live claim
     let r = golden_repo();
     let out = r.ank(AGENT, &["claim", GOLDEN_READY, "--json"]);
-    golden("claim", &stdout(&out));
+    fixture::pin("claim", &stdout(&out));
     let out = r.ank(AGENT, &["log", "what I learned", "--json"]);
-    golden("log-write", &stdout(&out));
+    fixture::pin("log-write", &stdout(&out));
     let out = r.ank(
         AGENT,
         &["release", "--reason", "the criterion is wrong", "--json"],
     );
-    golden("release", &stdout(&out));
+    fixture::pin("release", &stdout(&out));
 
     // done, over a claim and a proof the caller holds
     let r = golden_repo();
@@ -18556,14 +18474,14 @@ fn json_golden_writing_verbs() {
         AGENT,
         &["done", "--proof", &format!("commit:{head}"), "--json"],
     );
-    golden("done", &stdout(&out));
+    fixture::pin("done", &stdout(&out));
 
     // attest, on the task that proof now names
     let out = r.ank(
         AGENT,
         &["attest", GOLDEN_READY, "--proof", "test:12345", "--json"],
     );
-    golden("attest", &stdout(&out));
+    fixture::pin("attest", &stdout(&out));
 
     // amend and close, on a corpus that never claimed. A fourth task, because
     // the corpus already blocks ID on GOLDEN_BLOCKER: a blocker the task
@@ -18574,17 +18492,17 @@ fn json_golden_writing_verbs() {
         AGENT,
         &["amend", ID, "--blocked-by", GOLDEN_UNRELATED, "--json"],
     );
-    golden("amend", &stdout(&out));
+    fixture::pin("amend", &stdout(&out));
     let out = r.ank(
         AGENT,
         &["close", ID, "--reason", "overtaken by events", "--json"],
     );
-    golden("close", &stdout(&out));
+    fixture::pin("close", &stdout(&out));
 
     // config, writing
     let r = golden_repo();
     let out = r.ank(AGENT, &["config", "context_budget", "9000", "--json"]);
-    golden("config-write", &stdout(&out));
+    fixture::pin("config-write", &stdout(&out));
 }
 
 /// The four that need an environment of their own: a signature, an editor, a
@@ -18596,7 +18514,7 @@ fn json_golden_verbs_needing_their_own_environment() {
     let r = golden_repo();
     let out = r.ank(AGENT, &["accept", GOLDEN_ADR_PROPOSED, "--json"]);
     assert_eq!(code(&out), 0, "accept: {}", stderr(&out));
-    golden("accept", &stdout(&out));
+    fixture::pin("accept", &stdout(&out));
 
     // edit, with an editor that saves
     let r = Repo::new();
@@ -18604,7 +18522,7 @@ fn json_golden_verbs_needing_their_own_environment() {
     let editor = r.editor_saving(EDITED_TASK);
     let out = r.ank_edit(AGENT, &["edit", ID, "--json"], Some(&editor));
     assert_eq!(code(&out), 0, "edit: {}", stderr(&out));
-    golden("edit", &stdout(&out));
+    fixture::pin("edit", &stdout(&out));
 
     // migrate, over the layout that is read and never written
     let r = golden_repo();
@@ -18616,7 +18534,7 @@ fn json_golden_verbs_needing_their_own_environment() {
     .unwrap();
     let out = r.ank(AGENT, &["migrate", "--json"]);
     assert_eq!(code(&out), 0, "migrate: {}", stderr(&out));
-    golden("migrate", &stdout(&out));
+    fixture::pin("migrate", &stdout(&out));
 
     // init, which refuses --repo by name and so is run from a directory. Two
     // fixtures and not one: the second run is the idempotent case, and the
@@ -18633,10 +18551,10 @@ fn json_golden_verbs_needing_their_own_environment() {
     };
     let out = init_json(&fresh);
     assert_eq!(code(&out), 0, "init: {}", stderr(&out));
-    golden("init", &stdout(&out));
+    fixture::pin("init", &stdout(&out));
     let out = init_json(&fresh);
     assert_eq!(code(&out), 0, "init, again: {}", stderr(&out));
-    golden("init-again", &stdout(&out));
+    fixture::pin("init-again", &stdout(&out));
     let _ = std::fs::remove_dir_all(&fresh);
 }
 
@@ -18673,7 +18591,7 @@ fn json_golden_verbs_needing_their_own_environment() {
 /// reads is not one.
 #[test]
 fn every_golden_conforms_to_the_shape_its_verb_declares() {
-    let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join(GOLDEN_DIR);
+    let dir = fixture::dir();
     let mut checked = 0;
     let mut empty: Vec<String> = Vec::new();
     let mut filled: Vec<String> = Vec::new();

--- a/crates/ank-cli/tests/fixture/mod.rs
+++ b/crates/ank-cli/tests/fixture/mod.rs
@@ -1,23 +1,36 @@
-//! Writing and comparing a fixture of `tests/golden-json/`, for the suites that
-//! capture one outside `cli.rs` (TASK-49b10f02d209).
+//! The one redaction every fixture of `tests/golden-json/` is written under,
+//! and the comparison that pins it (TASK-7a9d945640e3).
 //!
 //! ADR-6fd69efb629c asks for a golden fixture per document the surface returns,
-//! and `cli.rs` captures twenty-six of them. Two cannot be captured there. `read`
-//! could be and is not, and `tui` cannot: its document only exists on a terminal
-//! (`ank tui --json` refuses at exit 9 into a pipe), so the one place it can be
-//! captured is the pseudo-terminal harness in `tui.rs`. An integration test is a
-//! crate of its own, so `cli.rs`'s `golden` is not reachable from either suite,
-//! and the choice was a second copy or a fixture nothing regenerates.
+//! and three suites capture them: `cli.rs` twenty-six, `schema.rs` `read`, and
+//! `tui.rs` `tui`, whose document only exists on a terminal (`ank tui --json`
+//! refuses at exit 9 into a pipe) so the pseudo-terminal harness is the one
+//! place it can be captured. An integration test is a crate of its own, so a
+//! function in `cli.rs` is not reachable from either of the others: this module
+//! is compiled into all three, which is what makes one redaction serve them.
 //!
-//! **What is copied is the redaction, and it is copied deliberately.** The two
-//! masks -- an instant, and an identifier the binary minted -- are what make a
-//! captured document comparable at all, and a fixture written under a different
-//! pair of masks would not be the same kind of file as the twenty-six beside it.
-//! Folding `cli.rs` onto this module is TASK-7a9d945640e3 and is not done here:
-//! that file is a perimeter three other agents are working in, and this task's
-//! footprint in it is one number.
+//! **The masks are what make a captured document comparable at all**, and they
+//! have to be the same masks for every file in the directory: an instant, and
+//! an identifier the binary minted. A fixture written under a different pair
+//! would not be the same kind of file as the twenty-seven beside it, and until
+//! this module became the only copy nothing failed when the two drifted apart:
+//! the shape ADR-6fd69efb629c spends its first page on -- four escapers that
+//! did not agree -- one rung down, in the suite rather than in the tool.
+//!
+//! Captured from the process and never from a function. A fixture compared
+//! against what an emitter returns proves the emitter, and what §4 promises is
+//! what leaves the process.
+//!
+//! Volatile values are named rather than kept: an instant, a commit, an
+//! identifier the binary generated. A golden that changes every run pins
+//! nothing, and everything outside those three is compared byte for byte.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
+
+/// `tests/golden-json/`, the directory every fixture lives in.
+pub fn dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/golden-json")
+}
 
 fn is_word_char(c: char) -> bool {
     c.is_ascii_alphanumeric()
@@ -84,12 +97,12 @@ fn redact(s: &str) -> String {
 /// `tests/golden-json/<name>.json`, compared against what the process printed,
 /// or written when `ANK_BLESS_GOLDEN` is set.
 ///
-/// The same env var `cli.rs` blesses on, so one variable regenerates every
-/// fixture in the directory whichever suite captured it.
+/// One env var regenerates every fixture in the directory, whichever suite
+/// captured it, and under the one redaction they are all written with. Read the
+/// diff a bless produces before committing it: that diff is the contract
+/// changing.
 pub fn pin(name: &str, actual: &str) {
-    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("tests/golden-json")
-        .join(format!("{name}.json"));
+    let path = dir().join(format!("{name}.json"));
     let actual = format!("{}\n", redact(actual.trim_end_matches('\n')));
     if std::env::var_os("ANK_BLESS_GOLDEN").is_some() {
         std::fs::create_dir_all(path.parent().unwrap()).unwrap();


### PR DESCRIPTION
cli.rs carried its own copy of the golden redactor -- is_word_char,
timestamp_len_at, redact, golden -- beside the copy tests/fixture/mod.rs
made for the two documents that cannot be captured there (read, tui).
Two redactions that must agree is what ADR-6fd69efb629c spends its first
page on, one rung down: nothing failed when they drifted.

The copy in cli.rs is deleted; its sixteen call sites go through
fixture::pin and its conformance walk through fixture::dir(). All 28
goldens are byte-identical, and none was re-blessed.

Measured. Perturbing the single redactor reddens 5 tests over 3 test
binaries (cli, schema, tui). The same perturbation applied to cli.rs's
copy on the pre-change tree reddened cli alone -- schema and tui stayed
green, which is the drift this closes.

Closes TASK-7a9d945640e3

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VDmVt6CnN6eYKtV6Yf4ndb
