### PR TITLE
skill/diagnose teaches the loop from a defect to its cause

### DIFF
--- a/.ank/entities/LOG-0a913072ac59.md
+++ b/.ank/entities/LOG-0a913072ac59.md
@@ -1,0 +1,18 @@
+---
+id: LOG-0a913072ac59
+type: log
+title: Read ADR-e4a5a8873fe3 accepted, skill/tdd (revision 5c0133123d36) and skill/loop for register.
+created: 2026-09-05T12:54:33Z
+author: claude-code/opus-5+diagnose
+scope:
+  - skill/diagnose/**
+  - skill/SKILL.md
+  - crates/ank-cli/tests/skill.rs
+  - .claude-plugin/**
+about: TASK-587a185bef49
+seq: 0
+schema: 4
+version: 1
+---
+
+ Measured what tests/skill.rs already holds generically over discovered siblings: revision recompute, 180-line/1500-word ceiling, the 'contract' token, the absence of 'ank accept', and the plugin manifest listing. Only the_named_sibling_skills_exist enumerates by hand, and its doc comment names TASK-587a185bef49 as the one that enrols diagnose. build.rs derives ANK_SKILL from skill/SKILL.md itself, so the contract's new revision needs no second edit.

--- a/.ank/entities/LOG-68703b6e0648.md
+++ b/.ank/entities/LOG-68703b6e0648.md
@@ -1,0 +1,18 @@
+---
+id: LOG-68703b6e0648
+type: log
+title: "Reviewed the diff on two axes before close. Against the criterion: the file exists and states the"
+created: 2026-09-05T12:57:16Z
+author: claude-code/opus-5+diagnose
+scope:
+  - skill/diagnose/**
+  - skill/SKILL.md
+  - crates/ank-cli/tests/skill.rs
+  - .claude-plugin/**
+about: TASK-587a185bef49
+seq: 1
+schema: 4
+version: 1
+---
+
+ contract applies before adding policy; the six steps appear in the criterion's order in one block and then one section each; patch-first guessing carries its own heading and is named the anti-pattern; the instrument step logs the observation and not the verdict, with GIT_TRACE, an empty TMPDIR and a pseudo-terminal as the measurements; body 132 lines and 1122 words against the 180/1500 ceiling; revision 98cd5d5badff recomputed by every_sibling_skill_says_which_revision_it_is; plugin.json and skill/SKILL.md both list the sibling. Against the constraints of ank context skill: ADR-e4a5a8873fe3 holds -- no rule of the contract is restated, accept is not mentioned at all, and the closing section states that done measures the tree and no verb grades the route. skill/SKILL.md moved to revision 82162945914d and build.rs recomputed ANK_SKILL from the file, so the binary and the file agree. docs/agents.md left untouched, out of scope; its skill count will be wrong until the task that carries it lands. cargo test -p ank-cli --test skill: 25 passed after cargo build --workspace, which ADR-93d8a requires for a result about the binary to be evidence.

--- a/.ank/entities/LOG-a9e50f6693b9.md
+++ b/.ank/entities/LOG-a9e50f6693b9.md
@@ -1,0 +1,16 @@
+---
+id: LOG-a9e50f6693b9
+type: log
+title: done, proof test:local/d18c2176b438@6ca8ee2
+created: 2026-09-05T13:01:08Z
+author: claude-code/opus-5+diagnose
+scope:
+  - skill/diagnose/**
+  - skill/SKILL.md
+  - crates/ank-cli/tests/skill.rs
+  - .claude-plugin/**
+about: TASK-587a185bef49
+seq: 2
+schema: 4
+version: 1
+---

--- a/.ank/entities/TASK-587a185bef49.md
+++ b/.ank/entities/TASK-587a185bef49.md
@@ -5,7 +5,7 @@ slug: skill-diagnose-teaches-the-disciplined-debugging
 title: skill/diagnose teaches the disciplined debugging loop
 created: 2026-09-02T13:55:32Z
 author: claude-code/fable-5
-status: open
+status: done
 scope:
   - skill/diagnose/**
   - skill/SKILL.md
@@ -16,8 +16,15 @@ done_criteria: |
   skill/diagnose/SKILL.md exists, opens by stating the ank contract applies, and teaches the loop for a task whose criterion names a defect: reproduce, minimise, hypothesise, instrument, fix, close with a regression test, in that order, with patch-first guessing named as the anti-pattern. It declares metadata.revision as the hash of its own body and tests/skill.rs recomputes it. The body stays within 180 lines and 1500 words. .claude-plugin/plugin.json and skill/SKILL.md list the sibling. cargo test --workspace passes.
 criteria_by: creator
 verify: [cargo-test]
+proof:
+  - type: test
+    ref: local/d18c2176b438@6ca8ee2
+    tree: scope/0cc5556f348e
+    criteria: d92a07344373
+    verifier: cargo-test@f14aeab36e1b
+    via: verifier
 schema: 4
-version: 1
+version: 3
 ---
 
 Blocked on the citation sweep for the same reason as the tdd sibling: legal

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -16,5 +16,5 @@
     "coordination",
     "agent"
   ],
-  "skills": ["./skill", "./skill/plan", "./skill/drift", "./skill/loop", "./skill/tdd"]
+  "skills": ["./skill", "./skill/plan", "./skill/drift", "./skill/loop", "./skill/tdd", "./skill/diagnose"]
 }

--- a/crates/ank-cli/tests/skill.rs
+++ b/crates/ank-cli/tests/skill.rs
@@ -748,16 +748,16 @@ fn sibling_skills() -> Vec<(String, String)> {
     found
 }
 
-/// The activities ADR-e4a5a8873fe3 names, enrolled here as each one lands:
-/// `tdd` arrives with TASK-135cde611e3f and `diagnose` with TASK-587a185bef49,
-/// which is the remaining one. A sibling beyond these is allowed and anchored
-/// like the rest; one of these missing is the skill system shipping a contract
-/// without its policies -- the tests below hold whatever exists, and this one
-/// is what makes a sibling's disappearance a failure rather than a silence.
+/// The five activities ADR-e4a5a8873fe3 names, all of them in the tree now that
+/// `tdd` has landed with TASK-135cde611e3f and `diagnose` with
+/// TASK-587a185bef49. A sibling beyond these is allowed and anchored like the
+/// rest; one of these missing is the skill system shipping a contract without
+/// its policies -- the tests below hold whatever exists, and this one is what
+/// makes a sibling's disappearance a failure rather than a silence.
 #[test]
 fn the_named_sibling_skills_exist() {
     let names: Vec<String> = sibling_skills().into_iter().map(|(n, _)| n).collect();
-    for expected in ["drift", "loop", "plan", "tdd"] {
+    for expected in ["diagnose", "drift", "loop", "plan", "tdd"] {
         assert!(
             names.contains(&expected.to_string()),
             "skill/{expected}/SKILL.md is missing: ADR-e4a5a8873fe3 names it as \

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -2,7 +2,7 @@
 name: ank
 description: Read a repository's tasks and binding constraints, claim work, and finish it with proof. Use when working in a repo that has a .ank/ directory.
 metadata:
-  revision: "c07abc6fa8a5"
+  revision: "82162945914d"
 ---
 
 # ank
@@ -36,6 +36,7 @@ This file is the contract. One skill per activity carries the policy:
     ank-drift    audit accepted decisions against the code, report findings
     ank-loop     work the backlog autonomously, one claim at a time
     ank-tdd      drive an implementation test-first against a frozen criterion
+    ank-diagnose work a defect back to its cause, and close it with a regression test
 
 Load them when the activity calls for them. Everything below suffices on its
 own to execute work.

--- a/skill/diagnose/SKILL.md
+++ b/skill/diagnose/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: ank-diagnose
+description: Work a defect back to its cause before changing anything, and close it with a regression test. Use when a claimed task's criterion names a defect in a repository with a .ank/ directory.
+metadata:
+  revision: "98cd5d5badff"
+---
+
+# ank-diagnose
+
+A criterion that names a defect names something somebody observed. It does not
+name the cause, and the distance between the two is the whole of this file.
+
+The ank skill is the contract and applies here in full. This file adds the
+diagnosis policy only.
+
+## The loop
+
+    reproduce      make it happen on demand, from a command you can rerun
+    minimise       cut the reproduction until nothing left in it can go
+    hypothesise    one cause the minimal case explains, and what would refute it
+    instrument     measure until the hypothesis is confirmed or dead
+    fix            change the cause, and nothing beside it
+    close          a regression test that goes red without the fix, then `ank done`
+
+The order is the method. Each step hands the next one something it could not
+otherwise have had, and a step skipped is paid for at the close, where the
+price is a green suite over a defect still in the tree.
+
+## Reproduce
+
+Until you can make it happen you hold a report and not a defect. Produce a
+command that fails every time, and write it down whole: the invocation, the
+environment it needs, and the failure exactly as it prints. That command is
+what the fix will be measured against and what the regression test is derived
+from, so a paraphrase of it costs you both.
+
+A defect that will not reproduce is a finding rather than a task. `ank log`
+what you ran and what came back instead, then `ank release --reason "<why>"`.
+A criterion wrong about what the tree does is wrong, and softening it is the
+one repair the contract forbids.
+
+## Minimise
+
+Take the reproduction apart. Remove one element -- a flag, a file, a step, a
+platform -- and rerun; keep the removal if it still fails, put it back if it
+does not. What survives is the statement of the defect, and everything you took
+out is noise you would otherwise have built a hypothesis about.
+
+A removal that makes the failure stop is not a dead end. It has just named
+something the cause needs, which is the first real fact of the session. Log it.
+
+## Hypothesise
+
+One cause at a time, phrased so that it could be wrong. *The status cache is
+keyed on file state alone and the orphaned claim lives in the refs* is a
+hypothesis. *Something is off in the caching* is a mood: nothing refutes it, so
+every observation will appear to confirm it.
+
+Name the observation that would kill it before you go looking. Where several
+survive, order them by what is cheapest to refute and never by what feels
+likeliest -- the ranking you trust is the one that put you here.
+
+## Instrument
+
+**A fact is measured, not read.** Reading the code and concluding is how a
+wrong hypothesis survives contact with evidence: you find the line that agrees
+with you, and the line that would not have agreed is never executed. Run it and
+count what comes back. `GIT_TRACE` at an absolute path prints one line per
+process, so processes are counted; an empty `TMPDIR` and then a listing says
+what the suite left behind; a pseudo-terminal and then a frame comparison says
+what the binary drew.
+
+`ank log` what you observed while you hold it, and log the observation rather
+than the verdict: the command you ran, the numbers it printed, expected against
+actual. *The key omitted the ref tip* is a conclusion the next reader has to
+take on faith. *Key computed over 41 files, ref tip 8f2c not in it, stale
+verdict served on the second call* is a measurement they can reach a different
+conclusion from, which is what they will need if yours was wrong.
+
+A refuted hypothesis is the ordinary outcome and worth exactly as much as a
+confirmed one. Log it too, then go back one step with a smaller space to search.
+
+## Fix
+
+Only once a measurement confirmed something. Change the cause, where the
+measurement pointed, and stop there. A second defect the diagnosis exposed is a
+new task with `blocked_by`, never a widening of this diff; the criterion you
+froze at claim is still the one you are answering.
+
+## Close with a regression test
+
+The test is derived from the minimal case, not from the original report: the
+report carries the noise you spent the second step removing.
+
+**Verify it goes red without the fix.** Undo the change, run the test, watch it
+fail with the failure from the first step, restore. A regression test that has
+never been seen red asserts the tree as it happens to be, and it will stay
+green through the return of the very defect it was written for. Then `ank done`
+runs the declared verifiers and records the proof.
+
+## Patch-first guessing
+
+The anti-pattern, and the reason the loop is written down. The defect is read,
+a plausible cause is guessed out of the source, an edit is made, the symptom
+stops, the task closes. It is faster than everything above, and it costs three
+things.
+
+The symptom can stop because it moved. Ordering, timing, one caller of three,
+a platform not in the suite: the change perturbed the conditions and the cause
+is still there, now with a passing test standing over it.
+
+Nothing was measured, so nothing outlives the session. The next holder finds a
+diff and a green suite, and has to redo from the report every step you skipped.
+
+The regression test comes last and is written against the fix. Never confronted
+with a red, it encodes the behaviour you just produced rather than the defect
+you were sent after, and it is green by construction.
+
+When you notice you are editing and no measurement has confirmed anything, you
+are here. Go back to hypothesise.
+
+## Where the method stops
+
+No verb enforces any of this. `done` runs the declared verifiers and measures
+the tree as it stands; the order you worked in is not a fact it holds, and
+nothing asks it to. There is no route to grade, deliberately: an agent graded
+on its process learns to produce the process.
+
+So what you hold at the close is what you measured. A cause located, logged
+with the numbers that located it, and pinned by a test somebody watched fail --
+that survives the session. A symptom that stopped appearing survives until the
+conditions move again, and so does whoever inherits it.


### PR DESCRIPTION
ADR-e4a5a8873fe3 reopened the sibling list to admit tdd and diagnose. This is
the second and last of the two, and the skill system now carries every activity
the decision names.

A criterion that names a defect names an observation, never a cause, and the
six steps are the road between them: reproduce until it happens on demand,
minimise until nothing left in the case can go, hypothesise one cause phrased so
that something could refute it, instrument until it is confirmed or dead, fix
the cause alone, close with a regression test somebody watched go red without
the fix. The order is the method, so a step skipped is paid for at the close.

The instrument step is where a fact is measured and not read: GIT_TRACE at an
absolute path counts processes, an empty TMPDIR and a listing say what the suite
left behind, a pseudo-terminal and a frame comparison say what the binary drew.
What ank log takes is the observation and never the verdict -- the command, the
numbers, expected against actual -- because the next reader needs to be able to
reach a different conclusion when yours was wrong.

Patch-first guessing carries its own heading and its three costs: a symptom that
stopped because it moved, a session that leaves nothing measured behind it, and
a regression test written against the fix and green by construction. Where the
method stops is a limit rather than dispatch: done runs the declared verifiers
and measures the tree, the order you worked in is not a fact it holds, and
accept is not mentioned at all.

tests/skill.rs enrols diagnose by name, so the sibling's disappearance fails
rather than falls silent; the generic sibling tests already recompute the
revision (98cd5d5badff), hold the 180-line and 1500-word ceiling at 132 and
1122, and check the manifest. plugin.json lists six directories. skill/SKILL.md
gains the row and therefore a new revision, 82162945914d, which build.rs
recomputes into the binary stamp.

docs/agents.md is left alone: its count of skills belongs to another task.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SsZX3d1rnWftRKirnNcN8a
