### PR TITLE
amend fixes the scope of a done task, and journals the correction

### DIFF
--- a/.ank/entities/LOG-677603dcb401.md
+++ b/.ank/entities/LOG-677603dcb401.md
@@ -1,0 +1,17 @@
+---
+id: LOG-677603dcb401
+type: log
+title: "red observed first: the binary test failed on the settled-field message ('is done, and its plan is"
+created: 2026-09-05T16:36:13Z
+author: claude-code/385
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/src/cli.rs
+  - crates/ank-cli/tests/**
+about: TASK-d64c3dbfe0a3
+seq: 2
+schema: 4
+version: 1
+---
+
+ settled' names no field), then on the scope amend refusing. Green with the refusal in the Task arm now conditional on criteria/blocked_by, message naming done_criteria and blocked_by as settled and the hint offering the scope flags. repair() in human.rs now returns the amend for a done/closed task too -- the dead-scope note used to withhold the command because it would have exited 7, and that reason is gone; test a_finished_task_is_told_where_the_file_went updated accordingly, the one test worth naming in review alongside the rewritten unit test amend_refuses_a_finished_task_and_a_ratified_scope (scope half now asserts Ok). closed keeps the same regime and the test covers it. Full ank-cli suites green, fmt clean.

--- a/.ank/entities/LOG-fd05d01c3628.md
+++ b/.ank/entities/LOG-fd05d01c3628.md
@@ -1,0 +1,17 @@
+---
+id: LOG-fd05d01c3628
+type: log
+title: done, proof test:local/1426e90a3f1b@915026e test:local/e3b0c44298fc@915026e
+created: 2026-09-05T16:39:33Z
+author: claude-code/385
+scope:
+  - crates/ank-cli/src/human.rs
+  - crates/ank-cli/src/cli.rs
+  - crates/ank-cli/tests/**
+about: TASK-d64c3dbfe0a3
+seq: 3
+schema: 4
+version: 1
+---
+
+ test:local/4a086666d18b@915026e

--- a/.ank/entities/TASK-d64c3dbfe0a3.md
+++ b/.ank/entities/TASK-d64c3dbfe0a3.md
@@ -5,7 +5,7 @@ slug: amend-fixes-the-scope-of-a-done-task-and-journal
 title: amend fixes the scope of a done task, and journals the correction
 created: 2026-09-05T13:44:55Z
 author: haksolot@vmi3223161
-status: open
+status: in_progress
 scope:
   - crates/ank-cli/src/human.rs
   - crates/ank-cli/src/cli.rs
@@ -16,7 +16,7 @@ done_criteria: |
 criteria_by: creator
 verify: [cargo-test, fmt-check, check-repo]
 schema: 4
-version: 3
+version: 4
 ---
 
 Implements ADR-b9156403c3d5 (issue #385, direction 1). The refusal today is at

--- a/.ank/entities/TASK-d64c3dbfe0a3.md
+++ b/.ank/entities/TASK-d64c3dbfe0a3.md
@@ -5,7 +5,7 @@ slug: amend-fixes-the-scope-of-a-done-task-and-journal
 title: amend fixes the scope of a done task, and journals the correction
 created: 2026-09-05T13:44:55Z
 author: haksolot@vmi3223161
-status: in_progress
+status: done
 scope:
   - crates/ank-cli/src/human.rs
   - crates/ank-cli/src/cli.rs
@@ -15,8 +15,27 @@ done_criteria: |
   Through the binary: on a task with status done, ank amend --drop-scope <entry> and --scope <entry> succeed, the entity's scope reflects the change, and a LOG entry records what was added or dropped; ank amend --criteria and --blocked-by on the same task still refuse at exit 7, with a message naming done_criteria as the settled field rather than the whole plan. A dead-scope fault on a done task is cleared by ank amend --drop-scope and ank check returns to green. All covered by binary tests in crates/ank-cli/tests/.
 criteria_by: creator
 verify: [cargo-test, fmt-check, check-repo]
+proof:
+  - type: test
+    ref: local/1426e90a3f1b@915026e
+    tree: scope/983fcc0c36b5
+    criteria: b26039da14ab
+    verifier: cargo-test@f14aeab36e1b
+    via: verifier
+  - type: test
+    ref: local/e3b0c44298fc@915026e
+    tree: scope/983fcc0c36b5
+    criteria: b26039da14ab
+    verifier: fmt-check@5ca6d10bcd55
+    via: verifier
+  - type: test
+    ref: local/4a086666d18b@915026e
+    tree: scope/983fcc0c36b5
+    criteria: b26039da14ab
+    verifier: check-repo@5734e9cf9d3d
+    via: verifier
 schema: 4
-version: 4
+version: 5
 ---
 
 Implements ADR-b9156403c3d5 (issue #385, direction 1). The refusal today is at

--- a/crates/ank-cli/src/human.rs
+++ b/crates/ank-cli/src/human.rs
@@ -1584,9 +1584,10 @@ fn literal_prefix(glob: &str) -> Option<(String, String)> {
 /// The one command that changes the scope of this entity without refusing on
 /// the spot.
 ///
-/// Four states and three answers, because `amend` accepts a scope change on
-/// exactly two of them. The refusals it would otherwise raise are what decides
-/// each branch, and each is a refusal this file writes itself.
+/// The refusals `amend` would otherwise raise are what decides each branch,
+/// and each is a refusal this file writes itself: a task's scope amends in
+/// every status, a ratified decision's change is a succession, and a log
+/// entry offers nothing.
 fn repair(entity: &Entity, from: &str, to: &str) -> Option<String> {
     let id = entity.id();
     let amend = format!("ank amend {id} --drop-scope \"{from}\" --scope \"{to}\"");
@@ -1597,12 +1598,11 @@ fn repair(entity: &Entity, from: &str, to: &str) -> Option<String> {
         Entity::Task(t) if matches!(t.status, TaskStatus::Open | TaskStatus::InProgress) => {
             Some(amend)
         }
-        // Done or closed, and `amend` refuses it: §3 allows one write to a
-        // finished task and it is a proof. The scope records where the work
-        // happened, which is a fact about the past that a later rename does not
-        // falsify — so the rename is named and nothing is proposed. Naming a
-        // command that exits 7 would be worse than naming none.
-        Entity::Task(_) => None,
+        // Done or closed: the scope of a finished task stays amendable under
+        // §3's post-completion regime (ADR-b9156403c3d5) — it records where
+        // the work happened, and no proof anchors it — so the same command an
+        // open task gets no longer refuses on the spot, and it is named.
+        Entity::Task(_) => Some(amend),
         Entity::Adr(a) if a.status == AdrStatus::Proposed => Some(amend),
         // Accepted or superseded: `constraint` and `scope` are hashed into the
         // ratification commit, so `amend` refuses with code 6 and the change is
@@ -6002,16 +6002,28 @@ pub fn amend(
 
     match loaded.entity {
         Entity::Task(mut task) => {
-            // §3 allows exactly one write to a task after completion, and it is
-            // an addition to the proof list — which is `attest`, not this.
-            // Amending a finished task would produce the corpus fault `check`
-            // reports as "done task modified beyond appending a proof".
-            if matches!(task.status, TaskStatus::Done | TaskStatus::Closed) {
+            // §3's post-completion regime (ADR-b9156403c3d5): `scope` stays
+            // amendable — it describes where the work happened, and no proof
+            // anchors it — while `done_criteria` is anchored by the hash the
+            // proof records and `blocked_by` is the plan's history, so both
+            // stay settled. The refusal names the settled fields rather than
+            // the whole plan: the wholesale refusal left a dead scope on a
+            // finished task as a fault no verb could clear, and a guard that
+            // holds only the traceable path pushes toward the untraceable one.
+            if matches!(task.status, TaskStatus::Done | TaskStatus::Closed)
+                && (criteria.is_some() || !add_blocked.is_empty() || !drop_blocked.is_empty())
+            {
                 return Err(CliError::new(
                     ExitCode::Prerequisite,
-                    format!("{id} is {}, and its plan is settled", task.status.as_str()),
+                    format!(
+                        "{id} is {}: done_criteria and blocked_by are settled, \
+                         and only scope stays amendable",
+                        task.status.as_str()
+                    ),
                 )
-                .with_hint(format!("ank show {id}")));
+                .with_hint(format!(
+                    "ank amend {id} --scope <glob> | --drop-scope <glob>"
+                )));
             }
 
             for b in &drop_blocked {
@@ -9385,17 +9397,26 @@ mod tests {
         assert!(!out.contains("warning"), "{out}");
     }
 
-    /// §3 allows exactly one write to a task after completion and it is
-    /// `attest`'s. Amending a finished task would produce the corpus fault
-    /// `check` reports as a done task modified beyond appending a proof.
+    /// §3's post-completion regime (ADR-b9156403c3d5): a finished task's
+    /// `scope` amends — no proof anchors it — while `done_criteria` and
+    /// `blocked_by` stay settled, and the refusal names the settled fields
+    /// rather than the whole plan.
     #[test]
     fn amend_refuses_a_finished_task_and_a_ratified_scope() {
         let t = Temp::new();
         t.write(&task("000000000001", TaskStatus::Done, &[]));
-        let err = t
+        let (code, out) = t
             .call(&["amend", "0000", "--scope", "docs/**"], "marie@laptop")
+            .unwrap();
+        assert_eq!(code, ExitCode::Ok, "{out}");
+        let err = t
+            .call(
+                &["amend", "0000", "--criteria", "Rewritten."],
+                "marie@laptop",
+            )
             .unwrap_err();
         assert_eq!(err.code, ExitCode::Prerequisite, "{}", err.message);
+        assert!(err.message.contains("done_criteria"), "{}", err.message);
         assert!(err.message.contains("settled"), "{}", err.message);
 
         // An accepted ADR's scope is hashed into the ratification commit, so

--- a/crates/ank-cli/tests/cli.rs
+++ b/crates/ank-cli/tests/cli.rs
@@ -7931,6 +7931,117 @@ fn an_unattested_task_is_not_reported_until_the_default_branch_carries_it() {
     );
 }
 
+const SETTLED: &str = "TASK-000000005e77";
+
+/// §3's post-`done` regime after ADR-b9156403c3d5: `scope` stays amendable on
+/// a finished task — it describes where the work happened and no proof anchors
+/// it — while `done_criteria` and `blocked_by` stay settled and the refusal
+/// names the settled field rather than the whole plan. Before this, a dead
+/// scope on a `done` task was a fault no verb could clear (issue #385):
+/// `amend` refused wholesale, and the only exit was the hand edit the skill
+/// contract forbids — a guard holding only the traceable path.
+#[test]
+fn amend_fixes_the_scope_of_a_done_task_and_the_criterion_stays_settled() {
+    let r = Repo::new();
+    seed_done(&r, SETTLED, "  - type: commit\n    ref: abc1234\n");
+    // A dead entry beside a live one: the perimeter has no hole, and the fault
+    // fires anyway — the exact shape the issue reports.
+    let text = r
+        .task_text(SETTLED)
+        .replace("  - src/**", "  - src/**\n  - config");
+    std::fs::write(
+        r.0.join(".ank/entities").join(format!("{SETTLED}.md")),
+        text,
+    )
+    .unwrap();
+    r.seed_task("TASK-000000000002", Some("Another criterion."));
+    std::fs::create_dir_all(r.0.join("src")).unwrap();
+    std::fs::write(r.0.join("src/lib.rs"), "// x\n").unwrap();
+    r.git(&["add", "-A"]);
+    r.git(&["commit", "-qm", "seed"]);
+
+    let out = r.ank("claude-code@ank", &["check"]);
+    let said = format!("{}{}", stdout(&out), stderr(&out));
+    assert_eq!(code(&out), 8, "the dead scope is a fault first: {said}");
+    assert!(said.contains("dead scope 'config'"), "{said}");
+
+    // The settled fields keep their refusal, and the message names the field
+    // instead of claiming the whole plan.
+    let before = r.task_text(SETTLED);
+    let out = r.ank(
+        "marie@laptop",
+        &["amend", SETTLED, "--criteria", "A rewritten criterion."],
+    );
+    assert_eq!(code(&out), 7, "{}", stderr(&out));
+    assert!(
+        stderr(&out).contains("done_criteria"),
+        "the refusal names the settled field: {}",
+        stderr(&out)
+    );
+    let out = r.ank(
+        "marie@laptop",
+        &["amend", SETTLED, "--blocked-by", "TASK-000000000002"],
+    );
+    assert_eq!(code(&out), 7, "{}", stderr(&out));
+    assert_eq!(r.task_text(SETTLED), before, "a refusal writes nothing");
+
+    // The scope amend passes, and the log carries the correction.
+    let out = r.ank(
+        "marie@laptop",
+        &[
+            "amend",
+            SETTLED,
+            "--drop-scope",
+            "config",
+            "--scope",
+            "docs/**",
+        ],
+    );
+    assert_eq!(code(&out), 0, "{}", stderr(&out));
+    let text = r.task_text(SETTLED);
+    assert!(!text.contains("- config"), "the dead entry is gone: {text}");
+    assert!(
+        text.contains("- docs/**"),
+        "the added entry is there: {text}"
+    );
+    assert!(
+        r.log_text(SETTLED).contains("-scope config")
+            && r.log_text(SETTLED).contains("+scope docs/**"),
+        "the log says what changed: {}",
+        r.log_text(SETTLED)
+    );
+
+    // And the fault the issue called permanent is cleared through the
+    // traceable path. docs/ exists below so the added entry is alive.
+    std::fs::create_dir_all(r.0.join("docs")).unwrap();
+    std::fs::write(r.0.join("docs/note.md"), "note\n").unwrap();
+    r.git(&["add", "-A"]);
+    r.git(&["commit", "-qm", "docs"]);
+    let out = r.ank("claude-code@ank", &["check"]);
+    let said = format!("{}{}", stdout(&out), stderr(&out));
+    assert_eq!(code(&out), 0, "the correction clears the fault: {said}");
+
+    // `close` keeps the same regime on the same terms (ADR-b9156403c3d5).
+    let closed = "TASK-00000000c105";
+    seed_done(&r, closed, "  - type: commit\n    ref: abc1234\n");
+    let text = r
+        .task_text(closed)
+        .replace("status: done", "status: closed");
+    std::fs::write(r.0.join(".ank/entities").join(format!("{closed}.md")), text).unwrap();
+    let out = r.ank("marie@laptop", &["amend", closed, "--scope", "docs/**"]);
+    assert_eq!(
+        code(&out),
+        0,
+        "a closed task's scope amends: {}",
+        stderr(&out)
+    );
+    let out = r.ank(
+        "marie@laptop",
+        &["amend", closed, "--criteria", "A rewritten criterion."],
+    );
+    assert_eq!(code(&out), 7, "{}", stderr(&out));
+}
+
 const EDITED_CRITERIA: &str = "TASK-00000000ed17";
 
 /// The proof anchors `done_criteria` by hash, and `check` replays that anchor
@@ -14663,16 +14774,17 @@ fn an_accepted_adr_is_offered_a_supersession_and_never_an_amend() {
     );
 }
 
-/// The two task states, which `amend` treats as opposites.
+/// The two task states, which `amend` no longer treats as opposites.
 ///
 /// An open task is amended, and the rename is what tells a typo from a file
-/// that moved under the work. A finished one is not: §3 allows a single write
-/// to it and that write is a proof, so `amend` exits 7 — and a proposal naming
-/// it would be the refusal this feature exists to avoid. The rename is named
-/// either way, because where the file went is the answer in both states.
+/// that moved under the work. A finished one gets the same command since
+/// §3's post-completion regime (ADR-b9156403c3d5) keeps `scope` amendable:
+/// the proposal would have been a refusal before, which is why it used to be
+/// withheld, and now it is not. The rename is named either way, because
+/// where the file went is the answer in both states.
 #[test]
-fn a_finished_task_is_told_where_the_file_went_and_offered_no_command() {
-    for (status, expected) in [("open", Some("ank amend ")), ("done", None)] {
+fn a_finished_task_is_told_where_the_file_went_and_offered_the_amend() {
+    for (status, expected) in [("open", Some("ank amend ")), ("done", Some("ank amend "))] {
         let r = Repo::new();
         std::fs::create_dir_all(r.0.join("src")).unwrap();
         std::fs::write(r.0.join("src/old.rs"), SIMILAR).unwrap();


### PR DESCRIPTION
Second half of #385, implementing ratified ADR-b9156403c3d5 under the successor specs of #396/#397: on a done or closed task, amend --scope/--drop-scope passes and is journalled, while --criteria and --blocked-by keep exit 7 with a message naming done_criteria and blocked_by as the settled fields. The dead-scope note now offers the same amend to a finished task, since it no longer refuses on the spot. TASK-d64c3dbfe0a3 closed by its declared verifiers (cargo-test, fmt-check, check-repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5jznYkUxwuxuEBwv5v4VK