### PR TITLE
Citations of ADR-91b77f036884 point at the decision that supersedes it

### DIFF
--- a/.ank/entities/LOG-263a049b2386.md
+++ b/.ank/entities/LOG-263a049b2386.md
@@ -1,0 +1,19 @@
+---
+id: LOG-263a049b2386
+type: log
+title: Swept. 79 citations across 11 files re-pointed to ADR-e4a5a8873fe3; three sites needed judgement
+created: 2026-09-05T10:53:33Z
+author: claude-code/opus-5+sweep
+scope:
+  - docs/**
+  - skill/**
+  - crates/**
+  - .claude-plugin/**
+  - .github/**
+about: TASK-88b0e120e235
+seq: 3
+schema: 4
+version: 1
+---
+
+ rather than substitution, and all three collapse two decisions into one identifier because fd74dc1's mechanical pass had already re-pointed both halves of a history to the same chain end. tests/skill.rs said the ceiling 'moved from 80/700 to 140/1200 with ADR-X and to 180/1500 with ADR-X', and said 'review, check and amend left it with ADR-X ... status and scope left it with ADR-X': each reads as one decision doing two different things at two different times. Both now name the decision in force once and send the sequence to supersedes:, which is the repair fd74dc1 chose for the same shape. The third: the sibling test's doc said 'the three activities ADR-X names', true of ADR-91b77f036884 and false of its successor, which names five -- reworded to three of the activities it names, the three the tree holds today, with tdd and diagnose owed to TASK-135cde611e3f and TASK-587a185bef49. Measured, not read: grep -rn over the tracked tree finds zero occurrences of ADR-91b77f036884 outside .ank/; cargo test --workspace 1227 passed, 0 failed; cargo fmt --check clean; ank check ok, 0 faults. Left standing for a drift audit rather than widened into here: crates/ank-cli/tests/skill.rs still opens by calling SKILL.md's content 'the thing actually frozen', which the decision it now cites unfroze -- prose that predates the unfreeze and that fd74dc1 carried forward untouched.

--- a/.ank/entities/LOG-6a60bbd7880b.md
+++ b/.ank/entities/LOG-6a60bbd7880b.md
@@ -1,0 +1,19 @@
+---
+id: LOG-6a60bbd7880b
+type: log
+title: "Applied the fd74dc1 convention rather than inventing one: that commit re-pointed 106 citations of"
+created: 2026-09-05T10:41:11Z
+author: claude-code/opus-5+sweep
+scope:
+  - docs/**
+  - skill/**
+  - crates/**
+  - .claude-plugin/**
+  - .github/**
+about: TASK-88b0e120e235
+seq: 2
+schema: 4
+version: 1
+---
+
+ 35 superseded documents to the end of each chain, and reserved the judgement call for sentences about the supersession itself, where a mechanical substitution would read as one decision superseding itself. That is what 'records history' means in this criterion, and it is why the past-tense attributions -- 'the layering ADR-... removed', 'the audience line is what ADR-... removes' -- re-point like the rest: the identifier names the decision in force, and .ank/ is where the chain is kept. Nine files done: docs/agents.md, .github/workflows/release.yml, .github/scripts/npm-assemble.sh, crates/ank-cli/src/{human,context,edit,cli,claim}.rs, crates/ank-contract/src/verbs.rs. grep over crates/*/src and docs and .github: clean. Note left standing for the sibling tasks: release.yml and npm-assemble.sh enumerate ank-plan, ank-drift, ank-loop in prose while walking the tree for the real list, so the enumeration goes stale the day skill/tdd and skill/diagnose land -- TASK-135c and TASK-587a, not this sweep.

--- a/.ank/entities/LOG-7eabd68cdafe.md
+++ b/.ank/entities/LOG-7eabd68cdafe.md
@@ -1,0 +1,17 @@
+---
+id: LOG-7eabd68cdafe
+type: log
+title: done, proof test:local/4a9785efeb36@b601e43
+created: 2026-09-05T10:56:38Z
+author: claude-code/opus-5+sweep
+scope:
+  - docs/**
+  - skill/**
+  - crates/**
+  - .claude-plugin/**
+  - .github/**
+about: TASK-88b0e120e235
+seq: 4
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-ca2f05cfe03b.md
+++ b/.ank/entities/LOG-ca2f05cfe03b.md
@@ -1,0 +1,18 @@
+---
+id: LOG-ca2f05cfe03b
+type: log
+title: +scope .github/** (version 2 to 3, replaced 21e423f62f91, produced e2b003858b8a)
+created: 2026-09-05T10:40:14Z
+author: claude-code/opus-5+sweep
+scope:
+  - docs/**
+  - skill/**
+  - crates/**
+  - .claude-plugin/**
+  - .github/**
+about: TASK-88b0e120e235
+seq: 1
+records: edit
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-d47d19afaf1d.md
+++ b/.ank/entities/LOG-d47d19afaf1d.md
@@ -1,0 +1,18 @@
+---
+id: LOG-d47d19afaf1d
+type: log
+title: "Sweep inventory, measured with grep -rn over tracked files outside .ank/: 79 citations of"
+created: 2026-09-05T10:39:09Z
+author: claude-code/opus-5+sweep
+scope:
+  - docs/**
+  - skill/**
+  - crates/**
+  - .claude-plugin/**
+about: TASK-88b0e120e235
+seq: 0
+schema: 4
+version: 1
+---
+
+ ADR-91b77f036884 across 11 files. docs/agents.md 1; crates/ank-cli/tests/skill.rs 22; crates/ank-cli/tests/cli.rs 11; crates/ank-cli/src/cli.rs 10; crates/ank-cli/src/claim.rs 3; crates/ank-contract/src/verbs.rs 4; crates/ank-cli/src/edit.rs 1; crates/ank-cli/src/context.rs 1; crates/ank-cli/src/human.rs 1; .github/workflows/release.yml 1; .github/scripts/npm-assemble.sh 1. skill/** and .claude-plugin/** cite it nowhere, so two of the four scope globs are already clean. Two of the eleven files are under .github/, outside this task's declared scope but inside what ADR-3b6b's refusal walks -- accept would still refuse on them -- so the scope needs amending rather than the criterion softening.

--- a/.ank/entities/TASK-88b0e120e235.md
+++ b/.ank/entities/TASK-88b0e120e235.md
@@ -5,19 +5,27 @@ slug: sweep-citations-of-adr-91b77f036884-ahead-of-its
 title: Sweep citations of ADR-91b77f036884 ahead of its supersession
 created: 2026-09-02T13:55:18Z
 author: claude-code/fable-5
-status: open
+status: done
 scope:
   - docs/**
   - skill/**
   - crates/**
   - .claude-plugin/**
+  - .github/**
 blocked_by: []
 done_criteria: |
   No file outside .ank/ cites ADR-91b77f036884 except where it records history; each live citation points at ADR-e4a5a8873fe3 instead. cargo test --workspace passes.
 criteria_by: creator
 verify: [cargo-test]
+proof:
+  - type: test
+    ref: local/4a9785efeb36@b601e43
+    tree: scope/baa1855647fd
+    criteria: 074b694da87d
+    verifier: cargo-test@f14aeab36e1b
+    via: verifier
 schema: 4
-version: 1
+version: 4
 ---
 
 ADR-e4a5a8873fe3 supersedes ADR-91b77f036884, and a supersession does not land

--- a/.github/scripts/npm-assemble.sh
+++ b/.github/scripts/npm-assemble.sh
@@ -92,7 +92,7 @@ cp ../../LICENSE LICENSE
 # pi reads a package's skills from its pi.skills path, and its convention is
 # skills/<name>/SKILL.md. The sources are skill/SKILL.md at the repository root
 # and every skill/<dir>/SKILL.md beside it: the contract and one policy per
-# activity (ADR-91b77f036884). Each is anchored where it lives -- build.rs
+# activity (ADR-e4a5a8873fe3). Each is anchored where it lives -- build.rs
 # hashes the contract into `ank --version`, tests/skill.rs holds every skill to
 # its declared revision -- and a copy committed beside them would have no such
 # anchor and would drift with nothing turning red, which is what

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -330,7 +330,7 @@ jobs:
       # tarball is what the registry receives -- a `files` entry that stopped
       # matching would leave the file on disk and out of the package.
       #
-      # Every skill, not only the contract (ADR-91b77f036884): an install that
+      # Every skill, not only the contract (ADR-e4a5a8873fe3): an install that
       # receives `ank` and none of `ank-plan`, `ank-drift`, `ank-loop` teaches
       # the rules and none of the activities. The list is walked from the tree
       # rather than written here, so a skill added later is checked by existing,

--- a/crates/ank-cli/src/claim.rs
+++ b/crates/ank-cli/src/claim.rs
@@ -466,7 +466,7 @@ fn live_claims_where(
 /// is a different question, answered by the transition check and by `acquire`,
 /// and this refusal has no business intercepting it.
 ///
-/// Refusing on state and never on identity (ADR-91b77f036884): what is read is
+/// Refusing on state and never on identity (ADR-e4a5a8873fe3): what is read is
 /// the coordination plane — which refs exist and who holds them — and the
 /// answer is the same for every caller. A lapsed claim is not a live one, so
 /// pickup after expiry (§3) passes through untouched.
@@ -1217,7 +1217,7 @@ fn renewed_by_working(
 /// freezes nothing, which is the reading `log` and `done` already apply.
 ///
 /// Any live claim, not this agent's: refusals are on state and never on identity
-/// (ADR-91b77f036884).
+/// (ADR-e4a5a8873fe3).
 pub fn live(cwd: &Path, id: &EntityId) -> Result<Option<ClaimRecord>> {
     let Some(Record::Claim(c)) = read(cwd, id)?.map(|h| h.record) else {
         return Ok(None);
@@ -2390,7 +2390,7 @@ fn other_ready_task(cwd: &Path, store: &Store, task: &Task) -> Option<EntityId> 
 /// module lands on them: claims in refs (ADR-4e7c25b1f639), the ref's second
 /// state (ADR-6d8736c04cfa), git per verb and plumbing by criterion
 /// (ADR-9307e5d214a7), freeze by hash (ADR-6b3f19e08a24), one surface
-/// (ADR-91b77f036884).
+/// (ADR-e4a5a8873fe3).
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/ank-cli/src/cli.rs
+++ b/crates/ank-cli/src/cli.rs
@@ -15,11 +15,11 @@
 //! exactly the drift the `owner_task` field was added to prevent.
 //!
 //! **The listing is grouped by the moment a verb is reached for, and inside a
-//! group the order of [`COMMANDS`] survives untouched** (ADR-91b77f036884). It
+//! group the order of [`COMMANDS`] survives untouched** (ADR-e4a5a8873fe3). It
 //! once grouped verbs under headings named after callers, which was the
 //! two-surface model still speaking through the output an agent reads; a
 //! heading that sorts callers is a claim about who a verb is for, and there is
-//! no such claim left to make. ADR-91b77f036884 removed those headings and left
+//! no such claim left to make. ADR-e4a5a8873fe3 removed those headings and left
 //! §4's order to carry the structure alone, which works for five verbs and not
 //! for twenty-one: the order only says something to a reader who already knows
 //! it is meaningful, which is precisely what a first reader does not know. So
@@ -505,7 +505,7 @@ fn globals_of(spec: &CommandSpec) -> Vec<&'static FlagSpec> {
 /// It states what the three globals of §4 are, once, for the surface — the
 /// exception belongs on the page of the verb that makes it, where a reader
 /// asking about `init` is looking. Qualifying it in the listing would put a
-/// second structure under headings that already carry one (ADR-91b77f036884),
+/// second structure under headings that already carry one (ADR-e4a5a8873fe3),
 /// on the three lines the whole surface shares.
 fn globals_line(globals: &[&'static FlagSpec], with_short: bool) -> String {
     globals
@@ -571,7 +571,7 @@ fn json_of(specs: &[&CommandSpec]) -> String {
             // same structure to everyone and lets only colour depend on the
             // reader, so giving a machine the grouping and withholding it from
             // the caller who scripts against it would be the split this ADR
-            // rejected, the other way round (ADR-91b77f036884).
+            // rejected, the other way round (ADR-e4a5a8873fe3).
             // What comes back, which is the half this document was missing
             // (ADR-6fd69efb629c). A caller can discover a flag by being refused
             // one; it cannot discover a field by being handed it, because it has
@@ -622,7 +622,7 @@ fn json_of(specs: &[&CommandSpec]) -> String {
 /// silently is worse than refusing the wrong one loudly.
 ///
 /// The listing is grouped by [`GROUPS`], and inside a group the order is
-/// [`COMMANDS`]', which is §4's (ADR-91b77f036884). No verb is hidden and there
+/// [`COMMANDS`]', which is §4's (ADR-e4a5a8873fe3). No verb is hidden and there
 /// is no second listing to ask for: git shows the common commands and sends the
 /// rest to `git help -a`, and hiding a verb from the one surface claiming to be
 /// complete is worse than never teaching it.
@@ -688,7 +688,7 @@ pub fn help(inv: &Invocation, out: &mut dyn Write) -> Result<ExitCode> {
     // says so rather than leaving the reader to discover it.
     //
     // **The width is computed across all of [`COMMANDS`] and never per group**
-    // (ADR-91b77f036884). Five widths would stop the columns lining up between
+    // (ADR-e4a5a8873fe3). Five widths would stop the columns lining up between
     // sections, and the listing would read as five tables rather than one thing
     // with five parts — which is the opposite of what the grouping is for.
     let width = COMMANDS.iter().map(|c| usage(c).len()).max().unwrap_or(0);
@@ -726,7 +726,7 @@ pub fn help(inv: &Invocation, out: &mut dyn Write) -> Result<ExitCode> {
     );
     // A trailing pointer, beside the one above it and in the same shape. The
     // three trailer lines are not a group and take no heading: they say where
-    // to look next rather than when a verb is used (ADR-91b77f036884). A flag
+    // to look next rather than when a verb is used (ADR-e4a5a8873fe3). A flag
     // nobody can discover answers nobody's question.
     let _ = writeln!(out, "ank --version for the build");
     Ok(ExitCode::Ok)
@@ -1601,7 +1601,7 @@ mod tests {
     #[test]
     fn the_listing_keeps_the_table_order_inside_every_group() {
         // The grouping is a second axis laid over COMMANDS, not a re-sort
-        // (ADR-91b77f036884) -- so it is asserted rather than assumed. The test
+        // (ADR-e4a5a8873fe3) -- so it is asserted rather than assumed. The test
         // above passes just as well on a renderer that sorts alphabetically,
         // which would bury the loop in the middle of its own group.
         let text = help_out(&["help"]);
@@ -1631,7 +1631,7 @@ mod tests {
     fn every_verb_has_a_group_and_every_group_has_verbs() {
         // The two halves of what stops a twenty-second verb from being added
         // with no home and disappearing off the end of a listing that renders
-        // by group (ADR-91b77f036884). The integration suite asserts the same
+        // by group (ADR-e4a5a8873fe3). The integration suite asserts the same
         // property through the binary, which is where a caller reads it; this
         // one fails at the table, which is where the mistake is made.
         for spec in COMMANDS {
@@ -1665,7 +1665,7 @@ mod tests {
         assert!(text.contains("--criteria <v>"), "{text}");
         assert!(
             !text.contains("audience"),
-            "the audience line is what ADR-91b77f036884 removes:\n{text}"
+            "the audience line is what ADR-e4a5a8873fe3 removes:\n{text}"
         );
         // One verb means one verb: no other usage line rides along.
         assert!(!text.contains("ank accept"), "{text}");

--- a/crates/ank-cli/src/context.rs
+++ b/crates/ank-cli/src/context.rs
@@ -1110,7 +1110,7 @@ pub(crate) fn coordination_of<'a>(
 /// carries it. The relevance argument for putting it in `context` is real —
 /// this is what an agent reads every turn — and it loses to two others.
 ///
-/// `context` is loaded on every call and ADR-91b77f036884 treats every word in
+/// `context` is loaded on every call and ADR-e4a5a8873fe3 treats every word in
 /// it as paid for, so a line covering a state that is rare, already announced
 /// at acquisition, and reported by a verb costing nothing would be paid on
 /// every turn of every session that never hits it. And the place the collision

--- a/crates/ank-cli/src/edit.rs
+++ b/crates/ank-cli/src/edit.rs
@@ -344,7 +344,7 @@ fn check_frozen(repo: &Repo, before: &Entity, after: &Entity) -> Result<()> {
                 return Ok(());
             }
             // Any live claim, not this agent's: refusals are on state and never
-            // on identity (ADR-91b77f036884). An expired claim is not in force
+            // on identity (ADR-e4a5a8873fe3). An expired claim is not in force
             // and freezes nothing, which is the same reading `log` and `done`
             // already apply to it.
             let Some(anchor) = live_claim_anchor(&repo.corpus, id)? else {

--- a/crates/ank-cli/src/human.rs
+++ b/crates/ank-cli/src/human.rs
@@ -1,7 +1,7 @@
 //! check, review, accept, close, attest, amend and show (§4, §8, §11).
 //!
 //! **This is a file, not a side.** The CLI exposes one surface
-//! (ADR-91b77f036884): every verb here is available to every caller, and what
+//! (ADR-e4a5a8873fe3): every verb here is available to every caller, and what
 //! the module holds is what grew together rather than what a class of caller
 //! was allowed to run. Successive headers described this as the human half, the
 //! side that may grow freely, the half outside the loop — each true when

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -4426,7 +4426,7 @@ fn a_short_flag_the_verb_does_not_take_names_the_flag_it_stands_for() {
 ///
 /// The second half is the one worth a test. The listing carries one line per
 /// verb, and a second spelling of every flag is exactly the kind of addition
-/// that arrives looking like an improvement. Grouping it (ADR-91b77f036884)
+/// that arrives looking like an improvement. Grouping it (ADR-e4a5a8873fe3)
 /// changed what stands between the lines and nothing on them.
 #[test]
 fn help_shows_both_forms_for_one_verb_and_leaves_the_listing_lines_alone() {
@@ -5551,7 +5551,7 @@ fn status_names_every_live_claim_of_this_identity() {
 /// an unmerged branch would not look free everywhere else, and named this gap
 /// without settling it -- on the ground that `close` is "a human act and a rare
 /// one", which the skill decision retired by dissolving the human side entirely
-/// (ADR-91b77f036884).
+/// (ADR-e4a5a8873fe3).
 /// That is history, and `.ank/` carries it (TASK-78326e2e3e89). The code has
 /// behaved this way throughout; what it lacked was a decision saying so and a
 /// test holding it.
@@ -9359,7 +9359,7 @@ fn help_from_nowhere(args: &[&str]) -> Output {
 ///
 /// The trailer is the block opening with `global:` at column 0, and it is what
 /// bounds the listing now that a blank line no longer does. The listing is
-/// grouped (ADR-91b77f036884), so an empty line is a boundary *between* groups
+/// grouped (ADR-e4a5a8873fe3), so an empty line is a boundary *between* groups
 /// -- a parser that stopped at the first one would read `run the loop`, find six
 /// verbs, and call that the whole surface. A folded description is indented and
 /// so can never be mistaken for the trailer.
@@ -9447,7 +9447,7 @@ fn help_answers_outside_a_repository_and_lists_every_verb() {
     }
 
     // Grouped by the moment a verb is used, and never by who uses it
-    // (ADR-91b77f036884). These four headings sorted callers -- agent loop,
+    // (ADR-e4a5a8873fe3). These four headings sorted callers -- agent loop,
     // agent off-loop, human -- which is the two-surface model speaking through
     // the output an agent reads, and a CLI that refuses on state and never on
     // identity has no such grouping to print. That refusal is untouched: what
@@ -9521,7 +9521,7 @@ fn help_for_one_verb_answers_and_an_unknown_one_is_a_two() {
     assert!(text.contains("--criteria"), "{text}");
     assert!(
         !text.contains("audience"),
-        "the audience line is what ADR-91b77f036884 removes, and it is the \
+        "the audience line is what ADR-e4a5a8873fe3 removes, and it is the \
          line an agent reads about itself:\n{text}"
     );
     assert!(
@@ -9615,7 +9615,7 @@ fn help_json_reaches_the_process_intact() {
 }
 
 /// Every verb of the table appears exactly once in the grouped listing, under a
-/// heading, and in the table's order inside it (ADR-91b77f036884).
+/// heading, and in the table's order inside it (ADR-e4a5a8873fe3).
 ///
 /// Through the binary, against `ank help --json`: the same table read out of the
 /// same process, so the assertion is that the two renderings agree rather than
@@ -9690,7 +9690,7 @@ fn the_grouped_listing_prints_every_verb_exactly_once() {
 }
 
 /// Every verb carries a non-empty group, and every group is a heading the
-/// listing prints (ADR-91b77f036884).
+/// listing prints (ADR-e4a5a8873fe3).
 ///
 /// This is what stops a twenty-second verb from being added with no home and
 /// disappearing off the end unnoticed. The test above would pass on such a verb
@@ -9730,7 +9730,7 @@ fn every_verb_carries_a_group_and_no_group_goes_unprinted() {
              heading:\n{listing}"
         );
         // And a group says when a verb is used, never who may use it: the wall
-        // ADR-91b77f036884 pulled down was built out of exactly these words.
+        // ADR-e4a5a8873fe3 pulled down was built out of exactly these words.
         for who in ["agent", "human", "caller", "you"] {
             assert!(
                 !group.split_whitespace().any(|w| w == who),
@@ -9751,7 +9751,7 @@ fn every_verb_carries_a_group_and_no_group_goes_unprinted() {
 }
 
 // ---------------------------------------------------------------------------
-// Dead constraints in the prose (ADR-91b77f036884)
+// Dead constraints in the prose (ADR-e4a5a8873fe3)
 // ---------------------------------------------------------------------------
 
 // ---------------------------------------------------------------------------
@@ -12860,7 +12860,7 @@ fn surface() -> Vec<(String, String, Vec<String>)> {
     for line in listing_body(&text) {
         // The listing is `<usage>` padded, then the description. Its folded
         // continuation lines are indented and open no verb (TASK-fe130d2b732c),
-        // and a group heading opens none either (ADR-91b77f036884).
+        // and a group heading opens none either (ADR-e4a5a8873fe3).
         let Some(rest) = line.strip_prefix("ank ") else {
             continue;
         };

--- a/crates/ank-cli/tests/skill.rs
+++ b/crates/ank-cli/tests/skill.rs
@@ -2,7 +2,7 @@
 //!
 //! `skill/SKILL.md` is not documentation: it is loaded into an agent's context
 //! permanently, on every session, in every repository that installs it. That is
-//! what makes its content the thing actually frozen (ADR-91b77f036884) -- the
+//! what makes its content the thing actually frozen (ADR-e4a5a8873fe3) -- the
 //! dispatch table refuses nobody, and the two modes exist because this file
 //! teaches them and teaches nothing else. Four properties are therefore worth a
 //! test rather than a habit: that it carries the whole loop, that it carries
@@ -181,7 +181,7 @@ fn section_4_order() -> Vec<String> {
 }
 
 /// The listing, as the headings `ank help` prints and the verbs under each of
-/// them (ADR-91b77f036884).
+/// them (ADR-e4a5a8873fe3).
 ///
 /// Through the binary, because the ADR is a statement about what the process
 /// prints, not about the table it is derived from. The listing is everything
@@ -301,7 +301,7 @@ fn every_verb_section_4_lists_ships_or_is_declared_unimplemented() {
 }
 
 /// **Grouped by the moment a verb is used, and §4's order inside every group**
-/// (ADR-91b77f036884). Until
+/// (ADR-e4a5a8873fe3). Until
 /// this test the ADR described the output rather than constraining it, and the
 /// two orders agreed only while somebody remembered. Fixing the drift of
 /// TASK-5c868c20472f introduced a fresh one in the same edit -- `attest` placed
@@ -334,19 +334,19 @@ fn help_prints_section_4s_order_inside_every_group() {
     }
 }
 
-/// The loop and what is off it: how work gets done (ADR-91b77f036884).
+/// The loop and what is off it: how work gets done (ADR-e4a5a8873fe3).
 const LOOP_VERBS: [&str; 8] = [
     "context", "claim", "show", "log", "done", "new", "find", "release",
 ];
 
-/// Planning: how the work that gets done comes to exist (ADR-91b77f036884).
+/// Planning: how the work that gets done comes to exist (ADR-e4a5a8873fe3).
 ///
 /// `new adr` is spelled out rather than covered by `new`, because the whole
 /// point of the addition is the path from noticing an architectural problem to
 /// recording one — and `ank new task` alone does not carry it.
 const PLANNING_VERBS: [&str; 5] = ["review", "graph", "check", "amend", "new adr"];
 
-/// Investigation: how an agent arrives informed (ADR-91b77f036884).
+/// Investigation: how an agent arrives informed (ADR-e4a5a8873fe3).
 ///
 /// The two that carry the mode are `scope` and `status`: they answer *what
 /// governs this file* and *where am I*, they were shipped long before this, and
@@ -373,7 +373,7 @@ fn the_skill_carries_the_whole_loop() {
     }
 }
 
-/// The half ADR-91b77f036884 added. An agent taught only the loop can execute
+/// The half ADR-e4a5a8873fe3 added. An agent taught only the loop can execute
 /// work and cannot propose a decision, correct a graph, or notice the corpus
 /// has gone incoherent -- which is the gap that ADR names and this asserts is
 /// closed.
@@ -397,7 +397,7 @@ fn the_skill_carries_the_planning_mode() {
     }
 }
 
-/// The third mode ADR-91b77f036884 added, asserted on the same terms as the
+/// The third mode ADR-e4a5a8873fe3 added, asserted on the same terms as the
 /// other two: the verb is named, because an agent only knows the verbs this
 /// file names.
 #[test]
@@ -413,7 +413,7 @@ fn the_skill_carries_the_investigation_mode() {
 }
 
 /// **The read form of `log` is taught, and it is the half that is easy to lose**
-/// (ADR-91b77f036884).
+/// (ADR-e4a5a8873fe3).
 ///
 /// `ank log "<message>"` writes and renews the claim; `ank log <id>` reads, needs
 /// no claim, and is where the previous holder said why they handed the task
@@ -431,7 +431,7 @@ fn the_skill_teaches_the_read_form_of_log() {
     );
 }
 
-/// **The file says why before it says how** (ADR-91b77f036884).
+/// **The file says why before it says how** (ADR-e4a5a8873fe3).
 ///
 /// Asserted by the two things the argument has to establish rather than by any
 /// phrasing, on the standard the accept and styling tests already set: a test
@@ -445,12 +445,12 @@ fn the_skill_says_what_the_rules_protect() {
         assert!(
             text.contains(token),
             "SKILL.md does not say {token:?}: it teaches the verbs without the \
-             model behind them, which is the gap ADR-91b77f036884 closed"
+             model behind them, which is the gap ADR-e4a5a8873fe3 closed"
         );
     }
 }
 
-/// **`accept` is described and never invited** (ADR-91b77f036884).
+/// **`accept` is described and never invited** (ADR-e4a5a8873fe3).
 ///
 /// The two halves are one rule and neither works alone. The skill must say what
 /// `accept` is, so a planning agent knows where its own authority ends rather
@@ -481,10 +481,11 @@ fn the_skill_describes_accept_without_inviting_it() {
 /// loaded on demand. The number is a ceiling to notice drift, not a target to
 /// fill.
 ///
-/// It moved from 80/700 to 140/1200 with ADR-91b77f036884 and to 180/1500 with
-/// ADR-91b77f036884, and each time because a decision said so — which is the
-/// only way it is allowed to move. A ceiling raised to accommodate whatever was
-/// just written is not a ceiling.
+/// It moved twice, from 80/700 to 140/1200 and then to 180/1500, and each time
+/// because a decision said so — which is the only way it is allowed to move.
+/// A ceiling raised to accommodate whatever was just written is not a ceiling.
+/// The number in force is the one ADR-e4a5a8873fe3 states; which decision made
+/// which move is the corpus's to answer, and `ank show` walks `supersedes:`.
 ///
 /// The last move carries a measurement the earlier ones did not: what a session
 /// pays for unconditionally is the frontmatter, `~58 tok` of `name` and
@@ -505,16 +506,17 @@ fn the_skill_stays_within_one_page() {
 }
 
 /// These verbs run for whoever types them -- nothing here is refused to an
-/// agent (ADR-91b77f036884). What this asserts is narrower and is the whole of
+/// agent (ADR-e4a5a8873fe3). What this asserts is narrower and is the whole of
 /// the freeze: SKILL.md does not *teach* them. Naming one as a thing to run
 /// would grow what every session pays for, by habit rather than by decision,
 /// which is how a permanently loaded file actually grows.
 ///
 /// The list shrinks only by decision, and it has three times. `show` left it
 /// when it moved into the loop, back when the loop was still called a surface;
-/// `review`, `check` and `amend` left it with ADR-91b77f036884, which bought
-/// planning with a raised ceiling and said so; `status` and `scope` left it
-/// with ADR-91b77f036884, which bought investigation the same way. `accept` is
+/// `review`, `check` and `amend` left it when planning was bought with a raised
+/// ceiling, which said so; `status` and `scope` left it when investigation was
+/// bought the same way. The decision in force is ADR-e4a5a8873fe3, and which
+/// earlier one made which removal is what `supersedes:` carries. `accept` is
 /// the interesting survivor: the skill now *describes* it, and still must not
 /// show the command, so it stays here while
 /// `the_skill_describes_accept_without_inviting_it` holds the other half.
@@ -577,7 +579,7 @@ fn the_skill_states_that_what_an_agent_reads_is_never_styled() {
 /// (TASK-a548c95261a5).
 ///
 /// Not a superseding ADR, and the reason is measured rather than assumed. What
-/// ADR-91b77f036884 freezes is which *verbs* the file teaches, which
+/// ADR-e4a5a8873fe3 freezes is which *verbs* the file teaches, which
 /// `the_skill_teaches_nothing_beyond_what_is_frozen` enforces, plus the ceiling
 /// below. This adds neither a verb nor a flag: it is a fact about the
 /// arrangement an agent is already working inside, the same register as "the
@@ -697,7 +699,7 @@ fn declared_revision(front: &str) -> Option<String> {
 /// It sits in `metadata`, which the Agent Skills standard defines as an
 /// arbitrary map for properties the standard does not itself define, so it is
 /// metadata about the file and not part of what the file teaches. That is the
-/// whole of the freeze (ADR-91b77f036884), and the three assertions above are
+/// whole of the freeze (ADR-e4a5a8873fe3), and the three assertions above are
 /// the enforcement -- none of them moves because of a fingerprint.
 #[test]
 fn the_skill_says_which_revision_it_is() {
@@ -720,7 +722,7 @@ fn the_skill_says_which_revision_it_is() {
 }
 
 // ---------------------------------------------------------------------------
-// The siblings, anchored the same way (ADR-91b77f036884, TASK-e26516d35da9)
+// The siblings, anchored the same way (ADR-e4a5a8873fe3, TASK-e26516d35da9)
 // ---------------------------------------------------------------------------
 
 /// The sibling skills beside the contract: every `skill/<dir>/SKILL.md`, as
@@ -746,17 +748,19 @@ fn sibling_skills() -> Vec<(String, String)> {
     found
 }
 
-/// The three activities ADR-91b77f036884 names. A sibling beyond these is
-/// allowed and anchored like the rest; one of these missing is the skill
-/// system shipping a contract without its policies.
+/// Three of the activities ADR-e4a5a8873fe3 names, which are the three the tree
+/// holds today: `tdd` and `diagnose` are the two that decision adds, and they
+/// arrive with TASK-135cde611e3f and TASK-587a185bef49 rather than here. A
+/// sibling beyond these is allowed and anchored like the rest; one of these
+/// missing is the skill system shipping a contract without its policies.
 #[test]
 fn the_three_sibling_skills_exist() {
     let names: Vec<String> = sibling_skills().into_iter().map(|(n, _)| n).collect();
     for expected in ["drift", "loop", "plan"] {
         assert!(
             names.contains(&expected.to_string()),
-            "skill/{expected}/SKILL.md is missing: ADR-91b77f036884 names it as \
-             one of the three policies beside the contract"
+            "skill/{expected}/SKILL.md is missing: ADR-e4a5a8873fe3 names it as \
+             one of the policies beside the contract"
         );
     }
 }
@@ -779,7 +783,7 @@ fn every_sibling_skill_says_which_revision_it_is() {
     }
 }
 
-/// The ceiling of ADR-91b77f036884 is per skill, for the by-hand route where a
+/// The ceiling of ADR-e4a5a8873fe3 is per skill, for the by-hand route where a
 /// harness loads whole files.
 #[test]
 fn every_sibling_skill_stays_within_one_page() {
@@ -813,7 +817,7 @@ fn every_sibling_defers_to_the_contract_and_never_invites_accept() {
         assert!(
             !text.contains("ank accept"),
             "skill/{name}/SKILL.md shows `ank accept`: described, never invited \
-             holds in every skill that mentions it (ADR-91b77f036884)"
+             holds in every skill that mentions it (ADR-e4a5a8873fe3)"
         );
     }
 }

--- a/crates/ank-contract/src/verbs.rs
+++ b/crates/ank-contract/src/verbs.rs
@@ -483,7 +483,7 @@ pub fn long_of(c: char) -> Option<&'static str> {
 pub struct CommandSpec {
     pub name: &'static str,
     /// **When** the verb is reached for, which is the heading `ank help` prints
-    /// it under (ADR-91b77f036884). One of [`GROUPS`], and never a claim about
+    /// it under (ADR-e4a5a8873fe3). One of [`GROUPS`], and never a claim about
     /// who may run it: `check` sits under keeping the corpus honest whether a
     /// human or an agent types it, and the refusal machinery consults no caller.
     ///
@@ -568,10 +568,10 @@ pub struct CommandSpec {
 }
 
 /// The moments a verb is reached for, in the order `ank help` prints them
-/// (ADR-91b77f036884).
+/// (ADR-e4a5a8873fe3).
 ///
 /// A group says **when** a verb is used and never **who** may use it. The
-/// layering ADR-91b77f036884 removed was the residue of an agent surface and a
+/// layering ADR-e4a5a8873fe3 removed was the residue of an agent surface and a
 /// human surface — headings that told a caller which verbs were theirs, behind
 /// a wall built from `$ANK_AGENT`, which the caller sets itself. Nothing here
 /// reopens that: the distinction is the one between a map and a gate.
@@ -675,7 +675,7 @@ pub const PUSH_NOTES: &[&str] = &[PUSH_DEGRADES, PUSH_FAILS, PUSH_NONE];
 /// **The order is the specification's, and it is load-bearing**: §4 puts the
 /// loop first — `context claim show log done`, then `release new find` — and
 /// the rest after it. `help` groups this table by [`GROUPS`] and keeps this
-/// order inside each group (ADR-91b77f036884): the grouping is a second axis
+/// order inside each group (ADR-e4a5a8873fe3): the grouping is a second axis
 /// laid over §4's order, not a re-sort, so a verb never moves relative to its
 /// neighbours and sorting this list would still erase what §4 says.
 pub const COMMANDS: &[CommandSpec] = &[

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -24,7 +24,7 @@ and it is self-sufficient: why ank is shaped as it is, the verbs grouped by the
 moment each is used, and the rules that are not negotiable. It names the other
 three so an agent reaching for an activity knows what to load, and never
 depends on them being installed. The three carry a policy each and are loaded
-when the activity calls for them (ADR-91b77f036884).
+when the activity calls for them (ADR-e4a5a8873fe3).
 
 **What that costs a session is the frontmatter, not the page.** The projection
 below is `~58 tok` always-on per skill, and that is a skill's `name` and


### PR DESCRIPTION
ADR-e4a5a8873fe3 supersedes ADR-91b77f036884, and ADR-3b6bf85dbb37 refuses
the ratification while any tracked file outside `.ank/` still cites what it
retires. This is that sweep: 79 citations across 11 files, re-pointed to the
end of the chain, which is the convention fd74dc1 set when it repaired 106
citations of 35 superseded documents the same way.

Swept by file rather than by ADR, because the hot files cite several retired
identifiers at once and only this one is in scope. `skill/**` and
`.claude-plugin/**` cite it nowhere, so two of the four declared globs were
already clean; `.github/**` was not in the scope and had to be, since
ADR-3b6bf85dbb37's refusal walks every tracked file outside `.ank/` and would
have found `release.yml` and `npm-assemble.sh` after this task closed green.
The scope is amended rather than the criterion softened.

## The three that needed a judgement

fd74dc1 reserved the judgement call for sentences about the supersession
itself, where a substitution reads as one decision superseding itself. The
three here are the same shape one step further on: both halves of a history
had already been re-pointed to one identifier, so the sentence now says one
decision did two different things at two different times.

`tests/skill.rs` said the ceiling "moved from 80/700 to 140/1200 with ADR-X
and to 180/1500 with ADR-X", and that "`review`, `check` and `amend` left it
with ADR-X ... `status` and `scope` left it with ADR-X". Both now name the
decision in force once and send the sequence to `supersedes:`, where the
corpus keeps it.

The third is not a citation but what the citation made false: the sibling
test's doc said "the three activities ADR-X names", true of the retired
decision and false of its successor, which names five. Reworded to the three
the tree holds today, with `tdd` and `diagnose` owed to TASK-135cde611e3f and
TASK-587a185bef49 rather than to this sweep.

## Measured

`grep -rn` over the tracked tree: zero occurrences outside `.ank/`.
`cargo test --workspace`: 1227 passed, 0 failed. `cargo fmt --check`: clean.
`ank check`: ok, 0 faults. `ank done` ran `cargo-test` itself and recorded
the proof.

Left standing, and logged rather than widened into here: `tests/skill.rs`
still opens by calling SKILL.md's content "the thing actually frozen", which
the decision it now cites unfroze. That is drift in the prose, not a stale
citation, and it belongs to an audit.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FNiHfksMdRK2VAoBNAzTsn
