### PR TITLE
docs/agents.md names the skills the tree actually ships

### DIFF
--- a/.ank/entities/LOG-47253c1c93c7.md
+++ b/.ank/entities/LOG-47253c1c93c7.md
@@ -1,0 +1,15 @@
+---
+id: LOG-47253c1c93c7
+type: log
+title: "Measured, not read. A listing of skill/ returns 6 SKILL.md files: skill/SKILL.md plus five siblings"
+created: 2026-09-05T13:13:38Z
+author: claude-code/opus-5+docs
+scope:
+  - docs/agents.md
+about: TASK-8b8aaf9fdd61
+seq: 0
+schema: 4
+version: 1
+---
+
+ (diagnose, drift, loop, plan, tdd); find skill -mindepth 1 -maxdepth 1 -type d counts 5. npx skills add haksolot/ank --list, run from an empty tmpdir against main, prints 'Found 6 skills' and the tree ank, ank-diagnose, ank-drift, ank-loop, ank-plan, ank-tdd, alphabetical. docs/agents.md says four in all four of its listings.

--- a/.ank/entities/LOG-60885cd6f48a.md
+++ b/.ank/entities/LOG-60885cd6f48a.md
@@ -1,0 +1,13 @@
+---
+id: LOG-60885cd6f48a
+type: log
+title: done, proof test:local/0eeae90d3803@d21e83c
+created: 2026-09-05T13:20:51Z
+author: claude-code/opus-5+docs
+scope:
+  - docs/agents.md
+about: TASK-8b8aaf9fdd61
+seq: 3
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-78b330c00e7b.md
+++ b/.ank/entities/LOG-78b330c00e7b.md
@@ -1,0 +1,15 @@
+---
+id: LOG-78b330c00e7b
+type: log
+title: "Plugin cost block measured by installing the tree as a plugin: claude plugin marketplace add $PWD,"
+created: 2026-09-05T13:13:47Z
+author: claude-code/opus-5+docs
+scope:
+  - docs/agents.md
+about: TASK-8b8aaf9fdd61
+seq: 1
+schema: 4
+version: 1
+---
+
+ claude plugin install ank@ank, claude plugin details ank, then uninstall and remove the marketplace so nothing is left behind. It reports Skills (6) ank, ank-diagnose, ank-drift, ank-loop, ank-plan, ank-tdd; always-on ~411 tok; per-component always-on ank ~50, ank-plan ~70, ank-drift ~80, ank-loop ~70, ank-tdd ~60, ank-diagnose ~70, on-invoke ~2.1k, ~830, ~540, ~1.3k, ~1.3k, ~1.9k. .claude-plugin/plugin.json already declared all six, so the manifest was right and only the prose was stale. The '~58 tok always-on per skill' line does not survive the measurement either: the six range from ~50 to ~80.

--- a/.ank/entities/LOG-b0db6cfcc405.md
+++ b/.ank/entities/LOG-b0db6cfcc405.md
@@ -1,0 +1,15 @@
+---
+id: LOG-b0db6cfcc405
+type: log
+title: "docs/agents.md corrected in all four listings: the table (six rows, tdd and diagnose added in the"
+created: 2026-09-05T13:15:01Z
+author: claude-code/opus-5+docs
+scope:
+  - docs/agents.md
+about: TASK-8b8aaf9fdd61
+seq: 2
+schema: 4
+version: 1
+---
+
+ ADR-e4a5a8873fe3 order), the skills-CLI tree (Found 6 skills, ank-diagnose and ank-tdd in the alphabetical positions the CLI actually prints them), the plugin inventory and cost block (Skills (6), always-on ~411 tok, six per-component rows, all measured), and the by-hand copy instructions (five sibling paths). The prose counts that hang off them followed: 'the other three' -> five, 'four descriptions' -> six, and '~58 tok always-on per skill' -> the measured ~50 to ~80 range.

--- a/.ank/entities/TASK-8b8aaf9fdd61.md
+++ b/.ank/entities/TASK-8b8aaf9fdd61.md
@@ -5,7 +5,7 @@ slug: docs-agents-md-names-the-skills-the-tree-actuall
 title: docs/agents.md names the skills the tree actually ships
 created: 2026-09-05T12:53:15Z
 author: haksolot@vmi3223161
-status: open
+status: done
 scope:
   - docs/agents.md
 blocked_by: [TASK-587a185bef49]
@@ -13,8 +13,15 @@ done_criteria: |
   docs/agents.md lists every sibling skill the tree ships -- plan, drift, loop, tdd, diagnose -- in each of its three sites (the table, the tree, the copy instructions), and its skill count matches what a listing of skill/ returns. cargo test --workspace passes.
 criteria_by: creator
 verify: [cargo-test]
+proof:
+  - type: test
+    ref: local/0eeae90d3803@d21e83c
+    tree: scope/e0a591a4a9d1
+    criteria: 704c680e4db4
+    verifier: cargo-test@f14aeab36e1b
+    via: verifier
 schema: 4
-version: 1
+version: 3
 ---
 
 Discovered while landing skill/tdd (TASK-135cde611e3f): docs/agents.md lists the siblings in three places and still says Skills (4). Out of scope of both skill-sibling tasks, so it is carried here. Blocked on the diagnose sibling so the count is written once, against the final tree.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -10,28 +10,30 @@ Everything below is for the cases those two do not fit.
 
 ## The skill
 
-Four plain markdown files, one per skill. Each is the only copy that exists in
+Six plain markdown files, one per skill. Each is the only copy that exists in
 git, and every route below points at it rather than holding one of its own, so
 no route can fall behind it.
 
-    ank         ../skill/SKILL.md          the contract
-    ank-plan    ../skill/plan/SKILL.md     interview a goal into ADRs, specs, tasks
-    ank-drift   ../skill/drift/SKILL.md    audit decisions against the code
-    ank-loop    ../skill/loop/SKILL.md     work the backlog autonomously
+    ank           ../skill/SKILL.md           the contract
+    ank-plan      ../skill/plan/SKILL.md      interview a goal into ADRs and tasks
+    ank-drift     ../skill/drift/SKILL.md     audit decisions against the code
+    ank-loop      ../skill/loop/SKILL.md      work the backlog autonomously
+    ank-tdd       ../skill/tdd/SKILL.md       drive an implementation test-first
+    ank-diagnose  ../skill/diagnose/SKILL.md  work a defect back to its cause
 
 [`../skill/SKILL.md`](../skill/SKILL.md) is the one an agent loads by default,
 and it is self-sufficient: why ank is shaped as it is, the verbs grouped by the
 moment each is used, and the rules that are not negotiable. It names the other
-three so an agent reaching for an activity knows what to load, and never
-depends on them being installed. The three carry a policy each and are loaded
+five so an agent reaching for an activity knows what to load, and never
+depends on them being installed. The five carry a policy each and are loaded
 when the activity calls for them (ADR-e4a5a8873fe3).
 
 **What that costs a session is the frontmatter, not the page.** The projection
-below is `~58 tok` always-on per skill, and that is a skill's `name` and
-`description`; a body is read when its skill is invoked. The ceiling on the
-bodies is kept anyway, because the by-hand route at the end of this page copies
-whole files into whatever a harness loads, and some harnesses load all of it
-every session, so it bounds the worst route rather than the measured one.
+below runs from `~50` to `~80 tok` always-on per skill, and that is a skill's
+`name` and `description`; a body is read when its skill is invoked. The ceiling
+on the bodies is kept anyway, because the by-hand route at the end of this page
+copies whole files into whatever a harness loads, and some harnesses load all of
+it every session, so it bounds the worst route rather than the measured one.
 
 One convention it carries is worth knowing before you watch an agent follow it:
 **`.ank/` is opaque to an agent, the way `.git/` is.** Reading goes through
@@ -48,7 +50,7 @@ install:
     $ npx skills add haksolot/ank --list
     Source: https://github.com/haksolot/ank.git
     Repository cloned
-    Found 4 skills
+    Found 6 skills
 
     Available Skills
     Ank
@@ -56,6 +58,9 @@ install:
         Read a repository's tasks and binding constraints, claim work, and
         finish it with proof. Use when working in a repo that has a .ank/
         directory.
+      ank-diagnose
+        Work a defect back to its cause before changing anything, and close it
+        with a regression test. ...
       ank-drift
         Audit the decisions in .ank/ against the current code and report what
         no longer holds. ...
@@ -64,6 +69,9 @@ install:
         a time. ...
       ank-plan
         Interview a goal into decisions and tasks recorded in .ank/. ...
+      ank-tdd
+        Drive an implementation test-first, red before green, against a claimed
+        task's frozen criterion. ...
 
     Use --skill <name> to install specific skills
 
@@ -89,19 +97,21 @@ worth asking of anything loaded on every session:
     agent can call.
 
     Component inventory
-      Skills (4)  ank, ank-drift, ank-loop, ank-plan
+      Skills (6)  ank, ank-diagnose, ank-drift, ank-loop, ank-plan, ank-tdd
 
     Projected token cost
-      Always-on:   ~282 tok   added to every session
+      Always-on:   ~411 tok   added to every session
 
     Per-component (rounded)
-      component  always-on  on-invoke
-      ank              ~50      ~1.9k
-      ank-plan         ~70       ~740
-      ank-drift        ~80       ~560
-      ank-loop         ~70       ~630
+      component     always-on  on-invoke
+      ank                 ~50      ~2.1k
+      ank-plan            ~70       ~830
+      ank-drift           ~80       ~540
+      ank-loop            ~70      ~1.3k
+      ank-tdd             ~60      ~1.3k
+      ank-diagnose        ~70      ~1.9k
 
-**Read the two columns as what they are.** Always-on is four descriptions, paid
+**Read the two columns as what they are.** Always-on is six descriptions, paid
 by every session whether or not anything fires; on-invoke is a body, paid by
 the session that wanted it. Splitting the teaching moved cost from the second
 column to the first, which is the trade the plural skill system makes: an agent
@@ -129,9 +139,10 @@ routes below.
 Each skill is one file with nothing generated in it. Where none of the routes
 above fits your harness, copy `skill/SKILL.md` into whatever that harness loads
 and you have lost nothing: the routes exist to save you a copy, not to add
-anything to it. Copy `skill/plan/SKILL.md`, `skill/drift/SKILL.md` and
-`skill/loop/SKILL.md` beside it for the activity policies, or copy none of them
-and keep the contract, which stands alone.
+anything to it. Copy `skill/plan/SKILL.md`, `skill/drift/SKILL.md`,
+`skill/loop/SKILL.md`, `skill/tdd/SKILL.md` and `skill/diagnose/SKILL.md`
+beside it for the activity policies, or copy none of them and keep the
+contract, which stands alone.
 
 ## The binary
 


### PR DESCRIPTION
docs/agents.md listed four skills in four places while the tree shipped six:
the contract plus five siblings, plan, drift, loop, tdd and diagnose. The
manifest at .claude-plugin/plugin.json already declared all six, so only the
prose was stale.

Every count here is measured rather than reasoned. A listing of skill/ returns
six SKILL.md files and five sibling directories. `npx skills add haksolot/ank
--list`, run from an empty tmpdir against main, prints "Found 6 skills" and the
alphabetical tree the section now reproduces. The plugin block comes from
installing the tree as a plugin and reading `claude plugin details ank`: six
skills, ~411 tok always-on, and per-component figures for all six. That last
measurement also retires the "~58 tok always-on per skill" line, which no skill
in the tree costs; the six run from ~50 to ~80.

Closes TASK-8b8aaf9fdd61.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UXgjSRNCM4Ubp6fP4bSzP8
