### PR TITLE
The specification carries the post-done amend rule ADR-b9156403c3d5 states

### DIFF
--- a/.ank/entities/LOG-32f936dd48ce.md
+++ b/.ank/entities/LOG-32f936dd48ce.md
@@ -1,0 +1,16 @@
+---
+id: LOG-32f936dd48ce
+type: log
+title: +references SPEC-e258796162c4, +references SPEC-77d99d8d1ef2, +references SPEC-a1234da5449a,
+created: 2026-09-05T14:22:04Z
+author: haksolot@vmi3223161
+scope:
+  - crates/ank-cli/**
+about: SPEC-4b79c265ccb6
+seq: 0
+records: edit
+schema: 4
+version: 1
+---
+
+ -references SPEC-a89ba4f755e9, -references SPEC-88e1ba60a95d, -references SPEC-6aed60cd3717 (version 1 to 2, replaced a519de7969f6, produced 33839fc05c88)

--- a/.ank/entities/LOG-487e4652f24c.md
+++ b/.ank/entities/LOG-487e4652f24c.md
@@ -1,0 +1,17 @@
+---
+id: LOG-487e4652f24c
+type: log
+title: +references SPEC-4b79c265ccb6, -references SPEC-f353359663d5 (version 2 to 3, replaced
+created: 2026-09-05T14:22:39Z
+author: haksolot@vmi3223161
+scope:
+  - crates/ank-core/**
+  - docs/format.md
+about: SPEC-e258796162c4
+seq: 1
+records: edit
+schema: 4
+version: 1
+---
+
+ ae4aceb83b19, produced 6b542dbdbc4f)

--- a/.ank/entities/LOG-5e28aca497ae.md
+++ b/.ank/entities/LOG-5e28aca497ae.md
@@ -1,0 +1,15 @@
+---
+id: LOG-5e28aca497ae
+type: log
+title: done, proof test:local/5a3105020e09@c08f852
+created: 2026-09-05T14:23:11Z
+author: claude-code/385
+scope:
+  - .ank/**
+  - crates/ank-contract/src/verbs.rs
+  - crates/ank-tui/src/view.rs
+about: TASK-5ce9bb43cdf7
+seq: 1
+schema: 4
+version: 1
+---

--- a/.ank/entities/LOG-7525f9031860.md
+++ b/.ank/entities/LOG-7525f9031860.md
@@ -1,0 +1,18 @@
+---
+id: LOG-7525f9031860
+type: log
+title: +references SPEC-e258796162c4, -references SPEC-a89ba4f755e9 (version 1 to 2, replaced
+created: 2026-09-05T14:22:04Z
+author: haksolot@vmi3223161
+scope:
+  - crates/ank-cli/src/done.rs
+  - crates/ank-cli/src/verify.rs
+  - .ank/allowed_signers
+about: SPEC-77d99d8d1ef2
+seq: 0
+records: edit
+schema: 4
+version: 1
+---
+
+ 5745a30f8b1f, produced dba903e3a8bf)

--- a/.ank/entities/LOG-7b1208b9ea4a.md
+++ b/.ank/entities/LOG-7b1208b9ea4a.md
@@ -1,0 +1,17 @@
+---
+id: LOG-7b1208b9ea4a
+type: log
+title: "Succession built as three proposals carried forward whole: SPEC-e258796162c4 (data model, section"
+created: 2026-09-05T14:22:39Z
+author: claude-code/385
+scope:
+  - .ank/**
+  - crates/ank-contract/src/verbs.rs
+  - crates/ank-tui/src/view.rs
+about: TASK-5ce9bb43cdf7
+seq: 0
+schema: 4
+version: 1
+---
+
+ 3's post-done sentence now legalises the scope amend and keeps done_criteria anchored), SPEC-77d99d8d1ef2 (proof: the two 'only legal post-done write' prose citations rephrased onto the append-only proof list), SPEC-4b79c265ccb6 (CLI surface: amend's refusal entry split by field, attest's line reworded, the dead-scope rationale updated to the new regime). Workspace sweep: 6 sites all citing SPEC-d58b3a9e4e4d (verbs.rs:412 doc comment, view.rs fixture row + 4 test assertions), re-pointed to SPEC-4b79c265ccb6 in one pass; no code cites a89b or 88e1. Successor cross-references re-pointed at each other's new ids, and inherited references to superseded ancestors (6aed -> a123, f353 -> 4b79) moved to their chain ends. check ok, 454 signals, the new ones all the expected pre-ratification kind.

--- a/.ank/entities/LOG-92bdc95d1b37.md
+++ b/.ank/entities/LOG-92bdc95d1b37.md
@@ -1,0 +1,17 @@
+---
+id: LOG-92bdc95d1b37
+type: log
+title: +references SPEC-77d99d8d1ef2, -references SPEC-88e1ba60a95d (version 1 to 2, replaced
+created: 2026-09-05T14:22:04Z
+author: haksolot@vmi3223161
+scope:
+  - crates/ank-core/**
+  - docs/format.md
+about: SPEC-e258796162c4
+seq: 0
+records: edit
+schema: 4
+version: 1
+---
+
+ a17c767d89af, produced 09c97572564e)

--- a/.ank/entities/LOG-97a0fc9a187c.md
+++ b/.ank/entities/LOG-97a0fc9a187c.md
@@ -1,0 +1,16 @@
+---
+id: LOG-97a0fc9a187c
+type: log
+title: +blocked_by TASK-5ce9bb43cdf7 (version 2 to 3, replaced e5ce6b345cd6, produced 71148d99a5cd)
+created: 2026-09-05T14:18:42Z
+author: haksolot@vmi3223161
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/src/cli.rs
+  - crates/ank-cli/tests/**
+about: TASK-d64c3dbfe0a3
+seq: 1
+records: edit
+schema: 4
+version: 1
+---

--- a/.ank/entities/SPEC-4b79c265ccb6.md
+++ b/.ank/entities/SPEC-4b79c265ccb6.md
@@ -1,0 +1,567 @@
+---
+id: SPEC-4b79c265ccb6
+type: spec
+slug: the-cli-surface
+title: The CLI surface
+created: 2026-09-05T14:21:06Z
+author: haksolot@vmi3223161
+status: proposed
+scope:
+  - crates/ank-cli/**
+references: [SPEC-89070ce7f3b8, SPEC-e258796162c4, SPEC-77d99d8d1ef2, SPEC-a1234da5449a]
+supersedes: SPEC-d58b3a9e4e4d
+schema: 4
+version: 2
+---
+
+One of the ten documents that carry the Ank specification (ADR-5a690829388d).
+This one carries **§4 without two of its halves**: the one surface and what the
+skill teaches, the verbs, the refusals and their exit codes, the commands block,
+configuration, short forms, self-correcting errors, and the catalogue `check`
+prints.
+
+## Why two halves left, and why the rest did not
+
+§4 was the longest section in the monolith and the only one this decomposition
+splits. Two passages sitting inside it failed the test in the direction nobody
+looks for — not *this cannot be read alone*, but *this is read by documents that
+are not this one*.
+
+**The presentation grammar left.** Its alphabet and its palette are declared
+before any code uses them, they read alone, and their dependencies point away
+from the verbs: the palette is keyed on the statuses the data model declares and
+on the markers synchronisation writes, not on anything in the verb table it sat
+inside. A passage whose dependencies lie outside the document holding it is a
+passage in the wrong document.
+
+**The proof half left**, and joined §8. Proofs, named verifiers and the trust
+hierarchy answer the same question §8 answers about identity — what is a claim
+about the world worth, and who validated it. The data model reads it for the
+`proof` field, synchronisation reads it for detached proofs, and a passage two
+documents depend on should not be buried inside a third.
+
+**The catalogue of `check` stayed.** It is the strongest candidate for a document
+of its own and it fails the test cleanly: nearly every finding restates a rule
+that lives elsewhere and cites the section that states it, so read alone it is an
+index of things it does not contain. An index that cannot be read without the
+things it indexes is not a document, and this one belongs beside the verb that
+prints it.
+
+Everything else here is one subject: what the caller may type, what comes back,
+and on what state it is refused. `config` and the short-form table are part of it
+for the same reason the exit codes are — they are the surface, not a mechanism
+behind it.
+
+## What it rests on
+
+- **The data model** — every verb here acts on the fields it declares.
+- **Presentation** — the grammar of what these verbs print.
+- **Proof, anchoring and authority** — what `done` requires and why a refusal is
+  never on identity.
+- **The attention budget** — `context`'s two modes, and the over-constrained
+  finding this catalogue reports.
+
+---
+
+## 4. CLI surface
+
+**Ank exposes one surface** (ADR-e17e1bbd93ff, superseding ADR-c656cbcc33a9). Every verb is available to every caller, and the CLI refuses on state, never on identity. Git has more than a hundred commands, every one of them reachable by anybody who types it, and stays learnable because of what a newcomer is taught first — not because the porcelain sorts callers into classes. Ank borrows that shape.
+
+The memorisation budget is real; it is simply not the binary's job. It is spent on documentation, and it is enforced where it operates: what an agent is taught is a contract every session loads and one policy per activity, each anchored where it lives. What a human may type is everything.
+
+### What the skills teach, and what anchors them
+
+```
+Loop:          context → claim → show → log → done
+Off-loop:      new, find, release
+Planning:      new adr, amend, review, graph, check, find --status open
+Investigation: context <path>, scope, find, show, log <id>, status, check <path>
+```
+
+**The teaching surface is plural, and no part of it is frozen by hash any more** (ADR-91b77f036884, superseding ADR-5dd7b4a9c875, which carried the freeze forward from ADR-f61e2d2c75e8 and ADR-e17e1bbd93ff unchanged). `skill/SKILL.md` is the contract: the verbs above, grouped by the moment each is used, the model behind them, and the rules that are not negotiable. Beside it lives one skill per activity: `ank-plan` interviews a goal into entities, `ank-drift` audits accepted decisions against the code, and `ank-loop` consumes planned tasks, each loaded when its activity calls for it.
+
+**What replaced the freeze is three anchors, and they are what the freeze was actually protecting.** Every skill declares `metadata.revision`, the hash of its own body, recomputed by test so it cannot drift by being forgotten; the binary names the contract revision it was built alongside, so a stale installed copy has nothing to hide behind (§9); and `accept` stays described and never invited, in every skill that mentions it. Content now evolves under review rather than by supersession, because the lock priced every edit and the anchors price none while catching the failure that was actually measured.
+
+**A description is the trigger, and it is the one line every session pays for** whether or not the skill fires. It names the activity that should load the skill, exactly, and it does not grow without a measurement (§9). The freeze constrained the documentation and never the dispatch table, and that is unchanged: an agent that runs `ank edit` gets the editor; it was simply never told the verb existed, and being untold is not being refused.
+
+**A policy is not restated in the contract, and the contract is not restated in a policy.** A rule written in two files drifts, and the drift between an installed skill and a ratified decision is a measured failure of this project rather than a hypothetical one (TASK-b495234f192c). The contract stays self-sufficient for executing work, since it is the only skill with a broad trigger and the routes of §9 may install it alone, so it names the others as invitations and never depends on them.
+
+**Three modes, because an agent that can only execute is half an agent, and one that cannot look is working blind.** The loop is how work gets done; planning is how the work that gets done comes to exist — deciding which tasks should exist, in what order, under which constraints. ADR-c656cbcc33a9 taught the loop alone, and an agent taught by it could not propose a decision, correct a graph, or notice that the corpus had gone incoherent: `ank new adr` was never mentioned, so an agent seeing an architectural problem had no documented path from the observation to a recorded ADR. Planning is the highest-leverage activity in the corpus, and a badly shaped backlog wastes more downstream than the teaching costs upstream.
+
+**Investigation is the third, and it is the one an agent needs first.** Before choosing a task — and often instead of choosing one — the question is *what governs this file* and *where am I*. `scope <path>` answers the first and `status` the second, both shipped and neither taught, so an agent holding the skill had the question and not the verb. The read form of `log <id>` is the third: it is how the next holder learns where the last one stopped, which is the whole reason `release --reason` is mandatory. And `find --type spec` reaches the specification itself, which is an entity of the corpus since ADR-5a690829388d — the normative answer is one `show` away, from inside the tool, under the rule that closes `.ank/` to direct reads. **Every verb the mode adds is a reader**: it teaches how to arrive informed, and adds no way to change anything.
+
+**The file says why before it says how.** It opened on where the files live and went straight to the verbs, which taught the moves and not what they protect: that constraints and work are two planes joined only by scope, and that nothing here is trusted because everything is anchored. An agent that does not know what a rule protects is the one that works around it, in good faith.
+
+**The ceiling is at most 180 lines and 1500 words, now per skill**, and it stays a ceiling to notice drift rather than a target to fill. The number rests on a measurement, because a ceiling raised to accommodate what was just written is not a ceiling. What every session pays for is the **frontmatter** and not the body: `claude plugin details ank` projects `Always-on: ~282 tok` across four skills, which is their `name` and `description` lines, against `~58 tok` when there was one, and a body is read when its skill is invoked. Splitting the teaching moved cost from the invoked column to the permanent one, and bought the trade §9 states: an agent executing a task no longer loads the planning policy it will not use. The ceiling is kept for the case it was always protecting: §9's by-hand route copies whole files into whatever a harness loads, and some load all of it every session. So it bounds the worst route rather than the best one, and the `description` lines do not grow at all, being the part paid for whether or not a skill is ever used.
+
+**`accept` is described and never invited.** The skill says what it is — a human act, signed, on the default branch only — so that a planning agent knows where its own authority ends, and it never shows the command as something to run. That is the one hard authority line in the system (§8, §12), and describing it is what makes it legible rather than mysterious. `close`, `attest` and `edit` stay outside for the ordinary reason: nothing has decided they are worth what every session pays for them.
+
+That distinction is the whole revision. ADR-3859eb46bdc3 froze an *agent surface* at these same eight verbs and sent everything else to a human side, but the split it protected was never a boundary — the CLI told callers apart by `$ANK_AGENT`, a variable the caller sets itself (§8). A wall whose bricks are self-declared identity is a sign, not a wall. What the freeze actually protected was the token budget, and that protection moves here, where it holds without pretending to be a check.
+
+`show` is in the loop by that route, and the reasoning is worth keeping because it is the argument any addition to SKILL.md has to beat. It sat outside at first, as the only unbounded reader in the system. That argument was about output size, and §5 answers size with a budget and a truncation notice that says what it cut. What it did not answer is the body: `context` serves the criterion and the constraints, never the prose that justifies them, and the prose is where the reasoning an agent is supposed to inherit actually lives. With `.ank/` closed to direct reads (ADR-01b6dd05f0db), withholding it entirely was the worse trade.
+
+### The rest of the surface
+
+These verbs are the rest of the surface. Four of them — `review`, `check`, `amend` and `graph` — are what the planning mode above teaches, and the others are outside what the skill teaches rather than withheld from anyone: none of the refusals below consults who is calling, and an agent that types one gets its answer.
+
+```
+review    ratification queue, pending proposals, corpus health
+accept    promotes a proposed ADR or spec to accepted (produces the signed commit,
+          §8, §12; requires the default branch)
+check     mechanical invariants, exit code usable in CI
+close     closes a task that will never be done (--reason mandatory)
+amend     changes `blocked_by`, `scope`, and a `done_criteria` no live claim freezes
+attest    appends a proof to a finished task: the proof-list write §3 allows after `done`
+status    where am I: branch, claim, perimeter, queue, findings
+edit      changes the content field named, or opens the entity in the editor
+graph     the `blocked_by` DAG in readable text
+scope     what covers a path
+```
+
+`review` and `accept` are not comfort features: **the entire authority model of ADRs depends on them**. Without them an agent creates in `proposed` and nothing ever becomes binding.
+
+`review` filters by default on **live scopes**; entities with a dead scope are grouped into a cleanup section with `close` suggested. An ageing corpus therefore produces an explicit closure queue rather than diffuse noise.
+
+**`accept` only runs on the default branch** (§7), and there is no way around it — no `--force`. An ADR ratified on a feature branch would be binding only on that branch: a constraint of variable geometry, and a ratification hash that depends on the reading context, which is exactly the ambiguity Ank eliminates everywhere else. The legitimate use case — introducing a constraint and the code that applies it in the same PR — is already covered by the model: the ADR is created in `proposed`, travels with the code, and is accepted only once it has reached the default branch. An unratified constraint binds nobody, so nothing is lost by waiting, and that is what makes the prohibition sustainable while strict. Off the default branch, `accept` exits with **code 7** — missing prerequisite, not illegal transition: the promotion is legal, the place is not.
+
+```
+$ ank accept 19d0
+error[7]: accept requires the default branch (current: feat/opaque-sessions, default: main)
+  -> git switch main && ank accept 19d0
+```
+
+**`read <id>` records that a person read this entity**, and it exists because the corpus asked a question nothing on this surface could answer. ADR-3877fef1d662 defines `verified:` as a list of readings, each naming a typed actor and an instant, and `check` reports an entity an agent wrote and no human has read. Exactly one place in the binary ever wrote a reading: `accept`, as a side effect of ratifying. So the signal cleared for an ADR or a spec at its ratification, cleared for nothing else, and could never clear for a task at all, since `accept` refuses a task by kind before it reads anything. On this repository's own corpus that was 186 entities, 122 of them tasks: half of every signal it carried, on a state no act could change. A finding nobody can clear is what a reader learns to skip, which is the one thing every severity rule in §4 exists to prevent.
+
+It **appends and never replaces**, which is the shape `attest` already carries: a reading is a fact about a moment, and a second reader does not overwrite the first. Two readings by one actor are two readings, because reading a document again a year later is a different act from reading it today, and deduplicating them would throw away the only thing the second one records.
+
+It **refuses a log entry** (§3, ADR-25f977377fa0). An entry is written once and never modified; a correction there is a new entry naming the one it corrects, so there is no second write for a reading to be. `check` already excludes entries from the signal for the reason that decides this one: an entry is a trace of work that happened, and there is nothing in it for a person to stand behind.
+
+**No signature, no branch precondition, and no refusal that consults who is calling.** A reading is not a ratification and does not borrow its ceremony. ADR-3877fef1d662 is explicit that the convention is a signal and not a wall: an agent can write `human:` in front of its own name exactly as it can set `$ANK_AGENT` to anything, and what the field buys is that the ordinary case becomes legible, not that the dishonest one becomes impossible. What the verb writes is the identity in effect, typed, and the instant. Judging it is the reader's work, not the tool's.
+
+It sits **beside `accept`** because that is where it was split from. The reading a ratification records is this act performed as a consequence of another, and everything `accept` cannot reach needs the act on its own.
+
+**`amend` covers the three fields a plan actually changes on**, `blocked_by`, `scope` and `done_criteria`, and covers nothing else. A subtask discovered after a task was filed is a `blocked_by` added to something that already exists; a scope found to omit the files the work must touch is a scope corrected before the task can be claimed at all. Both are ordinary, both were done by hand until this verb existed, and an edit done by hand is indistinguishable in the resulting file from any other edit done by hand — which is the argument that put `attest` on this surface too.
+
+It **adds and removes explicitly** and never takes a replacement list: a verb given the whole list silently drops whatever the caller forgot to repeat. On a `done` or `closed` task it refuses everything but `scope`: `done_criteria` is anchored by the hash the proof records and `blocked_by` is the plan's history, so both stay settled and the refusal names the settled field rather than the whole plan; `scope` describes where the work happened, is anchored by nothing, and stays amendable — journalled like every amend — because a dead scope on a finished task was otherwise a fault no verb could clear, and a guard that holds only the traceable path pushes toward the untraceable one (ADR-b9156403c3d5). And it refuses the `scope` of an accepted ADR or spec, whose `scope` is hashed into the ratification commit (§8) — changing a ratified decision is a succession, and succession has its own verb. The two are refused on the same terms and for the same reason, and a spec's anchor simply reaches wider: it covers the body as well, so what an ADR keeps editable after ratification a spec does not (§3).
+
+Amending the `scope` of a task under a live claim is **allowed and warned about**. The claim record anchors the hash of the constraints that scope selects (§7), so the change moves what binds the work in progress. Refusing would be wrong — a scope discovered false mid-task is exactly the situation the verb exists for — and allowing it silently would be worse.
+
+**`amend --criteria` is refused while a live claim freezes the criterion, and allowed the rest of the time.** That is the same state test `edit` already applies (below), and stating it once for both is the point: a criterion under no claim is anchored by nothing, so there is no freeze to respect and nothing for `check` to notice. Under a live claim the refusal is code 6 and names `release --reason`, which is what a criterion discovered wrong mid-work actually calls for.
+
+The route exists because a criterion can turn out **unmeasurable rather than wrong**, and that case had no continuation. Measured on this corpus: a task whose criterion ended on a clause about `gh api community/profile` reporting `issue_template`, which is `null` for any repository using an `ISSUE_TEMPLATE/` directory — the layout that task existed to produce (TASK-7c2fa14284ff). The work was finished and correct; the measurement never could be. The release was right and happened, and then the corrected criterion had two ways back in and both were wrong: a hand edit, which the tool exists to make unnecessary, or `claim --criteria`, which recorded a creator's correction as the claimer's.
+
+**`amend` does not touch `criteria_by`.** That field answers one question — was this criterion set at claim time, by the party the freeze constrains (§3) — and an amend is not a claim. Writing `claimer` there for a correction made under no claim would launder the correction into exactly the shape the signal exists to expose; writing `creator` would assert something about the caller, which no refusal and no field here does. What records the amend is the log entry, as it does for `scope` and `blocked_by`.
+
+**`claim --criteria` sets a criterion, and never replaces one.** On a task that already carries one it is refused, code 6, naming `ank amend <id> --criteria`. §3 gives the flag one job — a task cannot be claimed without a criterion, and the refusal for the empty case names the command that sets it and claims in the same call — and silently overwriting an existing one is not that job. It also keeps `criteria_by: claimer` meaning exactly one thing: nobody wrote a criterion for this task before the agent that took it.
+
+Everything else (editing fields, reordering, deleting) goes through **`ank edit`**, which is the paved road rather than a gate: it opens the same file in the same editor and validates what comes back. Below it, the direct edit remains possible, since the format is the specification and the CLI is not a gatekeeper. The actor matters there and is not decoration: ADR-01b6dd05f0db closes `.ank/` to direct reads and writes *by an agent*, and leaves **a human** with an editor every power they had. Written without the subject, that sentence reads as a general permission and hands back what the ADR withdrew.
+
+### Refusals are on state
+
+The binary refuses, and what it refuses on is always a fact about the corpus or the repository, never a fact about the caller.
+
+| Refusal | Code |
+|---|---|
+| frozen field diverged from its anchoring hash, or illegal transition | 6 |
+| claim held by another agent, or task already finished on another branch | 4 |
+| task blocked, no `done_criteria`, `accept` off the default branch, or a live claim already held by the calling identity | 7 |
+| proof missing or invalid | 5 |
+
+That list is the guarantee. A state refusal applies to every caller equally and means the same thing to all of them, which is what makes it worth writing an exit code for; a refusal conditioned on identity would mean whatever the caller declared itself to be. `$ANK_AGENT` names who acted — it goes into the log, into the claim ref and into `check`'s signals — and it is never consulted to decide whether a verb runs.
+
+**The one hard line of authority is the signed ratification commit** (§8, §12), and it holds precisely because it is not a role check: `accept` produces it, `check` verifies it against `allowed_signers`, and an anchor no key covers is reported as unverifiable. That is a proof requirement, the same shape as every other anchor in the system. Everything else that looks like permission is policy, and policy lives above the binary (§8).
+
+### Four verbs and two forms, for the reader at the keyboard
+
+With the surface no longer a boundary, verbs serving human ergonomics enter it without ceremony. None of them introduces state: each one composes what `context`, `find`, `review` and `check` already derive, or wraps a write that was being done by hand anyway.
+
+**`status`** answers *where am I* in one call: the branch, the identity in effect and where it came from, the active claim and its expiry, the constraints on the current perimeter, the ratification queue, completion refs the default branch has not caught up with (§7), and the corpus findings `check` would report. It **degrades with a warning** rather than failing when there is no remote or no determinable default branch — the parts that need neither are still worth printing. Terse `git status` register, and it ends with the next command to run, like every other output here.
+
+The identity line names its **source** and not only its value, for the reason `config` prints `8000 (default)` rather than `8000`: `$ANK_AGENT` names a session, the `<user>@<hostname>` fallback names a machine, and only the second is a trap — two sessions in one checkout that both let it fall back are one agent to every ref the tool writes. Nothing else on that path says so, since a `log` or a `done` from the wrong identity is refused on state, correctly talking about the claim somebody else holds (§8). Under `--json` the two are separate fields, `value` and `source`, on the terms `config` already set.
+
+**`edit <id>`** opens the entity in the editor named by `$EDITOR`, validates the result on save, and writes it back in canonical form (§3). **A change to a frozen field is refused by naming the command that legally performs it**: `release --reason` for a `done_criteria` frozen at claim, `new adr --supersedes` for the `constraint` of a ratified ADR. Frozen means anchored *now*: a `done_criteria` no live claim covers is not refused here, which is the same state test `amend --criteria` applies above and the reason the two agree by construction rather than by restatement. An invalid result leaves the entity untouched and says why, so a mistyped frontmatter costs a re-edit and never a corrupt file. This is the argument that put `amend` and `attest` on this surface, generalised: an edit performed by hand is indistinguishable, in the resulting file, from any other edit performed by hand, and chaperoning it through the tool strengthens the invariants instead of relaxing them.
+
+**A field may be named instead** (ADR-5bd8257dfeac): `--title`, `--body` and, on an ADR, `--constraint`, with `--body -` reading the body from stdin as `new` already does. A named edit writes only what is named, leaves every other field exactly as the file had it, and **never opens an editor** — so an unset `$EDITOR` is no failure for a caller who did not want one. With no field named, the editor opens on the whole entity, which stays the road for an edit that rewrites prose around a new argument, where a flag taking a body on stdin is the worse tool.
+
+**The refusals do not fork, and that is the load-bearing half.** A named edit meets `Freeze` where the editor path meets it, refuses with the same code and the same sentence, and differs in one thing only: the editor path adds where it kept the text that was typed, because a refusal after twenty minutes of typing must not discard them, and a flag value is still in the caller's shell. A flag naming a field the addressed kind does not carry is refused by name and nothing is written, since a caller who typed `--constraint` on a task believes they changed something and a verb answering `edited` to that would be lying about the corpus. What the surface changes is how a change is expressed, never what may be changed: `author` is unchangeable (§8), `version` is the store's, and `ratified` is `accept`'s.
+
+**`graph [<path>]`** prints the `blocked_by` DAG in readable text, restricted by an optional path the way `context` is, with `--json` for the raw edges. It **names the perimeter it drew** and says so explicitly when that perimeter holds no task. The ordering of §5 already walks these edges to count what a task unblocks, and this makes the same structure visible to a reader. `show` surfaces the narrow case from the same derivation: on a task it lists what that task **directly unblocks** alongside its blockers, one line each with status. Both are computed from the corpus at read time and stored nowhere — a stored reverse edge is a second copy of `blocked_by` that can disagree with the first.
+
+**`scope <path>`** lists every entity whose declared scope matches the path, grouped by type, one line each with its status, and says so explicitly when nothing matches. The resolution is the **same glob matching `context` uses**, resolved deterministically against the filesystem, so the answer is the one that will actually bind. It is the `check-ignore` of Ank: a dead or over-broad scope is otherwise visible only after the fact, through `check`, and this makes glob resolution observable before an entity is written wrong.
+
+**`new` without its mandatory flags opens a pre-filled template** in `$EDITOR` instead of failing, validates the result, and refuses to write an entity that would not pass validation. The `git commit` pattern: no `-m`, an editor. **The flag form is unchanged and remains the scripted path** — it is what SKILL.md teaches and what an agent uses, and nothing about the interactive form reaches it.
+
+**`log <id>` with no message reads** the entity's entries, newest first, and requires no claim. An entity nobody has logged against reads as an empty log, never as an error. `log` with a message keeps writing and renewing the claim, unchanged (§3). The disambiguation is stated rather than inferred: an argument that resolves to an entity id is a read, anything else is a message, and a message that also resolves to an id is an error naming both readings rather than picking one. This closes the one place the git intuition was betrayed — `git log` reads — without renaming the verb.
+
+**`$EDITOR` unset is an environment failure, not a task failure**: `edit` and the interactive form of `new` exit with **code 9** and name the flag form as the way through, consistent with how `sh` not found is treated below. Nothing falls back to a guessed editor.
+
+### HEAD
+
+Borrowed from git, and probably the highest-yield borrowing. `claim` sets a "current task" pointer per agent. Subsequent commands do without an ID:
+
+```
+$ ank claim 8f3a
+claimed TASK-8f3a migrate-auth-sessions -> HEAD
+
+$ ank log "jwt.verify removed from session.ts"
+$ ank done
+```
+
+The agent cannot get the identifier wrong, and every iteration saves a context round trip.
+
+**HEAD is not stored, it is derived**: it is the task on which the current agent holds an active claim. Nothing to synchronise, nothing to clean up, no state that can become inconsistent with the real claim.
+
+This assumes and enforces **one active claim at a time per agent**. That is a useful constraint in itself: an agent must finish or release before moving on, which prevents task hoarding and keeps work in progress readable by others.
+
+**Enforcing it is what `claim` does**, and for a long time this paragraph said so while the binary only warned. A `claim` made while the calling identity already holds a live claim on another task refuses with **code 7**, naming the task held, its expiry, and both ways through:
+
+```
+$ ank claim 8f3a
+error[7]: claude-code@host-3 holds a live claim on TASK-51c2 (expires in 24m)
+  -> ank release --reason "<why>"   (a second session on this machine sets its own ANK_AGENT)
+```
+
+**Code 7 and not 4.** The task asked for is available; it is the caller that is not. 4 means "take something else" and the reaction called for here is the opposite — finish or hand back what is already held — so the code that carries "missing prerequisite" is the one that says it.
+
+**The second way out is not decoration**, and it is why this hint carries a parenthetical the way the "another ready task" hints do. The default identity is `<user>@<hostname>` (§8), so two sessions in one working tree read as one agent, and the session being refused may never have claimed anything: it is being answered about somebody else's claim, and `ANK_AGENT` is the only thing that separates the two. That is also why the message names the identity rather than addressing the caller as the holder — under a shared identity, telling it "you already hold" would be false.
+
+The refusal comes **after** the refusals about the task itself — no criterion, blocked, already claimed elsewhere, illegal transition. An agent told to release the work it holds, for a task that would have refused it anyway, has been made to pay for nothing.
+
+The refusal is on state and not on identity, in the sense of the table above: what is read is the coordination plane — which refs exist and who holds them — and the answer is the same for every caller. A **lapsed** claim is not a live one, so pickup after expiry (§3) is untouched, and an agent returning to a task whose lease ran out claims it exactly as before.
+
+**It does not make the state unreachable, and nothing here assumes it does.** The CLI is not a gatekeeper (§7, §12): a ref written by hand, a claim taken by an earlier binary, or a claim that lapsed and was revived all produce one identity holding two live claims. What `log`, `release` and `done` do when they meet it is settled in §3, not here.
+
+The optional ID on `log`, `done` and `release` is therefore redundant in the nominal case: it exists for explicitness in scripts, and it **must name a task this agent holds a live claim on**, otherwise error 6. It is never a way to act on somebody else's task. Holding one claim, that is the same rule as "must match HEAD"; holding several — the state §3 describes and this section refuses to create — it is what names which of them a verb acts on.
+
+### Pickup and abandonment
+
+`release` closes a real gap: an agent that finds it cannot do the task otherwise has only TTL expiry, which means thirty minutes of dead work for everyone else.
+
+```
+$ ank release --reason "needs access to the staging Redis store"
+released TASK-8f3a -> open
+```
+
+**`--reason` is mandatory.** `release` is the delegation mechanism between agents: the reason goes into the log, and the next agent to claim the task receives the recent log in its `context`, so it resumes where the previous one stopped instead of starting from scratch. A silent release is exactly the gap this verb exists to close — the tool refuses it, with the full command as an example.
+
+### Commands
+
+```
+ank context [<path>]        [--json] [--limit N]
+ank claim <id>              [--criteria <c>: sets an absent one, never replaces] [--ttl 30m]
+ank show <id>
+ank log [<id>] [<message>]  (id alone reads; a message writes)
+ank done [<id>]             [--proof <type>:<ref>]
+ank release [<id>] --reason <r>
+ank new task --title <t> --scope <glob>... [--criteria <c>] [--blocked-by <id>...]
+ank new adr  --title <t> --scope <glob>... --constraint <c> [--supersedes <id>]
+ank new spec --title <t> --scope <glob>... [--supersedes <id>] [--reference <id>...]
+ank new task|adr|spec       (no flags: pre-filled template in $EDITOR)
+ank find <query>            [--type task|adr|spec|log] [--status ...] [--scope <path>] [--free]
+ank status                  [--remote]
+ank review [<path>]
+ank accept <id>
+ank read <id>
+ank close <id> --reason <r>
+ank amend <id>              [--blocked-by <id>...] [--drop-blocked-by <id>...]
+                            [--scope <glob>...] [--drop-scope <glob>...]
+                            [--criteria <c>]
+                            [--reference <id>...] [--drop-reference <id>...]
+ank attest <id> --proof <type>:<ref>   [--detached]
+ank edit <id>              [--title <t>] [--body <b>] [--constraint <c>]
+ank graph [<path>]
+ank scope <path>
+ank tui
+ank mcp                     (every verb of this table, over MCP on stdio, for a client that has no shell)
+ank watch                   [--list] [--once] [--interval <ms>] [--where]
+                            (keeps the corpora you declared warm, so the ank you run answers sooner)
+ank check [<path>]
+ank migrate                 (the previous log directory becomes entries; the command `check` names)
+ank config <key> [<value>]  [--unset] [--user]   (a value writes; the key alone reads)
+ank init [<path>]           [--at <path>]      (§9)
+ank help [<verb>]           (§9)
+
+ank --version               (the build itself: version, commit and skill revision, no verb, no repository)
+```
+
+**This block is the whole dispatch table**, and that is a property worth stating rather than assuming: `attest`, `init` and `help` were reachable in the binary while appearing nowhere here, so a reader comparing the two documents could not tell which one was wrong (TASK-5c868c20472f). `init` and `help` are specified in §9 and listed here only so the list is complete; `ank help` prints these verbs, minus whatever is not yet implemented, grouped by the moment each is reached for and in this order inside a group, which is what ADR-f61e2d2c75e8 requires of it. It prints one short description beside each verb rather than the verb's flag names, and the rules that description answers to are in §9.
+
+**`mcp` and `watch` are on that list and the binary answers to both**, having each been declared here before the code moved -- the form this block uses for a verb the specification decides on ahead of its landing -- and having each since landed. Measured on ank 0.7.0 (50f4b39): `ank help --json` carries 26 verbs and both are among them; an `initialize` and a `tools/list` piped into `ank mcp` return 26 tools, one per verb of this table; `ank watch --where` prints the declaration file this reader's environment names. Nothing marks either line, because there is nothing left to mark: `ank help` prints these verbs minus whatever is not yet implemented, and nothing on this list is unimplemented today -- `NOT_YET_DISPATCHED` in `crates/ank-cli/tests/skill.rs` is an array of length zero, so the suite that exists to name an undispatched verb names none. `read` and `tui` each sat here in the earlier state until the landing that shipped it, and `mcp` and `watch` have joined them.
+
+**The order is forced rather than chosen** (ADR-8bd76e8d7c4e). `crates/ank-cli/tests/skill.rs` holds every dispatched verb to this block, and it reads the *ratified* document to find it, so a verb that dispatched while its declaration was still a proposal would turn the suite red. Between the declaration and the dispatch sits a signed `accept`, which is a human act and not a step in a landing (§8, §12) -- so the declaration lands first and the implementation follows the signature instead of racing it. The declaration is carried on the other side by `NOT_YET_DISPATCHED` in that suite, which is where a verb this block lists and the binary does not answer to is named, with the task that will close the gap.
+
+**`ank tui` is the CLI drawing what it already prints**, for the one audience this surface serves worst: a human at a terminal. It opens a full-screen reader over one corpus, and it reaches that corpus only by running the CLI with `--json` -- never by linking `ank-core`, never by reading `.ank/`, never by touching `refs/ank/*` itself. So every refusal it shows is the refusal the binary gave, and there is no second dispatch path to keep in step. It writes nothing the person at the keyboard did not ask for in that session, it renews no claim on its own, and `accept` stays a signed human act it may drive and never perform unattended.
+
+It is listed **beside `graph` and `scope`** because that is the neighbourhood it belongs to, the verbs that answer *what is here* rather than change it, and the grouping `ank help` prints follows this order inside a group. A reader that also acts does not become a different kind of verb: what it acts through is `claim`, `log` and `done`, run as a shell would run them, which is what keeps ADR-052accd6e3b2 naming an intersecting claim and ADR-0bb7ea8991bc holding that a screen left open all night renews nothing.
+
+**`skill/SKILL.md` does not move for it**, and that is a decision rather than an omission (ADR-8bd76e8d7c4e). The skill teaches agents, an agent has `context`, `find` and `show`, which serve it better than any screen, and what the teaching surface costs every session is stated above.
+
+**`ank mcp` is the protocol surface, and it is a verb rather than a second executable** (ADR-fd98f4bc6dea). It exposes every verb this block carries, generated from the same table the CLI dispatches from -- no curated subset, under any protocol -- it refuses on state exactly as the CLI does and never on identity, it carries the exit codes above as the reason for a refusal, and it writes under a typed process identity (§3). It is folded into the one executable every route now carries (ADR-1ea31c2f3c5a) for the reason ADR-8bd76e8d7c4e gave for `tui`: a separate file is invisible to precisely the people it exists for, and has to be distributed, documented and discovered as a third thing.
+
+**One executable is not one process**, and that is the clause that keeps what the sibling binary bought. The verb still spawns `ank <verb> --repo <corpus> --json` per call, so what is folded here is the file and never the dispatch: linking the CLI into the surface would re-derive every refusal, and anything re-derived can differ, where spawning inherits them by construction. There is no second dispatch path, and every refusal a client sees is the refusal the binary gave.
+
+**It may speak for several corpora, and never for a merged one.** Every tool carries an optional corpus argument holding the repository identity of ADR-621a7fd96ce1; absent, the call goes to the corpus the process was addressed with at startup, the way `--repo` addresses one. The set a server may reach is what the reader declared in `corpora.yml` (ADR-96174f1ac2b7) plus that startup corpus, and nothing is discovered: a corpus argument naming an identity the reader did not declare is refused by name. Claims stay per clone and no server arbitrates across clones -- no merged claim space, no claim held on a client's behalf, no pooling of clients under one identity -- which is the ban ADR-372b82af1ec7 stated and ADR-fd98f4bc6dea carries forward in the same words.
+
+**`ank watch` is the watcher, and it answers no verb** (ADR-a22cd3196529). It keeps the corpora declared to it warm, so the `ank` a reader runs finds a cache already warm and returns sooner; it fetches `refs/ank/*` into a tracking namespace of its own and writes nothing else into a repository; and it emits an event when a corpus it watches changes, which states what changed and never what to do about it. It takes no claim, holds none on anybody's behalf and renews none. Nothing depends on it: every verb behaves identically with it stopped, its absence is never an error, and no route makes running it a condition of using ank.
+
+`--list` prints what would be watched and watches nothing, `--once` warms every declared corpus and exits, `--interval <ms>` is how often it looks, and `--where` prints the declaration file this reader's environment names. That is the whole flag surface, and the shape of it is the decision: not one of them asks the watcher a question about a corpus. A caller that wants an answer runs the CLI, which is what keeps this from being the third dispatch path in a project that has spent its history reducing to one.
+
+**Both are verbs for the same reason, and it is the reason `tui` is one.** ADR-1ea31c2f3c5a made every route carry one executable, so a surface that is not a verb is a surface that has to arrive beside the binary -- a workflow matrix, an installer branch and a rule, all of whose work is to put a second file where the first one already is. A verb cannot fail to arrive. `skill/SKILL.md` does not move for either of them, on the reading the paragraph above gives for `tui`: an agent has `context`, `find` and `show`, and teaching it a protocol it should not reach for would spend the contract to no end.
+
+**`ank context` with no argument** covers the whole repository. It is the first call an agent should make, before it even knows which path it works on — an agent launched on "fix the login bug" does not yet know its perimeter.
+
+**`context` with an active claim is always in execution mode** (§5). A path argument is then ignored, with a warning line: `active claim on TASK-8f3a, execution context (release to explore elsewhere)`. Exploring another perimeter mid-task is precisely what the one-claim-per-agent rule discourages.
+
+`--limit` applies **only to tasks**, never to constraints.
+
+**`find` is subject to the same cap as `context` on the page it prints for a human**, one line per result, and it announces what it cut. A search command without a budget is a context-explosion vector at least as effective as a badly bounded `context`. `--scope <path>` filters by scope match — it is the command the truncation counters point to (§5).
+
+**The budget stops at the terminal, and `--json` is served whole** (ADR-3e6ce108edcd). The four listing verbs — `find`, `review`, `scope` and `graph` — answer with every row under `--json`, whatever `context_budget` is set to. The cap above is the human page and nothing else: what a terminal shows and what a program receives are two questions, and only one of them has a page to fill. Measured on this repository's own corpus the day the decision was taken, `ank find --type adr --json` answered `{"total":63,"shown":40,"hidden":0}` — twenty-three decisions missing from a document meant for a parser, and a caller building the set of existing entities out of it counted entities that plainly exist as absent.
+
+**In a `--json` listing `shown` equals `total` unless a filter removed rows, and `hidden` counts what a filter withheld and nothing else.** The two numbers used to disagree on a corpus nobody had filtered, which is the state that misleads a parser most: `hidden` said zero, truthfully, while the page had silently dropped a third of the corpus, so a caller comparing the three fields was told the difference was nobody's doing. `--free` is the one filter there is, and a row it never considered a candidate — a task that is not open — does not inflate `hidden` either.
+
+**No flag lifts the budget and none restores the cut.** An `--all` would put the defect behind a discoverability problem: the parser that did not know to ask still gets a short answer, and the tool can then say it was told.
+
+**`context` is the exception, and it is the verb whose answer *is* the budget.** Deciding what a reader is handed first is what `context` does, rather than a limit imposed on what it does, so the rule above does not reach it (§5).
+
+The shape does not move, so the contract version does not either (ADR-6fd69efb629c): no field is gained, lost, renamed or retyped. A parser written against contract 1 reads the same document and receives more of it.
+
+**Scope overlap is reported and never refused** (ADR-052accd6e3b2). `claim` prints one line per live claim held by another identity whose scope meets the scope of the task being taken — the holder, the task, and the ground the two have in common — and then takes the task: the exit code is 0 and the claim stands. The line names paths rather than the fact of an overlap, because `crates/ank-cli/**` against `crates/ank-cli/tests/**` overlaps on everything under the second, and "these overlap" leaves the reader exactly where they started. Where both globs are literal the answer is a path; where one is a pattern the answer is the narrower pattern, written as a glob rather than expanded into a file list that would be wrong the moment a file is added.
+
+Refusing on it is the mistake, not the omission. Scope overlap is coarse: one held task scoped `crates/ank-cli/tests/**` locks every task that touches any test, and refusing would make the glob a mutex — which pushes agents to declare narrower scopes than the truth to get past it, the one failure mode a guard must not have. A **lapsed** claim is not a live one here either, exactly as in the refusals above: the signal would otherwise fire on abandoned work forever.
+
+**Every `elsewhere` line of `status` carries the title of the task it names**, after the id. The rows are already loaded where the line is built, so the join costs nothing, and without it a reader holds an id and has to run `show` once per claim to learn what anybody is doing — which is the question the section exists to answer.
+
+**`status --remote` is the only opt-in to the network outside `claim`** (ADR-47e2ac102f58). Without it, `status` describes the plane this clone has, as §7 says every verb but `claim` does; no network call is made at all. With it, the claims namespace is read off origin with `ls-remote` — read, never fetched, because writing refs into a clone as a side effect of a question would be a reader sanitising the plane underneath everybody else. What that costs is said on the line rather than papered over: `ls-remote` carries ref names and objects, never contents, so a claim seen only on origin is named with its id and the title the corpus already carries, is marked as being only there, and is never given a holder this clone cannot read. With no remote, or one that cannot be reached, the flag **warns once and answers on the local plane** instead of failing (§2).
+
+**`status` says how far this checkout's corpus is from the default branch**, on one line, whether or not it has drifted (§4, ADR-47e2ac102f58). The count comes out of the same inspection `check` renders, so there is one answer and not two, and it is a comparison of two revisions this clone already holds — `status` without `--remote` still makes no network call. Where the question could not be asked the line is absent, which is the one case `check`'s own signal covers in words.
+
+`find --free` is the same computation for the agent choosing rather than taking: it keeps the open tasks whose scope meets no live claim, and **says how many it hid**. A filter that silently returns two candidates out of seven is a filter that will be trusted for the wrong reason. Without the flag, `find` is unchanged.
+
+**Without the flag, a listing counts the open rows a `claim` would refuse, and names it.** `--status` filters on the status the file carries and the markers come from the coordination plane (§7), so a checkout behind the default branch lists ten rows under `--status open` that all read `[finished:… on …]` — every row correct, and the whole answering a question the reader was not asking. Measured: the reader concluded the filter was broken. The markers say it one row at a time; the line says it once and names `--free`, which is the service the truncation counter and the hidden count already perform for their own filters. It counts **open tasks alone**, because that is all `--free` keeps: a `--status done` listing carries `[finished:…]` too until `check` prunes the ref, and sending that reader to `--free` would name a command answering something else — the rule §7 states for hints, applied to a listing. Nothing is dropped, which is why the word is not *hidden*: the rows were listed, and only their number is restated.
+
+**Writing to `log` requires holding the claim wherever a claim arbitrates work**; reading it requires nothing. On an `open` or `in_progress` task the log is that task's anchoring register: if anyone can write to it, it stops being a reliable trace of what the holder did. That is a state condition on the claim, not a condition on who is calling, and it is why `log <id>` with no message is a read available to everybody.
+
+**The condition has a subject, and `done` and `closed` sit outside it.** Both statuses are terminal (§3), so there is no work left to arbitrate and no holder whose register could be diluted; a claim asked for there would be a refusal on the absence of a state rather than on a state, which is the argument that already exempts an ADR and a spec (ADR-25f977377fa0). `ank log <id> "<message>"` on a settled task therefore writes the entry, takes no claim and renews none. The task has to be named, since HEAD never points at one.
+
+**What that buys is the correction the surface could not carry.** A correction is a new entry naming the one it corrects, written once and never modified (ADR-25f977377fa0), and a settled task was the one place with nowhere to put one: `log` answered `no task in progress for this agent`, a terminal task cannot be claimed, and a closure reason naming an identifier written before the task it meant existed stayed wrong for the life of the corpus (TASK-c34392707a7b).
+
+**An entry settles nothing, which is what makes it safe.** The log is a file of its own and a task file changes only on a transition (ADR-ff294eff4d1a): the entity is not opened for writing at all, no frontmatter moves, `version` does not bump and `status` does not change. A closed task stays closed and a done task stays done with its proof intact. Nothing is reopened, no second transition is introduced, and the requirement is relaxed nowhere it is still doing its job. Someone who wants to annotate a task that is still live, without holding it, edits the body of the entity, which is already the normal route for anything that is not a state transition.
+
+Commands that take a perimeter take **paths**, uniformly: `review [<path>]`, `check [<path>]` and `graph [<path>]` share the same semantics as `context`, and `scope <path>` resolves against the same globs.
+
+**A path is normalised before it is matched, and a directory has one meaning however it is typed.** Separators are unified to `/`, repeated and trailing ones collapse, `.` disappears and `..` is resolved lexically — so `docs`, `docs/`, `docs\`, `./docs`, `.\docs\` and `docs/../docs` are one perimeter. A path naming nothing inside the repository, because it is absolute or because it climbs above the root, is **refused with the command to run next**; it is never answered. Case is not folded, deliberately: `DOCS` matches nothing here and matches nothing on Linux, and folding it on Windows alone would give one corpus two meanings depending on the machine reading it.
+
+The rule is not cosmetic, and it is written down because its absence was not obvious. Measured on this repository against `docs/`, which five accepted ADRs bind: `docs` answered five, `docs\` answered **four**, `./docs` answered zero (TASK-df4c39031583). The zeros announce themselves. The four does not — it is the form Windows tab-completion produces, it looks like an answer, and it withholds a binding rule from an agent that has no way to know one is missing. A perimeter resolved two ways is a constraint set that depends on typing.
+
+**The rule is about every path and every glob a caller supplies, not about the positional ones.** It covers flag values — `find --scope`, `new --scope`, `amend --scope` and `--drop-scope` — and a glob typed into the `$EDITOR` template, on the same terms: normalised before it reaches matching or is written into an entity, refused with the command to run next when it names nothing inside the repository. A glob normalising to nothing names the repository root, which is a perimeter and not a pattern; it is refused by name, with `**` as the pattern that means what was meant.
+
+Stating it as a property rather than as a list of verbs is the correction TASK-8dd89053fa33 exists for, and the reason is instructive. TASK-df4c39031583 measured the defect, fixed it, and wrote a criterion naming four verbs where the property was general. The fix satisfied that text exactly and its proof is real; the flag values were simply never in it, and the freeze then made the enumeration authoritative. Re-measured with `docs/` present: `--scope docs` and `docs/` answered eight tasks, `docs\` answered **five**, `./docs` and `.\docs\` answered none.
+
+`new --scope` was worse than a wrong answer, because it persisted. It stored `.\docs\` verbatim into the entity, where it matches nothing on any platform for the life of the corpus, and `check` then reported the consequence as `scope '.\docs\' matches no file yet: work not started, or a typo`. It was not a typo — it was the form the caller's own shell completed, which `new` accepted without a word. **A tool that writes what it cannot read back has no way to tell the two apart later**, which is why the normalisation belongs before storage and not in the reader.
+
+Global flags, deliberately limited to four: `--json`, `--quiet`, `--repo <path>`, `--worktree <path>`. Every global flag is a memorisation cost. `--json` is available on every command without exception: full scriptability is an invariant, not an option.
+
+**`--repo <path>` names a repository that already exists**, and that is the whole of what it means: it short-circuits the walk up of §6 without ever contradicting it, so the path it is given carries a `.ank/` or the flag fails. `init` is therefore the one verb that refuses it by name (§9), because `init` is what creates the `.ank/` the flag requires — and where the target is not the current directory, `ank init <path>` is how it is said. The refusal exists because the alternative was measured: accepting it, `init` initialised the *current* repository, appended the pointer paragraph to an `AGENTS.md` the caller was not editing, reported success, and left the named directory empty (TASK-b8a12d60686d). A flag that means an existing repository on twenty verbs and a directory to create on the twenty-first is the same defect as a `-s` meaning `--status` in one verb and `--scope` in another: not a saving, a silent wrong answer.
+
+**`--worktree <path>` names the tree the corpus is anchored to**, which is the half of an address `--repo` does not give (ADR-9e56318631f3). A corpus is confronted with a filesystem for four things: a scope glob, the path argument of a path-taking verb, the working directory of a verifier, and the commit a `commit:` proof names. Until this flag existed all four were held against the directory that happens to hold `.ank/`, because there was only one directory to reach for. §6 carries the assignment; this is the flag that makes the second root sayable.
+
+**Absent, the work tree is the corpus's own directory.** That default is what makes the flag additive rather than a change of behaviour, and it is what keeps the layout §6 describes as usable actually usable: one `.ank/` standing above several checkouts, with scopes written `repoA/src/**`, is a corpus whose work tree is its own directory. A work tree read off the caller's current directory would have killed that layout without anybody deciding to. **The divergence is named, never derived.**
+
+The two flags imply each other in neither direction. `--repo` alone says which corpus and leaves the anchor where it was; `--worktree` alone anchors the corpus the walk found. A work tree that is not a git repository is refused **by the verb that needs git there**, and named as the work tree, so that a reader is not sent to look at a corpus that is plainly a repository. `done` and `attest` are those verbs and no others: git is required per verb and never at startup (ADR-9307e5d214a7), so `show`, `find` and `graph` answer perfectly well from a corpus anchored to a directory that is no repository at all.
+
+### Configuration
+
+**`ank init --at <path>` puts the corpus outside the tree and declares it**, in one gesture (ADR-96174f1ac2b7). It creates the corpus at that path, writes the declaration keyed on this repository's identity, and writes nothing into the working tree -- not a pointer, not a gitignore line, not a comment. The moment it did, the promise would be gone and the design would be the committed pointer that decision refused.
+
+Three refusals, and each is what makes the detachment one. A target **inside the current work tree** is refused naming the tree: a corpus under the code is what `ank init` is for, and a declaration promising otherwise would promise something it does not deliver. A tree with **no repository identity** is refused, because a declaration would have nothing to be keyed on and a fallback is not a key. And a target that is **not itself inside a git repository** is refused naming `git init`, on the terms `ank init` already refuses one: the corpus repository is where claims and proofs land (ADR-9e56318631f3), and `git init` is not on the plumbing ADR-9307e5d214a7 allows, so this verb names the command rather than running it.
+
+What that buys, end to end: a task claimed, logged and finished with its proof anchored, and `git for-each-ref refs/ank` in the code repository printing nothing at all. That is the requirement in its original words -- leave no traces -- and it is the one assertion the whole design exists to make true.
+
+`.ank/config.yml` is read and written through `ank config` (ADR-e64dfaafd578). ADR-01b6dd05f0db closed `.ank/` to agents and stopped at the configuration, which left six errors telling their caller to open a file the same tool forbids them to open. This is the verb those errors name instead.
+
+```
+$ ank config claim_ttl_max
+2h
+$ ank config context_budget
+8000 (default)
+$ ank config verifiers.cargo-test.run "cargo test --workspace"
+verifiers.cargo-test.run (unset) -> cargo test --workspace
+$ ank config --unset default_branch
+**`--user` reads and writes the reader's declarations instead** of the repository's configuration (ADR-96174f1ac2b7), and it is the same verb for the same reason: the map is where a stale entry makes a corpus vanish, and the discipline `ank config` carries is what a file like that needs. Its key set is closed and holds two, `schema` and `corpora.<identity>`; an unknown key is refused by name with the set it knows; a key that is not a repository identity is refused on the terms the map itself applies, so the two surfaces cannot disagree about what a key is; comments and key order survive a write byte for byte outside the line named; no default is materialised, and no file is created to answer a read. A write that would leave the file unreadable is refused and the file is what it was -- differential, as the repository file's is, so the verb still repairs a file that already did not parse.default_branch main -> (unset)
+```
+
+**The key set is closed**, and it is the set the parser knows:
+
+| Key | Value |
+|---|---|
+| `schema` | the format revision of the file |
+| `context_budget` | tokens, default `8000` |
+| `claim_ttl_max` | duration, default `2h` |
+| `claim_ttl_default` | duration, default `30m`; what `claim` grants without `--ttl`, capped by `claim_ttl_max` (§3) |
+| `default_branch` | branch name; unset falls back to `refs/remotes/origin/HEAD` (§7) |
+| `peers.<name>` | the path to a peer corpus's root, read and never written (§7) |
+| `verifiers.<name>.run` | the command line, §4 |
+| `verifiers.<name>.timeout` | duration, default `10m` |
+
+Nested values are addressed by dotted path, and `<name>` is any verifier name — writing `verifiers.<name>.run` for a name the file does not carry is how a verifier is declared. `peers.<name>` works the same way and is how a peer is declared, which is what keeps the closed key set closed: federation adds a key rather than removing the strictness that refuses an unknown one. `verifiers.<name>` addresses the whole block and is legal for `--unset` alone, which is what makes declaring one reversible; reading it, or writing a value to it, is refused by name with `verifiers.<name>.run` to type instead. `roles` and `identities` are keys the parser knows and this verb does not address: their values are structured, the surgery below has no safe edit for them, and they are refused by name rather than guessed at. A key the parser does not know is refused by name too, with the set it does know, and nothing is written.
+
+**Reading prints the value in effect, and marks a resolved default as one.** `context_budget` on a file that does not carry it is `8000 (default)`, not `8000` — the difference between "the tool's value" and "this repository's value" is the whole question a reader is asking, and a release that moves a default moves the first and not the second. A key with no value in effect is `(unset)`. The marker is on the human surface only: `--json` carries `value` and `source` as separate fields, which is what a script reads.
+
+**Writing is text surgery, and never a round-trip through a serializer.** The file is a repository artifact, reviewed like code: comments, blank lines, key order and quoting style survive a write untouched, and every key other than the one named is byte-identical afterwards. A serializer would return `verifiers`, `roles` and `identities` alphabetised, drop every comment, and — the reason this is not a matter of taste — write out every field carrying a default. An unset key means "follows the tool"; a written one means "pinned here", and a round-trip that materialises the defaults converts every repository that ever ran one `ank config` into one that silently pins the old values the day a default moves. **No default is ever materialised**: a key the file did not carry is still absent after a write to another key.
+
+Two edits touch a byte outside the line named, and both are the parent of the key being written rather than a byte beside it: `verifiers: {}` becomes a block mapping when the first verifier is declared into it, and a block mapping becomes `verifiers: {}` when the last one is removed. Without the first, the file `ank init` writes could never receive a verifier; without the second, `verifiers:` would be left with no children, which is not an empty map but a parse error.
+
+**A form the surgery cannot edit safely is refused by name, never rewritten.** A `run` written as a block or folded scalar — `|` or `>` — is one: its resolved string depends on line structure the replacement would flatten, and `verify::definition_hash` is taken over the resolved value, so flattening it would move a hash that anchors historical proofs. The refusal names the key and says to edit the file by hand, which a human always may. Quoting alone is safe and stays safe: the hash is over the resolved string and over the timeout in seconds, so `run: cargo test` and `run: "cargo test"` hash identically, as do `600s` and `10m`.
+
+**A write that would produce a file the parser cannot read fails, and leaves the file as it was.** The result is parsed before anything is written, so the check is not a repair after the fact. The test is differential and has to be: it refuses a write that *introduces* a parse failure, not one performed on a file that already had one. A file carrying an unknown key fails every other verb, and a repair verb that refused to run on it would refuse exactly where it is needed — so on a file that did not parse to begin with, the write goes through and the parse error is reported as a warning rather than a refusal.
+
+**`ank config` runs without a parsed configuration**, as `init` and `help` do (§9). `startup` loads `config.yml` for every other verb, so a file that does not parse fails all of them — `check` included. A verb that exists to repair the file and is disabled by exactly the file it repairs is not a verb; the caller who most needs it is the one whose configuration does not load.
+
+This constrains the agent and not the human. A human with an editor keeps every power they had, and the file stays reviewable text in the repository.
+
+### Short forms
+
+Every long flag keeps its form. Short forms are an addition and never a replacement (ADR-962c25797569): single-dash, single-letter, and this table is the whole of them.
+
+| Short | Long | Legal on |
+|---|---|---|
+| `-j` | `--json` | every verb |
+| `-q` | `--quiet` | every verb |
+| `-r` | `--repo` | every verb |
+| `-b` | `--blocked-by` | `new`, `amend` |
+| `-c` | `--criteria` | `claim`, `new`, `amend` |
+| `-l` | `--limit` | `context` |
+| `-p` | `--proof` | `done`, `attest` |
+| `-s` | `--status` | `find` |
+| `-t` | `--type` | `find` |
+| `-u` | `--unset` | `config` |
+| `-v` | `--verify` | `new` |
+
+**The letter is the first letter of the long flag, and one letter has one meaning in every verb.** Where several long flags begin with the same letter, exactly one takes it and the others keep only their long form. That is the whole rule, and it is worth the flags it costs: a `-s` meaning `--status` in `find` and `--scope` in `new` would not be a saving but a silent wrong answer, since `ank find -s open` would filter on a scope named `open` and return nothing at all. A short form is only useful if it can be typed without checking which verb it is being typed at.
+
+The long flags left without one, with the letter that would have been theirs: `--body` and `--drop-blocked-by` (`b`), `--constraint` (`c`), `--reason` (`r`), `--scope`, `--supersedes` and `--drop-scope` (`s`), `--title` and `--ttl` (`t`), `--worktree` (`w`). The three globals that carry one take their letter ahead of everything else, because they are legal on every verb and a letter they did not hold everywhere would be a letter nobody could rely on — that is what leaves `--reason` on its long form, `r` being `--repo`'s.
+
+A short form takes its value both ways, exactly as the long form does: `ank find -s open` and `ank find -s=open`.
+
+**Bundling is refused, and the refusal names the flags to type instead.** `-st` is not `-s -t`, because a parser that accepts bundling has to decide what `-sopen` means, and every answer to that is a guess about the caller's intent:
+
+```
+$ ank find bug -st task
+error[1]: '-st' bundles short flags
+  -> ank find -s <v> -t <v>
+```
+
+**A single dash is a flag, which is what makes `--` matter.** It was already the only way to write a positional beginning with a dash; short forms make it reachable rather than theoretical, since `ank log "-1 rebuilt the index"` now names a flag where it used to name a message. An argument that begins with a dash and contains whitespace is refused as what it is — no flag contains a space — and the refusal names the escape:
+
+```
+$ ank log "-1 rebuilt the index"
+error[1]: '-1 rebuilt the index' is not a flag: it contains a space
+  -> ank log -- "-1 rebuilt the index"
+```
+
+Values are untouched by any of this. A flag's value is taken verbatim, whichever form the flag was typed in, so `ank release --reason "-x"` and `ank find bug -s=-x` both pass their dash through and only a positional ever needs escaping.
+
+**Verbs are never abbreviated.** `ank cl` is not `ank claim`, and it is `unknown command 'cl'` naming the verbs. A prefix that resolves today stops resolving the day a second verb shares it, which would make a working script break on a release that added a verb.
+
+`ank help <verb>` shows both forms; `ank help` does not, and the listing is unchanged (§9). The overview buys its token economy by staying short, and the detail is one call away for the caller who wants it.
+
+**`ank --version` is not a fourth global flag**, and the limit above is untouched. The three modify a verb; this one replaces it — there is no `ank check --version`, and asking for the build while also asking for something else is not a question anyone has. It prints the crate version, the commit the binary was built from and the revision of the `skill/SKILL.md` it was built alongside, on one line, and exits 0.
+
+It answers **before the foundation**, like `help` and for a sharper reason: the caller who needs it is the one holding an artifact they cannot identify. A version that required a resolved repository, a git of 2.34 and a readable `config.yml` would fall silent in exactly the situation it exists for. Outside any git repository, in a directory with no `.ank/`, it still prints and still exits 0.
+
+The commit is embedded at build time through `rev-parse`, which §8's plumbing rule already allows, and is `unknown` when the build had no checkout to ask — a source tarball, a vendored dependency. Naming the absence beats inventing a value, and it beats the silence that made TASK-1ea38a17d854 cost an investigation to conclude that the binary in hand predated the feature being measured for.
+
+**What the stamp guarantees, and on which builds.** It names the commit the build script last ran at, and the script reruns whenever the commit moves — including a commit that changes no source file, which is the case that catches a binary quietly left behind. It does not depend on the source having changed. The files a commit moves are located through `rev-parse --git-path` rather than assumed at `.git/`, so a linked worktree and a packed ref are covered rather than hoped for; on a detached HEAD the sha lives in the HEAD file, which is watched on its own account. A release, built from a fresh checkout, is exact by construction. The stamp is not a claim about the working tree: uncommitted edits are invisible to it, and a binary built from a dirty tree names the commit it was based on, not the code it contains (TASK-0b26c8b5bfc5).
+
+**The skill revision, and what it lets a reader do offline.** The third value is `skill <rev>`, where `<rev>` is the short form of the same freeze hash that anchors a frozen `done_criteria` (§3), taken over the body of `skill/SKILL.md` — the same value that file declares under `metadata.revision`, computed at build time from the file rather than typed. An agent has both halves in hand and nothing else: the skill is loaded into its context, the binary is on its `PATH`. Comparing the two strings tells it, with no repository and no network, whether the instructions it is following predate the tool it is holding. That is the check TASK-1ea38a17d854 needed and did not have, and the case that motivated it was measured (TASK-b495234f192c): an installed `SKILL.md` two commits behind a tree that had just withdrawn the invitation to read `.ank/` by hand. The hash covers the body and not the frontmatter, so the revision the frontmatter carries does not change its own input. It is `unknown` on a build with no `skill/` to read, for the same reason and with the same honesty as the commit.
+
+
+### Exit codes
+
+The semantics are carried by the code so that the shell can route without parsing output.
+
+| Code | Meaning |
+|---|---|
+| 0 | ok |
+| 1 | generic error |
+| 2 | entity not found, or ambiguous prefix |
+| 3 | version conflict — re-read and retry |
+| 4 | task unavailable — claim held by another agent, or task already finished on another branch (§7) |
+| 5 | proof missing or invalid |
+| 6 | illegal transition, or frozen field modified (hash diverged) |
+| 7 | missing prerequisite — no criterion, task blocked, `accept` off the default branch, or a live claim already held by the calling identity |
+| 8 | `check`: invariants violated (reserved for `check`, for CI) |
+| 9 | environment unavailable — not a task failure |
+
+Codes 3 and 4 are the ones the agentic loop must know how to handle. 3 literally means "redo `context`, somebody moved". 4 means "take something else", and its two causes call for the same reaction, which is the reason for uniting them under a single code: in both cases the task is not to be taken, and the message says which one to take instead. `check` exits 0 when the corpus is healthy and 8 when it has findings — never 1, so that CI can distinguish a sick corpus from a broken tool.
+
+9 covers the environment broadly and not only the verifiers': `sh` not found (§4), git absent or older than 2.34 (§12), default branch indeterminable (§7), a detached proof whose ref never reached the remote (§7). What they have in common is that none of them is a failure of the agent's work — it is an environment to repair, and confusing it with a 1 or a 5 would send the agent to fix sound code.
+
+### Self-correcting errors
+
+Never generic help, always the exact command to run next. One well-designed error round trip costs less than three blind attempts.
+
+```
+$ ank done
+error[5]: proof required to move TASK-8f3a to done
+  done_criteria: "Auth integration tests pass, and no reference
+                  to jwt.verify remains in src/auth/"
+  -> ank done --proof commit:<sha>
+```
+
+```
+$ ank claim 8f3a
+error[4]: TASK-8f3a held by codex@host-9 (expires in 12m)
+  -> ank claim 51c2   (another ready task in this scope)
+```
+
+```
+$ ank claim 51c2
+error[7]: TASK-51c2 has no done_criteria
+  -> ank claim 51c2 --criteria "<verifiable criterion>"
+```
+
+
+### Scope of `check`
+
+Summary of the invariants and signals, all mechanical:
+
+- expired claims, `blocked_by` cycles, broken supersede chains, dead scopes (no file matched, and see below), over-constrained scopes (§5);
+- frozen fields diverging from their anchoring hash — `done_criteria` against the claim, `constraint`/`scope` against the ratification commit, and the signature on that commit against `allowed_signers` (§8): an anchor read from a commit nobody signed anchors nothing;
+- weak proofs (`assertion`, unverified), `done` tasks modified beyond appending a proof;
+- a `commit:` proof naming **no commit this clone can reach** — rebased away, a branch never fetched — reported as a signal naming the task and the reference, one line per detached reference, never a fault and never re-anchored (see the trust hierarchy above). Skipped outright where the clone cannot see: shallow, or reaching no commit at all, since a truncated clone would otherwise have every commit proof in the corpus reported at once;
+- behavioural signals, reported without being faults: blockers created by the holder after claiming (`author` of the blocker is the current holder and its `created` is later than the claim), criterion set by the claimer, verifier modified inside the task's activity window or proof hash diverging from its definition, scope test files modified by the task that invokes them, burst creation by a single identity (**more than 10 entities by one `author` within an hour**, through `created`), implausible `created` (in the future, or well before the commit that introduces the file — the field is declarative, git is the anchor), repeated claim renewals with no modification to the scope files (possible hoarding; a best-effort signal, since another agent's tree is not observable), constraint accepted after the claim of a task in progress, tasks blocked by a `closed` task;
+- a **discrepancy recorded against a frozen criterion** (§3) — a log entry whose message opens with `discrepancy:` — reported as a signal on the task, at any status, and never as a fault: it says a holder measured one part of the criterion wrong and kept the criterion anyway, which is a judgement and not a corpus defect, and a criterion that actually moved is the divergence fault above. **One finding per task, with the entries listed under it**, because the task is what is being judged; and it is worth most on a `done` one, where it is the only thing telling a reader that the proof was produced under a disagreement. A log this reading cannot parse is said out loud on the same task rather than counted as no record, since a check that reports nothing because it read nothing is the quiet failure §4 refuses everywhere else;
+- a `done` task carrying no `test` proof **that anything validated** — none at all, or only ones a caller submitted — once the **default branch** carries it as `done`: the completion rests on a local run and nothing external anchors it. Read on `via` and not on the type (see the trust hierarchy above), so a submitted reference is named in the finding rather than counted by it, and an entry predating `via` counts as it always did. A signal and never a fault — the corpus is intact, the record is thin, and exiting 8 would redden CI on the very merge that introduces the task. The gate on the default branch is what makes it actionable: before the merge there is no run to cite, and reporting there would name work the reader cannot do. The window between the merge landing and its run going green is left to fire, since the statement is true when printed and clears when someone attests; buying that quiet would cost a grace constant, and the constants below are justified for flooding alone;
+- entities predating `author`, **reported once for the corpus and never per file**: they are skipped by the two signals above, and saying so once is what keeps that fact visible. One line per file would add a line for every entity written before the field existed — the volume that teaches a reader to stop reading `check`;
+- actor values not matching the typed convention of §3, **reported once for the corpus and never per file**, on the same reasoning and for the same volume as the line above: the convention binds new writes, and the entities that predate it mean what they meant. A malformed actor is a finding here and never a parse error, or a rule would lock out the files it postdates;
+- an entity whose `author` is an agent and which carries **no reading by a `human:`** in `verified` (§3): a signal, one per entity, and never a fault. Nothing requires `verified`, and `check` derives what the fields state and nothing further — no score, no confidence, no ranking;
+- a corpus still in the previous per-kind layout, or still holding a work trace in the shape that preceded entries (§6), **reported once each**, naming the command that moves it: a signal and never a fault, since such a corpus parses, round-trips and answers every verb;
+- **a `references` entry of a spec that does not resolve** (§3, ADR-c88f99e1c16e), one line per entry. **A reference names a document and not a revision of it**, so the entry is followed through its succession and what is judged is the entity the chain ends on, whatever the chain's length. A **fault** where the corpus holds no such entity, or holds one of a kind a specification does not cite — the reader following it finds nothing, and the repair is `ank amend <spec> --drop-reference <id>`; a **signal** where the chain ends on a document that is not `accepted`, naming `ank accept` on the entity it ends on, since two documents are legitimately drafted at once; and a **signal** where it ends on a `superseded` entity that nothing replaces, which is a citation with nowhere to follow to and a corpus defect reported against that entity rather than against whoever cites it. A chain ending on an accepted document is reported by nothing at all. **Nothing is written to make a reference resolve**: the file keeps the identifier its author wrote, no version moves, and no machinery entry is deposited by a read — which is the argument that settled the alternative, where repairing citations in place would have had one `accept` write to nine entities and leave nine entries behind (ADR-16813b3bcf37). The rule it replaces let a citation off only when the citing document *also* stored the end of the chain, which is this same resolution spelled by hand, stored twice, and re-stored on every citing document after every revision. Only the declared field is read: a section number written in prose is not a reference and no finding pretends otherwise;
+- **an entity identifier written in prose that names an entity the corpus does not hold** (§3, ADR-1e6bcbf62e61), **reported once for the corpus and never once per mention**: a signal naming the first few and carrying the rest as a count, and never a fault. The prose read is the free text no verb resolves, which is a log entry's message, a task's `done_criteria` and an entity's body; a `constraint` is outside it because the rules above already read it as the declared field it is, and a title because it is a line a lister prints whole. What is collected from that prose is what an `ank new` could have produced, a prefix the registry declares followed by twelve hex characters, decided by the same reader every other surface resolves an identifier with. A shape that reader refuses is reported by nothing at all: `SPEC-42`, a bare `ADR-6b3f` short form and thirteen hex characters are not identifiers this corpus mints, so they are not identifiers it can fail to hold, and reporting them would be the tool holding an opinion about prose. **An identifier that resolves is silent whatever its status**, superseded included, and `status` is not read at all: prose is where history is written, and a `done_criteria` naming a replaced document is frozen at claim, so a finding against it would be one nobody could ever clear, which is the failure §11 names and this corpus has already refused twice. An identifier whose file exists and did not parse is left unjudged, on the same doctrine as every other resolution in this pass. **What it derives**: that a run of characters shaped like an identifier this corpus mints resolves to no entity held here, and nothing beyond that. **What it deliberately does not conclude**: that the identifier is a reference, so no succession is followed for it, nothing is ordered by it and no `--drop` repair is proposed, which leaves the rule of the bullet above untouched; that the prose is wrong, since roughly half of what this names on this corpus is a fixture identifier quoted in prose about tests and is perfectly good writing; and that anything is owed in response, since nothing is refused at write time and nothing is rewritten, no verb resolving an identifier inside a message being the state that produced the decision, and a read repairing prose in place being the churn ADR-f7dc76886db2 already settled for citations. Measured before it was decided: 1087 distinct identifiers in the prose of log entries, of which 15 resolve to nothing. That 1.4 percent is what makes one line affordable, where a rule firing on a fifth of the corpus would be the volume this document names as what teaches a reader to stop reading `check`;
+- **an entity whose content its entries cannot account for** (§3, ADR-f7dc76886db2): a signal naming both hashes, one line per entity, and never a fault. A machinery entry records the hash of the content its write produced, where content is every field a transition does not write -- `status`, `proof`, `ratified` and `verified` belong to a transition and `version` to the store -- and `check` compares the newest such entry against the entity as it stands. Equal, and the entity has not moved since the CLI last wrote it; unequal, and it has. **The comparison is what survives a claim**, and that is why it replaced a count: `claim` and `release` each write a task file and leave no durable record naming a version, so a task claimed and released five times carries ten versions no reader can evidence, and a rule counting them would fire on the most ordinary sequence in the corpus. It is also stronger where both apply -- a hand edit that does not move `version`, which is the likelier one since `version` is machinery a human has no reason to touch, is invisible to a count and caught here. **It says the write happened and never that it was wrong**: editing an entity file by hand is legal, is what ADR-01b6dd05f0db permits a human while asking it of no agent, and exiting 8 over it would redden a pipeline on an act the corpus allows. An entry carrying no produced hash is silent, and an entity carrying no entry is silent: no corpus is migrated by a rule it predates;
+
+- **an entity whose version its entries cannot account for** (§3, ADR-f7dc76886db2), which is the count kept where it closes: a signal naming both numbers, one line per entity, never a fault, and reported only where the hash above found nothing, so one write is one finding. The regime opens with an entity's first machinery entry, so everything before it is forgiven and the baseline is that entry's `version <from>`; each entry accounts for one version, and so does each write the entity's own fields evidence -- `ratified` for a ratification, `status: superseded` for the far side of a succession. A version above that total is reported. **It is not attempted for a task**, and the silence is derived rather than chosen: `claim` and `release` leave nothing an evidence count could read, which is the whole of why the hash exists. What it still catches that the hash cannot is a version moved and nothing else. **And it concludes nothing about an entry whose message it cannot read**: an entry is written once, one marked as machinery by a newer build is entitled to a message of its own shape, and the accounting steps aside rather than reporting on prose it does not own;
+- **an entry written about a task that is `done` or `closed`**: reported by nothing at all, and named in this catalogue so that the silence is a decision a reader can find rather than a gap. Those two statuses accept an entry with no claim held and none taken, because a terminal status leaves no work for a claim to arbitrate (§4); `open` and `in_progress` do not, because there the claim is still doing the job it was put there for. What follows is that the fault above for a `done` task modified beyond appending a proof is not reachable this way: an entry is a file of its own and the task file changes only on a transition (ADR-ff294eff4d1a), so a correction moves no field that fault reads, and the hash and version accountings above are handed nothing to disagree with either. The one rule that does read these entries is the `discrepancy:` signal already listed, which reads a task's entries at any status and so reads a correction written after the fact exactly as it reads one written during the work;
+- unresolved git conflict markers in `.ank/` files (§7);
+- **the corpus this checkout carries against the corpus on the default branch** (§7, ADR-47e2ac102f58), **reported once for the corpus and never per entity**: a signal naming how many entity files differ — held here and not there, there and not here, or held on both sides with different content — and the git command that closes the gap. Nothing is fetched to answer and nothing is merged: both revisions are already in this clone, and the gap is git's to close on the operator's word;
+- maintenance of the coordination plane (§7): pruning orphan refs, and completion refs whose task is `done` or `closed` on the default branch. `check` is the only command that prunes. A task carrying a completion ref for a long time without the default branch catching up is reported as a signal — that is a branch never merged, not a corpus anomaly, and the answer is human.
+
+**A dead scope git can explain is a signal, and the severity rule only ever lowers.** Structural death is reported as a signal for an open or `in_progress` task — work not started, or a typo — and as a fault for an ADR or a finished task, which claimed to touch files that are not there. On top of that, and only for the entities that would fault, a second question is asked: did git record where the path went (ADR-97beaf55e73a)? A yes lowers the fault to a signal. Nothing here raises a severity, so an open task whose dead scope git cannot explain is a signal exactly as before.
+
+The reason is that the two states are not the same fact. When git names the commit that moved the path, the corpus is not broken — it is outdated in a way the reader can see and follow, which is what the rename walk was built to show. When git cannot explain it, the reader has nothing, and that is what the fault is for. Without the split, any directory rename reddens a corpus permanently: before ADR-b9156403c3d5, `amend` refused a `done` task outright, so such a task got the rename named and no repair command (§3), and a fault nobody can clear is a finding readers learn to skip. The scope of a `done` task is amendable now, and the split stays on its own ground: what git can explain is an outdated corpus the reader can follow, not a broken one.
+
+**A history that cannot answer is a third state, and it is not a fault.** A shallow clone holds no commit that could record where a path went, so the question the paragraph above asks has three answers and not two: git names the rename, git has the history and records none, or git has no history to consult. The last is reported as a signal saying so, naming the command that deepens the clone, and it is never rendered as a rename that did not happen nor as a defect in the corpus. This is the answer §3 already gives for a ratification anchor a shallow clone cannot verify, and for the same reason — a check that cries divergence over the shape of a clone is a check people learn to ignore. It follows that a pipeline running `check` must check out the history the walk needs, or it reports that it cannot verify and verifies nothing, which is worse than the failure it replaces because it is quiet.
+
+**The walk serves a glob through its literal prefix.** `rev-list` answers about a path and has no answer for "where did `src/**` go", so a glob is asked about the part of it before the first wildcard, truncated at the last separator: `.ank/adr/**` asks about `.ank/adr`. A prefix whose files git records as renamed into one directory is explained by that directory, and the repair proposal keeps the wildcard tail — `.ank/adr/**` becomes `.ank/entities/**`. Sources landing in more than one destination, or under a rename that also changed a file's name, produce no explanation: silence is never evidence, and "the prefix moved mostly there" is not a statement this document authorises anyone to print.
+
+**Drift is counted in entity files, never in commits.** How far this corpus has drifted from the default branch is a question about two trees, and `rev-list` answers a different one: a default branch can move ten times without touching `.ank/`, so a count in commits would fire on every merge and mean nothing. What is counted is entity files that differ, which is what a reader can act on — and it is one line for the corpus rather than one per file, the volume rule this section has already applied twice above.
+
+**Unable to compare is not "nothing has moved", and the two are never printed the same way.** The question is skipped in silence where it cannot be asked at all: no repository (the coordination half already says so once), or no resolvable default branch (the line about pruning already says so once). It is said out loud where it was asked and refused — a `default_branch` naming no commit in this clone — because a mistyped branch name rendered as silence is a reader told the corpus is level by a check that never looked. A repository with no commit at all is neither: that is the nominal state of one freshly `ank init`-ed, there is nothing to compare against yet, and it is silent.
+
+**The same fact reaches `status` on one line**, out of the same inspection pass rather than computed a second way, because two answers able to disagree is the defect that surface exists to avoid. `status` prints it whether or not there is drift — a reader who has to tell "level" from "not asked" by the absence of a line is reading silence, which is the thing this section refuses everywhere else.
+
+**The two signals that need `author`, and why they are signals.** A blocker written by the agent currently holding the task is the shape of an agent building itself an excuse — but it is also the shape of an agent doing exactly what §3 asks, since a discovered subtask *is* a new task with a `blocked_by`. Only a reader knows which, so it is reported and never refused. Burst creation is the same argument at the corpus scale: §3 accepts task flooding without a quota, on the grounds that the defence is visibility rather than restriction, and this is that visibility.
+
+**The numbers are constants, not configuration.** More than 10 entities by one `author` within an hour: a threshold high enough that a session filing the four tasks of a plan passes in silence, low enough that a runaway loop is named within minutes. They live in the tool rather than in `config.yml` because a repository that can raise its own flooding threshold has a flooding threshold that will be raised the first time it fires — and the signal costs nothing to ignore, which is what makes it safe to leave unadjustable.

--- a/.ank/entities/SPEC-77d99d8d1ef2.md
+++ b/.ank/entities/SPEC-77d99d8d1ef2.md
@@ -1,0 +1,208 @@
+---
+id: SPEC-77d99d8d1ef2
+type: spec
+slug: proof-anchoring-and-authority
+title: Proof, anchoring and authority
+created: 2026-09-05T14:21:06Z
+author: haksolot@vmi3223161
+status: proposed
+scope:
+  - crates/ank-cli/src/done.rs
+  - crates/ank-cli/src/verify.rs
+  - .ank/allowed_signers
+references: [SPEC-183d297253ac, SPEC-93531977642f, SPEC-e258796162c4]
+supersedes: SPEC-88e1ba60a95d
+schema: 4
+version: 2
+---
+
+One of the ten documents that carry the Ank specification (ADR-5a690829388d).
+This one carries the **proof half of §4** — proofs, named verifiers, the trust
+hierarchy — together with **§8 entire**: the three places policy lives, roles and
+what they are worth, and the anchoring of human identity.
+
+## Why two sections four apart are one document
+
+This is the longest merge the decomposition makes, and it is the one the monolith
+argued for without performing. Both halves answer a single question: **what is a
+claim about the world worth, and who validated it.**
+
+The trust hierarchy answers it about a run. A reference is worth what its route
+is worth — a `test:` reference is the strongest row in the table when a pipeline
+wrote it and the weakest when somebody typed it, and the type alone cannot tell
+them apart. §8 answers it about a person. An identity is declared and never
+proved, roles are advisory because a wall whose bricks are self-declared identity
+is a sign and not a wall, and the only hard line in the system is a signature
+verifiable against a versioned key file.
+
+Those are the same sentence about two subjects, and the corpus already treats
+them as one: the CLI refuses on state and never on identity **because** roles are
+advisory, and the ratification anchor is a proof requirement in exactly the shape
+every other anchor in this document has. The monolith put four sections between
+them, so a reader arriving at the trust hierarchy met the run half of the
+argument and had to reach §8 to learn why the person half is weaker — which is
+the entanglement the test names, in the form that costs most: two halves of one
+argument, each readable and each incomplete.
+
+**What this document does not carry** is the freeze machinery itself. `ratified`,
+the hash it holds and the walk that reaches the commit are the data model's,
+because they are fields of an entity; what is here is what that anchor is worth
+and what verifies the signature on it.
+
+## What it rests on
+
+- **The data model** — the `proof` list, `verify`, and the freezes this anchors.
+- **Synchronisation** — detached proofs on `refs/ank/proof/*`, the third
+  category of state, and the push that arbitrates them.
+- **Implementation, and the decisions that bound it** — the git plumbing that
+  produces and verifies a signature, and the rule that Ank never commits except
+  `accept`.
+
+---
+
+### Proofs
+
+**Ank runs the verification itself.** This is the central point: if the agent runs the tests and then reports the result through `--proof`, nothing is anchored — it can simply claim it passes. The task declares its verifiers, `ank done` runs them, captures the exit codes and a hash of the outputs. The agent never self-reports.
+
+```
+$ ank done
+verifying done_criteria hash ... ok
+running: auth-tests ... ok (2.4s)
+running: no-jwt ... ok (0.1s)
+proof recorded: auth-tests -> local/9c1f4a@a3f9c21
+proof recorded: no-jwt -> local/e51b22@a3f9c21  (tree:scope/4be2d10c)
+```
+
+**Two modes, never ambiguous.** If the task declares a `verify`, `ank done` runs **all** the verifiers in the list — a composite `done_criteria` ("the tests pass *and* no more jwt.verify") is mechanised by several verifiers, not by one that covers only part of it — and `--proof` is refused: the agent cannot short-circuit. Every verifier that runs produces **its own proof entry**, with its output hash and its definition anchored. Without `verify` — field absent or empty list, the two forms are equivalent and the canonical form omits the empty field — `--proof` is mandatory and Ank validates what it can: `commit:` is checked with git, `human-review:` and `assertion:` are recorded as they are and marked unverified. Every entry recorded on that path carries `via: submitted`, whatever its type, because that is what happened — the entries produced by a verifier above carry `via: verifier`, and an attestation reaching the task on a ref carries `via: attested` (§3).
+
+If a verifier fails or times out, the transition is refused. No dependency on any service: this is usable **inside** the loop, not only at the end.
+
+### Named verifiers
+
+A task's `verify` field references verifiers declared in `config.yml`, never an inline shell command.
+
+```yaml
+verifiers:
+  auth-tests:
+    run: pytest tests/auth/ -q
+    timeout: 10m              # default: 10m, a timeout failure is code 5
+  no-jwt:
+    run: "! grep -rq jwt.verify src/auth/"
+```
+
+The reason: a task may arrive through a PR from a fork. An inline command would be arbitrary code execution triggered by `ank done`. Git has exactly this problem with hooks and solved it by never running them on clone. Here, verifiers live in a file controlled by the repository, so modifying one goes through code review like any other change.
+
+**Execution: always `sh -c`, on all three operating systems.** Linux, macOS and Windows are supported natively in v1. On Windows, `sh` is resolved from Git for Windows, which ships it — Ank already requires git, so the dependency is free and verifiers are written once, in POSIX syntax, for the whole team. An `sh` that cannot be found is an explicit error with the installation link, never a silent fallback to `cmd`. **A broken environment is not a task failure**: `sh` not found, command absent (shell code 126/127), inability to spawn the process all exit with code 9 and the exact command that failed — the agent should report or repair the environment, not conclude that its code is wrong. Code 5 stays reserved for a verifier that ran and said no. The **timeout is fixed** (formerly open point 4): 10 minutes by default, overridable per verifier, exceeding it is a code 5 failure with the elapsed time in the message.
+
+`config.yml` remains editable by an agent — replacing a verifier with `true` is the obvious workaround. Two complementary defences, neither resting on good faith. First, **the proof records the hash of the definition that ran** (`verifier: auth-tests@<hash>`, a normalised hash of the `run` + `timeout` entry): what actually ran is anchored in the proof, not in the current state of `config.yml`, so a verifier weakened before or after the `done` — in the same commit or another — is detectable by comparing the proof's hash with the definition at the corresponding commit. Second, `check` reports the patterns: **verifier modified inside the task's activity window** (between the first log entry and the `done`), and **proof hash diverging from the definition in force at the `done` commit**. Splitting the workaround across several commits no longer hides it; it stays a diff in review — faithful to the principle that faking must cost more than doing.
+
+### Trust hierarchy
+
+| Type | `via` | What is guaranteed | What validated it |
+|---|---|---|---|
+| `assertion:"..."` | `submitted` | Nothing. The agent asserts. **Marked weak** in `check`. | Nobody. Recorded as given. |
+| `test:<ref>` | `submitted` | Nothing. A reference typed at a keyboard, in the shape of the strongest proof this table has. | Nobody. Recorded as given. |
+| `human-review:<ref>` | `submitted` | A person says they read it. **Marked weak** in `check`. | Nobody. Recorded as given. |
+| `test:local/<hash>@<sha>` | `verifier` | Ank executed it, in an environment the agent controls | Ank, running a verifier `config.yml` declares, its definition hashed into the entry |
+| `commit:<sha>` | `submitted` | Verifiable by anyone with `git` | Ank, against `git rev-parse` at the moment it was recorded |
+| `test:ci://<ref>` | `attested` | Third-party environment, out of the agent's reach | The pipeline that wrote it to `refs/ank/proof/<id>`, under its own identity (§7) |
+
+The dividing line is not local versus hosted, it is **who controls the environment**. Locally, an agent can weaken a test to make it pass — the same class of problem as an ADR edited to unblock oneself.
+
+**The type says what the reference points at; `via` says who put it there, and the second is what the trust rests on** (ADR-b6b69053a47b). The two rows for `test:` are the whole reason the column exists. A run reference is the strongest thing in this table when a pipeline wrote it and the weakest when somebody typed it, and until `via` existed the file said the same thing in both cases — so `--proof test:<anything>` was recorded as strong, unchecked, and silenced the one finding designed to catch a completion nothing external anchors. The fix is not to demote `test:`, which would punish the anchor `attest --detached` and §7 exist to build. It is to record the route and let the signal read it.
+
+**So the `done with no test proof` signal below is derived from the route and never from the type alone.** A `test` entry whose `via` is `verifier` or `attested` silences it; one whose `via` is `submitted` does not, and the finding names the reference it declined to count. **An entry carrying no `via` at all silences it, exactly as it always did**: the field is optional, its absence means the entry predates the distinction, and a rule that reinterpreted the corpus it postdates would redden every completion recorded before it landed. That is the same reading §3 gives to pre-convention actors and to entities predating `author` — the entities mean what they meant.
+
+**This changes what is reported and never what is refused.** A typed reference is still accepted by `done` and by `attest`, still recorded, still part of the proof list. The CLI is not a gatekeeper (§2), and a proof somebody typed in good faith is worth having in the record — it is worth having as what it is.
+
+**A `commit:` reference is validated once, and a rebase detaches it.** The table says what `git rev-parse` answered *at the moment the entry was recorded*, and nothing asked again afterwards — so the strongest proof this tool checks itself comes undone in silence under the routine this project prescribes: a branch rebased onto a newer default branch has its commits replaced, the recorded sha then resolves only on the stale branch, and nowhere at all once that branch is force-pushed. `check` therefore asks the question a second time, of the clone rather than of the entry: a `commit:` proof naming no commit this clone can reach is reported as a **signal naming the task and the reference**, never as a fault and never re-anchored. Never a fault, because an unreachable commit here is a shallow clone, a branch never fetched, or a rebase on somebody else's machine — a check that reddens over the shape of a clone is a check people learn to ignore, which is the reading this section already gives to a dead scope a truncated history cannot explain. Never re-anchored, because choosing which commit now carries the work is a judgement the tool cannot make — the rebase may have split it, or dropped it — and the proof list is append-only (§3): the repair is `ank attest <id> --proof commit:<sha>`, and it is the reader's to make. The dead entry stays where it is; a proof list is append-only, and removing an entry is the rewrite that append-only exists to prevent.
+
+**A clone that cannot see is not asked, and the question costs one git process.** A shallow clone reaches almost no history, so the question is skipped there outright rather than allowed to accuse every commit proof in the corpus at once — the volume failure this section legislates against everywhere else — and so is a clone with no reachable commit at all. It is asked only of `commit:` entries, and only of references in the shape of an object name: a reference git could not read as one is not a question this can ask, and silence is never evidence. The whole corpus is answered by **one git process per invocation and never one per proof**: the set of proofs is tested against a single listing of what this clone can reach.
+
+**What local proof anchors.** An agent's nominal case is an uncommitted working tree: anchoring proof on the HEAD SHA alone would almost always point at a stale state. The proof therefore records three things: the HEAD SHA, a dirty-tree indicator, and **a hash of the scope files' content at execution time** (`tree:scope/<hash>`, git hash-object style). That last one is what actually captures what was tested. `check` additionally reports the case where the task itself modified the test files it invokes.
+
+The levels stack: local proof at `done` time, a CI reference **appended** later to the `proof` list — the proof list is the record a later anchor reaches by appending (§3).
+
+**`ank attest` is in v1, and this settles it.** Earlier revisions deferred it with its shape frozen, on the reasoning that the data structure was ready and the command would come *when a CI called it*. The command was implemented before that happened, and has been used: this repository's own corpus carries `attest`ed CI references. A deferral whose condition has been overtaken is not a plan, it is a document disagreeing with its binary — the state ADR-63b59c5c26f7 orders the work to prevent, and the one a reader could not resolve from §4 and §10 alone (TASK-5c868c20472f).
+
+What that deferral was actually protecting is worth keeping, because it is still deferred and it is not a command: **nothing calls `attest` automatically**. A CI provider appending its own run reference at the end of a pipeline is an integration, not a verb, and it is listed below as such. The verb exists and anyone — an agent, a human, a CI script — can call it today.
+
+**What `check` does instead is notice the omission**, which is the same choice read from the other side. A pipeline that attests itself would assert "a green run existed on a tree containing this task"; the entry carries the frozen criteria hash, so that statement is mechanically true, and it is still not the statement a `test` proof makes. CI proves the tree passes its tests, not that *this* criterion was met — the link between the two exists only because somebody wrote a test encoding the criterion, and no pipeline can know whether they did. Collapsing the two is the rollup hole of §3 one level out. So the assertion stays human, and forgetting to make it is what gets reported (§4).
+
+The `assertion` type exists because "refactor for readability" has no hash to attach. It is allowed but visible as weak, which avoids a `--force` becoming the default path within two weeks.
+
+
+## 8. Permissions
+
+There is one surface (§4) and the CLI refuses on state. What is left here is **policy applied over that surface**, and policy has to live somewhere it can actually hold. Three places, in decreasing order of how much they hold:
+
+- **SKILL.md**, whose content is frozen (§4, §9). It is what an agent is taught, it is the only description of Ank most agents will ever read, and a verb it does not name is a verb that does not come up. This is the strongest of the three precisely because it does not pretend to be a check.
+- **Harness hooks**, which is where enforcement is real. A `PreToolUse` hook that refuses a tool call cannot be talked out of it by an environment variable, because the process it guards does not get to set it. This repository's own hook, refusing direct reads of `.ank/` per ADR-01b6dd05f0db, is the working example.
+- **Roles in `config.yml`**, which are **advisory** and are named as such. They catch honest drift and nothing else.
+
+### Roles, and what they are worth
+
+A declarative model in `.ank/config.yml`, identity through `$ANK_AGENT`.
+
+```yaml
+roles:
+  agent:
+    can: [context, find, claim, log, done, new:task, new:adr:proposed]
+    cannot: [adr:accept, adr:edit-constraint, task:close, delete]
+  human:
+    can: ["*"]
+identities:
+  "marie@laptop": human      # any identifier absent from the table gets the agent role
+```
+
+**The default role is `agent`.** An unknown identity — including `$ANK_AGENT` being absent, in which case the fallback identity is `<user>@<hostname>` — gets least privilege. Declaring yourself human in the config confers no real authority anyway: the signature is what carries it.
+
+They are kept, three lines and advisory, rather than dropped. They express intent where a reader can see it, an unknown identity defaulting to least privilege is a sane default, and `check` can say when the record and the behaviour disagree. What they never do is make the CLI refuse: a refusal derived from `$ANK_AGENT` would be a refusal the caller can lift by exporting a different string, and shipping that as a guarantee is worse than shipping no guarantee at all. Dropping them entirely was considered and rejected on the same grounds — the cost is three lines, and honest drift is worth catching.
+
+**One identity per concurrent session, and the fallback cannot tell them apart.** With `$ANK_AGENT` unset, two terminals on one machine both resolve to `<user>@<hostname>`: they are one agent as far as the refs can see, so they share and renew each other's claims in silence. Binding the identity to the session instead — a PID, a TTY — is rejected for the reason above: identity is declared, never proved, and a session-bound identity would also lose a claim to a restarted terminal, which is the one case the 30-minute TTL exists to survive. What the CLI owes the user is therefore the observation, not a stricter identity: `claim` **warns** when the claiming identity already holds a live claim on another task, naming that task and its expiry, and names `$ANK_AGENT` as the way to tell two sessions apart. It warns and never refuses — parallel agents, each with its own identity, are the design, and one claim at a time is a convention rather than a lock (§3).
+
+The main guardrail is not the permission but **the status**: an agent writes freely, in `proposed`. It captures information immediately without being able to constrain anyone. Human ratification is the only path to authority.
+
+### Anchoring human identity
+
+`$ANK_AGENT` is set by the agent itself: an agent going off the rails can declare itself `human`. No file-level check can prevent that, since it has filesystem access.
+
+The anchor that holds is therefore external: **a ratification is a commit, and a signature is what makes it answerable to somebody**. `accept` produces the ratification commit itself (§12), recording the SHA and the hash of what was made binding — the accepted ADR's `constraint` + `scope`, or the accepted spec's body + `scope`, under the key that names which (§3, [format.md](format.md)) — and `check` verifies that signature against the keys in `.ank/allowed_signers`. The key file is versioned: adding a key to it is a diff in review.
+
+**Signing is a regime the corpus is in, not a precondition of ratifying** (ADR-964be4d940b2). `accept` signs where the repository is configured to sign and produces an unsigned commit where it is not; it never refuses for want of a key. The two halves of this section used to disagree about that: `check` had the advisory mode described below, in which no key is declared and no signature is judged, while `accept` passed `-S` unconditionally and exited 9 — so a corpus running the very mode this document defines could not produce a ratification at all. Nobody chose that asymmetry; it was two halves written at different times.
+
+What permits the repair is stated a few lines down and is not withdrawn: we protect against drift, not against an adversary. A signature nobody is obliged to produce still anchors every ratification made by someone who does produce one, and git has taken this shape for twenty years without anybody calling its history unauthenticated.
+
+**What may never degrade is the corpus saying which regime it is in.** An optional signature is honest; a corpus that reads as ratified-and-verified when nothing verified it is not. That is the rule this section already applies to its fourth outcome below — a verification that degrades to success is not a verification — and it now governs the unsigned regime on the same terms: every surface reporting on ratification states it, and none lets an unsigned corpus read as a signed one.
+
+**The file uses git's allowed-signers layout**, `principal [options] keytype key`, with the key type naming the format:
+
+```
+sean.lamet@dekrow.com gpg 739A603FB05F9F2F7D3C8D50624FCFCC1482554A
+marie@laptop          ssh-ed25519 AAAAC3NzaC1lZDI1NTE5...
+```
+
+**Who enforces the allowlist depends on the signature format, and the difference is not cosmetic.** Under `gpg.format = ssh`, git reads the file itself and answers with the match: a signature whose principal the file covers verifies, one it does not comes back as good-but-unmatched. Under OpenPGP, **git never reads the file at all** — it resolves the signature through the keyring — so `check` parses the file and compares the signing key's fingerprint itself. A `gpg` entry may name the full fingerprint or the long key id, since the second is the tail of the first. Without this, the file would go on declaring something nothing enforced.
+
+**Four outcomes, and collapsing any two of them loses the check.**
+
+| Outcome | Reported as |
+|---|---|
+| signed by a declared key | nothing |
+| no signature, or one git refuses | fault: the anchor proves nothing |
+| good signature, key not declared | fault: not a ratification |
+| signature present, no local public key | signal: **not verified, and not refused** |
+
+The last row is the one that needs saying out loud. A clone without the public key is a correct repository on an incomplete machine: calling it a fault turns CI red on a sound corpus, and calling it verified is worse, because **a verification that degrades to success is not a verification**. It is reported once for the corpus rather than once per ADR, for the reason §4 gives about entities predating `author` — a line per file is the volume that teaches a reader to stop reading `check`.
+
+With **no key declared at all**, `check` does not judge signatures. There is no allowlist to judge against, the advisory notice below already covers it, and the abstention is also what keeps the tool honest: under `gpg.format = ssh` with no allowed-signers file configured, git reports a perfectly signed commit as unsigned, so a corpus without the file would otherwise have every ratification called a forgery.
+
+**What the signature proves — and does not.** It proves access to an authorised key, not human intent. An agent running on a developer's machine whose git signing is configured and unlocked can produce a valid signed commit. The defence against that case is operational, not cryptographic: a ratification key protected by passphrase or hardware (touch-to-sign), distinct from the everyday commit key if needed. This is consistent with the threat model (§1): we protect against drift, not against an adversary.
+
+**So the entity records who ran the ratification, and the signature is not asked to carry it.** `accept` writes the actor into `verified` (§3), typed like every other actor field, beside the anchor it writes into `ratified`. Three statements, and each is the answer to a question the other two do not ask: the anchor says *what* was made binding, the signature says *a key authorised it*, and the reading says *who ran the command*. Without the third, a ratification an agent performed under a cached passphrase and one a human typed at a keyboard are the same bytes in the file. That is not a hypothesis — ADR-782a3556cf2d, SPEC-93531977642f and SPEC-dbbd533cbc78 were ratified on 2026-08-16 by an agent, at the maintainer's explicit instruction from a phone, and every mechanism in this section reported exactly what it was built to report while none of them could say it.
+
+**It is a record and not a defence, and that is this document's bargain rather than an exception to it.** `$ANK_AGENT` is declared and never proved, so an agent can write `human:` in front of its own name exactly as it can write anything else there. What the reading buys is that an honest ratification leaves a trace and that a reader can tell the two cases apart — not that a dishonest one becomes impossible. It is a sign in the sense this section already gives to roles, the signature remains the only hard line, and nothing about the reading is verified by anything.
+
+**`check` reports self-ratification, as a signal and never as a fault**: an entity whose ratifying actor is its own `author`. It is the case the human act exists to prevent, and it is also what a solo maintainer legitimately does every time they write a decision and ratify it — a rule that reddened over it would redden a one-person corpus wholesale and be silenced within a week, which is the volume failure §4 legislates against everywhere else. Reported, and the reader judges.
+
+With no signing configured, **the hard line is gone and nothing replaces it**: roles were already advisory, and the ratification anchor becomes a hash in a commit message that anyone can write. Ank protects against accidental drift there, not against an agent actively trying to get around it. That is an accepted limitation, and `check` displays it rather than hiding it — a corpus whose ratifications cannot be verified says so, since a verification that degrades to success is not a verification.

--- a/.ank/entities/SPEC-e258796162c4.md
+++ b/.ank/entities/SPEC-e258796162c4.md
@@ -1,0 +1,488 @@
+---
+id: SPEC-e258796162c4
+type: spec
+slug: the-data-model
+title: The data model
+created: 2026-09-05T14:21:06Z
+author: haksolot@vmi3223161
+status: proposed
+scope:
+  - crates/ank-core/**
+  - docs/format.md
+references: [SPEC-183d297253ac, SPEC-77d99d8d1ef2, SPEC-4b79c265ccb6]
+supersedes: SPEC-a89ba4f755e9
+schema: 4
+version: 3
+---
+
+One of the ten documents that carry the Ank specification (ADR-5a690829388d).
+This one carries **§3 entire and undivided**: the two planes, the common base,
+canonical form, identifier allocation, the kind registry, the four kinds and the
+typed-actor convention.
+
+## Why this document is not split, although it is the largest
+
+It is the largest of the ten and the one a section-shaped decomposition would
+have cut first — a document per kind, four entities where there is one subject.
+The test refuses it outright: **a document that cannot be read without holding
+another one open is not a document**, and a `Task` section without the common
+base above it is exactly that. The registry declares every kind in one table,
+each kind's section is written against fields the base defines, and the
+strictness rule that closes the registry governs all four at once. Cutting
+between them would leave four fragments and one table none of them owns.
+
+The same answer holds for the boundary a reader is likeliest to propose inside
+it. **The claim TTL, renewal, return after expiry and the two-live-claims
+resolution stay here**, although they read like coordination and coordination is
+another document. They are the task's own lifecycle — what its status means, when
+it may move, what a lease is a property of — and the plane that enforces them is
+described in §7. Moving them would put a state machine in one document and its
+states in another, which is the fragmentation this decomposition exists not to
+commit.
+
+What did **not** stay is the proof half. `proof` is a field of a task and its
+table is here, but what a proof entry is *worth* is in the anchoring document
+(§4, §8), because the trust hierarchy is read by the data model and by
+synchronisation alike, and a passage two documents depend on should not be buried
+inside a third.
+
+## What it rests on
+
+- **The CLI surface** — the fields here are read by verbs and reported by
+  `check`'s catalogue, which states the signals this document only names.
+- **Proof, anchoring and authority** — what a `proof` entry guarantees, and what
+  a ratification commit anchors.
+- **Synchronisation** — where a claim lives, since §3 states that the claim is
+  never in the file and defers the whole of the plane.
+
+---
+
+## 3. Data model
+
+### Two orthogonal planes, not a pyramid
+
+Ank does not model a decision → epic → task chain. Constraints and work are **two independent planes, joined only by scope**.
+
+This is the property that separates Ank from a tracker: an agent receives what constrains it without traversing any hierarchy, and a constraint applies to work that did not exist when it was written. A pyramid would force every task to hang off a parent decision — factually wrong, and expensive to traverse when building context.
+
+### Where precision lives
+
+Ank lets you plan precisely, but the precision is about **the specification of the work**, not its placement on a calendar. Four fields carry it: `scope` (where), `done_criteria` (what proves it is finished), `constraint` (under which rules), `blocked_by` (in which order).
+
+Deliberately absent: estimates, points, declared priorities, cycles, deadlines. Those are instruments for coordinating human teams over time. They do not help an agent work correctly, and they are the slope that leads straight to reimplementing Linear.
+
+### Grouping happens by scope
+
+There is no epic, no milestone, no label. "Everything about the auth migration" is answered by `ank context src/auth/`.
+
+Scope is a better grouping axis than a label for one precise reason: it is **verifiable**. A label is declarative, it drifts, and nobody cleans it up; a glob is confronted with the filesystem. That is also what guarantees a grouping does not silently go stale when the code moves.
+
+### Common base
+
+Every Ank object is a markdown file with YAML frontmatter. Shared fields:
+
+| Field | Role |
+|---|---|
+| `id` | Canonical identifier, immutable, generated without coordination |
+| `type` | The entity kind, declared in the registry below. `task` \| `adr` \| `spec` \| `log` today. An unknown kind is rejected by name, never ignored. |
+| `slug` | Cosmetic, never used for resolution |
+| `created` | ISO 8601 timestamp of the act of creation, **always in UTC** (`Z` suffix): the ordering of §5 must not depend on a timezone. Immutable. This is what makes task ordering deterministic without depending on git, and what gives `check` a basis for the burst-creation and plausibility signals. |
+| `author` | The identity that ran `new`, in the form `$ANK_AGENT` resolves to (§8). Optional, immutable, and written by `new` on every entity it creates. Together with `created` it is what makes two of §4's signals computable at all: an authorless corpus cannot say who created a burst, nor whether a blocker was written by the agent that would benefit from it. |
+| `scope` | List of globs. Source of truth for context routing. **Mandatory**: without a scope an entity appears in no `context` and becomes invisible. `new` fails rather than create a silent orphan. |
+| `status` | Lifecycle, typed per entity. A kind with no lifecycle carries none, and the registry is what says which — a field with one legal value records nothing and would have to be written anyway. |
+| `verified` | Optional list of readings, each naming a typed actor and an instant: the record that somebody read this entity and stands behind it. Any kind may carry it, its absence is never a fault, and no verb requires it (see *Typed actors* below). |
+| `version` | Integer, incremented on every write. Intra-tree compare-and-swap (§7). |
+
+### Canonical form and round-trip
+
+The format has a **canonical form**: fixed field order, literal blocks for multi-line fields, flow lists for references, UTF-8 without BOM, LF line endings.
+
+The guarantee is exactly this: **`serialize(parse(x))` is byte-for-byte identical to `x` when `x` is in canonical form**. Valid but non-canonical input — another acceptable YAML form, superfluous quotes, CRLF line endings — is read correctly and **normalised on first rewrite**. That is what lets a third-party tool or a human hand write a file without knowing the canonical form, without making that form an authoritative variant, and it is what guarantees that a command which reads then rewrites never produces a spurious diff (§12).
+
+CRLF line endings are therefore **read, never written**. The parser accepts them; `check` reports the entity as non-canonical form — a finding, not a fatal error — with a diagnostic that **names the line endings** and gives the fix command. Never a syntax message that sends the reader to the wrong place: a `---\r\n` diagnosed as "missing frontmatter" costs the user an hour down the wrong path. `ank init` writes a `.gitattributes` (`.ank/** text eol=lf`): on Windows `core.autocrlf=true` is the default, and without this git would convert back on checkout whatever the tool has just normalised, on every clone.
+
+### Identifier allocation
+
+Borrowed directly from git, with one adaptation.
+
+Git derives the ID from content, which presupposes immutability. A task mutates (status, log, title): an ID derived from content would change on every edit and break every reference already written. Ank therefore hashes **the act of creation** — timestamp, agent identity, initial title, randomness — which is immutable. The ID is stable for life and generated without coordination, which is indispensable offline-first.
+
+- **12 hexadecimal characters** stored. Below 8, birthday collisions arrive within the first thousand entities.
+- **Short prefixes accepted** on input, four characters minimum (`TASK-8f3a`).
+- **Ambiguity is an error.** A prefix matching two entities fails with the list of candidates. The tool never guesses.
+- **A short form the tool prints is unambiguous in the corpus it was printed from**, and its length is therefore computed rather than fixed. It is the shortest prefix naming exactly one entity: four characters where four suffice, one more for each collision, never past the twelve stored.
+
+**The displayed length is measured, not declared** — git's answer, and for git's reason. Four characters is 65536 values, so a corpus of a few hundred entities already collides with double-digit probability, and the probability grows with the square of the corpus. A fixed four therefore prints, eventually and without warning, an identifier the tool itself refuses one command later: the rule above says ambiguity is an error, and the caller has no way to know the id they were handed is unusable until they use it. Reporting the collision afterwards — a `check` finding over a fixed four — was rejected: it names after the fact something the display could have avoided, and leaves every printed id unusable meanwhile. The cost of measuring is that the displayed length is no longer constant, which is a column-alignment question in §4 and nothing more.
+
+**Measured against the set resolution searches, and never against the rows a verb returned.** That set is every `<ID>.md` present on disk, which is what prefix resolution walks (§6) — including the entities a listing left out because this binary could not read them (§4). A prefix unique among four search results and ambiguous in the repository is a prefix that stops working when the query changes, and a prefix unique among the entities that parsed is one that stops working when a corpus is written by a newer release. Kinds are measured apart, since the printed form carries `TASK-` or `ADR-` and prefix resolution filters on it: two entities of different kinds sharing four hex characters lengthen neither.
+
+### Entity kinds are a registry
+
+A kind is **declared once, in a table**, and never restated per layer (ADR-c9f9d0d6f05d). The table gives, for each kind: the name written in `type`, the id prefix, the status values, which fields are required and which are optional, and the **canonical field order**. Adding a kind is an entry in that table, a golden fixture and a section here — never a second serializer, a second parser branch, and never a second directory.
+
+| Kind | `type` | Id prefix | `status` |
+|---|---|---|---|
+| Task | `task` | `TASK-` | `open` \| `in_progress` \| `done` \| `closed` |
+| ADR | `adr` | `ADR-` | `proposed` \| `accepted` \| `superseded` |
+| Spec | `spec` | `SPEC-` | `proposed` \| `accepted` \| `superseded` |
+| Log entry | `log` | `LOG-` | none: an entry is written once and has nothing to transition to |
+
+| Kind | Required, in canonical order | Optional, in canonical order |
+|---|---|---|
+| Task | `id`, `type`, `title`, `created`, `status`, `scope`, `blocked_by`, `schema`, `version` | `slug`, `author`, `done_criteria`, `criteria_by`, `verify`, `proof`, `verified` |
+| ADR | `id`, `type`, `title`, `created`, `status`, `scope`, `constraint`, `schema`, `version` | `slug`, `author`, `see`, `supersedes`, `ratified`, `verified` |
+| Spec | `id`, `type`, `title`, `created`, `status`, `scope`, `schema`, `version` | `slug`, `author`, `supersedes`, `ratified`, `verified` |
+| Log entry | `id`, `type`, `title`, `created`, `scope`, `about`, `seq`, `schema`, `version` | `slug`, `author`, `records`, `verified` |
+
+The canonical order interleaves the two lists and is fixed; it is written out per kind in the sections that follow, and reproduced as a numbered table in [format.md](format.md). `blocked_by` is required in the sense that matters to a serializer: it is always emitted, as `[]` when empty. Every optional field is **omitted when absent, never emitted empty** — that is what lets a file written before a field existed survive a rewrite unchanged.
+
+**Strictness does not move.** The registry makes a kind cheap to add; it never makes the format permissive. Inside a known kind, an unknown field is still rejected rather than preserved, and an **unknown kind is rejected naming the kind** — not naming the first field that kind happens to carry. The two refusals answer different questions and a reader sent to the wrong one loses an hour: `priorty:` inside a `task` is a typo, and `type: epic` is a document this tool does not know how to read.
+
+What this deliberately does not do is import the extensibility of a knowledge-interchange format, where `type` is the only required field and unknown keys are preserved. That is the right trade for sharing documents between organisations and the wrong one here: Ank's value is that a criterion is frozen and a proof is anchored, and neither survives a reader that must accept whatever it is handed. The shape is borrowed, the permissiveness is not.
+
+### Task
+
+`.ank/entities/TASK-8f3a91c2d4e7.md`
+
+```yaml
+---
+id: TASK-8f3a91c2d4e7
+type: task
+slug: migrate-auth-sessions
+title: Migrate auth to opaque sessions
+created: 2026-07-25T09:14:00Z
+author: claude-code/1.4.2    # the identity that ran `new`, typed (below). Optional: a corpus predates it.
+status: in_progress          # open | in_progress | done | closed   (blocked is derived)
+scope:
+  - src/auth/**
+  - src/middleware/session.ts
+blocked_by: [TASK-51c2a7f0]  # DAG. Empty = ready to be claimed.
+done_criteria: |             # required to claim, frozen by hash afterwards
+  Auth integration tests pass, and no reference to
+  jwt.verify remains in src/auth/
+criteria_by: creator         # creator | claimer — set by the tool, a signal for check
+verify: [auth-tests, no-jwt] # list of verifiers from config.yml, all must pass
+proof:                       # append-only list, required for done
+  - type: test               # test | commit | human-review | assertion
+    ref: local/9c1f4a@a3f9c21
+    tree: scope/4be2d10c     # hash of the scope files' content at execution time
+    criteria: 7d1e2a90b4c3   # hash of the frozen done_criteria, recorded by done
+    verifier: auth-tests@1f2e3d4c   # hash of the definition that ran (§4)
+    via: verifier            # the route: verifier | attested | submitted (§4)
+  - type: test
+    ref: local/e51b22@a3f9c21
+    tree: scope/4be2d10c
+    verifier: no-jwt@9ab0c1d2
+    via: verifier
+verified:                    # optional; a reading, not a run
+  - by: human:marie
+    at: 2026-07-27T09:40:00Z
+schema: 3
+version: 7
+---
+
+Free-form context, notes, links.
+```
+
+**A proof records the route by which it arrived** (ADR-b6b69053a47b). `via` is `verifier` when Ank ran a declared verifier itself, `attested` when the entry reached the task on `refs/ank/proof/<id>` (§7), and `submitted` when a caller passed it to `done --proof` or `attest --proof`. The field is optional and its absence is not a fourth value: it means the entry was written before the distinction existed, and §4 reads such an entry exactly as it was read then. What the route is *for* is the trust hierarchy, and it lives there.
+
+**The log is no part of the entity file, and an entry is an entity of its own**, of kind `log` (ADR-ff294eff4d1a, then ADR-25f977377fa0). What a reader sees is unchanged, and it is what it always was — one entry, one instant, one identity, one message, printed a dash, the timestamp, the identity, an em dash, the message:
+
+```
+- 2026-07-26T14:02Z claude-code/1.4.2 — jwt.verify removed from session.ts
+- 2026-07-26T14:31Z claude-code/1.4.2 — released: needs access to the staging Redis store
+```
+
+That grammar is now the **rendering** and no longer the storage. An entry carries the instant in `created`, the identity in `author`, the message in `title`, and the entity it is about in `about`; the field table is in the registry above and the kind is described below. **Any kind carries entries**, an ADR included, and an entity with none is an entity nobody has logged against — never an error.
+
+The move happened in two steps, and the second is not a reversal of the first. **The original decision put the log at the end of the task file**, and its argument was that appending at the end is a one-line git diff, which preserves the recovery property (§12), while a separate file would double the number of objects to resolve. The first half is right and is better served by leaving the body: a file that only ever grows produces an append with no context lines drawn from anything else. The second half is the real cost and it is paid — what doubles is the number of files on disk, not the number of decisions a reader makes, because resolution never went through the directory.
+
+Three costs sat on the other side and none of them was weighed, two of them not existing yet. **The file that must be most stable was the one that churned most**: a task file carries `done_criteria`, whose hash is frozen in the claim record, and 123 of 132 tasks in the reference corpus carry a log, so the one artifact the freeze exists to make observable was the one rewritten most often. **The merge driver loses the rule that only the shared file required**: §7 fixed two rules for a future `.ank/` driver, `version` = max + 1 and the log unioned by timestamp, and the second existed only because the log shared a file with fields that cannot be unioned. The reason given for dropping it was wrong — git's own three-way merge conflicts on two appends rather than unioning them, unless the repository says `merge=union` itself (§7) — and the rule stops being something to automate anyway, because after the second step there is no file two parties append to. **A second party had nowhere to append**: a pipeline recording that it ran, a reviewer noting why a task was handed back, a second agent in the same tree, each had to rewrite durable state carrying a frozen field to add one line of trace.
+
+Hence, and this is what the first step bought: **a task file changes only on a real transition.** Writing a log entry writes no frontmatter on the entity it is about, bumps no `version` of it, and touches no file carrying a frozen field.
+
+**The second step is that ADR-ff294eff4d1a decided between a section of the entity body and a file of its own, and never considered an entity per entry.** Nothing in it is overturned here — there is no argument to overturn, only one that was never made. An entity carries `version`, incremented on every write under compare-and-swap, so making the *log* an entity would turn every append back into a transition, which is exactly what the first step removed; making an *entry* one does not, because an entry is written once and never modified. Append-only then stops being a convention the format asks for and becomes a property of the storage: there is no file to append to, two concurrent entries are two new files, and the conflict does not arise instead of being asserted away. A correction is a new entry naming the one it corrects, never an edit.
+
+What it costs is written here rather than discovered later. The entries of an entity become **a query and no longer an address**: the previous shape computed `.ank/log/<ID>.md` from the entity's own id with no lookup, and that arithmetic goes. The flat directory grows by one file per entry, which on the reference corpus is 487 of them against roughly 210 entities. Both are accepted deliberately. What is bought is that an entry has an id, an author, an instant and a scope like anything else, so it is indexed, reachable through `find`, and able to cross a repository boundary (§7) — where the previous shape was reachable by no query at all.
+
+The log stays a **work trace, not proof**: nothing authoritative is anchored in it — freezes and proofs have their own hash anchors — and a rewritten past entry is a git diff visible in review like any other falsification of history. That is why a chained log hash, considered, was rejected: it would weigh the format down to defend a surface that carries no authority. It is also what makes an append by a second party harmless.
+
+Rejected alongside: **a log in a git ref**, which would take the log out of the tree, where it is read by humans looking at a diff and by anyone who clones without the `refs/ank/*` refspec — the log is durable state and travels with the code, and only the coordination plane belongs in refs. And **one log file for the whole corpus**, where every append would contend with every other, which is the same mistake as a single claim ref.
+
+**The claim is not in the file.** It lives exclusively in the ephemeral coordination plane (§7). Recording it here would produce a git diff on every task pickup, which is precisely what separating the two planes exists to avoid. A task that is `in_progress` with no active claim and no completion ref is simply a task whose TTL expired: it can be picked up again, and its log says where the previous holder stopped.
+
+**`schema`** carries the format version, with explicit migration and never a silent break. It is the counterpart of the promise "the format is the specification": a third-party tool must be able to cleanly refuse a file it does not know how to read.
+
+A tool therefore declares a **range of versions it reads**, not a single one, and refuses anything outside it naming the version rather than the symptom. The distinction is not academic, and adding `author` is what made it concrete. The frontmatter rejects unknown fields — that is what lets a typo like `priorty:` be an error instead of a silent loss — so a tool that read only its own version would report a file one version newer as *unknown field `author`*, while the file plainly declares the schema that explains it. The reader would go looking for a typo. Refusing on the version says the one true thing: this file is newer than this tool.
+
+The rule is asymmetric on purpose. Reading **older** versions is a promise the format keeps: a corpus is never migrated by a tool that refuses to read it, so every field introduced after version 1 is optional at parse time, and its absence means "written before this existed" rather than "invalid". Reading **newer** versions is refused, because the fields a tool does not know about are exactly the ones it would silently drop on the next rewrite.
+
+**The current version is 4**, and the reader range is **1 to 4**. The lower bound does not move, and there is no version at which it will: every field introduced after version 1 is optional at parse time, so a schema 1 file parses and re-serialises byte-identically under a schema 4 reader, and dropping the bound would be migrating a corpus by refusing to read it. Version 4 carries one field, `records` on a log entry, and it is a bump for the reason version 3 was one: a reader that does not know the field drops it on the next rewrite, and the entry silently rejoins the trace it was written to stay out of.
+
+Version 3 carries two changes: the **log leaving the entity body**, and the **`verified` list** with the typed-actor convention it names. The layout change of the same revision — entities in one flat directory (§6) — carries no bump, because it moves files rather than fields, and a reader that finds the file finds every field it knew before.
+
+The log is what makes the bump necessary, and the case is the one the version field exists for. A reader that does not know the log has left the body opens a task file, finds no `## Log` section, and shows an **empty history for a task that has one** — silently, and nothing anywhere reads as an error. Refusing on the version says the one true thing before any of that happens. `verified` on its own would not have earned a bump; it is an optional field whose absence already means "nobody recorded a reading", which is exactly what an older reader would conclude. It ships in the same version because splitting the two would move the corpus twice.
+
+**`via` does not earn one either, and the second reason is the decisive one.** The first is `verified`'s: an older reader that does not know the field reads a proof entry as it always read one — a type and a reference — and concludes nothing false from its absence, because before the field there was nothing to conclude. What it loses is a distinction it never drew, which is not the log's case, where the older reader showed an empty history for a task that had one.
+
+The second is what a bump would actually do to a live corpus. `attest` appends to a task that already exists, and every task in an existing corpus declares the version it was written at. A bump would leave that verb two choices: write `via` into a file still declaring the older version, which is a file contradicting its own header, or raise the header on append, which is a migration performed by a write — and the conformance suite holds older fixtures precisely to catch a rewrite that moves one. Neither is acceptable, and the way out is the rule this document already states: **every field introduced after version 1 is optional at parse time**, so a proof entry carrying `via` is readable at any version in the range and one without it means the entry predates the distinction. A bump is for a reader that would be *wrong*, never for a field that is merely new.
+
+**A new kind does not earn one either**, and the argument is the same one read from the other side. An entity of a kind a reader does not know is **rejected by name** — that is the strictness rule of the registry, and it is the honest refusal a version bump exists to produce, delivered by a mechanism already in place: a reader meeting a `spec` or a `log` it cannot read stops on that entity and says which kind stopped it. The one case that would be silent is narrower and no bump could reach it: a reader that opens a task file alone, and looks for its entries where the previous shape kept them, sees an empty history for a task that has one. Nothing written into that file would tell it otherwise, because the entries move without a byte of the task file changing, and raising its header on that occasion would be a migration performed by a write — refused just above. That case is covered where it can actually be covered, by continuing to read the previous shape for one window (§6), and it is named here rather than left to be met.
+
+**Lifecycle.** `open` → `in_progress` (via `claim`) → `done` (via `done`, proof mandatory). There is no separate `claimed` status: a successful claim puts the task directly into work. **`claim` on an `in_progress` task with no active claim is a legal transition** — that is pickup after expiry, not an anomaly. The single exception is a task carrying a **completion ref**: it was finished on another branch, and `claim` refuses with code 4, naming the commit and the branch (§7). That is precisely the case the file's status cannot express, since a `done` lives in the durable state of the branch that produced it and exists nowhere else before the merge. After `done`, the writes that stay legal are the ones no proof anchors: **appending** a proof to the `proof` list, and amending `scope` — a description of where the work happened, journalled like every amend (ADR-b9156403c3d5). `done_criteria` is anchored by the hash the proof records and `blocked_by` is the plan's history; a modification of either is reported by `check`.
+
+**A bug discovered in a `done` task yields a new task.** Never a reopening, never a re-edit of the code under cover of the finished task. This case is permanent, not exceptional: a task is finished when its criterion is proven, not when its code is perfect, and proving a criterion never meant nothing was left to fix. Reopening would dissolve the proof — a `proof` entry anchors a state of the tree at a point in time, and that content would change underneath it with nothing to signal the fact, which is exactly the falsification anchoring exists to make visible. The new task carries its own scope and its own criterion, and cites the one whose work it corrects. First example in this repository: `TASK-dc87e0ecfb6c` corrects the lock-retry strategy written by `TASK-244a842bc0cc`, which stays `done` with its proof intact.
+
+**`closed` is ratified abandonment.** Terminal, reachable from `open` and `in_progress` through `ank close <id> --reason <r>`, with the reason mandatory and going into the log. The verb is outside the loop SKILL.md teaches (§4) rather than closed to agents: what makes the abandonment ratified is the reason left in the record, not the identity of whoever typed it. It is the answer to an active corpus ageing: the dead scopes and orphan tasks `check` detects must be closable explicitly, never automatically, and never by deleting the file (deleting would break other tasks' `blocked_by` references, whereas `closed` preserves them). **`closed` does not unblock**: a closed task was not done, so its dependents stay blocked, and `check` reports "blocked by a closed task" so a human decides — close down the chain, or rewrite the dependency. Two operational points: `claim` refuses a task one of whose `blocked_by` is `closed` (code 7, naming the closed blocker, as for any active blocker), and `close` on an `in_progress` task revokes the active claim in the same operation — the ref is deleted, and the holding agent learns this at its next `log` (code 6, the task is no longer in work).
+
+**`blocked` is not a status, it is a derived property.** A task is blocked if and only if it has at least one unfinished `blocked_by`. Nothing is entered by hand, so nothing can go stale. `claim` refuses a blocked task and names the blocker.
+
+**`blocked_by` is the only relation between tasks.** A DAG, not a tree: no parent/child, no rollup, no cascade. Three reasons, in order of importance.
+
+*Rollup is completion without proof.* "The parent is finished when the children are finished" is structurally the same hole as `assertion:`, hidden in the topology instead of written in a field. With a DAG, when the blockers are finished the task is **unblocked, not finished**: it still goes through its own `done` with its own proof. The parent verifies the whole, not the sum of the parts — and that is exactly where integration regressions live.
+
+*Decomposition is discovered, not planned.* A human breaks an epic down from the top. An agent discovers mid-course that its task requires another. That is ordering, not containment: forcing a tree would require deciding on parentage at the moment when only an order is known.
+
+*The same work often serves two tasks.* "Add the Redis adapter" blocks both the auth migration and the session cleanup. A tree forbids that; a DAG represents it without duplication.
+
+Cycles are refused on write and reported by `check`.
+
+**Blocking defers the obligation, it does not release it.** An agent may create blockers after claiming, which is the legitimate case of discovered subtasks — but it is also a possible escape hatch for an agent in difficulty. The guardrail is not to forbid the act but to remove its payoff: the `done_criteria` stays frozen, the task stays to be finished, and creating a blocker costs the price of a real task (scope and verifiable criterion mandatory), so a fake blocker is visible to the naked eye. `check` reports the pattern "blockers created by the same agent after claiming" as a signal, not a fault. Faking must cost more than doing.
+
+**`done_criteria` is required in order to `claim`, and its freeze is anchored by hash.** The freeze cannot happen later: a task created without a criterion would then become permanently uncriteriable once claimed. `claim` therefore fails if the field is empty, with the exact command to set it and claim in the same call.
+
+The freeze mechanism accounts for the CLI not being a gatekeeper: any tool can rewrite the file. The freeze is therefore **verifiable, not defended**: `claim` records the hash of the `done_criteria` in the claim record (§7), `done` checks that the current criterion matches that hash before executing anything, and writes the hash into the proof. A criterion modified between claim and done makes `done` fail with code 6, and `check` reports the case. Editing the file unblocks nothing.
+
+The freeze prevents weakening a criterion *after the fact*; it does not prevent setting a lenient criterion *at claim time*. That is why the `criteria_by` field records who set the criterion: a task created by a human carries its criterion from creation (`creator`), and `check` reports "criterion set by the claimer" as a signal — the same logic as self-created blockers, visible without being forbidden.
+
+**A criterion proved wrong in part is recorded, and the record is a log entry.** The freeze holds against the case it was built for, an agent weakening what it must prove. It also catches a case nobody designed it for: a criterion written on a premise the work then disproves. Three sessions in this repository met it inside a fortnight. One carried a clause requiring that a file stop instructing something it had never instructed — unsatisfiable as written, one clause of four, the other three met. One demanded a fixture a binding ADR forbids. One asserted that a test file would pass untouched, and it did not, because two tests there read the very surface the task was changing. In each of the three the criterion was mostly right and locally false, and the tool offered two exits, both wrong: edit the criterion, which is the failure the hash exists to make visible, or `release`, which hands back work that is otherwise correct.
+
+The third exit is to **record the discrepancy and keep the criterion**. It is a `log` entry whose message opens with `discrepancy:`, followed by what the criterion assumes and what was measured against it:
+
+```
+- 2026-08-14T18:16Z claude-code/03fd — discrepancy: the criterion assumes tests/skill.rs passes untouched; two tests there read `ank help` and one asserts the clause this ADR supersedes
+```
+
+**It changes nothing mechanically, and that is the design rather than a limit of it.** `done_criteria` is not touched, so the hash `claim` recorded still anchors it and `done` still verifies the criterion it froze, whole. The record is never a condition of `done`, never an input `done` reads, and never a reason to accept less: a criterion genuinely unmet is unmet whatever the log says, and a task whose criterion has moved fails `done` with code 6 exactly as before. What the record buys is that the disagreement sits in the corpus instead of in a pull request comment nobody reopens — and that the next reader of the finished task sees, beside the proof, what the agent that produced it did not believe.
+
+**It is not an edit to the criterion**, and the layout is what makes that verifiable rather than merely promised: the record is an entry of its own, and the frozen field lives in a file writing that entry never opens. That is also the reason the log is the record and a new field is not. A field would put the record back into the one file the freeze exists to make observable, which is what ADR-ff294eff4d1a moved the log out of. It would be rewritable in place by whoever edits the file, where a log line is append-only and a rewritten one is a git diff visible in review. It would need a `by` and an `at` to be worth reading, which is the log's grammar restated in frontmatter. And it would be unwritable exactly where it is most needed, since `amend` refuses a `done` task's criterion and a criterion is most often disproved while it is being proved. The one thing a field could do that a message cannot is name *which* clause — and `done_criteria` is one block of prose with no addressable clauses, so that pointer would be a quotation, which the message already is.
+
+**It is not a release either, and the two are not ranked.** `release` hands the task and its criterion back to the pool, which is right when the whole task rests on a false premise and wrong when one clause of four does, because it throws away work that is correct. A criterion wrong in part is recorded and the task is carried to `done`; a criterion wrong entire is released, `--reason` mandatory — itself a log entry, on the same line grammar.
+
+**What an entry records is a field, and it is the one case that is not a convention on the message.** `records` is absent on a work entry, which is what every entry a corpus already holds is and what `ank log` means to a reader. A value names machinery: `edit`, written by the verbs that change an entity's content outside a status transition (ADR-16813b3bcf37). The work trace and the machinery are presented apart, and the count beside the trace is the trace's.
+
+**It is a field and not an opening on the message**, unlike the record below, and the two are worth reading together. An opening costs no schema bump, which is why the record below is one. This is not: `check` counts these entries against the version an entity carries, arithmetic wants a field rather than a prefix, and a value the reader can key on survives a message being rewritten around it. **The value is a free string at parse time and a vocabulary at `check` time**, on the terms §8 sets for a typed actor: a word this build does not know is a finding, never a parse error, because a corpus written by a newer build must stay readable.
+
+**The convention is the message, never the grammar.** Nothing in the form above moves: a dash, the timestamp, the identity, an em dash, the message. `released: <reason>` is the same kind of convention and older than this one. A reader that does not know it reads a sentence, a reader that does reads a record, and every log a corpus already holds stays valid — so this costs no schema bump and no migration. `show` needs no rule to display it either: the log prints under the entity as it stands, and the opening is the mark.
+
+`check` reads the log and reports the record as a signal on the task, never as a fault (§4). A judgement somebody wrote down is not a corpus defect, and the criterion that actually moved is the divergence fault above.
+
+**Claim TTL.** Short, 30 minutes by default — the default the repository states through **`claim_ttl_default` in `config.yml`**, itself **capped by `claim_ttl_max`** (2 hours by default), so an agent cannot grant itself 24 hours and hoard. It is **renewed implicitly by working**: working is enough to keep the lock, there is no `heartbeat` verb to memorise.
+
+Two keys and not one, because they answer different questions. The cap stops an agent granting itself a day; the default states what this repository's work actually looks like. Thirty minutes is shorter than a CI run on many repositories — this one included — so the shipped default is wrong for them, and every agent rediscovers `--ttl` by losing a claim first. A repository that can say so once says it once.
+
+**Renewal follows the holder's work, not `log` alone** (ADR-0bb7ea8991bc). The reasoning above is what the mechanism owed and did not deliver: `log` is *reporting*, not working, and the two come apart exactly where it costs. After the design is settled there is often an hour of mechanical fixing during which there is genuinely nothing to log, so the lease lapsed precisely during the stretch where nothing interesting was happening — which is also the stretch where a second agent would most safely take over. The lock was weakest where the work was least interruptible.
+
+The rule is **the holder's verbs against the task it holds**, and it is a rule rather than a list because a list is what goes stale when a verb is added. `ank show` on another task renews nothing. `ank context` in execution mode is about the task in hand and renews. `status` is about the repository and does not. `claim` grants a lease rather than extending one, and `done` and `release` settle it, so none of the three renews under this rule — `log` still does, as its own write. A lapsed claim is not renewed by reading either: taking one back stays the re-acquisition `log` and `done` perform, described below.
+
+The objection is that an agent could then hold a task forever by reading it, and the answer is not new machinery: §4 already has `check` report **repeated claim renewals with no modification to the scope files** as a possible-hoarding signal. Visibility rather than restriction is the standing choice — it is how task flooding is handled, how self-created blockers are handled, and how a criterion set by the claimer is handled. Reading to hold is a lie somebody wrote down, in a corpus that already reports it.
+
+**The TTL is a property of the claim, and a renewal reuses it.** `--ttl` states the rhythm of the work — how long this task goes between signs of life — and that does not change halfway through it. The granted duration is therefore recorded in the claim record (§7) and every renewal recomputes the expiry from it, **re-capped by `claim_ttl_max` at renewal time** so that a lowered cap takes effect on the next renewal rather than at the next claim.
+
+Recorded rather than derived, because it cannot be derived: a renewal moves `expires` and leaves `claimed` where it is — `check` reads `claimed` to report blockers the holder created after taking the task — so the interval between the two stops being the lease the moment the first renewal lands. Measured before it was written down: renewal recomputed the default instead, so an agent that asked for two hours held them once and fell back to thirty minutes at its first `log`, which is the command the loop tells it to run often. That is the flag failing at exactly the case it exists for — a long silent stretch, entered just after a log (TASK-1b45f41e7b99).
+
+Two hours granted and then honoured is not hoarding: `claim_ttl_max` is what bounds it, and it bounds it at every renewal rather than only at the first.
+
+**Return after expiry.** A 40-minute build with no `log` expires the claim; that is normal, not a fault. On expiry the task stays `in_progress` and becomes claimable again. When the original holder returns: if nobody took the task over, `log` and `done` **re-acquire silently** and carry on; if another agent took it over in the meantime, they fail with code 4 and the name of the new holder. Mechanically, "silently" means checking that no active claim exists for the task — the ref `refs/ank/claims/<id>` — then recreating it in the current agent's name, both steps resting on the atomic primitive of a ref update. No data is lost either way — the log says where each holder stopped.
+
+**Two live claims under one identity.** `claim` refuses to create that state (§4) and the CLI is not a gatekeeper, so it remains reachable: a ref written by hand, a claim taken by an earlier binary, a lapse revived. HEAD is then derived from more than one candidate, and what the verbs owe their caller is that **the choice is never silent** — the whole cost of the state is not that it exists but that `log`, `release` and `done` used to resolve it without a word.
+
+HEAD stays derived and the resolution stays deterministic: the lowest task id among the identity's live claims, because the refs are enumerated in refname order and nothing else would be reproducible. On top of that:
+
+- **`log` and `release` act, and say so first.** Before writing anything they name the task they resolved to, every other live claim of the identity with its expiry, the command that names another one explicitly, and the way out of a shared identity. On standard error, so that stdout stays what a parser already reads (§4); under `--json` the same sentences arrive in a `warnings` array, as `claim` already does — the caller that scripts around these verbs is exactly the caller running several sessions.
+- **`done` refuses**, code 6, and refuses **before running a single verifier**. It is the verb whose effect cannot be undone by running it again: an agent that meant the task it claimed a minute ago and got the one it claimed an hour ago finds a task marked `done`, carrying a proof, whose work was never verified. The refusal names every candidate and gives the command for one of them. Code 6 is what `log`, `release` and `done` already answer when HEAD resolves to no task at all; resolving to several is the same fact from the other side.
+
+**The explicit ID is what disambiguates**, which costs the refusal rather than a new flag. It stops meaning "must equal HEAD" and means "must name a task this agent holds a live claim on" — still never a way to act on somebody else's task, and still code 6 when it names one this agent does not hold. With one claim, which is the nominal case, the two readings are the same sentence.
+
+### ADR
+
+`.ank/entities/ADR-3c7e0b9142af.md`
+
+```yaml
+---
+id: ADR-3c7e0b9142af
+type: adr
+slug: opaque-sessions
+title: Opaque sessions rather than stateless JWT
+created: 2026-07-18T11:02:00Z
+author: human:marie          # the identity that ran `new`, typed (below)
+status: accepted             # proposed | accepted | superseded
+scope:
+  - src/auth/**
+constraint: |                # the only field injected into context
+  Do not introduce self-contained JWTs for user auth.
+  Every session goes through the Redis store.
+see: src/auth/session_store.ts    # optional, for positive constraints
+supersedes: ADR-9a12ff03b8e1
+ratified: 4c1e9a20            # hash of constraint+scope at acceptance (set by accept)
+schema: 3
+version: 2
+---
+
+Decision, alternatives rejected, consequences.
+```
+
+**`constraint` is short and imperative.** It alone goes into the agent's context, never the body of the document. A three-page ADR therefore costs about thirty tokens at injection time.
+
+**`see`** answers the fact that a negative constraint ("do not do X") is respected without context, whereas a positive one ("everything goes through adapter X") needs a pointer to the reference code.
+
+**Immutability, anchored like that of tasks.** An `accepted` ADR has `constraint`, `scope` and `status` locked; the body stays editable. The lock is verifiable: the signed ratification commit (§8) records the hash of `constraint` and `scope` at acceptance time, and `check` compares the current state against that hash. An ADR whose constraint has diverged from the ratified hash is reported as **altered** — and its injection into `context` is suspended with an explicit warning, because injecting an altered constraint would amount to letting the editor rewrite the rule.
+
+**How `check` reaches the commit.** `ratified` holds the hash, not the commit — a commit cannot contain its own identifier, so a field naming it could never be written by the single commit `accept` makes (§12). The pointer is the file's own history instead: walking back from `HEAD` over the ADR's path, through `rev-list`, the first commit whose message is the `ratify <id>` of §12 is the ratification, and `cat-file` reads the `constraint+scope` hash out of that message. Comparing against *that* hash is what makes the freeze verifiable at all: the copy in the file is written by whoever writes the file, whereas replacing the one in the commit means producing another signed commit, which is what a ratification key is for.
+
+Three outcomes, and the third must not be confused with the second. The hashes agree, and the constraint is the ratified one. They disagree, and the ADR is **altered**. Or no ratification commit is reachable — a shallow clone, a rewritten history, a corpus moved between repositories — and the honest report is that the freeze **cannot be verified**, never that it was broken. A check that cries divergence over a shallow clone is a check people learn to ignore.
+
+Modifying a decision means creating a new ADR that `supersedes` it. **The `accepted` → `superseded` transition is the only legal write on an accepted ADR**, and it is performed by `accept` of the new ADR, inside the same ratification commit — the replacement and its authorisation are inseparable.
+
+**Ratifying what was accepted by hand.** A corpus holds ADRs that are `accepted` and carry no `ratified` anchor: written before the tool existed, or promoted by editing the file. `check` reports them as a signal and not a violation (§4), because condemning a bootstrap corpus wholesale would block every `done` behind it. `accept` therefore admits one exception to "`proposed` → `accepted` is the only promotion": an `accepted` ADR **carrying no anchor at all** is ratified in place, which writes the anchor and produces the signed commit without changing the status. An ADR that already carries one is refused, and that refusal is the half doing the work — re-anchoring is precisely how an edited constraint would be laundered, and changing a ratified decision stays a succession. Supplying a *first* anchor launders nothing: there was no anchor to diverge from.
+
+The succession such an ADR declares follows the same reasoning. A `supersedes` whose target is already marked `superseded`, with no other accepted ADR claiming that target, is a succession already on record — bootstrap again, or an `accept` interrupted between its two writes — and ratification records it in the commit without rewriting the file. A target still `proposed` was never binding, and remains a refusal.
+
+**Ratification.** An agent creates in `proposed`. Promotion to `accepted` goes through `accept` and through nothing else, and `accept` produces the signed ratification commit (§8, §12): the authority is carried by the signature, verifiable by anyone against `allowed_signers`, not by the identity string of the caller. A `proposed` ADR is visible in orientation mode, **never injected in execution mode**: non-binding means it must not consume the attention budget of an agent that is writing code.
+
+The underlying principle, which explains the asymmetry with tasks: **ratification applies where an artifact commits others, not where it records work.** An ADR constrains every agent that comes after it; a task commits nobody. Hence `new task` without restriction and `new adr` in `proposed`.
+
+The symmetric risk — an agent going off the rails and flooding the repository with tasks — is **accepted, without a quota**. A quota would be unenforceable in this design: the format is the specification, an agent writes files directly, and there is no central arbiter offline-first to do the counting. The defence is visibility, not restriction: every task costs a valid scope, `check` reports burst creation by a single identity (through `created`), and `review` presents creations by author. Flooding is a noisy diff in review, not a silent state.
+
+### Spec
+
+`.ank/entities/SPEC-19c4f0a83b2e.md`
+
+```yaml
+---
+id: SPEC-19c4f0a83b2e
+type: spec
+slug: session-protocol
+title: Session protocol, version 2
+created: 2026-08-15T06:12:00Z
+author: human:marie
+status: accepted             # proposed | accepted | superseded
+scope:
+  - src/auth/**
+references: [SPEC-3f81c9d0a2b7, ADR-19d0e2f4a6b8]   # what this document rests on
+supersedes: SPEC-c07d1b4a92e5
+ratified: 9f2c81b0           # hash of the document and scope at acceptance (set by accept)
+schema: 3
+version: 4
+---
+
+The document itself.
+```
+
+**One entity per document, never one per section**, and §10's refusal is kept entire rather than worked around: a specification's authority comes from being one coherent document, its sections are not independent the way ADRs are, and cutting it into scoped fragments creates the drift one document prevents. A section is reached by reading the document. What fired is the remedy that row offered instead — distilling a section into a scoped ADR — and what it fired against is the vehicle: `constraint` is short by construction and frozen at ratification, orientation serves no rule text at all, and a perimeter is called over-constrained when constraints alone exceed half its budget (§5). A description does not fit through a channel sized for a rule, and §11's model has no sink for it either, every mechanism there being subtractive and presupposing a rule that could in principle be checked.
+
+**`references` is what makes several documents safe, and it is a declared field rather than a sentence** (ADR-5a690829388d). A specification cut into documents drifts unless the coherence between them is verified, and verifying it means the citation has to sit somewhere a parser can reach. So a spec declares what it rests on in a field of its own, `check` resolves every entry against the corpus, and three states are reported. A target the corpus does not hold is a **fault**: the reader following the reference finds nothing, which is exactly what a `blocked_by` naming nothing already is. A target that is not `accepted` is a **signal**, because two documents are legitimately written at once and refusing that would make it impossible to write the second — what it must not do is pass unmentioned. A target that is `superseded` is a **signal naming the successor**, so the repair is a citation update and not an investigation. Each of the three names the command that repairs it, and on the third that is the whole difference between a check that helps and one that scolds: the successor is known, so the message carries it. The field is optional and omitted when empty — a document that cites nothing says nothing, and emitting `[]` on every spec written before the field existed would make each of them non-canonical at the very release that introduced it.
+
+**A reference that follows the chain is not reported.** The finding on a superseded target fires only where the citing document does not also reference the end of that chain: a document that has followed the supersession has already done the thing the finding would ask for. Revising a ratified document *is* a supersession, so this is the state a split corpus produces most often, and a rule that fired anyway would fire on every correct citation the day after any document is revised.
+
+**A citation is not covered by the anchor, so the repair is an `amend` and not a supersession.** `ratified` hashes the body and the `scope`; a reference is neither of them. `amend --reference` and `--drop-reference` therefore reach an accepted document, where `--scope` on the same document is refused. That is what makes the repair each finding names actually available where it fires: revising a ratified document *is* a supersession, so the documents left citing a superseded target are usually accepted themselves, and a verb that refused them would be naming a command it turns down.
+
+**A reference names a `spec` or an `adr`, and no other kind.** A specification resting on a binding decision is ordinary and worth declaring; a task is work that finishes and an entry is a trace of a moment, so a document citing one would be citing something the corpus is designed to retire. The rule is enforced where the act can still be attributed — `new spec --reference`, `amend --reference` — and reported by `check` as a fault where a file arrived some other way. It is deliberately **not** a parse error: the format states shape, and refusing to read a whole corpus over one citation is a worse failure than naming it, which is the reading `about` already gets on a log entry.
+
+**Only what is declared is verified.** A section number written in a sentence is not a reference, and nothing scans a body for one. A check reading citations out of paragraphs would depend on how somebody phrased them, which is the drift this exists to catch, moved into the detector.
+
+**A spec declares no `constraint`, and the absence is what justifies the kind.** A spec describes, an ADR binds. An entity that did both would be an ADR with an unbounded constraint, which restates the ceiling rather than solving it. Nothing in the refusal machinery reads a spec, and a rule that must bind is still an ADR — writing one is what §11 already asks of a rule that has grown teeth.
+
+**What the kind buys is that the document moves the way every other decision does.** Before it, the specification had no status, no supersession, no ratification, no anchor and no version, in a tool whose premise is that a decision should be readable, anchored and verifiable — the premise unapplied to the document stating it. It now carries the lifecycle of §3, is promoted by `accept`, and is anchored by the signed ratification commit like an ADR.
+
+**Immutability is anchored over the whole document**, and that is the one place the anchor differs from an ADR's. `ratified` holds the hash of the body and `scope`, because there is no narrower field carrying the authority; an accepted spec whose body has moved is reported as **altered**, on the same terms and by the same walk (§8). The consequence is deliberate and is the doctrine applied rather than an exception to it: revising an accepted specification is a supersession, and a working draft stays `proposed` while it is one.
+
+**`context` names a spec and never quotes it**, in orientation and in execution alike — id and title, one line, beside the constraints. There is no mode that serves its body: there is no `constraint` to serve, and the body is the document. The proportion is what makes the rule non-negotiable rather than tidy: the specification this repository stores is over two hundred thousand bytes against a budget of eight thousand characters, so a single line of a spec body reaching `context` is the budget gone. `show` is the reader, byte for byte, which is the same split §5 settles for `help` and its per-verb page — what a thing *says* is one `show` away.
+
+The `scope` names **what the document governs, not where the document lives**. A specification of the format scopes the format's implementation; scoping it at the directory holding the file would serve it to the agents editing the prose and to nobody who has to obey it.
+
+The cost is worth writing down. A spec entity is large and every verb walking the corpus walks it; `check` verifies the byte-for-byte round trip on every entity, so the document is parsed and re-serialised on every run. That is accepted and it is not free.
+
+### Log entry
+
+`.ank/entities/LOG-6b0f39d7a4c1.md`
+
+```yaml
+---
+id: LOG-6b0f39d7a4c1
+type: log
+title: jwt.verify removed from session.ts
+created: 2026-07-26T14:02:00Z
+author: claude-code/1.4.2
+scope:
+  - src/auth/**
+about: TASK-8f3a91c2d4e7    # the entity the entry is about
+seq: 0                      # its rank among that entity's entries
+schema: 3
+version: 1
+---
+
+Anything the line cannot hold.
+```
+
+**An entry is written once and never modified**, which is what the kind is for. A correction is a new entry naming the one it corrects, and the previous shape's point that a rewritten past entry is a git diff visible in review still holds — it is now the only way one could happen.
+
+**`about` names the entity the entry is about**, and any kind may be named: a task, an ADR, a spec. This is what the previous shape computed from the id instead, and the trade is stated above — an address becomes a query, and in exchange an entry is indexed and reachable like anything else.
+
+**`seq` is the rank of this entry among the entries about the same entity**, counting from 0: one more than the highest `seq` on any entry its writer could already see about that subject. **The order of an entity's entries is `created`, then `seq`, then the identifier**, and every part of that key is read off the entity itself.
+
+**A timestamp is not an order, and the corpus proves it.** `created` has one-second resolution, and one `ank log` costs a few hundred milliseconds, so several entries inside one second is the ordinary case and not the exotic one: measured on a harness writing four entries about one task, 12 runs of 12 put all four in the same second. With no other key the order between them falls to the identifier, which is a hash of the act of creation and carries no order whatever — 10 of those 12 runs printed the four in the wrong order, in exactly descending identifier. The previous shape never had to answer this: an append-only file carried insertion order for free. **A set of files does not, so the order has to be a field.**
+
+Two alternatives were considered and both are worse. **A finer `created`** would fix new writes and could not recover the past: a corpus migrated from the previous layout carries second-resolution instants, and the only order that ever existed there is the line order of the file — refining those timestamps would be inventing precision that was never recorded, which this section forbids in as many words. `seq` carries the line index instead, which is a fact the file actually holds. And **grinding the entropy of an identifier until the hash sorts in line order** works, costs no field, and makes the identifier carry meaning §3 says it does not: the next reader would have to be told that ids sort, and the first id allocated any other way would break the order in silence.
+
+**What `seq` does not promise is as important as what it does.** It is not a clock and not a lock. Two writers who cannot see each other — two branches, two worktrees — produce the same value, and that is the honest answer rather than a defect: they were concurrent, and there is no order between them to record. `created` separates them when their instants differ, the identifier settles what is left, and the merge is still two new files and still conflict-free, which is the property the kind exists for. A reader must therefore treat the key as a total order and never as a claim that one entry caused another.
+
+**A migrated entry takes the line index of the file it came from**, counting from 0. That is the order the append-only file recorded, and it is what makes the previous layout's history survive the move.
+
+**Where a file's line order contradicts its own timestamps, the timestamps win**, because `created` is read before `seq`. That is a decision and not an oversight. A line order is only evidence of insertion order while every writer appended, and the reference corpus shows that did not hold: of 178 log files, **one** stores its two lines newest-first, so its own order disagrees with the instants each line records. Each entry states its instant; the file states a sequence somebody could get wrong, and did. So the guarantee is exact rather than sweeping — **across distinct instants the timestamps order the entries, and within one instant the file's line order does** — and the second half is the load-bearing one: 6 groups covering 12 entries in that corpus share a second, and for those the line order is the only order there has ever been.
+
+**The message is the `title`, and no field is added for it.** Every entity already carries the field a lister prints, and the message is exactly what a lister must print; a second field would be the same sentence in two places, which is how two fields come to disagree. What will not fit on a line goes in the body, where prose lives on every kind.
+
+**The split is fixed, and it is lossless.** A message of one line and at most **100 characters** is the whole of the `title` and the body is empty. Longer, the title is the message up to the last space at or before character 100 and at or after character 50 — the limit itself where there is no such space, and the first newline where one comes earlier — and the body is `"\n"`, the remainder verbatim, `"\n"`. **The message is the exact concatenation of the two**: the separating space belongs to the remainder, nothing is inserted on the way out and exactly one newline is removed at each end on the way back, never a trim. A reader recovers the message it was given, byte for byte, whatever it contained.
+
+The rule exists because a title is what *every* lister prints, on every kind. Measured on the reference corpus, an entry averages 453 characters and the longest is 2105; a title of that length is emitted as one enormous quoted scalar and printed in full by `find`, `context` and `scope`, wrecking them for kinds that have nothing to do with the log. So **a listing prints the head of the message with a trailing `…` when there is more**, which bounds the line whatever the message is, and `ank show <LOG-id>` prints it whole. `--json` always carries the whole message, because a parser reads no page and spends no budget. The alternative — the message whole in the `title`, elided at each lister — is lossless too and was rejected: it moves one storage rule into five printers, and it leaves the file itself unreadable in a diff.
+
+**The `scope` is the subject's, written when the entry is written.** An entry appears wherever what it is about appears, which is the only placement that makes a trace findable by perimeter, and it records the scope as it stood rather than tracking it — a trace of work is a statement about a moment.
+
+What that costs is stated here rather than discovered later: **the copy does not track.** When a task's scope is amended, or when the code under it moves, every entry already written keeps the perimeter as it stood — so the entries of one task can name several perimeters, and an old entry can name a dead one. Accepted, on two grounds. Tracking would mean rewriting an entity that is written once, which is the property the kind exists for; and the dead-scope machinery of §4 already makes a stale perimeter visible without a rule of its own. **An entry's scope is therefore not confronted with the filesystem by `check`**: every other kind chooses its perimeter and answers for it, an entry copies one it did not choose, and reporting a subject's dead scope once per entry about it is the volume that teaches a reader to stop reading `check`.
+
+**No `status`, and `version` stays**, which is not an inconsistency but the difference between what each would record. An entry has nothing to transition to, so a status would have one legal value and would only ever be copied. `version` is the compare-and-swap counter of §7, and on a kind written once it earns its place by the falsification it makes visible: an entry whose `version` is above 1 has been rewritten, and the format says it should not have been.
+
+Entries are written by `log`, one per call, and by nothing else. `attest --detached` still writes none, and §7 says why that is not an omission.
+
+### Typed actors, and a reading that is recorded
+
+A corpus written mostly by agents had no field that said so. `author` held whatever `$ANK_AGENT` resolved to, and nothing distinguished a person from a model. The distinction the whole authority model rests on was recorded nowhere except in the signed ratification commit (§8), which covers ADRs and only at the moment they are accepted — and the gap was widest exactly where it matters most: a `done_criteria` written by an agent, claimed by an agent and verified by a verifier an agent could edit is the normal case, and `criteria_by` says which *position* wrote the criterion, never what kind of actor.
+
+**An identity written into an entity is typed** (ADR-3877fef1d662):
+
+| Form | Actor |
+|---|---|
+| `human:<id>` | A person |
+| `<producer>/<version>` | An agent |
+| `process:<id>` | An automated process |
+
+The convention binds `author` and every later field that names an actor — today, the `by` of a `verified` entry. It is what makes the trust tiers fall out mechanically: no reading is *unverified*, a reading by a non-human actor is *machine-confirmed*, a reading by a `human:` is *human-reviewed*.
+
+**A value that does not match the convention is a `check` finding and never a parse error.** This is not a detail of severity: making it a parse error would lock every file written before the convention out of its own format, and those files mean what they meant. The corpus is not migrated by a rule it predates. `check` reports the pre-convention set **once for the corpus and never per file** — the same choice already made for the entities predating `author` entirely, and for the same reason: one line per file teaches a reader to stop reading `check`.
+
+**`verified` records a reading.** It is an optional list, each entry naming a typed actor and an ISO 8601 instant in UTC:
+
+```yaml
+verified:
+  - by: human:marie
+    at: 2026-07-27T09:40:00Z
+```
+
+`proof` anchors that something *ran*; `verified` anchors that somebody *read* and stands behind it. Those are different claims, and a corpus written by agents needs the second more than a corpus written by people did. It is optional on every kind, its absence is never a fault, and **no verb requires it** — a required trust field is a field filled in to make the tool stop complaining, at which point it records nothing.
+
+`check` derives what the fields state and nothing further: an entity whose `author` is an agent and which carries no reading by a `human:` is a **signal**. No score, no confidence, no ranking. The signals are recorded and the reader judges — the same reason §11 refuses temporal decay.
+
+**The convention is a signal and not a wall**, knowingly. ADR-9ede1ffd04e2 abolished the agent/human split in the CLI on the observation that a wall whose bricks are self-declared identity is a sign and not a wall; this adds a sign. Nothing prevents an agent from writing `human:` in front of its own name, any more than anything prevents it from setting `$ANK_AGENT` to a colleague's. What the convention buys is that the honest case becomes legible and the dishonest one becomes a lie somebody wrote down. Nothing in the refusal machinery consults these fields.
+
+Rejected: **`generated: {by, at}`**, redundant with `author` and `created`, and `created` is hashed into the identifier, so it is anchored in a way a new field would not be — two fields answering one question are two fields that eventually disagree. And **`stale_after`**, an absolute expiry, which §11 already argues against: a three-year-old constraint can be vital, and what Ank detects is structural death, not the calendar.

--- a/.ank/entities/TASK-5ce9bb43cdf7.md
+++ b/.ank/entities/TASK-5ce9bb43cdf7.md
@@ -5,7 +5,7 @@ slug: the-specification-carries-the-post-done-amend-ru
 title: The specification carries the post-done amend rule the ratified ADR states
 created: 2026-09-05T14:18:38Z
 author: haksolot@vmi3223161
-status: open
+status: in_progress
 scope:
   - .ank/**
   - crates/ank-contract/src/verbs.rs
@@ -16,7 +16,7 @@ done_criteria: |
 criteria_by: creator
 verify: [check-repo]
 schema: 4
-version: 1
+version: 2
 ---
 
 Found while preparing TASK-d64c3dbfe0a3: ADR-b9156403c3d5 was ratified while

--- a/.ank/entities/TASK-5ce9bb43cdf7.md
+++ b/.ank/entities/TASK-5ce9bb43cdf7.md
@@ -1,0 +1,31 @@
+---
+id: TASK-5ce9bb43cdf7
+type: task
+slug: the-specification-carries-the-post-done-amend-ru
+title: The specification carries the post-done amend rule the ratified ADR states
+created: 2026-09-05T14:18:38Z
+author: haksolot@vmi3223161
+status: open
+scope:
+  - .ank/**
+  - crates/ank-contract/src/verbs.rs
+  - crates/ank-tui/src/view.rs
+blocked_by: []
+done_criteria: |
+  Successors are proposed for the specs stating that appending a proof is the only legal post-done write: SPEC-a89b3e0b3f3d (the data model, section 3), SPEC-d58b3a9e4e4d (the CLI surface, the amend and attest entries) and SPEC-88e1 (proof, its two citing sentences), each carried forward whole with only the post-done regime amended to what ADR-b9156403c3d5 states: amend --scope/--drop-scope is legal on a done task and journalled, done_criteria and blocked_by stay settled. Every workspace citation of the three retired ids is re-pointed to its successor, so accept will not refuse the supersession (ADR-3b6ba766a42e). ank check green.
+criteria_by: creator
+verify: [check-repo]
+schema: 4
+version: 1
+---
+
+Found while preparing TASK-d64c3dbfe0a3: ADR-b9156403c3d5 was ratified while
+three accepted specs still state the opposite regime. SPEC-a89b carries section
+3 whole ("After done, the only legal write is appending a proof; any other
+modification is reported by check"), SPEC-d58b's amend entry refuses a done
+task on that ground, and SPEC-88e1 cites the rule twice in prose. The code
+change cannot land honestly before the specification says what the binary will
+do. Citations of the retired ids live in crates/ank-contract/src/verbs.rs and
+crates/ank-tui/src/view.rs and must move with the succession, grouped by file.
+Ratification of the successors is a human act and is not part of this task's
+criterion; the task ends with the proposals and the sweep in place.

--- a/.ank/entities/TASK-5ce9bb43cdf7.md
+++ b/.ank/entities/TASK-5ce9bb43cdf7.md
@@ -5,7 +5,7 @@ slug: the-specification-carries-the-post-done-amend-ru
 title: The specification carries the post-done amend rule the ratified ADR states
 created: 2026-09-05T14:18:38Z
 author: haksolot@vmi3223161
-status: in_progress
+status: done
 scope:
   - .ank/**
   - crates/ank-contract/src/verbs.rs
@@ -15,8 +15,15 @@ done_criteria: |
   Successors are proposed for the specs stating that appending a proof is the only legal post-done write: SPEC-a89b3e0b3f3d (the data model, section 3), SPEC-d58b3a9e4e4d (the CLI surface, the amend and attest entries) and SPEC-88e1 (proof, its two citing sentences), each carried forward whole with only the post-done regime amended to what ADR-b9156403c3d5 states: amend --scope/--drop-scope is legal on a done task and journalled, done_criteria and blocked_by stay settled. Every workspace citation of the three retired ids is re-pointed to its successor, so accept will not refuse the supersession (ADR-3b6ba766a42e). ank check green.
 criteria_by: creator
 verify: [check-repo]
+proof:
+  - type: test
+    ref: local/5a3105020e09@c08f852
+    tree: scope/2512f94bee67
+    criteria: 4705625452ab
+    verifier: check-repo@5734e9cf9d3d
+    via: verifier
 schema: 4
-version: 2
+version: 3
 ---
 
 Found while preparing TASK-d64c3dbfe0a3: ADR-b9156403c3d5 was ratified while

--- a/.ank/entities/TASK-d64c3dbfe0a3.md
+++ b/.ank/entities/TASK-d64c3dbfe0a3.md
@@ -10,13 +10,13 @@ scope:
   - crates/ank-cli/src/human.rs
   - crates/ank-cli/src/cli.rs
   - crates/ank-cli/tests/**
-blocked_by: []
+blocked_by: [TASK-5ce9bb43cdf7]
 done_criteria: |
   Through the binary: on a task with status done, ank amend --drop-scope <entry> and --scope <entry> succeed, the entity's scope reflects the change, and a LOG entry records what was added or dropped; ank amend --criteria and --blocked-by on the same task still refuse at exit 7, with a message naming done_criteria as the settled field rather than the whole plan. A dead-scope fault on a done task is cleared by ank amend --drop-scope and ank check returns to green. All covered by binary tests in crates/ank-cli/tests/.
 criteria_by: creator
 verify: [cargo-test, fmt-check, check-repo]
 schema: 4
-version: 2
+version: 3
 ---
 
 Implements ADR-b9156403c3d5 (issue #385, direction 1). The refusal today is at

--- a/crates/ank-contract/src/verbs.rs
+++ b/crates/ank-contract/src/verbs.rs
@@ -409,7 +409,7 @@ const fn refuses(code: ExitCode, when: &'static str) -> Refusal {
 /// The refusal every path-taking verb performs, declared once and named six
 /// times.
 ///
-/// SPEC-d58b3a9e4e4d states it for all of them at once — a path naming nothing
+/// SPEC-4b79c265ccb6 states it for all of them at once — a path naming nothing
 /// inside the repository, because it is absolute or because it climbs above the
 /// root, is refused with the command to run next and never answered — and the
 /// six verbs reach it through one helper, `context::normalised`. One sentence

--- a/crates/ank-tui/src/view.rs
+++ b/crates/ank-tui/src/view.rs
@@ -4781,7 +4781,7 @@ mod tests {
             entities: vec![
                 row("ADR-8bd76e8d7c4e", "adr", "accepted", "A terminal reader"),
                 row("TASK-49746735127f", "task", "in_progress", "ank tui opens"),
-                row("SPEC-d58b3a9e4e4d", "spec", "accepted", "The CLI surface"),
+                row("SPEC-4b79c265ccb6", "spec", "accepted", "The CLI surface"),
             ],
             total: 3,
         }
@@ -7238,7 +7238,7 @@ mod tests {
             [2, 1, 1, 1],
             "the list did not follow the needle keystroke by keystroke"
         );
-        assert_eq!(rendered_rows(&a), ["SPEC-d58b3a9e4e4d"]);
+        assert_eq!(rendered_rows(&a), ["SPEC-4b79c265ccb6"]);
         assert_eq!(a.note, None, "narrowing said something");
 
         // A Backspace widens it again, on the keystroke, for the same reason.
@@ -7750,7 +7750,7 @@ mod tests {
             // makes a selection mean anything.
             assert_eq!(
                 a.selected_id(Focus::Entities).as_deref(),
-                Some("SPEC-d58b3a9e4e4d")
+                Some("SPEC-4b79c265ccb6")
             );
             // The mark is drawn on it, and on no other row.
             let frame = a.frame();
@@ -7814,7 +7814,7 @@ mod tests {
 
             press_at(&mut a, &ank, at, start + SECOND_PRESS);
             assert!(
-                reached_for(&a).contains("SPEC-d58b3a9e4e4d"),
+                reached_for(&a).contains("SPEC-4b79c265ccb6"),
                 "two presses on the row at {size:?} opened nothing: {}",
                 reached_for(&a)
             );
@@ -7884,7 +7884,7 @@ mod tests {
 
         press_at(&mut a, &ank, at, past + Duration::from_millis(1));
         assert!(
-            reached_for(&a).contains("SPEC-d58b3a9e4e4d"),
+            reached_for(&a).contains("SPEC-4b79c265ccb6"),
             "the press past the interval was not counted as the one that \
              chooses: {}",
             reached_for(&a)

--- a/crates/ank-tui/src/view.rs
+++ b/crates/ank-tui/src/view.rs
@@ -6254,7 +6254,7 @@ mod tests {
         for expected in [
             "ADR-8bd7",
             "TASK-4974",
-            "SPEC-d58b",
+            "SPEC-4b79",
             "accepted",
             "in_progress",
             "wave4/tui-verb",
@@ -7756,7 +7756,7 @@ mod tests {
             let frame = a.frame();
             let marked = frame
                 .lines()
-                .filter(|l| l.contains("> ") && l.contains("SPEC-d58b"))
+                .filter(|l| l.contains("> ") && l.contains("SPEC-4b79"))
                 .count();
             assert_eq!(marked, 1, "{frame}");
         }


### PR DESCRIPTION
Follow-up of #385/#393: the ratified ADR contradicted three accepted specs still stating that appending a proof is the only legal post-done write. Three successors are proposed, carried forward whole with only that regime amended (SPEC-e258796162c4 for the data model's §3, SPEC-77d99d8d1ef2 for proof, SPEC-4b79c265ccb6 for the CLI surface), and the six workspace citations of SPEC-d58b3a9e4e4d are re-pointed to the successor. Ratification of the successors is the next, separate act.

TASK-5ce9bb43cdf7 closed by its declared verifier (check-repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5jznYkUxwuxuEBwv5v4VK