### PR TITLE
ank-loop instructs a two-axis self-review before ank done

### DIFF
--- a/.ank/entities/LOG-07761a3e8366.md
+++ b/.ank/entities/LOG-07761a3e8366.md
@@ -1,0 +1,14 @@
+---
+id: LOG-07761a3e8366
+type: log
+title: done, proof test:local/8b6dd1147ea9@b58d87a
+created: 2026-09-05T11:24:29Z
+author: claude-code/opus-5+loopsr
+scope:
+  - skill/loop/**
+  - crates/ank-cli/tests/skill.rs
+about: TASK-367594a6d98a
+seq: 2
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-24ecb48582c9.md
+++ b/.ank/entities/LOG-24ecb48582c9.md
@@ -1,0 +1,16 @@
+---
+id: LOG-24ecb48582c9
+type: log
+title: "self-review, two axes. Criterion: the two-axis instruction lands in a 'Reviewing your own diff'"
+created: 2026-09-05T11:20:49Z
+author: claude-code/opus-5+loopsr
+scope:
+  - skill/loop/**
+  - crates/ank-cli/tests/skill.rs
+about: TASK-367594a6d98a
+seq: 1
+schema: 4
+version: 1
+---
+
+ section plus a step in the One pass block; ceilings met at 94 lines and 711 words; revision e2b07833509b, tests/skill.rs green. Diff touches skill/loop/SKILL.md only, inside the declared scope, and no hunk is outside a clause. Constraints, from ank context over skill/loop: one finding, acted on here. A paragraph restated the frozen-criterion rule the contract carries and the release rows the table above already state, which ADR-91b77f036884 names as the drift the sibling system exists to catch; it now cross-references both instead of repeating them, and the revision was recomputed after the fix rather than before it. ADR-d3a8e9c1a83a (English), ADR-8b30 (single source, no second copy) hold unchanged.

--- a/.ank/entities/LOG-6ad37005be73.md
+++ b/.ank/entities/LOG-6ad37005be73.md
@@ -1,0 +1,16 @@
+---
+id: LOG-6ad37005be73
+type: log
+title: "skill/loop/SKILL.md gained a 'Reviewing your own diff' section and a step in the One pass block: 94"
+created: 2026-09-05T11:19:44Z
+author: claude-code/opus-5+loopsr
+scope:
+  - skill/loop/**
+  - crates/ank-cli/tests/skill.rs
+about: TASK-367594a6d98a
+seq: 0
+schema: 4
+version: 1
+---
+
+ lines and 717 words against the 180/1500 ceiling of ADR-e4a5a8873fe3, so the two axes cost about half the remaining room. metadata.revision moved 8ff677f38578 -> 0caf4dc266f8; tests/skill.rs recomputes it as freeze_hash_short over the body after the closing delimiter, and names the value it wants in the failure, so the value is read off a failing run rather than derived by hand.

--- a/.ank/entities/TASK-367594a6d98a.md
+++ b/.ank/entities/TASK-367594a6d98a.md
@@ -5,7 +5,7 @@ slug: ank-loop-closes-a-claim-with-a-logged-self-revie
 title: ank-loop closes a claim with a logged self-review
 created: 2026-09-02T13:55:36Z
 author: claude-code/fable-5
-status: open
+status: done
 scope:
   - skill/loop/**
   - crates/ank-cli/tests/skill.rs
@@ -14,8 +14,15 @@ done_criteria: |
   skill/loop/SKILL.md instructs, before ank done, a self-review on two axes -- the diff against the frozen criterion, and the diff against the constraints context served -- with the outcome recorded via ank log. The body stays within 180 lines and 1500 words and the declared revision matches. cargo test --workspace passes.
 criteria_by: creator
 verify: [cargo-test]
+proof:
+  - type: test
+    ref: local/8b6dd1147ea9@b58d87a
+    tree: scope/ddbcb9deb682
+    criteria: 85ae438daaee
+    verifier: cargo-test@f14aeab36e1b
+    via: verifier
 schema: 4
-version: 1
+version: 3
 ---
 
 Needs no ADR: ADR-91b77f036884 already lets skill content evolve under normal

--- a/skill/loop/SKILL.md
+++ b/skill/loop/SKILL.md
@@ -2,7 +2,7 @@
 name: ank-loop
 description: Work through the open tasks in .ank/ without supervision, one claim at a time. Use when asked to work the backlog, chain tasks, or run autonomously in a repository with a .ank/ directory.
 metadata:
-  revision: "8ff677f38578"
+  revision: "e2b07833509b"
 ---
 
 # ank-loop
@@ -23,6 +23,7 @@ This file adds the loop policy only.
     ank claim <id>
     ank show <id>                    the body carries the reasoning; read it first
     work; ank log "<discovery>" as you learn, not when you finish
+    review your own diff             two axes, below; ank log what it found
     ank done                         with its proof
     next pass
 
@@ -52,6 +53,37 @@ what you finished, and which task carries the remainder.
 
 Work you discover is a new task with blocked_by, left for a later pass. Never
 a detour in this one.
+
+## Reviewing your own diff
+
+Before `ank done`, never after it, read the diff you are about to close on two
+axes.
+
+    against the criterion     every clause answered, and nothing it did not ask for
+    against the constraints   every ADR that binds the paths the diff touches
+
+The first axis takes the frozen criterion clause by clause and points each one
+at a hunk. A clause you cannot point at is not done. A hunk no clause asked for
+is scope you took without being given it, and it comes back out.
+
+The second axis takes the constraints, not your memory of them: run `ank
+context <path>` again over the paths the diff actually touches, which is rarely
+the set you ran it on at the start of the pass, and read the diff against what
+comes back.
+
+Then `ank log` the outcome, whichever way it came out: the two axes, what each
+one found, and nothing found where nothing was. The log is what outlives the
+session, and a review nobody can read afterwards was not one.
+
+A finding is acted on in the pass that found it. A constraint the diff breaks
+is fixed before the close; scope the criterion never asked for comes back out
+of the diff; a clause left unanswered is the release of the table above, and
+never a smaller criterion.
+
+The review is not a grade and does not replace one. `ank done` still runs the
+verifiers and still measures. What the two axes catch is what a green suite
+cannot: a criterion answered beside the point, and a constraint no test
+encodes.
 
 ## Never in the loop
 


### PR DESCRIPTION
The loop skill closed a claim on a green verifier and nothing else. A
criterion answered beside the point and a constraint no test encodes both
survive that, so the skill now asks for a review of the diff on two axes
before the close -- against the frozen criterion clause by clause, and
against ank context rerun over the paths the diff actually touches -- with
the outcome recorded via ank log, where it outlives the session.

The section cross-references the release table and the contract rather than
restating either: a rule written twice is what ADR-91b77f036884 names as the
drift the sibling system exists to catch. Body at 94 lines and 711 words of
180 and 1500; metadata.revision recomputed to e2b07833509b.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01D2LnJSNsfFjizkGbVSSbUi
