### PR TITLE
skill/tdd teaches red-green against the frozen criterion

### DIFF
--- a/.ank/entities/LOG-110c2b1a8e54.md
+++ b/.ank/entities/LOG-110c2b1a8e54.md
@@ -1,0 +1,18 @@
+---
+id: LOG-110c2b1a8e54
+type: log
+title: "Two-axis self-review before close. Against the criterion, clause by clause: skill/tdd/SKILL.md"
+created: 2026-09-05T12:38:38Z
+author: claude-code/opus-5+tdd
+scope:
+  - skill/tdd/**
+  - skill/SKILL.md
+  - crates/ank-cli/tests/skill.rs
+  - .claude-plugin/**
+about: TASK-135cde611e3f
+seq: 3
+schema: 4
+version: 1
+---
+
+ exists and is enrolled by name in the_named_sibling_skills_exist, so its disappearance now fails rather than falls silent; the contract line sits where the three existing siblings put theirs; the red-green loop is taught against the frozen criterion split into clauses; the three anti-patterns carry the criterion's own words as their headings, which the first draft paraphrased and which a reader could not then point at. Revision 5c0133123d36 recomputed by test; 88 lines, 776 words against 180/1500. plugin.json and skill/SKILL.md both list the sibling. Against the constraints, re-run over the paths the diff touches rather than the ones I started from: ADR-e4a5a8873fe3 holds on every count -- the sibling states the contract and restates no rule of it, accept appears nowhere so the described-never-invited clause is met vacuously, and 'Where the method stops' states the limit as a limit, never instructing done to inspect the route. ADR-93d8ef477c00 governed how this was measured: cargo build --workspace before every reading, because the version stamp is compiled in and a -p run would have graded a stale binary. One thing found and not fixed here: docs/agents.md lists the three siblings in three places and is outside this task's scope and outside TASK-587a185bef49's, so nothing carries it.

--- a/.ank/entities/LOG-3fbe43b38bbd.md
+++ b/.ank/entities/LOG-3fbe43b38bbd.md
@@ -1,0 +1,18 @@
+---
+id: LOG-3fbe43b38bbd
+type: log
+title: "Red before green, measured rather than assumed: the three revision assertions failed first and"
+created: 2026-09-05T12:36:18Z
+author: claude-code/opus-5+tdd
+scope:
+  - skill/tdd/**
+  - skill/SKILL.md
+  - crates/ank-cli/tests/skill.rs
+  - .claude-plugin/**
+about: TASK-135cde611e3f
+seq: 0
+schema: 4
+version: 1
+---
+
+ named the values. skill/tdd body hashed 16e223aa140e; skill/SKILL.md moved d25cedf8fe35 -> c07abc6fa8a5 because the sibling table gained a line, and the build.rs stamp had to be rebuilt with it (cargo build --workspace, not -p, per ADR-93d8b8e0d0d6). tdd/SKILL.md measures 88 lines and 771 words against the 180/1500 ceiling.

--- a/.ank/entities/LOG-c8d6632c31a1.md
+++ b/.ank/entities/LOG-c8d6632c31a1.md
@@ -1,0 +1,16 @@
+---
+id: LOG-c8d6632c31a1
+type: log
+title: done, proof test:local/e0eaf408ae26@e3490f9
+created: 2026-09-05T12:42:29Z
+author: claude-code/opus-5+tdd
+scope:
+  - skill/tdd/**
+  - skill/SKILL.md
+  - crates/ank-cli/tests/skill.rs
+  - .claude-plugin/**
+about: TASK-135cde611e3f
+seq: 4
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-e9692192a57d.md
+++ b/.ank/entities/LOG-e9692192a57d.md
@@ -1,0 +1,18 @@
+---
+id: LOG-e9692192a57d
+type: log
+title: "Corrects LOG-3fbe43b38bbd, which cited ADR-93d8b8e0d0d6: no such entity, the workspace-build"
+created: 2026-09-05T12:37:13Z
+author: claude-code/opus-5+tdd
+scope:
+  - skill/tdd/**
+  - skill/SKILL.md
+  - crates/ank-cli/tests/skill.rs
+  - .claude-plugin/**
+about: TASK-135cde611e3f
+seq: 1
+schema: 4
+version: 1
+---
+
+ decision is ADR-93d8ef477c00. Caught by reading the identifier back through ank show rather than trusting the prefix I had in hand -- ADR-1e6b3 reports an unresolvable identifier in prose as a signal, and a log entry is written once, so the correction is this entry and not an edit.

--- a/.ank/entities/LOG-ff47b646aa8d.md
+++ b/.ank/entities/LOG-ff47b646aa8d.md
@@ -1,0 +1,18 @@
+---
+id: LOG-ff47b646aa8d
+type: log
+title: "Corrects LOG-e9692192a57d, which cited ADR-1e6b3: a truncated prefix resolves to nothing. The"
+created: 2026-09-05T12:37:49Z
+author: claude-code/opus-5+tdd
+scope:
+  - skill/tdd/**
+  - skill/SKILL.md
+  - crates/ank-cli/tests/skill.rs
+  - .claude-plugin/**
+about: TASK-135cde611e3f
+seq: 2
+schema: 4
+version: 1
+---
+
+ decision on identifiers in prose is ADR-1e6bcbf62e61, and check reports the corpus-level signal it defines -- 65 identifiers naming an entity the corpus does not hold, one signal for the corpus and not one per mention. Every id in this entry was resolved through ank show before it was written, which is the practice the two preceding entries did not follow. Signal count is 443 before and after this task's edits.

--- a/.ank/entities/TASK-135cde611e3f.md
+++ b/.ank/entities/TASK-135cde611e3f.md
@@ -5,7 +5,7 @@ slug: skill-tdd-teaches-red-green-against-the-frozen-c
 title: skill/tdd teaches red-green against the frozen criterion
 created: 2026-09-02T13:55:27Z
 author: claude-code/fable-5
-status: open
+status: done
 scope:
   - skill/tdd/**
   - skill/SKILL.md
@@ -16,8 +16,15 @@ done_criteria: |
   skill/tdd/SKILL.md exists, opens by stating the ank contract applies, teaches the red-green loop against a task's frozen done_criteria, and names the forbidden anti-patterns: tautological tests, horizontal slicing, testing the implementation rather than the behaviour. It declares metadata.revision as the hash of its own body and tests/skill.rs recomputes it. The body stays within 180 lines and 1500 words. .claude-plugin/plugin.json and skill/SKILL.md list the sibling. cargo test --workspace passes.
 criteria_by: creator
 verify: [cargo-test]
+proof:
+  - type: test
+    ref: local/e0eaf408ae26@e3490f9
+    tree: scope/0e6a01b71b28
+    criteria: d12f1f73edd6
+    verifier: cargo-test@f14aeab36e1b
+    via: verifier
 schema: 4
-version: 1
+version: 3
 ---
 
 Blocked on the citation sweep because the sibling is only legal once

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -16,5 +16,5 @@
     "coordination",
     "agent"
   ],
-  "skills": ["./skill", "./skill/plan", "./skill/drift", "./skill/loop"]
+  "skills": ["./skill", "./skill/plan", "./skill/drift", "./skill/loop", "./skill/tdd"]
 }

--- a/crates/ank-cli/tests/skill.rs
+++ b/crates/ank-cli/tests/skill.rs
@@ -748,15 +748,16 @@ fn sibling_skills() -> Vec<(String, String)> {
     found
 }
 
-/// Three of the activities ADR-e4a5a8873fe3 names, which are the three the tree
-/// holds today: `tdd` and `diagnose` are the two that decision adds, and they
-/// arrive with TASK-135cde611e3f and TASK-587a185bef49 rather than here. A
-/// sibling beyond these is allowed and anchored like the rest; one of these
-/// missing is the skill system shipping a contract without its policies.
+/// The activities ADR-e4a5a8873fe3 names, enrolled here as each one lands:
+/// `tdd` arrives with TASK-135cde611e3f and `diagnose` with TASK-587a185bef49,
+/// which is the remaining one. A sibling beyond these is allowed and anchored
+/// like the rest; one of these missing is the skill system shipping a contract
+/// without its policies -- the tests below hold whatever exists, and this one
+/// is what makes a sibling's disappearance a failure rather than a silence.
 #[test]
-fn the_three_sibling_skills_exist() {
+fn the_named_sibling_skills_exist() {
     let names: Vec<String> = sibling_skills().into_iter().map(|(n, _)| n).collect();
-    for expected in ["drift", "loop", "plan"] {
+    for expected in ["drift", "loop", "plan", "tdd"] {
         assert!(
             names.contains(&expected.to_string()),
             "skill/{expected}/SKILL.md is missing: ADR-e4a5a8873fe3 names it as \

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -2,7 +2,7 @@
 name: ank
 description: Read a repository's tasks and binding constraints, claim work, and finish it with proof. Use when working in a repo that has a .ank/ directory.
 metadata:
-  revision: "d25cedf8fe35"
+  revision: "c07abc6fa8a5"
 ---
 
 # ank
@@ -35,6 +35,7 @@ This file is the contract. One skill per activity carries the policy:
     ank-plan     interview a goal into ADRs, specs and tasks
     ank-drift    audit accepted decisions against the code, report findings
     ank-loop     work the backlog autonomously, one claim at a time
+    ank-tdd      drive an implementation test-first against a frozen criterion
 
 Load them when the activity calls for them. Everything below suffices on its
 own to execute work.

--- a/skill/tdd/SKILL.md
+++ b/skill/tdd/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: ank-tdd
+description: Drive an implementation test-first, red before green, against a claimed task's frozen criterion. Use when implementing a task in a repository with a .ank/ directory.
+metadata:
+  revision: "5c0133123d36"
+---
+
+# ank-tdd
+
+A criterion frozen at claim is already a test list. This file turns it into
+one, clause by clause, and writes each test before the code that answers it.
+
+The ank skill is the contract and applies here in full. This file adds the
+test-first policy only.
+
+## The criterion is the specification
+
+Freezing is what makes the criterion usable as one: it cannot move to fit
+what you built. Read it whole with `ank show <id>`, then split it into
+clauses -- one per statement something could check, not one per sentence --
+and write the list down before the first edit. Every clause becomes at least
+one test.
+
+A clause you cannot phrase as a test is a clause you have not understood.
+`ank log` what is ambiguous and say which reading you took; code that guesses
+silently is the same guess with no record of it.
+
+Read the constraints into the same list. `ank context <path>` over the paths
+the work will touch returns rules about behaviour, and a rule about behaviour
+is testable on the same terms as the criterion's own clauses.
+
+## The loop
+
+    red        write the test for one clause, run it, watch it fail
+    green      write the least code that passes it, run the suite
+    refactor   improve what you just wrote, suite stays green
+    next       the next clause, until the list is empty
+
+**A test that has never failed has proved nothing.** Watch the red, and read
+it: the failure message is the one you will be handed by this test for the
+rest of its life, and now is when it is cheap to make it name the behaviour.
+A test green on its first run is either behaviour the tree already had --
+fine, record that and move on -- or it is not testing what you think, which
+is the case this step exists to catch.
+
+**One clause at a time.** The suite is green between clauses, so when it
+breaks you know which clause did it: the last one. Two in flight and you
+bisect by hand.
+
+`ank log "<discovery>"` as you learn it. A red that surprised you is the
+finding, and it stops being recoverable the moment it goes green.
+
+## Three ways to write tests that prove nothing
+
+**Tautological tests.** The test compares the implementation against itself: it
+mirrors the code's own arithmetic into the expected value, rebuilds the
+structure under test to assert equality with it, or mocks the thing being
+tested and asserts the mock was called. It is green by construction and stays
+green through any change of behaviour whatever. Write the expected value as a
+literal somebody could have written before the code existed.
+
+**Horizontal slicing.** A layer is built across its full width before anything
+above it runs -- every field of the parser, then every field of the store, then
+the verb -- and nothing is exercised end to end until the last layer lands. The
+lower two were sized by guessing what the upper one would want, and the guess
+is discovered at the point where it is most expensive to correct. Cut
+vertically instead: one clause, through every layer it needs, green, then the
+next.
+
+**Testing the implementation rather than the behaviour.** The test names a
+private function, asserts on an intermediate value, or counts calls. It goes
+red on a refactor that changed no behaviour, which teaches its readers to
+delete tests, and it stays green on a rewrite that broke the behaviour it was
+meant to hold. Assert what a caller can observe. A criterion phrased about a
+binary is tested through that binary, at the outermost seam a caller actually
+reaches; the same rule applies inward, at whatever seam the clause names.
+
+## Where the method stops
+
+No verb enforces any of this. `done` runs the declared verifiers and measures
+the tree as it stands; the order the file was written in is not a fact it
+holds, and nothing asks it to. There is no route to grade, deliberately: an
+agent graded on its process learns to produce the process.
+
+So the discipline is yours, and so is the only thing it buys. A test you
+watched fail is the evidence you hold that green means something. A suite
+that has only ever been green is a suite nobody has measured, and it will
+report success in exactly the case you wrote it to catch.


### PR DESCRIPTION
ADR-e4a5a8873fe3 reopened the sibling list to admit tdd and diagnose. This
is the first of the two: a policy for a moment, carried by a sibling that
states the contract applies and restates none of it.

The criterion frozen at claim is already a test list, so the skill teaches
splitting it into clauses and writing each test before the code that answers
it, watching the red because a test that has never failed has proved nothing.
The three anti-patterns carry the criterion's own words as their headings --
tautological tests, horizontal slicing, testing the implementation rather
than the behaviour -- so a reader can point each one at the clause that asked
for it.

Where the method stops is stated as a limit and never as dispatch: done runs
the declared verifiers and measures the tree, the order the file was written
in is not a fact it holds, and nothing asks it to. accept is not mentioned.

tests/skill.rs enrols tdd by name, so the sibling's disappearance fails
rather than falls silent; the generic sibling tests already recompute the
revision, hold the ceiling and check the manifest. skill/SKILL.md gains the
row and therefore a new revision, c07abc6fa8a5, which the build stamp
follows.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DKKcHxiACyCzH7NMqHhXo4
