### PR TITLE
check replays the proof's criteria anchor on a done task

### DIFF
--- a/.ank/entities/LOG-98fa326b4797.md
+++ b/.ank/entities/LOG-98fa326b4797.md
@@ -1,0 +1,17 @@
+---
+id: LOG-98fa326b4797
+type: log
+title: "red observed before the code: the new binary test failed at exit 0 where 8 was asserted, two"
+created: 2026-09-05T13:59:33Z
+author: claude-code/385
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/src/done.rs
+  - crates/ank-cli/tests/**
+about: TASK-1a20081691ce
+seq: 0
+schema: 4
+version: 1
+---
+
+ byte-identical check runs around a sed on done_criteria of a done task -- the reproduction of issue #385's side finding, now pinned. Green with the replay inserted in check_task beside the verifier-anchor loop: one finding per distinct criteria anchor across proofs, fault, wording aligned on the claim-time replay ('diverges from the proof (proved X, now Y)'). A None done_criteria against an anchored proof is also a fault (proved X, now absent), untested by the criterion but the same hole. New binary run over this live corpus: check ok, 381 tasks, no divergence reported, so no false positive on historical proofs.

--- a/.ank/entities/LOG-e32b9717420d.md
+++ b/.ank/entities/LOG-e32b9717420d.md
@@ -1,0 +1,17 @@
+---
+id: LOG-e32b9717420d
+type: log
+title: done, proof test:local/6f43816b3904@9fb7867 test:local/e3b0c44298fc@9fb7867
+created: 2026-09-05T14:03:08Z
+author: claude-code/385
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/src/done.rs
+  - crates/ank-cli/tests/**
+about: TASK-1a20081691ce
+seq: 1
+schema: 4
+version: 1
+---
+
+ test:local/2fe2b3bc9d5a@9fb7867

--- a/.ank/entities/TASK-1a20081691ce.md
+++ b/.ank/entities/TASK-1a20081691ce.md
@@ -5,7 +5,7 @@ slug: check-replays-the-proof-s-criteria-hash-on-a-don
 title: check replays the proof's criteria hash on a done task, and an edited criterion is a fault
 created: 2026-09-05T13:44:55Z
 author: haksolot@vmi3223161
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/src/human.rs
   - crates/ank-cli/src/done.rs
@@ -15,8 +15,27 @@ done_criteria: |
   Through the binary: on a done task whose done_criteria no longer hashes to the criteria value its proof records, ank check reports a fault naming the task and the divergence, exit 8; reverting the edit returns check to green. A done task whose criterion matches its proof reports nothing new. Covered by a binary test in crates/ank-cli/tests/ that edits the entity file by hand between two check runs and compares the two outputs.
 criteria_by: creator
 verify: [cargo-test, fmt-check, check-repo]
+proof:
+  - type: test
+    ref: local/6f43816b3904@9fb7867
+    tree: scope/e6d09a448e75
+    criteria: 2a745f2ec845
+    verifier: cargo-test@f14aeab36e1b
+    via: verifier
+  - type: test
+    ref: local/e3b0c44298fc@9fb7867
+    tree: scope/e6d09a448e75
+    criteria: 2a745f2ec845
+    verifier: fmt-check@5ca6d10bcd55
+    via: verifier
+  - type: test
+    ref: local/2fe2b3bc9d5a@9fb7867
+    tree: scope/e6d09a448e75
+    criteria: 2a745f2ec845
+    verifier: check-repo@5734e9cf9d3d
+    via: verifier
 schema: 4
-version: 2
+version: 3
 ---
 
 Issue #385, side finding, reproduced on this tree at 0195eb1: sed on

--- a/.ank/entities/TASK-1a20081691ce.md
+++ b/.ank/entities/TASK-1a20081691ce.md
@@ -5,7 +5,7 @@ slug: check-replays-the-proof-s-criteria-hash-on-a-don
 title: check replays the proof's criteria hash on a done task, and an edited criterion is a fault
 created: 2026-09-05T13:44:55Z
 author: haksolot@vmi3223161
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/src/human.rs
   - crates/ank-cli/src/done.rs
@@ -16,7 +16,7 @@ done_criteria: |
 criteria_by: creator
 verify: [cargo-test, fmt-check, check-repo]
 schema: 4
-version: 1
+version: 2
 ---
 
 Issue #385, side finding, reproduced on this tree at 0195eb1: sed on

--- a/crates/ank-cli/src/human.rs
+++ b/crates/ank-cli/src/human.rs
@@ -1951,6 +1951,35 @@ fn check_task(
         }
     }
 
+    // The same freeze, replayed after `done`. The anchor moves from the claim
+    // record to the proof entry when the task closes (ADR-6b3f19e08a24), and
+    // nothing used to read it back: a criterion edited by hand on a finished
+    // task produced two byte-identical `check` runs, exit 0 both times, while
+    // the proof carried the hash all along (issue #385). One finding per
+    // distinct anchor, because one edit is one fact however many proof entries
+    // anchor the same text.
+    let anchors: BTreeSet<&str> = proofs
+        .iter()
+        .filter_map(|p| p.criteria.as_deref())
+        .collect();
+    for anchor in anchors {
+        match &t.done_criteria {
+            Some(criteria) if verify_frozen(criteria, anchor) => {}
+            Some(criteria) => report.findings.push(Finding::fault(
+                &t.id,
+                format!(
+                    "done_criteria diverges from the proof (proved {anchor}, now {}): \
+                     edited after done, and the git diff names the edit",
+                    freeze::freeze_hash_short(criteria)
+                ),
+            )),
+            None => report.findings.push(Finding::fault(
+                &t.id,
+                format!("done_criteria diverges from the proof (proved {anchor}, now absent)"),
+            )),
+        }
+    }
+
     // The field is declarative and git is the anchor. A creation in the future
     // is the half of that check reachable without porcelain (§4).
     if let Some(created) = claim::parse_utc(&t.created) {

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -7931,6 +7931,78 @@ fn an_unattested_task_is_not_reported_until_the_default_branch_carries_it() {
     );
 }
 
+const EDITED_CRITERIA: &str = "TASK-00000000ed17";
+
+/// The proof anchors `done_criteria` by hash, and `check` replays that anchor
+/// on a finished task (ADR-6b3f19e08a24: every freeze is checked at the point
+/// of use, and after `done` the point of use is `check`). Before this, a hand
+/// edit of the criterion on a `done` task produced two byte-identical `check`
+/// runs, exit 0 both times — effective and invisible, issue #385.
+///
+/// The fault is actionable, unlike the dead scope: the git diff names the
+/// edit, and reverting it is the repair the run below performs.
+#[test]
+fn check_replays_the_criteria_anchor_of_a_done_task_and_an_edited_criterion_is_a_fault() {
+    let r = Repo::new();
+    // `0d23d56872d6` is sha256("A verifiable criterion.") truncated to 12 —
+    // the anchor `done` would have recorded for the criterion `seed_done`
+    // writes.
+    seed_done(
+        &r,
+        EDITED_CRITERIA,
+        "  - type: commit\n    ref: abc1234\n    criteria: 0d23d56872d6\n",
+    );
+    std::fs::create_dir_all(r.0.join("src")).unwrap();
+    std::fs::write(r.0.join("src/lib.rs"), "// x\n").unwrap();
+    r.git(&["add", "-A"]);
+    r.git(&["commit", "-qm", "seed"]);
+
+    // A criterion that matches its anchor reports nothing new.
+    let out = r.ank("claude-code@ank", &["check"]);
+    let before = format!("{}{}", stdout(&out), stderr(&out));
+    assert_eq!(code(&out), 0, "a matching anchor is silent: {before}");
+    assert!(
+        !before.contains("diverges from the proof"),
+        "a matching anchor is silent: {before}"
+    );
+
+    // The hand edit issue #385 documents, made between two runs.
+    let entity =
+        r.0.join(".ank/entities")
+            .join(format!("{EDITED_CRITERIA}.md"));
+    let intact = std::fs::read_to_string(&entity).unwrap();
+    std::fs::write(
+        &entity,
+        intact.replace("A verifiable criterion.", "Another criterion entirely."),
+    )
+    .unwrap();
+
+    let out = r.ank("claude-code@ank", &["check"]);
+    let said = format!("{}{}", stdout(&out), stderr(&out));
+    assert_eq!(code(&out), 8, "an edited anchored field is a fault: {said}");
+    let fault: Vec<&str> = said
+        .lines()
+        .filter(|l| l.contains("diverges from the proof"))
+        .collect();
+    assert_eq!(fault.len(), 1, "one edit, one finding: {said}");
+    assert!(
+        fault[0].contains(EDITED_CRITERIA),
+        "the fault names the task: {said}"
+    );
+    assert!(
+        fault[0].contains("0d23d56872d6"),
+        "the fault names the anchor the proof holds: {said}"
+    );
+
+    // Reverting the edit is the repair, and the output says exactly what it
+    // said before the edit: nothing lingers.
+    std::fs::write(&entity, intact).unwrap();
+    let out = r.ank("claude-code@ank", &["check"]);
+    let after = format!("{}{}", stdout(&out), stderr(&out));
+    assert_eq!(code(&out), 0, "the revert clears the fault: {after}");
+    assert_eq!(before, after, "the two green runs read the same");
+}
+
 const REMOVED_SCOPE: &str = "TASK-00000000de1e";
 const REMOVED_TREE: &str = "TASK-00000000d132";
 const NEVER_SCOPE: &str = "TASK-00000000f00d";


### PR DESCRIPTION
Closes the side finding of #385: a hand edit of done_criteria on a done task was effective and invisible (two byte-identical check runs, exit 0, while the proof carried criteria:<hash>). check now replays the anchor on finished tasks — one fault per distinct anchor, wording aligned on the claim-time replay — which is the point of use ADR-6b3f19e08a24 promises. Verified against the live corpus: no false positive on 381 tasks.

TASK-1a20081691ce closed by its declared verifiers (cargo-test, fmt-check, check-repo).

The other half of #385 (amend --scope on a done task) waits on ADR-b9156403c3d5, proposed in #393.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5jznYkUxwuxuEBwv5v4VK